### PR TITLE
Fix deadlock by starting the Play app after we start the services

### DIFF
--- a/shoebox/app/com/keepit/dev/DevGlobal.scala
+++ b/shoebox/app/com/keepit/dev/DevGlobal.scala
@@ -19,9 +19,9 @@ object DevGlobal extends FortyTwoGlobal(Dev) {
   override def onStart(app: Application) {
     require(inject[FortyTwoServices].currentService == ServiceType.DEV_MODE,
         "DevGlobal can only be run on a dev service")
-    super.onStart(app)
     ShoeboxGlobal.startServices()
     SearchGlobal.startServices()
+    super.onStart(app)
   }
 }
 
@@ -30,8 +30,8 @@ object SearchDevGlobal extends FortyTwoGlobal(Dev) {
     Seq(Modules.`override`(new CommonModule, new SearchModule).`with`(new DevCommonModule, new SearchDevModule))
 
   override def onStart(app: Application) {
-    super.onStart(app)
     SearchGlobal.startServices()
+    super.onStart(app)
   }
 }
 
@@ -40,7 +40,7 @@ object ShoeboxDevGlobal extends FortyTwoGlobal(Dev) {
     Seq(Modules.`override`(new CommonModule, new ShoeboxModule).`with`(new DevCommonModule, new ShoeboxDevModule))
 
   override def onStart(app: Application) {
-    super.onStart(app)
     ShoeboxGlobal.startServices()
+    super.onStart(app)
   }
 }

--- a/shoebox/app/com/keepit/search/SearchGlobal.scala
+++ b/shoebox/app/com/keepit/search/SearchGlobal.scala
@@ -18,8 +18,8 @@ object SearchGlobal extends FortyTwoGlobal(Prod) {
 
   override def onStart(app: Application) {
     log.info("starting the search")
-    super.onStart(app)
     startServices()
+    super.onStart(app)
     log.info("search started")
   }
 

--- a/shoebox/app/com/keepit/shoebox/ShoeboxGlobal.scala
+++ b/shoebox/app/com/keepit/shoebox/ShoeboxGlobal.scala
@@ -21,8 +21,8 @@ object ShoeboxGlobal extends FortyTwoGlobal(Prod) {
 
   override def onStart(app: Application): Unit = {
     log.info("starting the shoebox")
-    super.onStart(app)
     startServices()
+    super.onStart(app)
     log.info("shoebox started")
   }
 


### PR DESCRIPTION
FortyTwoGlobal#onStart would start injecting dependencies while we were injecting those plugins in startServices. This change appears to have fixed the deadlock.
