### PR TITLE
use uri-to-user edges to get a public bookmark count for a uri

### DIFF
--- a/shoebox/app/com/keepit/controllers/SearchController.scala
+++ b/shoebox/app/com/keepit/controllers/SearchController.scala
@@ -67,13 +67,12 @@ object SearchController extends Controller with Logging {
   
   private[controllers] def toPersonalSearchResult(res: ArticleHit)(implicit conn: Connection): PersonalSearchResult = {
     val uri = NormalizedURI.get(res.uriId)
-    val count = uri.bookmarks().size
     val users = res.users.toSeq.map{ userId =>
       val user = User.get(userId) 
       val info = SocialUserInfo.getByUser(user.id.get).head
       UserWithSocial(user, info)
     }
-    PersonalSearchResult(uri, count, res.isMyBookmark, false, users, res.score)
+    PersonalSearchResult(uri, res.bookmarkCount, res.isMyBookmark, false, users, res.score)
   }
   
 }

--- a/shoebox/app/com/keepit/search/graph/EdgeSet.scala
+++ b/shoebox/app/com/keepit/search/graph/EdgeSet.scala
@@ -33,6 +33,7 @@ object EdgeSetUtil {
 class MaterializedEdgeSet[S,D](override val sourceId: Id[S], override val destIdSet: Set[Id[D]]) extends EdgeSet[S, D] {
   
   def destIdLongSet = destIdSet.map(_.id)
+  def size = destIdSet.size
   
   def getDestDocIdSetIterator(searcher: Searcher): DocIdSetIterator = getDestDocIdSetIterator(searcher.idMapper)
   
@@ -68,6 +69,8 @@ abstract class LuceneBackedEdgeSet[S, D](override val sourceId: Id[S], searcher:
 
   override def destIdLongSet = lazyDestIdLongSet
   override def destIdSet = lazyDestIdSet
+  
+  def size = getDestDocIdSetIterator(searcher).size
   
   def getDestDocIdSetIterator(searcher: Searcher) = {
     val termDocs = searcher.indexReader.termDocs(createSourceTerm)

--- a/shoebox/test/com/keepit/search/MainSearcherTest.scala
+++ b/shoebox/test/com/keepit/search/MainSearcherTest.scala
@@ -161,7 +161,10 @@ class MainSearcherTest extends SpecificationWithJUnit {
               res.hits.foreach{ h => 
                 if (h.isMyBookmark) mCnt += 1
                 else if (! h.users.isEmpty) fCnt += 1
-                else oCnt += 1
+                else {
+                  oCnt += 1
+                  h.bookmarkCount === graphSearcher.getUriToUserEdgeSet(h.uriId).size
+                }
               }
               //println(hits)
               //println(List(mCnt, fCnt, oCnt))


### PR DESCRIPTION
- no longer use DB to count bookmarks for "others" hits
- use URIGraph (lucene index) instead
- the count now excludes private bookmarks
- don't count bookmarks for my hits and friends' hits for performance reason (the count is set to 0)
