### PR TITLE
2.3.32: fixing JS error in hidePane due to hiding before fully shown

### DIFF
--- a/packrat/adapters/chrome/manifest.json
+++ b/packrat/adapters/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "KiFi Beta",
-  "version": "2.3.31",
+  "version": "2.3.32",
   "manifest_version": 2,
   "description": "KiFi Private Beta",
   "icons": {

--- a/packrat/adapters/firefox/package.json
+++ b/packrat/adapters/firefox/package.json
@@ -3,7 +3,7 @@
     "license": "MPL 2.0",
     "author": "FortyTwo Inc.",
     "homepage": "https://www.kifi.com/",
-    "version": "2.3.31",
+    "version": "2.3.32",
     "fullName": "KiFi Private Beta",
     "id": "kifi@42go.com",
     "icon": "data/icons/kifi.48.png",

--- a/packrat/scripts/slider2.js
+++ b/packrat/scripts/slider2.js
@@ -352,10 +352,9 @@ slider2 = function() {
         function(html) {
           var $html = $("html").addClass("kifi-pane-parent");
           $pane = $(html).append(bringSlider ? $slider : null).appendTo($html).layout()
-          .on("transitionend webkitTransitionEnd", function f(e) {
-            $pane.off("transitionend webkitTransitionEnd", f);
+          .on("transitionend webkitTransitionEnd", function onPaneShown(e) {
+            $pane.off("transitionend webkitTransitionEnd", onPaneShown);
             $box.data("shown", true).triggerHandler("kifi:shown");
-            if (!bringSlider) $pane.append($slider);
             $(tile).show();  // in case hidden
           })
           .on("keydown", ".kifi-pane-search", function(e) {
@@ -439,10 +438,13 @@ slider2 = function() {
     if (leaveSlider) {
       $slider.appendTo("html").layout();
     } else {
+      $slider.appendTo($pane);
       $slider = null;
       $(tile).removeClass("kifi-behind-slider");
     }
-    $pane.on("transitionend webkitTransitionEnd", function(e) {
+    $pane
+    .off("transitionend webkitTransitionEnd") // onPaneShown
+    .on("transitionend webkitTransitionEnd", function(e) {
       if (e.target.classList.contains("kifi-pane")) {
         var $pane = $(e.target);
         $pane.find(".kifi-pane-box").triggerHandler("kifi:remove");


### PR DESCRIPTION
also working around Chrome's occasional early firing of `transitionend`, which manifests as keeper jumping over to the right a bit (into the pane) just before the pane finishes sliding into the page
