### PR TITLE
article serialization

### DIFF
--- a/shoebox/app/com/keepit/scraper/Scraper.scala
+++ b/shoebox/app/com/keepit/scraper/Scraper.scala
@@ -68,7 +68,7 @@ class Scraper(articleStore: scala.collection.mutable.Map[Id[NormalizedURI], Arti
       	    case htmlData: HtmlParseData =>
       	      val title = htmlData.getTitle()
               val content = htmlData.getText()
-      		  Left(Article(normalizedUri, title, content)) // return Article             
+      		  Left(Article(normalizedUri.id.get, title, content)) // return Article             
       		case _ => Right(ScraperError(normalizedUri, statusCode, "not html"))
           }
       	} else {

--- a/shoebox/app/com/keepit/search/Article.scala
+++ b/shoebox/app/com/keepit/search/Article.scala
@@ -1,5 +1,6 @@
 package com.keepit.search
 
 import com.keepit.model.NormalizedURI
+import com.keepit.common.db.Id
 
-case class Article(normalizedUri: NormalizedURI, title:String, content:String)
+case class Article(normalizedUriId: Id[NormalizedURI], title:String, content:String)

--- a/shoebox/app/com/keepit/serializer/ArticleSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/ArticleSerializer.scala
@@ -1,0 +1,29 @@
+package com.keepit.serializer
+
+import com.keepit.common.db.ExternalId
+import com.keepit.common.db.Id
+import com.keepit.common.time._
+import securesocial.core._
+import securesocial.core.AuthenticationMethod._
+import play.api.libs.json._
+import com.keepit.search.Article
+
+class ArticleSerializer extends Writes[Article] with Reads[Article] {
+  
+  def writes(article: Article): JsValue =
+    JsObject(List(
+        "normalizedUriId" -> JsNumber(article.normalizedUriId.id),
+        "title" -> JsString(article.title),
+        "content" -> JsString(article.content)
+      )
+    )
+    
+  def reads(json: JsValue): Article = Article(
+      Id((json \ "normalizedUriId").as[Long]), 
+      (json \ "title").as[String], 
+      (json \ "content").as[String])
+}
+
+object ArticleSerializer {
+  implicit val articleSerializer = new ArticleSerializer
+}

--- a/shoebox/test/com/keepit/scraper/ScraperTest.scala
+++ b/shoebox/test/com/keepit/scraper/ScraperTest.scala
@@ -22,15 +22,12 @@ import scala.collection.mutable.{Map => MutableMap}
 @RunWith(classOf[JUnitRunner])
 class ScraperTest extends SpecificationWithJUnit {
 
-  def setup() = {
-  }
-
   "Scraper" should {
     "get a article from an existing website" in {
       val store = MutableMap.empty[Id[NormalizedURI], Article]
       val scraper = getMockScraper(store)
       val url = "http://www.keepit.com/existing"
-      val uri = NormalizedURI(title = "title", url = url, state = NormalizedURI.States.ACTIVE)
+      val uri = NormalizedURI(title = "title", url = url, state = NormalizedURI.States.ACTIVE).copy(id = Some(Id(33)))
       val result = scraper.fetchArticle(uri)
 
       result.isLeft === true // Left is Article
@@ -42,7 +39,7 @@ class ScraperTest extends SpecificationWithJUnit {
       val store = scala.collection.mutable.Map.empty[Id[NormalizedURI], Article]
       val scraper = getMockScraper(store)
       val url = "http://www.keepit.com/missing"
-      val uri = NormalizedURI(title = "title", url = url, state = NormalizedURI.States.ACTIVE)
+      val uri = NormalizedURI(title = "title", url = url, state = NormalizedURI.States.ACTIVE).copy(id = Some(Id(44)))
       val result = scraper.fetchArticle(uri)
       result.isRight === true // Right is ScraperError
       result.right.get.httpStatusCode === HttpStatus.SC_NOT_FOUND
@@ -73,13 +70,13 @@ class ScraperTest extends SpecificationWithJUnit {
   }
 
   def getMockScraper(articleStore: MutableMap[Id[NormalizedURI], Article]) = {
-	new Scraper(articleStore) {
-	  override def fetchArticle(uri: NormalizedURI): Either[Article, ScraperError]	 = {
-	    uri.url match {
-	      case "http://www.keepit.com/existing" => Left(Article(uri, "foo", "bar"))
-	      case "http://www.keepit.com/missing" => Right(ScraperError(uri, HttpStatus.SC_NOT_FOUND, "not found"))
-	    }
-	  } 
-	}
+  	new Scraper(articleStore) {
+  	  override def fetchArticle(uri: NormalizedURI): Either[Article, ScraperError]	 = {
+  	    uri.url match {
+  	      case "http://www.keepit.com/existing" => Left(Article(uri.id.get, "foo", "bar"))
+  	      case "http://www.keepit.com/missing" => Right(ScraperError(uri, HttpStatus.SC_NOT_FOUND, "not found"))
+  	    }
+  	  } 
+  	}
   }
 }

--- a/shoebox/test/com/keepit/serializer/ArticleSerializerTest.scala
+++ b/shoebox/test/com/keepit/serializer/ArticleSerializerTest.scala
@@ -1,0 +1,41 @@
+package com.keepit.serializer
+
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner.JUnitRunner
+import play.api.Play.current
+import play.api.libs.json.Json
+import play.api.test._
+import play.api.test.Helpers._
+import securesocial.core._
+import com.keepit.search.Article
+import com.keepit.common.db.Id
+
+@RunWith(classOf[JUnitRunner])
+class ArticleSerializerTest extends SpecificationWithJUnit {
+
+  "ArticleSerializer" should {
+    "do a basic serialization flow" in {
+      val article = Article(Id(22), "my title", "my content")
+      val serializer = new ArticleSerializer()
+      val json = serializer.writes(article)
+      println(json)
+      val newArticle = serializer.reads(json)
+      article === newArticle
+    }
+
+    "serialization of new lines and escapable stuff" in {
+      val article = Article(Id(22), "my title", """my content
+          has few lines in it
+          and "some qoutes"
+          and othercaracters like: \n \t and ':-)'
+          """)
+      val serializer = new ArticleSerializer()
+      val json = serializer.writes(article)
+      println(json)
+      val newArticle = serializer.reads(json)
+      article === newArticle
+    }
+  }
+
+}


### PR DESCRIPTION
1. keeping in the article the normalized uri id instead of the normalized uri. reason is for serialization/deserialization, the state of the uri may change by the time of serialization while its id won't.
2. creating a article serialiser
