### PR TITLE
Catch uncaught exceptions from all Actors

### DIFF
--- a/shoebox/app/com/keepit/classify/DomainClassifier.scala
+++ b/shoebox/app/com/keepit/classify/DomainClassifier.scala
@@ -13,12 +13,13 @@ import akka.actor.{Actor, Props, ActorSystem}
 import akka.dispatch.Future
 import akka.pattern.ask
 import akka.util.duration._
+import com.keepit.common.akka.FortyTwoActor
 
 
 private case class FetchDomainInfo(domain: String)
 
 private[classify] class DomainClassificationActor(db: DBConnection, client: HttpClient, updater: SensitivityUpdater,
-    domainRepo: DomainRepo, tagRepo: DomainTagRepo, domainToTagRepo: DomainToTagRepo) extends Actor {
+    domainRepo: DomainRepo, tagRepo: DomainTagRepo, domainToTagRepo: DomainToTagRepo) extends FortyTwoActor {
 
   private final val KEY = "42go42"
 

--- a/shoebox/app/com/keepit/classify/DomainTagImporter.scala
+++ b/shoebox/app/com/keepit/classify/DomainTagImporter.scala
@@ -30,6 +30,7 @@ import akka.util.duration._
 import play.api.Play.current
 import play.api.libs.json.{JsNumber, JsString, JsObject}
 import play.api.libs.ws.WS
+import com.keepit.common.akka.FortyTwoActor
 
 private case object RefetchAll
 private case class ApplyTag(tagName: DomainTagName, domainNames: Seq[String])
@@ -52,7 +53,7 @@ object DomainTagImportEvents {
 private[classify] class DomainTagImportActor(db: DBConnection, updater: SensitivityUpdater, clock: Provider[DateTime],
     domainRepo: DomainRepo, tagRepo: DomainTagRepo, domainToTagRepo: DomainToTagRepo,
     persistEventPlugin: PersistEventPlugin, settings: DomainTagImportSettings)
-    extends Actor with Logging {
+    extends FortyTwoActor with Logging {
 
   import DomainTagImportEvents._
 

--- a/shoebox/app/com/keepit/common/akka/FortyTwoActor.scala
+++ b/shoebox/app/com/keepit/common/akka/FortyTwoActor.scala
@@ -1,0 +1,18 @@
+package com.keepit.common.akka
+
+import akka.actor.Actor
+import com.keepit.inject._
+import com.keepit.common.healthcheck.{Healthcheck, HealthcheckError, HealthcheckPlugin}
+import play.api.Play.current
+
+trait FortyTwoActor extends Actor {
+  override def preRestart(reason: Throwable, message: Option[Any]) {
+    inject[HealthcheckPlugin].addError(
+      HealthcheckError(error = Some(reason),
+        callType = Healthcheck.INTERNAL,
+        errorMessage = Some("Actor %s threw an uncaught exception. Message: %s".format(this.getClass.getSimpleName,message))
+      )
+    )
+    postStop()
+  }
+}

--- a/shoebox/app/com/keepit/common/analytics/PersistEvent.scala
+++ b/shoebox/app/com/keepit/common/analytics/PersistEvent.scala
@@ -15,13 +15,14 @@ import akka.actor.ActorSystem
 import akka.actor.Props
 import play.api.Play.current
 import play.api.Plugin
+import com.keepit.common.akka.FortyTwoActor
 
 case object Load
 case class Update(userId: Id[User])
 case class Persist(event: Event, queueTime: DateTime)
 case class PersistMany(events: Seq[Event], queueTime: DateTime)
 
-private[analytics] class PersistEventActor extends Actor with Logging {
+private[analytics] class PersistEventActor extends FortyTwoActor with Logging {
 
   def receive() = {
     case Persist(event, queueTime) =>

--- a/shoebox/app/com/keepit/common/analytics/reports/ReportBuilder.scala
+++ b/shoebox/app/com/keepit/common/analytics/reports/ReportBuilder.scala
@@ -24,6 +24,7 @@ import com.google.inject.Inject
 import org.joda.time.DateTime
 import com.keepit.common.time._
 import com.keepit.common.analytics.reports.Reports.ReportGroup
+import com.keepit.common.akka.FortyTwoActor
 
 object Reports {
   lazy val dailyActiveUniqueUserReport = new DailyActiveUniqueUserReport
@@ -129,7 +130,7 @@ private[reports] case class ReportCron(sender: ReportBuilderPlugin)
 private[reports] case class BuildReport(startDate: DateTime, endDate: DateTime, report: Report)
 private[reports] case class BuildReports(startDate: DateTime, endDate: DateTime, reportGroup: Reports.ReportGroup)
 
-private[reports] class ReportBuilderActor() extends Actor with Logging {
+private[reports] class ReportBuilderActor() extends FortyTwoActor with Logging {
 
   def receive() = {
     case ReportCron(sender) =>

--- a/shoebox/app/com/keepit/common/healthcheck/Healthcheck.scala
+++ b/shoebox/app/com/keepit/common/healthcheck/Healthcheck.scala
@@ -26,6 +26,7 @@ import org.joda.time.DateTime
 import akka.dispatch.Future
 import com.google.inject.Inject
 import com.google.inject.Provider
+import com.keepit.common.akka.FortyTwoActor
 
 case class HealthcheckError(error: Option[Throwable] = None, method: Option[String] = None,
     path: Option[String] = None, callType: CallType, errorMessage: Option[String] = None,

--- a/shoebox/app/com/keepit/common/mail/MailSender.scala
+++ b/shoebox/app/com/keepit/common/mail/MailSender.scala
@@ -24,6 +24,7 @@ import play.api.libs.concurrent.Promise
 import com.keepit.common.net.ClientResponse
 import java.util.concurrent.TimeUnit
 import com.google.inject.Inject
+import com.keepit.common.akka.FortyTwoActor
 
 trait MailSenderPlugin extends Plugin {
   def processMail(mail: ElectronicMail) : Unit
@@ -61,7 +62,7 @@ class MailSenderPluginImpl @Inject() (system: ActorSystem, db: DBConnection, mai
 private[mail] case class ProcessOutbox(sender: MailSenderPlugin)
 private[mail] case class ProcessMail(mail: ElectronicMail, sender: MailSenderPlugin)
 
-private[mail] class MailSenderActor() extends Actor with Logging {
+private[mail] class MailSenderActor() extends FortyTwoActor with Logging {
 
   def receive() = {
     case ProcessOutbox(sender) => sender.processOutbox()

--- a/shoebox/app/com/keepit/common/social/SocialGraphPlugin.scala
+++ b/shoebox/app/com/keepit/common/social/SocialGraphPlugin.scala
@@ -14,12 +14,13 @@ import akka.util.Timeout
 import akka.util.duration._
 import play.api.Play.current
 import play.api.Plugin
+import com.keepit.common.akka.FortyTwoActor
 
 //case object FetchAll
 private case class FetchUserInfo(socialUserInfo: SocialUserInfo)
 private case object FetchAll
 
-private[social] class SocialGraphActor(graph: FacebookSocialGraph, db: DBConnection, socialRepo: SocialUserInfoRepo) extends Actor with Logging {
+private[social] class SocialGraphActor(graph: FacebookSocialGraph, db: DBConnection, socialRepo: SocialUserInfoRepo) extends FortyTwoActor with Logging {
   def receive() = {
     case FetchAll =>
       val unprocessedUsers = db.readOnly {implicit s =>

--- a/shoebox/app/com/keepit/common/social/SocialGraphRefresherPlugin.scala
+++ b/shoebox/app/com/keepit/common/social/SocialGraphRefresherPlugin.scala
@@ -25,11 +25,12 @@ import com.keepit.common.db.slick._
 import play.api.Play.current
 import play.api.libs.json.JsArray
 import securesocial.core.{SocialUser, UserId, AuthenticationMethod, OAuth2Info}
+import com.keepit.common.akka.FortyTwoActor
 
 private case class RefreshUserInfo(socialUserInfo: SocialUserInfo)
 private case object RefreshAll
 
-private[social] class SocialGraphRefresherActor(socialGraphPlugin : SocialGraphPlugin, db: DBConnection, socialRepo: SocialUserInfoRepo) extends Actor with Logging {
+private[social] class SocialGraphRefresherActor(socialGraphPlugin : SocialGraphPlugin, db: DBConnection, socialRepo: SocialUserInfoRepo) extends FortyTwoActor with Logging {
   def receive() = {
     case RefreshAll => {
       log.info("going to check which SocilaUserInfo Was not fetched Lately")

--- a/shoebox/app/com/keepit/scraper/DataIntegrity.scala
+++ b/shoebox/app/com/keepit/scraper/DataIntegrity.scala
@@ -21,6 +21,7 @@ import com.keepit.model.NormalizedURI
 import com.keepit.model.ScrapeInfo
 import play.api.libs.concurrent.Akka
 import akka.util.duration._
+import com.keepit.common.akka.FortyTwoActor
 
 
 trait DataIntegrityPlugin extends Plugin {
@@ -52,7 +53,7 @@ class DataIntegrityPluginImpl @Inject() (system: ActorSystem)
 
 private[scraper] case object CleanOrphans
 
-private[scraper] class DataIntegrityActor() extends Actor with Logging {
+private[scraper] class DataIntegrityActor() extends FortyTwoActor with Logging {
 
   def receive() = {
     case CleanOrphans =>

--- a/shoebox/app/com/keepit/scraper/ScraperPlugin.scala
+++ b/shoebox/app/com/keepit/scraper/ScraperPlugin.scala
@@ -12,11 +12,12 @@ import akka.pattern.ask
 import akka.util.Timeout
 import akka.util.duration._
 import play.api.Plugin
+import com.keepit.common.akka.FortyTwoActor
 
 case object Scrape
 case class ScrapeInstance(uri: NormalizedURI)
 
-private[scraper] class ScraperActor(scraper: Scraper) extends Actor with Logging {
+private[scraper] class ScraperActor(scraper: Scraper) extends FortyTwoActor with Logging {
   def receive() = {
     case Scrape => sender ! scraper.run()
     case ScrapeInstance(uri) => sender ! scraper.safeProcessURI(uri)

--- a/shoebox/app/com/keepit/search/graph/URIGraphPlugin.scala
+++ b/shoebox/app/com/keepit/search/graph/URIGraphPlugin.scala
@@ -21,11 +21,12 @@ import com.google.inject.Inject
 import com.google.inject.Provider
 import com.keepit.inject._
 import com.keepit.common.healthcheck.{Healthcheck, HealthcheckPlugin, HealthcheckError}
+import com.keepit.common.akka.FortyTwoActor
 
 case object Load
 case class Update(userId: Id[User])
 
-private[graph] class URIGraphActor(uriGraph: URIGraph) extends Actor with Logging {
+private[graph] class URIGraphActor(uriGraph: URIGraph) extends FortyTwoActor with Logging {
 
   def receive() = {
     case Load => try {

--- a/shoebox/app/com/keepit/search/index/ArticleIndexerPlugin.scala
+++ b/shoebox/app/com/keepit/search/index/ArticleIndexerPlugin.scala
@@ -21,10 +21,11 @@ import com.google.inject.Provider
 import scala.collection.mutable.{Map => MutableMap}
 import com.keepit.inject._
 import com.keepit.common.healthcheck.{Healthcheck, HealthcheckPlugin, HealthcheckError}
+import com.keepit.common.akka.FortyTwoActor
 
 case object Index
 
-private[index] class ArticleIndexerActor(articleIndexer: ArticleIndexer) extends Actor with Logging {
+private[index] class ArticleIndexerActor(articleIndexer: ArticleIndexer) extends FortyTwoActor with Logging {
 
   def receive() = {
     case Index => try {


### PR DESCRIPTION
Changed all of our Actors to extend `FortyTwoActor`
`FortyTwoActor` reports exceptions to Healthcheck before dying.

Side effect: We may get many more exception emails than before, because we missed them in production. @eishay 
