### PR TITLE
Create lazy read-only database sessions

### DIFF
--- a/shoebox/app/com/keepit/common/db/slick/Database.scala
+++ b/shoebox/app/com/keepit/common/db/slick/Database.scala
@@ -1,20 +1,18 @@
 package com.keepit.common.db.slick
 
-import com.google.inject.{Inject, Provider}
-import com.keepit.common.db.{ DbSequence, DbInfo, DatabaseDialect }
-import scala.collection.mutable
-import scala.slick.driver._
-import scala.slick.session.{ Database => SlickDatabase, Session, ResultSetConcurrency, ResultSetType, ResultSetHoldability }
-import scala.annotation.tailrec
-import com.keepit.common.logging.Logging
-import scala.util.Failure
-import scala.util.Success
-import com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException
-import akka.actor.ActorSystem
 import scala.concurrent._
-import scala.slick.lifted.DDL
+import scala.slick.session.ResultSetConcurrency
+import scala.slick.session.Session
+import scala.slick.session.{Database => SlickDatabase}
 import scala.util.DynamicVariable
+
+import com.google.inject.{Singleton, ImplementedBy, Inject, Provider}
+import com.keepit.common.db.DatabaseDialect
 import com.keepit.common.healthcheck._
+import com.keepit.common.logging.Logging
+import com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException
+
+import akka.actor.ActorSystem
 import play.api.Mode.Mode
 import play.api.Mode.Test
 
@@ -24,10 +22,28 @@ object DatabaseSessionLock {
   val inSession = new DynamicVariable[Boolean](false)
 }
 
+// this allows us to replace the database session implementation in tests and check when sessions are being obtained
+@ImplementedBy(classOf[SlickSessionProviderImpl])
+trait SlickSessionProvider {
+  def createReadOnlySession(handle: SlickDatabase): Session
+  def createReadWriteSession(handle: SlickDatabase): Session
+}
+
+@Singleton
+class SlickSessionProviderImpl extends SlickSessionProvider {
+  def createReadOnlySession(handle: SlickDatabase): Session = {
+    handle.createSession().forParameters(rsConcurrency = ResultSetConcurrency.ReadOnly)
+  }
+  def createReadWriteSession(handle: SlickDatabase): Session = {
+    handle.createSession().forParameters(rsConcurrency = ResultSetConcurrency.Updatable)
+  }
+}
+
 class Database @Inject() (
     val db: DataBaseComponent,
     val system: ActorSystem,
     val healthcheckPlugin: Provider[HealthcheckPlugin],
+    val sessionProvider: SlickSessionProvider,
     val playMode: Mode
   ) extends Logging {
 
@@ -51,12 +67,16 @@ class Database @Inject() (
   def readWriteAsync[T](attempts: Int)(f: RWSession => T): Future[T] = future { readWrite(attempts)(f) }
 
   def readOnly[T](f: ROSession => T): T = enteringSession {
-    val s = db.handle.createSession.forParameters(rsConcurrency = ResultSetConcurrency.ReadOnly)
-    try { f(new ROSession(s)) } finally s.close()
+    var initialized = false
+    lazy val s = {
+      initialized = true
+      sessionProvider.createReadOnlySession(db.handle)
+    }
+    try f(new ROSession(s)) finally if (initialized) s.close()
   }
 
   def readWrite[T](f: RWSession => T): T = enteringSession {
-    val s = db.handle.createSession.forParameters(rsConcurrency = ResultSetConcurrency.Updatable)
+    val s = sessionProvider.createReadWriteSession(db.handle)
     try {
       s.withTransaction {
         f(new RWSession(s))

--- a/shoebox/test/com/keepit/common/db/TestSlickSessionProvider.scala
+++ b/shoebox/test/com/keepit/common/db/TestSlickSessionProvider.scala
@@ -1,0 +1,34 @@
+package com.keepit.common.db
+
+import scala.slick.session.{Database => SlickDatabase}
+
+import com.google.inject.Singleton
+import com.keepit.common.db.slick.SlickSessionProviderImpl
+
+@Singleton
+class TestSlickSessionProvider extends SlickSessionProviderImpl {
+
+  private[this] var _readOnlySessionsCreated = 0
+  def readOnlySessionsCreated: Long = _readOnlySessionsCreated
+
+  private[this] var _readWriteSessionsCreated = 0
+  def readWriteSessionsCreated: Long = _readWriteSessionsCreated
+
+  override def createReadOnlySession(handle: SlickDatabase) = {
+    _readOnlySessionsCreated += 1
+    super.createReadOnlySession(handle)
+  }
+  override def createReadWriteSession(handle: SlickDatabase) = {
+    _readWriteSessionsCreated += 1
+    super.createReadWriteSession(handle)
+  }
+
+  def doWithoutCreatingSessions[A](block: => A): A = {
+    val (oldRO, oldRW) = (readOnlySessionsCreated, readWriteSessionsCreated)
+    val result = block
+    val (roCreated, rwCreated) = (readOnlySessionsCreated - oldRO, readWriteSessionsCreated - oldRW)
+    if (roCreated != 0) throw new IllegalStateException(s"Created $roCreated read-only database sessions")
+    if (rwCreated != 0) throw new IllegalStateException(s"Created $rwCreated read-write database sessions")
+    result
+  }
+}

--- a/shoebox/test/com/keepit/model/UserTest.scala
+++ b/shoebox/test/com/keepit/model/UserTest.scala
@@ -1,36 +1,36 @@
 package com.keepit.model
 
+import scala.util.Try
+
 import org.specs2.mutable._
 
-import com.keepit.test._
-import com.keepit.inject._
-import securesocial.core._
-
-import play.api.Play.current
-import play.api.test._
-import play.api.test.Helpers._
-import com.keepit.common.cache.{FortyTwoCachePlugin, FortyTwoCache}
-import com.keepit.common.db.slick.Database
 import com.keepit.common.db._
+import com.keepit.common.db.slick.Database
+import com.keepit.test._
 
 class UserRepoTest extends Specification with TestDBRunner {
 
   "UserRepo" should {
     "Use the cache" in {
       withDB() { implicit injector =>
-
-      val userRepoImpl = userRepo.asInstanceOf[UserRepoImpl]
+        val userRepoImpl = userRepo.asInstanceOf[UserRepoImpl]
+        val sessionProvider = inject[TestSlickSessionProvider]
         inject[Database].readWrite { implicit session =>
           userRepoImpl.idCache.get(UserIdKey(Id[User](1))).isDefined === false
           val user = userRepo.save(User(firstName = "Andrew", lastName = "Conner"))
 
           userRepoImpl.idCache.get(UserIdKey(Id[User](1))).get === user
-
           val updatedUser = userRepo.save(user.copy(lastName = "NotMyLastName"))
 
           userRepoImpl.idCache.get(UserIdKey(Id[User](1))).get !== user
           userRepoImpl.idCache.get(UserIdKey(Id[User](1))).get === updatedUser
         }
+
+        sessionProvider.doWithoutCreatingSessions {
+          db.readOnly { implicit s => userRepoImpl.get(Id[User](1)) }
+        }
+        Try(db.readOnly { implicit s => userRepoImpl.get(Id[User](2)) })
+        sessionProvider.readOnlySessionsCreated === 1
       }
     }
   }

--- a/shoebox/test/com/keepit/test/TestApplication.scala
+++ b/shoebox/test/com/keepit/test/TestApplication.scala
@@ -116,6 +116,7 @@ case class TestModule(dbInfo: Option[DbInfo] = None) extends ScalaModule {
     bind[MailToKeepPlugin].to[FakeMailToKeepPlugin]
     bind[SocialGraphPlugin].to[FakeSocialGraphPlugin]
     bind[HealthcheckPlugin].to[FakeHealthcheck]
+    bind[SlickSessionProvider].to[TestSlickSessionProvider]
 
     val listenerBinder = Multibinder.newSetBinder(binder(), classOf[EventListenerPlugin])
     listenerBinder.addBinding().to(classOf[ResultClickedListener])


### PR DESCRIPTION
In many cases we'll make a database call like

``` scala
db.readOnly { implicit s => userRepo.get(id) }
```

which will most of the time get the value from memcache and never use the database connection we just opened. This makes the database session lazy so we don't initialize it until we actually use it.
