### PR TITLE
Use ISO-8601 datetime format

### DIFF
--- a/shoebox/app/com/keepit/serializer/ArticleSearchResultSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/ArticleSearchResultSerializer.scala
@@ -10,6 +10,7 @@ import com.keepit.search.ArticleSearchResult
 import com.keepit.search.ArticleHit
 import com.keepit.model.User
 import com.keepit.search.ArticleSearchResultRef
+import org.joda.time.DateTime
 
 class ArticleSearchResultSerializer extends Format[ArticleSearchResult] {
 
@@ -24,7 +25,7 @@ class ArticleSearchResultSerializer extends Format[ArticleSearchResult] {
         "scorings" -> JsArray(res.scorings map ScoringSerializer.scoringSerializer.writes),
         "filter" -> JsArray(res.filter.map(id => JsNumber(id)).toSeq),
         "uuid" -> JsString(res.uuid.id),
-        "time" -> JsString(res.time.toStandardTimeString),
+        "time" -> Json.toJson(res.time),
         "millisPassed" -> JsNumber(res.millisPassed),
         "pageNumber" -> JsNumber(res.pageNumber),
         "svVariance" ->  JsNumber(res.svVariance)
@@ -63,7 +64,7 @@ class ArticleSearchResultSerializer extends Format[ArticleSearchResult] {
       scorings = (json \ "scorings").asInstanceOf[JsArray].value map (s => ScoringSerializer.scoringSerializer.reads(s).get),
       filter = (json \ "filter").asOpt[Seq[Long]].map(_.toSet).getOrElse(Set.empty[Long]),
       uuid = ExternalId[ArticleSearchResultRef]((json \ "uuid").as[String]),
-      time = parseStandardTime((json \ "time").as[String]),
+      time = (json \ "time").as[DateTime],
       millisPassed = (json \ "millisPassed").as[Int],
       pageNumber = (json \ "pageNumber").as[Int],
       svVariance = (json \ "svVariance").asOpt[Float].getOrElse(-1.0f)

--- a/shoebox/app/com/keepit/serializer/ArticleSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/ArticleSerializer.scala
@@ -8,6 +8,7 @@ import securesocial.core._
 import securesocial.core.AuthenticationMethod._
 import play.api.libs.json._
 import com.keepit.search.Article
+import org.joda.time.DateTime
 
 class ArticleSerializer extends Format[Article] {
 
@@ -16,7 +17,7 @@ class ArticleSerializer extends Format[Article] {
         "normalizedUriId" -> JsNumber(article.id.id),
         "title" -> JsString(article.title),
         "content" -> JsString(article.content),
-        "scrapedAt" -> JsString(article.scrapedAt.toStandardTimeString),
+        "scrapedAt" -> Json.toJson(article.scrapedAt),
         "httpContentType" -> (article.httpContentType map { t => JsString(t) } getOrElse(JsNull)),
         "httpOriginalContentCharset" -> (article.httpOriginalContentCharset map { t => JsString(t) } getOrElse(JsNull)),
         "state" -> JsString(article.state.toString),
@@ -31,7 +32,7 @@ class ArticleSerializer extends Format[Article] {
       Id((json \ "normalizedUriId").as[Long]),
       (json \ "title").as[String],
       (json \ "content").as[String],
-      parseStandardTime((json \ "scrapedAt").as[String]),
+      (json \ "scrapedAt").as[DateTime],
       (json \ "httpContentType").asOpt[String],
       (json \ "httpOriginalContentCharset").asOpt[String],
       State[NormalizedURI]((json \ "state").as[String]),

--- a/shoebox/app/com/keepit/serializer/BrowsingHistoryBinarySerializer.scala
+++ b/shoebox/app/com/keepit/serializer/BrowsingHistoryBinarySerializer.scala
@@ -12,6 +12,7 @@ import play.api.libs.json.JsNumber
 import com.keepit.common.db._
 import com.keepit.model.User
 import com.keepit.common.logging.Logging
+import org.joda.time.DateTime
 
 trait BinaryFormat {
 
@@ -39,8 +40,8 @@ class BrowsingHistoryBinarySerializer extends BinaryFormat with Logging {
   def historyJsonWrites(history: BrowsingHistory): JsObject =
     JsObject(List(
       "id"  -> history.id.map(u => JsNumber(u.id)).getOrElse(JsNull),
-      "createdAt" -> JsString(history.createdAt.toStandardTimeString),
-      "updatedAt" -> JsString(history.updatedAt.toStandardTimeString),
+      "createdAt" -> Json.toJson(history.createdAt),
+      "updatedAt" -> Json.toJson(history.updatedAt),
       "state" -> JsString(history.state.value),
       "userId"  -> JsNumber(history.userId.id),
       "tableSize" -> JsNumber(history.tableSize),
@@ -75,8 +76,8 @@ class BrowsingHistoryBinarySerializer extends BinaryFormat with Logging {
   def historyJsonReads(json: JsValue): BrowsingHistory =
     BrowsingHistory(
       id = (json \ "id").asOpt[Long].map(Id[BrowsingHistory](_)),
-      createdAt = parseStandardTime((json \ "createdAt").as[String]),
-      updatedAt = parseStandardTime((json \ "updatedAt").as[String]),
+      createdAt = (json \ "createdAt").as[DateTime],
+      updatedAt = (json \ "updatedAt").as[DateTime],
       state = State[BrowsingHistory]((json \ "state").as[String]),
       userId = Id[User]((json \ "userId").as[Long]),
       tableSize = (json \ "tableSize").as[Int],

--- a/shoebox/app/com/keepit/serializer/ClickHistoryBinarySerializer.scala
+++ b/shoebox/app/com/keepit/serializer/ClickHistoryBinarySerializer.scala
@@ -11,7 +11,7 @@ import play.api.libs.json.JsNumber
 import com.keepit.common.db._
 import com.keepit.model.User
 import com.keepit.common.logging.Logging
-
+import org.joda.time.DateTime
 
 class ClickHistoryBinarySerializer extends BinaryFormat with Logging {
 
@@ -35,8 +35,8 @@ class ClickHistoryBinarySerializer extends BinaryFormat with Logging {
   def historyJsonWrites(history: ClickHistory): JsObject =
     JsObject(List(
       "id"  -> history.id.map(u => JsNumber(u.id)).getOrElse(JsNull),
-      "createdAt" -> JsString(history.createdAt.toStandardTimeString),
-      "updatedAt" -> JsString(history.updatedAt.toStandardTimeString),
+      "createdAt" -> Json.toJson(history.createdAt),
+      "updatedAt" -> Json.toJson(history.updatedAt),
       "state" -> JsString(history.state.value),
       "userId"  -> JsNumber(history.userId.id),
       "tableSize" -> JsNumber(history.tableSize),
@@ -71,8 +71,8 @@ class ClickHistoryBinarySerializer extends BinaryFormat with Logging {
   def historyJsonReads(json: JsValue): ClickHistory =
     ClickHistory(
       id = (json \ "id").asOpt[Long].map(Id[ClickHistory](_)),
-      createdAt = parseStandardTime((json \ "createdAt").as[String]),
-      updatedAt = parseStandardTime((json \ "updatedAt").as[String]),
+      createdAt = (json \ "createdAt").as[DateTime],
+      updatedAt = (json \ "updatedAt").as[DateTime],
       state = State[ClickHistory]((json \ "state").as[String]),
       userId = Id[User]((json \ "userId").as[Long]),
       tableSize = (json \ "tableSize").as[Int],

--- a/shoebox/app/com/keepit/serializer/CompleteReportSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/CompleteReportSerializer.scala
@@ -15,7 +15,7 @@ class CompleteReportSerializer extends Format[Report] {
     JsObject(List(
         "reportName" -> JsString(report.reportName),
         "reportVersion" -> JsString(report.reportVersion),
-        "createdAt" -> JsString(report.createdAt.toStandardTimeString),
+        "createdAt" -> Json.toJson(report.createdAt),
         "report" -> JsObject(report.list map (r => UTC_DATETIME_FORMAT.print(r.date.withZone(DateTimeZone.UTC)) -> JsObject((r.fields map (s => s._1 -> JsArray(Seq(JsString(s._2.value), JsNumber(s._2.ordering))))).toSeq)))
       )
     )

--- a/shoebox/app/com/keepit/serializer/EventSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/EventSerializer.scala
@@ -11,6 +11,7 @@ import com.mongodb.casbah.commons.conversions.scala._
 import com.keepit.model._
 import com.mongodb.BasicDBObject
 import org.joda.time.format.ISODateTimeFormat
+import org.joda.time.DateTime
 
 class EventSerializer extends Format[Event] {
   // Play! 2.0 Json serializer
@@ -28,11 +29,11 @@ class EventSerializer extends Format[Event] {
       externalId = ExternalId[Event]((json \ "id").as[String]),
       metaData = EventSerializer.eventMetadataSerializer.reads(json \ "metaData").get,
       createdAt = (json \ "createdAt") match {
-        case s: JsString => parseStandardTime(s.as[String])
+        case s: JsString => s.as[DateTime]
         case s: JsObject =>
           val parser = ISODateTimeFormat.dateTime()
           parser.parseDateTime(s.values.head.as[String]) // necessary for Mongo parsing
-        case s: JsValue => parseStandardTime(s.toString)
+        case s: JsValue => s.as[DateTime]
       },
       serverVersion = (json \ "serverVersion").as[String]
     ))

--- a/shoebox/app/com/keepit/serializer/NormalizedURISerializer.scala
+++ b/shoebox/app/com/keepit/serializer/NormalizedURISerializer.scala
@@ -5,14 +5,15 @@ import com.keepit.common.time._
 import com.keepit.model._
 
 import play.api.libs.json._
+import org.joda.time.DateTime
 
 class NormalizedURISerializer extends Format[NormalizedURI] {
 
   def writes(uri: NormalizedURI): JsValue =
     JsObject(List(
       "id"  -> uri.id.map(u => JsNumber(u.id)).getOrElse(JsNull),
-      "createdAt" -> JsString(uri.createdAt.toStandardTimeString),
-      "updatedAt" -> JsString(uri.updatedAt.toStandardTimeString),
+      "createdAt" -> Json.toJson(uri.createdAt),
+      "updatedAt" -> Json.toJson(uri.updatedAt),
       "externalId" -> JsString(uri.externalId.id),
       "title"  -> (uri.title map { title => JsString(title) } getOrElse(JsNull)),
       "url"  -> JsString(uri.url),
@@ -24,8 +25,8 @@ class NormalizedURISerializer extends Format[NormalizedURI] {
   def reads(json: JsValue): JsResult[NormalizedURI] =
     JsSuccess(NormalizedURI(
       id = (json \ "id").asOpt[Long].map(Id[NormalizedURI](_)),
-      createdAt = parseStandardTime((json \ "createdAt").as[String]),
-      updatedAt = parseStandardTime((json \ "updatedAt").as[String]),
+      createdAt = (json \ "createdAt").as[DateTime],
+      updatedAt = (json \ "updatedAt").as[DateTime],
       externalId = ExternalId[NormalizedURI]((json \ "externalId").as[String]),
       title = (json \ "title").asOpt[String],
       url = (json \ "url").as[String],

--- a/shoebox/app/com/keepit/serializer/SendableNotificationSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/SendableNotificationSerializer.scala
@@ -7,12 +7,13 @@ import play.api.libs.json._
 import com.keepit.common.social.UserWithSocial
 import com.keepit.common.db._
 import com.keepit.realtime.SendableNotification
+import org.joda.time.DateTime
 
 class SendableNotificationSerializer extends Format[SendableNotification] {
 
   def writes(notify: SendableNotification): JsValue =
     Json.obj(
-      "time" -> JsString(notify.time.toStandardTimeString),
+      "time" -> Json.toJson(notify.time),
       "id" -> JsString(notify.id.id),
       "category"  -> JsString(notify.category.name),
       "details"  -> notify.details.payload,
@@ -22,7 +23,7 @@ class SendableNotificationSerializer extends Format[SendableNotification] {
   def reads(json: JsValue): JsResult[SendableNotification] =
     JsSuccess(SendableNotification(
       id = ExternalId[UserNotification]((json \ "id").as[String]),
-      time = parseStandardTime((json \ "time").as[String]),
+      time = (json \ "time").as[DateTime],
       category = UserNotificationCategory((json \ "firstName").as[String]),
       details = UserNotificationDetails((json \ "details").as[JsObject]),
       state = State[UserNotification]((json \ "state").as[String])

--- a/shoebox/app/com/keepit/serializer/SliderHistoryBinarySerializer.scala
+++ b/shoebox/app/com/keepit/serializer/SliderHistoryBinarySerializer.scala
@@ -12,7 +12,7 @@ import play.api.libs.json.JsNumber
 import com.keepit.common.db._
 import com.keepit.model.User
 import com.keepit.common.logging.Logging
-
+import org.joda.time.DateTime
 
 class SliderHistoryBinarySerializer extends BinaryFormat with Logging {
 
@@ -36,8 +36,8 @@ class SliderHistoryBinarySerializer extends BinaryFormat with Logging {
   def historyJsonWrites(history: SliderHistory): JsObject =
     JsObject(List(
       "id"  -> history.id.map(u => JsNumber(u.id)).getOrElse(JsNull),
-      "createdAt" -> JsString(history.createdAt.toStandardTimeString),
-      "updatedAt" -> JsString(history.updatedAt.toStandardTimeString),
+      "createdAt" -> Json.toJson(history.createdAt),
+      "updatedAt" -> Json.toJson(history.updatedAt),
       "state" -> JsString(history.state.value),
       "userId"  -> JsNumber(history.userId.id),
       "tableSize" -> JsNumber(history.tableSize),
@@ -72,8 +72,8 @@ class SliderHistoryBinarySerializer extends BinaryFormat with Logging {
   def historyJsonReads(json: JsValue): SliderHistory =
     SliderHistory(
       id = (json \ "id").asOpt[Long].map(Id[SliderHistory](_)),
-      createdAt = parseStandardTime((json \ "createdAt").as[String]),
-      updatedAt = parseStandardTime((json \ "updatedAt").as[String]),
+      createdAt = (json \ "createdAt").as[DateTime],
+      updatedAt = (json \ "updatedAt").as[DateTime],
       state = State[SliderHistory]((json \ "state").as[String]),
       userId = Id[User]((json \ "userId").as[Long]),
       tableSize = (json \ "tableSize").as[Int],

--- a/shoebox/app/com/keepit/serializer/SocialUserInfoSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/SocialUserInfoSerializer.scala
@@ -6,29 +6,30 @@ import com.keepit.common.social.SocialNetworks
 import com.keepit.model.SocialUserInfo
 import play.api.libs.json._
 import com.keepit.common.social.SocialId
+import org.joda.time.DateTime
 
 class SocialUserInfoSerializer extends Format[SocialUserInfo] {
 
   def writes(info: SocialUserInfo): JsValue =
     JsObject(List(
       "id" -> (info.id map { i => JsNumber(i.id) } getOrElse (JsNull)),
-      "createdAt" -> JsString(info.createdAt.toStandardTimeString),
-      "updatedAt" -> JsString(info.updatedAt.toStandardTimeString),
+      "createdAt" -> Json.toJson(info.createdAt),
+      "updatedAt" -> Json.toJson(info.updatedAt),
       "userId" -> (info.userId map { e => JsNumber(e.id) } getOrElse(JsNull)),
       "fullName" -> JsString(info.fullName),
       "state" -> JsString(info.state.value),
       "socialId" -> JsString(info.socialId.id),
       "networkType" -> JsString(info.networkType.name),
       "credentials" -> (info.credentials map { i => SocialUserSerializer.userSerializer.writes(i) } getOrElse (JsNull)),
-      "lastGraphRefresh" -> (info.lastGraphRefresh map { i => JsString(i.toStandardTimeString) } getOrElse (JsNull))
+      "lastGraphRefresh" -> Json.toJson(info.lastGraphRefresh)
     )
     )
 
   def reads(json: JsValue): JsResult[SocialUserInfo] =
     JsSuccess(SocialUserInfo(
       id = (json \ "id").asOpt[Long].map(Id[SocialUserInfo]),
-      createdAt = parseStandardTime((json \ "createdAt").as[String]),
-      updatedAt = parseStandardTime((json \ "updatedAt").as[String]),
+      createdAt = (json \ "createdAt").as[DateTime],
+      updatedAt = (json \ "updatedAt").as[DateTime],
       userId = (json \ "userId").asOpt[Long].map(Id(_)),
       fullName = (json \ "fullName").as[String],
       state = State[SocialUserInfo]((json \ "state").as[String]),
@@ -40,7 +41,7 @@ class SocialUserInfoSerializer extends Format[SocialUserInfo] {
         case n: JsObject => Some(SocialUserSerializer.userSerializer.reads(n).get)
         case n: JsValue => None
       },
-      lastGraphRefresh = ((json \ "lastGraphRefresh").asOpt[String]).map(parseStandardTime)
+      lastGraphRefresh = (json \ "lastGraphRefresh").asOpt[DateTime]
     ))
 
   def writesSeq(infos: Seq[SocialUserInfo]): JsValue =

--- a/shoebox/app/com/keepit/serializer/URLHistorySerializer.scala
+++ b/shoebox/app/com/keepit/serializer/URLHistorySerializer.scala
@@ -12,17 +12,18 @@ import play.api.libs.json.JsArray
 import play.api.libs.json.JsObject
 import play.api.libs.json.JsString
 import play.api.libs.json.JsNumber
+import org.joda.time.DateTime
 
 class URLHistorySerializer extends Format[Seq[URLHistory]] {
 
   def writes(history: Seq[URLHistory]): JsValue =
     JsArray(history map ( r => JsObject(
-        Seq("date" -> JsString(r.date.toStandardTimeString), "id" -> JsNumber(r.id.id), "cause" -> JsString(r.cause.value))
+        Seq("date" -> Json.toJson(r.date), "id" -> JsNumber(r.id.id), "cause" -> JsString(r.cause.value))
     )))
 
   def reads(json: JsValue): JsResult[Seq[URLHistory]] = 
     JsSuccess((json \ "history").asOpt[List[JsObject]].getOrElse(Nil).map { h =>
-      val date = parseStandardTime((h \ "date").as[String])
+      val date = (h \ "date").as[DateTime]
       val id = Id[NormalizedURI]((h \ "id").as[Int])
       val cause = URLHistoryCause((h \ "cause").as[String])
       URLHistory(date, id, cause)

--- a/shoebox/app/com/keepit/serializer/UnscrapableSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/UnscrapableSerializer.scala
@@ -6,14 +6,15 @@ import com.keepit.model.Unscrapable
 import play.api.libs.json._
 import com.keepit.common.social.UserWithSocial
 import com.keepit.common.db._
+import org.joda.time.DateTime
 
 class UnscrapableSerializer extends Format[Unscrapable] {
 
   def writes(unscrapable: Unscrapable): JsValue =
     JsObject(List(
       "id"  -> unscrapable.id.map(u => JsNumber(u.id)).getOrElse(JsNull),
-      "createdAt" -> JsString(unscrapable.createdAt.toStandardTimeString),
-      "updatedAt" -> JsString(unscrapable.updatedAt.toStandardTimeString),
+      "createdAt" -> Json.toJson(unscrapable.createdAt),
+      "updatedAt" -> Json.toJson(unscrapable.updatedAt),
       "pattern" -> JsString(unscrapable.pattern),
       "state"  -> JsString(unscrapable.state.value)
     )
@@ -25,8 +26,8 @@ class UnscrapableSerializer extends Format[Unscrapable] {
   def reads(json: JsValue): JsResult[Unscrapable] =
     JsSuccess(Unscrapable(
       id = (json \ "id").asOpt[Long].map(Id[Unscrapable](_)),
-      createdAt = parseStandardTime((json \ "createdAt").as[String]),
-      updatedAt = parseStandardTime((json \ "updatedAt").as[String]),
+      createdAt = (json \ "createdAt").as[DateTime],
+      updatedAt = (json \ "updatedAt").as[DateTime],
       pattern = (json \ "pattern").as[String],
       state = State[Unscrapable]((json \ "state").as[String])
     ))

--- a/shoebox/app/com/keepit/serializer/UserSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/UserSerializer.scala
@@ -6,14 +6,15 @@ import com.keepit.model.User
 import play.api.libs.json._
 import com.keepit.common.social.UserWithSocial
 import com.keepit.common.db._
+import org.joda.time.DateTime
 
 class UserSerializer extends Format[User] {
 
   def writes(user: User): JsValue =
     JsObject(List(
       "id"  -> user.id.map(u => JsNumber(u.id)).getOrElse(JsNull),
-      "createdAt" -> JsString(user.createdAt.toStandardTimeString),
-      "updatedAt" -> JsString(user.updatedAt.toStandardTimeString),
+      "createdAt" -> Json.toJson(user.createdAt),
+      "updatedAt" -> Json.toJson(user.updatedAt),
       "externalId" -> JsString(user.externalId.id),
       "firstName"  -> JsString(user.firstName),
       "lastName"  -> JsString(user.lastName)
@@ -22,8 +23,8 @@ class UserSerializer extends Format[User] {
   def reads(json: JsValue): JsResult[User] = 
     JsSuccess(User(
       id = (json \ "id").asOpt[Long].map(Id[User](_)),
-      createdAt = parseStandardTime((json \ "createdAt").as[String]),
-      updatedAt = parseStandardTime((json \ "updatedAt").as[String]),
+      createdAt = (json \ "createdAt").as[DateTime],
+      updatedAt = (json \ "updatedAt").as[DateTime],
       externalId = ExternalId[User]((json \ "externalId").as[String]),
       firstName = (json \ "firstName").as[String],
       lastName = (json \ "lastName").as[String]


### PR DESCRIPTION
We now serialize to ISO-8601 format, but we still parse both ISO-8601 and "standard" formats for backwards compatibility.

I also added a JSON format for DateTime to make things easier.

@2is10 Could this possibly have any impact on the client? The Date constructor can read both formats.
