### PR TITLE
live updating of comments/messages/threads

### DIFF
--- a/packrat/html/metro/message.html
+++ b/packrat/html/metro/message.html
@@ -1,4 +1,4 @@
-<div class="kifi-message-sent">
+<div class="kifi-message-sent" data-id="{{id}}">
   <time datetime="{{#formatIsoDate}}{{createdAt}}{{/formatIsoDate}}">{{#formatLocalDate}}{{createdAt}}{{/formatLocalDate}}</time>
   <img class="kifi-message-pic{{#isLoggedInUser}} kifi-self{{/isLoggedInUser}}" src="//graph.facebook.com/{{user.facebookId}}/picture?width=100&amp;height=100">
   <div class="kifi-message-body">

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -119,10 +119,9 @@ const socketHandlers = {
     if (d) {
       d.kept = o.kept;
       d.sensitive = o.sensitive;
-      for (var i = 0; i < d.tabs.length; i++) {
-        var tab = api.tabs.get(d.tabs[i]);
+      d.tabs.forEach(function(tab) {
         setIcon(tab, d.kept);
-      }
+      });
     }
   },
   uri_2: function(uri, o) {
@@ -136,15 +135,15 @@ const socketHandlers = {
       d.following = o.following;
       d.comments = o.comments || [];
       d.threads = o.threads || [];
+      d.messages = {};
       d.lastCommentRead = new Date(o.lastCommentRead || 0);
       d.lastMessageRead = {};
       for (var k in o.lastMessageRead) {
         d.lastMessageRead[k] = new Date(o.lastMessageRead);
       }
-      for (var i = 0; i < d.tabs.length; i++) {
-        var tab = api.tabs.get(d.tabs[i]);
+      d.tabs.forEach(function(tab) {
         initTab(tab, d);
-      }
+      });
     }
   },
   notification: function(notification) {
@@ -183,18 +182,46 @@ const socketHandlers = {
     notificationsRead.time = new Date(t);
     countUnreadNotifications();
   },
+  comment: function(nUri, c) {
+    api.log("[socket:comment]", c);
+    var d = pageData[nUri];
+    if (d && d.comments) {
+      d.comments.push(c);
+      d.tabs.forEach(function(tab) {
+        api.tabs.emit(tab, "comment", c);
+      });
+    }
+  },
   thread: function(th) {
     api.log("[socket:thread]", th);
     var d = pageData[th.uri];
-    if (d) {
-      d.threads.filter(hasId(th.id)).forEach(function(t) {
-        t.messages = th.messages;
+    if (d && d.messages) {
+      d.messages[th.id] = th.messages;
+      d.tabs.forEach(function(tab) {
+        api.tabs.emit(tab, "thread", {id: th.id, messages: th.messages});
       });
-      delete th.uri;
-      for (var i = 0; i < d.tabs.length; i++) {
-        var tab = api.tabs.get(d.tabs[i]);
-        api.tabs.emit(tab, "thread", th);
+    }
+  },
+  message: function(nUri, th, message) {
+    api.log("[socket:message]", nUri, th, message);
+    var d = pageData[nUri];
+    if (d && d.threads) {
+      for (var i = 0, n = d.threads.length; i < n; i++) {
+        if (d.threads[i].id == th.id) break;
       }
+      if (i < n) {
+        d.threads[i] = th;
+        var messages = d.messages[th.id];
+        if (messages && !messages.some(hasId(message.id))) {  // sent messages come via POST resp and socket
+          messages.push(message);
+        }
+      } else {
+        d.threads.push(th);
+        d.messages[th.id] = [message];
+      }
+      d.tabs.forEach(function(tab) {
+        api.tabs.emit(tab, "message", {thread: th, message: message});
+      });
     }
   }
 };
@@ -313,15 +340,20 @@ api.port.on({
             "facebookId": session.facebookId
           }});
       } else if (data.permissions == "message") {
+        var threadId = data.parent;
         d.threads.forEach(function(th) {
-          if (th.id == data.parent) {
-            th.messages.push(o.message);
+          if (th.id == threadId) {
             th.messageCount++;
             th.messageTimes[o.message.id] = o.message.createdAt;
             th.lastCommentedAt = o.message.createdAt;
             th.digest = o.message.text;
           }
         });
+        if (d.messages[threadId]) {
+          d.messages[threadId].push(o.message);
+        } else {
+          d.messages[threadId] = [o.message];
+        }
       }
       respond(o);
     });
@@ -361,9 +393,9 @@ api.port.on({
     }
   },
   thread: function(id, _, tab) {
-    var d = pageData[tab.nUri], th;
-    if (d && d.threads && (th = d.threads.filter(hasId(id))[0]) && th.messages) {
-      api.tabs.emit(tab, "thread", th);
+    var d = pageData[tab.nUri];
+    if (d && d.messages[id]) {
+      api.tabs.emit(tab, "thread", {id: id, messages: d.messages[id]});
     } else {
       socket.send(["get_thread", id]);
     }
@@ -682,9 +714,12 @@ function subscribe(tab) {
   }
   function finish(uri) {
     tab.nUri = uri;
-    if (d.tabs.indexOf(tab.id) < 0) {
-      d.tabs.push(tab.id);
+    for (var i = 0; i < d.tabs.length; i++) {
+      if (d.tabs[i].id == tab.id) {
+        d.tabs.splice(i--, 1);
+      }
     }
+    d.tabs.push(tab);
     api.log("[subscribe:finish] %i page data: %o", tab.id, d);
   }
 }
@@ -753,9 +788,13 @@ api.tabs.on.unload.add(function(tab) {
   api.log("#b8a", "[tabs.on.unload] %i %o", tab.id, tab);
   api.timers.clearTimeout(tab.autoShowTimer);
   delete tab.autoShowTimer;
-  var d = pageData[tab.nUri], i;
-  if (d && ~(i = d.tabs.indexOf(tab.id))) {
-    d.tabs.splice(i, 1);
+  var d = pageData[tab.nUri];
+  if (d) {
+    for (var i = 0; i < d.tabs.length; i++) {
+      if (d.tabs[i].id == tab.id) {
+        d.tabs.splice(i--, 1);
+      }
+    }
     if (!d.tabs.length) {
       delete pageData[tab.nUri];
     }

--- a/packrat/scripts/compose.js
+++ b/packrat/scripts/compose.js
@@ -101,7 +101,7 @@ function attachComposeBindings($c, composeTypeName) {
   });
 
   var hOld, elAbove = $f[0].previousElementSibling;
-  updateMaxHeight();
+  elAbove.clientHeight, updateMaxHeight();
 
   $(window).on("resize", updateMaxHeight);
 

--- a/packrat/scripts/lib/jquery-showhover.js
+++ b/packrat/scripts/lib/jquery-showhover.js
@@ -125,7 +125,7 @@ home-grown at FortyTwo, not intended for distribution (yet)
       }
       // Returns whether the viewport coords (x, y) are in the trapezoid between the top edge
       // of hover trigger element and the bottom edge of the hover element.
-      function between(x, y) {
+      function between(x, y) {  // TODO: fix "Cannot read property '0' of undefined" from onMouseLeave (from keeper)
         var rT = $a[0].getBoundingClientRect(), rH = data.$h[0].getBoundingClientRect();
         return y >= rH.bottom && y <= rT.top &&
           !leftOf(x, y, rH.left, rH.bottom, rT.left, rT.top) &&

--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -26,7 +26,7 @@ var renderNotices;
 
   $(document).on("visibilitychange webkitvisibilitychange", requestNotices);
 
-  renderNotices = function ($container, isAdmin) {
+  renderNotices = function($container) {
     render("html/metro/notices.html", {}, function (html) {
       var $notifyPane = $(html).appendTo($container);
       $notifyPane.scroll(function() {
@@ -38,7 +38,7 @@ var renderNotices;
         }
       });
       requestNotices();
-      
+
       $notifyPane.on('click', '.kifi-notice', function(e) {
         var url = $(this).find('.kifi-link').attr('href');
         if (url) {
@@ -73,7 +73,7 @@ var renderNotices;
   function getRenderedNotices(notices, $notifyPane, callback) {
     var renderedNotices = [];
     var done = 0;
-    $.each(notices, function (i, notice) { 
+    $.each(notices, function (i, notice) {
       if (~NOTICE_TYPES.indexOf(notice.category)) {
         var authors = notice.details.authors || [notice.details.author]
         render("html/metro/notice_" + notice.category + ".html", $.extend({

--- a/packrat/scripts/slider2.js
+++ b/packrat/scripts/slider2.js
@@ -10,6 +10,7 @@ jQuery.fn.layout = function() {
   return this.each(function() {this.clientHeight});  // forces layout
 };
 
+var commentsPane = 0, threadsPane = 0, threadPane = 0;  // set when api.require'd
 slider2 = function() {
   var $tile = $("#kifi-tile"), $slider, $pane, lastShownAt, info;
 
@@ -390,7 +391,7 @@ slider2 = function() {
     notices: function($box) {
       api.port.emit("session", function (session) {
         api.require("scripts/notices.js", function() {
-          renderNotices($box.find(".kifi-pane-tall"), ~session.experiments.indexOf("admin"));
+          renderNotices($box.find(".kifi-pane-tall"));
           api.port.emit("set_last_notify_read_time");
         });
       });
@@ -398,11 +399,8 @@ slider2 = function() {
     comments: function($box) {
       requireData("comments", function(comments) {
         api.port.emit("session", function(session) {
-          comments.forEach(function(c) {
-            c.isLoggedInUser = c.user.id == session.userId;
-          });
           api.require("scripts/comments.js", function() {
-            renderComments($box.find(".kifi-pane-tall"), comments, ~session.experiments.indexOf("admin"));
+            commentsPane.render($box.find(".kifi-pane-tall"), comments, session.userId, ~session.experiments.indexOf("admin"));
             var lastCom = comments[comments.length - 1];
             api.port.emit("set_comment_read", {id: lastCom.id, time: lastCom.createdAt});
           });
@@ -412,9 +410,9 @@ slider2 = function() {
     threads: function($box) {
       requireData("threads", function(threads) {
         api.require("scripts/threads.js", function() {
-          renderThreads($box.find(".kifi-pane-tall"), threads);
+          threadsPane.render($box.find(".kifi-pane-tall"), threads);
           threads.forEach(function(th) {
-            requireData("thread/" + th.id, api.noop);
+            requireData("thread/" + th.id, api.noop);  // preloading
           });
         });
       });
@@ -422,10 +420,12 @@ slider2 = function() {
     thread: function($box, threadId) {
       var $tall = $box.find(".kifi-pane-tall").css("margin-top", $box.find(".kifi-thread-who").outerHeight());
       requireData("thread/" + threadId, function(th) {
-        api.require("scripts/thread.js", function() {
-          renderThread($tall, th.id, th.messages);
-          var lastMsg = th.messages[th.messages.length - 1];
-          api.port.emit("set_message_read", {threadId: th.id, messageId: lastMsg.id, time: lastMsg.createdAt});
+        api.port.emit("session", function(session) {
+          api.require("scripts/thread.js", function() {
+            threadPane.render($tall, th.id, th.messages, session.userId);
+            var lastMsg = th.messages[th.messages.length - 1];
+            api.port.emit("set_message_read", {threadId: th.id, messageId: lastMsg.id, time: lastMsg.createdAt});
+          });
         });
       });
     },
@@ -490,6 +490,17 @@ slider2 = function() {
     comments: receiveData.bind(null, "comments"),
     threads: receiveData.bind(null, "threads"),
     thread: receiveData.bind(null, "thread", "id"),
+    comment: function(comment) {
+      api.port.emit("session", function(session) {
+        (commentsPane.update || api.noop)(comment, session.userId);
+      });
+    },
+    message: function(o) {
+      api.port.emit("session", function(session) {
+        (threadsPane.update || api.noop)(o.thread);
+        (threadPane.update || api.noop)(o.thread, o.message, session.userId);
+      });
+    },
     counts: function(o) {
       var $btns = $slider.find(".kifi-slider2-dock-btn");
       [[".kifi-slider2-notices", o.unreadNotices],


### PR DESCRIPTION
I also stopped storing a thread's messages as an array inside the cached `ThreadInfo` object (`pageData[normalizedUri].threads[threadId].messages`) and instead starting storing them as `pageData.messages[threadId]` 1) to make them easier to access and 2) so that the `ThreadInfo` will be smaller as we send it through ports to tabs.
