### PR TITLE
only supporting server-based authorities in URIs

### DIFF
--- a/shoebox/app/com/keepit/common/net/URI.scala
+++ b/shoebox/app/com/keepit/common/net/URI.scala
@@ -27,11 +27,11 @@ object URI extends Logging {
   }
   def unapplyTry(uriString: String): Try[(Option[String], Option[String], Option[Host], Int, Option[String], Option[Query], Option[String])] = Try {
     val uri = try {
-      new java.net.URI(uriString).normalize()
+      new java.net.URI(uriString).parseServerAuthority().normalize()
     } catch {
       case e: java.net.URISyntaxException =>
         val fixedUriString = encodeExtraDelimiters(encodeSymbols(fixMalformedEscape(uriString)))
-        new java.net.URI(fixedUriString).normalize()
+        new java.net.URI(fixedUriString).parseServerAuthority().normalize()
     }
     val scheme = normalizeScheme(Option(uri.getScheme))
     val userInfo = Option(uri.getUserInfo)

--- a/shoebox/test/com/keepit/common/net/URITest.scala
+++ b/shoebox/test/com/keepit/common/net/URITest.scala
@@ -65,7 +65,8 @@ class URITest extends Specification {
       success
     }
     "throw URISyntaxException upon .get after failed parse" in {
-      URI.parse("http:\\test").get must throwA[java.net.URISyntaxException]
+      URI.parse("http:\\\\host").get must throwA[java.net.URISyntaxException]
+      URI.parse("http://bad+host").get must throwA[java.net.URISyntaxException]
     }
   }
 }


### PR DESCRIPTION
Not supporting registry-based authorities.

This avoids the weird situation where a string will parse into a `java.net.URI` with `.isAbsolute()` returning `true` and `.getHost()` returning `null`.

See http://docs.oracle.com/javase/7/docs/api/java/net/URI.html#parseServerAuthority().
