### PR TITLE
Speed up domain import by computing sensitive domains lazily

### DIFF
--- a/shoebox/app/com/keepit/classify/Domain.scala
+++ b/shoebox/app/com/keepit/classify/Domain.scala
@@ -41,6 +41,7 @@ trait DomainRepo extends Repo[Domain] {
       (implicit session: RSession): Seq[Domain]
   def getOverrides(excludeState: Option[State[Domain]] = Some(DomainStates.INACTIVE))
       (implicit session: RSession): Seq[Domain]
+  def updateAutoSensitivity(domainIds: Seq[Id[Domain]], value: Option[Boolean])(implicit session: RSession): Int
 }
 
 @Singleton
@@ -67,6 +68,9 @@ class DomainRepoImpl @Inject()(val db: DataBaseComponent) extends DbRepo[Domain]
   def getOverrides(excludeState: Option[State[Domain]] = Some(DomainStates.INACTIVE))
       (implicit session: RSession): Seq[Domain] =
     (for (d <- table if d.state =!= excludeState.orNull && d.manualSensitive.isNotNull) yield d).list
+
+  def updateAutoSensitivity(domainIds: Seq[Id[Domain]], value: Option[Boolean])(implicit session: RSession): Int =
+    (for (d <- table if d.id.inSet(domainIds)) yield d.autoSensitive).update(value)
 }
 
 object DomainStates extends States[Domain]

--- a/shoebox/app/com/keepit/classify/DomainTagImporter.scala
+++ b/shoebox/app/com/keepit/classify/DomainTagImporter.scala
@@ -163,8 +163,8 @@ private[classify] class DomainTagImportActor(db: Database, updater: SensitivityU
     val startTime = currentDateTime
     val result = value
     db.readWrite { implicit s =>
-      log.debug("Updating sensitivity for changed domains")
-      updater.updateDomainsChangedSince(startTime)
+      log.debug("Clearing sensitivity for changed domains")
+      updater.clearDomainsChangedSince(startTime)
     }
     result
   }

--- a/shoebox/app/com/keepit/classify/SensitivityUpdater.scala
+++ b/shoebox/app/com/keepit/classify/SensitivityUpdater.scala
@@ -2,41 +2,37 @@ package com.keepit.classify
 
 import org.joda.time.DateTime
 
-import com.google.inject.{Inject, ImplementedBy}
+import com.google.inject.{Inject, ImplementedBy, Singleton}
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.DBSession.RWSession
 
 @ImplementedBy(classOf[SensitivityUpdaterImpl])
 trait SensitivityUpdater {
-  def updateSensitivity(domain: Domain)(implicit session: RWSession): Option[Boolean]
-  def updateDomainsChangedSince(dateTime: DateTime)(implicit session: RWSession)
+  def updateSensitivity(domain: Domain)(implicit session: RWSession): Boolean
+  def clearDomainsChangedSince(dateTime: DateTime)(implicit session: RWSession)
+  def clearDomainSensitivity(domains: Seq[Id[Domain]])(implicit session: RWSession)
 }
 
-// TODO(greg): do this stuff with fewer SQL queries (should be able to do it all in SQL)
+@Singleton
 class SensitivityUpdaterImpl @Inject()
     (domainRepo: DomainRepo, tagRepo: DomainTagRepo, domainToTagRepo: DomainToTagRepo) extends SensitivityUpdater {
 
-  def updateSensitivity(domain: Domain)(implicit session: RWSession): Option[Boolean] = {
+  def updateSensitivity(domain: Domain)(implicit session: RWSession): Boolean = {
     val tags = tagRepo.getTags(domainToTagRepo.getByDomain(domain.id.get).map(_.tagId))
-    val sensitive = tags.map(_.sensitive).foldLeft(Some(false): Option[Boolean]) {
-      // if any tags are sensitive, assume the domain is sensitive
-      case (Some(true), _) | (_, Some(true)) => Some(true)
-      // else if any are unknown, assume unknown (could be sensitive)
-      case (None, _) | (_, None) => None
-      // otherwise if all are not sensitive, assume not sensitive
-      case _ => Some(false)
+    val sensitive = tags.map(_.sensitive).foldLeft(false) { _ || _.getOrElse(false) }
+    if (domain.autoSensitive != Some(sensitive)) {
+      domainRepo.updateAutoSensitivity(Seq(domain.id.get), Some(sensitive))
     }
-    if (domain.autoSensitive != sensitive) {
-      domainRepo.save(domain.withAutoSensitive(sensitive)).sensitive
-    } else {
-      domain.sensitive
-    }
+    sensitive
   }
 
-  // update the relationships changed since the given time
-  def updateDomainsChangedSince(dateTime: DateTime)(implicit session: RWSession) {
-    domainToTagRepo.getDomainsChangedSince(dateTime).foreach { domainId: Id[Domain] =>
-      updateSensitivity(domainRepo.get(domainId))
+  // clear the domains since a given time
+  def clearDomainsChangedSince(dateTime: DateTime)(implicit session: RWSession) {
+    clearDomainSensitivity(domainToTagRepo.getDomainsChangedSince(dateTime).toSeq)
+  }
+  def clearDomainSensitivity(domainIds: Seq[Id[Domain]])(implicit session: RWSession) {
+    domainIds.grouped(1000).foreach { domainIds =>
+      domainRepo.updateAutoSensitivity(domainIds.toSeq, None)
     }
   }
 }

--- a/shoebox/app/com/keepit/controllers/UserController.scala
+++ b/shoebox/app/com/keepit/controllers/UserController.scala
@@ -36,9 +36,8 @@ object UserController extends FortyTwoController {
       val neverOnSite: Option[UserToDomain] = domain.flatMap { domain =>
         inject[UserToDomainRepo].get(userId, domain.id.get, UserToDomainKinds.NEVER_SHOW)
       }
-      val sensitive: Option[Boolean] = domain.flatMap(_.sensitive).orElse(
-        host.flatMap(inject[DomainClassifier].isSensitive(_).right.getOrElse(None)))
-
+      val sensitive: Option[Boolean] =
+        domain.flatMap(_.sensitive).orElse(host.flatMap(inject[DomainClassifier].isSensitive(_).right.toOption))
 
       nUri match {
         case Some(uri) =>

--- a/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
@@ -48,7 +48,8 @@ class ExtBookmarksController @Inject() (db: Database, bookmarkManager: BookmarkI
       val neverOnSite: Option[UserToDomain] = domain.flatMap { dom =>
         userToDomainRepo.get(userId, dom.id.get, UserToDomainKinds.NEVER_SHOW)
       }
-      val sensitive: Option[Boolean] = domain.flatMap(_.sensitive).orElse(host.flatMap(classifier.isSensitive(_).right.getOrElse(None)))
+      val sensitive: Option[Boolean] =
+        domain.flatMap(_.sensitive).orElse(host.flatMap(classifier.isSensitive(_).right.toOption))
 
       val bookmark: Option[Bookmark] = uriId.flatMap { uriId =>
         bookmarkRepo.getByUriAndUser(uriId, userId)

--- a/shoebox/test/com/keepit/classify/DomainClassifierTest.scala
+++ b/shoebox/test/com/keepit/classify/DomainClassifierTest.scala
@@ -3,9 +3,9 @@ package com.keepit.classify
 import org.joda.time.DateTime
 import org.specs2.mutable.SpecificationWithJUnit
 
-import com.keepit.common.analytics.{FakePersistEventPluginImpl, PersistEventPlugin}
+import com.keepit.common.analytics.FakePersistEventPluginImpl
 import com.keepit.common.db.slick.Database
-import com.keepit.common.net.{HttpClientImpl, FakeHttpClient}
+import com.keepit.common.net.FakeHttpClient
 import com.keepit.inject.{provide, inject}
 import com.keepit.test.{DbRepos, EmptyApplication}
 
@@ -14,7 +14,6 @@ import scala.concurrent.Await
 import play.api.Play.current
 import play.api.test.Helpers.running
 
-import play.api.libs.concurrent.Execution.Implicits._
 import scala.concurrent.duration._
 import java.util.concurrent.TimeUnit
 
@@ -46,10 +45,10 @@ class DomainClassifierTest extends SpecificationWithJUnit with DbRepos {
           ).foreach { Await.result(_, pairIntToDuration(100, TimeUnit.SECONDS) ) }
         }
 
-        classifier.isSensitive("google.com") === Right(Some(false))
-        classifier.isSensitive("yahoo.com") === Right(Some(false))
-        classifier.isSensitive("42go.com") === Right(Some(false))
-        classifier.isSensitive("playboy.com") === Right(Some(true))
+        classifier.isSensitive("google.com") === Right(false)
+        classifier.isSensitive("yahoo.com") === Right(false)
+        classifier.isSensitive("42go.com") === Right(false)
+        classifier.isSensitive("playboy.com") === Right(true)
       }
     }
     "fetch if necessary" in {
@@ -76,7 +75,7 @@ class DomainClassifierTest extends SpecificationWithJUnit with DbRepos {
           domainRepo.save(Domain(hostname = "google.com", manualSensitive = Some(false)))
         }
 
-        classifier.isSensitive("google.com") === Right(Some(false))
+        classifier.isSensitive("google.com") === Right(false)
 
         Seq(
           classifier.isSensitive("yahoo.com").left.get,
@@ -91,14 +90,14 @@ class DomainClassifierTest extends SpecificationWithJUnit with DbRepos {
           Await.result(future, pairIntToDuration(100, TimeUnit.MILLISECONDS))
         }
 
-        classifier.isSensitive("yahoo.com") === Right(Some(false))
-        classifier.isSensitive("zdnet.com") === Right(None)
-        classifier.isSensitive("schwab.com") === Right(Some(true))
-        classifier.isSensitive("hover.com") === Right(None)
-        classifier.isSensitive("42go.com") === Right(Some(false))
-        classifier.isSensitive("addepar.com") === Right(Some(false))
-        classifier.isSensitive("playboy.com") === Right(Some(true))
-        classifier.isSensitive("porn.com") === Right(Some(true))
+        classifier.isSensitive("yahoo.com") === Right(false)
+        classifier.isSensitive("zdnet.com") === Right(false)
+        classifier.isSensitive("schwab.com") === Right(true)
+        classifier.isSensitive("hover.com") === Right(false)
+        classifier.isSensitive("42go.com") === Right(false)
+        classifier.isSensitive("addepar.com") === Right(false)
+        classifier.isSensitive("playboy.com") === Right(true)
+        classifier.isSensitive("porn.com") === Right(true)
       }
     }
   }


### PR DESCRIPTION
Since our users may not actually visit most of the domains we know
about, we can wait until a user actually visits a domain before we
calculate the sensitivity for it.

I also simplified DomainClassifier#isSensitive to always give either a
true or false value for the domain, since the client wants a
true/false value.
