### PR TITLE
auto create sequence, less logs, fix prod issue

### DIFF
--- a/shoebox/app/com/keepit/common/db/SlickModule.scala
+++ b/shoebox/app/com/keepit/common/db/SlickModule.scala
@@ -16,7 +16,6 @@ import scala.slick.lifted.DDL
 
 class SlickModule(dbInfo: DbInfo) extends ScalaModule {
   def configure(): Unit = {
-    println("configuring SlickModule")
     //see http://stackoverflow.com/questions/6271435/guice-and-scala-injection-on-generics-dependencies
     bind[Database].in(classOf[Singleton])
     lazy val db = dbInfo.driverName match {

--- a/shoebox/app/com/keepit/common/db/slick/DataBaseComponent.scala
+++ b/shoebox/app/com/keepit/common/db/slick/DataBaseComponent.scala
@@ -33,7 +33,7 @@ trait DataBaseComponent {
 
   def entityName(name: String): String = name
 
-  def initTable(table: TableWithDDL): Unit = ???
+  def initTable(table: TableWithDDL): Unit = {}
 }
 
 class InSessionException(message: String) extends Exception(message)

--- a/shoebox/app/com/keepit/common/db/slick/DataBaseComponent.scala
+++ b/shoebox/app/com/keepit/common/db/slick/DataBaseComponent.scala
@@ -24,10 +24,7 @@ trait DataBaseComponent {
   val Driver: ExtendedDriver
   val dialect: DatabaseDialect[_]
   def dbInfo: DbInfo
-  lazy val handle: SlickDatabase = {
-    println("initiating DB handle")
-    dbInfo.database
-  }
+  lazy val handle: SlickDatabase = dbInfo.database
 
   def getSequence(name: String): DbSequence
 

--- a/shoebox/conf/dev-akka-sync.conf
+++ b/shoebox/conf/dev-akka-sync.conf
@@ -7,8 +7,8 @@ iteratee-threadpool-size=16
 play {
   akka {
     event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
-    loglevel = INFO
-    log-config-on-start = true
+    loglevel = DEBUG
+    log-config-on-start = false
     actor {
       actions-dispatcher = {
         fork-join-executor {

--- a/shoebox/test/com/keepit/model/BookmarkTest.scala
+++ b/shoebox/test/com/keepit/model/BookmarkTest.scala
@@ -23,8 +23,6 @@ class BookmarkTest extends Specification with TestDBRunner {
     val t2 = new DateTime(2012, 3, 22, 14, 30, 0, 0, PT)
 
     db.readWrite {implicit s =>
-      s.withPreparedStatement("CREATE SEQUENCE normalized_uri_sequence;")(_.execute)
-      s.withPreparedStatement("CREATE SEQUENCE bookmark_sequence;")(_.execute)
       val user1 = userRepo.save(User(firstName = "Andrew", lastName = "C", createdAt = t1))
       val user2 = userRepo.save(User(firstName = "Eishay", lastName = "S", createdAt = t2))
 

--- a/shoebox/test/com/keepit/model/NormalizedURITest.scala
+++ b/shoebox/test/com/keepit/model/NormalizedURITest.scala
@@ -15,15 +15,7 @@ import com.keepit.inject.RichInjector
 
 class NormalizedURITest extends Specification with TestDBRunner {
 
-  def initDbSequence()(implicit injector: RichInjector) = {
-    db.readWrite {implicit s =>
-      s.withPreparedStatement("CREATE SEQUENCE normalized_uri_sequence;")(_.execute)
-      s.withPreparedStatement("CREATE SEQUENCE bookmark_sequence;")(_.execute)
-    }
-  }
-
   def setup()(implicit injector: RichInjector) = {
-    initDbSequence()
     db.readWrite {implicit s =>
       uriRepo.count === 0 //making sure the db is clean, we had some strange failures
       userRepo.count === 0 //making sure the db is clean
@@ -127,8 +119,7 @@ class NormalizedURITest extends Specification with TestDBRunner {
   "NormalizedURIs get created url" should {
     "search gets nothing" in {
       withDB() { implicit injector =>
-        initDbSequence()
-      	db.readWrite { implicit s =>
+        db.readWrite { implicit s =>
       	  val user1 = userRepo.save(User(firstName = "Joe", lastName = "Smith"))
       	  val user2 = userRepo.save(User(firstName = "Moo", lastName = "Brown"))
       	  val uri1 = createUri(title = "short title", url = "http://www.keepit.com/short", state = NormalizedURIStates.INACTIVE)
@@ -141,8 +132,7 @@ class NormalizedURITest extends Specification with TestDBRunner {
     }
     "search gets short" in {
       withDB() { implicit injector =>
-        initDbSequence()
-      	db.readWrite { implicit s =>
+        db.readWrite { implicit s =>
       	  uriRepo.all.size === 0 //making sure the db is clean, trying to understand some strange failures we got
       	  val user1 = userRepo.save(User(firstName = "Joe", lastName = "Smith"))
       	  val user2 = userRepo.save(User(firstName = "Moo", lastName = "Brown"))

--- a/shoebox/test/com/keepit/test/TestDBRunner.scala
+++ b/shoebox/test/com/keepit/test/TestDBRunner.scala
@@ -40,22 +40,26 @@ trait TestDBRunner extends TestInjector {
   def emailAddressRepo(implicit injector: RichInjector) = inject[EmailAddressRepo]
   def unscrapableRepo(implicit injector: RichInjector) = inject[UnscrapableRepo]
 
-  def withDB[T](overrideingModules: Module*)(f: RichInjector => T) = {
-    withInjector(overrideingModules: _*) { implicit injector =>
+  def withDB[T](overridingModules: Module*)(f: RichInjector => T) = {
+    withInjector(overridingModules: _*) { implicit injector =>
       val h2 = inject[DataBaseComponent].asInstanceOf[H2]
       h2.initListener = Some(new TableInitListener {
         def init(table: TableWithDDL) = executeTableDDL(h2, table)
+        def initSequence(sequence: String) = executeSequenceinit(h2, sequence)
       })
       try {
-        (f(injector))
+        f(injector)
       } finally {
         readWrite(h2) { implicit session =>
           val conn = session.conn
-//          conn.createStatement().execute("SET REFERENTIAL_INTEGRITY FALSE")
-//          h2.tablesToInit.values foreach { table =>
-//            conn.createStatement().execute(s"TRUNCATE TABLE ${table.tableName}")
-//          }
-//          conn.createStatement().execute("SET REFERENTIAL_INTEGRITY TRUE")
+          // conn.createStatement().execute("SET REFERENTIAL_INTEGRITY FALSE")
+          // h2.tablesToInit.values foreach { table =>
+          //   conn.createStatement().execute(s"TRUNCATE TABLE ${table.tableName}")
+          // }
+          // conn.createStatement().execute("SET REFERENTIAL_INTEGRITY TRUE")
+          // h2.sequencesToInit.values foreach { sequence =>
+          //   conn.createStatement().execute(s"DROP SEQUENCE IF EXISTS $sequence")
+          // }
           conn.createStatement().execute("DROP ALL OBJECTS")
         }
       }
@@ -71,16 +75,33 @@ trait TestDBRunner extends TestInjector {
     } finally s.close()
   }
 
+  def executeSequenceinit(db: H2, sequence: String): Unit = {
+    println(s"initiating sequence [$sequence]")
+    readWrite(db) { implicit session =>
+      try {
+        val statment = s"CREATE SEQUENCE IF NOT EXISTS $sequence;"
+        try {
+          session.withPreparedStatement(statment)(_.execute)
+        } catch {
+          case t: Throwable => throw new Exception(s"fail initiating sequence $sequence, statement: [$statment]", t)
+        }
+      } catch {
+        case t: Throwable => throw new Exception(s"fail initiating table $sequence", t)
+      }
+    }
+  }
+
   def executeTableDDL(db: H2, table: TableWithDDL): Unit = {
     println(s"initiating table [${table.tableName}]")
     readWrite(db) { implicit session =>
       try {
         val ddl = table.ddl
         for (s <- ddl.createStatements) {
+          val statment = s.replace("create table ", "create table IF NOT EXISTS ")
           try {
-            session.withPreparedStatement(s)(_.execute)
+            session.withPreparedStatement(statment)(_.execute)
           } catch {
-            case t: Throwable => throw new Exception(s"fail initiating table ${table.tableName}, statement: [$s]", t)
+            case t: Throwable => throw new Exception(s"fail initiating table ${table.tableName}, statement: [$statment]", t)
           }
         }
       } catch {

--- a/shoebox/test/com/keepit/test/TestInjector.scala
+++ b/shoebox/test/com/keepit/test/TestInjector.scala
@@ -21,14 +21,14 @@ trait TestInjector {
 
   def inject[A](implicit m: Manifest[A], injector: RichInjector): A = injector.inject[A]
 
-  def withInjector[T](overrideingModules: Module*)(f: RichInjector => T) = {
+  def withInjector[T](overridingModules: Module*)(f: RichInjector => T) = {
     def dbInfo: DbInfo = TestDbInfo.dbInfo
     DriverManager.registerDriver(new play.utils.ProxyDriver(Class.forName("org.h2.Driver").newInstance.asInstanceOf[Driver]))
 //    val conn = DriverManager.getConnection(TestDbInfo.url)
     val modules = {
-      def overridModule(m: Module, overriding: Module) = Modules.`override`(Seq(m): _*).`with`(overriding)
-      val init = overridModule(TestModule(Some(dbInfo)), TestActorSystemModule(ActorSystem()))
-      overrideingModules.foldLeft(init)((init, over) => overridModule(init, over))
+      def overrideModule(m: Module, overriding: Module) = Modules.`override`(Seq(m): _*).`with`(overriding)
+      val init = overrideModule(TestModule(Some(dbInfo)), TestActorSystemModule(ActorSystem()))
+      overridingModules.foldLeft(init)((init, over) => overrideModule(init, over))
     }
 
     implicit val injector = new RichInjector(Guice.createInjector(Stage.DEVELOPMENT, modules))


### PR DESCRIPTION
`def initTable[M](withDDL: {def ddl: DDL}): Unit = ???` caused prod to blow up. fixed.
