### PR TITLE
fixing failure to draw reply after clicking notification

### DIFF
--- a/packrat/scripts/thread.js
+++ b/packrat/scripts/thread.js
@@ -37,9 +37,6 @@ threadPane = function() {
         attachComposeBindings($container, "message");
 
         $sent = $container.find(".kifi-messages-sent").data("threadId", threadId);
-        $container.closest(".kifi-pane-box").on("kifi:remove", function() {
-          $sent.length = 0;
-        });
 
         if (messages.length) emitRead(threadId, messages[messages.length - 1]);
       });


### PR DESCRIPTION
was failing because we remove a pane after creating a replacement pane, so `$sent` was empty after a `threadPane` → `threadPane` transition. those kinds of transitions were never supposed to happen. better fix coming next.
