### PR TITLE
Use images from S3 in the extension

### DIFF
--- a/packrat/adapters/chrome/options.js
+++ b/packrat/adapters/chrome/options.js
@@ -45,7 +45,7 @@ $(function() {
     console.log("[showSession] session:", session);
     $("#avatar").remove();
     if (session) {
-      $("#name").text(session.name).before("<img id=avatar src='" + session.avatarUrl + "'>");
+      $("#name").text(session.name).before("<img id=avatar src='" + cdnBase + "/users/" + session.userId + "/pics/100/0.jpg'>");
     }
     $("#session").attr("class", session ? "valid" : "none");
   }

--- a/packrat/html/friend_card.html
+++ b/packrat/html/friend_card.html
@@ -1,6 +1,6 @@
 <div class="kifi-kcard">
   <div class="kifi-kcard-top">
-    <img class="kifi-kcard-pic" src="https://graph.facebook.com/{{facebookId}}/picture?width=200&amp;height=200">
+    <img class="kifi-kcard-pic" src="{{cdnBase}}/users/{{id}}/pics/100/0.jpg">
     <div class="kifi-kcard-info">
       <div class="kifi-kcard-name">{{name}}</div>
       <div class="kifi-kcard-label">Relevant interests:</div>

--- a/packrat/html/metro/comment.html
+++ b/packrat/html/metro/comment.html
@@ -1,6 +1,6 @@
 <div class="kifi-comment-posted" data-id="{{id}}">
   <time datetime="{{createdAt}}">{{#formatLocalDate}}{{createdAt}}{{/formatLocalDate}}</time>
-  <img class="kifi-comment-pic{{#isLoggedInUser}} kifi-self{{/isLoggedInUser}}" src="//graph.facebook.com/{{user.facebookId}}/picture?width=100&amp;height=100">
+  <img class="kifi-comment-pic{{#isLoggedInUser}} kifi-self{{/isLoggedInUser}}" src="{{cdnBase}}/users/{{user.id}}/pics/100/0.jpg">
   <div class="kifi-comment-body">
     <div class="kifi-comment-name">{{user.firstName}} {{user.lastName}}</div>
     {{#formatComment}}{{{text}}}{{/formatComment}}

--- a/packrat/html/metro/general.html
+++ b/packrat/html/metro/general.html
@@ -6,7 +6,7 @@
 <div class="kifi-pane-kept-by">
   <div class="kifi-pane-keepers">
   {{#keepers}}
-    <a class="kifi-pane-keeper" href="javascript:" style="background-image:url(https://graph.facebook.com/{{facebookId}}/picture?type=square)"></a>
+    <a class="kifi-pane-keeper" href="javascript:" style="background-image:url({{cdnBase}}/users/{{id}}/pics/100/0.jpg)"></a>
   {{/keepers}}
   </div>
   <div class="kifi-pane-keepers-caption">

--- a/packrat/html/metro/keepers.html
+++ b/packrat/html/metro/keepers.html
@@ -4,7 +4,7 @@
 </div>
 <div class="kifi-slider2-keepers">
 {{#keepers}}
-  <a class="kifi-slider2-keeper"{{#link}} href="javascript:"{{/link}} style="background-image:url(https://graph.facebook.com/{{facebookId}}/picture?type=square)"></a>
+  <a class="kifi-slider2-keeper"{{#link}} href="javascript:"{{/link}} style="background-image:url({{cdnBase}}/{{id}}_100x100.jpg)"></a>
 {{/keepers}}
 </div>
 {{/anyKeepers}}

--- a/packrat/html/metro/message.html
+++ b/packrat/html/metro/message.html
@@ -1,6 +1,6 @@
 <div class="kifi-message-sent" data-id="{{id}}">
   <time datetime="{{createdAt}}">{{#formatLocalDate}}{{createdAt}}{{/formatLocalDate}}</time>
-  <img class="kifi-message-pic{{#isLoggedInUser}} kifi-self{{/isLoggedInUser}}" src="//graph.facebook.com/{{user.facebookId}}/picture?width=100&amp;height=100">
+  <img class="kifi-message-pic{{#isLoggedInUser}} kifi-self{{/isLoggedInUser}}" src="{{cdnBase}}/users/{{user.id}}/pics/100/0.jpg">
   <div class="kifi-message-body">
     <div class="kifi-message-name">{{user.firstName}} {{user.lastName}}</div>
     {{#formatMessage}}{{{text}}}{{/formatMessage}}

--- a/packrat/html/metro/notice_comment.html
+++ b/packrat/html/metro/notice_comment.html
@@ -1,5 +1,5 @@
 <div class="kifi-notice kifi-notice-comment kifi-notice-state-{{state}}{{#isNew}} kifi-notice-new{{/isNew}}" data-id="{{id}}" data-uri="{{details.page}}" data-locator="{{details.locator}}">
-  <img class="kifi-notice-avatar" src="{{details.author.avatar}}">
+  <img class="kifi-notice-avatar" src="{{cdnBase}}/users/{{details.author.id}}/pics/100/0.jpg">
   <div class="kifi-notice-name">
     <span class="kifi-author-name">{{details.author.firstName}} {{details.author.lastName}}</span>
   </div>

--- a/packrat/html/metro/notice_message.html
+++ b/packrat/html/metro/notice_message.html
@@ -1,5 +1,5 @@
 <div class="kifi-notice kifi-notice-message kifi-notice-state-{{state}}{{#isNew}} kifi-notice-new{{/isNew}}" data-id="{{id}}" data-uri="{{details.page}}" data-locator="{{details.locator}}">
-  <img class="kifi-notice-avatar" src="{{details.authors.0.avatar}}">
+  <img class="kifi-notice-avatar" src="{{cdnBase}}/users/{{details.authors.0.id}}/pics/200/0.jpg">
   <div class="kifi-notice-name">
     {{#oneAuthor}}
       <span class="kifi-author-name">{{details.authors.0.firstName}} {{details.authors.0.lastName}}</span>

--- a/packrat/html/metro/thread.html
+++ b/packrat/html/metro/thread.html
@@ -1,7 +1,7 @@
 <div class="kifi-thread" data-id="{{id}}">
   <div class="kifi-thread-pics">
     {{#recipientsPictured}}
-    <img class="kifi-thread-pic" src="//graph.facebook.com/{{facebookId}}/picture?width=100&amp;height=100" alt="{{firstName}} {{lastName}}">
+    <img class="kifi-thread-pic" src="{{cdnBase}}/users/{{id}}/pics/100/0.jpg" alt="{{firstName}} {{lastName}}">
     {{/recipientsPictured}}
     <span class="kifi-thread-msg-count{{#messagesUnread}} kifi-unread{{/messagesUnread}}">{{messageCount}}</span>
   </div>

--- a/packrat/html/search/google_hit.html
+++ b/packrat/html/search/google_hit.html
@@ -11,10 +11,10 @@
   <!--n-->
   <div class="kifi-who" id="kifi-who-{{bookmark.id}}">
     {{#displaySelf}}
-      <img class="kifi-face kifi-self{{^displayUsers}} kifi-only{{/displayUsers}}" src="{{session.avatarUrl}}" alt="You!" title="You! You look great!">
+      <img class="kifi-face kifi-self{{^displayUsers}} kifi-only{{/displayUsers}}" src="{{cdnBase}}/users/{{id}}/pics/100/0.jpg" alt="You!" title="You! You look great!">
     {{/displaySelf}}
     {{#displayUsers}}
-      <a class="kifi-face kifi-friend" href="javascript:" style="background-image:url(//graph.facebook.com/{{facebookId}}/picture?type=square)"></a>
+      <a class="kifi-face kifi-friend" href="javascript:" style="background-image:url({{cdnBase}}/users/{{id}}/pics/100/0.jpg)"></a>
     {{/displayUsers}}
     {{^displaySelf}}{{^displayUsers}}
       <img class="kifi-globe" src="{{globeUrl}}">

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -10,6 +10,7 @@ var friends = [];
 var friendsById = {};
 var ruleSet = {};
 var urlPatterns = [];
+var cdnBase;
 
 function clearDataCache() {
   pageData = {};
@@ -540,6 +541,9 @@ api.port.on({
   },
   add_deep_link_listener: function(locator, _, tab) {
     createDeepLinkListener(locator, tab.id);
+  },
+  get_cdn_base: function(_, respond) {
+    respond(cdnBase);
   }
 });
 
@@ -963,6 +967,7 @@ function authenticate(callback) {
       logEvent.catchUp();
 
       ruleSet = data.rules;
+      cdnBase = data.cdnBase;
       urlPatterns = compilePatterns(data.patterns);
       store("kifi_installation_id", data.installationId);
       delete session.rules;

--- a/packrat/scripts/render.js
+++ b/packrat/scripts/render.js
@@ -1,3 +1,7 @@
+api.port.emit('get_cdn_base', function (base) {
+  render.cdnBase = base;
+});
+
 function render(path, params, partialPaths, callback) {
   // sort out partialPaths and callback (both optional)
   if (!callback && typeof partialPaths == "function") {
@@ -7,6 +11,7 @@ function render(path, params, partialPaths, callback) {
 
   loadPartials(path.replace(/[^\/]*$/, ""), partialPaths || {}, function(partials) {
     loadFile(path, function(template) {
+      params = $.extend({ cdnBase: render.cdnBase }, params);
       callback(Mustache.render(template, params, partials));
     });
   });

--- a/shoebox/app/com/keepit/common/store/S3ImageConfig.scala
+++ b/shoebox/app/com/keepit/common/store/S3ImageConfig.scala
@@ -7,13 +7,12 @@ object S3ImageConfig {
   val ImageSizes = Seq(100, 200)
 }
 
-case class S3ImageConfig(bucketName: String, cloudfrontHost: String) {
+case class S3ImageConfig(bucketName: String, cdnBase: String, isLocal: Boolean = false) {
   def avatarUrlByExternalId(w: Int, userId: ExternalId[User]): String = {
     val size = S3ImageConfig.ImageSizes.find(_ >= w).getOrElse(S3ImageConfig.ImageSizes.last)
-    s"//${cloudfrontHost}/${keyByExternalId(size, userId)}"
+    s"${cdnBase}/${keyByExternalId(size, userId)}"
   }
 
-  def keyByExternalId(width: Int, userId: ExternalId[User]): String =
-    s"${userId}_${width}x${width}.jpg"
-
+  def keyByExternalId(size: Int, userId: ExternalId[User]): String =
+    s"users/$userId/pics/$size/0.jpg"
 }

--- a/shoebox/app/com/keepit/controllers/assets/UserPictureController.scala
+++ b/shoebox/app/com/keepit/controllers/assets/UserPictureController.scala
@@ -20,9 +20,9 @@ class UserPictureController @Inject() (
   imageStore: S3ImageStore)
   extends WebsiteController(actionAuthenticator) {
 
-  def get(width: Int, userExternalId: ExternalId[User]) = Action { implicit request =>
-    db.readOnly { implicit s => userRepo.getOpt(userExternalId) } map { user =>
-      imageStore.getPictureUrl(width, user)
+  def get(size: Int, id: ExternalId[User]) = Action { request =>
+    db.readOnly { implicit s => userRepo.getOpt(id) } map { user =>
+      imageStore.getPictureUrl(size, user)
     } map { futureImage =>
       Async {
         futureImage map { Redirect(_) }

--- a/shoebox/app/com/keepit/dev/S3DevModule.scala
+++ b/shoebox/app/com/keepit/dev/S3DevModule.scala
@@ -9,7 +9,7 @@ import com.keepit.common.analytics._
 import com.keepit.common.analytics.reports._
 import com.keepit.common.logging.Logging
 import com.keepit.common.social.{InMemorySocialUserRawInfoStoreImpl, SocialUserRawInfoStore}
-import com.keepit.common.store.S3Bucket
+import com.keepit.common.store.{S3ImageConfig, S3Bucket}
 import com.keepit.search._
 import com.tzavellas.sse.guice.ScalaModule
 
@@ -60,5 +60,16 @@ class S3DevModule() extends ScalaModule with Logging {
       case Some(name) => new S3Module().reportStore(amazonS3ClientProvider.get)
       case None => new InMemoryReportStoreImpl()
     }
+
+  @Singleton
+  @Provides
+  def s3ImageConfig: S3ImageConfig = {
+    val bucket = current.configuration.getString("cdn.bucket")
+    val base = current.configuration.getString("cdn.base")
+    S3ImageConfig(
+      if (base.isDefined) bucket.get else "",
+      base.getOrElse("http://dev.ezkeep.com:9000"),
+      base.isEmpty)
+  }
 
 }

--- a/shoebox/app/com/keepit/module/S3Module.scala
+++ b/shoebox/app/com/keepit/module/S3Module.scala
@@ -60,9 +60,9 @@ class S3Module() extends ScalaModule with Logging {
   @Singleton
   @Provides
   def s3ImageConfig: S3ImageConfig = {
-    S3ImageConfig(
-      current.configuration.getString("amazon.s3.images.bucket").get,
-      current.configuration.getString("amazon.s3.images.cloudfront").get)
+    val bucket = current.configuration.getString("cdn.bucket")
+    val base = current.configuration.getString("cdn.base")
+    S3ImageConfig(bucket.get, base.get)
   }
 
   @Singleton

--- a/shoebox/conf/application.conf
+++ b/shoebox/conf/application.conf
@@ -72,9 +72,11 @@ amazon.s3 = {
   articleSearch.bucket = "article-search-results-b-dev"
   accessKey = "AKIAJB5MKHQZU4GKCXSQ"
   secretKey = "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"
+}
 
-  images.bucket = "images-b-dev"
-  images.cloudfront = "d1scct5mnc9d9m.cloudfront.net"
+cdn {
+  #bucket = "images-b-dev"
+  #base = "//d1scct5mnc9d9m.cloudfront.net"
 }
 
 # Mongo Resources

--- a/shoebox/conf/prod/prod.conf
+++ b/shoebox/conf/prod/prod.conf
@@ -70,9 +70,11 @@ amazon.s3 = {
   articleSearch.bucket = "article-search-results-b-prod"
   accessKey = "AKIAJA24QAUWFTZN5JTQ"
   secretKey = "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"
+}
 
-  images.bucket = "images-b-prod"
-  images.cloudfront = "djty7jcqog9qu.cloudfront.net"
+cdn {
+  bucket = "images-b-prod"
+  base = "//djty7jcqog9qu.cloudfront.net"
 }
 
 # Mongo Resources

--- a/shoebox/conf/routes
+++ b/shoebox/conf/routes
@@ -72,7 +72,8 @@ POST    /users/slider/suppress      @com.keepit.controllers.ext.ExtUserControlle
 POST    /users/events               @com.keepit.controllers.ext.ExtEventController.logUserEvents
 POST    /error/report               @com.keepit.controllers.ext.ExtErrorReportController.addErrorReport
 
-GET     /users/picture/$width<[0-9]{2,3}>/:id.jpg       @com.keepit.controllers.assets.UserPictureController.get(width: Int, id: ExternalId[User])
+# This should match the output format of S3ImageConfig#keyByExternalId
+GET     /users/:id/pics/:size/0.jpg @com.keepit.controllers.assets.UserPictureController.get(size: Int, id: ExternalId[User])
 
 GET     /search                     @com.keepit.controllers.ext.ExtSearchController.search(q: String, f: Option[String], maxHits: Int, lastUUID: Option[String], context: Option[String], kifiVersion: Option[KifiVersion] ?= None)
 GET     /search/chatter             @com.keepit.controllers.ext.ExtCommentController.getCounts(ids: String)


### PR DESCRIPTION
Now the extension will use images stored in S3. This also disables S3 images by default on dev mode and goes directly to facebook for now.

@2is10 Is there a more elegant way to share the CDN information with the content scripts?
