### PR TITLE
Store active experiments in memcache

### DIFF
--- a/shoebox/app/com/keepit/common/db/State.scala
+++ b/shoebox/app/com/keepit/common/db/State.scala
@@ -1,6 +1,7 @@
 package com.keepit.common.db
 
 import play.api.mvc.{PathBindable, QueryStringBindable}
+import play.api.libs.json._
 
 case class State[T](val value: String) {
   override def toString = value
@@ -21,6 +22,10 @@ trait States[T] {
 class StateException(message: String) extends Exception(message)
 
 object State {
+  def format[T]: Format[State[T]] = new Format[State[T]] {
+    def reads(json: JsValue): JsResult[State[T]] = __.read[String].reads(json).map(State(_))
+    def writes(o: State[T]): JsValue = JsString(o.value)
+  }
 
   implicit def queryStringBinder[T](implicit stringBinder: QueryStringBindable[String]) = new QueryStringBindable[State[T]] {
     override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, State[T]]] = {


### PR DESCRIPTION
This is so we can access the experiments across servers in a distributed manner. Before we were storing the active experiments in memory on the server.
