### PR TITLE
supporting deep links to reply messages

### DIFF
--- a/packrat/scripts/deeplink.js
+++ b/packrat/scripts/deeplink.js
@@ -4,7 +4,7 @@
 !function() {
   document.querySelector(".kifi-deep-link-no-extension").style.display = "none";
   var deepLink = JSON.parse(document.documentElement.dataset.kifiDeepLink);
-  api.port.emit("add_deep_link_listener", deepLink);
+  api.port.emit("add_deep_link_listener", deepLink.locator);
   if (deepLink.uri) {
     window.location = deepLink.uri;
   }

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -390,7 +390,7 @@ api.log("[google_inject]");
           }, callback);
         }});
     }).on("click", ".kifi-chatter-deeplink", function() {
-      api.port.emit("add_deep_link_listener", {locator: $(this).data("locator")});
+      api.port.emit("add_deep_link_listener", $(this).data("locator"));
       location.href = $(this).closest("li.g").find("h3.r a")[0].href;
     });
   }


### PR DESCRIPTION
This change also does away with `requireData` mechanism in slider2.js for getting comments and threads from main.js in favor of the direct `respond` facility available to `api.port.on` handlers.
