### PR TITLE
separated private uri list and public uri list

### DIFF
--- a/shoebox/app/com/keepit/controllers/search/URIGraphController.scala
+++ b/shoebox/app/com/keepit/controllers/search/URIGraphController.scala
@@ -54,7 +54,7 @@ class URIGraphController @Inject()(
 
   def sharingUserInfo(userId: Id[User], uriId: Id[NormalizedURI]) = Action { implicit request =>
     val friendIds = db.readOnly { implicit s => connectionRepo.getConnectedUsers(userId) }
-    val searcher = uriGraph.getURIGraphSearcher
+    val searcher = uriGraph.getURIGraphSearcher(None)
     val friendEdgeSet = searcher.getUserToUserEdgeSet(userId, friendIds)
     val keepersEdgeSet = searcher.getUriToUserEdgeSet(uriId)
     val sharingUserIds = searcher.intersect(friendEdgeSet, keepersEdgeSet).destIdSet - userId

--- a/shoebox/app/com/keepit/search/BookmarkSearcher.scala
+++ b/shoebox/app/com/keepit/search/BookmarkSearcher.scala
@@ -24,11 +24,11 @@ import scala.math._
 class BookmarkSearcher(userId: Id[User], articleSearcher: Searcher, uriGraphSearcher: URIGraphSearcher) extends Logging {
   val currentTime = currentDateTime.getMillis()
 
-  val myUriEdges = uriGraphSearcher.getUserToUriEdgeSetWithCreatedAt(userId, publicOnly = false)
+  val myUriEdges = uriGraphSearcher.myUriEdgeSet
   val myUris = myUriEdges.destIdLongSet
 
   def getSearcher(query: Query) = {
-    val indexReader = uriGraphSearcher.openPersonalIndex(userId, query) match {
+    val indexReader = uriGraphSearcher.openPersonalIndex(query) match {
       case Some((personalReader, personalIdMapper)) =>
         articleSearcher.indexReader.add(personalReader, personalIdMapper)
       case None =>

--- a/shoebox/app/com/keepit/search/MainSearcher.scala
+++ b/shoebox/app/com/keepit/search/MainSearcher.scala
@@ -72,9 +72,9 @@ class MainSearcher(
   val tailCutting = if (filter.isDefault && isInitialSearch) config.asFloat("tailCutting") else 0.001f
 
   // initialize user's social graph info
-  private[this] val myUriEdges = uriGraphSearcher.getUserToUriEdgeSetWithCreatedAt(userId, publicOnly = false)
+  private[this] val myUriEdges = uriGraphSearcher.myUriEdgeSet
   private[this] val myUris = myUriEdges.destIdLongSet
-  private[this] val myPublicUris = uriGraphSearcher.getUserToUriEdgeSet(userId, publicOnly = true).destIdLongSet
+  private[this] val myPublicUris = uriGraphSearcher.myPublicUriEdgeSet.destIdLongSet
   private[this] val filteredFriendIds = filter.filterFriends(friendIds)
   private[this] val friendUris = filteredFriendIds.foldLeft(Set.empty[Long]){ (s, f) =>
     s ++ uriGraphSearcher.getUserToUriEdgeSet(f, publicOnly = true).destIdLongSet
@@ -101,7 +101,7 @@ class MainSearcher(
   }
 
   def getPersonalizedSearcher(query: Query) = {
-    val indexReader = uriGraphSearcher.openPersonalIndex(userId, query) match {
+    val indexReader = uriGraphSearcher.openPersonalIndex(query) match {
       case Some((personalReader, personalIdMapper)) =>
         articleSearcher.indexReader.add(personalReader, personalIdMapper)
       case None =>

--- a/shoebox/app/com/keepit/search/MainSearcherFactory.scala
+++ b/shoebox/app/com/keepit/search/MainSearcherFactory.scala
@@ -38,7 +38,7 @@ class MainSearcherFactory @Inject() (
 
   def apply(userId: Id[User], friendIds: Set[Id[User]], filter: SearchFilter, config: SearchConfig) = {
     val articleSearcher = articleIndexer.getSearcher
-    val uriGraphSearcher = uriGraph.getURIGraphSearcher
+    val uriGraphSearcher = uriGraph.getURIGraphSearcher(Some(userId))
     new MainSearcher(
         userId,
         friendIds,
@@ -57,13 +57,13 @@ class MainSearcherFactory @Inject() (
 
   def bookmarkSearcher(userId: Id[User]) = {
     val articleSearcher = articleIndexer.getSearcher
-    val uriGraphSearcher = uriGraph.getURIGraphSearcher
+    val uriGraphSearcher = uriGraph.getURIGraphSearcher(Some(userId))
     new BookmarkSearcher(userId, articleSearcher, uriGraphSearcher)
   }
 
   def semanticVectorSearcher() = {
     val articleSearcher = articleIndexer.getSearcher
-    val uriGraphSearcher = uriGraph.getURIGraphSearcher
+    val uriGraphSearcher = uriGraph.getURIGraphSearcher()
     new SemanticVectorSearcher(articleSearcher, uriGraphSearcher)
   }
 }

--- a/shoebox/app/com/keepit/search/SearchStatisticsExtractor.scala
+++ b/shoebox/app/com/keepit/search/SearchStatisticsExtractor.scala
@@ -243,11 +243,11 @@ class SearchStatisticsHelperSearcher (queryString: String, userId: Id[User], tar
   }
 
  // val searcher = mainSearcherFactory(userId, friendIds, searchFilter, config)
-  val uriGraphSearcher = uriGraph.getURIGraphSearcher
+  val uriGraphSearcher = uriGraph.getURIGraphSearcher(Some(userId))
   val articleSearcher = articleIndexer.getSearcher
-  val myUriEdges = uriGraphSearcher.getUserToUriEdgeSetWithCreatedAt(userId, publicOnly = false)            // my keeps
+  val myUriEdges = uriGraphSearcher.myUriEdgeSet // my keeps
   val myUris = myUriEdges.destIdLongSet
-  val myPublicUris = uriGraphSearcher.getUserToUriEdgeSet(userId, publicOnly = true).destIdLongSet
+  val myPublicUris = uriGraphSearcher.myPublicUriEdgeSet.destIdLongSet
   val filteredFriendIds = searchFilter.filterFriends(friendIds)
   val friendUris = filteredFriendIds.foldLeft(Set.empty[Long]) { (s, f) =>
     s ++ uriGraphSearcher.getUserToUriEdgeSet(f, publicOnly = true).destIdLongSet
@@ -275,7 +275,7 @@ class SearchStatisticsHelperSearcher (queryString: String, userId: Id[User], tar
   }
 
   def getPersonalizedSearcher(query: Query) = {
-    val indexReader = uriGraphSearcher.openPersonalIndex(userId, query) match {
+    val indexReader = uriGraphSearcher.openPersonalIndex(query) match {
       case Some((personalReader, personalIdMapper)) =>
         articleSearcher.indexReader.add(personalReader, personalIdMapper)
       case None =>

--- a/shoebox/app/com/keepit/search/index/DocUtil.scala
+++ b/shoebox/app/com/keepit/search/index/DocUtil.scala
@@ -81,10 +81,9 @@ object DocUtil {
       }
       val payloadBuffer = new Array[Byte](payload.length)
       System.arraycopy(payload.bytes, payload.offset, payloadBuffer, 0, payload.length)
-      val uriList = new URIList(payloadBuffer)
-      val publicList = toString(uriList.publicList, uriList.publicCreatedAt)
-      val privateList = toString(uriList.privateList, uriList.privateCreatedAt)
-      "public[%s] private[%s]".format(publicList, privateList)
+      val uriList = URIList(payloadBuffer)
+      val printable = toString(uriList.ids, uriList.createdAt)
+      "version=%d [%s]".format(uriList.version, printable)
     }
   }
 


### PR DESCRIPTION
1/4 of keeps are private. This separation should help query performance in loading friends' keeps.

I also added a cache of my keeps in URIGraphSearch for performance. There are a few places that retrieves my keeps. This will eliminate duplicate loading. The cache is held only for a search query duration.

This changes uri graph index format. I will reindex uri graph after deployed. I tried not to break compatibility, so search should be affected.
