### PR TITLE
Refactored FortyTwoController to allow setting a parser explicitly.

### DIFF
--- a/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
@@ -48,7 +48,7 @@ class ExtAuthController @Inject() (
   sliderRuleRepo: SliderRuleRepo,
   userExperimentRepo: UserExperimentRepo)
     extends BrowserExtensionController {
-  def start = AuthenticatedJsonAction { implicit request =>
+  def start = AuthenticatedJsonToJsonAction { implicit request =>
     val userId = request.userId
     val socialUser = request.socialUser
     log.info(s"start id: $userId, facebook id: ${socialUser.id}")

--- a/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
@@ -53,7 +53,8 @@ class ExtAuthController @Inject() (
     val socialUser = request.socialUser
     log.info(s"start id: $userId, facebook id: ${socialUser.id}")
 
-    val (userAgent, version, installationIdOpt) = request.body.asJson.map { json =>
+    val json = request.body
+    val (userAgent, version, installationIdOpt) =
       (UserAgent((json \ "agent").as[String]),
        KifiVersion((json \ "version").as[String]),
        (json \ "installation").asOpt[String].flatMap { id =>
@@ -69,7 +70,7 @@ class ExtAuthController @Inject() (
                errorMessage = Some("Invalid ExternalId passed in \"%s\" for userId %s".format(id, userId))))
          }
          kiId
-       })}.get
+       })
     log.info(s"start details: $userAgent, $version, $installationIdOpt")
 
     val (user, installation, experiments, sliderRuleGroup, urlPatterns) = db.readWrite{implicit s =>

--- a/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
@@ -64,7 +64,7 @@ class ExtBookmarksController @Inject() (db: Database, bookmarkManager: BookmarkI
   }
 
   def remove() = AuthenticatedJsonAction { request =>
-    val url = (request.body.asJson.get \ "url").as[String]
+    val url = (request.body \ "url").as[String]
     val bookmark = db.readWrite { implicit s =>
       uriRepo.getByNormalizedUrl(url).flatMap { uri =>
         bookmarkRepo.getByUriAndUser(uri.id.get, request.userId).map { b =>
@@ -80,7 +80,8 @@ class ExtBookmarksController @Inject() (db: Database, bookmarkManager: BookmarkI
   }
 
   def updatePrivacy() = AuthenticatedJsonAction { request =>
-    val (url, priv) = request.body.asJson.map{o => ((o \ "url").as[String], (o \ "private").as[Boolean])}.get
+    val json = request.body
+    val (url, priv) = ((json \ "url").as[String], (json \ "private").as[Boolean])
     db.readWrite { implicit s =>
       uriRepo.getByNormalizedUrl(url).flatMap { uri =>
         bookmarkRepo.getByUriAndUser(uri.id.get, request.userId).filter(_.isPrivate != priv).map {b =>
@@ -96,35 +97,18 @@ class ExtBookmarksController @Inject() (db: Database, bookmarkManager: BookmarkI
   def addBookmarks() = AuthenticatedJsonAction { request =>
     val userId = request.userId
     val installationId = request.kifiInstallationId
-    request.body.asJson match {
-      case Some(json) =>
-        val bookmarkSource = (json \ "source").asOpt[String]
-        bookmarkSource match {
-          case Some("PLUGIN_START") => Forbidden
-          case _ =>
-            log.info("adding bookmarks of user %s".format(userId))
-            val experiments = request.experimants
-            val user = db.readOnly { implicit s => userRepo.get(userId) }
-            bookmarkManager.internBookmarks(json \ "bookmarks", user, experiments, BookmarkSource(bookmarkSource.getOrElse("UNKNOWN")), installationId)
-            uriGraphPlugin.update()
-            Ok(JsObject(Seq()))
-        }
-      case None =>
-        val (user, experiments, installation) = db.readOnly{ implicit session =>
-          (userRepo.get(userId),
-           experimentRepo.getByUser(userId) map (_.experimentType),
-           installationId.map(_.id).getOrElse(""))
-        }
-        val msg = "Unsupported operation for user %s with old installation".format(userId)
-        val metaData = JsObject(Seq("message" -> JsString(msg)))
-        val event = Events.userEvent(EventFamilies.ACCOUNT, "deprecated_add_bookmarks", user, experiments, installation, metaData)
-        dispatch ({
-           event.persistToS3().persistToMongo()
-        }, { e =>
-          healthcheck.addError(HealthcheckError(error = Some(e), callType = Healthcheck.API,
-              errorMessage = Some("Can't persist event %s".format(event))))
-        })
-        BadRequest(msg)
+    val json = request.body
+
+    val bookmarkSource = (json \ "source").asOpt[String]
+    bookmarkSource match {
+      case Some("PLUGIN_START") => Forbidden
+      case _ =>
+        log.info("adding bookmarks of user %s".format(userId))
+        val experiments = request.experimants
+        val user = db.readOnly { implicit s => userRepo.get(userId) }
+        bookmarkManager.internBookmarks(json \ "bookmarks", user, experiments, BookmarkSource(bookmarkSource.getOrElse("UNKNOWN")), installationId)
+        uriGraphPlugin.update()
+        Ok(JsObject(Seq()))
     }
   }
 

--- a/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
@@ -63,7 +63,7 @@ class ExtBookmarksController @Inject() (db: Database, bookmarkManager: BookmarkI
     Ok(JsObject(result.flatten))
   }
 
-  def remove() = AuthenticatedJsonAction { request =>
+  def remove() = AuthenticatedJsonToJsonAction { request =>
     val url = (request.body \ "url").as[String]
     val bookmark = db.readWrite { implicit s =>
       uriRepo.getByNormalizedUrl(url).flatMap { uri =>
@@ -79,7 +79,7 @@ class ExtBookmarksController @Inject() (db: Database, bookmarkManager: BookmarkI
     }
   }
 
-  def updatePrivacy() = AuthenticatedJsonAction { request =>
+  def updatePrivacy() = AuthenticatedJsonToJsonAction { request =>
     val json = request.body
     val (url, priv) = ((json \ "url").as[String], (json \ "private").as[Boolean])
     db.readWrite { implicit s =>
@@ -94,7 +94,7 @@ class ExtBookmarksController @Inject() (db: Database, bookmarkManager: BookmarkI
     }
   }
 
-  def addBookmarks() = AuthenticatedJsonAction { request =>
+  def addBookmarks() = AuthenticatedJsonToJsonAction { request =>
     val userId = request.userId
     val installationId = request.kifiInstallationId
     val json = request.body

--- a/shoebox/app/com/keepit/controllers/ext/ExtCommentController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtCommentController.scala
@@ -63,7 +63,7 @@ class ExtCommentController @Inject() (db: Database,
     Ok(JsObject(counts.map { case (id, n) => id.id -> JsArray(Seq(JsNumber(n._1), JsNumber(n._2))) }))
   }
 
-  def createComment() = AuthenticatedJsonAction { request =>
+  def createComment() = AuthenticatedJsonToJsonAction { request =>
     val o = request.body
     val (urlStr, title, text, permissions, recipients, parent) = (
       (o \ "url").as[String],
@@ -230,7 +230,7 @@ class ExtCommentController @Inject() (db: Database,
     Ok(commentWithSocialUserSerializer.writes(CommentPermissions.MESSAGE -> messages))
   }
 
-  def startFollowing() = AuthenticatedJsonAction { request =>
+  def startFollowing() = AuthenticatedJsonToJsonAction { request =>
     val url = (request.body \ "url").as[String]
     db.readWrite { implicit session =>
       val uriId = normalizedURIRepo.getByNormalizedUrl(url).getOrElse(normalizedURIRepo.save(NormalizedURIFactory(url = url))).id.get
@@ -247,7 +247,7 @@ class ExtCommentController @Inject() (db: Database,
     Ok(JsObject(Seq("following" -> JsBoolean(true))))
   }
 
-  def stopFollowing() = AuthenticatedJsonAction { request =>
+  def stopFollowing() = AuthenticatedJsonToJsonAction { request =>
     val url = (request.body \ "url").as[String]
     db.readWrite { implicit session =>
       normalizedURIRepo.getByNormalizedUrl(url).map { uri =>

--- a/shoebox/app/com/keepit/controllers/ext/ExtCommentController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtCommentController.scala
@@ -64,7 +64,7 @@ class ExtCommentController @Inject() (db: Database,
   }
 
   def createComment() = AuthenticatedJsonAction { request =>
-    val o = request.body.asJson.get
+    val o = request.body
     val (urlStr, title, text, permissions, recipients, parent) = (
       (o \ "url").as[String],
       (o \ "title") match { case JsString(s) => s; case _ => ""},
@@ -231,7 +231,7 @@ class ExtCommentController @Inject() (db: Database,
   }
 
   def startFollowing() = AuthenticatedJsonAction { request =>
-    val url = (request.body.asJson.get \ "url").as[String]
+    val url = (request.body \ "url").as[String]
     db.readWrite { implicit session =>
       val uriId = normalizedURIRepo.getByNormalizedUrl(url).getOrElse(normalizedURIRepo.save(NormalizedURIFactory(url = url))).id.get
       followRepo.get(request.userId, uriId, excludeState = None) match {
@@ -248,7 +248,7 @@ class ExtCommentController @Inject() (db: Database,
   }
 
   def stopFollowing() = AuthenticatedJsonAction { request =>
-    val url = (request.body.asJson.get \ "url").as[String]
+    val url = (request.body \ "url").as[String]
     db.readWrite { implicit session =>
       normalizedURIRepo.getByNormalizedUrl(url).map { uri =>
         followRepo.get(request.userId, uri.id.get).map { follow =>

--- a/shoebox/app/com/keepit/controllers/ext/ExtEventController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtEventController.scala
@@ -42,13 +42,7 @@ class ExtEventController @Inject() (
   def logUserEvents = AuthenticatedJsonAction { request =>
     val userId = request.userId
 
-    val json = try {
-      request.body.asJson.get
-    } catch {
-      case ex: java.util.NoSuchElementException =>
-        log.error(s"Bad event json payload from user id ${request.userId.id}\n${request.headers}\n${request.body}")
-        throw ex
-    }
+    val json = request.body
     (json \ "version").as[Int] match {
       case 1 => createEventsFromPayload(json, userId)
       case i => throw new Exception("Unknown events version: %s".format(i))

--- a/shoebox/app/com/keepit/controllers/ext/ExtEventController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtEventController.scala
@@ -39,7 +39,7 @@ class ExtEventController @Inject() (
   persistEventPlugin: PersistEventPlugin)
     extends BrowserExtensionController {
 
-  def logUserEvents = AuthenticatedJsonAction { request =>
+  def logUserEvents = AuthenticatedJsonToJsonAction { request =>
     val userId = request.userId
 
     val json = request.body

--- a/shoebox/app/com/keepit/controllers/ext/ExtUserController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtUserController.scala
@@ -49,7 +49,7 @@ class ExtUserController @Inject() (
         "sensitive" -> JsBoolean(sliderInfo.sensitive.getOrElse(false))))
   }
 
-  def suppressSliderForSite() = AuthenticatedJsonAction { request =>
+  def suppressSliderForSite() = AuthenticatedJsonToJsonAction { request =>
     val json = request.body
     val host: String = URI.parse((json \ "url").as[String]).get.host.get.name
     val suppress: Boolean = (json \ "suppress").as[Boolean]

--- a/shoebox/app/com/keepit/controllers/ext/ExtUserController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtUserController.scala
@@ -50,7 +50,7 @@ class ExtUserController @Inject() (
   }
 
   def suppressSliderForSite() = AuthenticatedJsonAction { request =>
-    val json = request.body.asJson.get
+    val json = request.body
     val host: String = URI.parse((json \ "url").as[String]).get.host.get.name
     val suppress: Boolean = (json \ "suppress").as[Boolean]
     val utd = db.readWrite {implicit s =>

--- a/shoebox/test/com/keepit/controllers/admin/AdminAuthControllerTest.scala
+++ b/shoebox/test/com/keepit/controllers/admin/AdminAuthControllerTest.scala
@@ -57,6 +57,7 @@ class AdminAuthControllerTest extends Specification with DbRepos {
         val whoisRequest1 = FakeRequest("GET", "/whois").
             withSession(SecureSocial.UserKey -> "111", SecureSocial.ProviderKey -> "facebook", "userId" -> admin.id.get.toString)
         val whoisResult1 = route(whoisRequest1).get
+
         (Json.parse(contentAsString(whoisResult1)) \ "externalUserId").as[String] === admin.externalId.toString
 
         val impersonateRequest = FakeRequest("POST", "/admin/user/%s/impersonate".format(impersonate.id.get.toString)).

--- a/shoebox/test/com/keepit/controllers/ext/ExtAuthControllerTest.scala
+++ b/shoebox/test/com/keepit/controllers/ext/ExtAuthControllerTest.scala
@@ -50,11 +50,11 @@ class ExtAuthControllerTest extends Specification with DbRepos {
         }
 
         //first round
-        val fakeRequest1 = FakeRequest().
+        val fakeRequest1: FakeRequest[JsValue] = FakeRequest().
             withSession(SecureSocial.UserKey -> "111", SecureSocial.ProviderKey -> "facebook").
-            withJsonBody(JsObject(Seq("agent" -> JsString("crome agent"), "version" -> JsString("1.1.1"))))
+            withBody[JsValue](JsObject(Seq("agent" -> JsString("crome agent"), "version" -> JsString("1.1.1"))))
         val authRequest1 = AuthenticatedRequest(null, user.id.get, fakeRequest1)
-        val result1 = inject[ExtAuthController].start(authRequest1)
+        val result1: Result = inject[ExtAuthController].start(authRequest1)
         status(result1) must equalTo(OK)
         val kifiInstallation1 = db.readOnly {implicit s =>
           val all = installationRepo.all()(s)
@@ -75,7 +75,7 @@ class ExtAuthControllerTest extends Specification with DbRepos {
         //second round
         val fakeRequest2 = FakeRequest().
             withSession(SecureSocial.UserKey -> "111", SecureSocial.ProviderKey -> "facebook").
-            withJsonBody(JsObject(Seq("agent" -> JsString("crome agent"), "version" -> JsString("1.1.1"), "installation" -> JsString(kifiInstallation1.externalId.id))))
+            withBody[JsValue](JsObject(Seq("agent" -> JsString("crome agent"), "version" -> JsString("1.1.1"), "installation" -> JsString(kifiInstallation1.externalId.id))))
         val authRequest2 = AuthenticatedRequest(null, user.id.get, fakeRequest2)
         val result2 = inject[ExtAuthController].start(authRequest2)
         status(result2) must equalTo(OK)

--- a/shoebox/test/com/keepit/controllers/ext/ExtAuthControllerTest.scala
+++ b/shoebox/test/com/keepit/controllers/ext/ExtAuthControllerTest.scala
@@ -50,11 +50,11 @@ class ExtAuthControllerTest extends Specification with DbRepos {
         }
 
         //first round
-        val fakeRequest1: FakeRequest[JsValue] = FakeRequest().
+        val fakeRequest1 = FakeRequest().
             withSession(SecureSocial.UserKey -> "111", SecureSocial.ProviderKey -> "facebook").
             withBody[JsValue](JsObject(Seq("agent" -> JsString("crome agent"), "version" -> JsString("1.1.1"))))
         val authRequest1 = AuthenticatedRequest(null, user.id.get, fakeRequest1)
-        val result1: Result = inject[ExtAuthController].start(authRequest1)
+        val result1 = inject[ExtAuthController].start(authRequest1)
         status(result1) must equalTo(OK)
         val kifiInstallation1 = db.readOnly {implicit s =>
           val all = installationRepo.all()(s)

--- a/shoebox/test/com/keepit/model/CommentReadTest.scala
+++ b/shoebox/test/com/keepit/model/CommentReadTest.scala
@@ -163,7 +163,7 @@ class CommentReadTest extends Specification with DbRepos {
         }
 
 
-        val fakeRequest = FakeRequest().withSession(SecureSocial.UserKey -> "111", SecureSocial.ProviderKey -> "facebook").withBody[JsValue](JsNull)
+        val fakeRequest = FakeRequest().withSession(SecureSocial.UserKey -> "111", SecureSocial.ProviderKey -> "facebook")
         val authRequest = AuthenticatedRequest(null, user1.id.get, fakeRequest)
         authRequest.session.get(SecureSocial.ProviderKey) === Some("facebook")
         val result = inject[ExtCommentController].getMessageThread(externalId)(authRequest)

--- a/shoebox/test/com/keepit/model/CommentReadTest.scala
+++ b/shoebox/test/com/keepit/model/CommentReadTest.scala
@@ -4,6 +4,7 @@ import org.specs2.mutable._
 import com.keepit.test.{DbRepos, EmptyApplication}
 
 import play.api.Play.current
+import play.api.libs.json._
 import com.google.inject.{Inject, ImplementedBy, Singleton}
 import com.keepit.inject._
 import com.keepit.common.db._
@@ -162,7 +163,7 @@ class CommentReadTest extends Specification with DbRepos {
         }
 
 
-        val fakeRequest = FakeRequest().withSession(SecureSocial.UserKey -> "111", SecureSocial.ProviderKey -> "facebook")
+        val fakeRequest = FakeRequest().withSession(SecureSocial.UserKey -> "111", SecureSocial.ProviderKey -> "facebook").withBody[JsValue](JsNull)
         val authRequest = AuthenticatedRequest(null, user1.id.get, fakeRequest)
         authRequest.session.get(SecureSocial.ProviderKey) === Some("facebook")
         val result = inject[ExtCommentController].getMessageThread(externalId)(authRequest)


### PR DESCRIPTION
This affected many other files, and changes testing slightly. When merged, we need to make sure all clients don't have an issue with this (since we're not accepting AnyContent anymore). However, as explained below, this should be resilient.

In Play!, `parse.json` requires that the client's Content Type be set correctly, and the body to be valid Json. `parse.tolerantJson` ignores the Content Type, but still requires the body to be valid Json. We have several routes that we want to use AuthenticatedJsonAction because they return Json, but they don't actually use a body. So, `tolerantJson` fails with an empty body. This implementation includes a Json parser called `actuallyTolerantJsonForReals`, which allows an empty body, and sets the body to JsNull.
