### PR TITLE
scraper: bypassing ssl certificate verification

### DIFF
--- a/shoebox/app/com/keepit/module/CommonModule.scala
+++ b/shoebox/app/com/keepit/module/CommonModule.scala
@@ -138,7 +138,8 @@ class CommonModule extends ScalaModule with Logging {
     new HttpFetcherImpl(
       userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17",
       connectionTimeout = 30000,
-      soTimeOut = 30000
+      soTimeOut = 30000,
+      trustBlindly = true
     )
   }
 

--- a/shoebox/app/com/keepit/scraper/UnsafeSSLSocketFactory.scala
+++ b/shoebox/app/com/keepit/scraper/UnsafeSSLSocketFactory.scala
@@ -1,0 +1,13 @@
+package com.keepit.scraper
+
+import org.apache.http.conn.ssl.SSLSocketFactory
+import org.apache.http.conn.ssl.TrustStrategy
+import java.security.cert.X509Certificate
+
+object UnsafeSSLSocketFactory {
+  private val trustStrategy = new TrustStrategy {
+    def isTrusted(chain: Array[X509Certificate], authType: String): Boolean = true // blindly trust
+  }
+
+  def apply() = new SSLSocketFactory(trustStrategy, SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER)
+}


### PR DESCRIPTION
Some scraping failed due to
- our JDK not having all root certificates
- self-signed certificates
- expired certificates
- blah blah

We can simply bypass certificate verification. A drawback is that we are vulnerable to a man-in-the-middle attack.
