### PR TITLE
tweaked bookmark title search

### DIFF
--- a/shoebox/app/com/keepit/search/SearchConfig.scala
+++ b/shoebox/app/com/keepit/search/SearchConfig.scala
@@ -8,6 +8,7 @@ object SearchConfig {
     Map[String, String](
       "minMyBookmarks" -> "2",
       "myBookmarkBoost" -> "1.5",
+      "personalTitleBoost" -> "1.5",
       "sharingBoostInNetwork" -> "0.5",
       "sharingBoostOutOfNetwork" -> "0.1",
       "percentMatch" -> "75",
@@ -25,6 +26,7 @@ object SearchConfig {
     Map[String, String](
       "minMyBookmarks" -> "the minimum number of my bookmarks in a search result",
       "myBookmarkBoost" -> "importance my bookmark",
+      "personalTitleBoost" -> "boosting the personal bookmark title score when there is no match in the article",
       "sharingBoostInNetwork" -> "importance of the number of friends sharing the bookmark",
       "sharingBoostOutOfNetwork" -> "importance of the number of others sharing the bookmark",
       "percentMatch" -> "the minimum percentage of search terms have to match (weighted by IDF)",

--- a/shoebox/app/com/keepit/search/index/DefaultAnalyzer.scala
+++ b/shoebox/app/com/keepit/search/index/DefaultAnalyzer.scala
@@ -59,6 +59,7 @@ object DefaultAnalyzer {
   import AnalyzerBuilder._
 
   private val stdAnalyzer = analyzer[DefaultAnalyzer]
+  private val defaultAnalyzer = stdAnalyzer.withFilter[LowerCaseFilter] // lower case, no stopwords
 
   val langAnalyzers = Map[String, Analyzer](
     "ar" -> stdAnalyzer.withFilter[LowerCaseFilter].withStopFilter(_.Arabic).withFilter[ArabicNormalizationFilter],
@@ -116,7 +117,7 @@ object DefaultAnalyzer {
     m.erasure.getConstructor(classOf[Version]).newInstance(version).asInstanceOf[Analyzer]
   }
 
-  private def getAnalyzer(lang: Lang): Analyzer = langAnalyzers.getOrElse(lang.lang, stdAnalyzer)
+  private def getAnalyzer(lang: Lang): Analyzer = langAnalyzers.getOrElse(lang.lang, defaultAnalyzer)
   private def getAnalyzerWithStemmer(lang: Lang): Option[Analyzer] = langAnalyzerWithStemmer.get(lang.lang)
 
   def forIndexing: Analyzer = forIndexing(Lang("en"))

--- a/shoebox/app/com/keepit/search/line/LineQuery.scala
+++ b/shoebox/app/com/keepit/search/line/LineQuery.scala
@@ -32,13 +32,16 @@ object LineQuery  {
   }
 }
 
-abstract class LineQuery(val weight: Float) {
+abstract class LineQuery(initialWeight: Float) {
 
   private[line] var curDoc = -1
   private[line] var curLine = -1
   private[line] var curPos = -1
   private[line] var curScore = 0.0f
   private[line] var isScored = false
+
+  protected var internalWeight = initialWeight
+  def weight = internalWeight
 
   def fetch(targetDoc: Int) = {
     var done = false
@@ -90,6 +93,9 @@ abstract class LineQuery(val weight: Float) {
   }
 
   private[line] def fetchPos() = LineQuery.NO_MORE_POSITIONS
+
+  def normalize(norm: Float) { internalWeight *= norm }
+  def sumOfSquaredWeights = { internalWeight * internalWeight }
 }
 
 class NodeQueue(size: Int) extends PriorityQueue[LineQuery] {

--- a/shoebox/app/com/keepit/search/line/PhraseNode.scala
+++ b/shoebox/app/com/keepit/search/line/PhraseNode.scala
@@ -2,7 +2,7 @@ package com.keepit.search.line
 
 import org.apache.lucene.index.IndexReader
 
-class PhraseNode(termNodes: Array[TermNode], positions: Array[Int], weight: Float, reader: IndexReader) extends LineQuery(weight) {
+class PhraseNode(termNodes: Array[TermNode], positions: Array[Int], initialWeight: Float, reader: IndexReader) extends LineQuery(initialWeight) {
 
   override def fetchDoc(targetDoc: Int) = {
     if (curDoc < LineQuery.NO_MORE_DOCS) {

--- a/shoebox/app/com/keepit/search/line/TermNode.scala
+++ b/shoebox/app/com/keepit/search/line/TermNode.scala
@@ -3,7 +3,7 @@ package com.keepit.search.line
 import org.apache.lucene.index.IndexReader
 import org.apache.lucene.index.Term
 
-class TermNode(term: Term, weight: Float, reader: IndexReader) extends LineQuery(weight) {
+class TermNode(term: Term, initialWeight: Float, reader: IndexReader) extends LineQuery(initialWeight) {
   val tp = reader.termPositions(term)
   var posLeft = 0
 


### PR DESCRIPTION
- added lucene's wwight normalized logic to bookmark title search
- added personalTitleBoost search config parameter
  - personal a bookmark score is boosted by this value only when this particular hit has no match in article search. In this case it is very likely that the article does not have content because scraping was failed. As the result the score becomes lower compared to the article with content. This boosting is intended to compensate that situation. 
