### PR TITLE
tuning akka's config. may help us avoid these errors in prod:

### DIFF
--- a/shoebox/conf/akka-sync.conf
+++ b/shoebox/conf/akka-sync.conf
@@ -1,0 +1,32 @@
+#See:
+# * http://www.playframework.org/documentation/2.0/AkkaCore
+# * http://www.jamesward.com/2012/06/25/optimizing-play-2-for-database-driven-apps
+play {
+  akka {
+    actor {
+      deployment {
+        /actions {
+          router = round-robin
+          nr-of-instances = 100
+        }
+        /promises {
+          router = round-robin
+          nr-of-instances = 100
+        }
+      }
+      retrieveBodyParserTimeout = 30 seconds
+      actions-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 100
+          parallelism-max = 100
+        }
+      }
+      promises-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 100
+          parallelism-max = 100
+        }
+      }
+    }
+  }
+}

--- a/shoebox/conf/application.conf
+++ b/shoebox/conf/application.conf
@@ -22,6 +22,8 @@ session = {
 # ~~~~~
 akka.default-dispatcher.fork-join-executor.pool-size-max=64
 akka.actor.debug.receive=off
+include "akka-sync.conf"
+
 
 # Database configuration
 # ~~~~~

--- a/shoebox/conf/prod/akka-sync.conf
+++ b/shoebox/conf/prod/akka-sync.conf
@@ -1,0 +1,32 @@
+#See:
+# * http://www.playframework.org/documentation/2.0/AkkaCore
+# * http://www.jamesward.com/2012/06/25/optimizing-play-2-for-database-driven-apps
+play {
+  akka {
+    actor {
+      deployment {
+        /actions {
+          router = round-robin
+          nr-of-instances = 100
+        }
+        /promises {
+          router = round-robin
+          nr-of-instances = 100
+        }
+      }
+      retrieveBodyParserTimeout = 30 seconds
+      actions-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 100
+          parallelism-max = 100
+        }
+      }
+      promises-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 100
+          parallelism-max = 100
+        }
+      }
+    }
+  }
+}

--- a/shoebox/conf/prod/shoebox.conf
+++ b/shoebox/conf/prod/shoebox.conf
@@ -22,6 +22,7 @@ session = {
 # ~~~~~
 akka.default-dispatcher.fork-join-executor.pool-size-max=64
 akka.actor.debug.receive=off
+include "akka-sync.conf"
 
 # Database configuration
 # ~~~~~


### PR DESCRIPTION
[fortytwo@b01 run]$ ack "Cannot invoke the action, eventually got an error" --type=log
shoebox-20121219-1233-master-5f6e5eb/log/app.log
382:20:49:24.297 [play-akka.actor.promises-dispatcher-858] ERROR play - Cannot invoke the action, eventually got an error: Thrown(akka.pattern.AskTimeoutException: Timed out)
384:20:49:25.774 [play-akka.actor.promises-dispatcher-857] ERROR play - Cannot invoke the action, eventually got an error: Thrown(akka.pattern.AskTimeoutException: Timed out)

shoebox-20121213-1031-master-27ebe01/log/app.log
133:19:23:34.744 [play-akka.actor.promises-dispatcher-126] ERROR play - Cannot invoke the action, eventually got an error: Thrown(akka.pattern.AskTimeoutException: Timed out)
139:19:23:45.929 [play-akka.actor.promises-dispatcher-144] ERROR play - Cannot invoke the action, eventually got an error: Thrown(akka.pattern.AskTimeoutException: Timed out)
164:19:23:54.726 [play-akka.actor.promises-dispatcher-153] ERROR play - Cannot invoke the action, eventually got an error: Thrown(akka.pattern.AskTimeoutException: Timed out)
