### PR TITLE
Added versioning for the cache, with an example.

### DIFF
--- a/shoebox/app/com/keepit/common/cache/FortyTwoCache.scala
+++ b/shoebox/app/com/keepit/common/cache/FortyTwoCache.scala
@@ -95,8 +95,9 @@ class HashMapMemoryCache extends FortyTwoCachePlugin {
 
 trait Key[T] {
   val namespace: String
+  val version: Int = 1
   def toKey(): String
-  override final def toString: String = namespace + "#" + toKey()
+  override final def toString: String = namespace + "#" + version + "#" + toKey()
 }
 
 trait ObjectCache[K <: Key[T], T] {

--- a/shoebox/app/com/keepit/model/SocialUserInfo.scala
+++ b/shoebox/app/com/keepit/model/SocialUserInfo.scala
@@ -55,6 +55,7 @@ trait SocialUserInfoRepo extends Repo[SocialUserInfo] {
 
 case class SocialUserInfoUserKey(userId: Id[User]) extends Key[List[SocialUserInfo]] {
   val namespace = "social_user_info_by_userid"
+  override val version = 2
   def toKey(): String = userId.id.toString
 }
 class SocialUserInfoUserCache @Inject() (val repo: FortyTwoCachePlugin) extends FortyTwoCache[SocialUserInfoUserKey, List[SocialUserInfo]] {


### PR DESCRIPTION
When objects need to change, change the version for the respective keys. Old cached data will expire by itself.
