### PR TITLE
reduce the lock scope of AppScope to remove the annoying deadlocks onshutdown

### DIFF
--- a/shoebox/app/com/keepit/inject/AppScope.scala
+++ b/shoebox/app/com/keepit/inject/AppScope.scala
@@ -70,6 +70,29 @@ class AppScope extends Scope with Logging {
     }
   }
 
+  private def createInstance[T](key: Key[T], unscoped: Provider[T]) = {
+    if (stopped || stopping)
+      throw new IllegalStateException(s"requesting for $key (in lock) while the scope stopped=$stopped, stopping=$stopping")
+    val inst = unscoped.get()
+    log.debug(s"created new instance of ${inst.getClass().getName()}")
+
+    // if this instance is a plugin, start it and add to the list of plugins
+    startIfPlugin(inst)
+    instances += key -> inst
+    log.debug(s"returning initiated instance of ${inst.getClass().getName()}")
+    inst
+  }
+
+  private def startIfPlugin(instance: Any) =
+    instance match {
+      case plugin: Plugin =>
+        started match {
+          case true => startPlugin(plugin)
+          case false => pluginsToStart = plugin :: pluginsToStart
+        }
+      case _ =>
+    }
+
   def scope[T](key: Key[T], unscoped: Provider[T]): Provider[T] = {
     val appScope = this
     // return a provider that always gives the same instance
@@ -79,27 +102,16 @@ class AppScope extends Scope with Logging {
         val instance = {
           instances.get(key) match {
             case Some(inst) =>
-              log.debug(s"returning existing instance of ${inst.getClass().getName()}")
               inst.asInstanceOf[T]
             case None =>
-              if (stopped || stopping) throw new IllegalStateException(s"requesting for $key (pre lock) while the scope stopped=$stopped, stopping=$stopping")
               appScope synchronized {
-                if (stopped || stopping) throw new IllegalStateException(s"requesting for $key (in lock) while the scope stopped=$stopped, stopping=$stopping")
-                val inst = unscoped.get()
-                log.debug(s"created new instance of ${inst.getClass().getName()}")
-
-                // if this instance is a plugin, start it and add to the list of plugins
-                inst match {
-                  case plugin: Plugin =>
-                    started match {
-                      case true => startPlugin(plugin)
-                      case false => pluginsToStart = plugin :: pluginsToStart
-                    }
-                  case _ =>
+                //double check, it may have been initialized already
+                instances.get(key) match {
+                  case Some(inst) =>
+                    inst.asInstanceOf[T]
+                  case None =>
+                    createInstance(key, unscoped)
                 }
-                instances += key -> inst
-                log.debug(s"returning initiated instance of ${inst.getClass().getName()}")
-                inst
               }
           }
         }


### PR DESCRIPTION
 It would also make things run a bit faster since in the common case we won't hit that lock.
/cc @gmethvin & @andrewconner I think it will solve the problem with the deadlock
