### PR TITLE
client side request consolidation

### DIFF
--- a/shoebox/app/com/keepit/common/service/RequestConsolidator.scala
+++ b/shoebox/app/com/keepit/common/service/RequestConsolidator.scala
@@ -1,0 +1,46 @@
+package com.keepit.common.service
+
+import scala.collection.concurrent.{TrieMap=>ConcurrentMap}
+import scala.concurrent.duration._
+import scala.concurrent.Future
+import java.lang.ref.WeakReference
+import java.lang.ref.ReferenceQueue
+
+class RequestConsolidator[K, T](ttl: Duration) {
+
+  private[this] val ttlMillis = ttl.toMillis
+
+  private class FutureRef[T](val key: K, future: Future[T], val expireBy: Long) extends WeakReference[Future[T]](future)
+
+  private[this] val referenceQueue = new ReferenceQueue[FutureRef[T]]
+  private[this] val futureRefMap = new ConcurrentMap[K, FutureRef[T]]
+
+  private def clean() {
+    var ref = referenceQueue.poll()
+    while (ref != null) {
+      futureRefMap.remove(ref.asInstanceOf[FutureRef[T]].key)
+      ref = referenceQueue.poll()
+    }
+  }
+
+  def apply(key: K)(newFuture: K=>Future[T]): Future[T] = {
+    clean()
+
+    val now = System.currentTimeMillis
+
+    futureRefMap.get(key) match {
+      case Some(ref) =>
+        val existingFuture = ref.get
+        if (existingFuture != null && ref.expireBy < now) existingFuture
+        else {
+          val future = newFuture(key)
+          futureRefMap.put(key, new FutureRef(key, future, now + ttlMillis))
+          future
+        }
+      case _ =>
+        val future = newFuture(key)
+        futureRefMap.put(key, new FutureRef(key, future, now + ttlMillis))
+        future
+    }
+  }
+}

--- a/shoebox/app/com/keepit/common/service/RequestConsolidator.scala
+++ b/shoebox/app/com/keepit/common/service/RequestConsolidator.scala
@@ -31,7 +31,7 @@ class RequestConsolidator[K, T](ttl: Duration) {
     futureRefMap.get(key) match {
       case Some(ref) =>
         val existingFuture = ref.get
-        if (existingFuture != null && ref.expireBy < now) existingFuture
+        if (existingFuture != null && now < ref.expireBy) existingFuture
         else {
           val future = newFuture(key)
           futureRefMap.put(key, new FutureRef(key, future, now + ttlMillis))


### PR DESCRIPTION
The request consolidation tries to share a Future object if the same request is issued in a short period of time (right now TTL is 3 seconds). Three types of requests use this.
- getConnectedUsers
- getClickHistoryFilter
- getBrowsingHistoryFilter

Futures are wrapped in a WeakReference and put in a map. This allows JVM to garbage-collect unused Future objects even before expiration.
