### PR TITLE
Add functionality to keep by sending an email

### DIFF
--- a/shoebox/app/com/keepit/common/mail/MailToKeepPlugin.scala
+++ b/shoebox/app/com/keepit/common/mail/MailToKeepPlugin.scala
@@ -1,0 +1,215 @@
+package com.keepit.common.mail
+
+import scala.concurrent.duration._
+
+import com.google.inject.{ImplementedBy, Inject}
+import com.keepit.common.akka.FortyTwoActor
+import com.keepit.common.analytics.{EventFamilies, Events, PersistEventPlugin}
+import com.keepit.common.db.slick.Database
+import com.keepit.common.logging.Logging
+import com.keepit.common.net.URI
+import com.keepit.common.plugin.SchedulingPlugin
+import com.keepit.controllers.core.BookmarkInterner
+import com.keepit.model.{EmailAddress, EmailAddressRepo, User, UserRepo}
+
+import akka.actor.{Props, ActorSystem}
+import javax.mail._
+import javax.mail.internet.{InternetAddress, MimeMultipart}
+import javax.mail.search._
+import play.api.libs.json.Json
+
+private case object FetchNewKeeps
+
+case class MailToKeepServerSettings(
+  username: String,
+  password: String,
+  server: String,
+  protocol: String,
+  emailLabel: Option[String] = None
+)
+
+private class MailToKeepActor(
+    settings: MailToKeepServerSettings,
+    bookmarkInterner: BookmarkInterner,
+    persistEventPlugin: PersistEventPlugin,
+    postOffice: PostOffice,
+    messageParser: MailToKeepMessageParser
+  ) extends FortyTwoActor with Logging {
+
+  // add +$emailLabel to the end if provided
+  // this is so in dev mode we can append your username so as not to conflict with prod emails
+  private val KeepEmail = raw"""(\w+)${settings.emailLabel.map("""\+""" + _).getOrElse("")}@[\w\.]+""".r
+
+  private object KeepSearchTerm extends SearchTerm {
+    def `match`(m: Message) =
+      m.getAllRecipients.map(messageParser.getAddr).exists(KeepEmail.findFirstIn(_).isDefined)
+  }
+
+  private lazy val mailSession: Session = {
+    val props = System.getProperties()
+    props.setProperty("mail.store.protocol", settings.protocol)
+    Session.getInstance(props, null)
+  }
+
+  def receive = {
+    case FetchNewKeeps =>
+      val store = mailSession.getStore
+      try {
+        log.info("Looking for keeps by email")
+        store.connect(settings.server, settings.username, settings.password)
+        val inbox = store.getFolder("Inbox")
+        inbox.open(Folder.READ_WRITE)
+        val messages = inbox.search(KeepSearchTerm)
+        for (message <- messages) {
+          val senderAddr = messageParser.getSenderAddr(message)
+          (messageParser.getUser(message), messageParser.getUris(message)) match {
+            case (None, _) =>
+              sendEmail(
+                to = senderAddr,
+                subject = "Could not identify user",
+                htmlBody = s"<p>Kifi could not find a user for $senderAddr.</p>"
+              )
+            case (Some(user), Seq()) =>
+              sendEmail(
+                to = senderAddr,
+                subject = s"Your message '${message.getSubject}' contained no URLs",
+                htmlBody =
+                    s"<p>Hi ${user.firstName},</p>" +
+                    "<p>We couldn't find any URLs in your message. Try making sure your URL format is valid.</p>"
+              )
+            case (Some(user), uris) =>
+              for (uri <- uris) {
+                val bookmark = bookmarkInterner.internBookmarks(Json.obj(
+                  "url" -> uri.toString,
+                  "isPrivate" -> true
+                ), user, Seq(), "EMAIL").head
+                log.info(s"created bookmark from email with id ${bookmark.id.get}")
+                val event = Events.serverEvent(EventFamilies.GENERIC_SERVER, "email_keep", Json.obj(
+                  "user_id" -> user.id.get.id,
+                  "bookmark_id" -> bookmark.id.get.id
+                ))
+                persistEventPlugin.persist(event)
+                sendEmail(
+                  to = senderAddr,
+                  subject = s"Successfully kept $uri",
+                  htmlBody =
+                      s"<p>Hi ${user.firstName},</p>" +
+                      s"<p>Congratulations! We successfully kept $uri for you.</p>" +
+                      "<p>Sincerely,<br>The kifi elves</p>"
+                )
+              }
+          }
+          message.setFlags(new Flags(Flags.Flag.DELETED), true)
+        }
+        inbox.close(true)
+      } finally {
+        store.close()
+      }
+  }
+
+  private def sendEmail(to: String, subject: String, htmlBody: String) {
+    postOffice.sendMail(ElectronicMail(
+      from = EmailAddresses.NOTIFICATIONS,
+      fromName = Some("Kifi Elves"),
+      to = new EmailAddressHolder { val address = to },
+      subject = subject,
+      htmlBody = htmlBody,
+      category = PostOffice.Categories.EMAIL_KEEP
+    ))
+  }
+}
+
+class MailToKeepMessageParser @Inject() (
+    db: Database,
+    emailAddressRepo: EmailAddressRepo,
+    userRepo: UserRepo
+  ) {
+
+  private val Url = """\bhttps?://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]\b""".r
+
+  def getSenderAddr(m: Message): String = {
+    m.getReplyTo.headOption.orElse(m.getFrom.headOption).map(getAddr).head
+  }
+
+  def getUris(m: Message): Seq[URI] = {
+    Url.findAllIn(getContent(m) + " " + m.getSubject).map(URI.parse(_).toOption).flatten.toList.distinct
+  }
+
+  def getContent(m: Message): String = {
+    m.getContent match {
+      case mm: MimeMultipart =>
+        (0 until mm.getCount).map(mm.getBodyPart).foldLeft(None: Option[String]) { (v, part) =>
+          if (!Option(part.getDisposition).getOrElse("").equalsIgnoreCase("ATTACHMENT"))
+            v orElse getText(part)
+          else v
+        }.getOrElse("")
+      case c => c.toString
+    }
+  }
+
+  // see http://www.oracle.com/technetwork/java/javamail/faq/index.html#mainbody
+  // This makes no attempts to deal with malformed emails.
+  private def getText(p: Part): Option[String] = {
+    if (p.isMimeType("text/*")) {
+      Option(p.getContent.asInstanceOf[String])
+    } else if (p.isMimeType("multipart/alternative")) {
+      val mp = p.getContent.asInstanceOf[Multipart]
+      (0 until mp.getCount).map(mp.getBodyPart).foldLeft(None: Option[String]) { (text, bp) =>
+        if (bp.isMimeType("text/html"))
+          getText(bp) orElse text
+        else
+          text orElse getText(bp)
+      }
+    } else if (p.isMimeType("multipart/*")) {
+      val mp = p.getContent.asInstanceOf[Multipart]
+      (0 until mp.getCount).map(mp.getBodyPart).foldLeft(None: Option[String]) { _ orElse getText(_) }
+    } else {
+      None
+    }
+  }
+
+  def getUser(message: Message): Option[User] = {
+    db.readOnly { implicit s =>
+      message.getFrom.map(getAddr)
+        .map(emailAddressRepo.getByAddressOpt(_).map(_.userId)).headOption.flatten.map(userRepo.get)
+    }
+  }
+
+  def getAddr(address: javax.mail.Address): String =
+    address.asInstanceOf[InternetAddress].getAddress
+}
+
+@ImplementedBy(classOf[MailToKeepPluginImpl])
+trait MailToKeepPlugin extends SchedulingPlugin {
+  def fetchNewKeeps()
+}
+
+class MailToKeepPluginImpl @Inject()(
+  system: ActorSystem,
+  settings: MailToKeepServerSettings,
+  bookmarkInterner: BookmarkInterner,
+  persistEventPlugin: PersistEventPlugin,
+  postOffice: PostOffice,
+  messageParser: MailToKeepMessageParser
+) extends MailToKeepPlugin with Logging {
+
+  override def enabled: Boolean = true
+
+  val actor = system.actorOf(Props {
+    new MailToKeepActor(settings, bookmarkInterner, persistEventPlugin, postOffice, messageParser)
+  })
+
+  def fetchNewKeeps() {
+    actor ! FetchNewKeeps
+  }
+  override def onStart() {
+    log.info("Starting MailToKeepPluginImpl")
+    scheduleTask(system, 10 seconds, 1 minute, actor, FetchNewKeeps)
+  }
+}
+
+class FakeMailToKeepPlugin extends MailToKeepPlugin with Logging {
+  def fetchNewKeeps() {
+    log.info("Fake fetching new keeps")
+  }
+}

--- a/shoebox/app/com/keepit/common/mail/PostOffice.scala
+++ b/shoebox/app/com/keepit/common/mail/PostOffice.scala
@@ -41,6 +41,7 @@ object PostOffice {
     val COMMENT = ElectronicMailCategory("COMMENT")
     val MESSAGE = ElectronicMailCategory("MESSAGE")
     val ADMIN = ElectronicMailCategory("ADMIN")
+    val EMAIL_KEEP = ElectronicMailCategory("EMAIL_KEEP")
   }
 
   val BODY_MAX_SIZE = 524288

--- a/shoebox/app/com/keepit/common/mail/SendgridMailProvider.scala
+++ b/shoebox/app/com/keepit/common/mail/SendgridMailProvider.scala
@@ -46,7 +46,7 @@ class SendgridMailProvider @Inject() (db: Database, mailRepo: ElectronicMailRepo
     props.put("mail.smtp.auth", "true")
 
     val auth = new SMTPAuthenticator()
-    val mailSession = Session.getDefaultInstance(props, auth)
+    val mailSession = Session.getInstance(props, auth)
 //    mailSession.setDebug(log.isDebugEnabled)
     mailSession.setDebug(true)
     mailSession

--- a/shoebox/app/com/keepit/controllers/core/BookmarkInterner.scala
+++ b/shoebox/app/com/keepit/controllers/core/BookmarkInterner.scala
@@ -1,27 +1,15 @@
 package com.keepit.controllers.core
 
-import com.keepit.classify.{Domain, DomainClassifier, DomainRepo}
 import com.keepit.common.analytics.EventFamilies
 import com.keepit.common.analytics.Events
-import com.keepit.common.async._
 import com.keepit.common.db._
 import com.keepit.common.db.slick.DBSession._
 import com.keepit.common.db.slick._
-import com.keepit.common.healthcheck.{Healthcheck, HealthcheckPlugin, HealthcheckError}
-import com.keepit.common.net._
-import com.keepit.common.social._
 import com.keepit.model._
 import com.keepit.scraper.ScraperPlugin
-import com.keepit.search.graph.URIGraph
-import com.keepit.search.graph.URIGraphPlugin
-import com.keepit.serializer.BookmarkSerializer
 import com.keepit.common.logging.Logging
 
-import scala.concurrent.Await
-import play.api.libs.concurrent.Execution.Implicits._
-import play.api.Play.current
 import play.api.libs.json._
-import scala.concurrent.duration._
 
 import com.keepit.common.analytics.ActivityStream
 
@@ -40,7 +28,7 @@ class BookmarkInterner @Inject() (db: Database, uriRepo: NormalizedURIRepo, scra
   }
 
   private def internBookmark(json: JsObject, user: User, experiments: Seq[State[ExperimentType]], source: BookmarkSource, installationId: Option[ExternalId[KifiInstallation]] = None): Option[Bookmark] = {
-    val title = (json \ "title").as[String]
+    val title = (json \ "title").asOpt[String]
     val url = (json \ "url").as[String]
     val isPrivate = (json \ "isPrivate").asOpt[Boolean].getOrElse(true)
 
@@ -63,18 +51,20 @@ class BookmarkInterner @Inject() (db: Database, uriRepo: NormalizedURIRepo, scra
           case None =>
             Events.userEvent(EventFamilies.SLIDER, "newKeep", user, experiments, installationId.map(_.id).getOrElse(""), JsObject(Seq("source" -> JsString(source.value))))
             val urlObj = urlRepo.get(url).getOrElse(urlRepo.save(URLFactory(url = url, normalizedUriId = uri.id.get)))
-            Some(bookmarkRepo.save(BookmarkFactory(uri, user.id.get, title, urlObj, source, isPrivate, installationId)))
+            Some(bookmarkRepo.save(
+              BookmarkFactory(uri, user.id.get, title orElse uri.title, urlObj, source, isPrivate, installationId)))
         }
       }
       if(bookmark.isDefined) addToActivityStream(user, bookmark.get)
 
+      bookmark.foreach { b => log.info(db.readWrite { implicit s => bookmarkRepo.get(b.id.get) }.toString) }
       bookmark
     } else {
       None
     }
   }
 
-  private def createNewURI(title: String, url: String)(implicit session: RWSession) =
+  private def createNewURI(title: Option[String], url: String)(implicit session: RWSession) =
     uriRepo.save(NormalizedURIFactory(title = title, url = url, state = NormalizedURIStates.SCRAPE_WANTED))
 
   private def addToActivityStream(user: User, bookmark: Bookmark) = {

--- a/shoebox/app/com/keepit/controllers/ext/ExtSearchController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtSearchController.scala
@@ -151,7 +151,7 @@ class ExtSearchController @Inject() (
 
   private[ext] def toPersonalSearchHit(uri: NormalizedURI, bookmark: Option[Bookmark]) = {
     val (title, url) = bookmark match {
-      case Some(bookmark) => (Some(bookmark.title), bookmark.url)
+      case Some(bookmark) => (bookmark.title, bookmark.url)
       case None => (uri.title, uri.url)
     }
 

--- a/shoebox/app/com/keepit/dev/DevModule.scala
+++ b/shoebox/app/com/keepit/dev/DevModule.scala
@@ -1,9 +1,6 @@
 package com.keepit.dev
 
-import java.io.File
-
-import org.apache.lucene.store.{RAMDirectory, MMapDirectory, Directory}
-
+import akka.actor.ActorSystem
 import com.google.common.io.Files
 import com.google.inject.Provides
 import com.google.inject.Singleton
@@ -13,15 +10,18 @@ import com.keepit.common.analytics._
 import com.keepit.common.cache._
 import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
+import com.keepit.common.mail._
+import com.keepit.controllers.core.BookmarkInterner
 import com.keepit.inject._
-import com.keepit.model.PhraseRepo
+import com.keepit.model.{EmailAddressRepo, UserRepo, PhraseRepo}
 import com.keepit.search.graph.URIGraph
 import com.keepit.search.index.ArticleIndexer
 import com.keepit.search.phrasedetector.PhraseIndexer
 import com.keepit.search.{ResultClickTracker, ArticleStore}
 import com.mongodb.casbah.MongoConnection
 import com.tzavellas.sse.guice.ScalaModule
-
+import java.io.File
+import org.apache.lucene.store.{RAMDirectory, MMapDirectory, Directory}
 import play.api.Play.current
 
 class ShoeboxDevModule extends ScalaModule with Logging {
@@ -31,6 +31,33 @@ class ShoeboxDevModule extends ScalaModule with Logging {
   @Provides
   def domainTagImportSettings: DomainTagImportSettings = {
     DomainTagImportSettings(localDir = Files.createTempDir().getAbsolutePath, url = "http://localhost:8000/42.zip")
+  }
+
+  @AppScoped
+  @Provides
+  def mailToKeepPlugin(
+      system: ActorSystem,
+      bookmarkInterner: BookmarkInterner,
+      persistEventPlugin: PersistEventPlugin,
+      postOffice: PostOffice,
+      messageParser: MailToKeepMessageParser): MailToKeepPlugin = {
+    for {
+      username <- current.configuration.getString("mailtokeep.username")
+      password <- current.configuration.getString("mailtokeep.password")
+    } yield {
+      val server = current.configuration.getString("mailtokeep.server").getOrElse("imap.gmail.com")
+      val protocol = current.configuration.getString("mailtokeep.protocol").getOrElse("imaps")
+      val emailLabel = System.getProperty("user.name")
+      val settings = MailToKeepServerSettings(
+        username = username,
+        password = password,
+        server = server,
+        protocol = protocol,
+        emailLabel = Some(emailLabel))
+      new MailToKeepPluginImpl(system, settings, bookmarkInterner, persistEventPlugin, postOffice, messageParser)
+    }
+  } getOrElse {
+    new FakeMailToKeepPlugin
   }
 }
 

--- a/shoebox/app/com/keepit/model/Bookmark.scala
+++ b/shoebox/app/com/keepit/model/Bookmark.scala
@@ -32,7 +32,7 @@ case class Bookmark(
   createdAt: DateTime = currentDateTime,
   updatedAt: DateTime = currentDateTime,
   externalId: ExternalId[Bookmark] = ExternalId(),
-  title: String,
+  title: Option[String] = None,
   uriId: Id[NormalizedURI],
   urlId: Option[Id[URL]] = None, // todo(Andrew): remove Option after grandfathering process
   url: String, // denormalized for efficiency
@@ -66,6 +66,7 @@ trait BookmarkRepo extends Repo[Bookmark] with ExternalIdColumnFunction[Bookmark
   def allActive()(implicit session: RSession): Seq[Bookmark]
   def getByUriAndUser(uriId: Id[NormalizedURI], userId: Id[User])(implicit session: RSession): Option[Bookmark]
   def getByUri(uriId: Id[NormalizedURI])(implicit session: RSession): Seq[Bookmark]
+  def getByUriWithoutTitle(uriId: Id[NormalizedURI])(implicit session: RSession): Seq[Bookmark]
   def getByUser(userId: Id[User])(implicit session: RSession): Seq[Bookmark]
   def getUsersChanged(num: SequenceNumber)(implicit session: RSession): Seq[(Id[User], SequenceNumber)]
   def count(userId: Id[User])(implicit session: RSession): Int
@@ -101,7 +102,7 @@ class BookmarkRepoImpl @Inject() (
   private val sequence = db.getSequence("bookmark_sequence")
 
   override lazy val table = new RepoTable[Bookmark](db, "bookmark") with ExternalIdColumn[Bookmark] {
-    def title = column[String]("title", O.NotNull)
+    def title = column[Option[String]]("title", O.Nullable)
     def uriId = column[Id[NormalizedURI]]("uri_id", O.NotNull)
     def urlId = column[Id[URL]]("url_id", O.NotNull)
     def url =   column[String]("url", O.NotNull)
@@ -135,6 +136,9 @@ class BookmarkRepoImpl @Inject() (
   def getByUri(uriId: Id[NormalizedURI])(implicit session: RSession): Seq[Bookmark] =
     (for(b <- table if b.uriId === uriId && b.state === BookmarkStates.ACTIVE) yield b).list
 
+  def getByUriWithoutTitle(uriId: Id[NormalizedURI])(implicit session: RSession): Seq[Bookmark] =
+    (for(b <- table if b.uriId === uriId && b.state === BookmarkStates.ACTIVE && b.title.isNull) yield b).list
+
   def getByUser(userId: Id[User])(implicit session: RSession): Seq[Bookmark] =
     (for(b <- table if b.userId === userId && b.state === BookmarkStates.ACTIVE) yield b).list
 
@@ -166,11 +170,11 @@ class BookmarkRepoImpl @Inject() (
 
 object BookmarkFactory {
 
-  def apply(uri: NormalizedURI, userId: Id[User], title: String, url: URL, source: BookmarkSource, isPrivate: Boolean, kifiInstallation: Option[ExternalId[KifiInstallation]]): Bookmark =
+  def apply(uri: NormalizedURI, userId: Id[User], title: Option[String], url: URL, source: BookmarkSource, isPrivate: Boolean, kifiInstallation: Option[ExternalId[KifiInstallation]]): Bookmark =
     Bookmark(title = title, userId = userId, uriId = uri.id.get, urlId = Some(url.id.get), url = url.url, source = source, isPrivate = isPrivate)
 
   def apply(title: String, url: URL, uriId: Id[NormalizedURI], userId: Id[User], source: BookmarkSource): Bookmark =
-    Bookmark(title = title, urlId = Some(url.id.get), url = url.url, uriId = uriId, userId = userId, source = source)
+    Bookmark(title = Some(title), urlId = Some(url.id.get), url = url.url, uriId = uriId, userId = userId, source = source)
 
   def apply(title: String, urlId: Id[URL],  uriId: Id[NormalizedURI], userId: Id[User], source: BookmarkSource, isPrivate: Boolean): Bookmark =
     BookmarkFactory(title = title, urlId = urlId, uriId = uriId, userId = userId, source = source, isPrivate = isPrivate)

--- a/shoebox/app/com/keepit/search/graph/URIGraph.scala
+++ b/shoebox/app/com/keepit/search/graph/URIGraph.scala
@@ -157,11 +157,13 @@ class URIGraphImpl(indexDirectory: Directory, indexWriterConfig: IndexWriterConf
     }
 
     def buildLangMap(bookmarks: Seq[Bookmark], preferedLang: Lang) = {
-      bookmarks.foldLeft(Map.empty[String,Lang]){ (m, b) => m + (b.title -> LangDetector.detect(b.title, preferedLang)) }
+      bookmarks.foldLeft(Map.empty[String,Lang]){ (m, b) =>
+        m + (b.title.getOrElse("") -> LangDetector.detect(b.title.getOrElse(""), preferedLang))
+      }
     }
 
     def buildBookmarkTitleField(fieldName: String, uriList: URIList, bookmarks: Seq[Bookmark])(tokenStreamFunc: (String, String)=>Option[TokenStream]) = {
-      val titleMap = bookmarks.foldLeft(Map.empty[Long,String]){ (m, b) => m + (b.uriId.id -> b.title) }
+      val titleMap = bookmarks.foldLeft(Map.empty[Long,String]){ (m, b) => m + (b.uriId.id -> b.title.getOrElse("")) }
 
       val publicList = uriList.publicList
       val privateList = uriList.privateList

--- a/shoebox/app/com/keepit/serializer/BookmarkSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/BookmarkSerializer.scala
@@ -11,7 +11,7 @@ class BookmarkSerializer extends Writes[Bookmark] {
   def writes(bookmark: Bookmark): JsValue =
     JsObject(Seq(
       "externalId" -> JsString(bookmark.externalId.toString),
-      "title" -> JsString(bookmark.title),
+      "title" -> bookmark.title.map(JsString).getOrElse(JsNull),
       "url" -> JsString(bookmark.url),
       "isPrivate" -> JsBoolean(bookmark.isPrivate),
       "state" -> JsString(bookmark.state.toString)))

--- a/shoebox/app/com/keepit/shoebox/ShoeboxGlobal.scala
+++ b/shoebox/app/com/keepit/shoebox/ShoeboxGlobal.scala
@@ -5,7 +5,7 @@ import com.keepit.common.analytics.PersistEventPlugin
 import com.keepit.common.analytics.reports.ReportBuilderPlugin
 import com.keepit.common.cache.FortyTwoCachePlugin
 import com.keepit.common.healthcheck._
-import com.keepit.common.mail.MailSenderPlugin
+import com.keepit.common.mail.{MailToKeepPlugin, MailSenderPlugin}
 import com.keepit.common.social.SocialGraphPlugin
 import com.keepit.common.social.SocialGraphRefresher
 import com.keepit.inject._
@@ -32,6 +32,7 @@ object ShoeboxGlobal extends FortyTwoGlobal(Prod) {
     require(inject[SocialGraphRefresher].enabled)
     require(inject[MailSenderPlugin].enabled)
     inject[MailSenderPlugin].processOutbox()
+    require(inject[MailToKeepPlugin].enabled)
     require(inject[HealthcheckPlugin].enabled)
     require(inject[PersistEventPlugin].enabled)
     require(inject[ReportBuilderPlugin].enabled)

--- a/shoebox/app/com/keepit/shoebox/ShoeboxModule.scala
+++ b/shoebox/app/com/keepit/shoebox/ShoeboxModule.scala
@@ -6,10 +6,13 @@ import com.google.inject.Singleton
 import com.keepit.classify.DomainTagImportSettings
 import com.keepit.common.analytics.reports._
 import com.keepit.common.logging.Logging
+import com.keepit.common.mail.{MailToKeepPlugin, MailToKeepPluginImpl, MailToKeepServerSettings}
 import com.keepit.common.social.{SocialGraphRefresherImpl, SocialGraphRefresher}
 import com.keepit.inject.AppScoped
 import com.keepit.scraper._
 import com.tzavellas.sse.guice.ScalaModule
+
+import play.api.Play.current
 
 class ShoeboxModule() extends ScalaModule with Logging {
   def configure(): Unit = {
@@ -18,6 +21,7 @@ class ShoeboxModule() extends ScalaModule with Logging {
     bind[ReportBuilderPlugin].to[ReportBuilderPluginImpl].in[AppScoped]
     bind[DataIntegrityPlugin].to[DataIntegrityPluginImpl].in[AppScoped]
     bind[ScraperPlugin].to[ScraperPluginImpl].in[AppScoped]
+    bind[MailToKeepPlugin].to[MailToKeepPluginImpl].in[AppScoped]
   }
 
   @Singleton
@@ -25,6 +29,16 @@ class ShoeboxModule() extends ScalaModule with Logging {
   def domainTagImportSettings: DomainTagImportSettings = {
     val dirPath = Files.createTempDir().getAbsolutePath
     DomainTagImportSettings(localDir = dirPath, url = "http://www.komodia.com/clients/42.zip")
+  }
+
+  @Singleton
+  @Provides
+  def mailToKeepServerSettings: MailToKeepServerSettings = {
+    val username = current.configuration.getString("mailtokeep.username").get
+    val password = current.configuration.getString("mailtokeep.password").get
+    val server = current.configuration.getString("mailtokeep.server").getOrElse("imap.gmail.com")
+    val protocol = current.configuration.getString("mailtokeep.protocol").getOrElse("imaps")
+    MailToKeepServerSettings(username = username, password = password, server = server, protocol = protocol)
   }
 
 }

--- a/shoebox/app/views/admin/adminHelper/bookmarkDisplay.scala.html
+++ b/shoebox/app/views/admin/adminHelper/bookmarkDisplay.scala.html
@@ -2,5 +2,5 @@
 
 <a href="@com.keepit.controllers.admin.routes.AdminBookmarksController.edit(bookmark.id.get)">
 @admin.adminHelper.bookmarkBadge(bookmark)
-@{if (bookmark.title.size > 70) bookmark.title.substring(0, 70) + "..." else bookmark.title}
+@{bookmark.title.map(t => if (t.size > 70) t.substring(0, 70) + "..." else t).getOrElse("(no title)")}
 </a>

--- a/shoebox/app/views/admin/bookmarks.scala.html
+++ b/shoebox/app/views/admin/bookmarks.scala.html
@@ -77,6 +77,9 @@
           case "PLUGIN_START" => {
             <span class="label label-info">Plugin Restart</span>
           }
+          case "EMAIL" => {
+            <span class="label label-success">Email</span>
+          }
         }}
       </td>
       <td>@adminHelper.dateTimeDisplay(bookmark.createdAt)</td>

--- a/shoebox/conf/application.conf
+++ b/shoebox/conf/application.conf
@@ -118,6 +118,13 @@ parsers.text.maxLength=1048576
 memcached.host="zz9pluralzalpha.g4hldh.cfg.usw1.cache.amazonaws.com:11211"
 
 # ~~~~~~~~~~~~~~~~~~
+# Mail to Keep
+# ~~~~~~~~~~~~~~~~~~
+# disable this by default on dev
+#mailtokeep.username = "keep@42go.com"
+#mailtokeep.password = "m7N71k0Yd85RFlOr"
+
+# ~~~~~~~~~~~~~~~~~~
 # Scheduler
 # ~~~~~~~~~~~~~~~~~~
 scheduler.enabled = true

--- a/shoebox/conf/evolutions/shoebox/50.sql
+++ b/shoebox/conf/evolutions/shoebox/50.sql
@@ -1,0 +1,9 @@
+# ALTER TABLE bookmark MODIFY COLUMN title VARCHAR(2048) NULL;
+
+# --- !Ups
+
+ALTER TABLE bookmark ALTER COLUMN title SET NULL;
+
+insert into evolutions (name, description) values('50.sql', 'make bookmark title nullable');
+
+# --- !Downs

--- a/shoebox/conf/prod/prod.conf
+++ b/shoebox/conf/prod/prod.conf
@@ -110,6 +110,12 @@ slider-history-tracker = {
 }
 
 # ~~~~~~~~~~~~~~~~~~
+# Mail to Keep
+# ~~~~~~~~~~~~~~~~~~
+mailtokeep.username = "keep@42go.com"
+mailtokeep.password = "m7N71k0Yd85RFlOr"
+
+# ~~~~~~~~~~~~~~~~~~
 # Cache Resources
 # ~~~~~~~~~~~~~~~~~~
 memcached.host="zz9pluralzalpha.g4hldh.cfg.usw1.cache.amazonaws.com:11211"

--- a/shoebox/test/com/keepit/common/mail/MailToKeepMessageParserTest.scala
+++ b/shoebox/test/com/keepit/common/mail/MailToKeepMessageParserTest.scala
@@ -1,0 +1,89 @@
+package com.keepit.common.mail
+
+import java.util.Properties
+
+import org.specs2.mutable.Specification
+
+import com.keepit.common.db.slick.Database
+import com.keepit.inject.inject
+import com.keepit.model.{EmailAddress, User, UserRepo, EmailAddressRepo}
+
+import javax.mail.Message.RecipientType
+import javax.mail.Session
+import javax.mail.internet.{MimeMultipart, MimeBodyPart, InternetAddress, MimeMessage}
+import play.api.Play.current
+import play.api.test.Helpers.running
+import com.keepit.test.EmptyApplication
+
+class MailToKeepMessageParserTest extends Specification {
+  "MailToKeepMessageParser" should {
+    "parse out the content from multipart emails" in {
+      running(new EmptyApplication()) {
+        val parser = new MailToKeepMessageParser(inject[Database], inject[EmailAddressRepo], inject[UserRepo])
+
+        val session = Session.getDefaultInstance(new Properties())
+        val message = new MimeMessage(session)
+        message.setSubject("hi")
+        message.setFrom(new InternetAddress("eishay@42go.com"))
+        message.setRecipient(RecipientType.TO, new InternetAddress("greg@42go.com"))
+
+        val content = new MimeMultipart("alternative")
+        val (text, html) = (new MimeBodyPart(), new MimeBodyPart())
+        text.setText("Hey, this is plain text")
+        val htmlText = "<p>Hey, this is html</p>"
+        html.setContent(htmlText, "text/html")
+        content.addBodyPart(html)
+        content.addBodyPart(text)
+        message.setContent(content)
+
+        parser.getContent(message) === htmlText
+      }
+    }
+  }
+  "parse out uris correctly" in {
+    running(new EmptyApplication()) {
+      val parser = new MailToKeepMessageParser(inject[Database], inject[EmailAddressRepo], inject[UserRepo])
+
+      val session = Session.getDefaultInstance(new Properties())
+      val message = new MimeMessage(session)
+      message.setSubject("hi")
+      message.setFrom(new InternetAddress("eishay@42go.com"))
+      message.setRecipient(RecipientType.TO, new InternetAddress("greg@42go.com"))
+
+      val content = new MimeMultipart("alternative")
+      val (text, html) = (new MimeBodyPart(), new MimeBodyPart())
+      text.setText("Hey, you should check out http://google.com/.")
+      val htmlText = "<p>Hey, you should check out http://google.com/search and http://yahoo.com/</p>"
+      html.setContent(htmlText, "text/html")
+      content.addBodyPart(html)
+      content.addBodyPart(text)
+      message.setContent(content)
+
+      parser.getUris(message).map(_.host.get.toString) === Seq("google.com", "yahoo.com")
+    }
+  }
+  "parse out users correctly" in {
+    running(new EmptyApplication()) {
+      val db = inject[Database]
+      val emailAddressRepo = inject[EmailAddressRepo]
+      val userRepo = inject[UserRepo]
+      val (eishay, greg) = db.readWrite { implicit s =>
+        (userRepo.save(User(firstName = "Eishay", lastName = "Smith")),
+        userRepo.save(User(firstName = "Greg", lastName = "Methvin")))
+      }
+      db.readWrite { implicit s =>
+        emailAddressRepo.save(EmailAddress(address = "eishay@42go.com", userId = eishay.id.get))
+        emailAddressRepo.save(EmailAddress(address = "greg@42go.com", userId = greg.id.get))
+      }
+      val parser = new MailToKeepMessageParser(db, emailAddressRepo, userRepo)
+      val session = Session.getDefaultInstance(new Properties())
+      val message = new MimeMessage(session)
+      message.setSubject("hi")
+      message.setFrom(new InternetAddress("eishay@42go.com"))
+      message.setRecipient(RecipientType.TO, new InternetAddress("greg@42go.com"))
+      message.setContent("Hey, you should check out http://google.com/.", "text/html")
+
+      parser.getUser(message).get.firstName === "Eishay"
+    }
+  }
+}

--- a/shoebox/test/com/keepit/model/BookmarkTest.scala
+++ b/shoebox/test/com/keepit/model/BookmarkTest.scala
@@ -36,9 +36,12 @@ class BookmarkTest extends Specification with DbRepos {
 
       val hover = BookmarkSource("HOVER_KEEP")
 
-      bookmarkRepo.save(Bookmark(title = "G1", userId = user1.id.get, url = url1.url, urlId = url1.id, uriId = uri1.id.get, source = hover, createdAt = t1.plusMinutes(3)))
-      bookmarkRepo.save(Bookmark(title = "A1", userId = user1.id.get, url = url2.url, urlId = url2.id, uriId = uri2.id.get, source = hover, createdAt = t1.plusHours(50)))
-      bookmarkRepo.save(Bookmark(title = "G2", userId = user2.id.get, url = url1.url, urlId = url1.id, uriId = uri1.id.get, source = hover, createdAt = t2.plusDays(1)))
+      bookmarkRepo.save(Bookmark(title = Some("G1"), userId = user1.id.get, url = url1.url, urlId = url1.id,
+        uriId = uri1.id.get, source = hover, createdAt = t1.plusMinutes(3)))
+      bookmarkRepo.save(Bookmark(title = Some("A1"), userId = user1.id.get, url = url2.url, urlId = url2.id,
+        uriId = uri2.id.get, source = hover, createdAt = t1.plusHours(50)))
+      bookmarkRepo.save(Bookmark(title = None, userId = user2.id.get, url = url1.url, urlId = url1.id,
+        uriId = uri1.id.get, source = hover, createdAt = t2.plusDays(1)))
 
       (user1, user2, uri1, uri2)
     }
@@ -53,15 +56,15 @@ class BookmarkTest extends Specification with DbRepos {
         }
         println(cxAll mkString "\n")
         val all = inject[Database].readOnly(implicit session => bookmarkRepo.all)
-        all.map(_.title) === Seq("G1", "A1", "G2")
+        all.map(_.title) === Seq(Some("G1"), Some("A1"), None)
       }
     }
     "load by user" in {
       running(new EmptyApplication()) {
         val (user1, user2, uri1, uri2) = setup()
         db.readOnly {implicit s =>
-          bookmarkRepo.getByUser(user1.id.get).map(_.title) === Seq("G1", "A1")
-          bookmarkRepo.getByUser(user2.id.get).map(_.title) === Seq("G2")
+          bookmarkRepo.getByUser(user1.id.get).map(_.title) === Seq(Some("G1"), Some("A1"))
+          bookmarkRepo.getByUser(user2.id.get).map(_.title) === Seq(None)
         }
       }
     }
@@ -69,8 +72,8 @@ class BookmarkTest extends Specification with DbRepos {
       running(new EmptyApplication()) {
         val (user1, user2, uri1, uri2) = setup()
         db.readOnly {implicit s =>
-          bookmarkRepo.getByUri(uri1.id.get).map(_.title) === Seq("G1", "G2")
-          bookmarkRepo.getByUri(uri2.id.get).map(_.title) === Seq("A1")
+          bookmarkRepo.getByUri(uri1.id.get).map(_.title) === Seq(Some("G1"), None)
+          bookmarkRepo.getByUri(uri2.id.get).map(_.title) === Seq(Some("A1"))
         }
       }
     }

--- a/shoebox/test/com/keepit/scraper/ScraperTest.scala
+++ b/shoebox/test/com/keepit/scraper/ScraperTest.scala
@@ -288,7 +288,8 @@ class ScraperTest extends Specification {
       def close() {}
     }
     new Scraper(inject[Database], mockHttpFetcher, articleStore, ScraperConfig(),
-      inject[ScrapeInfoRepo], inject[NormalizedURIRepo], inject[HealthcheckPlugin], inject[UnscrapableRepo]) {
+      inject[ScrapeInfoRepo], inject[NormalizedURIRepo], inject[HealthcheckPlugin],
+      inject[BookmarkRepo], inject[UnscrapableRepo]) {
       override protected def getExtractor(url: String): Extractor = {
         new TikaBasedExtractor(url, 10000) {
           protected def getContentHandler = new BodyContentHandler(output)

--- a/shoebox/test/com/keepit/test/TestApplication.scala
+++ b/shoebox/test/com/keepit/test/TestApplication.scala
@@ -18,7 +18,7 @@ import com.keepit.common.db.slick._
 import com.keepit.common.healthcheck.FakeHealthcheckModule
 import com.keepit.common.healthcheck.{Babysitter, BabysitterImpl, BabysitterTimeout}
 import com.keepit.common.logging.Logging
-import com.keepit.common.mail.FakeMailModule
+import com.keepit.common.mail.{FakeMailToKeepPlugin, MailToKeepPlugin, FakeMailModule}
 import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.common.social.FakeSecureSocialUserServiceModule
 import com.keepit.common.store.FakeStoreModule
@@ -88,6 +88,7 @@ case class TestModule() extends ScalaModule {
       lazy val driverName = Play.current.configuration.getString("db.shoebox.driver").get
     }))
     bind[FortyTwoCachePlugin].to[HashMapMemoryCache]
+    bind[MailToKeepPlugin].to[FakeMailToKeepPlugin]
 
     val listenerBinder = Multibinder.newSetBinder(binder(), classOf[EventListenerPlugin])
     listenerBinder.addBinding().to(classOf[KifiResultClickedListener])


### PR DESCRIPTION
This lets you keep by sending an email to keep@kifi.com with the URL. If the email is associated with your account on kifi, it will keep the URL for you and send you a confirmation.

Next, I plan to implement finding by email with find@kifi.com.
