### PR TITLE
removing "externalId" field from some serializers

### DIFF
--- a/shoebox/app/com/keepit/controllers/admin/AdminCommentController.scala
+++ b/shoebox/app/com/keepit/controllers/admin/AdminCommentController.scala
@@ -15,8 +15,6 @@ import com.keepit.model._
 import com.keepit.search.graph.URIGraph
 import com.keepit.search.index.ArticleIndexer
 import com.keepit.serializer.UserWithSocialSerializer.userWithSocialSerializer
-import com.keepit.serializer.CommentWithBasicUserSerializer.commentWithBasicUserSerializer
-import com.keepit.serializer.ThreadInfoSerializer.threadInfoSerializer
 import play.api.http.ContentTypes
 import play.api.libs.concurrent.Akka
 import play.api.libs.json.{JsArray, JsBoolean, JsNumber, JsObject, JsString}
@@ -24,7 +22,6 @@ import play.api.mvc.Action
 import play.api.mvc.Controller
 import securesocial.core.SecureSocial
 import securesocial.core.java.SecureSocial.SecuredAction
-import com.keepit.common.social.ThreadInfo
 import com.keepit.common.healthcheck.BabysitterTimeout
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json._

--- a/shoebox/app/com/keepit/serializer/BookmarkSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/BookmarkSerializer.scala
@@ -11,7 +11,6 @@ class BookmarkSerializer extends Writes[Bookmark] {
   def writes(bookmark: Bookmark): JsValue =
     JsObject(Seq(
       "id" -> JsString(bookmark.externalId.toString),
-      "externalId" -> JsString(bookmark.externalId.toString),  // TODO: deprecate, eliminate
       "title" -> bookmark.title.map(JsString).getOrElse(JsNull),
       "url" -> JsString(bookmark.url),
       "isPrivate" -> JsBoolean(bookmark.isPrivate),

--- a/shoebox/app/com/keepit/serializer/CommentWithBasicUserSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/CommentWithBasicUserSerializer.scala
@@ -12,7 +12,6 @@ class CommentWithBasicUserSerializer extends Writes[CommentWithBasicUser] {
   def writes(commentWithBasicUser: CommentWithBasicUser): JsValue =
     Json.obj(
       "id" -> commentWithBasicUser.comment.externalId.id,
-      "externalId" -> commentWithBasicUser.comment.externalId.id,  // TODO: remove after metro launch
       "createdAt" -> commentWithBasicUser.comment.createdAt,
       "text" -> JsString(commentWithBasicUser.comment.text),
       "user" -> commentWithBasicUser.user,

--- a/shoebox/app/com/keepit/serializer/ThreadInfoSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/ThreadInfoSerializer.scala
@@ -13,7 +13,6 @@ class ThreadInfoSerializer extends Writes[ThreadInfo] {
   def writes(o: ThreadInfo): JsValue =
     Json.obj(
       "id" -> o.externalId.id,
-      "externalId" -> o.externalId.id,  // TODO: deprecate, eliminate
       "recipients" -> o.recipients,
       "digest" -> o.digest,
       "messageCount" -> o.messageCount,


### PR DESCRIPTION
These serializers appear to only be used by the extension.
