### PR TITLE
Schedule rescrape of URIGraph

### DIFF
--- a/shoebox/app/com/keepit/dev/DevGlobal.scala
+++ b/shoebox/app/com/keepit/dev/DevGlobal.scala
@@ -17,6 +17,7 @@ import com.keepit.common.social.SocialGraphRefresher
 import com.keepit.common.mail.MailSenderPlugin
 import com.keepit.common.analytics.reports.ReportBuilderPlugin
 import com.keepit.common.cache.{FortyTwoCachePlugin, MemcachedPlugin, MemcachedCache}
+import com.keepit.search.graph.URIGraphPlugin
 
 object DevGlobal extends FortyTwoGlobal(Dev) {
 
@@ -34,6 +35,7 @@ object DevGlobal extends FortyTwoGlobal(Dev) {
     inject[ReportBuilderPlugin].enabled
     inject[DataIntegrityPlugin].enabled
     inject[FortyTwoCachePlugin].enabled
+    inject[URIGraphPlugin].enabled
     log.info("shoebox started")
   }
 }

--- a/shoebox/app/com/keepit/search/graph/URIGraphPlugin.scala
+++ b/shoebox/app/com/keepit/search/graph/URIGraphPlugin.scala
@@ -1,30 +1,18 @@
 package com.keepit.search.graph
 
-import scala.collection.mutable.MutableList
-import com.keepit.common.logging.Logging
-import com.keepit.common.db.Id
-import com.keepit.model.User
-import play.api.Play.current
-import play.api.templates.Html
-import akka.util.Timeout
 import akka.actor._
-import akka.actor.Actor._
-import akka.actor.ActorRef
-import play.api.libs.concurrent.Execution.Implicits._
 import akka.pattern.ask
-import play.api.libs.concurrent._
-import org.joda.time.DateTime
+import akka.util.Timeout
 import com.google.inject.Inject
-import com.google.inject.Provider
-import com.keepit.inject._
-import com.keepit.common.healthcheck.{Healthcheck, HealthcheckPlugin, HealthcheckError}
-import scala.concurrent.duration._
-import scala.concurrent.Await
-import scala.concurrent.Future
 import com.keepit.common.akka.FortyTwoActor
+import com.keepit.common.healthcheck.{Healthcheck, HealthcheckPlugin, HealthcheckError}
+import com.keepit.common.logging.Logging
 import com.keepit.common.plugin.SchedulingPlugin
+import com.keepit.inject._
+import play.api.Play.current
+import scala.concurrent.Future
+import scala.concurrent.duration._
 
-case object Load
 case object Update
 
 private[graph] class URIGraphActor(uriGraph: URIGraph) extends FortyTwoActor with Logging {
@@ -54,10 +42,12 @@ class URIGraphPluginImpl @Inject() (system: ActorSystem, uriGraph: URIGraph) ext
 
   override def enabled: Boolean = true
   override def onStart() {
+    scheduleTask(system, 30 seconds, 1 minute, actor, Update)
     log.info("starting URIGraphPluginImpl")
   }
   override def onStop() {
-    log.info("stopping URIGrpahPluginImpl")
+    log.info("stopping URIGraphPluginImpl")
+    cancelTasks()
     uriGraph.close()
   }
 

--- a/shoebox/app/com/keepit/shoebox/ShoeboxGlobal.scala
+++ b/shoebox/app/com/keepit/shoebox/ShoeboxGlobal.scala
@@ -18,6 +18,7 @@ import com.keepit.common.healthcheck._
 import com.keepit.common.analytics.PersistEventPlugin
 import com.keepit.common.analytics.reports.ReportBuilderPlugin
 import com.keepit.common.cache.MemcachedPlugin
+import com.keepit.search.graph.URIGraphPlugin
 
 object ShoeboxGlobal extends FortyTwoGlobal(Prod) {
   private var creatingInjector = false
@@ -48,6 +49,7 @@ object ShoeboxGlobal extends FortyTwoGlobal(Prod) {
     require(inject[ReportBuilderPlugin].enabled)
     require(inject[DataIntegrityPlugin].enabled)
     require(inject[MemcachedPlugin].enabled)
+    require(inject[URIGraphPlugin].enabled)
     log.info("shoebox started")
   }
 


### PR DESCRIPTION
For the initial split of the search server I don't want to have to send messages to the URI graph for the update. We can add that in later. Even if we do decide to trigger a URIGraph update on every change, it is useful to have a scheduled task to make sure we didn't miss any events.
