### PR TITLE
adding api.tabs.getActive() to the cross-browser api for notifications

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -69,7 +69,7 @@ api = function() {
     if (lastPage) { // ignore popups, etc.
       if (/^https?:/.test(lastPage.url)) {
         dispatch.call(api.tabs.on.blur, lastPage);
-      } else {
+      } else if (lastPage.id) {
         // Chrome Instant search feature sometimes silently destroys chrome://newtab tabs (crbug.com/88458)
         chrome.tabs.get(lastPage.id, function(tab) {
           if (!tab) {
@@ -149,9 +149,10 @@ api = function() {
     delete selectedTabPages[winId];
   });
 
-  var focusedWinId;
+  var focusedWinId, topNormalWinId;
   chrome.windows.getLastFocused(null, function(win) {
     focusedWinId = win.focused ? win.id : chrome.windows.WINDOW_ID_NONE;
+    topNormalWinId = win.type == "normal" ? win.id : chrome.windows.WINDOW_ID_NONE;
   });
   chrome.windows.onFocusChanged.addListener(function(winId) {
     api.log("[onFocusChanged] win:", winId, "was:", focusedWinId);
@@ -163,6 +164,9 @@ api = function() {
     }
     focusedWinId = winId;
     if (winId !== chrome.windows.WINDOW_ID_NONE) {
+      if (selectedTabPages[winId]) {
+        topNormalWinId = winId;
+      }
       var page = selectedTabPages[winId];
       if (page && /^https?:/.test(page.url)) {
         dispatch.call(api.tabs.on.focus, page);
@@ -421,6 +425,10 @@ api = function() {
       },
       get: function(tabId) {
         return pages[tabId];
+      },
+      getActive: function() {
+        var page = selectedTabPages[topNormalWinId];
+        return page && /^https?:/.test(page.url) ? page : null;
       },
       isFocused: function(tab) {
         return selectedTabPages[focusedWinId] === tab;

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -25,7 +25,7 @@ const windows = require("sdk/windows").browserWindows;
 const tabs = require("sdk/tabs");
 const privateMode = require("sdk/private-browsing");
 
-var nextTabId = 1;
+var nextTabId = 1, topTabWin = windows.activeWindow;
 const pages = {}, workers = {}, tabsById = {};  // all by tab.id
 function createPage(tab) {
   if (!tab || !tab.id) throw Error(tab ? "tab without id" : "tab required");
@@ -199,8 +199,9 @@ exports.tabs = {
     return pages[pageId];
   },
   getActive: function() {
-    var win = windows.activeWindow, tab = win && win.tabs.activeTab;
-    return tab && pages[tab.id];
+    var tab = topTabWin && topTabWin.tabs.activeTab;
+    var page = tab && pages[tab.id];
+    return page && /^https?:/.test(page.url) ? page : null;
   },
   isFocused: function(page) {
     var tab = tabsById[page.id], win = tab.window;
@@ -286,6 +287,9 @@ windows
   removeFromWindow(win);
 })
 .on("activate", function(win) {
+  if (win.tabs.activeTab) {  // TODO: better detection of a window's tab support (popups have activeTab)
+    topTabWin = win;
+  }
   var page = pages[win.tabs.activeTab.id];
   if (page && /^https?:/.test(page.url)) {
     dispatch.call(exports.tabs.on.focus, page);

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -198,6 +198,10 @@ exports.tabs = {
   get: function(pageId) {
     return pages[pageId];
   },
+  getActive: function() {
+    var win = windows.activeWindow, tab = win && win.tabs.activeTab;
+    return tab && pages[tab.id];
+  },
   isFocused: function(page) {
     var tab = tabsById[page.id], win = tab.window;
     return win === windows.activeWindow && tab === win.tabs.activeTab;


### PR DESCRIPTION
`api.tabs.getActive()` returns the selected tab in the focused (or most recently focused) tabbed window, as long as the page's url scheme is `http:` or `https:`. Returns `null` if the scheme is different or if there are no open tab-capable windows.
