### PR TITLE
v2.2.5: truthify

### DIFF
--- a/packrat/adapters/chrome/manifest.json
+++ b/packrat/adapters/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Kifi Beta",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "manifest_version": 2,
   "description": "Keep it, Find it!",
   "icons": {

--- a/packrat/adapters/firefox/package.json
+++ b/packrat/adapters/firefox/package.json
@@ -3,7 +3,7 @@
     "license": "MPL 2.0",
     "author": "FortyTwo Inc.",
     "homepage": "http://www.keepitfindit.com/",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "fullName": "Keep It, Find It!",
     "id": "kifi@42go.com",
     "icon": "data/icons/kifi.48.png",

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -339,7 +339,7 @@ api.log("[google_inject]");
       mayHaveMore: response.mayHaveMore};
 
     $res.append(Mustache.to_html(hitsHtml, params, {google_hit: hitHtml}))
-      .toggleClass("kifi-debug", response.showScores);
+      .toggleClass("kifi-debug", !!response.showScores);
 
     api.log("[appendResults] done");
   }


### PR DESCRIPTION
to make sure "debug" link is hidden when it should be
