### PR TITLE
grouping our content scripts under "kifi" in the Chrome debugger

### DIFF
--- a/packrat/bin/build.sh
+++ b/packrat/bin/build.sh
@@ -16,7 +16,7 @@ done
 
 cd out/chrome/scripts
 for f in $(find * -type f); do
-  echo "//@ sourceURL="$f >> $f
+  echo "//@ sourceURL=http://kifi/"$f >> $f
 done
 cd -
 


### PR DESCRIPTION
(might want to strip this prefix in error reports)
