### PR TITLE
processing a list of Facebook graph jsons instead of a single one. 

### DIFF
--- a/shoebox/README
+++ b/shoebox/README
@@ -1,4 +1,4 @@
-This is your new Play 2.0 application
-=====================================
+What's new
+============
 
-This file will be packaged with your application, when using `play dist`.
+

--- a/shoebox/app/com/keepit/common/social/SocialGraphPlugin.scala
+++ b/shoebox/app/com/keepit/common/social/SocialGraphPlugin.scala
@@ -55,9 +55,9 @@ private[social] class SocialGraphActor(graph: FacebookSocialGraph) extends Actor
         }
         val store = inject[SocialUserRawInfoStore]
         store += (socialUserInfo.id.get -> rawInfo)
-        inject[SocialUserImportFriends].importFriends(rawInfo.json)
+        inject[SocialUserImportFriends].importFriends(rawInfo.jsons)
         
-        inject[SocialUserCreateConnections].createConnections(socialUserInfo, rawInfo.json)
+        inject[SocialUserCreateConnections].createConnections(socialUserInfo, rawInfo.jsons)
       }
       catch {
         case ex => 

--- a/shoebox/app/com/keepit/common/social/SocialUserCreateConnections.scala
+++ b/shoebox/app/com/keepit/common/social/SocialUserCreateConnections.scala
@@ -12,7 +12,12 @@ import com.keepit.model.User
 
 class SocialUserCreateConnections() extends Logging {
   
-  def createConnections(socialUserInfo: SocialUserInfo, parentJson: JsValue): Seq[SocialConnection] =
+  def createConnections(socialUserInfo: SocialUserInfo, parentJsons: Seq[JsValue]): Seq[SocialConnection] =
+    parentJsons map {json => 
+      createConnectionsFromJson(socialUserInfo, json)
+    } flatten
+    
+  def createConnectionsFromJson(socialUserInfo: SocialUserInfo, parentJson: JsValue): Seq[SocialConnection] =
     CX.withConnection { implicit conn => 
       extractFriends(parentJson) map { friend =>
         SocialUserInfo.get(SocialId((friend \ "id").as[String]), SocialNetworks.FACEBOOK)

--- a/shoebox/app/com/keepit/common/social/SocialUserImportFriends.scala
+++ b/shoebox/app/com/keepit/common/social/SocialUserImportFriends.scala
@@ -34,8 +34,10 @@ import com.keepit.common.logging.Logging
 
 
 class SocialUserImportFriends() extends Logging {
+
+  def importFriends(parentJsons: Seq[JsValue]): Seq[SocialUserRawInfo] = parentJsons map importFriendsFromJson flatten
   
-  def importFriends(parentJson: JsValue): Seq[SocialUserRawInfo] = {
+  private def importFriendsFromJson(parentJson: JsValue): Seq[SocialUserRawInfo] = {
     val socialUserInfos = CX.withConnection { implicit conn =>
       extractFriends(parentJson) filter infoNotInDb map createSocialUserInfo map {t => (t._1.save, t._2)}
     }
@@ -70,5 +72,5 @@ class SocialUserImportFriends() extends Logging {
                                                 networkType = SocialNetworks.FACEBOOK, state = SocialUserInfo.States.FETCHED_USING_FRIEND), friend)
                                                 
   private def createSocialUserRawInfo(socialUserInfo: SocialUserInfo, friend: JsValue) = SocialUserRawInfo(socialUserInfo = socialUserInfo, json = friend)
-  
+
 }

--- a/shoebox/app/com/keepit/common/social/SocialUserRawInfo.scala
+++ b/shoebox/app/com/keepit/common/social/SocialUserRawInfo.scala
@@ -5,7 +5,7 @@ import com.keepit.common.db.Id
 import play.api.libs.json.JsValue
 import com.keepit.model.SocialUserInfo
 
-case class SocialUserRawInfo(userId: Option[Id[User]], socialUserInfoId: Option[Id[SocialUserInfo]], socialId: SocialId, networkType: SocialNetworkType, fullName: String, json: JsValue) {
+case class SocialUserRawInfo(userId: Option[Id[User]], socialUserInfoId: Option[Id[SocialUserInfo]], socialId: SocialId, networkType: SocialNetworkType, fullName: String, jsons: Seq[JsValue]) {
   def toSocialUserInfo = socialUserInfoId match {
     case Some(id) => throw new Exception("socialUserInfo with id %s already exist!".format(socialUserInfoId))
     case None => SocialUserInfo(userId = userId, fullName = fullName, socialId = socialId, networkType = networkType)
@@ -13,9 +13,11 @@ case class SocialUserRawInfo(userId: Option[Id[User]], socialUserInfoId: Option[
 }
 
 object SocialUserRawInfo {
-  def apply(socialUserInfo: SocialUserInfo, json: JsValue): SocialUserRawInfo = {
+  def apply(socialUserInfo: SocialUserInfo, jsons: Seq[JsValue]): SocialUserRawInfo = {
     SocialUserRawInfo(userId = socialUserInfo.userId, socialUserInfoId = socialUserInfo.id, 
                       socialId = socialUserInfo.socialId, networkType = socialUserInfo.networkType,
-                      fullName = socialUserInfo.fullName, json = json)
+                      fullName = socialUserInfo.fullName, jsons = jsons)
   }
+
+  def apply(socialUserInfo: SocialUserInfo, json: JsValue): SocialUserRawInfo = apply(socialUserInfo, Seq(json))
 }

--- a/shoebox/app/com/keepit/serializer/SocialUserRawInfoSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/SocialUserRawInfoSerializer.scala
@@ -19,7 +19,7 @@ class SocialUserRawInfoSerializer extends Format[SocialUserRawInfo] {
         "socialId" -> JsString(info.socialId.id),
         "networkType" -> JsString(info.networkType.name),
         "fullName" -> JsString(info.fullName),
-        "json" -> info.json 
+        "jsons" -> JsArray(info.jsons)
       )
     )
     
@@ -31,7 +31,7 @@ class SocialUserRawInfoSerializer extends Format[SocialUserRawInfo] {
         case SocialNetworks.FACEBOOK.name => SocialNetworks.FACEBOOK 
       },
       fullName = (json \ "fullName").as[String],
-      json = (json \ "json")
+      jsons = (json \ "jsons").asInstanceOf[JsArray].value
    )
 }
 

--- a/shoebox/test/com/keepit/common/social/SocialUserCreateConnectionsTest.scala
+++ b/shoebox/test/com/keepit/common/social/SocialUserCreateConnectionsTest.scala
@@ -42,14 +42,14 @@ class SocialUserCreateConnectionsTest extends SpecificationWithJUnit {
          */
         val json = Json.parse(io.Source.fromFile(new File("test/com/keepit/common/social/facebook_graph_eishay.json")).mkString)
         
-        val result = inject[SocialUserImportFriends].importFriends(json)
+        val result = inject[SocialUserImportFriends].importFriends(Seq(json))
         
         val socialUserInfo = CX.withConnection { implicit conn =>
           SocialUserInfo(fullName = "Bob Smith", socialId = SocialId("bsmith"), networkType = SocialNetworks.FACEBOOK).withUser(User(firstName = "fn1", lastName = "ln1").save).save
         }
         
         
-        val connections = inject[SocialUserCreateConnections].createConnections(socialUserInfo, json)
+        val connections = inject[SocialUserCreateConnections].createConnections(socialUserInfo, Seq(json))
 
         connections.size === 199    
       }

--- a/shoebox/test/com/keepit/common/social/SocialUserImportFriendsTest.scala
+++ b/shoebox/test/com/keepit/common/social/SocialUserImportFriendsTest.scala
@@ -44,7 +44,7 @@ class SocialUserImportFriendsTest extends SpecificationWithJUnit {
   
   def testFacebookGraph(jsonFilename: String, numOfFriends: Int, firstFriend: String) = {
     val json = Json.parse(io.Source.fromFile(new File("test/com/keepit/common/social/%s".format(jsonFilename))).mkString)
-    val rawFriends = inject[SocialUserImportFriends].importFriends(json)
+    val rawFriends = inject[SocialUserImportFriends].importFriends(Seq(json))
     val store = inject[SocialUserRawInfoStore].asInstanceOf[Map[Id[SocialUserInfo], SocialUserRawInfo]]
     store.size === numOfFriends
     store.clear

--- a/shoebox/test/com/keepit/model/SocialConnectionTest.scala
+++ b/shoebox/test/com/keepit/model/SocialConnectionTest.scala
@@ -29,7 +29,7 @@ class SocialConnectionTest extends SpecificationWithJUnit {
         
         def loadJsonImportFriends(filename: String): Unit = {
           val json = Json.parse(io.Source.fromFile(new File("test/com/keepit/common/social/%s".format(filename))).mkString)
-          println(inject[SocialUserImportFriends].importFriends(json).size)
+          println(inject[SocialUserImportFriends].importFriends(Seq(json)).size)
         }
         
         loadJsonImportFriends("facebook_graph_andrew_min.json")
@@ -66,8 +66,8 @@ class SocialConnectionTest extends SpecificationWithJUnit {
           SocialUserInfo.get(SocialId("113102"), SocialNetworks.FACEBOOK).withUser(users(2)).save
         }
         
-        inject[SocialUserCreateConnections].createConnections(eishaySocialUserInfo, eishayJson)
-        inject[SocialUserCreateConnections].createConnections(andrewSocialUserInfo, andrewJson)
+        inject[SocialUserCreateConnections].createConnections(eishaySocialUserInfo, Seq(eishayJson))
+        inject[SocialUserCreateConnections].createConnections(andrewSocialUserInfo, Seq(andrewJson))
         
         val (eishayFortyTwoConnection, andrewFortyTwoConnection) = CX.withConnection { implicit conn =>
           SocialConnection.all.size === 18
@@ -93,7 +93,7 @@ class SocialConnectionTest extends SpecificationWithJUnit {
         
         def loadJsonImportFriends(filename: String): Unit = {
           val json = Json.parse(io.Source.fromFile(new File("test/com/keepit/common/social/%s".format(filename))).mkString)
-          println(inject[SocialUserImportFriends].importFriends(json).size)
+          println(inject[SocialUserImportFriends].importFriends(Seq(json)).size)
         }
         
         loadJsonImportFriends("facebook_graph_andrew.json")
@@ -130,8 +130,8 @@ class SocialConnectionTest extends SpecificationWithJUnit {
           SocialUserInfo.get(SocialId("113102"), SocialNetworks.FACEBOOK).withUser(users(2)).save
         }
         
-        inject[SocialUserCreateConnections].createConnections(eishaySocialUserInfo, eishayJson)
-        inject[SocialUserCreateConnections].createConnections(andrewSocialUserInfo, andrewJson)
+        inject[SocialUserCreateConnections].createConnections(eishaySocialUserInfo, Seq(eishayJson))
+        inject[SocialUserCreateConnections].createConnections(andrewSocialUserInfo, Seq(andrewJson))
         
         val (eishayFortyTwoConnection, andrewFortyTwoConnection) = CX.withConnection { implicit conn =>
           SocialConnection.all.size === 612


### PR DESCRIPTION
Facebook may paginate their results, we should fetch all pages and process them in a batch, in the future we may break it down

@yonatanm & @andrewconner please merge, it may effect you
