### PR TITLE
new search api and endpoint for pagination support

### DIFF
--- a/shoebox/README
+++ b/shoebox/README
@@ -1,6 +1,9 @@
 What's new
 ============
 
+October 31, 2012
+* new search api and endpoint for pagination support
+
 October 30, 2012
 * Fixing a scraping bug. Caused by our scraping lib that needs a trailing slash at the end of a domain name
 * New slider animations :)

--- a/shoebox/app/com/keepit/search/IdFilterCompressor.scala
+++ b/shoebox/app/com/keepit/search/IdFilterCompressor.scala
@@ -1,0 +1,53 @@
+package com.keepit.search
+
+import org.apache.lucene.store.OutputStreamDataOutput
+import org.apache.lucene.store.InputStreamDataInput
+import java.io.ByteArrayOutputStream
+import java.io.ByteArrayInputStream
+import java.util.Arrays
+import javax.xml.bind.DatatypeConverter._
+
+object IdFilterCompressor {
+  def toByteArray(ids: Set[Long]): Array[Byte] = {
+    val arr = ids.toArray
+    Arrays.sort(arr)
+    val baos = new ByteArrayOutputStream(arr.length * 4)
+    val out = new OutputStreamDataOutput(baos)
+    
+    // version
+    out.writeVInt(1)
+    // size
+    out.writeVInt(arr.length)
+    // TODO: obfuscation method
+    var current = 0L
+    arr.foreach{ id  =>
+      out.writeVLong(id - current)
+      current = id
+    }
+    baos.flush()
+    baos.toByteArray()
+  }
+  
+  def toSet(bytes: Array[Byte]): Set[Long]= {
+    val in = new InputStreamDataInput(new ByteArrayInputStream(bytes))
+    var idSet = Set.empty[Long]
+    
+    val version = in.readVInt()
+    val size = in.readVInt()
+    var current = 0L;
+    var i = 0
+    while (i < size) {
+      val id = current + in.readVLong
+      idSet += id
+      current = id
+      i += 1
+    }
+    idSet
+  }
+  
+  def fromSetToBase64(ids: Set[Long]):String = printBase64Binary(toByteArray(ids))
+  
+  def fromBase64ToSet(base64: String) = {
+    if (base64.length == 0) Set.empty[Long] else toSet(parseBase64Binary(base64))
+  }
+}

--- a/shoebox/app/com/keepit/search/MainSearcher.scala
+++ b/shoebox/app/com/keepit/search/MainSearcher.scala
@@ -138,7 +138,8 @@ class MainSearcher(userId: Id[User], friendIds: Set[Id[User]], filterOut: Set[Lo
     }
     
     val hitList = hits.toList
-    ArticleSearchResult(lastUUID, queryString, hitList.map(_.toArticleHit), myTotal, friendsTotal, mayHaveMore, hitList.map(_.scoring), userId)
+    val newFilter = filterOut ++ hitList.map(_.id)
+    ArticleSearchResult(lastUUID, queryString, hitList.map(_.toArticleHit), myTotal, friendsTotal, mayHaveMore, hitList.map(_.scoring), newFilter, userId)
   }
   
   private def getPublicBookmarkCount(id: Long) = {
@@ -246,6 +247,7 @@ case class ArticleSearchResult(
   friendsTotal: Int,
   mayHaveMoreHits: Boolean,
   scorings: Seq[Scoring],
+  filter: Set[Long],
   userId: Id[User],
   uuid: ExternalId[ArticleSearchResultRef] = ExternalId(),
   time: DateTime = currentDateTime)

--- a/shoebox/app/com/keepit/serializer/ArticleSearchResultSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/ArticleSearchResultSerializer.scala
@@ -22,6 +22,7 @@ class ArticleSearchResultSerializer extends Format[ArticleSearchResult] {
         "friendsTotal" -> JsNumber(res.friendsTotal),
         "mayHaveMoreHits" -> JsBoolean(res.mayHaveMoreHits),
         "scorings" -> JsArray(res.scorings map ScoringSerializer.scoringSerializer.writes),
+        "filter" -> JsArray(res.filter.map(id => JsNumber(id)).toSeq),
         "userId" -> JsNumber(res.userId.id),
         "uuid" -> JsString(res.uuid.id),
         "time" -> JsString(res.time.toStandardTimeString)
@@ -49,7 +50,7 @@ class ArticleSearchResultSerializer extends Format[ArticleSearchResult] {
       (json \ "bookmarkCount").as[Int]      
     )
   }
-      
+  
   def reads(json: JsValue): ArticleSearchResult = ArticleSearchResult(
       last = (json \ "last").asOpt[String] map (j => ExternalId[ArticleSearchResultRef](j)), 
       query = (json \ "query").as[String], 
@@ -58,6 +59,7 @@ class ArticleSearchResultSerializer extends Format[ArticleSearchResult] {
       friendsTotal = (json \ "friendsTotal").as[Int],
       mayHaveMoreHits = (json \ "mayHaveMoreHits").as[Boolean],
       scorings = (json \ "scorings").asInstanceOf[JsArray].value map ScoringSerializer.scoringSerializer.reads,
+      filter = (json \ "filter").asOpt[Seq[Long]].map(_.toSet).getOrElse(Set.empty[Long]),
       userId = Id[User]((json \ "userId").as[Int]),
       uuid = ExternalId[ArticleSearchResultRef]((json \ "uuid").as[String]),
       time = parseStandardTime((json \ "time").as[String])

--- a/shoebox/app/com/keepit/serializer/PersonalSearchResultPacketSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/PersonalSearchResultPacketSerializer.scala
@@ -1,0 +1,28 @@
+package com.keepit.serializer
+
+import com.keepit.common.logging.Logging
+import com.keepit.common.db.ExternalId
+import com.keepit.common.time._
+import com.keepit.controllers._
+import play.api.libs.json._
+
+class PersonalSearchResultPacketSerializer extends Writes[PersonalSearchResultPacket] with Logging {
+  def writes(res: PersonalSearchResultPacket): JsValue =
+    try {
+      JsObject(List(
+        "uuid" -> JsString(res.uuid.toString),
+        "query" -> JsString(res.query),
+        "hits" -> URIPersonalSearchResultSerializer.resSerializer.writes(res.hits),
+        "mayHaveMore" -> JsBoolean(res.mayHaveMoreHits),
+        "context" -> JsString(res.context)
+      ))
+    } catch {
+      case e =>
+        log.error("can't serialize %s".format(res))
+        throw e
+    }
+}
+
+object PersonalSearchResultPacketSerializer {
+  implicit val resSerializer = new PersonalSearchResultPacketSerializer
+}

--- a/shoebox/conf/routes
+++ b/shoebox/conf/routes
@@ -19,6 +19,7 @@ GET     /bookmarks/check            com.keepit.controllers.BookmarksController.c
 GET     /users/keepurl              com.keepit.controllers.UserController.usersKeptUrl(url: String)
 
 GET     /search                     com.keepit.controllers.SearchController.search(term: String, externalId: ExternalId[User])
+GET     /search2                    com.keepit.controllers.SearchController.search2(term: String, externalId: ExternalId[User], lastUUID: Option[String], context: Option[String])
 
 GET     /welcome                    com.keepit.controllers.AuthController.welcome
 GET     /isLoggedIn                 com.keepit.controllers.AuthController.isLoggedIn

--- a/shoebox/test/com/keepit/search/ArticleSearchResultTest.scala
+++ b/shoebox/test/com/keepit/search/ArticleSearchResultTest.scala
@@ -35,6 +35,7 @@ class ArticleSearchResultTest extends SpecificationWithJUnit {
               friendsTotal = 3232,
               mayHaveMoreHits = true,
               scorings = Seq(new Scoring(.2F, .3F, .4F, .5F)),
+              filter = Set(100L, 200L, 300L),
               userId = Id[User](55),
               uuid = ExternalId[ArticleSearchResultRef]())
          val json = new ArticleSearchResultSerializer().writes(res)
@@ -57,6 +58,7 @@ class ArticleSearchResultTest extends SpecificationWithJUnit {
               friendsTotal = 3232,
               mayHaveMoreHits = true,
               scorings = Seq(new Scoring(.2F, .3F, .4F, .5F)),
+              filter = Set(100L, 200L, 300L),
               userId = user.id.get,
               uuid = ExternalId[ArticleSearchResultRef]())
          val model = CX.withConnection { implicit conn =>

--- a/shoebox/test/com/keepit/search/IdFilterCompressorTest.scala
+++ b/shoebox/test/com/keepit/search/IdFilterCompressorTest.scala
@@ -1,0 +1,46 @@
+package com.keepit.search
+
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner.JUnitRunner
+import play.api.Play.current
+import play.api.libs.json.Json
+import play.api.test._
+import play.api.test.Helpers._
+import scala.math._
+import scala.util.Random
+
+@RunWith(classOf[JUnitRunner])
+class IdFilterCompressorTest extends SpecificationWithJUnit {
+
+  "IdFilterCompressor" should {
+    "comrpess/decompress id set" in {
+      val rand = new Random
+      val idSet = (0 to 100).foldLeft(Set.empty[Long]){ (s, n) => s + rand.nextInt(1000).toLong }
+      
+      val bytes = IdFilterCompressor.toByteArray(idSet)
+      val decoded = IdFilterCompressor.toSet(bytes)
+      
+      //println(bytes.mkString(","))
+      decoded === idSet
+    }
+    
+    "encode/decode id set" in {
+      val rand = new Random
+      val idSet = (0 to 100).foldLeft(Set.empty[Long]){ (s, n) => s + rand.nextInt(1000).toLong }
+      
+      val base64 = IdFilterCompressor.fromSetToBase64(idSet)
+      val decoded = IdFilterCompressor.fromBase64ToSet(base64)
+      
+      //println(base64)
+      decoded === idSet
+    }
+    
+    "handle the empty string" in {
+      val decoded = IdFilterCompressor.fromBase64ToSet("")
+      
+      decoded === Set.empty[Long]
+    }
+    
+  }
+}


### PR DESCRIPTION
new endpoint is /search2

NOTE: It binds lastUUID as Option[String]. I don't know why but play didn't like Option[ExternalId[ArticleSearchResultRef]].
