### PR TITLE
Uri exception

### DIFF
--- a/shoebox/app/com/keepit/common/net/URI.scala
+++ b/shoebox/app/com/keepit/common/net/URI.scala
@@ -133,7 +133,11 @@ class URI(val raw: Option[String], val scheme: Option[String], val userInfo: Opt
       case (Some("/"), None) => None
       case _ => path
     }
-    var uri = new java.net.URI(scheme.orNull, userInfo.orNull, host.map(_.toString).orNull, port, updatedPath.orNull, null, null).toString
+    var uri = try {
+      new java.net.URI(scheme.orNull, userInfo.orNull, host.map(_.toString).orNull, port, updatedPath.orNull, null, null).toString
+    } catch {
+      case e: Exception => throw new Exception("can't create java.net.URI from this object %s".format(this), e)
+    }
     query.foreach{ query => uri = uri + "?" + query }
     fragment.foreach{ fragment => uri = uri + "#" + fragment }
     uri


### PR DESCRIPTION
shedding some light on exceptions like 

```
from cause: java.net.URISyntaxException: Expected scheme-specific part at index 5: http: 
java.net.URI$Parser.fail(URI.java:2829) 
  java.net.URI$Parser.failExpecting(URI.java:2835) 
  java.net.URI$Parser.parse(URI.java:3038) 
  java.net.URI.(URI.java:680) 
  com.keepit.common.net.URI.toString(URI.scala:136) 
  com.keepit.common.net.URINormalizer$DefaultNormalizer$.apply(URINormalizer.scala:39) 
  com.keepit.common.net.URINormalizer$DefaultNormalizer$.apply(URINormalizer.scala:24) 
  com.keepit.common.net.URINormalizer$$anonfun$normalize$2.apply(URINormalizer.scala:14) 
  com.keepit.common.net.URINormalizer$$anonfun$normalize$2.apply(URINormalizer.scala:13) 
  scala.Option.map(Option.scala:133) 
  com.keepit.common.net.URINormalizer$.normalize(URINormalizer.scala:13) 
  com.keepit.model.NormalizedURI$.normalize(NormalizedURI.scala:82) 
  com.keepit.model.NormalizedURI$.getByNormalizedUrl(NormalizedURI.scala:98) 
  com.keepit.controllers.BookmarksController$$anonfun$checkIfExists$1$$anonfun$11.apply(BookmarksController.scala:124) 
  com.keepit.controllers.BookmarksController$$anonfun$checkIfExists$1$$anonfun$11.apply(BookmarksController.scala:123) 
  com.keepit.common.db.CX$$anonfun$executeBlockWithConnection$1$$anonfun$apply$1.apply(Circumflex.scala:465) 
  ru.circumflex.orm.package$$anonfun$using$1.apply(package.scala:38) 
```
