### PR TITLE
Revert "Additional reporting of the future's failure exceptions"

### DIFF
--- a/shoebox/app/com/keepit/common/akka/MonitoredAwait.scala
+++ b/shoebox/app/com/keepit/common/akka/MonitoredAwait.scala
@@ -1,10 +1,13 @@
 package com.keepit.common.akka
 
 import com.keepit.common.performance._
-import scala.concurrent.{Await, Awaitable, Future}
+import scala.concurrent.Await
+import scala.concurrent.Awaitable
 import scala.concurrent.duration._
 import com.google.inject.Inject
-import com.keepit.common.healthcheck.{ErrorMessage, HealthcheckPlugin, HealthcheckError, Healthcheck}
+import com.keepit.common.healthcheck.HealthcheckPlugin
+import com.keepit.common.healthcheck.HealthcheckError
+import com.keepit.common.healthcheck.Healthcheck
 
 class MonitoredAwait @Inject() (healthcheckPlugin: HealthcheckPlugin) {
 
@@ -17,14 +20,7 @@ class MonitoredAwait @Inject() (healthcheckPlugin: HealthcheckPlugin) {
       Await.result(awaitable, atMost)
     } catch {
       case ex: Throwable =>
-
-        val additionalInfo = awaitable match {
-          case future: Future[T] => Some(future.failed.value.get.get.getMessage)
-          case _ => None
-        }
-
-        val errorMessage = ErrorMessage(ex.getMessage, additionalInfo)
-        healthcheckPlugin.addError(HealthcheckError(Some(ex), None, None, Healthcheck.INTERNAL, Some(errorMessage)))
+        healthcheckPlugin.addError(HealthcheckError(Some(ex), None, None, Healthcheck.INTERNAL, Some(ex.getMessage)))
         valueOnFailure
     } finally {
       sw.stop()


### PR DESCRIPTION
This reverts commit 84ca945e0f1d333ebdf9ea54a369ea76fd0a5256.
This failed to retrieve a timed-out future's exception, this approach won't work. I should probably piggy back on Yingjie's monitoring process.
