### PR TITLE
Use getHostName instead of getCanonicalHostName in Healthcheck

### DIFF
--- a/shoebox/app/com/keepit/module/CommonModule.scala
+++ b/shoebox/app/com/keepit/module/CommonModule.scala
@@ -104,7 +104,7 @@ class CommonModule extends ScalaModule with Logging {
   @Provides
   @AppScoped
   def healthcheckProvider(system: ActorSystem, postOffice: PostOffice, services: FortyTwoServices): HealthcheckPlugin = {
-    val host = InetAddress.getLocalHost().getCanonicalHostName()
+    val host = InetAddress.getLocalHost().getHostName()
     new HealthcheckPluginImpl(system, host, postOffice, services)
   }
 


### PR DESCRIPTION
Currently getCanonicalHostName() just returns localhost on all our servers, and according to the documentation, it's only a best-effort attempt to get the canonical host name.

getHostName appears to work in a more useful way on our servers. It provides the hostname as returned by the "hostname" command, e.g. b01.
