### PR TITLE
Capture uncaught errors in the extension

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -591,6 +591,10 @@ api.port.on({
   },
   add_deep_link_listener: function(locator, _, tab) {
     createDeepLinkListener(locator, tab.id);
+  },
+  report_error: function(data, _, tag) {
+    api.log('Logging error from content script:', data);
+    reportError(data.message, data.url, data.lineNo);
   }
 });
 
@@ -1091,3 +1095,16 @@ authenticate(function() {
 
   api.tabs.eachSelected(subscribe);
 });
+
+// Global error logging
+
+function reportError(errMsg, url, lineNo) {
+  ajax("POST", "/error/report", {
+    message: 'Error ' + errMsg + ' at ' + url + ' line ' + lineNo
+  }, function () {
+    api.log('Logged error "%s" in %s line %s', errMsg, url, lineNo);
+  });
+}
+
+window.onerror = reportError;
+

--- a/packrat/scripts/scout.js
+++ b/packrat/scripts/scout.js
@@ -6,6 +6,10 @@ function logEvent() {  // parameters defined in main.js
   api.port.emit("log_event", Array.prototype.slice.call(arguments));
 }
 
+window.onerror = function (message, url, lineNo) {
+  api.port.emit("report_error", { message: message, url: url, lineNo: lineNo });
+};
+
 var injected, t0 = +new Date, tile, paneHistory;
 
 !function() {

--- a/shoebox/app/com/keepit/common/db/ExternalId.scala
+++ b/shoebox/app/com/keepit/common/db/ExternalId.scala
@@ -5,7 +5,7 @@ import play.api.libs.json._
 import play.api.mvc.{PathBindable, QueryStringBindable}
 
 case class ExternalId[T](id: String) {
-  if (!ExternalId.UUID_PATTERN.pattern.matcher(id).matches()) {
+  if (!ExternalId.UUIDPattern.pattern.matcher(id).matches()) {
     throw new Exception("external id [%s] does not match uuid pattern".format(id))
   }
   override def toString = id
@@ -17,15 +17,12 @@ object ExternalId {
     new Writes[ExternalId[T]]{ def writes(o: ExternalId[T]) = JsString(o.id)}
   )
 
-  val UUID_PATTERN = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$".r
+  val UUIDPattern = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}".r
 
   def asOpt[T](id: String): Option[ExternalId[T]] = {
-    if (ExternalId.UUID_PATTERN.pattern.matcher(id).matches()) {
+    if (ExternalId.UUIDPattern.pattern.matcher(id).matches())
       Some(ExternalId[T](id))
-    }
-    else {
-      None
-    }
+    else None
   }
 
   implicit def queryStringBinder[T](implicit stringBinder: QueryStringBindable[String]) = new QueryStringBindable[ExternalId[T]] {

--- a/shoebox/app/com/keepit/common/healthcheck/HealthcheckError.scala
+++ b/shoebox/app/com/keepit/common/healthcheck/HealthcheckError.scala
@@ -85,9 +85,10 @@ case class HealthcheckError(
       case None => t
       case Some(c) => cause(c)
     }
-    def displayMessage(str: String) = {
-      Option(str).getOrElse("").replaceAll("\\d", "*").take(60)
-    }
+
+    def displayMessage(str: String) =
+      ExternalId.UUIDPattern.replaceAllIn(Option(str).getOrElse(""), "********-****-****-****-************")
+        .replaceAll("\\d", "*").take(60)
     error match {
       case None =>
         val message = errorMessage.getOrElse(path.getOrElse(callType.toString()))

--- a/shoebox/app/com/keepit/controllers/ext/ExtErrorReportController.scala
+++ b/shoebox/app/com/keepit/controllers/ext/ExtErrorReportController.scala
@@ -30,7 +30,8 @@ class ExtErrorReportController @Inject() (
     val errorReport = healthcheck.addError(
       HealthcheckError(error = None,
         callType = Healthcheck.EXTENSION,
-        errorMessage = Some(s"error on user ${request.userId} extension installation id ${request.kifiInstallationId}" +
+        errorMessage = Some(
+          s"error on user ${request.userId} extension installation id ${request.kifiInstallationId.getOrElse("")}" +
           s" using experiments [${request.experiments.mkString(",")}]" +
           s": $message")
       )


### PR DESCRIPTION
This should catch all exceptions that occur in content scripts or in main.js.

This is a very basic first iteration; looking for suggestions on what to improve.
