### PR TITLE
not using @deprecated to avoid compiler warnings (nothing can be done to...

### DIFF
--- a/shoebox/app/com/keepit/controllers/CommentController.scala
+++ b/shoebox/app/com/keepit/controllers/CommentController.scala
@@ -87,7 +87,7 @@ object CommentController extends FortyTwoController {
     Ok(ThreadInfoSerializer.writes(comments))
   }
 
-  @deprecated("comments will soon not have replies", "2012-11-27")
+  // TODO: delete once no beta users have old plugin supporting replies
   def getReplies(commentId: ExternalId[Comment]) = AuthenticatedJsonAction { request =>
     val replies = CX.withConnection { implicit conn =>
       val comment = Comment.get(commentId)

--- a/shoebox/app/com/keepit/controllers/UserController.scala
+++ b/shoebox/app/com/keepit/controllers/UserController.scala
@@ -69,7 +69,7 @@ object UserController extends FortyTwoController {
         "numMessages" -> JsNumber(numMessages))))
   }
 
-  @deprecated("replaced by getSliderInfo, still here for backwards compatibility", "2012-11-26")
+  // TODO: delete once no beta users have old plugin using this (replaced by getSliderInfo)
   def usersKeptUrl(url: String) = AuthenticatedJsonAction { request =>
     val socialUsers = CX.withConnection { implicit c =>
       NormalizedURI.getByNormalizedUrl(url) match {


### PR DESCRIPTION
... fix callers right now)
