### PR TITLE
versioning slider rule sets and sending them down to browser extension

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -394,8 +394,9 @@ function checkKeepStatus(tab, callback) {
   api.log("[checkKeepStatus]", tab);
 
   tab.keepStatusKnown = true;  // setting before request to avoid making two overlapping requests
-  ajax("GET", "http://" + getConfigs().server + "/bookmarks/check", {uri: tab.url}, function done(o) {
+  ajax("GET", "http://" + getConfigs().server + "/bookmarks/check", {uri: tab.url, ver: session.rules.version}, function done(o) {
     setIcon(tab, o.kept);
+    session.rules = o.rules || session.rules;
     callback && callback(o);
   }, function fail(xhr) {
     api.log("[checkKeepStatus] error:", xhr.responseText);

--- a/shoebox/app/com/keepit/controllers/AuthController.scala
+++ b/shoebox/app/com/keepit/controllers/AuthController.scala
@@ -82,7 +82,7 @@ object AuthController extends FortyTwoController {
          }
          kiId
        })}.get
-    val (user, installation) = inject[DBConnection].readWrite{implicit s =>
+    val (user, installation, sliderRuleGroup) = inject[DBConnection].readWrite{implicit s =>
       val repo = inject[KifiInstallationRepo]
       log.info("start. details: %s, %s, %s".format(userAgent, version, installationIdOpt))
       val installation: KifiInstallation = installationIdOpt flatMap { id =>
@@ -98,7 +98,7 @@ object AuthController extends FortyTwoController {
           }
       }
 
-      (inject[UserRepo].get(request.userId), installation)
+      (inject[UserRepo].get(request.userId), installation, inject[SliderRuleRepo].getGroup("default"))
     }
 
     Ok(JsObject(Seq(
@@ -107,7 +107,9 @@ object AuthController extends FortyTwoController {
       "facebookId" -> JsString(socialUser.id.id),
       "provider" -> JsString(socialUser.id.providerId),
       "userId" -> JsString(user.externalId.id),
-      "installationId" -> JsString(installation.externalId.id)))).withCookies(KifiInstallationCookie.encodeAsCookie(Some(installation.externalId)))
+      "installationId" -> JsString(installation.externalId.id),
+      "rules" -> sliderRuleGroup.compactJson)))
+    .withCookies(KifiInstallationCookie.encodeAsCookie(Some(installation.externalId)))
   }
 
   // where SecureSocial sends users if it can't figure out the right place (see securesocial.conf)

--- a/shoebox/app/com/keepit/controllers/admin/SliderAdminController.scala
+++ b/shoebox/app/com/keepit/controllers/admin/SliderAdminController.scala
@@ -13,10 +13,10 @@ object SliderAdminController extends FortyTwoController {
 
   def index = AdminHtmlAction { implicit request =>
     val groupName = "default"
-    val rules = inject[DBConnection].readOnly { implicit session =>
+    val group = inject[DBConnection].readOnly { implicit session =>
       inject[SliderRuleRepo].getGroup(groupName)
     }
-    Ok(views.html.sliderAdmin(groupName, rules.map(r => r.name -> r).toMap))
+    Ok(views.html.sliderAdmin(groupName, group.rules.map(r => r.name -> r).toMap))
   }
 
   def save = AdminHtmlAction { implicit request =>
@@ -24,7 +24,7 @@ object SliderAdminController extends FortyTwoController {
     val groupName = body("group").head
     inject[DBConnection].readWrite { implicit session =>
       val repo = inject[SliderRuleRepo]
-      repo.getGroup(groupName).foreach { rule =>
+      repo.getGroup(groupName).rules.foreach { rule =>
         val newRule = rule
           .withState(if (body.contains(rule.name)) ACTIVE else INACTIVE)
           .withParameters(body.get(rule.name + "Params").map { arr => JsArray(arr.map(Json.parse)) })

--- a/shoebox/conf/routes
+++ b/shoebox/conf/routes
@@ -12,7 +12,7 @@ GET     /bookmarks/all              com.keepit.controllers.BookmarksController.a
 GET     /bookmarks/edit             com.keepit.controllers.BookmarksController.edit(id: Id[Bookmark])
 POST    /bookmarks/rescrape         com.keepit.controllers.BookmarksController.rescrape
 POST    /bookmarks/delete           com.keepit.controllers.BookmarksController.delete(id: Id[Bookmark])
-GET     /bookmarks/check            com.keepit.controllers.BookmarksController.checkIfExists(uri: String)
+GET     /bookmarks/check            com.keepit.controllers.BookmarksController.checkIfExists(uri: String, ver: Option[String] ?= None)
 POST    /bookmarks/remove           com.keepit.controllers.BookmarksController.remove()
 POST    /bookmarks/private          com.keepit.controllers.BookmarksController.updatePrivacy()
 

--- a/shoebox/test/com/keepit/controllers/AuthControllerTest.scala
+++ b/shoebox/test/com/keepit/controllers/AuthControllerTest.scala
@@ -129,7 +129,15 @@ class AuthControllerTest extends SpecificationWithJUnit with DbRepos {
           all.size === 1
           all.head
         }
-        Json.parse(contentAsString(result1)) === Json.parse("""{"avatarUrl":"http://www.fb.com/me","name":"A 1","facebookId":"111","provider":"facebook","userId":"%s","installationId":"%s"}""".format(user.externalId, kifiInstallation1.externalId.id))
+        val json1 = Json.parse(contentAsString(result1)).asInstanceOf[JsObject]
+        json1 \ "avatarUrl" === JsString("http://www.fb.com/me")
+        json1 \ "name" === JsString("A 1")
+        json1 \ "facebookId" === JsString("111")
+        json1 \ "provider" === JsString("facebook")
+        json1 \ "userId" === JsString(user.externalId.id)
+        json1 \ "installationId" === JsString(kifiInstallation1.externalId.id)
+        json1 \ "rules" \ "version" must beAnInstanceOf[JsString]
+        json1 \ "rules" \ "rules" must beAnInstanceOf[JsObject]
 
         //second round
         val fakeRequest2 = FakeRequest().
@@ -143,7 +151,8 @@ class AuthControllerTest extends SpecificationWithJUnit with DbRepos {
           all.size === 1
           all.head
         }
-        Json.parse(contentAsString(result2)) === Json.parse("""{"avatarUrl":"http://www.fb.com/me","name":"A 1","facebookId":"111","provider":"facebook","userId":"%s","installationId":"%s"}""".format(user.externalId, kifiInstallation2.externalId.id))
+        val json2 = Json.parse(contentAsString(result2))
+        json2 === json1
         kifiInstallation1 === kifiInstallation2
       }
     }

--- a/shoebox/test/com/keepit/model/SliderRuleTest.scala
+++ b/shoebox/test/com/keepit/model/SliderRuleTest.scala
@@ -1,0 +1,67 @@
+package com.keepit.model
+
+import org.joda.time.DateTime
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner.JUnitRunner
+
+import com.keepit.common.db.slick._
+import com.keepit.common.time._
+import com.keepit.inject._
+import com.keepit.test._
+
+import play.api.Play.current
+import play.api.libs.json._
+import play.api.test._
+import play.api.test.Helpers._
+
+class SliderRuleTest extends SpecificationWithJUnit with DbRepos {
+  "SliderRule" should {
+    "save, load by group name, cache group versions" in {
+      running(new EmptyApplication().withFakeTime()) {
+        val repo = inject[SliderRuleRepo]
+        inject[SliderRuleRepo] must be(repo) // singleton
+
+        val (r1, r2, r3, r4, vFoo, vBar) = inject[DBConnection].readWrite{ implicit session =>
+          (repo.save(SliderRule(None, "foo", "rule1", None)),
+           repo.save(SliderRule(None, "foo", "rule2", Some(JsArray(Seq(JsNumber(8)))))),
+           repo.save(SliderRule(None, "bar", "rule1", None)),
+           repo.save(SliderRule(None, "bar", "rule2", Some(JsArray(Seq(JsNumber(9)))))),
+           repo.asInstanceOf[SliderRuleRepoImpl].groupVersionCache("foo"),
+           repo.asInstanceOf[SliderRuleRepoImpl].groupVersionCache("bar"))
+        }
+
+        inject[DBConnection].readOnly{ implicit session =>
+          repo.getGroup("foo").rules.map(_.id) === Seq(r1.id, r2.id)
+          repo.getGroup("bar").rules.map(_.id) === Seq(r3.id, r4.id)
+          repo.getGroupVersion("foo") === vFoo
+          repo.getGroupVersion("bar") === vBar
+        }
+
+        inject[DBConnection].readWrite{ implicit session =>
+          repo.save(repo.getGroup("foo").rules(1).withParameters(None))
+          repo.getGroupVersion("foo") must be_>(vFoo)
+          repo.getGroupVersion("bar") === vBar
+        }
+      }
+    }
+
+    "compute group version based on last update time" in {
+      val t1 = new DateTime(2008, 12, 15, 16, 42, 38, 180, zones.PT)
+      val (t2, t3) = (t1.plus(2), t1.plus(4))
+      SliderRuleGroup(Seq(
+        SliderRule(None, "foo", "a", None, updatedAt = t2),
+        SliderRule(None, "foo", "b", None, updatedAt = t3),
+        SliderRule(None, "foo", "c", None, updatedAt = t1)))
+      .version === "fortytwo"
+    }
+
+    "format compact JSON representation" in {
+      val t = new DateTime(2008, 12, 15, 16, 42, 38, 184, zones.PT)
+      SliderRuleGroup(Seq(
+        SliderRule(None, "foo", "a", None, updatedAt = t),
+        SliderRule(None, "foo", "b", Some(JsArray(Seq(JsBoolean(true), JsNumber(9)))), updatedAt = t)))
+      .compactJson.toString === """{"version":"fortytwo","rules":{"a":1,"b":[true,9]}}"""
+    }
+  }
+}


### PR DESCRIPTION
Rules are always sent in `/kifi/start` responses. They are sent in a `/bookmarks/check` response if the request includes an out-of-date rule version parameter.
