### PR TITLE
fixed personalization of semantic vectors in a query...

### DIFF
--- a/shoebox/app/com/keepit/search/index/ArticleIndexer.scala
+++ b/shoebox/app/com/keepit/search/index/ArticleIndexer.scala
@@ -96,8 +96,6 @@ class ArticleIndexer(indexDirectory: Directory, indexWriterConfig: IndexWriterCo
 
   def getArticleSearcher() = searcher
 
-  def getPersonalizedArticleSearcher(uris: Set[Id[NormalizedURI]]) = PersonalizedSearcher(searcher, uris.map(id => id.id))
-
   def search(queryText: String): Seq[Hit] = {
     parseQuery(queryText) match {
       case Some(query) => searcher.search(query)


### PR DESCRIPTION
Just found that semantic vectors were averaged regardless of personal keeps... (ouch!)
Now it is fixed.
