### PR TITLE
added delete support in Indexer, fixed boolean explanation

### DIFF
--- a/shoebox/app/com/keepit/search/graph/URIGraph.scala
+++ b/shoebox/app/com/keepit/search/graph/URIGraph.scala
@@ -101,12 +101,16 @@ class URIGraphImpl(indexDirectory: Directory, indexWriterConfig: IndexWriterConf
     val bookmarks = inject[Database].readOnly { implicit session =>
       inject[BookmarkRepo].getByUser(userId)
     }
-    new URIListIndexable(userId, seq, bookmarks)
+    new URIListIndexable(id = userId,
+                         sequenceNumber = seq,
+                         isDeleted = false,
+                         bookmarks = bookmarks)
   }
 
   class URIListIndexable(
     override val id: Id[User],
     override val sequenceNumber: SequenceNumber,
+    override val isDeleted: Boolean,
     val bookmarks: Seq[Bookmark]
   ) extends Indexable[User] with LineFieldBuilder {
 

--- a/shoebox/app/com/keepit/search/index/ArticleIndexer.scala
+++ b/shoebox/app/com/keepit/search/index/ArticleIndexer.scala
@@ -8,6 +8,7 @@ import com.keepit.common.net.Host
 import com.keepit.common.net.URI
 import com.keepit.inject._
 import com.keepit.model._
+import com.keepit.model.NormalizedURIStates._
 import com.keepit.search.ArticleStore
 import com.keepit.search.Lang
 import java.io.StringReader
@@ -63,12 +64,17 @@ class ArticleIndexer(indexDirectory: Directory, indexWriterConfig: IndexWriterCo
   }
 
   def buildIndexable(uri: NormalizedURI): ArticleIndexable = {
-    new ArticleIndexable(uri.id.get, uri.seq, uri, articleStore)
+    new ArticleIndexable(id = uri.id.get,
+                         sequenceNumber = uri.seq,
+                         isDeleted = (uri.state == INACTIVE),
+                         uri = uri,
+                         articleStore = articleStore)
   }
 
   class ArticleIndexable(
-    val id: Id[NormalizedURI],
-    val sequenceNumber: SequenceNumber,
+    override val id: Id[NormalizedURI],
+    override val sequenceNumber: SequenceNumber,
+    override val isDeleted: Boolean,
     val uri: NormalizedURI,
     articleStore: ArticleStore
   ) extends Indexable[NormalizedURI] {

--- a/shoebox/app/com/keepit/search/index/ArticleIndexer.scala
+++ b/shoebox/app/com/keepit/search/index/ArticleIndexer.scala
@@ -25,6 +25,9 @@ object ArticleIndexer {
 
     new ArticleIndexer(indexDirectory, config, articleStore)
   }
+
+  private[this] val toBeDeletedStates = Set[State[NormalizedURI]](ACTIVE, INACTIVE, SCRAPE_WANTED, UNSCRAPABLE)
+  def shouldDelete(uri: NormalizedURI): Boolean = toBeDeletedStates.contains(uri.state)
 }
 
 class ArticleIndexer(indexDirectory: Directory, indexWriterConfig: IndexWriterConfig, articleStore: ArticleStore)
@@ -66,7 +69,7 @@ class ArticleIndexer(indexDirectory: Directory, indexWriterConfig: IndexWriterCo
   def buildIndexable(uri: NormalizedURI): ArticleIndexable = {
     new ArticleIndexable(id = uri.id.get,
                          sequenceNumber = uri.seq,
-                         isDeleted = (uri.state == INACTIVE),
+                         isDeleted = ArticleIndexer.shouldDelete(uri),
                          uri = uri,
                          articleStore = articleStore)
   }

--- a/shoebox/app/com/keepit/search/index/Indexable.scala
+++ b/shoebox/app/com/keepit/search/index/Indexable.scala
@@ -19,6 +19,8 @@ trait Indexable[T] {
 
   val sequenceNumber: SequenceNumber
   val id: Id[T]
+  val isDeleted: Boolean
+
   val idTerm = Indexer.idFieldTerm.createTerm(id.toString)
 
   def buildDocument: Document = {

--- a/shoebox/app/com/keepit/search/index/Indexer.scala
+++ b/shoebox/app/com/keepit/search/index/Indexer.scala
@@ -98,7 +98,11 @@ abstract class Indexer[T](indexDirectory: Directory, indexWriterConfig: IndexWri
           val error = document match {
             case Left(doc) =>
               try {
-                indexWriter.updateDocument(indexable.idTerm, doc)
+                if (indexable.isDeleted) {
+                  indexWriter.deleteDocuments(indexable.idTerm)
+                } else {
+                  indexWriter.updateDocument(indexable.idTerm, doc)
+                }
                 if (maxSequenceNumber < indexable.sequenceNumber)
                   maxSequenceNumber = indexable.sequenceNumber
                 log.debug("indexed id=%s seq=%s".format(indexable.id, indexable.sequenceNumber))

--- a/shoebox/app/com/keepit/search/phrasedetector/PhraseDetector.scala
+++ b/shoebox/app/com/keepit/search/phrasedetector/PhraseDetector.scala
@@ -156,6 +156,7 @@ class PhraseIndexerImpl(indexDirectory: Directory, db: Database, phraseRepo: Phr
 
 class PhraseIndexable(override val id: Id[Phrase], phrase: String, lang: Lang) extends Indexable[Phrase] with PhraseFieldBuilder {
   override val sequenceNumber = SequenceNumber.ZERO
+  override val isDeleted = false
   override def buildDocument = {
     val doc = super.buildDocument
     doc.add(buildPhraseField("p", phrase, lang))

--- a/shoebox/test/com/keepit/search/query/SemanticVectorQueryTest.scala
+++ b/shoebox/test/com/keepit/search/query/SemanticVectorQueryTest.scala
@@ -50,6 +50,7 @@ class SemanticVectorQueryTest extends Specification {
       implicit def toReader(text: String) = new StringReader(text)
 
       override val sequenceNumber = SequenceNumber.ZERO
+      override val isDeleted = false
 
       override def buildDocument = {
         val doc = super.buildDocument


### PR DESCRIPTION
With this change, ArticleIndexer can delete URIs with ACTIVE, INACTIVE, UNSCRAPABLE or SCRAPE_WANTED state.
Note that the sequence number is updated only by scraper when it successfully scraped. I think we need to update the sequence number whenever the state changes.
