### PR TITLE
added percentMatch threshold parameter for multi-term query

### DIFF
--- a/shoebox/app/com/keepit/search/MainSearcher.scala
+++ b/shoebox/app/com/keepit/search/MainSearcher.scala
@@ -14,6 +14,7 @@ class MainSearcher(articleIndexer: ArticleIndexer, uriGraph: URIGraph, config: S
   val maxTextHitsPerCategory = config.asInt("maxTextHitsPerCategory")
   val myBookmarkBoost = config.asFloat("myBookmarkBoost")
   val sharingBoost = config.asFloat("sharingBoost")
+  val percentMatch = config.asDouble("percentMatch")
     
   // get searchers. subsequent operations should use these for consistency since indexing may refresh them
   val articleSearcher = articleIndexer.getArticleSearcher
@@ -31,7 +32,9 @@ class MainSearcher(articleIndexer: ArticleIndexer, uriGraph: URIGraph, config: S
     val friendsHits = createQueue(maxTextHitsPerCategory)
     val othersHits = createQueue(maxTextHitsPerCategory)
     
-    articleIndexer.parse(queryString).map{ articleQuery =>
+    val parser = articleIndexer.getQueryParser
+    parser.setPercentMatch(percentMatch)
+    parser.parseQuery(queryString).map{ articleQuery =>
       articleSearcher.doSearch(articleQuery){ scorer =>
         var doc = scorer.nextDoc()
         while (doc != NO_MORE_DOCS) {

--- a/shoebox/app/com/keepit/search/SearchConfig.scala
+++ b/shoebox/app/com/keepit/search/SearchConfig.scala
@@ -6,7 +6,8 @@ object SearchConfig {
       "minMyBookmarks" -> "3",
       "maxTextHitsPerCategory" -> "1000",
       "myBookmarkBoost" -> "2",
-      "sharingBoost" -> "0.5")
+      "sharingBoost" -> "0.5",
+      "percentMatch" -> "50")
   
   var defaultConfig = new SearchConfig(defaultParams)
 
@@ -26,6 +27,7 @@ object SearchConfig {
 class SearchConfig(params: Map[String, String]) {
   def asInt(name: String) = params(name).toInt
   def asFloat(name: String) = params(name).toFloat
+  def asDouble(name: String) = params(name).toDouble
   def asBoolean(name: String) = params(name).toBoolean
   def asString(name: String) = params(name)
 }

--- a/shoebox/app/com/keepit/search/graph/URIGraph.scala
+++ b/shoebox/app/com/keepit/search/graph/URIGraph.scala
@@ -3,7 +3,7 @@ package com.keepit.search.graph
 import com.keepit.common.logging.Logging
 import com.keepit.common.db.Id
 import com.keepit.model.{Bookmark, NormalizedURI, User}
-import com.keepit.search.index.{Hit, Indexable, Indexer, IndexError, Searcher}
+import com.keepit.search.index.{Hit, Indexable, Indexer, IndexError, Searcher, QueryParser}
 import com.keepit.common.db.CX
 import play.api.Play.current
 import org.apache.lucene.analysis.KeywordAnalyzer
@@ -12,7 +12,6 @@ import org.apache.lucene.document.Field
 import org.apache.lucene.index.IndexWriter
 import org.apache.lucene.index.IndexWriterConfig
 import org.apache.lucene.index.Term
-import org.apache.lucene.queryParser.QueryParser
 import org.apache.lucene.search.Query
 import org.apache.lucene.store.Directory
 import org.apache.lucene.util.Version
@@ -87,12 +86,10 @@ class URIGraphImpl(indexDirectory: Directory, indexWriterConfig: IndexWriterConf
     }
   }
 
-  private val parser = new QueryParser(Version.LUCENE_36, "b", indexWriterConfig.getAnalyzer())
-
-  def parse(queryText: String): Option[Query] = Option(parser.parse(queryText))
+  def getQueryParser = new QueryParser(indexWriterConfig)
   
   def search(queryText: String): Seq[Hit] = {
-    parse(queryText) match {
+    parseQuery(queryText) match {
       case Some(query) => searcher.search(query)
       case None => Seq.empty[Hit]
     }

--- a/shoebox/app/com/keepit/search/index/ArticleIndexer.scala
+++ b/shoebox/app/com/keepit/search/index/ArticleIndexer.scala
@@ -14,7 +14,6 @@ import org.apache.lucene.document.Document
 import org.apache.lucene.document.Field
 import org.apache.lucene.index.IndexWriter
 import org.apache.lucene.index.IndexWriterConfig
-import org.apache.lucene.queryParser.QueryParser
 import org.apache.lucene.search.Query
 import org.apache.lucene.search.BooleanQuery
 import org.apache.lucene.search.BooleanClause._
@@ -24,6 +23,7 @@ import org.apache.lucene.util.PriorityQueue
 import org.apache.lucene.util.Version
 import java.io.File
 import java.io.IOException
+import scala.math._
 
 object ArticleIndexer {
   def apply(indexDirectory: Directory, articleStore: ArticleStore): ArticleIndexer = {
@@ -73,14 +73,12 @@ class ArticleIndexer(indexDirectory: Directory, indexWriterConfig: IndexWriterCo
     }
   }
   
-  private val parser = new ArticleQueryParser
-
-  def parse(queryText: String): Option[Query] = Option(parser.parse(queryText))
+  def getQueryParser: QueryParser = new ArticleQueryParser
   
   def getArticleSearcher() = searcher
   
   def search(queryText: String): Seq[Hit] = {
-    parse(queryText) match {
+    parseQuery(queryText) match {
       case Some(query) => searcher.search(query)
       case None => Seq.empty[Hit]
     }
@@ -105,7 +103,7 @@ class ArticleIndexer(indexDirectory: Directory, indexWriterConfig: IndexWriterCo
     }
   }
   
-  class ArticleQueryParser extends QueryParser(Version.LUCENE_36, "b", indexWriterConfig.getAnalyzer()) {
+  class ArticleQueryParser extends QueryParser(indexWriterConfig) {
     
     super.setAutoGeneratePhraseQueries(true)
     
@@ -123,4 +121,3 @@ class ArticleIndexer(indexDirectory: Directory, indexWriterConfig: IndexWriterCo
     }
   }
 }
-

--- a/shoebox/test/com/keepit/search/index/ArticleIndexerTest.scala
+++ b/shoebox/test/com/keepit/search/index/ArticleIndexerTest.scala
@@ -143,5 +143,30 @@ class ArticleIndexerTest extends SpecificationWithJUnit {
       res.size === 3
       res.head.id === uriIdArray(2)
     }
+    
+    "limit the result by percentMatch" in {
+      val indexer = ArticleIndexer(ramDir, store)
+      
+      val parser = indexer.getQueryParser
+
+      var res = indexer.search("title1 alldocs")
+      res.size === 3
+      
+      parser.setPercentMatch(50)
+      res = indexer.getArticleSearcher.search(parser.parseQuery("title1 alldocs").get)
+      res.size === 3
+      
+      parser.setPercentMatch(60)
+      res = indexer.getArticleSearcher.search(parser.parseQuery("title1 alldocs").get)
+      res.size === 1
+      
+      parser.setPercentMatch(60)
+      res = indexer.getArticleSearcher.search(parser.parseQuery("title1 title2 alldocs").get)
+      res.size === 2
+      
+      parser.setPercentMatch(75)
+      res = indexer.getArticleSearcher.search(parser.parseQuery("title1 title2 alldocs").get)
+      res.size === 0
+    }
   }
 }


### PR DESCRIPTION
The default is 50 right now, which means 50 percent of query terms required to appear in an article to be qualified as a hit. 
