### PR TITLE
Message parser improvements and tests

### DIFF
--- a/shoebox/test/com/keepit/common/mail/MailToKeepMessageParserTest.scala
+++ b/shoebox/test/com/keepit/common/mail/MailToKeepMessageParserTest.scala
@@ -17,7 +17,7 @@ import com.keepit.test.EmptyApplication
 
 class MailToKeepMessageParserTest extends Specification {
   "MailToKeepMessageParser" should {
-    "parse out the content from multipart emails" in {
+    "parse out the text from multipart emails" in {
       running(new EmptyApplication()) {
         val parser = new MailToKeepMessageParser(inject[Database], inject[EmailAddressRepo], inject[UserRepo])
 
@@ -29,61 +29,60 @@ class MailToKeepMessageParserTest extends Specification {
 
         val content = new MimeMultipart("alternative")
         val (text, html) = (new MimeBodyPart(), new MimeBodyPart())
-        text.setText("Hey, this is plain text")
-        val htmlText = "<p>Hey, this is html</p>"
+        text.setText("Hey, this is plain text (http://google.com)")
+        val htmlText = "<p>Hey, this is html (yahoo.com)</p>"
         html.setContent(htmlText, "text/html")
         content.addBodyPart(html)
         content.addBodyPart(text)
         message.setContent(content)
+        message.saveChanges()
 
-        parser.getContent(message) === htmlText
+        parser.getText(message) must beSome("Hey, this is plain text (http://google.com)")
+        parser.getUris(message).map(_.toString) === Seq("http://google.com")
       }
     }
-  }
-  "parse out uris correctly" in {
-    running(new EmptyApplication()) {
-      val parser = new MailToKeepMessageParser(inject[Database], inject[EmailAddressRepo], inject[UserRepo])
+    "parse out uris correctly from HTML" in {
+      running(new EmptyApplication()) {
+        val parser = new MailToKeepMessageParser(inject[Database], inject[EmailAddressRepo], inject[UserRepo])
 
-      val session = Session.getDefaultInstance(new Properties())
-      val message = new MimeMessage(session)
-      message.setSubject("Hey, this is Eishay from 42go.com")
-      message.setFrom(new InternetAddress("eishay@42go.com"))
-      message.setRecipient(RecipientType.TO, new InternetAddress("greg@methvin.net"))
+        val session = Session.getDefaultInstance(new Properties())
+        val message = new MimeMessage(session)
+        message.setSubject("Hey, this is Eishay from 42go.com")
+        message.setFrom(new InternetAddress("eishay@42go.com"))
+        message.setRecipient(RecipientType.TO, new InternetAddress("greg@methvin.net"))
 
-      val content = new MimeMultipart("alternative")
-      val (text, html) = (new MimeBodyPart(), new MimeBodyPart())
-      text.setText("Hey greg@methvin.net, you should check out http://google.com/.")
-      val htmlText = "<p>Hey, you should check out fuks.co.il, google.com/search and HTTP://YAHOO.COM/</p>"
-      html.setContent(htmlText, "text/html")
-      content.addBodyPart(html)
-      content.addBodyPart(text)
-      message.setContent(content)
+        val htmlText = "<p>Hey, you should check out fuks.co.il, google.com/search and HTTP://YAHOO.COM/</p>"
+        message.setContent(htmlText, "text/html")
+        message.saveChanges()
 
-      parser.getUris(message).map(_.host.get.toString) === Seq("42go.com", "fuks.co.il", "google.com", "yahoo.com")
+        parser.getUris(message).map(_.toString.toLowerCase) ===
+            Seq("http://42go.com", "http://fuks.co.il", "http://google.com/search", "http://yahoo.com")
+      }
     }
-  }
-  "parse out users correctly" in {
-    running(new EmptyApplication()) {
-      val db = inject[Database]
-      val emailAddressRepo = inject[EmailAddressRepo]
-      val userRepo = inject[UserRepo]
-      val (eishay, greg) = db.readWrite { implicit s =>
-        (userRepo.save(User(firstName = "Eishay", lastName = "Smith")),
-        userRepo.save(User(firstName = "Greg", lastName = "Methvin")))
-      }
-      db.readWrite { implicit s =>
-        emailAddressRepo.save(EmailAddress(address = "eishay@42go.com", userId = eishay.id.get))
-        emailAddressRepo.save(EmailAddress(address = "greg@42go.com", userId = greg.id.get))
-      }
-      val parser = new MailToKeepMessageParser(db, emailAddressRepo, userRepo)
-      val session = Session.getDefaultInstance(new Properties())
-      val message = new MimeMessage(session)
-      message.setSubject("hi")
-      message.setFrom(new InternetAddress("eishay@42go.com"))
-      message.setRecipient(RecipientType.TO, new InternetAddress("greg@42go.com"))
-      message.setContent("Hey, you should check out http://google.com/.", "text/html")
+    "parse out users correctly" in {
+      running(new EmptyApplication()) {
+        val db = inject[Database]
+        val emailAddressRepo = inject[EmailAddressRepo]
+        val userRepo = inject[UserRepo]
+        val (eishay, greg) = db.readWrite { implicit s =>
+          (userRepo.save(User(firstName = "Eishay", lastName = "Smith")),
+              userRepo.save(User(firstName = "Greg", lastName = "Methvin")))
+        }
+        db.readWrite { implicit s =>
+          emailAddressRepo.save(EmailAddress(address = "eishay@42go.com", userId = eishay.id.get))
+          emailAddressRepo.save(EmailAddress(address = "greg@42go.com", userId = greg.id.get))
+        }
+        val parser = new MailToKeepMessageParser(db, emailAddressRepo, userRepo)
+        val session = Session.getDefaultInstance(new Properties())
+        val message = new MimeMessage(session)
+        message.setSubject("hi")
+        message.setFrom(new InternetAddress("eishay@42go.com"))
+        message.setRecipient(RecipientType.TO, new InternetAddress("greg@42go.com"))
+        message.setContent("Hey, you should check out http://google.com/.", "text/html")
+        message.saveChanges()
 
-      parser.getUser(message).get.firstName === "Eishay"
+        parser.getUser(message).get.firstName === "Eishay"
+      }
     }
   }
 }


### PR DESCRIPTION
In particular, we always prefer plain text (I noticed HTML caused some issues finding URLs) and remove all HTML tags from the email in getText.

I also noticed the headers were not being set correctly on the message because I didn't call saveChanges() after I made changes to the message.
