### PR TITLE
idf based coord value to adjust scores at the top level scorer

### DIFF
--- a/shoebox/app/com/keepit/search/MainSearcher.scala
+++ b/shoebox/app/com/keepit/search/MainSearcher.scala
@@ -41,6 +41,7 @@ extends Logging {
   val svWeightBrowsingHistory = config.asInt("svWeightBrowsingHistory")
   val similarity = Similarity(config.asString("similarity"))
   val progressiveRelaxation = config.asBoolean("progressiveRelaxation")
+  val enableCoordinator = config.asBoolean("enableCoordinator")
 
   // get searchers. subsequent operations should use these for consistency since indexing may refresh them
   val articleSearcher = articleIndexer.getSearcher
@@ -76,6 +77,7 @@ extends Logging {
                             clickBoosts: ResultClickTracker.ResultClickBoosts, initial: Boolean)(implicit lang: Lang) {
     val parser = MainQueryParser(lang, proximityBoost, semanticBoost)
     parser.setPercentMatch(if (initial) 100.0f else percentMatch)
+    parser.enableCoord = enableCoordinator
     parser.parseQuery(queryString).map{ articleQuery =>
       log.debug("articleQuery: %s".format(articleQuery.toString))
 

--- a/shoebox/app/com/keepit/search/SearchConfig.scala
+++ b/shoebox/app/com/keepit/search/SearchConfig.scala
@@ -10,6 +10,7 @@ import java.io.FileOutputStream
 object SearchConfig {
   private[search] val defaultParams =
     Map[String, String](
+      "enableCoordinator" -> "false",
       "progressiveRelaxation" -> "true",
       "similarity" -> "default",
       "svWeightMyBookMarks" -> "1",
@@ -32,6 +33,7 @@ object SearchConfig {
     )
   private[this] val descriptions =
     Map[String, String](
+      "enableCoordinator" -> "enables the IDF based coordinator",
       "progressiveRelaxation" -> "on/off progressiveRelaxation",
       "similarity" -> "similarity characteristics",
       "svWeightMyBookMarks" -> "semantics vector weight for my bookmarks",

--- a/shoebox/app/com/keepit/search/index/WrappedIndexReader.scala
+++ b/shoebox/app/com/keepit/search/index/WrappedIndexReader.scala
@@ -15,6 +15,10 @@ object WrappedIndexReader {
     doOpen(inner, Map.empty[String, IdMapper])
   }
 
+  def apply(inner: IndexReader, idMapper: IdMapper): WrappedIndexReader = {
+    apply(inner, ArrayBuffer(new WrappedSubReader("", inner, idMapper)))
+  }
+
   def reopen(oldReader: WrappedIndexReader): WrappedIndexReader = {
     val oldInner = oldReader.inner
     val newInner = IndexReader.openIfChanged(oldInner)

--- a/shoebox/app/com/keepit/search/query/ConditionalQuery.scala
+++ b/shoebox/app/com/keepit/search/query/ConditionalQuery.scala
@@ -1,13 +1,146 @@
 package com.keepit.search.query
 
+import com.keepit.common.logging.Logging
+import com.keepit.search.index.Searcher
+import org.apache.lucene.index.IndexReader
 import org.apache.lucene.index.Term
+import org.apache.lucene.index.TermPositions
 import org.apache.lucene.search.Query
-import org.apache.lucene.search.FilteredQuery
-import org.apache.lucene.search.QueryWrapperFilter
+import org.apache.lucene.search.Scorer
+import org.apache.lucene.search.Weight
+import org.apache.lucene.search.ComplexExplanation
+import org.apache.lucene.search.Explanation
+import org.apache.lucene.search.Similarity
+import org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS
+import org.apache.lucene.util.PriorityQueue
 import org.apache.lucene.util.ToStringUtils
+import java.util.{Set => JSet}
 
-class ConditionalQuery(val source: Query, val condition: Query) extends FilteredQuery(source, new QueryWrapperFilter(condition)) {
-  override def toString(s: String) = {
-    "conditional(%s, %s)%s".format(source.toString(s), condition.toString(s), ToStringUtils.boost(getBoost()))
+
+class ConditionalQuery(val source: Query, val condition: Query) extends Query2 with Coordinator {
+
+  override def createWeight2(searcher: Searcher): Weight = new ConditionalWeight(this, searcher)
+
+  override def rewrite(reader: IndexReader): Query = {
+    val rewrittenSrc = source.rewrite(reader)
+    val rewrittenCond = condition.rewrite(reader)
+
+    if ((rewrittenSrc eq source) && (rewrittenCond eq condition)) this
+    else new ConditionalQuery(source.rewrite(reader), condition.rewrite(reader))
   }
+
+  override def extractTerms(out: JSet[Term]): Unit = {
+    source.extractTerms(out)
+    condition.extractTerms(out)
+  }
+
+  override def toString(s: String) = "Conditional(%s, %s, %s)".format(source.toString(s), condition.toString(s))
+
+  override def equals(obj: Any): Boolean = obj match {
+    case query: ConditionalQuery => (source == query.source) && (condition == query.condition)
+    case _ => false
+  }
+
+  override def hashCode(): Int = source.hashCode() + condition.hashCode()
+}
+
+class ConditionalWeight(query: ConditionalQuery, searcher: Searcher) extends Weight with Logging {
+
+  val sourceWeight = query.source.createWeight(searcher)
+  val conditionWeight = query.condition.createWeight(searcher)
+
+  override def getQuery() = query
+  override def getValue() = query.getBoost()
+  override def scoresDocsOutOfOrder() = false
+
+  override def sumOfSquaredWeights() = {
+    val sum = sourceWeight.sumOfSquaredWeights
+    val value = query.getBoost()
+    (sum * value * value)
+  }
+
+  override def normalize(norm: Float) {
+    sourceWeight.normalize(norm * getValue())
+  }
+
+  override def explain(reader: IndexReader, doc: Int) = {
+    val sc = scorer(reader, true, false);
+    val exists = (sc != null && sc.advance(doc) == doc);
+
+    val result = new ComplexExplanation()
+    if (exists) {
+      result.setDescription("conditional, product of:")
+      val score = sc.score
+      val boost = query.getBoost
+      result.setValue(score * boost)
+      result.setMatch(true)
+      result.addDetail(new Explanation(score, "source score"))
+      result.addDetail(new Explanation(boost, "boost"))
+    } else {
+      result.setDescription("condition, doesn't match id %d".format(doc))
+      result.setValue(0)
+      result.setMatch(false)
+    }
+
+    val eSrc = sourceWeight.explain(reader, doc)
+    eSrc.isMatch() match {
+      case false =>
+        val r = new Explanation(0.0f, "no match in (" + sourceWeight.getQuery.toString() + ")")
+        result.addDetail(r)
+        result.setMatch(false)
+        result.setValue(0.0f)
+        result.setDescription("Failure to the match source query");
+      case true =>
+        result.addDetail(eSrc)
+        val eCond = conditionWeight.explain(reader, doc)
+        eCond.isMatch() match {
+          case true =>
+            result.addDetail(eCond)
+          case false =>
+            val r = new Explanation(0.0f, "no match in (" + conditionWeight.getQuery.toString() + ")")
+            r.addDetail(eCond)
+            result.addDetail(r)
+        }
+    }
+    result
+  }
+
+  override def scorer(reader: IndexReader, scoreDocsInOrder: Boolean, topScorer: Boolean): Scorer = {
+    val sourceScorer = sourceWeight.scorer(reader, true, false)
+    if (sourceScorer == null) null
+    else {
+      // main scorer has to implement Coordinator trait
+      val mainScorer = if (sourceScorer.isInstanceOf[Coordinator]) {
+        sourceScorer.asInstanceOf[Scorer with Coordinator]
+      } else {
+        QueryUtil.toScorerWithCoordinator(sourceScorer)
+      }
+      val conditionScorer = conditionWeight.scorer(reader, true, false)
+      new ConditionalScorer(this, mainScorer, conditionScorer)
+    }
+  }
+}
+
+class ConditionalScorer(weight: ConditionalWeight, sourceScorer: Scorer with Coordinator, conditionScorer: Scorer) extends Scorer(weight) with Coordinator {
+  private[this] var doc = -1
+
+  override def docID(): Int = doc
+  override def nextDoc(): Int = advance(0)
+  override def advance(target: Int): Int = {
+    if (doc < NO_MORE_DOCS) {
+      doc = if (target <= doc) doc + 1 else target
+      doc = sourceScorer.advance(doc)
+      var cond = conditionScorer.advance(doc)
+      while (doc != cond && doc < NO_MORE_DOCS) {
+        if (doc < cond) doc = sourceScorer.advance(cond)
+        else {
+          cond = conditionScorer.advance(doc)
+          if (cond == NO_MORE_DOCS) doc == NO_MORE_DOCS
+        }
+      }
+    }
+    doc
+  }
+  override def score() = sourceScorer.score()
+  override def coord = sourceScorer.coord
 }

--- a/shoebox/app/com/keepit/search/query/Coordinator.scala
+++ b/shoebox/app/com/keepit/search/query/Coordinator.scala
@@ -1,0 +1,5 @@
+package com.keepit.search.query
+
+trait Coordinator {
+  def coord: Float = 1.0f
+}

--- a/shoebox/app/com/keepit/search/query/QueryUtil.scala
+++ b/shoebox/app/com/keepit/search/query/QueryUtil.scala
@@ -80,10 +80,17 @@ object QueryUtil extends Logging {
     query.getClauses.foldLeft(Seq.empty[Term]){ (s, c) => if (!c.isProhibited) s ++ getTerms(fieldName, c.getQuery) else s }
   }
 
-  def emptyScorer(weight: Weight) = new Scorer(weight) {
+  def emptyScorer(weight: Weight) = new Scorer(weight) with Coordinator {
     override def score(): Float = 0.0f
     override def docID() = DocIdSetIterator.NO_MORE_DOCS
     override def nextDoc(): Int = DocIdSetIterator.NO_MORE_DOCS
     override def advance(target: Int): Int = DocIdSetIterator.NO_MORE_DOCS
+  }
+
+  def toScorerWithCoordinator(scorer: Scorer) = new Scorer(null.asInstanceOf[Weight]) with Coordinator {
+    override def score() = scorer.score()
+    override def docID() = scorer.docID()
+    override def nextDoc() = scorer.nextDoc()
+    override def advance(target: Int) = scorer.advance(target)
   }
 }


### PR DESCRIPTION
idf based coord value to adjust scores including text, semantic vec, and proximity at the top level scorer
- need to use search config to enable this
- I will do so for everyone after I test this in prod using my user specific config
