### PR TITLE
Splitting MailSenderPlugin and PostOffice.

### DIFF
--- a/shoebox/app/com/keepit/common/db/slick/Database.scala
+++ b/shoebox/app/com/keepit/common/db/slick/Database.scala
@@ -56,7 +56,9 @@ class Database @Inject() (
   def enteringSession[T](f: => T) = {
     if (DatabaseSessionLock.inSession.value) {
       val message = "already in a DB session!"
+      log.warn("Already in a DB session!", new InSessionException(message))
       //healthcheckPlugin.get.addError(HealthcheckError(Some(new InSessionException(message)), None, None, Healthcheck.INTERNAL, Some(message)))
+      
       if (playMode == Test) throw new InSessionException("already in a DB session!")
     }
     DatabaseSessionLock.inSession.withValue(true) { f }

--- a/shoebox/app/com/keepit/common/mail/PostOffice.scala
+++ b/shoebox/app/com/keepit/common/mail/PostOffice.scala
@@ -22,9 +22,7 @@ object PostOffice {
   val BODY_MAX_SIZE = 524288
 }
 
-class PostOfficeImpl @Inject() (
-    mailRepo: ElectronicMailRepo,
-    mailer: MailSenderPlugin)
+class PostOfficeImpl @Inject() (mailRepo: ElectronicMailRepo)
   extends PostOffice with Logging {
 
   def sendMail(mail: ElectronicMail)(implicit session: RWSession): ElectronicMail = {
@@ -35,7 +33,6 @@ class PostOfficeImpl @Inject() (
       } else {
         mailRepo.save(mail.prepareToSend())
       }
-    mailer.processMail(prepared)
     prepared
   }
 }

--- a/shoebox/app/com/keepit/search/SearchGlobal.scala
+++ b/shoebox/app/com/keepit/search/SearchGlobal.scala
@@ -27,8 +27,6 @@ trait SearchServices { self: FortyTwoGlobal =>
   def startSearchServices() {
     require(injector.inject[ArticleIndexerPlugin].enabled)
     require(injector.inject[URIGraphPlugin].enabled)
-    require(injector.inject[MailSenderPlugin].enabled)
-    injector.inject[MailSenderPlugin].processOutbox()
     require(injector.inject[HealthcheckPlugin].enabled)
     require(injector.inject[PersistEventPlugin].enabled)
     require(injector.inject[FortyTwoCachePlugin].enabled)


### PR DESCRIPTION
Now only shoebox will run MailSenderPlugin, but either can use PostOffice as before.
