### PR TITLE
Mutli-client enumerator and iteratee framework

### DIFF
--- a/shoebox/app/com/keepit/common/db/slick/FortyTwoTypeMappers.scala
+++ b/shoebox/app/com/keepit/common/db/slick/FortyTwoTypeMappers.scala
@@ -3,11 +3,8 @@ package com.keepit.common.db.slick
 import scala.slick.driver._
 import scala.slick.lifted.{BaseTypeMapper, TypeMapperDelegate}
 import scala.slick.session.{PositionedParameters, PositionedResult}
-
 import java.sql.{Timestamp, Clob, Blob}
-
 import org.joda.time.DateTime
-
 import com.keepit.classify.{DomainTagName, DomainTag, Domain, DomainToTag}
 import com.keepit.common.db.{Id, State, Model, ExternalId, LargeString}
 import com.keepit.common.mail._
@@ -16,10 +13,10 @@ import com.keepit.common.time._
 import com.keepit.model._
 import com.keepit.search._
 import com.keepit.serializer.{URLHistorySerializer => URLHS, SocialUserSerializer}
-
 import javax.sql.rowset.serial.{SerialBlob, SerialClob}
 import play.api.libs.json._
 import securesocial.core.{SocialUser, UserId, AuthenticationMethod}
+import com.keepit.model.UserNotificationCategory
 
 object FortyTwoTypeMappers {
   // Time
@@ -42,6 +39,10 @@ object FortyTwoTypeMappers {
 
   implicit object NormalizedURIExternalIdTypeMapper extends BaseTypeMapper[ExternalId[NormalizedURI]] {
     def apply(profile: BasicProfile) = new ExternalIdMapperDelegate[NormalizedURI](profile)
+  }
+
+  implicit object UserNotificationExternalIdTypeMapper extends BaseTypeMapper[ExternalId[UserNotification]] {
+    def apply(profile: BasicProfile) = new ExternalIdMapperDelegate[UserNotification](profile)
   }
 
   //Ids
@@ -89,6 +90,10 @@ object FortyTwoTypeMappers {
     def apply(profile: BasicProfile) = new IdMapperDelegate[SearchConfigExperiment](profile)
   }
 
+  implicit object UserNotificationIdTypeMapper extends BaseTypeMapper[Id[UserNotification]] {
+    def apply(profile: BasicProfile) = new IdMapperDelegate[UserNotification](profile)
+  }
+
   //States
   implicit object NormalizedURIStateTypeMapper extends BaseTypeMapper[State[NormalizedURI]] {
     def apply(profile: BasicProfile) = new StateMapperDelegate[NormalizedURI](profile)
@@ -116,6 +121,10 @@ object FortyTwoTypeMappers {
 
   implicit object UserToDomainKindTypeMapper extends BaseTypeMapper[State[UserToDomainKind]] {
     def apply(profile: BasicProfile) = new StateMapperDelegate[UserToDomainKind](profile)
+  }
+
+  implicit object UserNotificationStateMapper extends BaseTypeMapper[State[UserNotification]] {
+    def apply(profile: BasicProfile) = new StateMapperDelegate[UserNotification](profile)
   }
 
   //Other
@@ -193,6 +202,14 @@ object FortyTwoTypeMappers {
 
   implicit object LangTypeMapper extends BaseTypeMapper[Lang] {
     def apply(profile: BasicProfile) = new LangMapperDelegate(profile)
+  }
+
+  implicit object UserNotificationCategoryTypeMapper extends BaseTypeMapper[UserNotificationCategory] {
+    def apply(profile: BasicProfile) = new UserNotificationCategoryMapperDelegate(profile)
+  }
+
+  implicit object UserNotificationDetailsTypeMapper extends BaseTypeMapper[UserNotificationDetails] {
+    def apply(profile: BasicProfile) = new UserNotificationDetailsMapperDelegate(profile)
   }
 }
 
@@ -456,5 +473,23 @@ class LangMapperDelegate(profile: BasicProfile) extends StringMapperDelegate[Lan
   def zero = Lang("")
   def sourceToDest(value: Lang) = value.lang
   def safeDestToSource(str: String) = Lang(str)
+}
+
+//************************************
+//       UserNotificationCategory -> String
+//************************************
+class UserNotificationCategoryMapperDelegate(profile: BasicProfile) extends StringMapperDelegate[UserNotificationCategory](profile) {
+  def zero = UserNotificationCategory("")
+  def sourceToDest(value: UserNotificationCategory) = value.name
+  def safeDestToSource(str: String) = UserNotificationCategory(str)
+}
+
+//************************************
+//       UserNotificationDetails -> String
+//************************************
+class UserNotificationDetailsMapperDelegate(profile: BasicProfile) extends StringMapperDelegate[UserNotificationDetails](profile) {
+  def zero = UserNotificationDetails(Json.obj())
+  def sourceToDest(value: UserNotificationDetails) = Json.stringify(value.payload)
+  def safeDestToSource(str: String) = UserNotificationDetails(Json.parse(str).asInstanceOf[JsObject])
 }
 

--- a/shoebox/app/com/keepit/controllers/StreamController.scala
+++ b/shoebox/app/com/keepit/controllers/StreamController.scala
@@ -6,16 +6,80 @@ import play.api.libs.json._
 import play.api.mvc.Controller
 import com.keepit.inject._
 import com.keepit.common.controller.FortyTwoController
-import com.keepit.realtime.StreamManager
+import com.keepit.realtime._
+import play.api.Play.current
+import play.api.libs.iteratee._
+import play.api.libs.concurrent._
+import com.keepit.common.db._
+import com.keepit.model.User
+import play.api.libs.concurrent.Execution.Implicits._
+import scala.concurrent.duration._
+import com.google.inject.{Inject, Singleton, ImplementedBy}
+import securesocial.core.SecureSocial
+import securesocial.core.UserService
+import securesocial.core.UserId
+import com.keepit.model.KifiInstallation
+import com.keepit.common.controller.FortyTwoController._
+import com.keepit.common.social.SocialId
+import com.keepit.model._
+import com.keepit.common.db._
+import com.keepit.common.social.SocialNetworks
+import com.keepit.common.db.slick.Database
+import play.api.mvc.RequestHeader
 
-class StreamController extends FortyTwoController {
+case class StreamSession(userId: Id[User], socialUser: SocialUserInfo, experiments: Seq[State[ExperimentType]], adminUserId: Option[Id[User]])
 
-//  def ws() = WebSocket.async[JsValue] { implicit request  =>
-//    inject[StreamManager
-//  }
+@Singleton
+class StreamController @Inject() (db: Database, socialUserInfoRepo: SocialUserInfoRepo, userRepo: UserRepo, experimentRepo: UserExperimentRepo, streamManager: StreamManager, streams: Streams) extends FortyTwoController {
+  private def secureRequestHeader(request: RequestHeader): Option[StreamSession] = {
+    /*
+     * Unfortunately, everything related to existing secured actions intimately deals with Action, Request, Result, etc.
+     * WebSockets cannot use these, so I've implemented what I need below.
+     */
+    for (
+      userId <- request.session.get(SecureSocial.UserKey);
+      providerId <- request.session.get(SecureSocial.ProviderKey);
+      secSocialUser <- UserService.find(UserId(userId, providerId))
+    ) yield {
+      //val userIdOpt = request.session.get(FORTYTWO_USER_ID).map{id => Id[User](id.toLong)}
+      val impersonatedUserIdOpt: Option[ExternalId[User]] = ImpersonateCookie.decodeFromCookie(request.cookies.get(ImpersonateCookie.COOKIE_NAME))
 
-  def giveMeA200 = Action { request =>
-    Ok("You got it!")
+      db.readOnly { implicit session =>
+        val socialUser = socialUserInfoRepo.get(SocialId(secSocialUser.id.id), SocialNetworks.FACEBOOK)
+        val userId = socialUser.userId.get
+        val experiments = experimentRepo.getByUser(userId).map(_.experimentType)
+        impersonatedUserIdOpt match {
+          case Some(impExtUserId) if experiments.find(e => e == ExperimentTypes.ADMIN).isDefined =>
+            val impUserId =  userRepo.get(impExtUserId).id.get
+            val impSocUserInfo = socialUserInfoRepo.getByUser(impUserId)
+            StreamSession(impUserId, impSocUserInfo.head, experiments, Some(userId))
+          case _ =>
+            StreamSession(userId, socialUser, experiments, None)
+        }
+      }
+    }
+  }
+
+  def ws() = WebSocket.using[JsValue] { implicit request  =>
+    secureRequestHeader(request) match {
+      case Some(streamSession) =>
+        val enumerator = streamManager.connect(streamSession.userId) >- streams.welcome(streamSession.userId) >- streams.unreadNotifications(streamSession.userId)
+        val iteratee = Iteratee.foreach[JsValue]{ s =>
+          println(s)
+        }.mapDone { _ =>
+          log.info(s"Client ${streamSession.userId} disconnecting!")
+          inject[StreamManager].disconnect(streamSession.userId)
+        }
+
+        (iteratee, enumerator)
+
+      case None =>
+        log.info(s"Anonymous user trying to connect. Disconnecting!")
+        val enumerator: Enumerator[JsValue] = Enumerator(Json.obj("error" -> "Permission denied. Are you logged in? Connect again to re-authenticate."))
+        val iteratee = Iteratee.foreach[JsValue]{ s=> /* sink */}
+
+        (iteratee, enumerator >>> Enumerator.eof)
+    }
   }
 
 }

--- a/shoebox/app/com/keepit/controllers/StreamController.scala
+++ b/shoebox/app/com/keepit/controllers/StreamController.scala
@@ -1,0 +1,21 @@
+package com.keepit.controllers
+
+import play.api.mvc.Action
+import play.api.mvc.WebSocket
+import play.api.libs.json._
+import play.api.mvc.Controller
+import com.keepit.inject._
+import com.keepit.common.controller.FortyTwoController
+import com.keepit.realtime.StreamManager
+
+class StreamController extends FortyTwoController {
+
+//  def ws() = WebSocket.async[JsValue] { implicit request  =>
+//    inject[StreamManager
+//  }
+
+  def giveMeA200 = Action { request =>
+    Ok("You got it!")
+  }
+
+}

--- a/shoebox/app/com/keepit/model/UserNotification.scala
+++ b/shoebox/app/com/keepit/model/UserNotification.scala
@@ -49,7 +49,7 @@ class UserNotificationRepoImpl @Inject() (val db: DataBaseComponent) extends DbR
     def * = id.? ~ createdAt ~ updatedAt ~ userId ~ externalId ~ category ~ details ~ commentId.? ~ state <> (UserNotification, UserNotification.unapply _)
   }
 
-  def getWithUserId(userId: Id[User], howMany: Option[Int], excludeState: Option[State[UserNotification]] = Some(UserNotificationStates.INACTIVE))(implicit session: RSession): Seq[UserNotification] = {
+  def getWithUserId(userId: Id[User], startingTime: DateTime, howMany: Option[Int], excludeState: Option[State[UserNotification]] = Some(UserNotificationStates.INACTIVE))(implicit session: RSession): Seq[UserNotification] = {
 
     Nil
   }

--- a/shoebox/app/com/keepit/model/UserNotification.scala
+++ b/shoebox/app/com/keepit/model/UserNotification.scala
@@ -1,0 +1,76 @@
+package com.keepit.model
+
+import com.google.inject.{ Inject, ImplementedBy, Singleton }
+import com.keepit.common.db._
+import com.keepit.common.db.slick._
+import com.keepit.common.db.slick.DBSession._
+import com.keepit.common.time._
+import org.joda.time.DateTime
+import com.keepit.search.Lang
+import scala.slick.util.CloseableIterator
+import play.api.libs.json.JsObject
+import com.keepit.common.logging.Logging
+
+case class UserNotificationDetails(payload: JsObject)
+
+case class UserNotification(
+  id: Option[Id[UserNotification]] = None,
+  createdAt: DateTime = currentDateTime,
+  updatedAt: DateTime = currentDateTime,
+  userId: Id[User],
+  externalId: ExternalId[UserNotification],
+  category: UserNotificationCategory,
+  details: UserNotificationDetails,
+  commentId: Option[Id[Comment]],
+  state: State[UserNotification] = UserNotificationStates.UNDELIVERED) extends ModelWithExternalId[UserNotification] {
+  def withId(id: Id[UserNotification]): UserNotification = copy(id = Some(id))
+  def withUpdateTime(now: DateTime): UserNotification = this.copy(updatedAt = now)
+  def isActive: Boolean = state != UserNotificationStates.INACTIVE
+  def withState(state: State[UserNotification]): UserNotification = copy(state = state)
+}
+
+@ImplementedBy(classOf[UserNotificationRepoImpl])
+trait UserNotificationRepo extends Repo[UserNotification] with ExternalIdColumnFunction[UserNotification]  {
+  def getWithUserId(userId: Id[User], howMany: Option[Int], excludeState: Option[State[UserNotification]] = Some(UserNotificationStates.INACTIVE))(implicit session: RSession): Seq[UserNotification]
+  def getWithCommentId(userId: Id[User], commentId: Id[Comment])(implicit session: RSession): Seq[UserNotification]
+}
+
+@Singleton
+class UserNotificationRepoImpl @Inject() (val db: DataBaseComponent) extends DbRepo[UserNotification] with UserNotificationRepo with ExternalIdColumnDbFunction[UserNotification] with Logging {
+  import db.Driver.Implicit._
+  import DBSession._
+  import FortyTwoTypeMappers._
+
+  override lazy val table = new RepoTable[UserNotification](db, "phrase") with ExternalIdColumn[UserNotification] {
+    def userId = column[Id[User]]("user_id", O.NotNull)
+    def category = column[UserNotificationCategory]("category", O.NotNull)
+    def details = column[UserNotificationDetails]("details", O.NotNull)
+    def commentId = column[Id[Comment]]("comment_id", O.Nullable)
+    def * = id.? ~ createdAt ~ updatedAt ~ userId ~ externalId ~ category ~ details ~ commentId.? ~ state <> (UserNotification, UserNotification.unapply _)
+  }
+
+  def getWithUserId(userId: Id[User], howMany: Option[Int], excludeState: Option[State[UserNotification]] = Some(UserNotificationStates.INACTIVE))(implicit session: RSession): Seq[UserNotification] = {
+
+    Nil
+  }
+
+  def getWithCommentId(userId: Id[User], commentId: Id[Comment])(implicit session: RSession): Seq[UserNotification] = {
+    Nil
+  }
+}
+
+object UserNotificationStates {
+  val INACTIVE = State[UserNotification]("inactive")
+  val UNDELIVERED = State[UserNotification]("undelivered")
+  val DELIVERED = State[UserNotification]("delivered")
+  val VISITED = State[UserNotification]("visited")
+}
+
+case class UserNotificationCategory(val name: String)
+
+object UserNotificationCategories {
+  val COMMENT =  UserNotificationCategory("comment")
+  val GLOBAL = UserNotificationCategory("global")
+}
+
+

--- a/shoebox/app/com/keepit/realtime/ClientStream.scala
+++ b/shoebox/app/com/keepit/realtime/ClientStream.scala
@@ -1,0 +1,63 @@
+package com.keepit.realtime
+
+import akka.actor._
+import scala.concurrent.duration._
+
+import play.api._
+import play.api.libs.json._
+import play.api.libs.iteratee._
+import play.api.libs.concurrent._
+
+import akka.util.Timeout
+import akka.pattern.ask
+
+import play.api.Play.current
+import play.api.libs.concurrent.Execution.Implicits._
+import com.keepit.common.akka.FortyTwoActor
+import scala.concurrent.Future
+import com.keepit.serializer.EventSerializer
+import com.google.inject.{Inject, Singleton, ImplementedBy}
+import com.keepit.model._
+import com.keepit.common.time._
+import org.joda.time.DateTime
+import com.keepit.inject._
+import com.keepit.common.db.slick.Database
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.concurrent.{Map => ConcurrentMap}
+import com.keepit.common.db._
+
+trait ClientStreamLike[T] {
+  def connect(): Enumerator[T]
+  def disconnect(): Unit
+  def push(msg: T): Unit
+  def close(): Unit
+  def hasListeners: Boolean
+  def getConnectionCount: Int
+}
+
+case class ClientStream[T](userId: Id[User]) extends ClientStreamLike[T] {
+  private var connections = new AtomicInteger(0)
+
+  val (enumerator, channel) = Concurrent.broadcast[T]
+
+  def connect(): Enumerator[T] = {
+    connections.incrementAndGet()
+    enumerator
+  }
+
+  def disconnect(): Unit = {
+    connections.decrementAndGet()
+  }
+
+  def push(json: T): Unit = channel.push(json)
+  def close() {
+    connections.set(0)
+    channel.eofAndEnd()
+  }
+  def hasListeners: Boolean = getConnectionCount == 0
+
+  def getConnectionCount: Int = connections.get
+
+}
+

--- a/shoebox/app/com/keepit/realtime/StreamManager.scala
+++ b/shoebox/app/com/keepit/realtime/StreamManager.scala
@@ -12,7 +12,7 @@ import akka.actor.ActorSystem
 
 trait StreamManager[T, S] {
   def connect(identifier: T): Enumerator[S]
-  def clientIsConnected: Boolean
+  def clientIsConnected(clientIdentifier: T): Boolean
   def disconnect(identifier: T): Unit
   def disconnectAll(identifier: T): Unit
   def push(idenifier: T, msg: S): Unit

--- a/shoebox/app/com/keepit/realtime/StreamManager.scala
+++ b/shoebox/app/com/keepit/realtime/StreamManager.scala
@@ -1,43 +1,58 @@
 package com.keepit.realtime
 
 import java.util.concurrent.ConcurrentHashMap
-
 import com.keepit.common.db.Id
 import com.keepit.model.User
-
 import play.api.libs.iteratee.Enumerator
-import play.api.libs.json.JsObject
+import play.api.libs.json.{JsObject, JsValue}
 import com.google.inject.{Inject, Singleton, ImplementedBy}
+import com.keepit.common.logging.Logging
 
 @Singleton
-class StreamManager {
+class StreamManager extends Logging {
   type Message = JsObject
 
-  private var clients = new collection.mutable.HashMap[Id[User], ClientStreamLike[JsObject]]()
+  private var clients = new ConcurrentHashMap[Id[User], ClientStreamLike[JsValue]]()
 
-  def connect(userId: Id[User]): Enumerator[JsObject] = {
-    println(s"Client $userId connecting.")
-    val clientStream = clients.get(userId).getOrElse {
-      println(s"Client $userId doesn't exist. Creating.")
-      ClientStream[JsObject](userId)
+  def connect(userId: Id[User]): Enumerator[JsValue] = {
+    log.info(s"Client $userId connecting.")
+    val clientStream = Option(clients.get(userId)).getOrElse {
+      log.info(s"Client $userId doesn't exist. Creating.")
+      val stream = new ClientStream[JsValue](userId)
+      clients.put(userId, stream)
+      stream
     }
     clientStream.connect
   }
 
   def disconnect(userId: Id[User]) {
-    clients.get(userId).map { client =>
+    Option(clients.get(userId)).map { client =>
       client.disconnect()
       if(!client.hasListeners) {
         client.close()
         clients.remove(userId)
+        log.info(s"Client $userId disconnected.")
       }
     }
   }
 
+  def disconnectAll(userId: Id[User]) {
+    Option(clients.get(userId)).map { client =>
+      client.close()
+      clients.remove(userId)
+      log.info(s"Client $userId disconnected.")
+    }
+  }
+
   def push(userId: Id[User], msg: JsObject) {
-    println(s"Pushing for $userId")
-    clients.get(userId).map{ client =>
-      println("PUSHED!")
+    Option(clients.get(userId)).map { client =>
+      client.push(msg)
+    }
+  }
+
+  def pushAll(msg: JsObject) {
+    import scala.collection.JavaConversions.mapAsScalaConcurrentMap
+    for((_, client) <- clients) {
       client.push(msg)
     }
   }

--- a/shoebox/app/com/keepit/realtime/StreamManager.scala
+++ b/shoebox/app/com/keepit/realtime/StreamManager.scala
@@ -11,10 +11,10 @@ import com.keepit.common.db.slick.Database
 import akka.actor.ActorSystem
 
 trait StreamManager[T, S] {
-  def connect(identifier: T): Enumerator[T]
+  def connect(identifier: T): Enumerator[S]
   def clientIsConnected: Boolean
   def disconnect(identifier: T): Unit
-  def disconnectAll(): Unit
+  def disconnectAll(identifier: T): Unit
   def push(idenifier: T, msg: S): Unit
   def pushAll(msg: S): Unit
 }

--- a/shoebox/app/com/keepit/realtime/StreamManager.scala
+++ b/shoebox/app/com/keepit/realtime/StreamManager.scala
@@ -1,0 +1,44 @@
+package com.keepit.realtime
+
+import java.util.concurrent.ConcurrentHashMap
+
+import com.keepit.common.db.Id
+import com.keepit.model.User
+
+import play.api.libs.iteratee.Enumerator
+import play.api.libs.json.JsObject
+import com.google.inject.{Inject, Singleton, ImplementedBy}
+
+@Singleton
+class StreamManager {
+  type Message = JsObject
+
+  private var clients = new collection.mutable.HashMap[Id[User], ClientStreamLike[JsObject]]()
+
+  def connect(userId: Id[User]): Enumerator[JsObject] = {
+    println(s"Client $userId connecting.")
+    val clientStream = Option(clients.get(userId)).getOrElse {
+      println(s"Client $userId doesn't exist. Creating.")
+      ClientStream[JsObject](userId)
+    }
+    clientStream.connect
+  }
+
+  def disconnect(userId: Id[User]) {
+    Option(clients.get(userId)).map { client =>
+      client.disconnect()
+      if(!client.hasListeners) {
+        client.close()
+        clients.remove(userId)
+      }
+    }
+  }
+
+  def push(userId: Id[User], msg: JsObject) {
+    println(s"Pushing for $userId")
+    Option(clients.get(userId)).map{ client =>
+      println("PUSHED!")
+      client.push(msg)
+    }
+  }
+}

--- a/shoebox/app/com/keepit/realtime/StreamManager.scala
+++ b/shoebox/app/com/keepit/realtime/StreamManager.scala
@@ -10,7 +10,7 @@ import com.keepit.common.logging.Logging
 import com.keepit.common.db.slick.Database
 import akka.actor.ActorSystem
 
-trait StreamManager0[T, S] {
+trait StreamManager[T, S] {
   def connect(identifier: T): Enumerator[T]
   def clientIsConnected: Boolean
   def disconnect(identifier: T): Unit
@@ -20,7 +20,7 @@ trait StreamManager0[T, S] {
 }
 
 
-trait MultiClientStreamManager[T, S] extends StreamManager0[T, S] with Logging {
+trait MultiClientStreamManager[T, S] extends StreamManager[T, S] with Logging {
 
   private var clients = new ConcurrentHashMap[T, ClientStreamLike[S]]()
   protected def safeGet(key: T) = Option(clients.get(key))

--- a/shoebox/app/com/keepit/realtime/StreamManager.scala
+++ b/shoebox/app/com/keepit/realtime/StreamManager.scala
@@ -2,58 +2,131 @@ package com.keepit.realtime
 
 import java.util.concurrent.ConcurrentHashMap
 import com.keepit.common.db.Id
-import com.keepit.model.User
+import com.keepit.model._
 import play.api.libs.iteratee.Enumerator
 import play.api.libs.json.{JsObject, JsValue}
 import com.google.inject.{Inject, Singleton, ImplementedBy}
 import com.keepit.common.logging.Logging
+import com.keepit.common.db.slick.Database
+import akka.actor.ActorSystem
 
-@Singleton
-class StreamManager extends Logging {
-  type Message = JsObject
+trait StreamManager0[T, S] {
+  def connect(identifier: T): Enumerator[T]
+  def clientIsConnected: Boolean
+  def disconnect(identifier: T): Unit
+  def disconnectAll(): Unit
+  def push(idenifier: T, msg: S): Unit
+  def pushAll(msg: S): Unit
+}
 
-  private var clients = new ConcurrentHashMap[Id[User], ClientStreamLike[JsValue]]()
 
-  def connect(userId: Id[User]): Enumerator[JsValue] = {
-    log.info(s"Client $userId connecting.")
-    val clientStream = Option(clients.get(userId)).getOrElse {
-      log.info(s"Client $userId doesn't exist. Creating.")
-      val stream = new ClientStream[JsValue](userId)
-      clients.put(userId, stream)
+trait MultiClientStreamManager[T, S] extends StreamManager0[T, S] with Logging {
+
+  private var clients = new ConcurrentHashMap[T, ClientStreamLike[S]]()
+  protected def safeGet(key: T) = Option(clients.get(key))
+
+  def connect(clientIdentifier: T): Enumerator[S] = {
+    log.info(s"Client $clientIdentifier connecting.")
+    val clientStream = safeGet(clientIdentifier).getOrElse {
+      log.info(s"Client $clientIdentifier doesn't exist. Creating.")
+      val stream = new ClientStream[T, S](clientIdentifier)
+      clients.put(clientIdentifier, stream)
       stream
     }
     clientStream.connect
   }
 
-  def disconnect(userId: Id[User]) {
-    Option(clients.get(userId)).map { client =>
+  def clientIsConnected(clientIdentifier: T): Boolean =
+    safeGet(clientIdentifier).isDefined
+
+  def disconnect(clientIdentifier: T) {
+   safeGet(clientIdentifier).map { client =>
       client.disconnect()
       if(!client.hasListeners) {
         client.close()
-        clients.remove(userId)
-        log.info(s"Client $userId disconnected.")
+        clients.remove(clientIdentifier)
+        log.info(s"Client $clientIdentifier disconnected.")
       }
     }
   }
 
-  def disconnectAll(userId: Id[User]) {
-    Option(clients.get(userId)).map { client =>
+  def disconnectAll(clientIdentifier: T) {
+    safeGet(clientIdentifier).map { client =>
       client.close()
-      clients.remove(userId)
-      log.info(s"Client $userId disconnected.")
+      clients.remove(clientIdentifier)
+      log.info(s"Client $clientIdentifier disconnected.")
     }
   }
 
-  def push(userId: Id[User], msg: JsObject) {
-    Option(clients.get(userId)).map { client =>
+  def push(clientIdentifier: T, msg: S) {
+    safeGet(clientIdentifier).map { client =>
       client.push(msg)
     }
   }
 
-  def pushAll(msg: JsObject) {
+  def pushAll(msg: S) {
     import scala.collection.JavaConversions.mapAsScalaConcurrentMap
     for((_, client) <- clients) {
       client.push(msg)
     }
   }
 }
+
+trait UserStreamManager extends MultiClientStreamManager[Id[User], JsValue]
+
+@Singleton
+class DouglasAdamsQuoteStreamManager @Inject() (streams: Streams, system: ActorSystem) extends UserStreamManager {
+  import scala.concurrent.ExecutionContext.Implicits.global
+  import play.api.libs.concurrent.Akka
+  import scala.concurrent.duration._
+  import play.api.Play.current
+  import play.api.libs.json.Json
+  import com.keepit.common.admin.DouglasAdamsQuotes
+
+  override def connect(userId: Id[User]) = {
+    val maybeCancel = if(!clientIsConnected(userId)) {
+      Some(system.scheduler.schedule(5.seconds, 10.seconds) {
+        log.info("Sending quote!")
+        push(userId, Json.obj("quote" -> DouglasAdamsQuotes.random.quote))
+      })
+    } else None
+    val enumerator = super.connect(userId)
+
+    if(maybeCancel.isDefined) {
+      safeGet(userId).map(_.attach(maybeCancel.get))
+    }
+
+    enumerator
+  }
+}
+
+
+@Singleton
+class UserDefaultStreamManager @Inject() (streams: Streams) extends UserStreamManager {
+  override def connect(userId: Id[User]) = {
+    super.connect(userId) >- streams.welcome(userId)
+  }
+}
+
+@Singleton
+class UserNotificationStreamManager @Inject() (streams: Streams)  extends UserStreamManager {
+  override def connect(userId: Id[User]) = {
+    super.connect(userId) >- streams.unreadNotifications(userId)
+  }
+}
+
+@Singleton
+class AdminEventStreamManager extends UserStreamManager
+
+@Singleton
+class UserStreamProvider @Inject() (userDefault: UserDefaultStreamManager, userNotification: UserNotificationStreamManager, hgttg: DouglasAdamsQuoteStreamManager){
+  def getStreams(feeds: Seq[String]): Seq[UserStreamManager] = {
+    feeds.collect {
+        case "notifications" =>  userNotification
+        case "hgttg" => hgttg
+    } :+ userDefault
+  }
+}
+
+
+

--- a/shoebox/app/com/keepit/realtime/StreamManager.scala
+++ b/shoebox/app/com/keepit/realtime/StreamManager.scala
@@ -17,7 +17,7 @@ class StreamManager {
 
   def connect(userId: Id[User]): Enumerator[JsObject] = {
     println(s"Client $userId connecting.")
-    val clientStream = Option(clients.get(userId)).getOrElse {
+    val clientStream = clients.get(userId).getOrElse {
       println(s"Client $userId doesn't exist. Creating.")
       ClientStream[JsObject](userId)
     }
@@ -25,7 +25,7 @@ class StreamManager {
   }
 
   def disconnect(userId: Id[User]) {
-    Option(clients.get(userId)).map { client =>
+    clients.get(userId).map { client =>
       client.disconnect()
       if(!client.hasListeners) {
         client.close()
@@ -36,7 +36,7 @@ class StreamManager {
 
   def push(userId: Id[User], msg: JsObject) {
     println(s"Pushing for $userId")
-    Option(clients.get(userId)).map{ client =>
+    clients.get(userId).map{ client =>
       println("PUSHED!")
       client.push(msg)
     }

--- a/shoebox/app/com/keepit/realtime/Streams.scala
+++ b/shoebox/app/com/keepit/realtime/Streams.scala
@@ -1,0 +1,23 @@
+package com.keepit.realtime
+
+import java.util.concurrent.ConcurrentHashMap
+import com.keepit.common.db.Id
+import com.keepit.model._
+import play.api.libs.iteratee.Enumerator
+import play.api.libs.json.{JsObject, JsValue}
+import com.google.inject.{Inject, Singleton, ImplementedBy}
+import com.keepit.common.logging.Logging
+import play.api.libs.json.Json
+import com.keepit.common.db.slick.Database
+
+@Singleton
+class Streams @Inject() (db: Database, commentRepo: CommentRepo) {
+  def welcome(userId: Id[User]): Enumerator[JsValue] = {
+    Enumerator(Json.obj("connected" -> true, "userStatus" -> "awesome"))
+  }
+
+  def unreadNotifications(userId: Id[User]): Enumerator[JsValue] = {
+    Enumerator(Json.obj("unreadNotifications" -> 0))
+  }
+
+}

--- a/shoebox/conf/routes
+++ b/shoebox/conf/routes
@@ -20,6 +20,9 @@ POST    /signup                     securesocial.controllers.Registration.handle
 GET     /authenticate/:provider     securesocial.controllers.LoginPage.authenticate(provider)
 POST    /authenticate/:provider     securesocial.controllers.LoginPage.authenticateByPost(provider)
 
+
+GET     /ws                         @com.keepit.controllers.StreamController.ws()
+
 ##########################################
 # Extension API
 ##########################################

--- a/shoebox/test/realtime/StreamManagerTest.scala
+++ b/shoebox/test/realtime/StreamManagerTest.scala
@@ -20,9 +20,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class StreamManagerTest extends SpecificationWithJUnit {
 
-  "DouglasAdamsQuotes" should {
-    "load" in {
-      val streamManager = new StreamManager
+  "StreamManagerTest" should {
+    "do something" in {
+      /*val streamManager = new StreamManager
       val enumerator = streamManager.connect(Id[User](1))
       val printlnIteratee = Iteratee.foreach[JsObject](s => println(s))
       val consume: Iteratee[JsObject,JsObject] = {
@@ -39,7 +39,7 @@ class StreamManagerTest extends SpecificationWithJUnit {
 
       println(Await.result(promise, Duration(1, SECONDS)))
 
-
+*/
       1===1
     }
 

--- a/shoebox/test/realtime/StreamManagerTest.scala
+++ b/shoebox/test/realtime/StreamManagerTest.scala
@@ -1,0 +1,47 @@
+package com.keepit.realtime
+
+import scala.concurrent._
+import scala.language.implicitConversions
+
+import org.specs2.mutable._
+
+import com.keepit.model._
+import com.keepit.model.NormalizedURIStates._
+import com.keepit.test.EmptyApplication
+
+import play.api.libs.iteratee._
+import play.api.libs.json._
+import play.api.test.Helpers._
+import com.keepit.common.db._
+import concurrent._
+import concurrent.duration._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class StreamManagerTest extends SpecificationWithJUnit {
+
+  "DouglasAdamsQuotes" should {
+    "load" in {
+      val streamManager = new StreamManager
+      val enumerator = streamManager.connect(Id[User](1))
+      val printlnIteratee = Iteratee.foreach[JsObject](s => println(s))
+      val consume: Iteratee[JsObject,JsObject] = {
+        Iteratee.fold[JsObject,JsObject](JsObject(Nil)) { (result, chunk) =>
+          println(s"consuming $chunk")
+          result ++ chunk
+        }
+      }
+
+      streamManager.push(Id[User](1), Json.obj("test" -> "value"))
+
+      val promise = (enumerator |>> Iteratee.fold[JsObject, JsObject](JsObject(Nil))(_ ++ _)).flatMap(_.run)
+            streamManager.disconnect(Id[User](0))
+
+      println(Await.result(promise, Duration(1, SECONDS)))
+
+
+      1===1
+    }
+
+  }
+}


### PR DESCRIPTION
This is the foundations of the multi-client enumerator and iteratee framework. It is not tied to any specific real-time technology (WebSockets, Comet, etc), but the WebSocket implementation is here.

Just a note: "Stream" here is not related to Scala `Stream`. It's simply a potential flow of data.

Features:
- Single endpoint for managing the system's streams
- User authentication. Right now, we return a friendly error message and close the connection.
- Support for many streams across the system, such as Admin event dumps, a global user specific stream, user specific notifications, Hitchhiker's Guide to the Galaxy quotes, etc.
- When user connects initially, they subscribe to different streams. The extension may subscribe to a global stream, notifications, etc.
- The `MultiClientStreamManager` (the only one so far) cleans up when a client disconnects. Note that clients may maintain several active connections at once. If one disconnects but the others remain, the manager doesn't clean up.

Feeding the streams will happen elsewhere in the system on event triggers (on notification, for example). Alternatively, we can tie cron events to these streams as well (see the Hitchhiker's Guide Quote example). 

The test is currently useless.
