### PR TITLE
2.3.51: queueing api.tabs.emit messages in api layer until content scripts are ready to receive them

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -218,6 +218,18 @@ api = function() {
         api.log("[onDisconnect]");
         delete ports[tab.id];
       });
+
+      var page = pages[tab.id];
+      if (page && page.toEmit) {
+        if (tab.url !== page.url) {
+          api.log("#a00", "[onConnect] %i mismatch:\n%s\n%s", tab.id, tab.url, page.url);
+        }
+        page.toEmit.forEach(function emit(m) {
+          api.log("#0c0", "[onConnect:emit] %i %s %o", tab.id, m[0], m[1] != null ? m[1] : "");
+          port.postMessage(m);
+        });
+        delete page.toEmit;
+      }
     }
   });
 
@@ -541,6 +553,8 @@ api = function() {
           if (port) {
             api.log("#0c0", "[api.tabs.emit] %i %s %o", tab.id, type, data);
             port.postMessage([type, data]);
+          } else {
+            (currTab.toEmit || (currTab.toEmit = [])).push([type, data]);
           }
         } else {
           api.log("#a00", "[api.tabs.emit] suppressed %i %s navigated: %s -> %s", tab.id, type, tab.url, currTab && currTab.url);

--- a/packrat/adapters/chrome/manifest.json
+++ b/packrat/adapters/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "KiFi Beta",
-  "version": "2.3.50",
+  "version": "2.3.51",
   "manifest_version": 2,
   "description": "KiFi Private Beta",
   "icons": {

--- a/packrat/adapters/firefox/package.json
+++ b/packrat/adapters/firefox/package.json
@@ -3,7 +3,7 @@
     "license": "MPL 2.0",
     "author": "FortyTwo Inc.",
     "homepage": "https://www.kifi.com/",
-    "version": "2.3.50",
+    "version": "2.3.51",
     "fullName": "KiFi Private Beta",
     "id": "kifi@42go.com",
     "icon": "data/icons/kifi.48.png",

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -801,36 +801,26 @@ function subscribe(tab) {
     api.icon.set(tab, "icons/keep.faint.png");
   }
   var d = pageData[tab.nUri || tab.url];
-  api.log("[subscribe] HERE");
   if (d && d.seq == socket.seq) {  // no need to ask server again
-    api.log("[subscribe] HERE 1");
     if (tab.seq == socket.seq) {  // tab is up-to-date
-      api.log("[subscribe] HERE 2");
       if (d.counts) {
-        api.log("[subscribe] HERE 3");
         api.tabs.emit(tab, "counts", d.counts);
       }
     } else {
-      api.log("[subscribe] HERE 4");
       var tabUpToDate = tab.seq == d.seq;
       finish(tab.nUri || tab.url);
       if (d.hasOwnProperty("kept")) {
-        api.log("[subscribe] HERE 5");
         if (!tabUpToDate) {
-          api.log("[subscribe] HERE 6");
           setIcon(tab, d.kept);
           sendKept(tab, d);
           if (d.counts) {
-            api.log("[subscribe] HERE 7");
             initTab(tab, d);
           } // else wait for uri_2
         }
       } // else wait for uri_1
     }
   } else if (socket) {
-    api.log("[subscribe] HERE 8");
     socket.send(["subscribe_uri", tab.url], function(uri) {
-      api.log("[subscribe] HERE 9");
       if (api.tabs.get(tab.id).url != tab.url) return;
       d = pageData[uri] = pageData[uri] || new PageData;
       d.seq = socket.seq;


### PR DESCRIPTION
Immediate reason for doing this is that it fixes an issue with counts not being shown on pages when reloaded in an additional tab.
