### PR TITLE
Set up multiple dev modules

### DIFF
--- a/shoebox/app/com/keepit/dev/DevGlobal.scala
+++ b/shoebox/app/com/keepit/dev/DevGlobal.scala
@@ -27,20 +27,20 @@ object DevGlobal extends FortyTwoGlobal(Dev) {
 
 object SearchDevGlobal extends FortyTwoGlobal(Dev) {
   override val modules =
-    Seq(Modules.`override`(new CommonModule, new SearchModule).`with`(new DevModule))
+    Seq(Modules.`override`(new CommonModule, new SearchModule).`with`(new DevCommonModule, new SearchDevModule))
 
   override def onStart(app: Application) {
     super.onStart(app)
-    ShoeboxGlobal.startServices()
+    SearchGlobal.startServices()
   }
 }
 
 object ShoeboxDevGlobal extends FortyTwoGlobal(Dev) {
   override val modules =
-    Seq(Modules.`override`(new CommonModule, new ShoeboxModule).`with`(new DevModule))
+    Seq(Modules.`override`(new CommonModule, new ShoeboxModule).`with`(new DevCommonModule, new ShoeboxDevModule))
 
   override def onStart(app: Application) {
     super.onStart(app)
-    SearchGlobal.startServices()
+    ShoeboxGlobal.startServices()
   }
 }


### PR DESCRIPTION
DevModule included some search dependencies as well as shoebox dependencies, so ShoeboxDevGlobal and SearchDevGlobal provided some dependencies that didn't exist in production. Now that should no longer be the case.
