### PR TITLE
Remove indexing states from NormalizedURI

### DIFF
--- a/shoebox/app/com/keepit/model/NormalizedURI.scala
+++ b/shoebox/app/com/keepit/model/NormalizedURI.scala
@@ -169,26 +169,14 @@ object NormalizedURIStates extends States[NormalizedURI] {
   val SCRAPED	= State[NormalizedURI]("scraped")
   val SCRAPE_FAILED = State[NormalizedURI]("scrape_failed")
   val UNSCRAPABLE = State[NormalizedURI]("unscrapable")
-  val INDEXED = State[NormalizedURI]("indexed")
-  val INDEX_FAILED = State[NormalizedURI]("index_failed")
-  val FALLBACKED = State[NormalizedURI]("fallbacked")
-  val FALLBACK_FAILED = State[NormalizedURI]("fallback_failed")
-  val UNSCRAPE_FALLBACK = State[NormalizedURI]("unscrape_fallback")
-  val UNSCRAPE_FALLBACK_FAILED = State[NormalizedURI]("unscrape_fallback_failed")
 
   type Transitions = Map[State[NormalizedURI], Set[State[NormalizedURI]]]
 
   val ALL_TRANSITIONS: Transitions = Map(
       (ACTIVE -> Set(SCRAPED, SCRAPE_FAILED, UNSCRAPABLE, INACTIVE)),
-      (SCRAPED -> Set(ACTIVE, INDEXED, INDEX_FAILED, INACTIVE)),
-      (SCRAPE_FAILED -> Set(ACTIVE, FALLBACKED, FALLBACK_FAILED, INACTIVE)),
-      (UNSCRAPABLE -> Set(ACTIVE, UNSCRAPE_FALLBACK, UNSCRAPE_FALLBACK_FAILED, INACTIVE)),
-      (INDEXED -> Set(ACTIVE, SCRAPED, INACTIVE, INDEXED)),
-      (INDEX_FAILED -> Set(ACTIVE, SCRAPED, INACTIVE, INDEX_FAILED)),
-      (FALLBACKED -> Set(ACTIVE, SCRAPE_FAILED, INACTIVE, FALLBACKED)),
-      (FALLBACK_FAILED -> Set(ACTIVE, SCRAPE_FAILED, INACTIVE, FALLBACK_FAILED)),
-      (UNSCRAPE_FALLBACK -> Set(ACTIVE, UNSCRAPABLE, INACTIVE, UNSCRAPE_FALLBACK)),
-      (UNSCRAPE_FALLBACK_FAILED -> Set(ACTIVE, UNSCRAPABLE, INACTIVE, UNSCRAPE_FALLBACK_FAILED)),
+      (SCRAPED -> Set(ACTIVE, INACTIVE)),
+      (SCRAPE_FAILED -> Set(ACTIVE, INACTIVE)),
+      (UNSCRAPABLE -> Set(ACTIVE, INACTIVE)),
       (INACTIVE -> Set(ACTIVE, INACTIVE)))
 
   val ADMIN_TRANSITIONS: Transitions = Map(
@@ -196,12 +184,6 @@ object NormalizedURIStates extends States[NormalizedURI] {
       (SCRAPED -> Set(ACTIVE)),
       (SCRAPE_FAILED -> Set(ACTIVE)),
       (UNSCRAPABLE -> Set(ACTIVE)),
-      (INDEXED -> Set(ACTIVE, SCRAPED)),
-      (INDEX_FAILED -> Set(ACTIVE, SCRAPED)),
-      (FALLBACKED -> Set(ACTIVE, SCRAPE_FAILED)),
-      (FALLBACK_FAILED -> Set(ACTIVE, SCRAPE_FAILED)),
-      (UNSCRAPE_FALLBACK -> Set(ACTIVE, UNSCRAPABLE)),
-      (UNSCRAPE_FALLBACK_FAILED -> Set(ACTIVE, UNSCRAPABLE)),
       (INACTIVE -> Set.empty))
 
   def transitionByAdmin[T](transition: (State[NormalizedURI], Set[State[NormalizedURI]]))(f:State[NormalizedURI]=>T) = {

--- a/shoebox/app/com/keepit/serializer/NormalizedURISerializer.scala
+++ b/shoebox/app/com/keepit/serializer/NormalizedURISerializer.scala
@@ -17,7 +17,8 @@ class NormalizedURISerializer extends Format[NormalizedURI] {
       "title"  -> (uri.title map { title => JsString(title) } getOrElse(JsNull)),
       "url"  -> JsString(uri.url),
       "urlHash"  -> JsString(uri.urlHash),
-      "state"  -> JsString(uri.state.value)
+      "state"  -> JsString(uri.state.value),
+      "seq" -> JsNumber(uri.seq.value)
     ))
 
   def reads(json: JsValue): JsResult[NormalizedURI] =
@@ -29,7 +30,8 @@ class NormalizedURISerializer extends Format[NormalizedURI] {
       title = (json \ "title").asOpt[String],
       url = (json \ "url").as[String],
       urlHash = (json \ "urlHash").as[String],
-      state = State[NormalizedURI]((json \ "state").as[String])
+      state = State[NormalizedURI]((json \ "state").as[String]),
+      seq = SequenceNumber((json \ "seq").as[Long])
     ))
 }
 

--- a/shoebox/app/views/admin/adminHelper/uriStateDisplay.scala.html
+++ b/shoebox/app/views/admin/adminHelper/uriStateDisplay.scala.html
@@ -1,22 +1,25 @@
-@(uri: NormalizedURI)
+@(uri: com.keepit.model.NormalizedURI)
+@import com.keepit.model.NormalizedURIStates._
 
-@{uri.state.value match {
-  case "indexed" => {
-    <span class="label label-success">{uri.state.value}</span>
-  }
-  case "active" => {
+<span data-seq="@uri.seq" class="uri-state">
+@{uri.state match {
+  case ACTIVE => {
     <span class="label label-important">{uri.state.value}</span>
   }
-  case "fallbacked" => {
-    <span class="label label-warning">{uri.state.value}</span>
+  case SCRAPED => {
+    <span class="label label-info if-not-indexed">scraped</span>
+    <span class="label label-success if-indexed" style="display: none">indexed</span>
   }
-  case "scraped" => {
-    <span class="label label-info">{uri.state.value}</span>
+  case SCRAPE_FAILED => {
+    <span class="label label-inverse if-not-indexed">scrape_failed</span>
+    <span class="label label-warning if-indexed" style="display: none">fallbacked</span>
   }
-  case "fallback_failed" => {
-    <span class="label label-inverse">{uri.state.value}</span>
+  case UNSCRAPABLE => {
+      <span class="label if-not-indexed">unscrapable</span>
+      <span class="label if-indexed" style="display: none">unscrape_fallback</span>
   }
   case _ => {
     <span class="label">{uri.state.value}</span>
   }
 }}
+</span>

--- a/shoebox/app/views/admin/bookmarks.scala.html
+++ b/shoebox/app/views/admin/bookmarks.scala.html
@@ -1,11 +1,13 @@
 @(bookmarksAndUsers: Seq[((User, SocialUserInfo), (Bookmark, NormalizedURI, Option[ScrapeInfo]))], page: Int, count: Long, pageCount: Int)
+@import com.keepit.model.NormalizedURIStates._
+@import com.keepit.controllers.admin.routes
 
 @pagination(page: Int, pageCount: Int) = {
   <div class="pagination pagination-centered pagination-mini">
     <ul>
       <li>
         @if(page > 0) {
-          <a href="@com.keepit.controllers.admin.routes.AdminBookmarksController.bookmarksView(page - 1)">
+          <a href="@routes.AdminBookmarksController.bookmarksView(page - 1)">
         } else {
          <a href="#">
         }
@@ -14,28 +16,28 @@
       </li>
       @if(page - 20 > 0) {
         <li class="disabled">
-          <a href="@com.keepit.controllers.admin.routes.AdminBookmarksController.bookmarksView(0)">...</a>
+          <a href="@routes.AdminBookmarksController.bookmarksView(0)">...</a>
         </li>
       }
       @for(i <- (0.max(page - 20) to (pageCount - 1).min(page + 20))) {
         @if(i == page) {
 	        <li class="disabled">
-	          <a href="@com.keepit.controllers.admin.routes.AdminBookmarksController.bookmarksView(i)">@{i + 1}</a>
+	          <a href="@routes.AdminBookmarksController.bookmarksView(i)">@{i + 1}</a>
 	        </li>
         } else {
 	        <li class="active">
-	          <a href="@com.keepit.controllers.admin.routes.AdminBookmarksController.bookmarksView(i)">@{i + 1}</a>
+	          <a href="@routes.AdminBookmarksController.bookmarksView(i)">@{i + 1}</a>
 	        </li>
 	      }
       }
       @if(page + 20 < pageCount - 1) {
         <li class="disabled">
-          <a href="@com.keepit.controllers.admin.routes.AdminBookmarksController.bookmarksView(pageCount - 1)">...</a>
+          <a href="@routes.AdminBookmarksController.bookmarksView(pageCount - 1)">...</a>
         </li>
       }
       <li>
         @if(bookmarksAndUsers.size > 0) {
-          <a href="@com.keepit.controllers.admin.routes.AdminBookmarksController.bookmarksView(page + 1)">
+          <a href="@routes.AdminBookmarksController.bookmarksView(page + 1)">
         } else {
          <a href="#">
         }
@@ -85,3 +87,16 @@
   </table>
   @pagination(page, pageCount)
 }
+
+<script type="text/javascript">
+  $.get("@routes.ArticleIndexerController.getSequenceNumber", function (data) {
+    var sequenceNumber = data.sequenceNumber
+    $(".uri-state").each(function () {
+      var seq = $(this).data('seq');
+      var indexed = seq <= sequenceNumber
+      $(this)
+        .find('.if-indexed').toggle(indexed).end()
+        .find('.if-not-indexed').toggle(!indexed);
+    });
+  });
+</script>

--- a/shoebox/conf/routes
+++ b/shoebox/conf/routes
@@ -99,11 +99,12 @@ GET     /admin/data/renormalize     com.keepit.controllers.admin.UrlController.r
 POST    /admin/data/handleDuplicate com.keepit.controllers.admin.ScraperController.handleDuplicate
 POST    /admin/data/handleDuplicates com.keepit.controllers.admin.ScraperController.handleDuplicates
 
-GET     /admin/article/index        com.keepit.controllers.admin.ArticleIndexerController.index
-GET     /admin/article/index/:state com.keepit.controllers.admin.ArticleIndexerController.indexByState(state: State[NormalizedURI])
-GET     /admin/article/indexInfo    com.keepit.controllers.admin.ArticleIndexerController.indexInfo
-GET     /admin/article/refreshSearcher com.keepit.controllers.admin.ArticleIndexerController.refreshSearcher
-GET     /admin/article/dumpDoc/:uriId  com.keepit.controllers.admin.ArticleIndexerController.dumpLuceneDocument(uriId: Id[NormalizedURI])
+GET     /admin/article/index        @com.keepit.controllers.admin.ArticleIndexerController.index
+GET     /admin/article/getSequenceNumber @com.keepit.controllers.admin.ArticleIndexerController.getSequenceNumber
+GET     /admin/article/index/:state @com.keepit.controllers.admin.ArticleIndexerController.indexByState(state: State[NormalizedURI])
+GET     /admin/article/indexInfo    @com.keepit.controllers.admin.ArticleIndexerController.indexInfo
+GET     /admin/article/refreshSearcher @com.keepit.controllers.admin.ArticleIndexerController.refreshSearcher
+GET     /admin/article/dumpDoc/:uriId  @com.keepit.controllers.admin.ArticleIndexerController.dumpLuceneDocument(uriId: Id[NormalizedURI])
 
 GET     /admin/uriGraph/load        com.keepit.controllers.admin.URIGraphController.load
 GET     /admin/uriGraph/update/:userId com.keepit.controllers.admin.URIGraphController.update(userId: Id[User])

--- a/shoebox/test/com/keepit/scraper/ScraperTest.scala
+++ b/shoebox/test/com/keepit/scraper/ScraperTest.scala
@@ -76,8 +76,10 @@ class ScraperTest extends Specification {
         inject[Database].readWrite { implicit s =>
           val uriRepo = inject[NormalizedURIRepo]
           val scrapeRepo = inject[ScrapeInfoRepo]
-          val uri1 = uriRepo.save(NormalizedURIFactory(title = "existing", url = "http://www.keepit.com/existing").withState(NormalizedURIStates.INDEXED))
-          val uri2 = uriRepo.save(NormalizedURIFactory(title = "missing", url = "http://www.keepit.com/missing").withState(NormalizedURIStates.INDEXED))
+          val uri1 = uriRepo.save(NormalizedURIFactory(title = "existing", url = "http://www.keepit.com/existing")
+              .withState(NormalizedURIStates.SCRAPED))
+          val uri2 = uriRepo.save(NormalizedURIFactory(title = "missing", url = "http://www.keepit.com/missing")
+              .withState(NormalizedURIStates.SCRAPED))
           val info1 = scrapeRepo.getByUri(uri1.id.get).get
           val info2 = scrapeRepo.getByUri(uri2.id.get).get
           val all = scrapeRepo.allActive

--- a/shoebox/test/com/keepit/search/index/ArticleIndexerTest.scala
+++ b/shoebox/test/com/keepit/search/index/ArticleIndexerTest.scala
@@ -80,7 +80,7 @@ class ArticleIndexerTest extends Specification with DbRepos {
       indexer.sequenceNumber = SequenceNumber(3) // skip initial documents
 
       db.readWrite { implicit s =>
-        uri1 = uriRepo.save(uriRepo.get(uri1.id.get).withState(INDEXED))
+        uri1 = uriRepo.save(uriRepo.get(uri1.id.get).withState(SCRAPED))
         uri2 = uriRepo.saveAsIndexable(uriRepo.get(uri2.id.get).withState(SCRAPED))
         uri3 = uriRepo.save(uriRepo.get(uri3.id.get).withState(ACTIVE))
       }
@@ -98,15 +98,6 @@ class ArticleIndexerTest extends Specification with DbRepos {
       indexer.run()
       indexer.sequenceNumber.value === 7
       indexer.numDocs === 3
-
-      db.readOnly { implicit s =>
-        uri1 = uriRepo.get(uri1.id.get)
-        uri2 = uriRepo.get(uri2.id.get)
-        uri3 = uriRepo.get(uri3.id.get)
-      }
-      uri1.state === INDEXED
-      uri2.state === INDEXED
-      uri3.state === INDEXED
 
       indexer = ArticleIndexer(ramDir, store)
       indexer.sequenceNumber.value === 7


### PR DESCRIPTION
Remove the indexing states (INDEXED, FALLBACKED, UNSCRAPE_FALLBACK) and rely on only the sequence number to see if a page has been indexed.

Also remove the indexing failure states (INDEX_FAILED, FALLBACK_FAILED, UNSCRAPE_FALLBACK_FAILED). Replace them with a healthcheck error, since they usually indicate a serious problem and they rarely occur (there are none in the production DB now). In the future we can have a table with more detailed information on indexing errors.
