### PR TITLE
index keywords in the url

### DIFF
--- a/shoebox/app/com/keepit/search/MainQueryParserFactory.scala
+++ b/shoebox/app/com/keepit/search/MainQueryParserFactory.scala
@@ -7,9 +7,11 @@ import com.keepit.inject._
 
 @Singleton
 class MainQueryParserFactory @Inject() (phraseDetector: PhraseDetector) {
-  def apply(lang: Lang, proximityBoost: Float = 0.0f, semanticBoost: Float = 0.0f, phraseBoost: Float = 0.0f): MainQueryParser = {
+  def apply(lang: Lang, proximityBoost: Float = 0.0f, semanticBoost: Float = 0.0f, phraseBoost: Float = 0.0f,
+      siteBoost: Float = 0.0f): MainQueryParser = {
     val total = 1.0f + proximityBoost + semanticBoost
-    val parser = new MainQueryParser(DefaultAnalyzer.forParsing(lang), 1.0f/total, proximityBoost/total, semanticBoost/total, phraseBoost, phraseDetector)
+    val parser = new MainQueryParser(DefaultAnalyzer.forParsing(lang), 1.0f/total, proximityBoost/total,
+      semanticBoost/total, phraseBoost, siteBoost, phraseDetector)
     DefaultAnalyzer.forParsingWithStemmer(lang).foreach{ parser.setStemmingAnalyzer(_) }
     parser
   }

--- a/shoebox/app/com/keepit/search/MainSearcher.scala
+++ b/shoebox/app/com/keepit/search/MainSearcher.scala
@@ -49,6 +49,7 @@ class MainSearcher(
   val similarity = Similarity(config.asString("similarity"))
   val enableCoordinator = config.asBoolean("enableCoordinator")
   val phraseBoost = config.asFloat("phraseBoost")
+  val siteBoost = config.asFloat("siteBoost")
 
   // following config params are enabled only when the default filter is in use
   val minMyBookmarks = if (filter.isDefault) config.asInt("minMyBookmarks") else 0
@@ -85,7 +86,7 @@ class MainSearcher(
     val friendsHits = createQueue(maxTextHitsPerCategory)
     val othersHits = createQueue(maxTextHitsPerCategory)
 
-    val parser = parserFactory(lang, proximityBoost, semanticBoost, phraseBoost)
+    val parser = parserFactory(lang, proximityBoost, semanticBoost, phraseBoost, siteBoost)
     parser.setPercentMatch(percentMatch)
     parser.enableCoord = enableCoordinator
     parser.parseQuery(queryString).map{ articleQuery =>
@@ -219,7 +220,7 @@ class MainSearcher(
 
   def explain(queryString: String, uriId: Id[NormalizedURI]): Option[(Query, Explanation)] = {
     val lang = Lang("en") // TODO: detect
-    val parser = parserFactory(lang, proximityBoost, semanticBoost, phraseBoost)
+    val parser = parserFactory(lang, proximityBoost, semanticBoost, phraseBoost, siteBoost)
     parser.setPercentMatch(percentMatch)
     parser.enableCoord = enableCoordinator
 

--- a/shoebox/app/com/keepit/search/SearchConfig.scala
+++ b/shoebox/app/com/keepit/search/SearchConfig.scala
@@ -15,6 +15,7 @@ object SearchConfig {
   private[search] val defaultParams =
     Map[String, String](
       "phraseBoost" -> "0.0",
+      "siteBoost" -> "2.0",
       "enableCoordinator" -> "true",
       "similarity" -> "default",
       "svWeightMyBookMarks" -> "1",
@@ -39,6 +40,7 @@ object SearchConfig {
   private[this] val descriptions =
     Map[String, String](
       "phraseBoost" -> "boost value for the detected phrase",
+      "siteBoost" -> "boost value for matching website names and domains",
       "enableCoordinator" -> "enables the IDF based coordinator",
       "similarity" -> "similarity characteristics",
       "svWeightMyBookMarks" -> "semantics vector weight for my bookmarks",

--- a/shoebox/app/com/keepit/search/index/ArticleIndexer.scala
+++ b/shoebox/app/com/keepit/search/index/ArticleIndexer.scala
@@ -123,6 +123,7 @@ class ArticleIndexer(indexDirectory: Directory, indexWriterConfig: IndexWriterCo
           URI.parse(uri.url).toOption.flatMap(_.host) match {
             case Some(Host(domain @ _*)) =>
               doc.add(buildIteratorField("site", (1 to domain.size).iterator){ n => domain.take(n).reverse.mkString(".") })
+              doc.add(buildIteratorField("site_keywords", (0 until domain.size).iterator)(domain))
             case _ =>
           }
 


### PR DESCRIPTION
@ymatsuda 

This lets us search domain names by splitting the domain into keywords and searching a field, "site_keywords" in Lucene. We use the siteBoost parameter to weight that query.

In addition, if a keyword looks like a domain name, we search the "site" field.

I'm not sure if this is fully mergeable right now, but I wanted to get some feedback.
