### PR TITLE
Making EventListener use Akka

### DIFF
--- a/shoebox/app/com/keepit/common/analytics/EventListener.scala
+++ b/shoebox/app/com/keepit/common/analytics/EventListener.scala
@@ -12,7 +12,6 @@ import play.api.Play.current
 import java.sql.Connection
 import com.keepit.common.healthcheck.HealthcheckPlugin
 import java.util.{Set => JSet}
-import com.google.inject.Inject
 import scala.collection.JavaConversions._
 import com.keepit.search.ResultClickTracker
 import com.keepit.search.BrowsingHistoryTracker
@@ -38,7 +37,6 @@ trait EventListenerPlugin extends SchedulingPlugin {
   }
 }
 
-@Singleton
 class EventHelper @Inject() (system: ActorSystem, listeners: JSet[EventListenerPlugin]) {
   private val default = system.actorOf(Props(new EventHelperActor(listeners)))
   def newEvent(event: Event): Seq[String] = {

--- a/shoebox/app/com/keepit/common/healthcheck/Healthcheck.scala
+++ b/shoebox/app/com/keepit/common/healthcheck/Healthcheck.scala
@@ -123,7 +123,7 @@ private[healthcheck] class HealthcheckActor(postOffice: PostOffice, services: Fo
         val messages = errors map {case(sig, errorList) =>
           s"${errorList.size} since last report, ${errorsSinceStart(sig)} since start of errorList sig ${sig.value}:\n<br/>${errorList.last.toHtml}"
         } mkString "\n<br/><hr/>"
-        val subject = s"ERROR REPORT: $errorCount errors since start on ${services.currentService.name} version ${services.currentVersion} compiled on ${services.compilationTime}"
+        val subject = s"ERROR REPORT: ${errors.map(_._2.size).sum} errors since last report on ${services.currentService.name} version ${services.currentVersion} compiled on ${services.compilationTime}"
         errors = initErrors
 
         val htmlMessage = Html(s"$titles<br/><hr/><br/>$messages")

--- a/shoebox/app/com/keepit/model/ScrapeInfo.scala
+++ b/shoebox/app/com/keepit/model/ScrapeInfo.scala
@@ -31,7 +31,7 @@ case class ScrapeInfo(
   def withUpdateTime(now: DateTime) = this
 
   def withState(state: State[ScrapeInfo]) = state match {
-    case ScrapeInfoStates.ACTIVE => copy(state = state, nextScrape = currentDateTime) // scrape ASAP when switched to ACTIVE
+    case ScrapeInfoStates.ACTIVE => copy(state = state, nextScrape = START_OF_TIME) // scrape ASAP when switched to ACTIVE
     case ScrapeInfoStates.INACTIVE => copy(state = state, nextScrape = END_OF_TIME) // never scrape when switched to INACTIVE
   }
 

--- a/shoebox/test/com/keepit/common/analytics/EventListenerTest.scala
+++ b/shoebox/test/com/keepit/common/analytics/EventListenerTest.scala
@@ -13,6 +13,7 @@ import com.keepit.model._
 import com.keepit.common.db._
 import play.api.Play.current
 import com.keepit.inject.inject
+import akka.actor.ActorSystem
 
 class EventListenerTest extends Specification with DbRepos {
 
@@ -39,9 +40,9 @@ class EventListenerTest extends Specification with DbRepos {
         val listener = new EventListenerPlugin {
          def onEvent: PartialFunction[Event,Unit] = { case _ => }
         }
-        val (user2, result) = db.readWrite {implicit s => 
-          listener.searchParser(user.externalId, 
-            JsObject(Seq("url" -> JsString("http://google.com/"), "query" -> JsString("potatoes")))) 
+        val (user2, result) = db.readWrite {implicit s =>
+          listener.searchParser(user.externalId,
+            JsObject(Seq("url" -> JsString("http://google.com/"), "query" -> JsString("potatoes"))))
         }
 
         user2.id === user.id
@@ -54,6 +55,7 @@ class EventListenerTest extends Specification with DbRepos {
   "EventListener" should {
     "process events" in {
       running(new EmptyApplication()) {
+        val system = ActorSystem("system")
         val (normUrlId, url, user, bookmark) = setup()
 
         val unrelatedEvent = Events.userEvent(EventFamilies.SEARCH,"someOtherEvent", user, Seq(), "", JsObject(Seq()), Seq())

--- a/shoebox/test/com/keepit/test/TestApplication.scala
+++ b/shoebox/test/com/keepit/test/TestApplication.scala
@@ -42,6 +42,8 @@ import akka.actor.ActorRef
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import com.keepit.common.actor.ActorPlugin
+import akka.actor.ActorSystem
 
 class TestApplication(val _global: TestGlobal) extends play.api.test.FakeApplication() {
   override lazy val global = _global // Play 2.1 makes global a lazy val, which can't be directly overridden.
@@ -81,6 +83,7 @@ case class TestModule() extends ScalaModule {
     val appScope = new AppScope
     bindScope(classOf[AppScoped], appScope)
     bind[AppScope].toInstance(appScope)
+    bind[ActorSystem].toProvider[ActorPlugin].in[AppScoped]
     bind[Babysitter].to[FakeBabysitter]
     install(new SlickModule(new DbInfo() {
       //later on we can customize it by the application name
@@ -103,6 +106,10 @@ case class TestModule() extends ScalaModule {
 
   @Provides
   def localDate(clock: FakeClock) : LocalDate = clock.pop.toLocalDate
+
+  @Provides
+  @AppScoped
+  def actorPluginProvider: ActorPlugin = new ActorPlugin("shoebox-test-actor-system")
 
   @Provides
   @Singleton


### PR DESCRIPTION
Making EventListener use Akka to process events faster, and to avoid race conditions.

Fixing Healthcheck emails to show number of exceptions since last email in title, instead of since error reset.
