### PR TITLE
assume top-level domains are sensitive

### DIFF
--- a/shoebox/test/com/keepit/classify/DomainClassifierTest.scala
+++ b/shoebox/test/com/keepit/classify/DomainClassifierTest.scala
@@ -103,6 +103,8 @@ class DomainClassifierTest extends Specification with DbRepos {
         classifier.isSensitive("playboy.com") === Right(true)
         classifier.isSensitive("www.porn.com") === Right(true)
         classifier.isSensitive("porn.com") === Right(true)
+
+        classifier.isSensitive("local-domain") === Right(true)
       }
     }
   }


### PR DESCRIPTION
komodia will not have results for top-level domains (i.e. domains with no dots). These generally refer to local domains on the network, which we would normally want to keep private. We've run into issues with requests timing out so let's just always return a sensitive value of true here.
