### PR TITLE
remove others from highscore

### DIFF
--- a/shoebox/app/com/keepit/search/MainSearcher.scala
+++ b/shoebox/app/com/keepit/search/MainSearcher.scala
@@ -141,8 +141,8 @@ class MainSearcher(
 
     val hits = createQueue(numHitsToReturn)
 
-    // global high score
-    val highScore = max(max(myHits.highScore, friendsHits.highScore), othersHits.highScore)
+    // global high score excluding others (an orphan uri sometimes makes results disappear)
+    val highScore = max(myHits.highScore, friendsHits.highScore)
 
     var threshold = highScore * tailCutting
 


### PR DESCRIPTION
I saw an orphan keep with high relevance score makes the tailcutting criterion very high, and removes all other hits. And since the orphan keep is not kept by anyone, it is also eliminated from the result.
To avoid this, I excluded others from the calculation fo the tailcutting criterion.
