### PR TITLE
do not ever store a string representation of null or undefined in local storage

### DIFF
--- a/packrat/scripts/main.js
+++ b/packrat/scripts/main.js
@@ -536,7 +536,7 @@ function removeFromConfigs(key) {
 
 function setConfigs(key, value) {
   var prev = localStorage[getFullyQualifiedKey(key)];
-  if (prev !== String(value)) {
+  if (value != null && prev !== String(value)) {
     log("[setConfigs]", key, " = ", value, " (was ", prev, ")");
     localStorage[getFullyQualifiedKey(key)] = value;
   }


### PR DESCRIPTION
please review @andrewconner 
