### PR TITLE
show that .get after a failed URI.parse throws URISyntaxException

### DIFF
--- a/shoebox/test/com/keepit/common/net/URITest.scala
+++ b/shoebox/test/com/keepit/common/net/URITest.scala
@@ -59,5 +59,8 @@ class URITest extends Specification {
       }
       success
     }
+    "throw URISyntaxException upon .get after failed parse" in {
+      URI.parse("`").get must throwA[java.net.URISyntaxException]
+    }
   }
 }


### PR DESCRIPTION
This test passes.
