### PR TITLE
v2.2.4 minor filtering bug fixes

### DIFF
--- a/packrat/adapters/chrome/manifest.json
+++ b/packrat/adapters/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Kifi Beta",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "manifest_version": 2,
   "description": "Keep it, Find it!",
   "icons": {

--- a/packrat/adapters/firefox/package.json
+++ b/packrat/adapters/firefox/package.json
@@ -3,7 +3,7 @@
     "license": "MPL 2.0",
     "author": "FortyTwo Inc.",
     "homepage": "http://www.keepitfindit.com/",
-    "version": "2.2.3",
+    "version": "2.2.4",
     "fullName": "Keep It, Find It!",
     "id": "kifi@42go.com",
     "icon": "data/icons/kifi.48.png",

--- a/packrat/html/search/google.html
+++ b/packrat/html/search/google.html
@@ -1,6 +1,10 @@
 <div id="kifi-res">
   <div style="position:relative">
-    <h3 class="kifi-res-title r">KiFi Trusted Results<span class="kifi-res-title-arrow">&raquo;</span></h3>
+    <h3 class="kifi-res-title r">
+      KiFi Trusted Results{{!
+    }}<a class="kifi-res-debug" href="javascript:" target="_blank">debug</a>{{!
+    }}<span class="kifi-res-title-arrow">&raquo;</span>
+    </h3>
     <a class="kifi-res-filter-keeps" href="javascript:">Filter Keeps</a>
   </div>
   <menu class="kifi-res-filters">
@@ -14,5 +18,4 @@
     <input type="text" class="kifi-res-filter-cust" id="kifi-res-filter-cust" placeholder="Type a friend’s name">
     <span class="kifi-res-filter-custom-x">&times;</span>
   </div>
-  {{>google_hits}}
 </div>

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -339,7 +339,7 @@ function searchOnServer(request, respond) {
   var config = getConfigs();
   ajax("GET", "http://" + config.server + "/search", {
       q: request.query,
-      f: request.filter === "a" ? undefined : request.filter,
+      f: request.filter === "a" ? null : request.filter,
       maxHits: request.lastUUID ? 5 : api.prefs.get("maxResults"),
       lastUUID: request.lastUUID,
       context: request.context,

--- a/packrat/styles/google_inject.css
+++ b/packrat/styles/google_inject.css
@@ -350,9 +350,14 @@ div.token-input-dropdown-googly ul li.token-input-selected-dropdown-item-googly 
   transform: rotate(90deg) scale(1,1.2);
 }
 
+.kifi-debug .kifi-res-debug {
+  display: inline-block;
+}
 .kifi-res-debug {
-  float: left;
-  margin: 4px 0 0 10px;
+  display: none;
+  width: 0;
+  position: relative;
+  left: 6px;
   font-size: 8px;
   opacity: .3;
   text-decoration: none;


### PR DESCRIPTION
The main innovation here is that we keep a reference to our KiFi results DOM node, and when Google overwrites it, we just reattach it. This way we don't have to re-render, re-bind event listeners, etc.

Should fix double-rendering of KiFi results and occasional rendering of "no results" message when no filter was explicitly chosen.
