### PR TITLE
Cache user info in search results

### DIFF
--- a/shoebox/app/com/keepit/common/social/BasicUser.scala
+++ b/shoebox/app/com/keepit/common/social/BasicUser.scala
@@ -6,16 +6,39 @@ import com.keepit.common.db._
 import com.keepit.common.db.slick.DBSession._
 import com.keepit.model._
 import com.keepit.inject._
+import com.google.inject.Inject
+import com.keepit.serializer.UserSerializer
+import com.keepit.serializer.BasicUserSerializer
+import com.keepit.common.cache.FortyTwoCache
+import com.keepit.common.cache.FortyTwoCachePlugin
+import com.keepit.common.cache.Key
+import play.api.libs.json.Json
+import play.api.libs.json.JsObject
+import scala.concurrent.duration._
 
-case class BasicUser(externalId: ExternalId[User], firstName: String, lastName: String, avatar: String) // todo: avatar is a URL
+case class BasicUser(externalId: ExternalId[User], firstName: String, lastName: String, facebookId: String, avatar: String) // todo: avatar is a URL
 
-class BasicUserRepo {
-  def load(user: User)(implicit session: RSession): BasicUser = {
-  	val socialUserInfo = inject[SocialUserInfoRepo].getByUser(user.id.get)
+case class BasicUserUserIdKey(userId: Id[User]) extends Key[BasicUser] {
+  val namespace = "basic_user_userid"
+  def toKey(): String = userId.id.toString
+}
+
+class BasicUserUserIdCache @Inject() (val repo: FortyTwoCachePlugin) extends FortyTwoCache[BasicUserUserIdKey, BasicUser] {
+  val ttl = 7 days
+  def deserialize(obj: Any): BasicUser = BasicUserSerializer.basicUserSerializer.reads(Json.parse(obj.asInstanceOf[String]).asInstanceOf[JsObject]).get
+  def serialize(basicUser: BasicUser) = BasicUserSerializer.basicUserSerializer.writes(basicUser)
+  // TODO(andrew): Invalidate cache. More tricky on this multi-object cache. Right now, the data doesn't change. When we go multi-network, it will.
+}
+
+class BasicUserRepo @Inject() (socialUserRepo: SocialUserInfoRepo, userRepo: UserRepo, userCache: BasicUserUserIdCache){
+  def load(userId: Id[User])(implicit session: RSession): BasicUser = userCache.getOrElse(BasicUserUserIdKey(userId)) {
+    val user = userRepo.get(userId)
+    val socialUserInfo = socialUserRepo.getByUser(user.id.get)
     BasicUser(
       externalId = user.externalId,
       firstName = user.firstName,
       lastName = user.lastName,
+      facebookId = socialUserInfo.head.socialId.id, // This needs to be refactored when we switch to multiple social networks. However, the extension relies on it now.
       avatar = "https://graph.facebook.com/" + socialUserInfo.head.socialId.id + "/picture?type=square" // todo: fix?
     )
   }

--- a/shoebox/app/com/keepit/common/social/ThreadInfo.scala
+++ b/shoebox/app/com/keepit/common/social/ThreadInfo.scala
@@ -40,6 +40,6 @@ class ThreadInfoRepo extends Logging {
   private def filteredRecipients(userIds: Seq[Id[User]], sessionUser: Option[Id[User]])(implicit session: RSession): Seq[BasicUser] = {
     val basicUserRepo = inject[BasicUserRepo]
     val userRepo = inject[UserRepo]
-    userIds.filterNot(recepientUserId => sessionUser map (_ == recepientUserId) getOrElse(false)).distinct map (u => basicUserRepo.load(userRepo.get(u)))
+    userIds.filterNot(recepientUserId => sessionUser map (_ == recepientUserId) getOrElse(false)).distinct map (u => basicUserRepo.load(u))
   }
 }

--- a/shoebox/app/com/keepit/controllers/ext/ExtSearchController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtSearchController.scala
@@ -7,7 +7,6 @@ import play.api.data.validation.Constraints._
 import play.api.libs.ws.WS
 import play.api.mvc._
 import play.api.http.ContentTypes
-
 import play.api.Play.current
 import com.keepit.common.db._
 import com.keepit.common.db.slick._
@@ -25,15 +24,15 @@ import com.keepit.common.social.UserWithSocial
 import com.keepit.search.ArticleSearchResultStore
 import com.keepit.common.controller.BrowserExtensionController
 import com.keepit.common.performance._
-
 import scala.util.Try
 import views.html
-
 import com.google.inject.{Inject, Singleton}
+import com.keepit.common.social.BasicUser
+import com.keepit.common.social.BasicUserRepo
 
 //note: users.size != count if some users has the bookmark marked as private
 case class PersonalSearchHit(id: Id[NormalizedURI], externalId: ExternalId[NormalizedURI], title: Option[String], url: String)
-case class PersonalSearchResult(hit: PersonalSearchHit, count: Int, isMyBookmark: Boolean, isPrivate: Boolean, users: Seq[UserWithSocial], score: Float)
+case class PersonalSearchResult(hit: PersonalSearchHit, count: Int, isMyBookmark: Boolean, isPrivate: Boolean, users: Seq[BasicUser], score: Float)
 case class PersonalSearchResultPacket(
   uuid: ExternalId[ArticleSearchResultRef],
   query: String,
@@ -53,7 +52,8 @@ class ExtSearchController @Inject() (
   articleSearchResultRefRepo: ArticleSearchResultRefRepo,
   socialUserInfoRepo: SocialUserInfoRepo,
   bookmarkRepo: BookmarkRepo,
-  uriRepo: NormalizedURIRepo)
+  uriRepo: NormalizedURIRepo,
+  basicUserRepo: BasicUserRepo)
     extends BrowserExtensionController {
 
   def search(query: String, filter: Option[String], maxHits: Int, lastUUIDStr: Option[String], context: Option[String], kifiVersion: Option[KifiVersion] = None) = AuthenticatedJsonAction { request =>
@@ -143,11 +143,7 @@ class ExtSearchController @Inject() (
     //todo:eishay why do we need the next line?
     val uri = uriRepo.get(res.uriId)
     val bookmark = if (res.isMyBookmark) bookmarkRepo.getByUriAndUser(uri.id.get, userId) else None
-    val users = res.users.toSeq.map{ userId =>
-      val user = userRepo.get(userId)
-      val info = socialUserInfoRepo.getByUser(userId).head
-      UserWithSocial(user, info, 0, Nil, Nil)
-    }
+    val users = res.users.toSeq.map(basicUserRepo.load)
     PersonalSearchResult(
       toPersonalSearchHit(uri, bookmark), res.bookmarkCount, res.isMyBookmark,
       bookmark.map(_.isPrivate).getOrElse(false), users, res.score)

--- a/shoebox/app/com/keepit/controllers/ext/ExtUserController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtUserController.scala
@@ -73,7 +73,7 @@ class ExtUserController @Inject() (
 
   def getSocialConnections() = AuthenticatedJsonAction { authRequest =>
     val socialConnections = db.readOnly {implicit s =>
-      socialConnectionRepo.getFortyTwoUserConnections(authRequest.userId).map(uid => basicUserRepo.load(userRepo.get(uid))).toSeq
+      socialConnectionRepo.getFortyTwoUserConnections(authRequest.userId).map(uid => basicUserRepo.load(uid)).toSeq
     }
 
     Ok(Json.obj("friends" -> socialConnections.map(sc => BasicUserSerializer.basicUserSerializer.writes(sc))))

--- a/shoebox/app/com/keepit/serializer/BasicUserSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/BasicUserSerializer.scala
@@ -1,19 +1,30 @@
 package com.keepit.serializer
 
 import com.keepit.common.db.ExternalId
-import com.keepit.common.time._
-import com.keepit.model.User
-import play.api.libs.json._
-import com.keepit.common.social.UserWithSocial
 import com.keepit.common.social.BasicUser
+import com.keepit.model.User
 
-class BasicUserSerializer extends Writes[BasicUser] {
+import play.api.libs.json._
+
+class BasicUserSerializer extends Format[BasicUser] {
+
+  def reads(json: JsValue): JsResult[BasicUser] = {
+    JsSuccess(BasicUser(
+      externalId = ExternalId[User]((json \ "externalId").as[String]),
+      firstName = (json \ "firstName").as[String],
+      lastName = (json \ "lastName").as[String],
+      avatar = (json \ "avatar").as[String],
+      facebookId = (json \ "facebookId").as[String]
+    ))
+  }
+
   def writes(basicUser: BasicUser): JsValue =
-    JsObject(List(
+    JsObject(Seq(
       "externalId"  -> JsString(basicUser.externalId.toString),
       "firstName" -> JsString(basicUser.firstName),
       "lastName"  -> JsString(basicUser.lastName),
-      "avatar" -> JsString(basicUser.avatar)
+      "avatar" -> JsString(basicUser.avatar),
+      "facebookId" -> JsString(basicUser.facebookId)
       )
     )
 

--- a/shoebox/app/com/keepit/serializer/PersonalSearchResultSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/PersonalSearchResultSerializer.scala
@@ -13,7 +13,7 @@ class PersonalSearchResultSerializer extends Writes[PersonalSearchResult] with L
       JsObject(List(
         "count"  -> JsString(res.count.toString()),
         "bookmark" -> PersonalSearchHitSerializer.hitSerializer.writes(res.hit),
-        "users" -> UserWithSocialSerializer.userWithSocialSerializer.writes(res.users),
+        "users" -> BasicUserSerializer.basicUserSerializer.writes(res.users),
         "score" -> JsNumber(res.score),
         "isMyBookmark" -> JsBoolean(res.isMyBookmark),
         "isPrivate" -> JsBoolean(res.isPrivate)


### PR DESCRIPTION
This migrates from using UserWithSocial to BasicUser, which is more lightweight and is designed for serialization. Additionally, this includes a cache for BasicUser so lookups will be faster.
