### PR TITLE
a race condition in URIGraph w.r.t sequence numbers

### DIFF
--- a/shoebox/app/com/keepit/controllers/admin/URIGraphController.scala
+++ b/shoebox/app/com/keepit/controllers/admin/URIGraphController.scala
@@ -45,7 +45,7 @@ object URIGraphController extends AdminController {
   def dumpLuceneDocument(id: Id[User]) =  AdminHtmlAction { implicit request =>
     val indexer = inject[URIGraph].asInstanceOf[URIGraphImpl]
     try {
-      val doc = indexer.buildIndexable(id).buildDocument
+      val doc = indexer.buildIndexable(id, SequenceNumber.ZERO).buildDocument
       Ok(html.admin.luceneDocDump("URIGraph", doc, indexer))
     } catch {
       case e: Throwable => Ok(html.admin.luceneDocDump("No URIGraph", new Document, indexer))

--- a/shoebox/app/com/keepit/search/index/ArticleIndexer.scala
+++ b/shoebox/app/com/keepit/search/index/ArticleIndexer.scala
@@ -76,12 +76,12 @@ class ArticleIndexer(indexDirectory: Directory, indexWriterConfig: IndexWriterCo
     }
   }
 
-  def buildIndexable(id: Id[NormalizedURI]) = {
+  def buildIndexable(id: Id[NormalizedURI]): ArticleIndexable = {
     val uri = inject[Database].readOnly { implicit c => inject[NormalizedURIRepo].get(id) }
     buildIndexable(uri)
   }
 
-  def buildIndexable(uri: NormalizedURI) = {
+  def buildIndexable(uri: NormalizedURI): ArticleIndexable = {
     new ArticleIndexable(uri.id.get, uri.seq, uri, articleStore)
   }
 

--- a/shoebox/app/com/keepit/search/index/Indexer.scala
+++ b/shoebox/app/com/keepit/search/index/Indexer.scala
@@ -148,9 +148,6 @@ abstract class Indexer[T](indexDirectory: Directory, indexWriterConfig: IndexWri
     searcher = Searcher.reopen(searcher)
   }
 
-  def buildIndexable(data: T): Indexable[T]
-  def buildIndexable(id: Id[T]): Indexable[T]
-
   def getFieldDecoder(fieldName: String) = {
     fieldDecoders.get(fieldName) match {
       case Some(decoder) => decoder

--- a/shoebox/app/com/keepit/search/phrasedetector/PhraseDetector.scala
+++ b/shoebox/app/com/keepit/search/phrasedetector/PhraseDetector.scala
@@ -151,9 +151,6 @@ class PhraseIndexerImpl(indexDirectory: Directory, db: Database, phraseRepo: Phr
     indexDocuments(indexableIterator, 500000, refresh = false){ s => log.info(s"[PhraseIndexer] imported ${s.length} phrases. First in batch id: ${s.headOption.map(t=> t._1.id.id).getOrElse("")}") }
     if (refresh) refreshSearcher()
   }
-
-  def buildIndexable(data: Phrase): Indexable[Phrase] = throw new UnsupportedOperationException
-  def buildIndexable(id: Id[Phrase]): Indexable[Phrase] = throw new UnsupportedOperationException
 }
 
 

--- a/shoebox/test/com/keepit/search/graph/URIGraphTest.scala
+++ b/shoebox/test/com/keepit/search/graph/URIGraphTest.scala
@@ -373,7 +373,7 @@ class URIGraphTest extends Specification with DbRepos {
         uris.foreach{ uri => store += (uri.id.get -> mkArticle(uri.id.get, "title", "content")) }
 
         val indexer = URIGraph(ramDir).asInstanceOf[URIGraphImpl]
-        val doc = indexer.buildIndexable(user.id.get).buildDocument
+        val doc = indexer.buildIndexable(user.id.get, SequenceNumber.ZERO).buildDocument
         doc.getFields.forall{ f => indexer.getFieldDecoder(f.name).apply(f).length > 0 } === true
       }
     }


### PR DESCRIPTION
URIGraph needs to remember seq numbers at the time of getUsersChanged call and should not use seq numbers from bookmarks. Otherwise, if a new bookmark is added after getUsersChanged call, the Indexer's sequence number will jump, and the next indexing run can miss some changes. 
