### PR TITLE
reactivate inactive keeps instead of creating new ones

### DIFF
--- a/shoebox/app/com/keepit/controllers/core/BookmarkInterner.scala
+++ b/shoebox/app/com/keepit/controllers/core/BookmarkInterner.scala
@@ -51,7 +51,7 @@ class BookmarkInterner @Inject() (
   private def internBookmark(uri: NormalizedURI, user: User, isPrivate: Boolean, experiments: Set[State[ExperimentType]],
       installationId: Option[ExternalId[KifiInstallation]], source: BookmarkSource, title: Option[String], url: String) = {
     db.readWrite(attempts = 2) { implicit s =>
-      bookmarkRepo.getByUriAndUser(uri.id.get, user.id.get) match {
+      bookmarkRepo.getByUriAndUser(uri.id.get, user.id.get, excludeState = None) match {
         case Some(bookmark) if bookmark.isActive => Some(bookmark) // TODO: verify isPrivate?
         case Some(bookmark) => Some(bookmarkRepo.save(bookmark.withActive(true).withPrivate(isPrivate)))
         case None =>


### PR DESCRIPTION
I think this was the behavior we intended originally anyway.

This will be useful for at least two reasons:
- Since now it's so fun to unkeep and keep things with the button, we won't have a ton of database entries and events coming in from people doing that.
- When we add a keep to a collection, unkeep, then keep again, the keep can be added back to the old collection based on the existing relationship.
