### PR TITLE
code optimization in phrase proxmity

### DIFF
--- a/shoebox/app/com/keepit/search/query/PhraseProximityQuery.scala
+++ b/shoebox/app/com/keepit/search/query/PhraseProximityQuery.scala
@@ -129,7 +129,8 @@ class PhraseHelper(terms: Seq[String], phrases: Set[(Int, Int)]) {
         lp(id) = lastPos
         prevPos = lastPos
         localSum = 0.0f
-        for (i <- 0 until numPhrases) {
+        var i = 0
+        while (i < numPhrases) {
           if (i == id) {
             ls(i) = (runLen - phraseLen) * phraseLen + localPhraseScore(phraseLen)      // first summand comes from 'run length growth bonus' (if current phrase is consecutive to the previous phrase)
           } else {
@@ -137,6 +138,7 @@ class PhraseHelper(terms: Seq[String], phrases: Set[(Int, Int)]) {
             lp(i) = lastPos
           }
           localSum += ls(i)
+          i += 1
         }
         maxScore = max(maxScore, localSum)
     }


### PR DESCRIPTION
"for (i <- 0 to n)" is nice, but it has hidden costs.
- creation of a Range instance
- creation and use of an iterator instance
- creation of a closure
- slow local var access from a closure

A simple test revealed that "for" is 100 - 400 times slower than "while".
In general, the functional style is preferred because it is more readable and less error prone. But, I rewrote to use "while" for performance. This particular code runs in the query execution.
