### PR TITLE
v2.2.22: refining new keep/lock user experience

### DIFF
--- a/packrat/adapters/chrome/manifest.json
+++ b/packrat/adapters/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Kifi Beta",
-  "version": "2.2.21",
+  "version": "2.2.22",
   "manifest_version": 2,
   "description": "Keep it, Find it!",
   "icons": {

--- a/packrat/adapters/firefox/package.json
+++ b/packrat/adapters/firefox/package.json
@@ -3,7 +3,7 @@
     "license": "MPL 2.0",
     "author": "FortyTwo Inc.",
     "homepage": "http://www.keepitfindit.com/",
-    "version": "2.2.21",
+    "version": "2.2.22",
     "fullName": "Keep It, Find It!",
     "id": "kifi@42go.com",
     "icon": "data/icons/kifi.48.png",

--- a/packrat/html/metro/slider2.html
+++ b/packrat/html/metro/slider2.html
@@ -1,5 +1,6 @@
 <div class="kifi-slider2">
   <span class="kifi-slider2-keep {{#isKept}}{{#isPrivate}}kifi-private{{/isPrivate}}{{^isPrivate}}kifi-public{{/isPrivate}}{{/isKept}}{{^isKept}}kifi-unkept{{/isKept}}">
+    <span class="kifi-slider2-keep-btn kifi-hoverless"></span>
     <span class="kifi-slider2-lock" style="background-image:url({{bgUrl}})"></span>
   </span>
   <span class="kifi-slider2-dock">

--- a/packrat/scripts/slider2.js
+++ b/packrat/scripts/slider2.js
@@ -3,7 +3,7 @@
 // #require styles/comments.css
 // @require scripts/lib/jquery-1.8.2.min.js
 // #require scripts/lib/jquery-ui-1.9.1.custom.min.js
-// #require scripts/lib/jquery-showhover.js
+// @require scripts/lib/jquery-showhover.js
 // #require scripts/lib/jquery-tokeninput-1.6.1.min.js
 // #require scripts/lib/jquery.timeago.js
 // @require scripts/lib/keymaster.min.js
@@ -63,24 +63,39 @@ slider2 = function() {
           });
 
           // attach event bindings
-          $slider.on("click", ".kifi-slider2-keep", function() {
-            if (this.classList.contains("kifi-unkept")) {
-              keepPage(this, false);
+          $slider.on("mouseout", ".kifi-slider2-keep-btn", function() {
+            this.classList.remove("kifi-hoverless");
+          }).on("click", ".kifi-slider2-keep-btn", function() {
+            var el = this.parentNode;
+            if (el.classList.contains("kifi-unkept")) {
+              keepPage(el, false);
             } else {
-              unkeepPage(this);
+              unkeepPage(el);
             }
+            this.classList.add("kifi-hoverless");
+          }).on("mouseenter", ".kifi-slider2-lock", function() {
+            $(this).showHover({
+              reuse: false,
+              showDelay: 250,
+              hideDelay: 100,
+              recovery: Infinity,
+              create: function(callback) {
+                var html = this.parentNode.classList.contains("kifi-unkept") ?
+                  "keep privately<br>(so only you can see it)" :
+                  this.parentNode.classList.contains("kifi-public") ? "make private" : "make  public";
+                var $h = $("<div class=kifi-slider2-tip>").html(html)
+                  .css({display: "block", visibility: "hidden"}).appendTo(this);
+                callback($h.css("left", 8 - $h[0].offsetWidth / 2).detach().css({display: "", visibility: ""}));
+              }});
           }).on("click", ".kifi-slider2-lock", function(e) {
-            e.stopPropagation();
-            var btn = this.parentNode;
-            if (btn.classList.contains("kifi-unkept")) {
-              keepPage(btn, true);
+            if (e.target !== this) return;
+            $(this).showHover("destroy");
+            var el = this.parentNode;
+            if (el.classList.contains("kifi-unkept")) {
+              keepPage(el, true);
             } else {
-              togglePrivate(btn);
+              togglePrivate(el);
             }
-          }).on("mouseover", ".kifi-slider2-lock", function() {
-            this.parentNode.classList.add("kifi-lock-hover");
-          }).on("mouseout", ".kifi-slider2-lock", function() {
-            this.parentNode.classList.remove("kifi-lock-hover");
           }).on("click", ".kifi-slider2-pane", function() {
             if (this.classList.contains("kifi-slider2-pane-hide")) {
               this.classList.remove("kifi-slider2-pane-hide");

--- a/packrat/styles/metro.css
+++ b/packrat/styles/metro.css
@@ -44,7 +44,7 @@
   right: 0;
   height: 62px;
   width: 120px;
-  font: 12px/42px sans-serif;
+  font-size: 12px;
   opacity: 1;
 }
 .kifi-slider2.kifi-visible {
@@ -68,58 +68,48 @@
   right: 10px;
   width: 120px;
   height: 42px;
-  line-height: 42px;
   border-radius: 5px;
+}
+.kifi-slider2-keep-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 100%;
+  height: 42px;
+  line-height: 42px;
+  border-radius: inherit;
   background: #34495e;
   color: #fff;
   font-family: Lato,sans-serif;
   text-align: center;
   cursor: pointer;
 }
-.kifi-slider2-keep.kifi-unkept::before {
+.kifi-unkept .kifi-slider2-keep-btn::before {
   content: "keep";
 }
-.kifi-slider2-keep.kifi-unkept.kifi-lock-hover::before {
-  content: "keep";
-}
-.kifi-slider2-keep.kifi-unkept.kifi-lock-hover::after {
-  content: "(private)";
-  font-size: 9px;
-  margin-left: 2px;
-}
-.kifi-slider2-keep.kifi-public::before {
+.kifi-public .kifi-slider2-keep-btn::before,
+.kifi-private .kifi-slider2-keep-btn::before,
+.kifi-public .kifi-slider2-keep-btn.kifi-hoverless:hover::before,
+.kifi-private .kifi-slider2-keep-btn.kifi-hoverless:hover::before {
   content: "kept";
 }
-.kifi-slider2-keep.kifi-public:hover::before {
-  content: "unkeep";
-}
-.kifi-slider2-keep.kifi-public.kifi-lock-hover::before {
-  content: "make private";
-}
-.kifi-slider2-keep.kifi-private::before {
-  content: "kept";
-}
-.kifi-slider2-keep.kifi-private::after {
+.kifi-private .kifi-slider2-keep-btn::after,
+.kifi-private .kifi-slider2-keep-btn.kifi-hoverless:hover::after {
   content: "(private)";
   font-size: 9px;
-  margin-left: 2px;
+  margin-left: 3px;
 }
-.kifi-slider2-keep.kifi-private:hover::before {
+.kifi-public .kifi-slider2-keep-btn:hover::before,
+.kifi-private .kifi-slider2-keep-btn:hover::before {
   content: "unkeep";
 }
-.kifi-slider2-keep.kifi-private:hover::after {
+.kifi-private .kifi-slider2-keep-btn:hover::after {
   content: "";
 }
-.kifi-slider2-keep.kifi-private.kifi-lock-hover::before {
-  content: "make public";
-}
-.kifi-slider2-keep.kifi-private.kifi-lock-hover::after {
-  content: "";
-}
-.kifi-slider2-keep:hover {
+.kifi-slider2-keep-btn:hover {
   background: #36526f;
 }
-.kifi-slider2-keep:active {
+.kifi-slider2-keep-btn:active {
   background: #304357;
 }
 .kifi-slider2-lock {
@@ -133,6 +123,7 @@
   background-color: #465f78;
   background-repeat: no-repeat;
   background-position: 0 999px;
+  cursor: pointer;
 }
 .kifi-slider2-lock:hover {
   background-color: #4c6c8c;
@@ -159,6 +150,7 @@
 .kifi-slider2-lock:hover::before {
   background-position: -98px 0;
 }
+
 .kifi-slider2-dock {
   position: absolute;
   bottom: 10px;
@@ -262,6 +254,36 @@
   height: 34px;
   margin-top: 4px;
   background: #506982;
+}
+.kifi-slider2-tip {
+  position: absolute;
+  bottom: 100%;
+  width: auto;
+  height: auto;
+  margin-bottom: 20px;
+  border-radius: 6px;
+  padding: 16px 24px 18px;
+  background-color: #2c3e50;
+  color: #fff;
+  font: 12px/16px Lato,sans-serif;
+  text-align: center;
+  white-space: nowrap;
+  cursor: default;
+  display: none;
+}
+.kifi-hover-showing .kifi-slider2-tip {
+  display: block;
+}
+.kifi-slider2-tip::before {
+  content: " ";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -8px;
+  font: 0/0 serif;
+  border-style: solid;
+  border-width: 8px 8px 0;
+  border-color: #2c3e50 transparent;
 }
 
 .kifi-pane {


### PR DESCRIPTION
- not putting the keep button in its `:hover` state if mouse is over the lock
- putting lock description in a delayed hover tip instead of in the button (less distracting)
- showing "kept" instead of "unkeep" initially if kept
- showing "kept" instead of "unkeep" immediately after keeping, then "unkeep" if the mouse leaves and re-enters
- adding a `$.showHover` option to immediately dispose of hover elements after use
