### PR TITLE
remove unnecessary awaits in tests

### DIFF
--- a/shoebox/test/com/keepit/classify/DomainClassifierTest.scala
+++ b/shoebox/test/com/keepit/classify/DomainClassifierTest.scala
@@ -1,11 +1,5 @@
 package com.keepit.classify
 
-import scala.concurrent.Await
-import scala.concurrent.Future
-import scala.concurrent.duration._
-
-import java.util.concurrent.TimeUnit
-
 import org.specs2.mutable.Specification
 
 import com.keepit.common.db.slick.Database
@@ -19,10 +13,6 @@ import play.api.Play.current
 import play.api.test.Helpers.running
 
 class DomainClassifierTest extends TestKit(ActorSystem()) with Specification with DbRepos {
-
-  private def await[T](f: Future[T]): T = {
-    Await.result(f, pairIntToDuration(100, TimeUnit.MILLISECONDS))
-  }
 
   "The domain classifier" should {
     "use imported classifications and not fetch for known domains" in {
@@ -38,10 +28,9 @@ class DomainClassifierTest extends TestKit(ActorSystem()) with Specification wit
           tagRepo.save(DomainTag(name = DomainTagName("Porn"), sensitive = Some(true)))
         }
 
-        Seq(importer.applyTagToDomains(DomainTagName("search engines"), Seq("google.com", "yahoo.com")),
-          importer.applyTagToDomains(DomainTagName("Technology and Computers"), Seq("42go.com", "google.com")),
-          importer.applyTagToDomains(DomainTagName("Porn"), Seq("playboy.com"))
-        ) foreach await
+        importer.applyTagToDomains(DomainTagName("search engines"), Seq("google.com", "yahoo.com"))
+        importer.applyTagToDomains(DomainTagName("Technology and Computers"), Seq("42go.com", "google.com"))
+        importer.applyTagToDomains(DomainTagName("Porn"), Seq("playboy.com"))
 
         classifier.isSensitive("google.com") === Right(false)
         classifier.isSensitive("yahoo.com") === Right(false)
@@ -79,16 +68,14 @@ class DomainClassifierTest extends TestKit(ActorSystem()) with Specification wit
 
         classifier.isSensitive("google.com") === Right(false)
 
-        Seq(
-          classifier.isSensitive("yahoo.com").left.get,
-          classifier.isSensitive("zdnet.com").left.get,
-          classifier.isSensitive("schwab.com").left.get,
-          classifier.isSensitive("hover.com").left.get,
-          classifier.isSensitive("42go.com").left.get,
-          classifier.isSensitive("addepar.com").left.get,
-          classifier.isSensitive("playboy.com").left.get,
-          classifier.isSensitive("porn.com").left.get
-        ) foreach await
+        classifier.isSensitive("yahoo.com").left.get
+        classifier.isSensitive("zdnet.com").left.get
+        classifier.isSensitive("schwab.com").left.get
+        classifier.isSensitive("hover.com").left.get
+        classifier.isSensitive("42go.com").left.get
+        classifier.isSensitive("addepar.com").left.get
+        classifier.isSensitive("playboy.com").left.get
+        classifier.isSensitive("porn.com").left.get
 
         classifier.isSensitive("www.yahoo.com") === Right(false)
         classifier.isSensitive("yahoo.com") === Right(false)


### PR DESCRIPTION
When using the test actor system we process actor messages in the calling thread, so we don't need to await anymore.
