### PR TITLE
fixing a JS error that was stopping searchUnload events

### DIFF
--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -173,7 +173,7 @@ api.log("[google_inject]");
         "queryUUID": response.uuid,
         "kifiResultsClicked": clicks.kifi.length,
         "googleResultsClicked": clicks.google.length,
-        "kifiShownURIs": resp.expanded ? resp.hits.map(function(hit) {return hit.bookmark.url}) : [],
+        "kifiShownURIs": response.expanded ? response.hits.map(function(hit) {return hit.bookmark.url}) : [],
         "kifiClickedURIs": clicks.kifi,
         "googleClickedURIs": clicks.google});
     }


### PR DESCRIPTION
Handy tip: right-click Chrome console and check "Preserve Log upon Navigation"
