### PR TITLE
fixed looping in bookmark title query execution. added proximity query

### DIFF
--- a/shoebox/app/com/keepit/search/line/LineQuery.scala
+++ b/shoebox/app/com/keepit/search/line/LineQuery.scala
@@ -21,9 +21,12 @@ object LineQuery  {
   val NO_MORE_DOCS = DocIdSetIterator.NO_MORE_DOCS
   
   val emptyQueryNode = new LineQuery(0) {
-    override def fetch(targetDoc: Int) = NO_MORE_DOCS
-    override def fetchDoc(targetDoc: Int) = NO_MORE_DOCS
-    override def fetchLine(targetDoc: Int) = NO_MORE_LINES
+    curDoc = NO_MORE_DOCS
+    curLine = NO_MORE_LINES
+    
+    override def fetch(targetDoc: Int) = curDoc
+    override def fetchDoc(targetDoc: Int) = curDoc
+    override def fetchLine(targetDoc: Int) = curLine
     override def score = 0.0f
   }
 }

--- a/shoebox/app/com/keepit/search/query/ProximityQuery.scala
+++ b/shoebox/app/com/keepit/search/query/ProximityQuery.scala
@@ -1,0 +1,243 @@
+package com.keepit.search.query
+
+import org.apache.lucene.index.IndexReader
+import org.apache.lucene.index.Term
+import org.apache.lucene.index.TermPositions
+import org.apache.lucene.search.Query
+import org.apache.lucene.search.Scorer
+import org.apache.lucene.search.Weight
+import org.apache.lucene.search.Searcher
+import org.apache.lucene.search.ComplexExplanation
+import org.apache.lucene.search.Explanation
+import org.apache.lucene.search.Similarity
+import org.apache.lucene.search.DocIdSetIterator
+import org.apache.lucene.util.PriorityQueue
+import org.apache.lucene.util.ToStringUtils
+import scala.collection.JavaConversions._
+import scala.math._
+
+object ProximityQuery {
+  def apply(fieldName: String, query: Query): ProximityQuery = {
+    val terms: Set[Term] = {
+      val termSet: java.util.Set[Term] = new java.util.HashSet[Term]
+      query.extractTerms(termSet)
+      termSet.toSet.filter{ _.field() == fieldName }
+    }
+    
+    apply(terms)
+  }
+  
+  def apply(terms: Set[Term]): ProximityQuery = new ProximityQuery(terms)
+  
+  val scoreFactorHalfDecay = 5
+  val scoreFactorTable = {
+    val arr = new Array[Float](2000)
+    for (i <- 1 until arr.length) {
+      arr(i) = 1.0f/(1.0f + (i.toFloat/scoreFactorHalfDecay))
+    }
+    arr
+  }
+  def scoreFactor(distance: Int) = {
+    if (distance < scoreFactorTable.length) scoreFactorTable(distance) else 0.0f
+  }
+}
+
+class ProximityQuery(val terms: Set[Term]) extends Query {
+    
+  override def createWeight(searcher: Searcher): Weight = new ProximityWeight(this, searcher.getSimilarity)
+  
+  override def rewrite(reader: IndexReader): Query = this
+  
+  override def extractTerms(out: java.util.Set[Term]): Unit = out.addAll(terms)
+
+  override def toString(s: String) = {
+    val buffer = new StringBuilder()
+    buffer.append("proximity(")
+    buffer.append(terms.mkString(","))
+    buffer.append(")")
+    buffer.append(ToStringUtils.boost(getBoost()));
+    buffer.toString
+  }
+
+  override def equals(obj: Any): Boolean = obj match {
+    case prox: ProximityQuery => (terms == prox.terms && getBoost() == prox.getBoost())
+    case _ => false
+  }
+
+  override def hashCode(): Int = terms.hashCode() + java.lang.Float.floatToRawIntBits(getBoost())
+}
+
+class ProximityWeight(query: ProximityQuery, similarity: Similarity) extends Weight {
+  var value = 0.0f
+  
+  override def getValue() = value
+  override def scoresDocsOutOfOrder() = false
+  
+  override def sumOfSquaredWeights() = {
+    value = query.getBoost()
+    value * value
+  }
+  
+  override def normalize(norm: Float) { value *= norm }
+  
+  override def explain(reader: IndexReader, doc: Int) = {
+    val sc = scorer(reader, true, false);
+    val exists = (sc != null && sc.advance(doc) == doc);
+    
+    val result = new ComplexExplanation()
+    if (exists) {
+      result.setDescription("proximity(%), product of:".format(query.terms.mkString(",")))
+      val proxScore = sc.score
+      val boost = query.getBoost
+      result.setValue(proxScore * boost)
+      result.setMatch(true)
+      result.addDetail(new Explanation(proxScore, "proximity score"))
+      result.addDetail(new Explanation(boost, "boost"))
+    } else {
+      result.setDescription("proximity(%), doesn't match id %d".format(query.terms.mkString(","), doc))
+      result.setValue(0)
+      result.setMatch(false)
+    }
+    result
+  }
+  
+  def getQuery() = query
+
+  override def scorer(reader: IndexReader, scoreDocsInOrder: Boolean, topScorer: Boolean): Scorer = {
+    if (query.terms.size > 1) {
+      val tps = query.terms.map{
+        term => new PositionAndWeight(reader.termPositions(term), similarity.idf(reader.docFreq(term), reader.numDocs))
+      }
+      new ProximityScorer(this, tps)
+    } else {
+      new EmptyProximityScorer(this)
+    }
+  }
+}
+
+class PositionAndWeight(val tp: TermPositions, val weight: Float) {
+  var doc = -1
+  var pos = -1
+  var posLeft = 0
+  
+  def fetchDoc(target: Int): Int = {
+    pos = -1
+    if (tp.skipTo(target)) {
+      doc = tp.doc()
+      posLeft = tp.freq()
+    } else {
+      doc = DocIdSetIterator.NO_MORE_DOCS
+    }
+    doc
+  }
+  
+  def nextDoc(): Int = {
+    pos = -1
+    if (tp.next()) {
+      doc = tp.doc()
+      posLeft = tp.freq()
+    } else {
+      doc = DocIdSetIterator.NO_MORE_DOCS
+      posLeft = 0
+    }
+    doc
+  }
+  
+  def nextPos(): Int = {
+    if (posLeft > 0) {
+      pos = tp.nextPosition()
+      posLeft -= 1
+    }
+    else {
+      pos = Int.MaxValue
+    }
+    pos
+  }
+}
+
+class ProximityScorer(weight: ProximityWeight, tps: Set[PositionAndWeight]) extends Scorer(weight) {
+  var proximityScore = 0.0f
+  
+  val pq = new PriorityQueue[PositionAndWeight] {
+    super.initialize(tps.size)
+    
+    override def lessThan(nodeA: PositionAndWeight, nodeB: PositionAndWeight) = {
+      if (nodeA.doc == nodeB.doc) {
+        if (nodeA.pos == nodeB.pos) {
+          nodeA.weight > nodeB.weight
+        } else {
+          nodeA.pos < nodeB.pos
+        }
+      }
+      else {
+        nodeA.doc < nodeB.doc
+      }
+    }
+  }
+  tps.foreach{ tp => pq.insertWithOverflow(tp)}
+  
+  override def score(): Float = {
+    var sum = 0.0f
+    var top = pq.top
+    val doc = top.doc
+    if (top.pos < Int.MaxValue) {
+      // start fetching position for all terms
+      while (top.doc == doc && top.pos == -1) {
+        top.nextPos()
+        top = pq.updateTop()
+      }
+      
+      var prev = top
+      var prevPos = top.pos
+      var prevWeight = top.weight
+      while (top.doc == doc && top.pos < Int.MaxValue) {
+        top.nextPos()
+        top = pq.updateTop()
+        if (prev eq top) {
+          prev = top
+          prevPos = top.pos
+          prevWeight = top.weight
+        } else {
+          if (prevPos < top.pos) {
+            sum += (prevWeight + top.weight) * ProximityQuery.scoreFactor(top.pos - prevPos)
+            prevPos = top.pos
+            prevWeight = top.weight
+          }
+        }
+      }
+    }
+    proximityScore = sqrt(sum.toDouble).toFloat
+    proximityScore
+  }
+  
+  override def docID(): Int = pq.top.doc
+  
+  override def nextDoc(): Int = {
+    proximityScore = 0.0f
+    var top = pq.top
+    val doc = if (top.doc < DocIdSetIterator.NO_MORE_DOCS) top.doc + 1 else DocIdSetIterator.NO_MORE_DOCS
+    while (top.doc < doc) {
+      top.nextDoc()
+      top = pq.updateTop()
+    }
+    top.doc
+  }
+  
+  override def advance(target: Int): Int = {
+    proximityScore = 0.0f
+    var top = pq.top
+    val doc = if (target <= top.doc && top.doc < DocIdSetIterator.NO_MORE_DOCS) top.doc + 1 else target
+    while (top.doc < doc) {
+      top.fetchDoc(target)
+      top = pq.updateTop()
+    }
+    top.doc
+  }
+}
+
+class EmptyProximityScorer(weight: ProximityWeight) extends Scorer(weight) {
+  override def score() = 0.0f
+  override def docID() = DocIdSetIterator.NO_MORE_DOCS
+  override def nextDoc()= DocIdSetIterator.NO_MORE_DOCS
+  override def advance(target: Int) = DocIdSetIterator.NO_MORE_DOCS
+}

--- a/shoebox/test/com/keepit/search/line/LineQueryTest.scala
+++ b/shoebox/test/com/keepit/search/line/LineQueryTest.scala
@@ -24,6 +24,7 @@ import org.apache.lucene.search.TermQuery
 import org.apache.lucene.store.RAMDirectory
 import org.apache.lucene.util.Version
 import com.keepit.search.index.DefaultAnalyzer
+import org.apache.lucene.search.WildcardQuery
 
 @RunWith(classOf[JUnitRunner])
 class LineQueryTest extends SpecificationWithJUnit {
@@ -142,7 +143,15 @@ class LineQueryTest extends SpecificationWithJUnit {
       plan.fetchLine(0) === 2
       plan.fetchDoc(0) === LineQuery.NO_MORE_DOCS
     }
-
+    
+    "ignore wildcard query" in {
+      val q = new BooleanQuery
+      q.add(new TermQuery(new Term("B", "d2")), BooleanClause.Occur.SHOULD)
+      q.add(new WildcardQuery(new Term("B", "wild*")), BooleanClause.Occur.SHOULD)
+      val plan = builder.build(q)
+      plan.fetchDoc(2) === 2
+    }
+    
     "find lines with boolean query" in {
       var q = new BooleanQuery
       q.add(new TermQuery(new Term("B", "l1")), BooleanClause.Occur.MUST)

--- a/shoebox/test/com/keepit/search/query/ProximityQueryTest.scala
+++ b/shoebox/test/com/keepit/search/query/ProximityQueryTest.scala
@@ -1,0 +1,110 @@
+package com.keepit.search.query
+
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner.JUnitRunner
+import play.api.Play.current
+import play.api.libs.json.Json
+import play.api.test._
+import play.api.test.Helpers._
+import scala.math._
+import scala.collection.mutable.ArrayBuffer
+import org.apache.lucene.document.Document
+import org.apache.lucene.index.IndexWriterConfig
+import org.apache.lucene.index.IndexWriter
+import org.apache.lucene.index.IndexReader
+import org.apache.lucene.index.Term
+import org.apache.lucene.index.TermEnum
+import org.apache.lucene.search.BooleanQuery
+import org.apache.lucene.search.BooleanClause
+import org.apache.lucene.search.DefaultSimilarity
+import org.apache.lucene.search.PhraseQuery
+import org.apache.lucene.search.Query
+import org.apache.lucene.search.TermQuery
+import org.apache.lucene.search.IndexSearcher
+import org.apache.lucene.store.RAMDirectory
+import org.apache.lucene.util.Version
+import com.keepit.search.index.DefaultAnalyzer
+import org.apache.lucene.document.Field
+import org.apache.lucene.search.DocIdSetIterator
+
+@RunWith(classOf[JUnitRunner])
+class ProximityQueryTest extends SpecificationWithJUnit {
+
+  val analyzer = new DefaultAnalyzer
+  val config = new IndexWriterConfig(Version.LUCENE_36, analyzer)
+
+  val ramDir = new RAMDirectory
+  implicit val indexReader = {
+    val writer = new IndexWriter(ramDir, config)
+    (0 until 10).foreach{ d =>
+      val text = ("abc %s def %s ghi".format("xyz "*d, "xyz "*(5 - d)))
+      val doc = new Document()
+      doc.add(new Field("B", text, Field.Store.NO, Field.Index.ANALYZED, Field.TermVector.NO))
+      writer.addDocument(doc)
+    }
+    writer.commit()
+    writer.close()
+    
+    IndexReader.open(ramDir)
+  }
+  
+  val searcher = new IndexSearcher(indexReader)
+  
+  "ProximityQuery" should {
+    
+    "score using proximity" in {
+      var q = ProximityQuery(Set(new Term("B", "abc"), new Term("B", "def")))
+      var rewrittenQuery = searcher.rewrite(q)
+      var weight = searcher.createNormalizedWeight(rewrittenQuery)
+      (weight != null) === true
+      
+      var scorer = weight.scorer(indexReader, true, true)
+      val buf = new ArrayBuffer[(Int, Float)]()
+      var doc = scorer.nextDoc()
+      while (doc < DocIdSetIterator.NO_MORE_DOCS) {
+        buf += ((doc, scorer.score()))
+        println(buf)
+        doc = scorer.nextDoc()
+      }
+      indexReader.numDocs() === 10
+      buf.size === 10
+      buf.sortBy(_._2).map(_._1) === Seq(9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+
+      q = ProximityQuery(Set(new Term("B", "def"), new Term("B", "ghi")))
+      rewrittenQuery = searcher.rewrite(q)
+      weight = searcher.createNormalizedWeight(rewrittenQuery)
+      
+      (weight != null) === true
+      
+      scorer = weight.scorer(indexReader, true, true)
+      buf.clear
+      doc = scorer.nextDoc()
+      while (doc < DocIdSetIterator.NO_MORE_DOCS) {
+        buf += ((doc, scorer.score()))
+        println(buf)
+        doc = scorer.nextDoc()
+      }
+      buf.size === 10
+      buf.sortBy(_._2).map(_._1) === Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    }
+    
+    "not return hits when the number of terms is 1 or less" in {
+      var q = ProximityQuery(Set(new Term("B", "abc")))
+      var rewrittenQuery = searcher.rewrite(q)
+      var weight = searcher.createNormalizedWeight(rewrittenQuery)
+      (weight != null) === true
+      
+      var scorer = weight.scorer(indexReader, true, true)
+      scorer.nextDoc() === DocIdSetIterator.NO_MORE_DOCS
+
+      q = ProximityQuery(Set.empty[Term])
+      rewrittenQuery = searcher.rewrite(q)
+      weight = searcher.createNormalizedWeight(rewrittenQuery)
+      (weight != null) === true
+      
+      scorer = weight.scorer(indexReader, true, true)
+      scorer.nextDoc() === DocIdSetIterator.NO_MORE_DOCS
+    }
+  }
+}


### PR DESCRIPTION
- fixed 100% load issue (hopefully)
  - there is no direct evidence, but it is most likely that the bug in LineQuery.emptyQueryNode is the cause.
  - emptyQueryNode is used when translation from a Lucene query is failed. From the log, there was a query that causes translation failure around the time the problem started.
- my first proximity query implementation
  - NOT enabled yet.
  - I will integrate it tomorrow
