### PR TITLE
Don't log search queries

### DIFF
--- a/shoebox/app/com/keepit/controllers/ext/ExtSearchController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtSearchController.scala
@@ -63,7 +63,7 @@ class ExtSearchController @Inject() (
     }
 
     val userId = request.userId
-    log.info("searching with %s using userId id %s".format(query, userId))
+    log.info(s"""User ${userId} searched ${query.length} characters""")
     val idFilter = IdFilterCompressor.fromBase64ToSet(context.getOrElse(""))
     val (friendIds, searchFilter) = time("search-connections") {
       db.readOnly { implicit s =>


### PR DESCRIPTION
I'd like to start archiving the logs in S3 so we should make sure private information like this isn't logged in production.
