### PR TITLE
using a long-lived port for chrome tab <=> background page messaging

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -176,7 +176,7 @@ api = function() {
   });
 
   var portHandlers;
-  chrome.extension.onMessage.addListener(function(msg, sender, respond) {
+  chrome.runtime.onMessage.addListener(function(msg, sender, respond) {
     var tab = sender.tab, tabId = tab && tab.id, page = pages[tabId];
     if (tab && page && tab.url !== page.url) {
       api.log.error(Error("url mismatch:\n" + tab.url + "\n" + page.url), "onMessage");

--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -1,8 +1,6 @@
 // API for main.js
 
 api = function() {
-  var t0 = +new Date;
-
   function dispatch() {
     var args = arguments;
     this.forEach(function(f) {f.apply(null, args)});
@@ -114,7 +112,7 @@ api = function() {
             dispatch.call(api.tabs.on.complete, page);
           }
         } else {
-          api.log.error(Error("no page for " + tabId), "onUpdated");
+          api.log("#800", "[onUpdated] %i no page", tabId);
         }
       }
     }
@@ -175,51 +173,71 @@ api = function() {
     });
   });
 
-  var portHandlers;
-  chrome.runtime.onMessage.addListener(function(msg, sender, respond) {
-    var tab = sender.tab, tabId = tab && tab.id, page = pages[tabId];
-    if (tab && page && tab.url !== page.url) {
-      api.log.error(Error("url mismatch:\n" + tab.url + "\n" + page.url), "onMessage");
+  var ports = {}, portHandlers;
+  chrome.runtime.onConnect.addListener(function(port) {
+    var tab = port.sender.tab;
+    if (port.sender.id === chrome.runtime.id) {
+      api.log("[onConnect]", tab.id, tab.url);
+      if (ports[tab.id]) {
+        api.log("#a00", "[onConnect] %i disconnecting prev port", tab.id);
+        ports[tab.id].disconnect();
+      }
+      ports[tab.id] = port;
+      port.onMessage.addListener(function(msg) {
+        var kind = msg[0], data = msg[1], callbackId = msg[2];
+        if (kind == "api:require") {
+          injectWithDeps(tab.id, data, port.postMessage.bind(port, ["api:respond", callbackId]));
+        } else if (portHandlers) {
+          var handler = portHandlers[kind];
+          if (handler) {
+            var page = pages[tab.id];
+            if (page) {
+              if (tab.url !== page.url) {
+                api.log("#a00", "[onMessage] %i url mismatch:\n%s\n%s", tab.id, tab.url, page.url);
+              }
+              api.log("#0a0", "[onMessage]", tab.id, kind, data != null ? data : "");
+              handler(data, function(response) {
+                port.postMessage(["api:respond", callbackId, response]);
+              }, page);
+            } else {
+              api.log("#a00", "[api:dom_ready] no page for " + tab.id + " at " + tab.url);
+            }
+          } else {
+            api.log("#a00", "[onMessage] ignoring:", kind, "from:", tab.id);
+          }
+        }
+      });
+      port.onDisconnect.addListener(function() {
+        api.log("[onDisconnect]");
+        delete ports[tab.id];
+      });
     }
-    if (msg === "api:dom_ready") {
+  });
+
+  chrome.runtime.onMessage.addListener(function(msg, sender) {
+    var tab = sender.tab;
+    if (sender.id === chrome.runtime.id && tab && /^https?:/.test(tab.url) && msg === "api:dom_ready") {
+      var page = pages[tab.id];
       if (page) {
+        if (tab.url === page.url) {
+          api.log("[api:dom_ready]", tab.id, tab.url);
+        } else {
+          api.log("#a00", "[api:dom_ready] %i url mismatch:\n%s\n%s", tab.id, tab.url, page.url);
+        }
         injectContentScripts(page);
       } else if (tab.windowId !== chrome.windows.WINDOW_ID_NONE) {  // Chrome Instant results disappear quickly
         chrome.windows.get(tab.windowId, function(win) {
           if (win && win.type == "normal") {
-            api.log.error(Error("no page for " + tabId), "api:dom_ready");
+            api.log("#a00", "[api:dom_ready] no page for " + tab.id + " at " + tab.url);
           }
         });
-      }
-    } else if (msg[0] === "api:require") {
-      if (tab) {
-        injectWithDeps(tab.id, msg[1], respond);
-        return true;
-      }
-    } else if (portHandlers) {
-      var handler = portHandlers[msg[0]];
-      if (handler) {
-        api.log("#0a0", "[onMessage] %i %s %o", tabId, msg[0], msg[1]);
-        try {
-          return handler(msg[1], respond, page);
-        } catch (e) {
-          api.log.error(e);
-        }
-      } else {
-        api.log("#c00", "[onMessage] ignoring:", msg, "from:", tabId);
       }
     }
   });
 
   function injectContentScripts(page, suppressOnReady) {
     if (page.injecting || page.ready) return;
-
     page.injecting = true;
-
-    // for ignoring messages from future updates/installs/reloads of this extension
-    chrome.tabs.executeScript(page.id, {
-      code: "lifeId=" + t0 + ";!function(e){e.initEvent('kifiunload');e.lifeId=lifeId;dispatchEvent(e)}(document.createEvent('Event'))",
-      runAt: "document_start"});
 
     for (var i = 0, n = 0, N = 0; i < meta.contentScripts.length; i++) {
       var cs = meta.contentScripts[i];
@@ -279,7 +297,7 @@ api = function() {
   }
 
   var hostRe = /^https?:\/\/[^\/]*/, hexRe = /^#[0-9a-f]{3}$/i;
-  var api = {
+  return {
     bookmarks: {
       create: function(parentId, name, url, callback) {
         chrome.bookmarks.create({parentId: parentId, title: name, url: url}, callback);
@@ -492,10 +510,13 @@ api = function() {
       emit: function(tab, type, data) {
         var currTab = pages[tab.id];
         if (tab === currTab || currTab && currTab.url.match(hostRe)[0] == tab.url.match(hostRe)[0]) {
-          api.log("#0c0", "[api.tabs.emit] %i %s %o", tab.id, type, data);
-          chrome.tabs.sendMessage(tab.id, [t0, type, data]);
+          var port = ports[tab.id];
+          if (port) {
+            api.log("#0c0", "[api.tabs.emit] %i %s %o", tab.id, type, data);
+            port.postMessage([type, data]);
+          }
         } else {
-          api.log("[api.tabs.emit] SUPPRESSED %i %s navigated: %s -> %s", tab.id, type, tab.url, currTab && currTab.url);
+          api.log("#a00", "[api.tabs.emit] suppressed %i %s navigated: %s -> %s", tab.id, type, tab.url, currTab && currTab.url);
         }
       },
       get: function(tabId) {
@@ -513,11 +534,4 @@ api = function() {
         unload: new Listeners}},
     timers: window,
     version: chrome.app.getDetails().version};
-
-  api.log.error = function(exception, context) {
-    var d = new Date, ds = d.toString();
-    console.error("[" + ds.substr(0, 2) + ds.substr(15,9) + "." + String(+d).substr(10) + "]" + (context ? "[" + context + "] " : ""), exception.message, exception.stack);
-  };
-
-  return api;
 }();

--- a/packrat/adapters/chrome/options.js
+++ b/packrat/adapters/chrome/options.js
@@ -1,5 +1,5 @@
 $(function() {
-  chrome.extension.sendMessage(["get_prefs"], function init(o) {
+  chrome.runtime.sendMessage(["get_prefs"], function init(o) {
     console.log("[init] prefs:", o.prefs);
     $("[name=env][value=" + o.prefs.env + "]").prop("checked", true);
     $("#show-slider").prop("checked", o.prefs.showSlider);
@@ -8,7 +8,7 @@ $(function() {
     showSession(o.session);
   });
   $("#save").click(function() {
-    chrome.extension.sendMessage(["set_prefs", {
+    chrome.runtime.sendMessage(["set_prefs", {
       env: $("input[name=env][value=development]").is(":checked") ? "development" : "production",
       showSlider: $("#show-slider").is(":checked"),
       maxResults: $("#max-results").val(),
@@ -17,13 +17,13 @@ $(function() {
   });
   $("#log-out").click(function(e) {
     e.preventDefault();
-    chrome.extension.sendMessage(["log_out"], function() {
+    chrome.runtime.sendMessage(["log_out"], function() {
       showSession();
     });
   });
   $("#log-in").click(function(e) {
     e.preventDefault();
-    chrome.extension.sendMessage(["log_in"], function(session) {
+    chrome.runtime.sendMessage(["log_in"], function(session) {
       showSession(session);
     });
   });

--- a/packrat/adapters/chrome/scripts/api.js
+++ b/packrat/adapters/chrome/scripts/api.js
@@ -24,11 +24,11 @@ api = function() {
       if (!callback && typeof data == "function") {
         callback = data, data = null;
       }
-      chrome.extension.sendMessage([type, data], callback || api.noop);
+      chrome.runtime.sendMessage([type, data], callback || api.noop);
     },
     on: function(handlers) {
       msgListeners.push(f);
-      chrome.extension.onMessage.addListener(f);
+      chrome.runtime.onMessage.addListener(f);
       function f(msg, sender, respond) {
         if (msg && msg.length && msg[0] === lifeId) {
           var kind = msg[1], handler = handlers[kind];
@@ -51,7 +51,7 @@ api = function() {
       api.port.emit("api:require", path, callback);
     }
   },
-  url: chrome.extension.getURL.bind(chrome.extension)};
+  url: chrome.runtime.getURL.bind(chrome.runtime)};
 
   api.log.error = function(exception, context) {
     console.error((context ? "[" + context + "] " : "") + exception);
@@ -63,7 +63,7 @@ api = function() {
       api.log("\u2205 end life:", lifeId);
       window.removeEventListener("kifiunload", f);
       msgListeners.forEach(function(ml) {
-        chrome.extension.onMessage.removeListener(ml);
+        chrome.runtime.onMessage.removeListener(ml);
       });
       api.port.emit = api.noop;
     }

--- a/packrat/adapters/chrome/scripts/api.js
+++ b/packrat/adapters/chrome/scripts/api.js
@@ -1,8 +1,36 @@
 // API for content scripts
 
 api = function() {
-  var msgListeners = [];
-  var api = {
+  var msgHandlers = [], callbacks = {}, nextCallbackId = 1;
+
+  var port = chrome.runtime.connect({name: ""});
+  port.onMessage.addListener(function(msg) {
+    var kind = msg[0];
+    if (kind == "api:respond") {
+      var id = msg[1], cb = callbacks[id];
+      if (cb) {
+        delete callbacks[id];
+        cb(msg[2]);
+      }
+    } else {
+      var data = msg[1];
+      api.log("[onMessage]", kind, data != null ? data : "");
+      for (var i in msgHandlers) {
+        var handler = msgHandlers[i][kind];
+        handler && handler(data);
+      }
+    }
+  });
+  port.onDisconnect.addListener(function() {
+    api.log("[onDisconnect]");
+    api.port = {emit: api.noop};
+    for (var i in api.onEnd) {
+      api.onEnd[i]();
+    }
+    api.onEnd.length = msgHandlers.length = 0;
+  });
+
+  return {  // TODO: indent below
   load: function(path, callback) {
     var req = new XMLHttpRequest();
     req.open("GET", api.url(path), true);
@@ -13,36 +41,26 @@ api = function() {
     };
     req.send(null);
   },
-  log: function(message) {
+  log: function() {
     var d = new Date, ds = d.toString();
     arguments[0] = "[" + ds.substr(0, 2) + ds.substr(15,9) + "." + String(+d).substr(10) + "] " + arguments[0];
     console.log.apply(console, arguments);
   },
   noop: function() {},
+  onEnd: [],
   port: {
     emit: function(type, data, callback) {
       if (!callback && typeof data == "function") {
         callback = data, data = null;
       }
-      chrome.runtime.sendMessage([type, data], callback || api.noop);
+      if (callback) {
+        var callbackId = nextCallbackId++;
+        callbacks[callbackId] = callback;
+      }
+      port.postMessage([type, data, callbackId]);
     },
     on: function(handlers) {
-      msgListeners.push(f);
-      chrome.runtime.onMessage.addListener(f);
-      function f(msg, sender, respond) {
-        if (msg && msg.length && msg[0] === lifeId) {
-          var kind = msg[1], handler = handlers[kind];
-          if (handler) {
-            var data = msg[2];
-            api.log("[onMessage]", kind, data != null ? data : "");
-            try {
-              handler(data);
-            } catch (e) {
-              api.log.error(e, "onMessage");
-            }
-          }
-        }
-      }
+      msgHandlers.push(handlers);
     }},
   require: function(path, callback) {
     if (injected[path]) {
@@ -51,25 +69,5 @@ api = function() {
       api.port.emit("api:require", path, callback);
     }
   },
-  url: chrome.runtime.getURL.bind(chrome.runtime)};
-
-  api.log.error = function(exception, context) {
-    console.error((context ? "[" + context + "] " : "") + exception);
-    console.error(exception.stack);
-  };
-
-  window.addEventListener("kifiunload", function f(e) {
-    if (e.lifeId !== lifeId) {
-      api.log("\u2205 end life:", lifeId);
-      window.removeEventListener("kifiunload", f);
-      msgListeners.forEach(function(ml) {
-        chrome.runtime.onMessage.removeListener(ml);
-      });
-      api.port.emit = api.noop;
-    }
-  });
-
-  return api;
+  url: chrome.runtime.getURL};
 }();
-
-api.log("\u2058 new life:", lifeId);

--- a/packrat/adapters/chrome/scripts/ready.js
+++ b/packrat/adapters/chrome/scripts/ready.js
@@ -1,1 +1,1 @@
-chrome.extension.sendMessage("api:dom_ready");
+chrome.runtime.sendMessage("api:dom_ready");

--- a/packrat/adapters/firefox/data/scripts/api.js
+++ b/packrat/adapters/firefox/data/scripts/api.js
@@ -41,6 +41,7 @@ api = function() {
       console.log("'" + ds.substr(0,2) + ds.substr(15,9) + "." + String(+d).substr(10) + "'", args.join(" "));
     },
     noop: function() {},
+    onEnd: [],  // TODO: find an event that will allows us to invoke these
     port: {
       emit: function(type, data, callback) {
         if (!callback && typeof data == "function") {

--- a/packrat/adapters/firefox/data/scripts/api.js
+++ b/packrat/adapters/firefox/data/scripts/api.js
@@ -7,7 +7,7 @@ api = function() {
     var cb = callbacks[callbackId];
     if (cb) {
       delete callbacks[callbackId];
-      cb[0](response);
+      cb(response);
     }
   }
 
@@ -19,9 +19,8 @@ api = function() {
       el.innerHTML = css;
       (document.head || document.body).appendChild(el);
     });
-    var result;
     scripts.forEach(function(js) {
-      result = window.eval(js);
+      window.eval(js);
     });
     invokeCallback(callbackId);
   });
@@ -49,7 +48,7 @@ api = function() {
         }
         if (callback) {
           var callbackId = nextCallbackId++;
-          callbacks[callbackId] = [callback, +new Date];
+          callbacks[callbackId] = callback;
         }
         self.port.emit(type, data, callbackId);
       },
@@ -62,15 +61,10 @@ api = function() {
       }},
     require: function(path, callback) {
       var callbackId = nextCallbackId++;
-      callbacks[callbackId] = [callback, +new Date];
+      callbacks[callbackId] = callback;
       self.port.emit("api:require", path, callbackId);
     },
     url: function(path) {
       return self.options.dataUriPrefix + path;
     }};
 }();
-
-api.log.error = function(exception, context) {
-  console.error((context ? "[" + context + "] " : "") + exception);
-  console.error(exception.stack);
-};

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -170,17 +170,6 @@ api.log("[google_inject]");
         "kifiResultsClicked": clicks.kifi,
         "googleResultsClicked": clicks.google});
     }
-  }).on("kifiunload", function f(e) {
-    if (e.lifeId !== lifeId) {
-      api.log("[google_inject] end life:", lifeId);
-      $(window).off("hashchange unload kifiunload");
-      observer.disconnect();
-      $q.off("input");
-      $qf.off("submit");
-      clearTimeout(idleTimer);
-      $res.remove();
-      $res.length = 0;
-    }
   });
 
   var MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
@@ -202,6 +191,16 @@ api.log("[google_inject]");
   });
   observer.observe(document.getElementById("main"), {childList: true, subtree: true});  // TODO: optimize away subtree
 
+  api.onEnd.push(function() {
+    api.log("[google_inject:onEnd]");
+    $(window).off("hashchange unload");
+    observer.disconnect();
+    $q.off("input");
+    $qf.off("submit");
+    clearTimeout(idleTimer);
+    $res.remove();
+    $res.length = 0;
+  });
 
   /*******************************************************/
 


### PR DESCRIPTION
This allows the extension to detect with great precision when a page is unloaded, and a page to detect with great precision with the extension is unloaded. Lately we've had some false positives before that were causing KiFi results not to show for follow-up/edited queries.
