### PR TITLE
Live extension fix

### DIFF
--- a/chrome/keep.js
+++ b/chrome/keep.js
@@ -710,15 +710,48 @@ function hasKeepitIdAndFacebookId() {
 
 // Check if the version has changed.
 var currVersion = getVersion();
-var prevVersion = getConfigs().version || "";
+var prevVersion = getConfigs().version;
 if (currVersion != prevVersion) { // Check if we just installed this extension.
-  if (typeof prevVersion == 'undefined') { //install
-    onInstall();      
+  if (typeof prevVersion == 'undefined' || prevVersion == '') { //install
+    onInstall();
   } else { //update 
-    onUpdate()
+    onUpdate();
   }
   setConfigs('version', currVersion);
 }
+
+function generateBrowserInstanceId() {
+  var S4 = function () {
+      return Math.floor(Math.random() * 0x10000).toString(16);
+  };
+  return ( S4()+S4() + "-" + S4() + "-" + S4() + "-" + S4() + "-" + S4()+S4()+S4() );
+}
+
+function getBrowserInstanceId() {
+  var browserInstanceId = getConfigs().browserInstanceId;
+  if(typeof browserInstanceId == 'undefined' || browserInstanceId == '') {
+    browserInstanceId = generateBrowserInstanceId();
+    setConfigs('browserInstanceId', browserInstanceId);
+  }
+  return browserInstanceId;
+}
+
+
+var userAgent = navigator.userAgent || navigator.appVersion || navigator.vendor;
+var platform = navigator.platform;
+var language = navigator.language;
+
+
+$.get("http://" + getConfigs().server + "/bookmarks/check?externalId=" + userConfig.user["keepit_external_id"] + "&uri=" + encodeURIComponent(location), null,
+  function(data) {
+    callback(data["user_has_bookmark"]) 
+  },
+  "json"
+).error(function(error) {
+  log(error.responseText);
+  callback(false);
+});
+
 var popup = null;
 
 function openFacebookConnect() {

--- a/chrome/keep.js
+++ b/chrome/keep.js
@@ -93,7 +93,7 @@ setTimeout(function() {
 }, 4000);
 
 function error(exception, message) {
-  debugger;
+  //debugger;
   var errMessage = exception.message;
   if(message) {
     errMessage = "[" + message + "] " + exception.message;
@@ -103,7 +103,7 @@ function error(exception, message) {
   }
   console.error(errMessage);
   console.error(exception.stack);
-  alert("exception: " + exception.message);
+  //alert("exception: " + exception.message);
 }
 
 log("background page kicking in!");
@@ -639,9 +639,13 @@ function getConfigs() {
     //debugger;
     var userInfo = localStorage[getFullyQualifiedKey("user")];
     var userInfoString;
-    if (userInfo) {
-      userInfoString = JSON.parse(userInfo);
+
+    try {
+      if (userInfo && userInfo != 'undefined') {
+        userInfoString = JSON.parse(userInfo);
+      }
     }
+    catch(e) {} // if we can't parse the JSON, just let is stay undefined.
     var config = {
       "env": env, 
       "hover_timeout": hoverTimeout, 
@@ -655,6 +659,8 @@ function getConfigs() {
     //log(config);
     return config;
   } catch (e) {
+    console.log("User config")
+    console.log(userInfo);
     error(e);
   }
 }
@@ -704,7 +710,7 @@ function hasKeepitIdAndFacebookId() {
 
 // Check if the version has changed.
 var currVersion = getVersion();
-var prevVersion = getConfigs().version;
+var prevVersion = getConfigs().version || "";
 if (currVersion != prevVersion) { // Check if we just installed this extension.
   if (typeof prevVersion == 'undefined') { //install
     onInstall();      
@@ -716,7 +722,6 @@ if (currVersion != prevVersion) { // Check if we just installed this extension.
 var popup = null;
 
 function openFacebookConnect() {
-
   chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     if(changeInfo.status == "loading") {
       if (tabId === popup && tab.url === "http://" + getConfigs().server + "/#_=_") {

--- a/chrome/keep.js
+++ b/chrome/keep.js
@@ -742,15 +742,6 @@ var platform = navigator.platform;
 var language = navigator.language;
 
 
-$.get("http://" + getConfigs().server + "/bookmarks/check?externalId=" + userConfig.user["keepit_external_id"] + "&uri=" + encodeURIComponent(location), null,
-  function(data) {
-    callback(data["user_has_bookmark"]) 
-  },
-  "json"
-).error(function(error) {
-  log(error.responseText);
-  callback(false);
-});
 
 var popup = null;
 

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Kifi Beta",
-  "version": "1.9",
+  "version": "2.0",
   "manifest_version": 2,
   "description": "Keep it, Find it!",
   "icons" : {


### PR DESCRIPTION
We were having odd upgrade issues, with the `user' localStorage var being set to "undefined" (yes, the string). Added checks and better failures.

(This has already been pushed live.)
