### PR TITLE
cutting the tail of the result by text score

### DIFF
--- a/shoebox/app/com/keepit/common/net/URINormalizer.scala
+++ b/shoebox/app/com/keepit/common/net/URINormalizer.scala
@@ -37,7 +37,7 @@ object URINormalizer extends Logging {
         Some((scheme, userInfo, host, port, path, query))
       } catch {
         case e: Exception =>
-          log.error("uri normalization failed: [%s]".format(uriString), e)
+          log.error("uri normalization failed: [%s]".format(uriString))
           None
       }
     }
@@ -141,7 +141,7 @@ object URINormalizer extends Logging {
         java.net.URLEncoder.encode(decoded, "UTF-8")
       } catch {
         case e: Exception =>
-          log.error("parameter normalization failed: [%s]".format(string), e)
+          log.error("parameter normalization failed: [%s]".format(string))
           string
       }
     }

--- a/shoebox/app/com/keepit/search/MainSearcher.scala
+++ b/shoebox/app/com/keepit/search/MainSearcher.scala
@@ -13,7 +13,7 @@ import scala.math._
 import org.joda.time.DateTime
 
 class MainSearcher(userId: Id[User], friendIds: Set[Id[User]], filterOut: Set[Long], articleIndexer: ArticleIndexer, uriGraph: URIGraph, config: SearchConfig) {
-  val currentTime = System.currentTimeMillis()
+  val currentTime = currentDateTime.getMillis()
   
   // get config params
   val minMyBookmarks = config.asInt("minMyBookmarks")

--- a/shoebox/app/com/keepit/search/MainSearcher.scala
+++ b/shoebox/app/com/keepit/search/MainSearcher.scala
@@ -23,6 +23,7 @@ class MainSearcher(userId: Id[User], friendIds: Set[Id[User]], filterOut: Set[Lo
   val percentMatch = config.asDouble("percentMatch")
   val recencyBoost = config.asFloat("recencyBoost")
   val halfDecayMillis = config.asFloat("halfDecayHours") * (60.0f * 60.0f * 1000.0f) // hours to millis
+  val tailCutting = config.asFloat("tailCutting")
   
   // get searchers. subsequent operations should use these for consistency since indexing may refresh them
   val articleSearcher = articleIndexer.getArticleSearcher
@@ -80,7 +81,8 @@ class MainSearcher(userId: Id[User], friendIds: Set[Id[User]], filterOut: Set[Lo
     val hits = createQueue(numHitsToReturn)
     
     var highScore = myHits.highScore
-    myHits.foreach{ h =>
+    var threshold = highScore * tailCutting
+    myHits.iterator.filter(_.score > threshold).foreach{ h =>
       val id = Id[NormalizedURI](h.id)
       val sharingUsers = uriGraphSearcher.intersect(friendEdgeSet, uriGraphSearcher.getUriToUserEdgeSet(id)).destIdSet - userId
       
@@ -92,10 +94,12 @@ class MainSearcher(userId: Id[User], friendIds: Set[Id[User]], filterOut: Set[Lo
     
     if (friendsHits.size > 0) {
       highScore = max(highScore, friendsHits.highScore)
+      threshold = highScore * tailCutting
+      
       val queue = createQueue(numHitsToReturn - min(minMyBookmarks, hits.size))
       hits.drop(hits.size - minMyBookmarks).foreach{ h => queue.insert(h) }
       
-      friendsHits.foreach{ h =>
+      friendsHits.iterator.filter(_.score > threshold).foreach{ h =>
         val id = Id[NormalizedURI](h.id)
         val sharingUsers = uriGraphSearcher.intersect(friendEdgeSet, uriGraphSearcher.getUriToUserEdgeSet(id)).destIdSet
         
@@ -106,12 +110,15 @@ class MainSearcher(userId: Id[User], friendIds: Set[Id[User]], filterOut: Set[Lo
       }
       queue.foreach{ h => hits.insert(h) }
     }
+    var mayHaveMore = hits.overflowed // true if we _may_ have more hits
     
     // if we don't have enough hits, backfill the result with hits in the "others" category
-    val moreOthers = if (hits.size < numHitsToReturn && othersHits.size > 0) {
+    if (hits.size < numHitsToReturn && othersHits.size > 0) {
       highScore = max(highScore, othersHits.highScore)
+      threshold = highScore * tailCutting
+      
       val queue = createQueue(numHitsToReturn - hits.size)
-      othersHits.foreach{ h =>
+      othersHits.iterator.filter(_.score > threshold).foreach{ h =>
         h.bookmarkCount = getPublicBookmarkCount(h.id) // TODO: revisit this later. We probably want the private count.
         if (h.bookmarkCount > 0) {
           h.scoring = new Scoring(h.score, h.score / highScore, bookmarkScore(h.bookmarkCount), 0.0f)
@@ -127,12 +134,8 @@ class MainSearcher(userId: Id[User], friendIds: Set[Id[User]], filterOut: Set[Lo
         h.score = h.score * normalizer
         hits.insert(h)
       }
-      queue.overflowed
-    } else {
-      othersHits.size > 0 // we may have more hits
+      if (queue.overflowed) mayHaveMore = true
     }
-    
-    val mayHaveMore = hits.overflowed || moreOthers // true if we _may_ have more hits
     
     val hitList = hits.toList
     ArticleSearchResult(lastUUID, queryString, hitList.map(_.toArticleHit), myTotal, friendsTotal, mayHaveMore, hitList.map(_.scoring), userId)
@@ -198,6 +201,20 @@ class ArticleHitQueue(sz: Int) extends PriorityQueue[MutableArticleHit] {
     otherQueue.foreach{ h => thisQueue.insert(h) }
   }
   
+  def iterator = {
+    val arr = getHeapArray()
+    val sz = size()
+    
+    new Iterator[MutableArticleHit] {
+      var i = 0
+      def hasNext() = (i < sz)
+      def next() = {
+        i += 1
+        arr(i).asInstanceOf[MutableArticleHit]
+      }
+    }
+  }
+  
   def foreach(f: MutableArticleHit => Unit) {
     val arr = getHeapArray()
     val sz = size()
@@ -239,7 +256,7 @@ class Scoring(val textScore: Float, val normalizedTextScore: Float, val bookmark
   var boostedRecencyScore: Float = Float.NaN
   
   def score(textBoost: Float, bookmarkBoost: Float, recencyBoost: Float) = {
-    boostedTextScore = textScore * textBoost
+    boostedTextScore = normalizedTextScore * textBoost
     boostedBookmarkScore = bookmarkScore * bookmarkBoost
     boostedRecencyScore = recencyScore * recencyBoost
     

--- a/shoebox/app/com/keepit/search/SearchConfig.scala
+++ b/shoebox/app/com/keepit/search/SearchConfig.scala
@@ -9,7 +9,8 @@ object SearchConfig {
       "sharingBoost" -> "0.5",
       "percentMatch" -> "50",
       "halfDecayHours" -> "24",
-      "recencyBoost" -> "1.0")
+      "recencyBoost" -> "1.0",
+      "tailCutting" -> "0.1")
   
   var defaultConfig = new SearchConfig(defaultParams)
 

--- a/shoebox/test/com/keepit/search/MainSearcherTest.scala
+++ b/shoebox/test/com/keepit/search/MainSearcherTest.scala
@@ -25,6 +25,24 @@ import scala.util.Random
 @RunWith(classOf[JUnitRunner])
 class MainSearcherTest extends SpecificationWithJUnit {
 
+  def initData(numUsers: Int, numUris: Int) = CX.withConnection { implicit c =>
+    ((0 until numUsers).map(n => User(firstName = "foo" + n, lastName = "").save).toList,
+     (0 until numUris).map(n => NormalizedURI(title = "a" + n, url = "http://www.keepit.com/article" + n, state=SCRAPED).save).toList)
+  }
+  
+  def initIndexes(store: ArticleStore) = {
+    val graphDir = new RAMDirectory
+    val indexDir = new RAMDirectory
+    (URIGraph(graphDir), ArticleIndexer(indexDir, store))
+  }
+  
+  def mkStore(uris: Seq[NormalizedURI]) = {
+    uris.zipWithIndex.foldLeft(new FakeArticleStore){ case (store, (uri, idx)) =>
+    store += (uri.id.get -> mkArticle(uri.id.get, "title%d".format(idx), "content%d alldocs".format(idx)))
+    store
+    }
+  }
+  
   def mkArticle(normalizedUriId: Id[NormalizedURI], title: String, content: String) = {
     Article(
         id = normalizedUriId,
@@ -37,38 +55,28 @@ class MainSearcherTest extends SpecificationWithJUnit {
         message = None)
   }
   
+  val source = BookmarkSource("test")
+  
   "MainSearcher" should {
     "search and categorize using social graph" in {
       running(new EmptyApplication()) {
-        val (users, uris) = CX.withConnection { implicit c =>
-          ((0 to 9).map(n => User(firstName = "foo" + n, lastName = "").save).toList,
-           (0 to 9).map(n => NormalizedURI(title = "a" + n, url = "http://www.keepit.com/article" + n, state=SCRAPED).save).toList)
-        }
+        val (users, uris) = initData(numUsers = 9, numUris = 9)
         val expectedUriToUserEdges = uris.toIterator.zip((1 to 9).iterator.map(users.take(_))).toList
         val bookmarks = CX.withConnection { implicit c =>
           expectedUriToUserEdges.flatMap{ case (uri, users) =>
             users.map{ user =>
-              Bookmark(title = uri.title, url = uri.url,  uriId = uri.id.get, userId = user.id.get, source = BookmarkSource("test")).save
+              Bookmark(title = uri.title, url = uri.url,  uriId = uri.id.get, userId = user.id.get, source = source).save
             }
           }
         }
 
-        val store = {
-          uris.zipWithIndex.foldLeft(new FakeArticleStore){ case (store, (uri, idx)) =>
-            store += (uri.id.get -> mkArticle(uri.id.get, "title%d".format(idx), "content%d alldocs".format(idx)))
-            store
-          }
-        }
-        
-        val graphDir = new RAMDirectory
-        val graph = URIGraph(graphDir)
-        val indexDir = new RAMDirectory
-        val indexer = ArticleIndexer(indexDir, store)
+        val store = mkStore(uris)
+        val (graph, indexer) = initIndexes(store)
         
         graph.load() === users.size
         indexer.run() === uris.size
         
-        val config = SearchConfig.getDefaultConfig
+        val config = SearchConfig(Map("tailCutting" -> "0"))
         
         val numHitsPerCategory = 1000
         users.foreach{ user =>
@@ -108,189 +116,185 @@ class MainSearcherTest extends SpecificationWithJUnit {
         }
         indexer.numDocs === uris.size
       }
-      
-      "return a single list of hits" in {
-        running(new EmptyApplication()) {
-          val (users, uris) = CX.withConnection { implicit c =>
-            ((0 to 9).map(n => User(firstName = "foo" + n, lastName = "").save).toList,
-             (0 to 9).map(n => NormalizedURI(title = "a" + n, url = "http://www.keepit.com/article" + n, state=SCRAPED).save).toList)
-          }
-          val expectedUriToUserEdges = uris.toIterator.zip((1 to 9).iterator.map(users.take(_))).toList
-          val bookmarks = CX.withConnection { implicit c =>
-            expectedUriToUserEdges.flatMap{ case (uri, users) =>
-              users.map{ user =>
-                Bookmark(title = uri.title, url = uri.url,  uriId = uri.id.get, userId = user.id.get, source = BookmarkSource("test")).save
-              }
+    }
+    
+    "return a single list of hits" in {
+      running(new EmptyApplication()) {
+        val (users, uris) = initData(numUsers = 9, numUris = 9)
+        val expectedUriToUserEdges = uris.toIterator.zip((1 to 9).iterator.map(users.take(_))).toList
+        val bookmarks = CX.withConnection { implicit c =>
+          expectedUriToUserEdges.flatMap{ case (uri, users) =>
+            users.map{ user =>
+              Bookmark(title = uri.title, url = uri.url,  uriId = uri.id.get, userId = user.id.get, source = source).save
             }
           }
-
-          val store = {
-            uris.zipWithIndex.foldLeft(new FakeArticleStore){ case (store, (uri, idx)) =>
-              store += (uri.id.get -> mkArticle(uri.id.get, "title%d".format(idx), "content%d alldocs".format(idx)))
-              store
-            }
-          }
-          
-          val graphDir = new RAMDirectory
-          val graph = URIGraph(graphDir)
-          val indexDir = new RAMDirectory
-          val indexer = ArticleIndexer(indexDir, store)
-          
-          graph.load() === users.size
-          indexer.run() === uris.size
-          
-          val config = SearchConfig.getDefaultConfig
-          
-          val numHitsToReturn = 7
-          users.foreach{ user =>
-            val userId = user.id.get
-            //println("user:" + userId)
-            users.sliding(3).foreach{ friends =>
-              val friendIds = friends.map(_.id.get).toSet - userId
-
-              val mainSearcher= new MainSearcher(userId, friendIds, Set.empty[Long], indexer, graph, config)
-              val graphSearcher = mainSearcher.uriGraphSearcher
-              val res = mainSearcher.search("alldocs", numHitsToReturn, None)
-              
-              val myUriIds = graphSearcher.getUserToUriEdgeSet(userId).destIdSet
-              val friendsUriIds = friends.foldLeft(Set.empty[Id[NormalizedURI]]){ (s, f) => 
-                s ++ graphSearcher.getUserToUriEdgeSet(f.id.get).destIdSet
-              } -- myUriIds
-              val othersUriIds = (uris.map(_.id.get).toSet) -- friendsUriIds -- myUriIds
-
-              
-              var mCnt = 0
-              var fCnt = 0
-              var oCnt = 0
-              res.hits.foreach{ h => 
-                if (h.isMyBookmark) mCnt += 1
-                else if (! h.users.isEmpty) fCnt += 1
-                else {
-                  oCnt += 1
-                  h.bookmarkCount === graphSearcher.getUriToUserEdgeSet(h.uriId).size
-                }
-              }
-              //println(hits)
-              //println(List(mCnt, fCnt, oCnt)+ " <-- " + List(myUriIds.size, friendsUriIds.size, othersUriIds.size))
-              (mCnt >= min(myUriIds.size, config.asInt("minMyBookmarks"))) === true
-              fCnt === min(friendsUriIds.size, numHitsToReturn - mCnt)
-              oCnt === (res.hits.size - mCnt - fCnt)
-            }
-          }
-          indexer.numDocs === uris.size
         }
-      }
-      
-      "paginate" in {
-        running(new EmptyApplication()) {
-          val (users, uris) = CX.withConnection { implicit c =>
-            ((0 to 9).map(n => User(firstName = "foo" + n, lastName = "").save).toList,
-             (0 to 9).map(n => NormalizedURI(title = "a" + n, url = "http://www.keepit.com/article" + n, state=SCRAPED).save).toList)
-          }
-          val expectedUriToUserEdges = uris.toIterator.zip((1 to 9).iterator.map(users.take(_))).toList
-          val bookmarks = CX.withConnection { implicit c =>
-            expectedUriToUserEdges.flatMap{ case (uri, users) =>
-              users.map{ user =>
-                Bookmark(title = uri.title, url = uri.url,  uriId = uri.id.get, userId = user.id.get, source = BookmarkSource("test")).save
-              }
-            }
-          }
 
-          val store = {
-            uris.zipWithIndex.foldLeft(new FakeArticleStore){ case (store, (uri, idx)) =>
-              store += (uri.id.get -> mkArticle(uri.id.get, "title%d".format(idx), "content%d alldocs".format(idx)))
-              store
-            }
-          }
-          
-          val graphDir = new RAMDirectory
-          val graph = URIGraph(graphDir)
-          val indexDir = new RAMDirectory
-          val indexer = ArticleIndexer(indexDir, store)
-          
-          graph.load() === users.size
-          indexer.run() === uris.size
-          
-          val config = SearchConfig.getDefaultConfig
-          
-          
-          val numHitsToReturn = 3
-          val userId = Id[User](8)
-          
-          val friendIds = Set(Id[User](6))
-          var uriSeen = Set.empty[Long]
-
-          val mainSearcher= new MainSearcher(userId, friendIds, uriSeen, indexer, graph, config)
-          val graphSearcher = mainSearcher.uriGraphSearcher
-          val reachableUris = users.foldLeft(Set.empty[Long])((s, u) => s ++ graphSearcher.getUserToUriEdgeSet(u.id.get, publicOnly = true).destIdLongSet)
-          
-          var uuid : Option[ExternalId[ArticleSearchResultRef]] = None
-          while(uriSeen.size < reachableUris.size) {
-            val mainSearcher= new MainSearcher(userId, friendIds, uriSeen, indexer, graph, config)
-            //println("---" + uriSeen + ":" + reachableUris)
-            val res = mainSearcher.search("alldocs", numHitsToReturn, uuid)
-            res.hits.foreach{ h => 
-              //println(h)
-              uriSeen.contains(h.uriId.id) === false
-              uriSeen += h.uriId.id
-            }
-            uuid = Some(res.uuid)
-          }
-          indexer.numDocs === uris.size
-        }
-      }
-      
-      "boost recent bookmarks" in {
-        running(new EmptyApplication()) {
-          val user = CX.withConnection { implicit c =>
-            User(firstName = "foo", lastName = "").save
-          }
+        val store = mkStore(uris)
+        val (graph, indexer) = initIndexes(store)
+        
+        graph.load() === users.size
+        indexer.run() === uris.size
+        
+        val config = SearchConfig(Map("tailCutting" -> "0"))
+        
+        val numHitsToReturn = 7
+        users.foreach{ user =>
           val userId = user.id.get
-          
-          val uris = CX.withConnection { implicit c =>
-             (0 to 20).map(n => NormalizedURI(title = "a" + n, url = "http://www.keepit.com/article" + n, state=SCRAPED).save).toList
-          }
-          
-          val source = BookmarkSource("test")
-          val now = currentDateTime
-          val rand = new Random
-          
-          val bookmarkMap = CX.withConnection { implicit c =>
-            uris.foldLeft(Map.empty[Id[NormalizedURI], Bookmark]){ (m, uri) =>
-              val createdAt = now.minusHours(rand.nextInt(100))
-              val uriId = uri.id.get
-              m + (uriId -> Bookmark(createdAt = createdAt, title = uri.title, url = uri.url,  uriId = uriId, userId = userId, source = source).save)
-            }
-          }
-          
-          val store = {
-            uris.zipWithIndex.foldLeft(new FakeArticleStore){ case (store, (uri, idx)) =>
-              store += (uri.id.get -> mkArticle(uri.id.get, "title%d".format(idx), "content%d alldocs".format(idx)))
-              store
-            }
-          }
-          
-          val graphDir = new RAMDirectory
-          val graph = URIGraph(graphDir)
-          val indexDir = new RAMDirectory
-          val indexer = ArticleIndexer(indexDir, store)
-          
-          graph.load() === 1
-          indexer.run() === uris.size
-          
-          val config = SearchConfig.getDefaultConfig
-          
-          val mainSearcher= new MainSearcher(userId, Set.empty[Id[User]], Set.empty[Long], indexer, graph, config)
-          val res = mainSearcher.search("alldocs", uris.size, None)
+          //println("user:" + userId)
+          users.sliding(3).foreach{ friends =>
+            val friendIds = friends.map(_.id.get).toSet - userId
+
+            val mainSearcher= new MainSearcher(userId, friendIds, Set.empty[Long], indexer, graph, config)
+            val graphSearcher = mainSearcher.uriGraphSearcher
+            val res = mainSearcher.search("alldocs", numHitsToReturn, None)
             
-          var lastTime = Long.MaxValue
+            val myUriIds = graphSearcher.getUserToUriEdgeSet(userId).destIdSet
+            val friendsUriIds = friends.foldLeft(Set.empty[Id[NormalizedURI]]){ (s, f) => 
+              s ++ graphSearcher.getUserToUriEdgeSet(f.id.get).destIdSet
+            } -- myUriIds
+            val othersUriIds = (uris.map(_.id.get).toSet) -- friendsUriIds -- myUriIds
             
-          res.hits.map{ h => bookmarkMap(h.uriId) }.foreach{ b =>
-            b.createdAt.getMillis <= lastTime === true
-            lastTime = b.createdAt.getMillis
+            var mCnt = 0
+            var fCnt = 0
+            var oCnt = 0
+            res.hits.foreach{ h => 
+              if (h.isMyBookmark) mCnt += 1
+              else if (! h.users.isEmpty) fCnt += 1
+              else {
+                oCnt += 1
+                h.bookmarkCount === graphSearcher.getUriToUserEdgeSet(h.uriId).size
+              }
+            }
+            //println(hits)
+            //println(List(mCnt, fCnt, oCnt)+ " <-- " + List(myUriIds.size, friendsUriIds.size, othersUriIds.size))
+            (mCnt >= min(myUriIds.size, config.asInt("minMyBookmarks"))) === true
+            fCnt === min(friendsUriIds.size, numHitsToReturn - mCnt)
+            oCnt === (res.hits.size - mCnt - fCnt)
           }
-          indexer.numDocs === uris.size
         }
+        indexer.numDocs === uris.size
+      }
+    }
+    
+    "paginate" in {
+      running(new EmptyApplication()) {
+        val (users, uris) = initData(numUsers = 9, numUris = 9)
+        val expectedUriToUserEdges = uris.toIterator.zip((1 to 9).iterator.map(users.take(_))).toList
+        val bookmarks = CX.withConnection { implicit c =>
+          expectedUriToUserEdges.flatMap{ case (uri, users) =>
+            users.map{ user =>
+              Bookmark(title = uri.title, url = uri.url,  uriId = uri.id.get, userId = user.id.get, source = source).save
+            }
+          }
+        }
+        
+        val store = mkStore(uris)
+        val (graph, indexer) = initIndexes(store)
+        
+        graph.load() === users.size
+        indexer.run() === uris.size
+        
+        val config = SearchConfig(Map("tailCutting" -> "0"))
+        
+        val numHitsToReturn = 3
+        val userId = Id[User](8)
+        
+        val friendIds = Set(Id[User](6))
+        var uriSeen = Set.empty[Long]
+
+        val mainSearcher= new MainSearcher(userId, friendIds, uriSeen, indexer, graph, config)
+        val graphSearcher = mainSearcher.uriGraphSearcher
+        val reachableUris = users.foldLeft(Set.empty[Long])((s, u) => s ++ graphSearcher.getUserToUriEdgeSet(u.id.get, publicOnly = true).destIdLongSet)
+        
+        var uuid : Option[ExternalId[ArticleSearchResultRef]] = None
+        while(uriSeen.size < reachableUris.size) {
+          val mainSearcher= new MainSearcher(userId, friendIds, uriSeen, indexer, graph, config)
+          //println("---" + uriSeen + ":" + reachableUris)
+          val res = mainSearcher.search("alldocs", numHitsToReturn, uuid)
+          res.hits.foreach{ h => 
+            //println(h)
+            uriSeen.contains(h.uriId.id) === false
+            uriSeen += h.uriId.id
+          }
+          uuid = Some(res.uuid)
+        }
+        indexer.numDocs === uris.size
+      }
+    }
+    
+    "boost recent bookmarks" in {
+      running(new EmptyApplication()) {
+        val (users, uris) = initData(numUsers = 1, numUris = 20)
+        val userId = users.head.id.get
+        val now = currentDateTime
+        val rand = new Random
+        
+        val bookmarkMap = CX.withConnection { implicit c =>
+          uris.foldLeft(Map.empty[Id[NormalizedURI], Bookmark]){ (m, uri) =>
+            val createdAt = now.minusHours(rand.nextInt(100))
+            val uriId = uri.id.get
+            m + (uriId -> Bookmark(createdAt = createdAt, title = uri.title, url = uri.url,  uriId = uriId, userId = userId, source = source).save)
+          }
+        }
+        
+        val store = mkStore(uris)
+        val (graph, indexer) = initIndexes(store)
+        
+        graph.load() === 1
+        indexer.run() === uris.size
+        
+        val config = SearchConfig(Map("tailCutting" -> "0"))
+        
+        val mainSearcher= new MainSearcher(userId, Set.empty[Id[User]], Set.empty[Long], indexer, graph, config)
+        val res = mainSearcher.search("alldocs", uris.size, None)
+        
+        var lastTime = Long.MaxValue
+        
+        res.hits.map{ h => bookmarkMap(h.uriId) }.foreach{ b =>
+          b.createdAt.getMillis <= lastTime === true
+         lastTime = b.createdAt.getMillis
+        }
+        indexer.numDocs === uris.size
+      }
+    }
+    
+    "be able to cut the long tail" in {
+      running(new EmptyApplication()) {
+        val (users, uris) = initData(numUsers = 1, numUris = 10)
+        val userId = users.head.id.get
+        
+        val bookmarks = CX.withConnection { implicit c =>
+          uris.map{ uri => Bookmark(title = uri.title, url = uri.url,  uriId = uri.id.get, userId = userId, source = source).save }
+        }
+        
+        val store = {
+         val sz = uris.size
+          uris.zipWithIndex.foldLeft(new FakeArticleStore){ case (store, (uri, idx)) =>
+            store += (uri.id.get -> mkArticle(uri.id.get, "title%d".format(idx), "alldocs " * idx + "dummy" * (sz - idx)))
+            store
+          }
+        }
+        val (graph, indexer) = initIndexes(store)
+        
+        graph.load() === 1
+        indexer.run() === uris.size
+        
+        var config = SearchConfig(Map("myBookmarkBoost" -> "1", "sharingBoost" -> "0", "recencyBoost" -> "0", "tailCutting" -> "0"))
+        var mainSearcher= new MainSearcher(userId, Set.empty[Id[User]], Set.empty[Long], indexer, graph, config)
+        var res = mainSearcher.search("alldocs", uris.size, None)
+        //println("Scores: " + res.hits.map(_.score))
+        val sz = res.hits.size
+        val maxScore = res.hits.head.score
+        val minScore = res.hits(sz - 1).score
+        val medianScore = res.hits(sz/2).score
+        (minScore < medianScore && medianScore < maxScore) === true // this is a sanity check of test data
+        
+        config = SearchConfig(Map("myBookmarkBoost" -> "1", "sharingBoost" -> "0", "recencyBoost" -> "0", "tailCutting" -> medianScore.toString))
+        mainSearcher= new MainSearcher(userId, Set.empty[Id[User]], Set.empty[Long], indexer, graph, config)
+        res = mainSearcher.search("alldocs", uris.size, None)
+        //println("Scores: " + res.hits.map(_.score))
+        res.hits.map(h => h.score).reduce((s1, s2) => min(s1, s2)) >= medianScore === true
       }
     }
   }


### PR DESCRIPTION
- new config param
  - tailCutting
  - the default is 0.1
-  the threshold of cutting is ( _max-text-score_ \* _tailCutting_ )
- Cutting happens before graph and recency boosting.
