### PR TITLE
add tab replace handler

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -138,6 +138,12 @@ api = function() {
     delete selectedTabPages[winId];
   });
 
+  chrome.tabs.onReplaced.addListener(function (addedId, removedId) {
+    api.log("[onReplaced]", addedId, removedId)
+    dispatch.call(api.tabs.on.unload, pages[removedId]);
+    delete pages[removedId];
+  });
+
   var focusedWinId, topNormalWinId;
   chrome.windows.getLastFocused(null, function(win) {
     focusedWinId = win.focused ? win.id : chrome.windows.WINDOW_ID_NONE;


### PR DESCRIPTION
@2is10 

If you enable preloading in Chrome (Settings -> Show advanced settings -> Predict network actions to improve page load performance), Chrome will attempt to predict which page you're visiting and load it as you type, then if it's wrong it will swap it out for another tab after. It calls the onReplaced handler but does not call onRemoved, so we have to remove the dead tab in onReplaced.
