### PR TITLE
Caching for Comment/Message counts, ClickHistory

### DIFF
--- a/shoebox/app/com/keepit/common/db/slick/DbRepo.scala
+++ b/shoebox/app/com/keepit/common/db/slick/DbRepo.scala
@@ -36,7 +36,7 @@ trait DbRepo[M <: Model[M]] extends Repo[M] {
   val db: DataBaseComponent
   import db.Driver.Implicit._ // here's the driver, abstracted away
 
-  def invalidateCache(model: M): M = model
+  def invalidateCache(model: M)(implicit session: RWSession): M = model
 
   implicit val idMapper = new BaseTypeMapper[Id[M]] {
     def apply(profile: BasicProfile) = new IdMapperDelegate[M]

--- a/shoebox/app/com/keepit/controllers/CommentController.scala
+++ b/shoebox/app/com/keepit/controllers/CommentController.scala
@@ -101,22 +101,20 @@ object CommentController extends FortyTwoController {
   }
 
   def getUpdates(url: String) = AuthenticatedJsonAction { request =>
-    val (messageCount, privateCount, publicCount) = inject[DBConnection].readOnly{ implicit s => 
+    val (messageCount, publicCount) = inject[DBConnection].readOnly{ implicit s =>
       val commentRepo = inject[CommentRepo]
       inject[NormalizedURIRepo].getByNormalizedUrl(url) map {uri =>
         val uriId = uri.id.get
         val userId = request.userId
         val messageCount = commentRepo.getMessagesWithChildrenCount(uriId, userId)
-        val privateCount = commentRepo.getPrivateCount(uriId, userId)
         val publicCount = commentRepo.getPublicCount(uriId)
-        (messageCount, privateCount, publicCount)
-      } getOrElse (0, 0, 0)
+        (messageCount, publicCount)
+      } getOrElse (0, 0)
     }
     Ok(JsObject(List(
         "publicCount" -> JsNumber(publicCount),
-        "privateCount" -> JsNumber(privateCount),
         "messageCount" -> JsNumber(messageCount),
-        "countSum" -> JsNumber(publicCount + privateCount + messageCount)
+        "countSum" -> JsNumber(publicCount + messageCount)
     )))
   }
 

--- a/shoebox/app/com/keepit/model/BrowsingHistory.scala
+++ b/shoebox/app/com/keepit/model/BrowsingHistory.scala
@@ -49,7 +49,7 @@ case class BrowsingHistoryUserIdKey(userId: Id[User]) extends Key[BrowsingHistor
   def toKey(): String = userId.id.toString
 }
 class BrowsingHistoryUserIdCache @Inject() (val repo: FortyTwoCachePlugin) extends FortyTwoCache[BrowsingHistoryUserIdKey, BrowsingHistory] {
-  val ttl = 24 hours
+  val ttl = 7 days
   def deserialize(obj: Any): BrowsingHistory = BrowsingHistoryBinarySerializer.browsingHistoryBinarySerializer.reads(obj.asInstanceOf[Array[Byte]])
   def serialize(browsingHistory: BrowsingHistory) = BrowsingHistoryBinarySerializer.browsingHistoryBinarySerializer.writes(browsingHistory)
 }

--- a/shoebox/app/com/keepit/model/BrowsingHistory.scala
+++ b/shoebox/app/com/keepit/model/BrowsingHistory.scala
@@ -76,7 +76,7 @@ class BrowsingHistoryRepoImpl @Inject() (val db: DataBaseComponent, val browsing
     def * = id.? ~ createdAt ~ updatedAt ~ state ~ userId ~ tableSize ~ filter ~ numHashFuncs ~ minHits ~ updatesCount <> (BrowsingHistory, BrowsingHistory.unapply _)
   }
 
-  override def invalidateCache(browsingHistory: BrowsingHistory) = {
+  override def invalidateCache(browsingHistory: BrowsingHistory)(implicit session: RWSession) = {
     browsingCache.set(BrowsingHistoryUserIdKey(browsingHistory.userId), browsingHistory)
     browsingHistory
   }

--- a/shoebox/app/com/keepit/model/ClickHistory.scala
+++ b/shoebox/app/com/keepit/model/ClickHistory.scala
@@ -65,7 +65,7 @@ class ClickHistoryRepoImpl @Inject() (val db: DataBaseComponent, val clickCache:
     def * = id.? ~ createdAt ~ updatedAt ~ state ~ userId ~ tableSize ~ filter ~ numHashFuncs ~ minHits ~ updatesCount <> (ClickHistory, ClickHistory.unapply _)
   }
 
-  override def invalidateCache(clickHistory: ClickHistory) = {
+  override def invalidateCache(clickHistory: ClickHistory)(implicit session: RWSession) = {
     clickCache.set(ClickHistoryUserIdKey(clickHistory.userId), clickHistory)
     clickHistory
   }

--- a/shoebox/app/com/keepit/model/Comment.scala
+++ b/shoebox/app/com/keepit/model/Comment.scala
@@ -80,7 +80,7 @@ class CommentCountUriIdCache @Inject() (val repo: FortyTwoCachePlugin) extends F
 }
 case class MessageWithChildrenCountUriIdUserIdKey(normUriId: Id[NormalizedURI], userId: Id[User]) extends Key[Int] {
   val namespace = "comment_by_normurlid_userid"
-  def toKey(): String = normUriId.id.toString
+  def toKey(): String = normUriId.id.toString + "_" + userId.id.toString
 }
 class MessageWithChildrenCountUriIdUserIdCache @Inject() (val repo: FortyTwoCachePlugin) extends FortyTwoCache[MessageWithChildrenCountUriIdUserIdKey, Int] {
   val ttl = 1 hour
@@ -122,6 +122,7 @@ class CommentRepoImpl @Inject() (val db: DataBaseComponent, val commentCountCach
             case None =>
           }
         }
+      case CommentPermissions.PRIVATE =>
     }
     comment
   }

--- a/shoebox/app/com/keepit/model/Comment.scala
+++ b/shoebox/app/com/keepit/model/Comment.scala
@@ -22,6 +22,8 @@ import ru.circumflex.orm.COUNT
 import play.api.libs.json._
 import com.keepit.inject._
 import com.keepit.common.healthcheck._
+import com.keepit.common.cache._
+import akka.util.duration._
 
 case class Comment(
   id: Option[Id[Comment]] = None,
@@ -61,15 +63,33 @@ trait CommentRepo extends Repo[Comment] with ExternalIdColumnFunction[Comment] {
   def getPublic(uriId: Id[NormalizedURI])(implicit session: RSession): Seq[Comment]
   def getPublicCount(uriId: Id[NormalizedURI])(implicit session: RSession): Int
   def getPrivate(uriId: Id[NormalizedURI], userId: Id[User])(implicit session: RSession): Seq[Comment]
-  def getPrivateCount(uriId: Id[NormalizedURI], userId: Id[User])(implicit session: RSession): Int
   def getChildren(commentId: Id[Comment])(implicit session: RSession): Seq[Comment]
   def getMessagesWithChildrenCount(uriId: Id[NormalizedURI], userId: Id[User])(implicit session: RSession): Int
   def getMessages(uriId: Id[NormalizedURI], userId: Id[User])(implicit session: RSession): Seq[Comment]
   def count(permissions: State[CommentPermission] = CommentPermissions.PUBLIC)(implicit session: RSession): Int
 }
 
+case class CommentCountUriIdKey(normUriId: Id[NormalizedURI]) extends Key[Int] {
+  val namespace = "comment_by_normuriid"
+  def toKey(): String = normUriId.id.toString
+}
+class CommentCountUriIdCache @Inject() (val repo: FortyTwoCachePlugin) extends FortyTwoCache[CommentCountUriIdKey, Int] {
+  val ttl = 1 hour
+  def deserialize(obj: Any): Int = obj.asInstanceOf[Int]
+  def serialize(count: Int) = count
+}
+case class MessageWithChildrenCountUriIdUserIdKey(normUriId: Id[NormalizedURI], userId: Id[User]) extends Key[Int] {
+  val namespace = "comment_by_normurlid_userid"
+  def toKey(): String = normUriId.id.toString
+}
+class MessageWithChildrenCountUriIdUserIdCache @Inject() (val repo: FortyTwoCachePlugin) extends FortyTwoCache[MessageWithChildrenCountUriIdUserIdKey, Int] {
+  val ttl = 1 hour
+  def deserialize(obj: Any): Int = obj.asInstanceOf[Int]
+  def serialize(count: Int) = count
+}
+
 @Singleton
-class CommentRepoImpl @Inject() (val db: DataBaseComponent) extends DbRepo[Comment] with CommentRepo with ExternalIdColumnDbFunction[Comment] {
+class CommentRepoImpl @Inject() (val db: DataBaseComponent, val commentCountCache: CommentCountUriIdCache, val messageWithChildrenCountCache: MessageWithChildrenCountUriIdUserIdCache) extends DbRepo[Comment] with CommentRepo with ExternalIdColumnDbFunction[Comment] {
   import FortyTwoTypeMappers._
   import org.scalaquery.ql._
   import org.scalaquery.ql.TypeMapper._
@@ -91,6 +111,21 @@ class CommentRepoImpl @Inject() (val db: DataBaseComponent) extends DbRepo[Comme
     def * = id.? ~ createdAt ~ updatedAt ~ externalId ~ uriId ~ urlId.? ~ userId ~ text ~ pageTitle ~ parent.? ~ permissions ~ state <> (Comment, Comment.unapply _)
   }
 
+  override def invalidateCache(comment: Comment)(implicit session: RWSession) = {
+    comment.permissions match {
+      case CommentPermissions.PUBLIC =>
+        commentCountCache.remove(CommentCountUriIdKey(comment.uriId))
+      case CommentPermissions.MESSAGE =>
+        inject[CommentRecipientRepo].getByComment(comment.id.get) foreach { cr =>
+          cr.userId match {
+            case Some(user) => messageWithChildrenCountCache.remove(MessageWithChildrenCountUriIdUserIdKey(comment.uriId, user))
+            case None =>
+          }
+        }
+    }
+    comment
+  }
+
   def all(permissions: State[CommentPermission])(implicit session: RSession): Seq[Comment] =
     (for(b <- table if b.permissions === permissions && b.state === CommentStates.ACTIVE) yield b).list
 
@@ -109,27 +144,21 @@ class CommentRepoImpl @Inject() (val db: DataBaseComponent) extends DbRepo[Comme
     } yield b).list
   
   def getPublicCount(uriId: Id[NormalizedURI])(implicit session: RSession): Int =
-    (for {
-      b <- table if b.uriId === uriId && b.permissions === CommentPermissions.PUBLIC && b.parent.isNull && b.state === CommentStates.ACTIVE
-    } yield b.id.count).first
+    commentCountCache.getOrElse(CommentCountUriIdKey(uriId)) {
+      (for {
+        b <- table if b.uriId === uriId && b.permissions === CommentPermissions.PUBLIC && b.parent.isNull && b.state === CommentStates.ACTIVE
+      } yield b.id.count).first
+    }
 
   def getPrivate(uriId: Id[NormalizedURI], userId: Id[User])(implicit session: RSession): Seq[Comment] =
     (for {
       b <- table if b.uriId === uriId && b.userId === userId && b.permissions === CommentPermissions.PRIVATE && b.state === CommentStates.ACTIVE
     } yield b).list
-  
-  def getPrivateCount(uriId: Id[NormalizedURI], userId: Id[User])(implicit session: RSession): Int =
-    (for {
-      b <- table if b.uriId === uriId && b.userId === userId && b.permissions === CommentPermissions.PRIVATE  && b.state === CommentStates.ACTIVE
-    } yield b.id.count).first
 
   def getChildren(commentId: Id[Comment])(implicit session: RSession): Seq[Comment] =
     (for(b <- table if b.parent === commentId && b.state === CommentStates.ACTIVE) yield b).list
 
   def getMessages(uriId: Id[NormalizedURI], userId: Id[User])(implicit session: RSession): Seq[Comment] = {
-    // Get all messages *from* and/or *to* the user
-    // (side effect: User cannot be removed from own messages)
-    //selectMessages({c => c.*}, uriId, userId).list.map(_.view)
     val q1 = for {
       Join(c, cr) <- table innerJoin inject[CommentRecipientRepoImpl].table on (_.id is _.commentId) if (c.uriId === uriId && cr.userId === userId && c.permissions === CommentPermissions.MESSAGE && c.parent.isNull)
     } yield (c.*)
@@ -140,9 +169,11 @@ class CommentRepoImpl @Inject() (val db: DataBaseComponent) extends DbRepo[Comme
   }
 
   def getMessagesWithChildrenCount(uriId: Id[NormalizedURI], userId: Id[User])(implicit session: RSession): Int = {
-    val comments = getMessages(uriId, userId)
-    val childrenCounts: Seq[Int] = (comments.toList map {c => getChildCount(c.id.get).toInt})
-    childrenCounts.foldLeft(0)((sum, count) => sum + count) + comments.size
+    messageWithChildrenCountCache.getOrElse(MessageWithChildrenCountUriIdUserIdKey(uriId, userId)) {
+      val comments = getMessages(uriId, userId)
+      val childrenCounts: Seq[Int] = (comments.toList map {c => getChildCount(c.id.get).toInt})
+      childrenCounts.foldLeft(0)((sum, count) => sum + count) + comments.size
+    }
   }
 
   def count(permissions: State[CommentPermission])(implicit session: RSession): Int =

--- a/shoebox/app/com/keepit/model/SocialUserInfo.scala
+++ b/shoebox/app/com/keepit/model/SocialUserInfo.scala
@@ -97,7 +97,7 @@ class SocialUserInfoRepoImpl @Inject() (val db: DataBaseComponent, userCache: So
     def * = id.? ~ createdAt ~ updatedAt ~ userId.? ~ fullName ~ state ~ socialId ~ networkType ~ credentials.? ~ lastGraphRefresh.? <> (SocialUserInfo, SocialUserInfo.unapply _)
   }
 
-  override def invalidateCache(socialUser: SocialUserInfo) = {
+  override def invalidateCache(socialUser: SocialUserInfo)(implicit session: RWSession) = {
     socialUser.userId match {
       case Some(userId) => userCache.remove(SocialUserInfoUserKey(userId))
       case None =>

--- a/shoebox/app/com/keepit/model/User.scala
+++ b/shoebox/app/com/keepit/model/User.scala
@@ -79,7 +79,7 @@ class UserRepoImpl @Inject() (val db: DataBaseComponent, val externalIdCache: Us
     def * = id.? ~ createdAt ~ updatedAt ~ externalId ~ firstName ~ lastName ~ state <> (User, User.unapply _)
   }
 
-  override def invalidateCache(user: User) = {
+  override def invalidateCache(user: User)(implicit session: RWSession) = {
     externalIdCache.set(UserExternalIdKey(user.externalId), user)
     user.id match {
       case Some(id) => idCache.set(UserIdKey(id), user)

--- a/shoebox/test/com/keepit/model/CommentTest.scala
+++ b/shoebox/test/com/keepit/model/CommentTest.scala
@@ -86,22 +86,6 @@ class CommentTest extends SpecificationWithJUnit {
         }
       }
     }
-    "count and load private comments by URI and UserId" in {
-      running(new EmptyApplication()) {
-        val (user1, user2, uri1, uri2, msg3) = setup()
-        inject[DBConnection].readOnly {implicit s =>
-          val repo = inject[CommentRepo]
-          repo.getPrivateCount(uri1.id.get, user1.id.get) === 2
-          repo.getPrivateCount(uri1.id.get, user2.id.get) === 0
-          repo.getPrivateCount(uri2.id.get, user1.id.get) === 0
-          repo.getPrivateCount(uri2.id.get, user2.id.get) === 0
-          repo.getPrivate(uri1.id.get, user1.id.get).length === 2
-          repo.getPrivate(uri1.id.get, user2.id.get).length === 0
-          repo.getPrivate(uri2.id.get, user1.id.get).length === 0
-          repo.getPrivate(uri2.id.get, user2.id.get).length === 0
-        }
-      }
-    }
     "count and load messages by URI and UserId" in {
       running(new EmptyApplication()) {
         val (user1, user2, uri1, uri2, msg3) = setup()

--- a/shoebox/test/com/keepit/serializer/ClickHistoryBinarySerializer.scala
+++ b/shoebox/test/com/keepit/serializer/ClickHistoryBinarySerializer.scala
@@ -1,0 +1,75 @@
+package com.keepit.serializer
+
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner.JUnitRunner
+import play.api.Play.current
+import play.api.libs.json.Json
+import play.api.test._
+import play.api.test.Helpers._
+import securesocial.core._
+import com.keepit.model.{ClickHistory, User}
+import com.keepit.common.db._
+
+@RunWith(classOf[JUnitRunner])
+class ClickHistorySerializerTest extends SpecificationWithJUnit {
+
+  "ClickHistorySerializer" should {
+    "do a basic serialization flow" in {
+
+      val filter = Array.fill[Byte](10)(0) ++ Array.fill[Byte](10)(1) ++ Array.fill[Byte](3047)(2)
+
+      val clickHistory = ClickHistory(
+        id = Some(Id[ClickHistory](1)),
+        userId = Id[User](1),
+        tableSize = 3067,
+        filter = filter,
+        numHashFuncs = 5,
+        minHits = 1,
+        updatesCount = 42
+      )
+      
+      val serializer = ClickHistoryBinarySerializer.clickHistoryBinarySerializer
+      val serializedHistory = serializer.writes(clickHistory)
+
+      val deserializedHistory = serializer.reads(serializedHistory)
+
+      deserializedHistory.filter.deep === filter.deep
+      deserializedHistory.copy(filter = filter) === clickHistory
+    }
+    "handle edge cases like The Edge" in {
+
+      val filter1 = Array.fill[Byte](0)(0)
+
+      val clickHistory = ClickHistory(
+        id = Some(Id[ClickHistory](1)),
+        userId = Id[User](1),
+        tableSize = 0,
+        filter = filter1,
+        numHashFuncs = 5,
+        minHits = 1,
+        updatesCount = 42
+      )
+      val serializer = ClickHistoryBinarySerializer.clickHistoryBinarySerializer
+      val serializedHistory = serializer.writes(clickHistory)
+      serializer.reads(serializedHistory) must throwA[AssertionError]
+    }
+    "Fail appropriately" in {
+
+      val filter1 = Array.fill[Byte](10)(0)
+
+      val clickHistory = ClickHistory(
+        id = Some(Id[ClickHistory](1)),
+        userId = Id[User](1),
+        tableSize = 30,
+        filter = filter1,
+        numHashFuncs = 5,
+        minHits = 1,
+        updatesCount = 42
+      )
+      val serializer = ClickHistoryBinarySerializer.clickHistoryBinarySerializer
+      serializer.writes(clickHistory) must throwA[AssertionError]
+    }
+  }
+
+}


### PR DESCRIPTION
- Caches requests to Comment.getMessagesWithChildrenCount and Comment.getPublicCount
- Removed references to private comments. This was the old notes, which is now dead code and will likely be implemented outside of Comments (re: discussion with Effi)
- Caches requests to ClickHistory
- Tests for caches.
