### PR TITLE
Two small bugfixes

### DIFF
--- a/shoebox/app/com/keepit/controllers/ext/ExtCommentController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtCommentController.scala
@@ -88,7 +88,9 @@ class ExtCommentController @Inject() (
 
       val parentIdOpt = parent match {
         case "" => None
-        case id => commentRepo.get(ExternalId[Comment](id)).id
+        case id =>
+          val parent = commentRepo.get(ExternalId[Comment](id))
+          Some(parent.parent.getOrElse(parent.id.get))
       }
 
       val url: URL = urlRepo.save(urlRepo.get(urlStr).getOrElse(URLFactory(url = urlStr, normalizedUriId = uri.id.get)))

--- a/shoebox/app/com/keepit/social/SecureSocialUserService.scala
+++ b/shoebox/app/com/keepit/social/SecureSocialUserService.scala
@@ -12,6 +12,8 @@ import com.keepit.inject._
 import com.keepit.common.logging.Logging
 import com.keepit.common.social.{SocialId, SocialNetworks, SocialNetworkType}
 import com.google.inject.{Inject, Singleton}
+import play.api.Play
+import play.api.Play.current
 
 class SecureSocialUserService(implicit val application: Application) extends UserServicePlugin(application) {
   lazy val injector = application.global.asInstanceOf[FortyTwoGlobal].injector
@@ -61,7 +63,7 @@ class SecureSocialUserPlugin @Inject() (
     val nameParts = displayName.split(' ')
     User(firstName = nameParts(0),
         lastName = nameParts.tail.mkString(" "),
-        state = UserStates.PENDING
+        state = if(Play.isDev) UserStates.ACTIVE else UserStates.PENDING
     )
   }
 


### PR DESCRIPTION
- Not requiring an admin to set user to ACTIVE when in dev mode
- Force a message's parent to point to the real parent if the client sends the wrong ID.
