### PR TITLE
models (including reports) should not persist/save themselves (i.e. they...

### DIFF
--- a/shoebox/app/com/keepit/common/analytics/reports/Report.scala
+++ b/shoebox/app/com/keepit/common/analytics/reports/Report.scala
@@ -83,10 +83,7 @@ case class CompleteReport(reportName: String, reportVersion: String, list: Seq[R
     CompleteReport(newName, reportVersion, newList.sortWith((a,b) => a.date.isAfter(b.date)))
   }
 
-  def persist = {
-    inject[ReportStore] += ("%s %s".format(createdAt.toStandardTimeString, reportName) -> this)
-  }
-
+  def persistenceKey = "%s %s".format(createdAt.toStandardTimeString, reportName)
 }
 
 trait Report {


### PR DESCRIPTION
... are like princesses). it makes it hard in few ways, on is to guide up the system. the inject in the report builder will be kicked out later on.

\cc @andrewconner 
