### PR TITLE
moving to scalaquery and adding guice

### DIFF
--- a/shoebox/app/com/keepit/common/db/Connection.scala
+++ b/shoebox/app/com/keepit/common/db/Connection.scala
@@ -1,0 +1,19 @@
+package com.keepit.common.db
+
+//import scala.slick.session.{Database, Session, ResultSetConcurrency}
+import org.scalaquery.session.{Database, Session, ResultSetConcurrency}
+import com.keepit.common.db.Session._
+
+case class ReadOnlyConnection(database: Database) {
+  def run[T](f: Session => T): T = {
+    val s = database.createSession.forParameters(rsConcurrency = ResultSetConcurrency.ReadOnly)
+    try { f(s) } finally s.close()
+  }
+}
+
+case class ReadWriteConnection(database: Database) {
+  def run[T](f: Session => T): T = {
+    val s = database.createSession.forParameters(rsConcurrency = ResultSetConcurrency.Updatable)
+    try { f(s) } finally s.close()
+  }
+}

--- a/shoebox/app/com/keepit/common/db/Session.scala
+++ b/shoebox/app/com/keepit/common/db/Session.scala
@@ -1,0 +1,15 @@
+package com.keepit.common.db
+
+//import scala.slick.session.Database
+//import scala.slick.session.Session
+import org.scalaquery.session.Database
+import org.scalaquery.session.Session
+import java.sql.PreparedStatement
+
+case class ReadOnlySession(session: Session)
+case class ReadWriteSession(session: Session)
+
+object Session {
+  implicit def readOnlySession2Session(readOnly: ReadOnlySession): Session = readOnly.session
+  implicit def readWriteSession2Session(readWrite: ReadWriteSession): Session = readWrite.session
+}

--- a/shoebox/app/com/keepit/common/db/SlickModule.scala
+++ b/shoebox/app/com/keepit/common/db/SlickModule.scala
@@ -1,0 +1,33 @@
+package com.keepit.common.db
+
+import com.tzavellas.sse.guice.ScalaModule
+import com.google.inject.{Provides, Inject, Singleton}
+import com.keepit.common.time._
+import org.joda.time.DateTime
+import org.joda.time.LocalDate
+import akka.actor.ActorSystem
+import akka.actor.Scheduler
+import org.scalaquery.session.Database
+import org.scalaquery.session.Session
+import org.scalaquery.session.ResultSetConcurrency
+//import scala.slick.session.Database
+//import scala.slick.session.Session
+//import scala.slick.session.ResultSetConcurrency
+
+case class SlickModule() extends ScalaModule {
+  def configure(): Unit = {
+  }
+
+  @Provides
+  @Singleton
+  def database(): Database = Database.forURL("jdbc:h2:mem:shoebox;MODE=MYSQL;MVCC=TRUE", driver = "org.h2.Driver")
+
+  @Provides
+  @Singleton
+  def readOnlyConnection(database: Database): ReadOnlyConnection = ReadOnlyConnection(database)
+
+  @Provides
+  @Singleton
+  def readWriteConnection(database: Database): ReadWriteConnection = ReadWriteConnection(database)
+
+}

--- a/shoebox/app/com/keepit/inject/FortyTwoModule.scala
+++ b/shoebox/app/com/keepit/inject/FortyTwoModule.scala
@@ -8,12 +8,14 @@ import org.joda.time.DateTime
 import org.joda.time.LocalDate
 import akka.actor.ActorSystem
 import akka.actor.Scheduler
+import com.keepit.common.db.SlickModule
 
 case class FortyTwoModule() extends ScalaModule {
   def configure(): Unit = {
     val appScope = new AppScope
     bindScope(classOf[AppScoped], appScope)
     bind[AppScope].toInstance(appScope)
+    install(new SlickModule())
   }
 
   @Provides

--- a/shoebox/project/Build.scala
+++ b/shoebox/project/Build.scala
@@ -87,7 +87,9 @@ object ApplicationBuild extends Build {
       libraryDependencies ++= Seq(
         "com.google.inject" % "guice" % "3.0",
         "org.scalatest" %% "scalatest" % "2.0.M4" % "test",
-        "com.typesafe" % "slick_2.10" % "1.0.0-RC1"
+        //"com.typesafe" % "slick_2.10" % "1.0.0-RC1"
+        "org.scalaquery" % "scalaquery_2.9.1" % "0.10.0-M1"
+            
       )
     )
 }

--- a/shoebox/test/com/keepit/common/db/SlickTest.scala
+++ b/shoebox/test/com/keepit/common/db/SlickTest.scala
@@ -1,0 +1,44 @@
+package com.keepit.common.db
+
+import com.keepit.test._
+import com.keepit.TestAkkaSystem
+import com.keepit.inject._
+import com.keepit.common.db.Session._
+import org.scalaquery.ql._
+import org.scalaquery.ql.TypeMapper._
+import org.scalaquery.ql.extended.H2Driver.Implicit._
+import org.scalaquery.ql.extended.{ExtendedTable => Table}
+import play.api.Play.current
+import play.api.libs.json.JsValue
+import play.api.test.Helpers._
+import akka.actor.ActorRef
+import akka.testkit.ImplicitSender
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.mutable.SpecificationWithJUnit
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class SlickTest extends SpecificationWithJUnit {
+
+  "Slick" should {
+    "run in session" in {
+      running(new ShoeboxApplication().withFakeHealthcheck()) {
+
+        object Test extends Table[(String)]("TEST") {
+          def name = column[String]("NAME", O.PrimaryKey)
+          def * = name
+        }
+
+        inject[ReadWriteConnection].run { implicit session =>
+          Test.ddl.create
+          Test.insertAll(("test 1"), ("test 2"))
+        }
+
+        inject[ReadOnlyConnection].run { implicit session =>
+          Query(Test.count).first === 2
+        }
+      }
+    }
+  }
+}

--- a/shoebox/test/com/keepit/common/mail/SendgridMailProviderTest.scala
+++ b/shoebox/test/com/keepit/common/mail/SendgridMailProviderTest.scala
@@ -15,7 +15,6 @@ import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 import com.keepit.common.db.CX
 
-
 @RunWith(classOf[JUnitRunner])
 class SendgridMailProviderTest extends Specification with TestAkkaSystem {
 

--- a/shoebox/test/com/keepit/test/TestApplication.scala
+++ b/shoebox/test/com/keepit/test/TestApplication.scala
@@ -26,6 +26,7 @@ import org.joda.time.LocalDate
 import com.keepit.common.healthcheck.{Babysitter, BabysitterImpl, BabysitterTimeout, HealthcheckPlugin}
 import akka.actor.{Scheduler, Cancellable, ActorRef}
 import akka.util.Duration
+import com.keepit.common.db.SlickModule
 
 class TestApplication(override val global: TestGlobal) extends play.api.test.FakeApplication() {
   def withFakeMail() = overrideWith(FakeMailModule())
@@ -48,6 +49,7 @@ class EmptyApplication() extends TestApplication(new TestGlobal(TestModule()))
 case class TestModule() extends ScalaModule {
   def configure(): Unit = {
     bind[Babysitter].to[FakeBabysitter]
+    install(new SlickModule())
   }
 
   @Provides @Singleton


### PR DESCRIPTION
- Converting to scalaquery - Slick's ancestor since Slick can run only on scala 2.10
- Creating Slick Guice module and wrappers
