### PR TITLE
2.3.26: proper pane history for back button

### DIFF
--- a/packrat/adapters/chrome/manifest.json
+++ b/packrat/adapters/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "KiFi Beta",
-  "version": "2.3.25",
+  "version": "2.3.26",
   "manifest_version": 2,
   "description": "KiFi Private Beta",
   "icons": {

--- a/packrat/adapters/firefox/package.json
+++ b/packrat/adapters/firefox/package.json
@@ -3,7 +3,7 @@
     "license": "MPL 2.0",
     "author": "FortyTwo Inc.",
     "homepage": "http://www.keepitfindit.com/",
-    "version": "2.3.25",
+    "version": "2.3.26",
     "fullName": "Keep It, Find It!",
     "id": "kifi@42go.com",
     "icon": "data/icons/kifi.48.png",

--- a/packrat/html/metro/pane_thread.html
+++ b/packrat/html/metro/pane_thread.html
@@ -1,6 +1,6 @@
 <div class="kifi-pane-box kifi-pane-thread">
   <div class="kifi-pane-title">Messages</div>
-  <a class="kifi-pane-back" href="javascript:" data-pane="threads">&lsaquo; Back</a>
+  <a class="kifi-pane-back" href="javascript:" data-loc="/messages">&lsaquo; Back</a>
   <div class="kifi-thread-who">
     A conversation with{{!
   }}{{^numRecipients}}:

--- a/packrat/html/metro/slider2.html
+++ b/packrat/html/metro/slider2.html
@@ -5,18 +5,18 @@
     <span class="kifi-slider2-lock" style="background-image:url({{bgUrl}})"></span>
   </span>
   <span class="kifi-slider2-dock">
-    <span class="kifi-slider2-dock-btn kifi-slider2-notices" style="background-image:url({{bgUrl}})" data-pane="notices">
+    <span class="kifi-slider2-dock-btn kifi-slider2-notices" style="background-image:url({{bgUrl}})" data-loc="/notices">
       <span class="kifi-count kifi-unread"{{^noticesCount}} style="display:none"{{/noticesCount}}>{{noticesCount}}</span>
     </span>
     <span class="kifi-slider2-dock-sep"></span>
-    <span class="kifi-slider2-dock-btn kifi-slider2-comments" style="background-image:url({{bgUrl}})" data-pane="comments">
+    <span class="kifi-slider2-dock-btn kifi-slider2-comments" style="background-image:url({{bgUrl}})" data-loc="/comments">
       <span class="kifi-count{{#commentsUnread}} kifi-unread{{/commentsUnread}}"{{^commentCount}} style="display:none"{{/commentCount}}>{{commentCount}}</span>
     </span>
     <span class="kifi-slider2-dock-sep"></span>
-    <span class="kifi-slider2-dock-btn kifi-slider2-threads" style="background-image:url({{bgUrl}})" data-pane="threads">
+    <span class="kifi-slider2-dock-btn kifi-slider2-threads" style="background-image:url({{bgUrl}})" data-loc="/messages">
       <span class="kifi-count{{#messagesUnread}} kifi-unread{{/messagesUnread}}"{{^messageCount}} style="display:none"{{/messageCount}}>{{messageCount}}</span>
     </span>
     <span class="kifi-slider2-dock-sep"></span>
-    <span class="kifi-slider2-dock-btn kifi-slider2-general" style="background-image:url({{bgUrl}})" data-pane="general"></span>
+    <span class="kifi-slider2-dock-btn kifi-slider2-general" style="background-image:url({{bgUrl}})" data-loc="/general"></span>
   </span>
 </div>

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -459,10 +459,7 @@ api.port.on({
         var id = (th || data).id;
         socket.send(["get_thread", id]);
         if (data.respond) {
-          if (!d.threadCallbacks) {
-            d.threadCallbacks = [];
-          }
-          d.threadCallbacks.push({id: id, respond: respond});
+          (d.threadCallbacks = d.threadCallbacks || []).push({id: id, respond: respond});
           return true;
         }
       }

--- a/packrat/scripts/thread.js
+++ b/packrat/scripts/thread.js
@@ -37,6 +37,11 @@ threadPane = function() {
         attachComposeBindings($container, "message");
 
         $sent = $container.find(".kifi-messages-sent").data("threadId", threadId);
+        $container.closest(".kifi-pane-box").on("kifi:remove", function() {
+          if (this.contains($sent[0])) {
+            $sent = $();
+          }
+        });
 
         if (messages.length) emitRead(threadId, messages[messages.length - 1]);
       });

--- a/packrat/scripts/threads.js
+++ b/packrat/scripts/threads.js
@@ -40,7 +40,7 @@ threadsPane = function() {
           var $th = $(this), id = $th.data("id");
           var recipients = $th.data("recipients") ||
             o.threads.filter(function(t) {return t.id == id})[0].recipients;
-          $th.closest(".kifi-pane").triggerHandler("kifi:show-pane", ["thread", recipients, id])
+          $th.closest(".kifi-pane").triggerHandler("kifi:show-pane", ["/messages/" + id, recipients])
         })
         .on("kifi:compose-submit", sendMessage.bind(null, $container))
         .find("time").timeago();


### PR DESCRIPTION
This also avoids switching from a pane to the exact same pane (e.g. by clicking a notification that we shouldn't have shown).
