### PR TITLE
dropping .externalId in BasicUser JSON, using .id

### DIFF
--- a/shoebox/app/com/keepit/serializer/BasicUserSerializer.scala
+++ b/shoebox/app/com/keepit/serializer/BasicUserSerializer.scala
@@ -9,7 +9,7 @@ import play.api.libs.json._
 class BasicUserSerializer extends Format[BasicUser] {
   def reads(json: JsValue): JsResult[BasicUser] =
     JsSuccess(BasicUser(
-      externalId = ExternalId[User]((json \ "externalId").as[String]),  // TODO: read "id" or else "externalId"
+      externalId = ExternalId[User]((json \ "id").as[String]),
       firstName = (json \ "firstName").as[String],
       lastName = (json \ "lastName").as[String],
       avatar = (json \ "avatar").as[String],
@@ -18,7 +18,6 @@ class BasicUserSerializer extends Format[BasicUser] {
   def writes(basicUser: BasicUser): JsValue =
     Json.obj(
       "id" -> basicUser.externalId.id,
-      "externalId" -> basicUser.externalId.id,  // TODO: deprecate, eliminate
       "firstName" -> basicUser.firstName,
       "lastName" -> basicUser.lastName,
       "avatar" -> basicUser.avatar,


### PR DESCRIPTION
I think this is safe because it appears that the only uses of BasicUser JSON are the extension and memcache, which has a 7-day ttl, and we've been writing .id for the past 7 days.
