### PR TITLE
using a precompiled Regex for KifiVersion parsing

### DIFF
--- a/shoebox/app/com/keepit/controllers/SearchController.scala
+++ b/shoebox/app/com/keepit/controllers/SearchController.scala
@@ -61,19 +61,17 @@ object SearchController extends FortyTwoController {
     val searchRes = searcher.search(term, maxHits, lastUUID)
     val realResults = toPersonalSearchResultPacket(userId, searchRes)
 
-    val version = kifiVersion.getOrElse(KifiVersion())
-    val res = version match {
-      case v: KifiVersion if v >= KifiVersion(2,0,2) => realResults
-      case _ =>
-        val upgradeResult = PersonalSearchResult(
-          hit = PersonalSearchHit(id = Id[NormalizedURI](0), externalId = ExternalId[NormalizedURI](), title = Some("★★★ KiFi has updated! Please reload your plugin. ★★★"), url = "http://keepitfindit.com/upgrade"),
-          count = 0,
-          isMyBookmark = false,
-          isPrivate = false,
-          users = Nil,
-          score = 42f
-        )
-        realResults.copy(hits = Seq(upgradeResult) ++ realResults.hits)
+    val res = if (kifiVersion.getOrElse(KifiVersion(0,0,0)) >= KifiVersion(2,0,2)) {
+      realResults
+    } else {
+      val upgradeResult = PersonalSearchResult(
+        hit = PersonalSearchHit(id = Id[NormalizedURI](0), externalId = ExternalId[NormalizedURI](), title = Some("★★★ KiFi has updated! Please reload your plugin. ★★★"), url = "http://keepitfindit.com/upgrade"),
+        count = 0,
+        isMyBookmark = false,
+        isPrivate = false,
+        users = Nil,
+        score = 42f)
+      realResults.copy(hits = Seq(upgradeResult) ++ realResults.hits)
     }
 
     reportArticleSearchResult(searchRes)

--- a/shoebox/app/com/keepit/model/KifiInstallation.scala
+++ b/shoebox/app/com/keepit/model/KifiInstallation.scala
@@ -44,12 +44,12 @@ case class KifiVersion(major: Int, minor: Int, patch: Int, tag: String = "") ext
   }
 }
 object KifiVersion extends Logging {
-  private val R = """(\d{1,3})\.(\d{1,3})(?:\.(\d{1,3}))?(?:-([a-zA-Z0-9-])+)?""".r
+  private val R = """(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?:-([a-zA-Z0-9-])+)?""".r
 
   def apply(version: String): KifiVersion = {
     version match {
       case R(major, minor, patch, tag) =>
-        KifiVersion(major.toInt, minor.toInt, Option(patch).map(_.toInt).getOrElse(0), Option(tag).getOrElse(""))
+        KifiVersion(major.toInt, minor.toInt, patch.toInt, Option(tag).getOrElse(""))
       case _ =>
         throw new Exception("Invalid kifi version: " + version)
     }

--- a/shoebox/app/com/keepit/model/KifiInstallation.scala
+++ b/shoebox/app/com/keepit/model/KifiInstallation.scala
@@ -33,7 +33,7 @@ object UserAgent extends Logging {
     }
 }
 
-case class KifiVersion(major: Int, minor: Int, patch: Int = 0, tag: String = "") extends Ordered[KifiVersion]  {
+case class KifiVersion(major: Int, minor: Int, patch: Int, tag: String = "") extends Ordered[KifiVersion]  {
   assert(major >= 0 && minor >= 0 && patch >= 0)
   def compare(that: KifiVersion) =
     ((this.major - that.major) << 20) +
@@ -44,23 +44,14 @@ case class KifiVersion(major: Int, minor: Int, patch: Int = 0, tag: String = "")
   }
 }
 object KifiVersion extends Logging {
-  def apply(): KifiVersion = {
-    KifiVersion(0,0,0)
-  }
+  private val R = """(\d{1,3})\.(\d{1,3})(?:\.(\d{1,3}))?(?:-([a-zA-Z0-9-])+)?""".r
+
   def apply(version: String): KifiVersion = {
-    try {
-      def safeVersion(v: Array[String], i: Int) = if(v.length <= i) 0 else v(i).toInt
-      assert(version.length > 2)
-      val t = version.split('-')
-      assert(t.length > 0)
-      val v = t(0).split('.')
-      assert(v.length > 1)
-      val tag = if(t.length > 1) t(1) else ""
-      KifiVersion(safeVersion(v,0), safeVersion(v,1), safeVersion(v,2), tag)
-    } catch {
+    version match {
+      case R(major, minor, patch, tag) =>
+        KifiVersion(major.toInt, minor.toInt, Option(patch).map(_.toInt).getOrElse(0), Option(tag).getOrElse(""))
       case _ =>
-        log.warn("Invalid kifi version: %s".format(version))
-        throw new Exception("Invalid kifi version: %s".format(version))
+        throw new Exception("Invalid kifi version: " + version)
     }
   }
 

--- a/shoebox/test/com/keepit/model/KifiInstallationTest.scala
+++ b/shoebox/test/com/keepit/model/KifiInstallationTest.scala
@@ -27,6 +27,9 @@ class KifiInstallationTest extends SpecificationWithJUnit {
       v3 must be_>  (v4)
       v4 must be_>  (v2)
     }
+    "fail to parse an invalid version string" in {
+      KifiVersion("foo") must throwA[Exception]
+    }
     "persist" in {
       running(new EmptyApplication()) {
         val (user, install) = CX.withConnection { implicit conn =>

--- a/shoebox/test/com/keepit/model/KifiInstallationTest.scala
+++ b/shoebox/test/com/keepit/model/KifiInstallationTest.scala
@@ -14,7 +14,7 @@ class KifiInstallationTest extends SpecificationWithJUnit {
 
   "KifiInstallation" should {
     "parse version strings and order correctly" in {
-      val v0 = KifiVersion()
+      val v0 = KifiVersion("0.0")
       val v1 = KifiVersion("2.1.0")
       val v2 = KifiVersion("2.1")
       val v3 = KifiVersion("3.0.1")

--- a/shoebox/test/com/keepit/model/KifiInstallationTest.scala
+++ b/shoebox/test/com/keepit/model/KifiInstallationTest.scala
@@ -14,9 +14,9 @@ class KifiInstallationTest extends SpecificationWithJUnit {
 
   "KifiInstallation" should {
     "parse version strings and order correctly" in {
-      val v0 = KifiVersion("0.0")
+      val v0 = KifiVersion("0.0.0")
       val v1 = KifiVersion("2.1.0")
-      val v2 = KifiVersion("2.1")
+      val v2 = KifiVersion("2.1.0")
       val v3 = KifiVersion("3.0.1")
       val v4 = KifiVersion("2.4.8")
 


### PR DESCRIPTION
also not defaulting the patch level to 0 (until we change it to Option[Int] to preserve whether it was specified)
