### PR TITLE
Change HttpClient error handling and use it in SocialGraphPlugin

### DIFF
--- a/shoebox/app/com/keepit/classify/DomainClassifier.scala
+++ b/shoebox/app/com/keepit/classify/DomainClassifier.scala
@@ -53,7 +53,7 @@ private[classify] class DomainClassificationActor @Inject() (
     val id = encodeHex(md5).toLowerCase
     val encodedUrl = URLEncoder.encode(url, UTF8)
 
-    client.getFuture(s"http://$server/url.php?version=w11&guid=$guid&id=$id&url=$encodedUrl", client.ignoreConnectionFailure).map { resp =>
+    client.getFuture(s"http://$server/url.php?version=w11&guid=$guid&id=$id&url=$encodedUrl", client.ignoreFailure).map { resp =>
       (resp.body.split("~", 2).toList match {
         case ("FM" | "FR") :: tagString :: Nil =>
           // response is comma separated, but includes commas inside parentheses

--- a/shoebox/app/com/keepit/common/social/FacebookSocialGraph.scala
+++ b/shoebox/app/com/keepit/common/social/FacebookSocialGraph.scala
@@ -2,12 +2,16 @@ package com.keepit.common.social
 
 import com.keepit.common.net.HttpClient
 import com.keepit.common.logging.Logging
-import com.keepit.model.{User, SocialUserInfo}
+import com.keepit.model.SocialUserInfo
 import com.google.inject.Inject
 import play.api.libs.json._
 
 object FacebookSocialGraph {
   val FULL_PROFILE = "name,first_name,middle_name,last_name,gender,username,languages,installed,devices,email,picture"
+
+  object ErrorSubcodes {
+    val AppNotInstalled = 458
+  }
 }
 
 class FacebookSocialGraph @Inject() (httpClient: HttpClient) extends Logging {
@@ -40,7 +44,7 @@ class FacebookSocialGraph @Inject() (httpClient: HttpClient) extends Logging {
 
   def nextPageUrl(json: JsValue): Option[String] = (json \ "friends" \ "paging" \ "next").asOpt[String]
 
-  private def get(url: String): JsValue = httpClient.longTimeout.get(url).json
+  private def get(url: String): JsValue = httpClient.longTimeout.get(url, httpClient.ignoreFailure).json
 
   private def url(id: SocialId, accessToken: String) = "https://graph.facebook.com/%s?access_token=%s&fields=%s,friends.fields(%s)".format(
       id.id, accessToken, FacebookSocialGraph.FULL_PROFILE, FacebookSocialGraph.FULL_PROFILE)

--- a/shoebox/app/com/keepit/model/SocialUserInfo.scala
+++ b/shoebox/app/com/keepit/model/SocialUserInfo.scala
@@ -130,5 +130,6 @@ object SocialUserInfoStates {
   val FETCHED_USING_FRIEND = State[SocialUserInfo]("fetched_using_friend")
   val FETCHED_USING_SELF = State[SocialUserInfo]("fetched_using_self")
   val FETCH_FAIL = State[SocialUserInfo]("fetch_fail")
+  val APP_NOT_AUTHORIZED = State[SocialUserInfo]("app_not_authorized")
   val INACTIVE = State[SocialUserInfo]("inactive")
 }

--- a/shoebox/test/com/keepit/common/net/FakeHttpClient.scala
+++ b/shoebox/test/com/keepit/common/net/FakeHttpClient.scala
@@ -7,8 +7,8 @@ import java.net.ConnectException
 class FakeHttpClient(
     requestToResponse: Option[PartialFunction[String, FakeClientResponse]] = None
   ) extends HttpClient {
-  
-  override val defaultOnFailure = ignoreConnectionFailure
+
+  override val defaultOnFailure = ignoreFailure
 
   override def get(url: String, onFailure: => String => PartialFunction[Throwable, Unit] = defaultOnFailure): ClientResponse = assertUrl(url)
 


### PR DESCRIPTION
@andrewconner

Basically this makes NonOKResponseException fail the future, and all healthchecking happens in the onFailure handler. This way, we can prevent healthchecks completely if we want for errors with well-defined recovery schemes. NonOKResponseException can either be thrown as usual or recovered from if desired.
