### PR TITLE
 apply different update strengths to result click tracking

### DIFF
--- a/shoebox/app/com/keepit/common/analytics/EventListener.scala
+++ b/shoebox/app/com/keepit/common/analytics/EventListener.scala
@@ -51,7 +51,7 @@ class KifiResultClickedListener extends EventListenerPlugin {
         (user, meta, bookmark)
       }
       // handle KifiResultClicked
-      meta.normUrl.foreach(n => resultClickTracker.add(user.id.get, meta.query, n.id.get))
+      meta.normUrl.foreach(n => resultClickTracker.add(user.id.get, meta.query, n.id.get, !bookmark.isEmpty))
   }
 }
 

--- a/shoebox/app/com/keepit/search/ProbablisticLRU.scala
+++ b/shoebox/app/com/keepit/search/ProbablisticLRU.scala
@@ -72,8 +72,8 @@ class ProbablisticLRU(byteBuffer: ByteBuffer, tableSize: Int, numHashFuncs: Int,
 
   def setSeed(seed: Long) = rnd.setSeed(seed)
 
-  def put(key: Long, value: Long) {
-    putValueHash(key, value)
+  def put(key: Long, value: Long, updateStrength: Double = 0.5d) {
+    putValueHash(key, value, updateStrength)
     val ins = inserts.incrementAndGet()
     if ((ins % syncEvery) == 0) sync
   }
@@ -103,7 +103,7 @@ class ProbablisticLRU(byteBuffer: ByteBuffer, tableSize: Int, numHashFuncs: Int,
   def numInserts = inserts.get
   def numSyncs = syncs
 
-  private[this] def putValueHash(key: Long, value: Long) {
+  private[this] def putValueHash(key: Long, value: Long, updateStrength: Double) {
     var positions = new Array[Int](numHashFuncs)
     var i = 0
     foreachPosition(key){ pos =>
@@ -112,7 +112,8 @@ class ProbablisticLRU(byteBuffer: ByteBuffer, tableSize: Int, numHashFuncs: Int,
     }
     // randomly overwrite the half of the positions
     i = 0
-    while (i < numHashFuncs/2) {
+    val numUpdatePositions = (numHashFuncs.toDouble * updateStrength).toInt
+    while (i < numUpdatePositions) {
       val index = rnd.nextInt(positions.length - i) + i
       val pos = positions(index)
       positions(index) = positions(i)

--- a/shoebox/app/com/keepit/search/ResultClickTracker.scala
+++ b/shoebox/app/com/keepit/search/ResultClickTracker.scala
@@ -26,9 +26,10 @@ object ResultClickTracker {
 class ResultClickTracker(lru: ProbablisticLRU) {
   private[this] val analyzer = DefaultAnalyzer.defaultAnalyzer
 
-  def add(userId: Id[User], query: String, uriId: Id[NormalizedURI]) = {
+  def add(userId: Id[User], query: String, uriId: Id[NormalizedURI], isUserKeep: Boolean) = {
     val hash = QueryHash(userId, query, analyzer)
-    lru.put(hash, uriId.id)
+    val updateStrength = if (isUserKeep) 0.5d else 0.25d // user's keep => half the slots, others => quarter
+    lru.put(hash, uriId.id, updateStrength)
   }
 
   def getBoosts(userId: Id[User], query: String, maxBoost: Float) = {

--- a/shoebox/test/com/keepit/search/ProbablisticLRUTest.scala
+++ b/shoebox/test/com/keepit/search/ProbablisticLRUTest.scala
@@ -61,6 +61,37 @@ class ProbablisticLRUTest extends SpecificationWithJUnit {
       ret(v1) must be_>= (4)
     }
 
+    "put with different updateStrength" in {
+      val lru = create(1000, 8)
+      val key = rand.nextLong()
+      val v1 = rand.nextLong()
+      val v2 = rand.nextLong()
+      val v3 = rand.nextLong()
+      val v4 = rand.nextLong()
+      val values = Seq(v1, v2, v3, v4)
+
+      lru.put(key, v1, 1.0d)
+      var ret = lru.get(key, values)
+      ret.get(v1) must beSome[Int]
+      ret(v1) === 8
+
+      lru.put(key, v2, 0.5d)
+      ret = lru.get(key, values)
+      ret = lru.get(key, values)
+
+      ret(v1) must be_<= (4)
+      ret = lru.get(key, values)
+      ret(v2) === 4
+
+      lru.put(key, v3, 0.25d)
+      ret = lru.get(key, values)
+      ret(v3) === 2
+
+      lru.put(key, v4, 0.1)
+      ret = lru.get(key, values)
+      ret.get(v4) must beNone
+    }
+
     "put/get multiple keys" in {
       val numPairs = 50
       val lru = create(1000, 10)


### PR DESCRIPTION
- if the click is on the user's keep, the strength is 0.5 (4 out of 8 slots are updated)
- otherwise, the strength is 0.25 (2 out of 8 slots are updated) 
