### PR TITLE
initiating a ping immediately after a send if it's been a while (ping timer stopped working)

### DIFF
--- a/packrat/scripts/lib/reconnecting-websocket.js
+++ b/packrat/scripts/lib/reconnecting-websocket.js
@@ -62,6 +62,9 @@ function ReconnectingWebSocket(url, onMessage, onConnect) {
   }
 
   function onMessage1(e) {
+    clearTimeout(t);
+    t = setTimeout(ping, idlePingDelayMs);
+    lastRecOrPingTime = +new Date;
     if (e.data === '["hi"]') {
       api.log("#0bf", "[RWS.onMessage1]", e.data);
       ws.greeted = true;
@@ -79,20 +82,17 @@ function ReconnectingWebSocket(url, onMessage, onConnect) {
       api.log("#a00", "[RWS.onMessage1] relaying");
       onMessage.call(self, e);
     }
-    clearTimeout(t);
-    t = setTimeout(ping, idlePingDelayMs);
-    lastRecOrPingTime = +new Date;
   }
 
   function onMessageN(e) {
+    clearTimeout(t);
+    t = setTimeout(ping, idlePingDelayMs);
+    lastRecOrPingTime = +new Date;
     if (e.data === '["pong"]') {
       api.log("#0ac", "[RWS.pong]");
     } else {
       onMessage.call(self, e);
     }
-    clearTimeout(t);
-    t = setTimeout(ping, idlePingDelayMs);
-    lastRecOrPingTime = +new Date;
   }
 
   function onConnectTimeout(ws) {


### PR DESCRIPTION
I've seen the extension go minutes without realizing it's not getting any responses, because the ping timer stopped working. The only way I can imagine this happening is if there's an exception in a handler that breaks the ping timer continuity. This pull request adds a second (redundant) mechanism on send that checks whether it's been a while since we've received a message, and restarts the ping timer mechanism if necessary. Also moves the ping timer accounting before message handling, where errors in handlers cannot affect it.
