### PR TITLE
result click boost: adjusting the update strength according to the rank of the clicked hit

### DIFF
--- a/shoebox/app/com/keepit/controllers/search/SearchEventController.scala
+++ b/shoebox/app/com/keepit/controllers/search/SearchEventController.scala
@@ -9,7 +9,7 @@ import com.keepit.search.ResultClickTracker
 import play.api.libs.json.{JsObject, JsString, Json}
 import play.api.mvc.Action
 
-case class ResultClicked(userId: Id[User], query: String, uriId: Id[NormalizedURI], isUserKeep: Boolean)
+case class ResultClicked(userId: Id[User], query: String, uriId: Id[NormalizedURI], rank: Int, isUserKeep: Boolean)
 
 object ResultClickedJson {
   private implicit val uriIdFormat = Id.format[NormalizedURI]
@@ -23,7 +23,7 @@ class SearchEventController @Inject()(resultClickTracker: ResultClickTracker) ex
 
   def logResultClicked = Action(parse.json) { request =>
     val rc = Json.fromJson[ResultClicked](request.body).get
-    resultClickTracker.add(rc.userId, rc.query, rc.uriId, rc.isUserKeep)
+    resultClickTracker.add(rc.userId, rc.query, rc.uriId, rc.rank, rc.isUserKeep)
     Ok(JsObject(Seq("stored" -> JsString("ok"))))
   }
 }

--- a/shoebox/app/com/keepit/search/ProbablisticLRU.scala
+++ b/shoebox/app/com/keepit/search/ProbablisticLRU.scala
@@ -1,5 +1,6 @@
 package com.keepit.search
 
+import scala.math._
 import java.io.File
 import java.io.RandomAccessFile
 import java.nio.channels.FileChannel.MapMode
@@ -110,9 +111,9 @@ class ProbablisticLRU(byteBuffer: ByteBuffer, tableSize: Int, numHashFuncs: Int,
       positions(i) = pos
       i += 1
     }
-    // randomly overwrite the half of the positions
+    // randomly overwrite the positions proportionally to updateStrength
     i = 0
-    val numUpdatePositions = (numHashFuncs.toDouble * updateStrength).toInt
+    val numUpdatePositions = min(ceil(numHashFuncs.toDouble * updateStrength).toInt, numHashFuncs)
     while (i < numUpdatePositions) {
       val index = rnd.nextInt(positions.length - i) + i
       val pos = positions(index)

--- a/shoebox/app/com/keepit/search/SearchServiceClient.scala
+++ b/shoebox/app/com/keepit/search/SearchServiceClient.scala
@@ -14,7 +14,7 @@ import scala.concurrent.Future
 trait SearchServiceClient extends ServiceClient {
   final val serviceType = ServiceType.SEARCH
 
-  def logResultClicked(userId: Id[User], query: String, uriId: Id[NormalizedURI], isUserKeep: Boolean): Future[Unit]
+  def logResultClicked(userId: Id[User], query: String, uriId: Id[NormalizedURI], rank: Int, isUserKeep: Boolean): Future[Unit]
   def updateURIGraph(): Future[Int]
   def index(): Future[Int]
   def articleIndexInfo(): Future[ArticleIndexInfo]
@@ -42,8 +42,8 @@ class SearchServiceClientImpl(override val host: String, override val port: Int,
   import com.keepit.controllers.search.ResultClickedJson._
   import com.keepit.controllers.search.URIGraphJson._
 
-  def logResultClicked(userId: Id[User], query: String, uriId: Id[NormalizedURI], isKeep: Boolean): Future[Unit] = {
-    val json = Json.toJson(ResultClicked(userId, query, uriId, isKeep))
+  def logResultClicked(userId: Id[User], query: String, uriId: Id[NormalizedURI], rank: Int, isKeep: Boolean): Future[Unit] = {
+    val json = Json.toJson(ResultClicked(userId, query, uriId, rank, isKeep))
     call(routes.SearchEventController.logResultClicked(), json).map(_ => Unit)
   }
 

--- a/shoebox/test/com/keepit/search/ProbablisticLRUTest.scala
+++ b/shoebox/test/com/keepit/search/ProbablisticLRUTest.scala
@@ -86,7 +86,7 @@ class ProbablisticLRUTest extends Specification {
 
       lru.put(key, v4, 0.1)
       ret = lru.get(key, values)
-      ret.get(v4) must beNone
+      ret(v4) === 1
     }
 
     "put/get multiple keys" in {


### PR DESCRIPTION
A result far from the top gets a stronger update strength, and a result near the top gets a weaker update strength. This means that a clicked hit climbs up faster from the bottom. Near the top, the changes slows down. So the mixed state (a few frequently clicked hits being shown together) is kept for longer time before KiFi decide on a single hit.
