### PR TITLE
early work on better slider auto-show logic

### DIFF
--- a/packrat/adapters/chrome/manifest.json
+++ b/packrat/adapters/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Kifi Beta",
-  "version": "2.1.35",
+  "version": "2.1.36",
   "manifest_version": 2,
   "description": "Keep it, Find it!",
   "icons": {

--- a/packrat/adapters/chrome/options.html
+++ b/packrat/adapters/chrome/options.html
@@ -32,11 +32,7 @@ button {padding: 4px 10px; margin-top: 6px}
   Environment:
     <label><input type="radio" name="env" value="production"> <span>Production</span></label>
     <label><input type="radio" name="env" value="development"> <span>Development</span></label><br>
-  <label>
-    Slider Delay (sec):
-    <input id="slider-delay" name="slider_delay">
-  </label>
-  <span style="font-size:10px">("0" to not show it automatically)</span><br>
+  <label><input type="checkbox" id="show-slider" name="show_slider"> <span>Show Slider Automatically</span></label><br>
   <label>
     Max Search Results:
     <input id="max-results" name="max_results">

--- a/packrat/adapters/chrome/options.js
+++ b/packrat/adapters/chrome/options.js
@@ -2,7 +2,7 @@ $(function() {
   chrome.extension.sendMessage(["get_prefs"], function init(o) {
     console.log("[init] prefs:", o.prefs);
     $("[name=env][value=" + o.prefs.env + "]").prop("checked", true);
-    $("#slider-delay").val(o.prefs.sliderDelay);
+    $("#show-slider").prop("checked", o.prefs.showSlider);
     $("#max-results").val(o.prefs.maxResults);
     $("#show-scores").prop("checked", o.prefs.showScores);
     showSession(o.session);
@@ -10,7 +10,7 @@ $(function() {
   $("#save").click(function() {
     chrome.extension.sendMessage(["set_prefs", {
       env: $("input[name=env][value=development]").is(":checked") ? "development" : "production",
-      sliderDelay: $("#slider-delay").val(),
+      showSlider: $("#show-slider").is(":checked"),
       maxResults: $("#max-results").val(),
       showScores: $("#show-scores").is(":checked")}]);
     window.close();

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -310,12 +310,7 @@ for each (let win in windows) {
       exports.log("[windows]", tab.id, tab.url);
       tabsById[tab.id] = tab;
     }
-    let page = pages[tab.id];
-    if (page) {
-      //page.active = tab === tab.window.tabs.activeTab;
-    } else {
-      createPage(tab);
-    }
+    let page = pages[tab.id] || createPage(tab);
     // TODO: initialize page.complete somehow
   }
 };

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -28,7 +28,7 @@ var nextTabId = 1;
 const pages = {}, workers = {}, tabsById = {};  // all by tab.id
 function createPage(tab) {
   if (!tab || !tab.id) throw Error(tab ? "tab without id" : "tab required");
-  return pages[tab.id] = {id: tab.id, url: tab.url, active: tab === tab.window.tabs.activeTab};
+  return pages[tab.id] = {id: tab.id, url: tab.url};
 }
 
 exports.bookmarks = require("./bookmarks");
@@ -36,13 +36,12 @@ exports.browserVersion = xulApp.name + "/" + xulApp.version;
 
 exports.icon = {
   on: {click: []},
-  set: function(tabId, path) {
-    var page = pages[tabId];
-    exports.log("[icon.set]", tabId, path, page);
-    if (page) {
+  set: function(page, path) {
+    if (page === pages[page.id]) {
       page.icon = path;
-      if (page.active) {
-        icon.show(tabsById[tabId].window, url(path));
+      var tab = tabsById[page.id], win = tab.window;
+      if (tab === win.tabs.activeTab) {
+        icon.show(win, url(path));
       }
     }
   }};
@@ -194,14 +193,24 @@ exports.tabs = {
       exports.log.error(Error("tab " + tab.id + " no longer at " + tab.url), "api.tabs.emit:" + type);
     }
   },
-  get: function(tabId) {
-    return pages[tabId];
+  get: function(pageId) {
+    return pages[pageId];
+  },
+  isFocused: function(page) {
+    var tab = tabsById[page.id], win = tab.window;
+    return win === windows.activeWindow && tab === win.tabs.activeTab;
+  },
+  isSelected: function(page) {
+    var tab = tabsById[page.id];
+    return tab === tab.window.tabs.activeTab;
   },
   on: {
-    activate: [],
+    focus: [],
+    blur: [],
     loading: [],
     ready: [],
-    complete: []}};
+    complete: [],
+    unload: []}};
 
 exports.timers = timers;
 exports.version = self.version;
@@ -216,9 +225,13 @@ tabs
 })
 .on("close", function(tab) {
   exports.log("[tabs.close]", tab.id, tab.url);
+  var page = pages[tab.id];
   delete pages[tab.id];
   delete workers[tab.id];
   delete tabsById[tab.id];
+  if (/^https?:/.test(page.url)) {
+    dispatch.call(exports.tabs.on.unload, page);
+  }
 })
 .on("activate", function(tab) {
   var page = pages[tab.id];
@@ -226,7 +239,6 @@ tabs
     exports.log("[tabs.activate]", tab.id, tab.url);
     if (!/^about:/.test(tab.url)) {
       if (page) {
-        page.active = true;
         if (page.icon) {
           icon.show(tab.window, url(page.icon));
         } else {
@@ -235,16 +247,18 @@ tabs
       } else {
         page = createPage(tab);
       }
-      dispatch.call(exports.tabs.on.activate, page);
+      if (tab.window === windows.activeWindow && /^https?:/.test(page.url)) {
+        dispatch.call(exports.tabs.on.focus, page);
+      }
     }
   }
 })
-.on("deactivate", function(tab) {
+.on("deactivate", function(tab) {  // note: can fire after "close"
+  exports.log("[tabs.deactivate]", tab.id, tab.url);
   if (tab.window === windows.activeWindow) {
-    exports.log("[tabs.deactivate]", tab.id, tab.url);
     var page = pages[tab.id];
-    if (page) {
-      page.active = false;
+    if (page && /^https?:/.test(page.url)) {
+      dispatch.call(exports.tabs.on.blur, page);
     }
   }
 })
@@ -252,7 +266,12 @@ tabs
   if (privateMode.isActive) return;
   exports.log("[tabs.ready]", tab.id, tab.url);
   var page = pages[tab.id] || createPage(tab);
-  dispatch.call(exports.tabs.on.ready, page);  // TODO: ensure content scripts are fully injected before dispatch
+  if (/^https?:/.test(page.url)) {
+    timers.setTimeout(function() {  // hoping any on-ready page mods will be injected by time this runs
+      page.ready = true;
+      dispatch.call(exports.tabs.on.ready, page);
+    }, 0);
+  }
 });
 
 windows
@@ -265,6 +284,18 @@ windows
   if (privateMode.isActive) return;
   exports.log("[windows.close]", win.title);
   removeFromWindow(win);
+})
+.on("activate", function(win) {
+  var page = pages[win.tabs.activeTab.id];
+  if (page && /^https?:/.test(page.url)) {
+    dispatch.call(exports.tabs.on.focus, page);
+  }
+})
+.on("deactivate", function(win) {
+  var page = pages[win.tabs.activeTab.id];
+  if (page && /^https?:/.test(page.url)) {
+    dispatch.call(exports.tabs.on.blur, page);
+  }
 });
 
 for each (let win in windows) {
@@ -281,7 +312,7 @@ for each (let win in windows) {
     }
     let page = pages[tab.id];
     if (page) {
-      page.active = tab === tab.window.tabs.activeTab;
+      //page.active = tab === tab.window.tabs.activeTab;
     } else {
       createPage(tab);
     }
@@ -304,6 +335,10 @@ PageMod({
     exports.log("[onAttach]", tab.id, "start.js", tab.url);
     worker.port.on("api:start", function() {
       exports.log("[api:start]", tab.id, tab.url);
+      var oldPage = pages[tab.id];
+      if (oldPage && /^https?:/.test(oldPage.url)) {
+        dispatch.call(exports.tabs.on.unload, oldPage);
+      }
       dispatch.call(exports.tabs.on.loading, createPage(tab));
     });
     worker.port.on("api:complete", function() {
@@ -314,6 +349,10 @@ PageMod({
     });
     worker.port.on("api:nav", function() {
       exports.log("[api:nav]", tab.id, tab.url);
+      var oldPage = pages[tab.id];
+      if (oldPage) {
+        dispatch.call(exports.tabs.on.unload, oldPage);
+      }
       dispatch.call(exports.tabs.on.loading, createPage(tab));
     });
   }});
@@ -339,6 +378,10 @@ timers.setTimeout(function() {  // async to allow main.js to complete (so portHa
         pw.push(worker);
         worker.on("detach", function() {
           pw.length = 0;
+        // }).on("pageshow", function() {
+        //   exports.log("[pageshow] tab:", tab.id, "url:", tab.url);
+        // }).on("pagehide", function() {
+        //   exports.log("[pagehide] tab:", tab.id, "url:", tab.url);
         });
         Object.keys(portHandlers).forEach(function(type) {
           worker.port.on(type, function(data, callbackId) {

--- a/packrat/adapters/firefox/package.json
+++ b/packrat/adapters/firefox/package.json
@@ -3,7 +3,7 @@
     "license": "MPL 2.0",
     "author": "FortyTwo Inc.",
     "homepage": "http://www.keepitfindit.com/",
-    "version": "2.1.35",
+    "version": "2.1.36",
     "fullName": "Keep It, Find It!",
     "id": "kifi@42go.com",
     "icon": "data/icons/kifi.48.png",
@@ -20,11 +20,10 @@
             "value": "production"
         },
         {
-            "title": "Slider delay (sec)",
-            "description": "(0 to not show it automatically)",
-            "type": "integer",
-            "name": "sliderDelay",
-            "value": 30
+            "title": "Show slider automatically",
+            "type": "bool",
+            "name": "showSlider",
+            "value": true
         },
         {
             "title": "Maximum search results",

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -501,7 +501,7 @@ function scheduleAutoShow(tab) {
           tab.autoShowOnReady = true;
         }
       }
-    }, 2000/*30000*/);
+    }, 30000);
   }
 }
 

--- a/packrat/scripts/slider_scout.js
+++ b/packrat/scripts/slider_scout.js
@@ -33,12 +33,10 @@ var slider, injected, t0 = +new Date;
         slider.toggle("button");
       });
     },
-    auto_show_after: function(ms) {
-      setTimeout(function() {
-        withSlider(function() {
-          slider.shown() || slider.show("auto");
-        });
-      }, ms);
+    auto_show: function() {
+      withSlider(function() {
+        slider.shown() || slider.show("auto");
+      });
     },
     deep_link: function(link) {
       withSlider(function() {


### PR DESCRIPTION
- auto-showing slider after page has focus for 30 consecutive sec
- users have a new checkbox option allowing them to disable auto-showing
  - option is initially on for all users, regardless of their previous slider delay setting
- added cross-browser API support for detecting tab/window focus
- made `api.icon.set` and `api.tabs.emit` smarter
  - they now take a `tab` arg and will do nothing if it is no longer valid (tab has navigated away)
- releasing version 2.1.36
