### PR TITLE
emptying but not blowing away browser output directories

### DIFF
--- a/packrat/bin/build.sh
+++ b/packrat/bin/build.sh
@@ -2,7 +2,7 @@
 
 pushd "$(dirname $0)/.." > /dev/null
 
-rm -rf out/*
+rm -rf out/*/* out/*.*
 mkdir -p out
 cp -R adapters/chrome out/
 cp -R adapters/firefox out/

--- a/packrat/scripts/slider.js
+++ b/packrat/scripts/slider.js
@@ -235,6 +235,8 @@ slider = function() {
     })
     .on("mousewheel", ".comment_body_view,.comment-compose", function(e) {
       this.scrollTop += e.originalEvent.wheelDeltaY / 3;
+    })
+    .on("mousewheel", function(e) {
       e.preventDefault();
     });
 


### PR DESCRIPTION
also disabling scrolling of page while mouse is anywhere over the slider, as effi requested in an asana ticket
