### PR TITLE
fixed arrayindexoutofbound in private bookmark title search

### DIFF
--- a/shoebox/app/com/keepit/search/graph/URIGraphSearcher.scala
+++ b/shoebox/app/com/keepit/search/graph/URIGraphSearcher.scala
@@ -121,7 +121,7 @@ class URIGraphSearcher(searcher: Searcher) {
             val id = publicList(line)
             result += (id -> plan.score)
           } else if (line < publicList.length + privateList.length) {
-            val id = privateList(line + publicList.length)
+            val id = privateList(line - publicList.length)
             result += (id -> plan.score)
           }
           line = plan.fetchLine(0)


### PR DESCRIPTION
This is pretty bad. Bookmark Title Search fails when you have a hit in bookmark kept private. As a result no search result is shown.
