### PR TITLE
force Tika to use HttpParser when HTTP header says it is html

### DIFF
--- a/shoebox/app/com/keepit/scraper/HttpFetcher.scala
+++ b/shoebox/app/com/keepit/scraper/HttpFetcher.scala
@@ -59,7 +59,7 @@ class HttpFetcher extends Logging {
 //    }
 //  })
 
-  def fetch(url: String)(f: InputStream => Unit): HttpFetchStatus = {
+  def fetch(url: String)(f: HttpInputStream => Unit): HttpFetchStatus = {
     val httpget = new HttpGet(url)
     log.info("executing request " + httpget.getURI())
     
@@ -70,7 +70,14 @@ class HttpFetcher extends Logging {
     
     // If the response does not enclose an entity, there is no need to bother about connection release
     if (entity != null) {
-      val input = entity.getContent
+      
+      
+      val input = new HttpInputStream(entity.getContent)
+      
+      Option(response.getHeaders("Content-Type")).foreach{ headers =>
+        if (headers.length > 0) input.setContentType(headers(headers.length - 1).getValue())
+      }
+      
       try {
         val statusCode = response.getStatusLine.getStatusCode
         statusCode match {

--- a/shoebox/app/com/keepit/scraper/HttpInputStream.scala
+++ b/shoebox/app/com/keepit/scraper/HttpInputStream.scala
@@ -1,0 +1,14 @@
+package com.keepit.scraper
+
+import java.io.FilterInputStream
+import java.io.InputStream
+
+class HttpInputStream(input: InputStream) extends FilterInputStream(input) {
+  
+  var httpContentType: Option[String] = None
+ 
+  def setContentType(contentType: String) {
+    httpContentType = Some(contentType)
+  }
+  def getContentType() = httpContentType
+}

--- a/shoebox/app/com/keepit/scraper/extractor/Extractor.scala
+++ b/shoebox/app/com/keepit/scraper/extractor/Extractor.scala
@@ -1,7 +1,7 @@
 package com.keepit.scraper.extractor
 
 import com.keepit.common.net.URI
-import java.io.InputStream
+import com.keepit.scraper.HttpInputStream
 
 object Extractor {
   val factories = Seq(
@@ -10,7 +10,7 @@ object Extractor {
   )
 }
 trait Extractor {
-  def process(input: InputStream): Unit
+  def process(input: HttpInputStream): Unit
   def getContent(): String
   def getMetadata(name: String): Option[String]
 }


### PR DESCRIPTION
Some site has illegal htmls. Tika thinks they are XML and bombs out.
As a workaround, I changed Scraper to use HtmlParser when HTTP header information says the content type is text/html. If the header says text/html, and the content is not really HTML we will have a problem...
