### PR TITLE
very compact and fast reverse lookup data structure for idmapper

### DIFF
--- a/shoebox/app/com/keepit/search/graph/EdgeSet.scala
+++ b/shoebox/app/com/keepit/search/graph/EdgeSet.scala
@@ -38,7 +38,7 @@ class MaterializedEdgeSet[S,D](override val sourceId: Id[S], override val destId
   def getDestDocIdSetIterator(searcher: Searcher): DocIdSetIterator = getDestDocIdSetIterator(searcher.idMapper)
 
   private def getDestDocIdSetIterator(mapper: IdMapper): DocIdSetIterator = {
-    val docids = destIdSet.flatMap{ id => mapper.getDocId(id.id) }.toArray
+    val docids = destIdSet.map{ id => mapper.getDocId(id.id) }.filter{ _ >= 0 }.toArray
     Sorting.quickSort(docids)
     new DocIdSetIterator {
       var curDoc = NO_MORE_DOCS

--- a/shoebox/app/com/keepit/search/index/IdMapper.scala
+++ b/shoebox/app/com/keepit/search/index/IdMapper.scala
@@ -1,11 +1,12 @@
 package com.keepit.search.index
 
 import org.apache.lucene.index.IndexReader
-import scala.collection.immutable.LongMap
+import scala.collection.mutable.ArrayStack
+import java.lang.Long.bitCount
 
 abstract class IdMapper {
   def getId(docid: Int): Long
-  def getDocId(id: Long): Option[Int]
+  def getDocId(id: Long): Int
 }
 
 object ArrayIdMapper {
@@ -51,8 +52,167 @@ object ArrayIdMapper {
 }
 
 class ArrayIdMapper(idArray: Array[Long]) extends IdMapper {
-  lazy val reserveMap: Map[Long, Int] = idArray.zipWithIndex.foldLeft(LongMap.empty[Int]){ (m, t) => m + t }
+  val reserveMapper = ReverseArrayMapper(idArray, 0.9d)
 
   def getId(docid: Int) = idArray(docid) // no range check done for performance
-  def getDocId(id: Long) = reserveMap.get(id)
+  def getDocId(id: Long) = reserveMapper(id)
+}
+
+class ReverseArrayMapper(ids: Array[Long], indexes: Array[Int], sz: Int, ranks: Array[Int], bitmaps: Array[Long], chains: Array[Long]) {
+  def apply(id: Long): Int = {
+    val h = ReverseArrayMapper.hash(id)
+    val bucket = (h % sz).toInt
+    val start = ranks(bucket)
+    val bitmap = bitmaps(bucket)
+    var mask = (1L << ((h / sz) & 0x3F))
+    if ((bitmap & mask) != 0) {
+      var c = bitCount(bitmap & (mask - 1L))
+      var index = indexes(start + c)
+      if (ids(index) == id) {
+        return index
+      } else {
+        val chain = chains(bucket)
+        mask = (1L << c)
+        if ((chain & mask) != 0) {
+          // we have a chain
+          val base = bitCount(bitmap)
+          while (true) {
+            c = base + bitCount(chain & (mask - 1L))
+            index = indexes(start + c)
+            if (ids(index) == id) return index // fount it by traversing the chain. now return.
+            else {
+              if (c < 64) {
+                // traverse the chain
+                mask = (1L << c)
+                if ((chain & mask) == 0) return -1 // end of the chain. not found.
+              } else {
+                // run out of chain bits. resort to the linear search
+                c = (start + c + 1)
+                val end = ranks(bucket + 1)
+                while (c < end) {
+                  index = indexes(c)
+                  if (ids(index) == id) return index // found it by the linear search. now return.
+                  c += 1
+                }
+                return -1 // not found
+              }
+            }
+          }
+          -1
+        } else {
+          -1
+        }
+      }
+    } else {
+      -1
+    }
+  }
+}
+
+object ReverseArrayMapper {
+
+  def apply(ids: Array[Long], loadFactor: Double = 0.5d) = {
+    val sz = (ids.length.toDouble / loadFactor).toInt / 64 + 1
+    val ranks = genRanks(sz, ids)
+    val (indexes, bitmaps, chains) = genBitmaps(ids, sz, ranks)
+    new ReverseArrayMapper(ids, indexes, sz, ranks, bitmaps, chains)
+  }
+
+  private[this] def genRanks(sz: Int, ids: Array[Long]) = {
+    val ranks = new Array[Int](sz + 1)
+    var i = 0
+    while (i < ids.length) {
+      ranks((hash(ids(i)) % sz).toInt) += 1
+      i += 1
+    }
+    i = 0
+    while (i < sz) {
+      ranks(i + 1) += ranks(i)
+      i += 1
+    }
+    ranks
+  }
+
+  private[this] def genBitmaps(ids: Array[Long], sz: Int, ranks: Array[Int]) = {
+    val indexes = distribute(ids, sz, ranks)
+    val bitmaps = new Array[Long](sz)
+    val chains = new Array[Long](sz)
+    val slots = new Array[ArrayStack[Int]](64)
+    var i = 0
+    while(i < 64) {
+      slots(i) = new ArrayStack[Int]
+      i += 1
+    }
+    i = 0
+    while (i < sz) {
+      var start = ranks(i)
+      var end = ranks(i + 1)
+      val (bitmap, chain) = genBitmap(ids, indexes, start, end, sz, slots)
+      bitmaps(i) = bitmap
+      chains(i) = chain
+      i += 1
+    }
+    (indexes, bitmaps, chains)
+  }
+
+  private[this] def genBitmap(ids: Array[Long], indexes: Array[Int], start: Int, end: Int, sz: Int, slots: Array[ArrayStack[Int]]) = {
+    val l = end - start
+    var bitmap = 0L
+    var chain = 0L
+    var c = 0
+
+    // bucketing
+    while (c < l) {
+      val index = indexes(start + c)
+      val id = ids(index)
+      val i = ((hash(id) / sz) & 0x3FL).toInt
+      slots(i) += index
+      c += 1
+    }
+    // first level
+    c = 0
+    var i = 0
+    while (i < 64) {
+      val slot = slots(i)
+      if (!slot.isEmpty) {
+        bitmap |= (1L << i)
+        indexes(start + c) = slot.pop
+        if (!slot.isEmpty) {
+          chain |= (1L << c)
+        }
+        c += 1
+      }
+      i += 1
+    }
+    // chains
+    i = 0
+    while (c < l) {
+      val slot = slots(i % 64)
+      if (!slot.isEmpty) {
+        indexes(start + c) = slot.pop
+        if (!slot.isEmpty) {
+          if (c < 64) chain |= (1L << c)
+        }
+        c += 1
+      }
+      i += 1
+    }
+    (bitmap, chain)
+  }
+
+  private[this] def distribute(ids: Array[Long], sz: Int, ranks: Array[Int]) = {
+    val indexes = new Array[Int](ids.length)
+    var i = 0
+    while (i < ids.length) {
+      val v = ids(i)
+      val bucket = (hash(v) % sz).toInt
+      ranks(bucket) -= 1
+      indexes(ranks(bucket)) = i
+      i += 1
+    }
+    indexes
+  }
+
+  private[this] val MIXER = 2147482951L; // a prime number
+  def hash(v: Long) = (((v >> 32) + v) * MIXER) >>> 1
 }

--- a/shoebox/test/com/keepit/search/index/IdMapperTest.scala
+++ b/shoebox/test/com/keepit/search/index/IdMapperTest.scala
@@ -1,0 +1,65 @@
+package com.keepit.search.index
+
+import com.keepit.test.EmptyApplication
+import com.keepit.search.Lang
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner.JUnitRunner
+import play.api.Play.current
+import play.api.libs.json.Json
+import play.api.test._
+import play.api.test.Helpers._
+import com.keepit.search.graph.UserToUserEdgeSet
+import org.apache.lucene.index.IndexWriterConfig
+import org.apache.lucene.util.Version
+import org.apache.lucene.search.Query
+import scala.util.Random
+
+@RunWith(classOf[JUnitRunner])
+class IdMapperTest extends SpecificationWithJUnit {
+
+  "ReverseArrayMapper" should {
+    "map ids back indexes" in {
+      var seen = Set.empty[Long]
+      val data = new Array[Long](1000)
+      val nodata = new Array[Long](1000)
+      val rnd = new Random
+      val seed = rnd.nextInt
+      rnd.setSeed(seed)
+      var i = 0
+
+      while (i < data.length) {
+        val v = rnd.nextLong
+        if (!seen.contains(v)) {
+          seen = seen + v
+          data(i) = v
+          i += 1
+        }
+      }
+      i = 0
+      while (i < nodata.length) {
+        val v = rnd.nextLong
+        if (!seen.contains(v)) {
+          seen = seen + v
+          nodata(i) = v
+          i += 1
+        }
+      }
+
+      Seq(0.7, 0.8, 0.9, 1.0, 2.0, 4.0, 8.0).forall { f =>
+        val revMapper = ReverseArrayMapper(data, f)
+        i = 0
+        while (i < data.length) {
+          revMapper(data(i)) === i
+          i += 1
+        }
+        i = 0
+        while (i < nodata.length) {
+          revMapper(nodata(i)) === -1
+          i += 1
+        }
+        true
+      } === true
+    }
+  }
+}


### PR DESCRIPTION
A new implementation of the reverse lookup in IdMapper.

IdMapper provides DOCID->UID mapping. UID is application's IDs such as UriID and UserID.
This mapping is implemented as a simple array of UID indexed by DOCID, so the look up is just a array index look up. (Very fast!)

Sometimes we need to do reverse lookups (get DOCID by UserID). We used scala map for that, but scala map is not memory efficient. I wanted a compact structure for it. I implemented a new mapping structure inspired by Rank Indexed Hashing (http://www.cc.gatech.edu/~nanhua/brief_icnp08.pdf). I borrowed the basic idea from it and optimized for our usage.
