### PR TITLE
Add models and admin interface for search configurations

### DIFF
--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -28,7 +28,7 @@ api.load("html/google_inject.html", function(tmpl) {
 
     if (href && resIdx >= 0) {
       logEvent("search", isKifi ? "kifiResultClicked" : "googleResultClicked",
-        {"url": href, "whichResult": resIdx, "query": response.query, "kifiResultsCount": $kifiLi.length});
+        {"url": href, "whichResult": resIdx, "query": response.query, "experimentId": response.experimentId, "kifiResultsCount": $kifiLi.length});
     }
   });
 
@@ -81,7 +81,7 @@ api.load("html/google_inject.html", function(tmpl) {
 
       logEvent("search", "kifiLoaded", {"query": query, "queryUUID": resp.uuid});
       if (resp.hits.length) {
-        logEvent("search", "kifiAtLeastOneResult", {"query": query, "queryUUID": resp.uuid});
+        logEvent("search", "kifiAtLeastOneResult", {"query": query, "queryUUID": resp.uuid, experimentId: response.experimentId});
         showResultsAndPrefetchMore();
       }
     });

--- a/shoebox/app/assets/stylesheets/admin_search_config.less
+++ b/shoebox/app/assets/stylesheets/admin_search_config.less
@@ -1,0 +1,40 @@
+ul.experiments {
+  margin: 0;
+  padding: 0;
+  li {
+    border: 1px solid #999;
+    margin: 1em 0;
+    padding: 0.5em;
+    list-style: none;
+  }
+  .experiment-desc {
+    margin: 0 0 1em 0;
+  }
+  .experiment-settings {
+    margin: 1em 0;
+    padding: 0;
+    border: 2px solid #666;
+    display: none;
+    input {
+      margin: 0;
+    }
+    td {
+      padding: 4px;
+    }
+  }
+  .basic-settings {
+    float: right;
+    .show-settings {
+      margin: 0 1em;
+    }
+  }
+  .experiment-description {
+    width: 30em;
+  }
+  .experiment-weight {
+    width: 2em;
+  }
+  input.search-param {
+    width: 4em;
+  }
+}

--- a/shoebox/app/com/keepit/controllers/SearchLabsController.scala
+++ b/shoebox/app/com/keepit/controllers/SearchLabsController.scala
@@ -42,7 +42,7 @@ object SearchLabsController extends FortyTwoController {
     val topN = 50
     val fakeUserId = Id[User](-1)
     val mainSearcherFactory = inject[MainSearcherFactory]
-    val config = inject[SearchConfigManager].getDefaultConfig
+    val config = inject[SearchConfigManager].defaultConfig
     val searcher = mainSearcherFactory(fakeUserId, Set.empty[Id[User]], Set.empty[Long], config)
     val hits = new HitQueue(topN)
     val nullClickBoost = new ResultClickBoosts{ def apply(value: Long) = 1.0f }

--- a/shoebox/app/com/keepit/search/SearchConfigExperiment.scala
+++ b/shoebox/app/com/keepit/search/SearchConfigExperiment.scala
@@ -1,0 +1,62 @@
+package com.keepit.search
+
+import com.google.inject.{Inject, Singleton, ImplementedBy}
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.DBSession.{RWSession, RSession}
+import com.keepit.common.db.slick._
+import com.keepit.common.db.{Model, State, States}
+import com.keepit.common.time._
+import org.joda.time.DateTime
+import java.util.concurrent.atomic.AtomicReference
+
+case class SearchConfigExperiment(
+    id: Option[Id[SearchConfigExperiment]] = None,
+    weight: Double = 0,
+    description: String = "",
+    config: Map[String, String] = Map(),
+    state: State[SearchConfigExperiment] = SearchConfigExperimentStates.CREATED,
+    createdAt: DateTime = currentDateTime,
+    updatedAt: DateTime = currentDateTime
+    ) extends Model[SearchConfigExperiment] {
+  def withId(id: Id[SearchConfigExperiment]) = this.copy(id = Some(id))
+  def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
+  def withState(state: State[SearchConfigExperiment]) = this.copy(state = state)
+  def isActive: Boolean = state == SearchConfigExperimentStates.ACTIVE
+  def isStartable = Seq(SearchConfigExperimentStates.PAUSED, SearchConfigExperimentStates.CREATED) contains state
+  def isPausable = state == SearchConfigExperimentStates.ACTIVE
+  def isEditable = state == SearchConfigExperimentStates.CREATED
+}
+
+@ImplementedBy(classOf[SearchConfigExperimentRepoImpl])
+trait SearchConfigExperimentRepo extends Repo[SearchConfigExperiment] {
+  def getActive()(implicit session: RSession): Seq[SearchConfigExperiment]
+  def getNotInactive()(implicit session: RSession): Seq[SearchConfigExperiment]
+}
+
+@Singleton
+class SearchConfigExperimentRepoImpl @Inject()(val db: DataBaseComponent)
+    extends DbRepo[SearchConfigExperiment] with SearchConfigExperimentRepo {
+
+  import DBSession._
+  import FortyTwoTypeMappers._
+  import db.Driver.Implicit._
+
+  override lazy val table = new RepoTable[SearchConfigExperiment](db, "search_config_experiment") {
+    def weight = column[Double]("weight", O.NotNull)
+    def description = column[String]("description", O.NotNull)
+    def config = column[Map[String, String]]("config", O.NotNull)
+    def * = id.? ~ weight ~ description ~ config ~ state ~ createdAt ~ updatedAt <>
+        (SearchConfigExperiment.apply _, SearchConfigExperiment.unapply _)
+  }
+
+  def getActive()(implicit session: RSession): Seq[SearchConfigExperiment] =
+    (for (v <- table if v.state === SearchConfigExperimentStates.ACTIVE) yield v).list
+
+  def getNotInactive()(implicit session: RSession): Seq[SearchConfigExperiment] =
+    (for (v <- table if v.state =!= SearchConfigExperimentStates.INACTIVE) yield v).list
+}
+
+object SearchConfigExperimentStates extends States[SearchConfigExperiment] {
+  val CREATED = State[SearchConfigExperiment]("created")
+  val PAUSED = State[SearchConfigExperiment]("paused")
+}

--- a/shoebox/app/com/keepit/serializer/PersonalSearchResultPacketSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/PersonalSearchResultPacketSerializer.scala
@@ -14,6 +14,7 @@ class PersonalSearchResultPacketSerializer extends Writes[PersonalSearchResultPa
         "query" -> JsString(res.query),
         "hits" -> PersonalSearchResultSerializer.resSerializer.writes(res.hits),
         "mayHaveMore" -> JsBoolean(res.mayHaveMoreHits),
+        "experimentId" -> res.experimentId.map(id => JsNumber(id.id)).getOrElse(JsNull),
         "context" -> JsString(res.context)
       ))
     } catch {

--- a/shoebox/app/views/searchConfigExperiments.scala.html
+++ b/shoebox/app/views/searchConfigExperiments.scala.html
@@ -1,0 +1,129 @@
+@(experiments: Seq[com.keepit.search.SearchConfigExperiment], defaultConfig: Map[String,String])
+
+
+@paramValue(parameter: String, value: String, description: Option[String], editable: Boolean, showDefault: Boolean) = {
+  <tr>
+    <td>@parameter</td>
+    <td>
+      @if(editable) {
+        <input type="text" size="10" class="search-param" name="@parameter" value="@value">
+      } else {
+        <input type="hidden" class="search-param" name="@parameter" value="@value">@value
+      }
+      @if(showDefault) { (default @{defaultConfig.get(parameter)}) }
+    </td>
+    <td>@description.getOrElse("")</td>
+  </tr>
+}
+
+@admin("Search Experiments", stylesheets = List("admin_search_config")) {
+  <h2>Experiment config</h2>
+  <ul class="experiments">
+    @experiments.map { experiment =>
+    <li class="@if(experiment.isActive) { active-experiment }" data-id="@experiment.id">
+      <div class="experiment-desc">
+        <input class="experiment-description" value="@experiment.description">
+        @if(experiment.isPausable) { <button type="button" class="btn pause-experiment">Pause</button> }
+        @if(experiment.isStartable) { <button type="button" class="btn start-experiment">Start</button> }
+        (currently @experiment.state.value)
+        <div class="basic-settings">
+          <strong><input class="experiment-weight" value="@{(experiment.weight * 100).toInt}">%</strong>
+          <button class="btn show-settings">Show settings</button>
+          <button type="button" class="btn update-experiment">Update</button>
+          <button type="button" class="btn delete-experiment">Delete</button>
+        </div>
+      </div>
+      <table class="table table-bordered experiment-settings">
+        <tr> <th>Parameter</th><th>Value</th><th>Description</th> </tr>
+        @defining((experiment.config.toSet -- defaultConfig.toSet).toSeq.sortBy(_._1)) { nonDefaults =>
+          @nonDefaults.map { case (p, v) =>
+            @paramValue(p, v, com.keepit.search.SearchConfig.getDescription(p), experiment.isEditable, true)
+          }
+          @{(defaultConfig -- nonDefaults.map(_._1)).toSeq.sortBy(_._1).map { case (p, v) =>
+            paramValue(p, v, com.keepit.search.SearchConfig.getDescription(p), experiment.isEditable, false)
+          }}
+        }
+      </table>
+    </li>
+    }
+    <li class="default">
+      <div class="experiment-desc">
+        <strong>Default Values</strong>
+        <div class="basic-settings">
+          <button class="btn show-settings">Show settings</button>
+        </div>
+      </div>
+      <table class="table table-bordered experiment-settings">
+        <tr> <th>Parameter</th><th>Value</th><th>Description</th> </tr>
+        @defaultConfig.map { case (p, v) =>
+          @paramValue(p, v, com.keepit.search.SearchConfig.getDescription(p), false, false)
+        }
+      </table>
+    </li>
+  </ul>
+  <button type="button" class="btn" id="save-all-experiments">Save All Changes</button>
+  <button type="submit" class="btn" id="add-new-experiment">Add New Experiment</button><br/>
+}
+<script>
+$(function() {
+  function updateExperiment(element, callback) {
+    var $li = $(element).closest("li");
+    var data = {
+      id: +$li.data("id"),
+      description: $li.find(".experiment-description").val(),
+      weight: (parseFloat($li.find(".experiment-weight").val()) || 0) / 100
+    };
+    if ($(element).hasClass("pause-experiment")) {
+      data["state"] = "paused";
+    } else if ($(element).hasClass("start-experiment")) {
+      data["state"] = "active";
+    }
+    $li.find(".search-param").each(function() {
+      data["param_" + $(this).attr("name")] = $(this).val();
+    });
+    $.post("@com.keepit.controllers.routes.SearchConfigController.updateExperiment()", data, callback);
+  }
+
+  $(".experiments").on("change", ".experiment-weight", function() {
+    var max = 100;
+    $(".experiment-weight").not(this).each(function() {
+      max -= parseFloat($(this).val()) || 0;
+    });
+    var value = parseFloat($(this).val()) || 0;
+    $(this).val(Math.min(value, max));
+  });
+  $(".experiments").on("click", ".delete-experiment", function() {
+    var $li = $(this).closest("li")
+    var data = {
+      id: +$li.data("id")
+    };
+    $.post("@com.keepit.controllers.routes.SearchConfigController.deleteExperiment()", data, function() {
+      window.location.reload();
+    });
+  });
+  $(".experiments").on("click", ".update-experiment, .pause-experiment, .start-experiment", function() {
+    updateExperiment(this, function() {
+      window.location.reload();
+    });
+  });
+  $(".experiments").on("click", ".show-settings", function() {
+    $(this).closest("li").find(".experiment-settings").toggle();
+  });
+  $("#save-all-experiments").on("click", function() {
+    var updating = 0;
+    $(".experiments").find(".update-experiment").each(function() {
+      updating++;
+      updateExperiment(this, function() {
+        console.log(updating);
+        if (!--updating) window.location.reload();
+      });
+    });
+    $(this).closest("li").find(".experiment-settings").toggle();
+  });
+  $("#add-new-experiment").on("click", function() {
+    $.post("@com.keepit.controllers.routes.SearchConfigController.addNewExperiment()", function() {
+      window.location.reload();
+    });
+  });
+});
+</script>

--- a/shoebox/conf/evolutions/shoebox/39.sql
+++ b/shoebox/conf/evolutions/shoebox/39.sql
@@ -1,0 +1,17 @@
+# --- !Ups
+
+CREATE TABLE search_config_experiment (
+    id bigint(20) NOT NULL AUTO_INCREMENT,
+    description VARCHAR(256) NOT NULL,
+    weight DOUBLE NOT NULL,
+    config TEXT NOT NULL,
+    state VARCHAR(20) NOT NULL,
+    created_at datetime NOT NULL,
+    updated_at datetime NOT NULL,
+    PRIMARY KEY (id),
+    INDEX search_config_experiment_state (state)
+);
+
+insert into evolutions (name, description) values('39.sql', 'adding search experiment tables');
+
+# --- !Downs

--- a/shoebox/conf/routes
+++ b/shoebox/conf/routes
@@ -120,6 +120,10 @@ GET     /admin/messages/:page       com.keepit.controllers.CommentController.mes
 GET     /admin/searchConfig/:id     com.keepit.controllers.SearchConfigController.showUserConfig(id: Id[User])
 POST    /admin/searchConfig/:id/set   com.keepit.controllers.SearchConfigController.setUserConfig(id: Id[User])
 GET     /admin/searchConfig/:id/reset com.keepit.controllers.SearchConfigController.resetUserConfig(id: Id[User])
+GET     /admin/searchExperiments    com.keepit.controllers.SearchConfigController.getExperiments
+POST    /admin/searchExperiments    com.keepit.controllers.SearchConfigController.addNewExperiment
+POST    /admin/searchExperiments/delete    com.keepit.controllers.SearchConfigController.deleteExperiment
+POST    /admin/searchExperiments/update    com.keepit.controllers.SearchConfigController.updateExperiment
 
 GET     /admin/explainResult        com.keepit.controllers.SearchController.explain(query: String, uriId: Id[NormalizedURI])
 

--- a/shoebox/test/com/keepit/search/MainSearcherTest.scala
+++ b/shoebox/test/com/keepit/search/MainSearcherTest.scala
@@ -76,7 +76,7 @@ class MainSearcherTest extends SpecificationWithJUnit with DbRepos {
 
   val source = BookmarkSource("test")
 
-  val defaultConfig = new SearchConfigManager(None).getDefaultConfig
+  val defaultConfig = new SearchConfig(SearchConfig.defaultParams)
   val noBoostConfig = defaultConfig("myBookmarkBoost" -> "1", "sharingBoost" -> "0", "recencyBoost" -> "0", "proximityBoost" -> "0", "semanticBoost" -> "0",
                                    "percentMatch" -> "0", "tailCutting" -> "0", "dumpingByRank" -> "false")
   val allHitsConfig = defaultConfig("tailCutting" -> "0")

--- a/shoebox/test/com/keepit/search/SearchConfigTest.scala
+++ b/shoebox/test/com/keepit/search/SearchConfigTest.scala
@@ -1,0 +1,112 @@
+package com.keepit.search
+
+import com.keepit.common.db.slick.DBConnection
+import com.keepit.inject._
+import com.keepit.model.{UserRepo, User}
+import com.keepit.test.{DbRepos, EmptyApplication}
+import org.specs2.mutable.SpecificationWithJUnit
+import play.api.Play.current
+import play.api.test.Helpers._
+
+class SearchConfigTest extends SpecificationWithJUnit with DbRepos {
+  "The search configuration" should {
+    "load defaults correctly" in {
+      running(new EmptyApplication()) {
+        val searchConfigManager =
+          new SearchConfigManager(None, inject[SearchConfigExperimentRepo], inject[DBConnection])
+        val userRepo = inject[UserRepo]
+        inject[DBConnection].readWrite { implicit s =>
+          val andrew = userRepo.save(User(firstName = "Andrew", lastName = "Connor"))
+          val greg = userRepo.save(User(firstName = "Greg", lastName = "Metvin"))
+          val c1 = searchConfigManager.getConfig(andrew.id.get, "fortytwo")
+          val c2 = searchConfigManager.getConfig(greg.id.get, "fortytwo")
+          c1 === c2
+          c1 === SearchConfig(SearchConfig.defaultParams)
+        }
+      }
+    }
+    "load overrides for experiments" in {
+      running(new EmptyApplication()) {
+        val searchConfigManager =
+          new SearchConfigManager(None, inject[SearchConfigExperimentRepo], inject[DBConnection])
+        val userRepo = inject[UserRepo]
+        inject[DBConnection].readWrite { implicit s =>
+          val andrew = userRepo.save(User(firstName = "Andrew", lastName = "Connor"))
+          val v1 = searchConfigManager.saveExperiment(SearchConfigExperiment(config = Map(
+            "recencyBoost" -> "2.0",
+            "percentMatch" -> "70",
+            "tailCutting" -> "0.30"
+          ), weight = 0.5, state = SearchConfigExperimentStates.ACTIVE))
+          val v2 = searchConfigManager.saveExperiment(SearchConfigExperiment(config = Map(
+            "recencyBoost" -> "1.0",
+            "percentMatch" -> "90",
+            "tailCutting" -> "0.10"
+          ), weight = 0.5, state = SearchConfigExperimentStates.ACTIVE))
+          val c1 = searchConfigManager.getConfig(andrew.id.get, "andrew conner")
+          val c2 = searchConfigManager.getConfig(andrew.id.get, "Andrew  Conner")
+          c1 === c2
+          Seq(70, 90) must contain(c1.asInt("percentMatch"))
+          Seq(2.0, 1.0) must contain(c1.asDouble("recencyBoost"))
+          Seq(0.30, 0.10) must contain(c1.asDouble("tailCutting"))
+
+          c1.asInt("percentMatch") match {
+            case 70 => c1.experimentId.get === v1.id.get
+            case 90 => c2.experimentId.get === v2.id.get
+          }
+        }
+      }
+    }
+    "load correct override based on weights" in {
+      running(new EmptyApplication()) {
+        val searchConfigManager = new SearchConfigManager(None, inject[SearchConfigExperimentRepo], inject[DBConnection])
+        val userRepo = inject[UserRepo]
+        inject[DBConnection].readWrite { implicit s =>
+          val andrew = userRepo.save(User(firstName = "Andrew", lastName = "Connor"))
+          searchConfigManager.saveExperiment(SearchConfigExperiment(config = Map(
+            "recencyBoost" -> "2.0",
+            "percentMatch" -> "70",
+            "tailCutting" -> "0.30"
+          ), weight = 0, state = SearchConfigExperimentStates.ACTIVE))
+          searchConfigManager.saveExperiment(SearchConfigExperiment(config = Map(
+            "recencyBoost" -> "1.0",
+            "percentMatch" -> "90",
+            "tailCutting" -> "0.10"
+          ), weight = 1000, state = SearchConfigExperimentStates.ACTIVE))
+
+          val c1 = searchConfigManager.getConfig(andrew.id.get, "andrew conner")
+          val c2 = searchConfigManager.getConfig(andrew.id.get, "software engineer")
+          val c3 = searchConfigManager.getConfig(andrew.id.get, "fortytwo inc")
+          c1 === c2
+          c1 === c3
+          c1.asDouble("recencyBoost") === 1.0
+          c1.asDouble("percentMatch") === 90
+          c1.asDouble("tailCutting") === 0.1
+        }
+      }
+    }
+    "not get configs from inactive experiments" in {
+      running(new EmptyApplication()) {
+        val searchConfigManager =
+          new SearchConfigManager(None, inject[SearchConfigExperimentRepo], inject[DBConnection])
+        val userRepo = inject[UserRepo]
+        inject[DBConnection].readWrite { implicit s =>
+          val greg = userRepo.save(User(firstName = "Greg", lastName = "Metvin"))
+          val ex = searchConfigManager.saveExperiment(SearchConfigExperiment(config = Map(
+            "percentMatch" -> "700",
+            "phraseBoost" -> "500.0"
+          ), weight = 1, state = SearchConfigExperimentStates.ACTIVE))
+
+          val c1 = searchConfigManager.getConfig(greg.id.get, "turtles")
+          c1.asInt("percentMatch") === 700
+          c1.asDouble("phraseBoost") === 500.0
+
+          searchConfigManager.saveExperiment(ex.withState(SearchConfigExperimentStates.INACTIVE))
+
+          val c2 = searchConfigManager.getConfig(greg.id.get, "turtles")
+          c2.asInt("percentMatch") !== 700
+          c2.asDouble("phraseBoost") !== 500.0
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This lets us configure different search experiments and record which experiment generated the search for a search click event.

Since we don't want to fetch the experiments every time, all operations are done through the SearchConfigManager, which keeps a local cache and reloads experiments only after we save new ones.
