### PR TITLE
Add sequence number to bookmark and simplify URIGraph updating

### DIFF
--- a/shoebox/app/com/keepit/common/db/DbSequence.scala
+++ b/shoebox/app/com/keepit/common/db/DbSequence.scala
@@ -22,6 +22,10 @@ case class SequenceNumber(value: Long) extends AnyVal with Ordered[SequenceNumbe
   override def toString = value.toString
 }
 
+object SequenceNumber {
+  val ZERO = SequenceNumber(0)
+}
+
 abstract class DbSequence(val name: String) {
   if (DbSequence.validSequenceName.findFirstIn(name).isEmpty)
     throw new IllegalArgumentException(s"Sequence name $name is invalid")

--- a/shoebox/app/com/keepit/common/db/slick/FortyTwoTypeMappers.scala
+++ b/shoebox/app/com/keepit/common/db/slick/FortyTwoTypeMappers.scala
@@ -262,7 +262,7 @@ class DateTimeMapperDelegate(val profile: BasicProfile) extends DelegateMapperDe
 class SequenceNumberTypeMapperDelegate(val profile: BasicProfile)
     extends DelegateMapperDelegate[SequenceNumber, Long] {
   protected val delegate = profile.typeMapperDelegates.longTypeMapperDelegate
-  def zero = SequenceNumber(0)
+  def zero = SequenceNumber.ZERO
   def sourceToDest(value: SequenceNumber): Long = value.value
   def safeDestToSource(value: Long): SequenceNumber = SequenceNumber(value)
 }

--- a/shoebox/app/com/keepit/controllers/admin/URIGraphController.scala
+++ b/shoebox/app/com/keepit/controllers/admin/URIGraphController.scala
@@ -1,40 +1,45 @@
 package com.keepit.controllers.admin
 
-import play.api.data._
-import java.util.concurrent.TimeUnit
-import play.api._
-import play.api.Play.current
-import play.api.mvc._
-import play.api.libs.json.JsArray
-import play.api.libs.json.Json
-import play.api.libs.json.JsObject
-import play.api.libs.json.JsString
-import play.api.libs.json.JsValue
-import play.api.libs.json.JsNumber
-import com.keepit.common.db._
-import com.keepit.common.logging.Logging
+import scala.concurrent.ExecutionContext.Implicits.global
 
+import org.apache.lucene.document.Document
+
+import com.keepit.common.controller.AdminController
+import com.keepit.common.db._
+import com.keepit.common.db.slick.Database
 import com.keepit.inject._
+import com.keepit.model.{BookmarkRepo, User}
 import com.keepit.search.graph.URIGraph
 import com.keepit.search.graph.URIGraphImpl
 import com.keepit.search.graph.URIGraphPlugin
-import com.keepit.model.User
-import com.keepit.common.controller.AdminController
-import org.apache.lucene.document.Document
+
+import play.api.Play.current
 import views.html
 
 object URIGraphController extends AdminController {
 
   def load = AdminHtmlAction { implicit request =>
     val uriGraphPlugin = inject[URIGraphPlugin]
-    val cnt = uriGraphPlugin.load()
-    Ok("indexed %d users".format(cnt))
+    Async {
+      uriGraphPlugin.update().map { cnt =>
+        Ok(s"indexed $cnt users")
+      }
+    }
   }
 
   def update(userId: Id[User]) = AdminHtmlAction { implicit request =>
     val uriGraphPlugin = inject[URIGraphPlugin]
-    val cnt = uriGraphPlugin.update(userId)
-    Ok("indexed %d users".format(cnt))
+    val bookmarkRepo = inject[BookmarkRepo]
+    val db = inject[Database]
+    Async {
+      val bookmarks = db.readOnly { implicit s => bookmarkRepo.getByUser(userId) }
+      bookmarks.grouped(1000).foreach { group =>
+        db.readWrite { implicit s => group.foreach(bookmarkRepo.save) }
+      }
+      uriGraphPlugin.update().map { cnt =>
+        Ok(s"indexed $cnt users")
+      }
+    }
   }
 
   def dumpLuceneDocument(id: Id[User]) =  AdminHtmlAction { implicit request =>

--- a/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
@@ -108,7 +108,7 @@ class ExtBookmarksController @Inject() (db: Database, bookmarkManager: BookmarkI
         }
       }
     }
-    uriGraphPlugin.update(request.userId)
+    uriGraphPlugin.update()
     bookmark match {
       case Some(bookmark) => Ok(BookmarkSerializer.bookmarkSerializer writes bookmark)
       case None => NotFound
@@ -142,7 +142,7 @@ class ExtBookmarksController @Inject() (db: Database, bookmarkManager: BookmarkI
             val experiments = request.experimants
             val user = db.readOnly { implicit s => userRepo.get(userId) }
             bookmarkManager.internBookmarks(json \ "bookmarks", user, experiments, BookmarkSource(bookmarkSource.getOrElse("UNKNOWN")), installationId)
-            uriGraphPlugin.update(userId)
+            uriGraphPlugin.update()
             Ok(JsObject(Seq()))
         }
       case None =>

--- a/shoebox/app/com/keepit/model/NormalizedURI.scala
+++ b/shoebox/app/com/keepit/model/NormalizedURI.scala
@@ -40,7 +40,7 @@ case class NormalizedURI  (
   url: String,
   urlHash: String,
   state: State[NormalizedURI] = NormalizedURIStates.ACTIVE,
-  seq: SequenceNumber = SequenceNumber(0)
+  seq: SequenceNumber = SequenceNumber.ZERO
 ) extends ModelWithExternalId[NormalizedURI] with Logging {
   def withId(id: Id[NormalizedURI]): NormalizedURI = copy(id = Some(id))
   def withUpdateTime(now: DateTime): NormalizedURI = copy(updatedAt = now)

--- a/shoebox/app/com/keepit/search/index/Indexer.scala
+++ b/shoebox/app/com/keepit/search/index/Indexer.scala
@@ -108,18 +108,18 @@ abstract class Indexer[T](indexDirectory: Directory, indexWriterConfig: IndexWri
           (indexable, error)
         }
         commit()
-        log.info("index commited")
         afterCommit(commitBatch)
       }
     }
     if (refresh) refreshSearcher()
   }
 
-  def commit() {
+  private def commit() {
     indexWriter.commit(Map(
-      Indexer.CommitData.committedAt -> currentDateTime.toStandardTimeString,
-      Indexer.CommitData.sequenceNumber -> sequenceNumber.toString
+          Indexer.CommitData.committedAt -> currentDateTime.toStandardTimeString,
+          Indexer.CommitData.sequenceNumber -> sequenceNumber.toString
     ))
+    log.info("index committed")
   }
 
   def deleteAllDocuments(refresh: Boolean = true) {

--- a/shoebox/app/views/admin/user.scala.html
+++ b/shoebox/app/views/admin/user.scala.html
@@ -103,7 +103,8 @@
     }
     <input type="submit" value="Search"/>
   </form>
-  <form class="navbar-form" action="/bookmarks/update" method="POST">
+  <form class="navbar-form" action="@com.keepit.controllers.admin.routes.AdminBookmarksController.updateBookmarks()"
+  method="POST">
     <button type="submit" class="btn">Update</button><br/><br/>
 			<table class="table table-bordered">
 		    <tr>

--- a/shoebox/conf/evolutions/shoebox/45.sql
+++ b/shoebox/conf/evolutions/shoebox/45.sql
@@ -1,0 +1,16 @@
+# --- !Ups
+
+-- MySQL:
+-- ALTER TABLE bookmark ADD seq INT NOT NULL DEFAULT 0;
+-- CREATE TABLE bookmark_sequence (id INT NOT NULL);
+-- INSERT INTO bookmark_sequence VALUES (0);
+-- H2:
+CREATE SEQUENCE bookmark_sequence;
+---
+
+ALTER TABLE bookmark ADD seq INT NOT NULL DEFAULT 0;
+CREATE INDEX bookmark_seq_index ON bookmark(seq);
+
+insert into evolutions (name, description) values('45.sql', 'add sequence number to bookmark');
+
+# --- !Downs

--- a/shoebox/test/com/keepit/search/MainSearcherTest.scala
+++ b/shoebox/test/com/keepit/search/MainSearcherTest.scala
@@ -102,7 +102,7 @@ class MainSearcherTest extends Specification with DbRepos {
         val store = mkStore(uris)
         val (graph, indexer, mainSearcherFactory) = initIndexes(store)
         val clickBoosts = resultClickTracker.getBoosts(Id[User](0), "", 1.0f)
-        graph.load() === users.size
+        graph.update() === users.size
         indexer.run() === uris.size
 
         val numHitsPerCategory = 1000
@@ -161,7 +161,7 @@ class MainSearcherTest extends Specification with DbRepos {
         val store = mkStore(uris)
         val (graph, indexer, mainSearcherFactory) = initIndexes(store)
 
-        graph.load() === users.size
+        graph.update() === users.size
         indexer.run() === uris.size
 
         val numHitsToReturn = 7
@@ -219,7 +219,7 @@ class MainSearcherTest extends Specification with DbRepos {
         val store = mkStore(uris)
         val (graph, indexer, mainSearcherFactory) = initIndexes(store)
 
-        graph.load() === users.size
+        graph.update() === users.size
 
         def run = {
           val numHitsToReturn = 100
@@ -282,7 +282,7 @@ class MainSearcherTest extends Specification with DbRepos {
         val store = mkStore(uris)
         val (graph, indexer, mainSearcherFactory) = initIndexes(store)
 
-        graph.load() === users.size
+        graph.update() === users.size
         indexer.run() === uris.size
 
         val numHitsToReturn = 100
@@ -317,7 +317,7 @@ class MainSearcherTest extends Specification with DbRepos {
         val store = mkStore(uris)
         val (graph, indexer, mainSearcherFactory) = initIndexes(store)
 
-        graph.load() === users.size
+        graph.update() === users.size
         indexer.run() === uris.size
 
         val numHitsToReturn = 3
@@ -369,7 +369,7 @@ class MainSearcherTest extends Specification with DbRepos {
         val store = mkStore(uris)
         val (graph, indexer, mainSearcherFactory) = initIndexes(store)
 
-        graph.load() === 1
+        graph.update() === users.size
         indexer.run() === uris.size
 
         val mainSearcher = mainSearcherFactory(userId, Set.empty[Id[User]], SearchFilter.default(), noBoostConfig("recencyBoost" -> "1.0"))
@@ -406,7 +406,7 @@ class MainSearcherTest extends Specification with DbRepos {
         }
         val (graph, indexer, mainSearcherFactory) = initIndexes(store)
 
-        graph.load() === 1
+        graph.update() === users.size
         indexer.run() === uris.size
 
         var mainSearcher = mainSearcherFactory(userId, Set.empty[Id[User]], SearchFilter.default(), noBoostConfig)
@@ -446,11 +446,11 @@ class MainSearcherTest extends Specification with DbRepos {
         val store = mkStore(uris)
         val (graph, indexer, mainSearcherFactory) = initIndexes(store)
 
-        graph.load() === users.size
+        graph.update() === 1
         indexer.run() === uris.size
 
-        var mainSearcher = mainSearcherFactory(user1.id.get, Set(user2.id.get), SearchFilter.default(), noBoostConfig)
-        var res = mainSearcher.search("alldocs", uris.size, None)
+        val mainSearcher = mainSearcherFactory(user1.id.get, Set(user2.id.get), SearchFilter.default(), noBoostConfig)
+        val res = mainSearcher.search("alldocs", uris.size, None)
 
         val publicSet = publicUris.map(u => u.id.get).toSet
         val privateSet = privateUris.map(u => u.id.get).toSet
@@ -479,11 +479,11 @@ class MainSearcherTest extends Specification with DbRepos {
         val store = mkStore(uris)
         val (graph, indexer, mainSearcherFactory) = initIndexes(store)
 
-        graph.load() === users.size
+        graph.update() === 1
         indexer.run() === uris.size
 
-        var mainSearcher = mainSearcherFactory(user1.id.get, Set(user2.id.get), SearchFilter.default(), noBoostConfig)
-        var res = mainSearcher.search("alldocs", uris.size, None)
+        val mainSearcher = mainSearcherFactory(user1.id.get, Set(user2.id.get), SearchFilter.default(), noBoostConfig)
+        val res = mainSearcher.search("alldocs", uris.size, None)
 
         val publicSet = publicUris.map(u => u.id.get).toSet
         val privateSet = privateUris.map(u => u.id.get).toSet
@@ -512,7 +512,7 @@ class MainSearcherTest extends Specification with DbRepos {
         val store = mkStore(uris)
         val (graph, indexer, mainSearcherFactory) = initIndexes(store)
 
-        graph.load() === users.size
+        graph.update() === users.size
         indexer.run() === uris.size
 
         val numHitsToReturn = 100


### PR DESCRIPTION
Use a sequence number in the bookmark table to determine which users
to update both on load of the graph and on update. Remove the
URIGraph#update(user) method and use a single update() method for
loading and updating the graph.
