### PR TITLE
2.4.7: using normalized URIs to load chatter comment/message counts

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.4.6
+version=2.4.7

--- a/packrat/html/search/google_hit.html
+++ b/packrat/html/search/google_hit.html
@@ -9,7 +9,7 @@
     </div>
   </div>
   <!--n-->
-  <div class="kifi-who" id="kifi-who-{{bookmark.id}}">
+  <div class="kifi-who" data-url="{{bookmark.url}}">
     {{#displaySelf}}
       <img class="kifi-face kifi-self{{^displayUsers}} kifi-only{{/displayUsers}}" src="{{cdnBase}}/users/{{session.userId}}/pics/100/0.jpg" alt="You!" title="You! You look great!">
     {{/displaySelf}}

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -388,9 +388,9 @@ const socketHandlers = {
 
 api.port.on({
   get_keeps: searchOnServer,
-  get_chatter: function(data, respond) {
-    api.log("[get_chatter]", data.ids);
-    ajax("GET", "/search/chatter", {ids: data.ids.join(".")}, respond);
+  get_chatter: function(urls, respond) {
+    api.log("[get_chatter]", urls);
+    ajax("POST", "/search/chatter", urls, respond);
   },
   get_keepers: function(_, respond, tab) {
     api.log("[get_keepers]", tab.id);

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -430,13 +430,13 @@ api.log("[google_inject]");
 
   function loadChatter(hits) {
     if (!hits.length) return;
-    api.port.emit("get_chatter", {ids: hits.map(function(h) {return h.bookmark.id})}, function gotChatter(counts) {
+    api.port.emit("get_chatter", hits.map(function(h) {return h.bookmark.url}), function gotChatter(counts) {
       api.log("[gotChatter]", counts);
       var bgImg = "url(" + api.url("images/chatter.png") + ")";
-      for (var id in counts) {
-        var n = counts[id];
+      for (var url in counts) {
+        var n = counts[url];
         if (n[0] || n[1]) {
-          $res.find("#kifi-who-" + id).append(
+          $res.find(".kifi-who[data-url='" + url + "']").append(
             $("<span class=kifi-chatter>").css("background-image", bgImg).data("n", n));
         }
       }

--- a/shoebox/modules/common/conf/common.routes
+++ b/shoebox/modules/common/conf/common.routes
@@ -94,7 +94,8 @@ GET     /users/:id/pics/:size/0.jpg @com.keepit.controllers.assets.UserPictureCo
 POST    /users/pics/update      @com.keepit.controllers.assets.UserPictureController.update()
 
 GET     /search                     @com.keepit.controllers.ext.ExtSearchController.search(q: String, f: Option[String], maxHits: Int, lastUUID: Option[String], context: Option[String], kifiVersion: Option[KifiVersion] ?= None, start: Option[String], end: Option[String], tz: Option[String], coll: Option[String])
-GET     /search/chatter             @com.keepit.controllers.ext.ExtCommentController.getCounts(ids: String)
+GET     /search/chatter             @com.keepit.controllers.ext.ExtCommentController.getCountsDeprecated(ids: String)
+POST    /search/chatter             @com.keepit.controllers.ext.ExtCommentController.getCounts
 
 POST    /kifi/start                 @com.keepit.controllers.ext.ExtAuthController.start
 GET     /whois                      @com.keepit.controllers.ext.ExtAuthController.whois


### PR DESCRIPTION
@ymatsuda This was the extension's only use of `hit.bookmark.id` (a `NormalizedURI.externalId`) in the search result JSON.
