### PR TITLE
Add sequences for indexing scraped NormalizedURIs

### DIFF
--- a/shoebox/app/com/keepit/common/db/DbSequence.scala
+++ b/shoebox/app/com/keepit/common/db/DbSequence.scala
@@ -1,0 +1,33 @@
+package com.keepit.common.db
+
+import com.keepit.common.db.slick.DBSession.RWSession
+import scalax.io.JavaConverters._
+import scala.util.matching.Regex
+
+/*
+
+MySQL:
+
+CREATE TABLE $sequenceName (id INT NOT NULL);
+INSERT INTO $sequenceName VALUES (0);
+
+H2:
+
+CREATE SEQUENCE $sequenceName;
+
+*/
+
+case class SequenceNumber(value: Long) extends AnyVal with Ordered[SequenceNumber] {
+  def compare(that: SequenceNumber) = value compare that.value
+  override def toString = value.toString
+}
+
+abstract class DbSequence(val name: String) {
+  if (DbSequence.validSequenceName.findFirstIn(name).isEmpty)
+    throw new IllegalArgumentException(s"Sequence name $name is invalid")
+  def incrementAndGet()(implicit session: RWSession): SequenceNumber
+}
+
+object DbSequence {
+  val validSequenceName = "^([a-zA-Z_][a-zA-Z0-9_]*)$".r
+}

--- a/shoebox/app/com/keepit/common/db/slick/H2.scala
+++ b/shoebox/app/com/keepit/common/db/slick/H2.scala
@@ -1,17 +1,23 @@
 package com.keepit.common.db.slick
 
+import com.keepit.common.db.slick.DBSession.RWSession
+import com.keepit.common.db.{DbSequence, SequenceNumber, DbInfo}
 import scala.slick.driver.H2Driver
-import scala.slick.lifted._
-
-import javax.sql._
-
-import _root_.com.keepit.common.db.DbInfo
 
 // see https://groups.google.com/forum/?fromgroups=#!topic/scalaquery/36uU8koz8Gw
 class H2(val dbInfo: DbInfo)
     extends DataBaseComponent {
   println("initiating H2 driver")
   val Driver = H2Driver
+
+  def getSequence(name: String): DbSequence = new DbSequence(name) {
+    def incrementAndGet()(implicit sess: RWSession): SequenceNumber = {
+      val stmt = sess.conn.prepareStatement(s"""SELECT NEXTVAL('$name')""")
+      val rs = stmt.executeQuery()
+      rs.next()
+      SequenceNumber(rs.getLong(1))
+    }
+  }
 
   override def entityName(name: String): String = name.toUpperCase()
 }

--- a/shoebox/app/com/keepit/common/db/slick/MySQL.scala
+++ b/shoebox/app/com/keepit/common/db/slick/MySQL.scala
@@ -1,18 +1,26 @@
 package com.keepit.common.db.slick
 
+import com.keepit.common.db.slick.DBSession.RWSession
+import com.keepit.common.db.{DbSequence, SequenceNumber, DbInfo}
 import scala.slick.driver.MySQLDriver
-import scala.slick.lifted._
-
-import javax.sql._
-
-import _root_.com.keepit.common.db.DbInfo
 
 // see https://groups.google.com/forum/?fromgroups=#!topic/scalaquery/36uU8koz8Gw
 class MySQL(val dbInfo: DbInfo)
     extends DataBaseComponent {
   println("initiating MySQL driver")
   val Driver = MySQLDriver
+
+  def getSequence(name: String): DbSequence = new DbSequence(name) {
+    def incrementAndGet()(implicit sess: RWSession): SequenceNumber = {
+      val stmt = sess.getPreparedStatement(s"""UPDATE $name SET id=LAST_INSERT_ID(id+1); SELECT LAST_INSERT_ID();""")
+      val rs = stmt.executeQuery()
+      rs.next()
+      SequenceNumber(rs.getLong(1))
+    }
+  }
 }
+
+
 
 object MySQL {
   val driverName = "com.mysql.jdbc.Driver"

--- a/shoebox/app/com/keepit/scraper/Scraper.scala
+++ b/shoebox/app/com/keepit/scraper/Scraper.scala
@@ -88,14 +88,14 @@ class Scraper @Inject() (httpFetcher: HttpFetcher, articleStore: ArticleStore, s
         val scrapedURI = db.readWrite { implicit s =>
           // update the scrape schedule and the uri state to SCRAPED
           scrapeInfoRepo.save(info.withDestinationUrl(article.destinationUrl).withDocumentChanged(signature.toBase64))
-          uriRepo.save(uri.withTitle(article.title).withState(NormalizedURIStates.SCRAPED))
+          uriRepo.saveAsIndexable(uri.withTitle(article.title).withState(NormalizedURIStates.SCRAPED))
         }
         log.info("fetched uri %s => %s".format(uri, article))
         (scrapedURI, Some(article))
       case NotScrapable(destinationUrl) =>
         val unscrapableURI = db.readWrite { implicit s =>
           scrapeInfoRepo.save(info.withDestinationUrl(destinationUrl).withDocumentUnchanged())
-          uriRepo.save(uri.withState(NormalizedURIStates.UNSCRAPABLE))
+          uriRepo.saveAsIndexable(uri.withState(NormalizedURIStates.UNSCRAPABLE))
         }
         (unscrapableURI, None)
       case NotModified =>
@@ -122,7 +122,7 @@ class Scraper @Inject() (httpFetcher: HttpFetcher, articleStore: ArticleStore, s
         // the article is saved. update the scrape schedule and the state to SCRAPE_FAILED and save
         val errorURI = db.readWrite { implicit s =>
           scrapeInfoRepo.save(info.withFailure())
-          uriRepo.save(uri.withState(NormalizedURIStates.SCRAPE_FAILED))
+          uriRepo.saveAsIndexable(uri.withState(NormalizedURIStates.SCRAPE_FAILED))
         }
         (errorURI, None)
     }

--- a/shoebox/app/com/keepit/search/index/Indexer.scala
+++ b/shoebox/app/com/keepit/search/index/Indexer.scala
@@ -1,25 +1,22 @@
 package com.keepit.search.index
 
-import com.keepit.common.db.Id
-import com.keepit.common.logging.Logging
-import com.keepit.common.time._
-import com.keepit.search.Lang
+import scala.collection.JavaConversions._
+
+import java.io.IOException
+import java.lang.OutOfMemoryError
+
 import org.apache.lucene.document.Document
 import org.apache.lucene.document.Field
 import org.apache.lucene.index.CorruptIndexException
 import org.apache.lucene.index.IndexReader
 import org.apache.lucene.index.IndexWriter
 import org.apache.lucene.index.IndexWriterConfig
-import org.apache.lucene.index.Payload
 import org.apache.lucene.index.Term
 import org.apache.lucene.store.Directory
-import org.apache.lucene.search.Query
-import org.apache.lucene.util.Version
-import java.io.File
-import java.io.IOException
-import java.lang.OutOfMemoryError
-import scala.collection.JavaConversions._
-import scala.math._
+
+import com.keepit.common.db.{SequenceNumber, Id}
+import com.keepit.common.logging.Logging
+import com.keepit.common.time._
 
 case class IndexError(msg: String)
 
@@ -34,6 +31,7 @@ object Indexer {
 
   object CommitData {
     val committedAt = "COMMITTED_AT"
+    val sequenceNumber = "SEQUENCE_NUMBER"
   }
 }
 
@@ -54,6 +52,9 @@ abstract class Indexer[T](indexDirectory: Directory, indexWriterConfig: IndexWri
   }
 
   def getSearcher = searcher
+
+  protected[search] var sequenceNumber =
+    SequenceNumber(commitData.getOrElse(Indexer.CommitData.committedAt, "0").toLong)
 
   def doWithIndexWriter(f: IndexWriter=>Unit) = {
     try {
@@ -106,7 +107,7 @@ abstract class Indexer[T](indexDirectory: Directory, indexWriterConfig: IndexWri
           }
           (indexable, error)
         }
-        indexWriter.commit(Map(Indexer.CommitData.committedAt -> currentDateTime.toStandardTimeString))
+        commit()
         log.info("index commited")
         afterCommit(commitBatch)
       }
@@ -114,11 +115,18 @@ abstract class Indexer[T](indexDirectory: Directory, indexWriterConfig: IndexWri
     if (refresh) refreshSearcher()
   }
 
+  def commit() {
+    indexWriter.commit(Map(
+      Indexer.CommitData.committedAt -> currentDateTime.toStandardTimeString,
+      Indexer.CommitData.sequenceNumber -> sequenceNumber.toString
+    ))
+  }
+
   def deleteAllDocuments(refresh: Boolean = true) {
     if (IndexReader.indexExists(indexDirectory)) {
       doWithIndexWriter{ indexWriter =>
         indexWriter.deleteAll()
-        indexWriter.commit(Map(Indexer.CommitData.committedAt -> currentDateTime.toStandardTimeString))
+        commit()
       }
     }
     if (refresh) refreshSearcher()
@@ -127,8 +135,8 @@ abstract class Indexer[T](indexDirectory: Directory, indexWriterConfig: IndexWri
   def commitData: Map[String, String] = {
     // get the latest commit
     val indexReader = Option(IndexReader.openIfChanged(searcher.indexReader.inner)).getOrElse(searcher.indexReader.inner)
-    var indexCommit = indexReader.getIndexCommit()
-    var mutableMap = indexCommit.getUserData()
+    val indexCommit = indexReader.getIndexCommit()
+    val mutableMap = indexCommit.getUserData()
     log.info("commit data =" + mutableMap)
     Map() ++ mutableMap
   }

--- a/shoebox/conf/evolutions/shoebox/44.sql
+++ b/shoebox/conf/evolutions/shoebox/44.sql
@@ -1,0 +1,15 @@
+# --- !Ups
+
+-- MySQL:
+-- CREATE TABLE normalized_uri_sequence (id INT NOT NULL);
+-- INSERT INTO normalized_uri_sequence VALUES (0);
+-- H2:
+CREATE SEQUENCE normalized_uri_sequence;
+---
+
+ALTER TABLE normalized_uri ADD seq INT;
+CREATE INDEX normalized_uri_seq_index ON normalized_uri(seq);
+
+insert into evolutions (name, description) values('44.sql', 'add sequence number to normalized uri');
+
+# --- !Downs

--- a/shoebox/test/com/keepit/search/MainSearcherTest.scala
+++ b/shoebox/test/com/keepit/search/MainSearcherTest.scala
@@ -37,7 +37,8 @@ class MainSearcherTest extends Specification with DbRepos {
 
   def initData(numUsers: Int, numUris: Int) = db.readWrite { implicit s =>
     ((0 until numUsers).map(n => userRepo.save(User(firstName = "foo" + n, lastName = ""))).toList,
-     (0 until numUris).map(n => uriRepo.save(NormalizedURIFactory(title = "a" + n, url = "http://www.keepit.com/article" + n, state = SCRAPED))).toList)
+     (0 until numUris).map(n => uriRepo.saveAsIndexable(NormalizedURIFactory(title = "a" + n,
+       url = "http://www.keepit.com/article" + n, state = SCRAPED))).toList)
   }
 
   def initIndexes(store: ArticleStore) = {

--- a/shoebox/test/com/keepit/search/index/ArticleIndexerTest.scala
+++ b/shoebox/test/com/keepit/search/index/ArticleIndexerTest.scala
@@ -31,9 +31,12 @@ class ArticleIndexerTest extends Specification with DbRepos {
     var (uri1, uri2, uri3) = db.readWrite { implicit s =>
       val user1 = userRepo.save(User(firstName = "Joe", lastName = "Smith"))
       val user2 = userRepo.save(User(firstName = "Moo", lastName = "Brown"))
-      (uriRepo.save(NormalizedURIFactory(title = "a1", url = "http://www.keepit.com/article1", state = SCRAPED)),
-          uriRepo.save(NormalizedURIFactory(title = "a2", url = "http://www.keepit.org/article2", state = SCRAPED)),
-          uriRepo.save(NormalizedURIFactory(title = "a3", url = "http://www.findit.com/article3", state = SCRAPED)))
+      (uriRepo.saveAsIndexable(
+        NormalizedURIFactory(title = "a1", url = "http://www.keepit.com/article1", state = SCRAPED)),
+          uriRepo.saveAsIndexable(
+            NormalizedURIFactory(title = "a2", url = "http://www.keepit.org/article2", state = SCRAPED)),
+          uriRepo.saveAsIndexable(
+            NormalizedURIFactory(title = "a3", url = "http://www.findit.com/article3", state = SCRAPED)))
     }
     store += (uri1.id.get -> mkArticle(uri1.id.get, "title1 titles", "content1 alldocs body soul"))
     store += (uri2.id.get -> mkArticle(uri2.id.get, "title2 titles", "content2 alldocs bodies soul"))
@@ -73,24 +76,27 @@ class ArticleIndexerTest extends Specification with DbRepos {
   }
 
   "ArticleIndexer" should {
-    "index scraped URIs" in running(new EmptyApplication())(new IndexerScope {
+    "index indexable URIs" in running(new EmptyApplication())(new IndexerScope {
+      indexer.sequenceNumber = SequenceNumber(3) // skip initial documents
 
       db.readWrite { implicit s =>
         uri1 = uriRepo.save(uriRepo.get(uri1.id.get).withState(INDEXED))
-        uri2 = uriRepo.save(uriRepo.get(uri2.id.get).withState(SCRAPED))
+        uri2 = uriRepo.saveAsIndexable(uriRepo.get(uri2.id.get).withState(SCRAPED))
         uri3 = uriRepo.save(uriRepo.get(uri3.id.get).withState(ACTIVE))
       }
-
+      indexer.sequenceNumber.value === 3
       indexer.run()
+      indexer.sequenceNumber.value === 4
       indexer.numDocs === 1
 
       db.readWrite { implicit s =>
-        uri1 = uriRepo.save(uri1.withState(SCRAPED))
-        uri2 = uriRepo.save(uri2.withState(SCRAPED))
-        uri3 = uriRepo.save(uri3.withState(SCRAPED))
+        uri1 = uriRepo.saveAsIndexable(uri1.withState(SCRAPED))
+        uri2 = uriRepo.saveAsIndexable(uri2.withState(SCRAPED))
+        uri3 = uriRepo.saveAsIndexable(uri3.withState(SCRAPED))
       }
 
       indexer.run()
+      indexer.sequenceNumber.value ==== 7
       indexer.numDocs === 3
 
       db.readOnly { implicit s =>


### PR DESCRIPTION
Now we use a sequence number to determine whether to index an article instead of using the state. When we want to index an article, we call `saveAsIndexable`, which increments the sequence number and saves the record.

We figure out which articles to index by getting all the `NormalizedURI`s with a greater number than that of the indexer. This should let us have multiple indexers on multiple machines.

One unresolved issue is how to deal with changing the states when we have separate machines doing the indexing. We can't have two machines try to change the state to `INDEXED` since it would require an invalid state transition.
