### PR TITLE
Remove facebookId and provider from /kifi/start

### DIFF
--- a/shoebox/modules/common/app/com/keepit/controllers/ext/ExtAuthController.scala
+++ b/shoebox/modules/common/app/com/keepit/controllers/ext/ExtAuthController.scala
@@ -76,8 +76,6 @@ class ExtAuthController @Inject() (
     Ok(Json.obj(
       "avatarUrl" -> avatarUrl,
       "name" -> identity.fullName,
-      "facebookId" -> identity.id.id,
-      "provider" -> identity.id.providerId,
       "userId" -> user.externalId.id,
       "installationId" -> installation.externalId.id,
       "experiments" -> experiments,

--- a/shoebox/modules/common/test/com/keepit/controllers/ext/ExtAuthControllerTest.scala
+++ b/shoebox/modules/common/test/com/keepit/controllers/ext/ExtAuthControllerTest.scala
@@ -71,8 +71,6 @@ class ExtAuthControllerTest extends Specification with DbRepos {
         }
         val json1 = Json.parse(contentAsString(result1)).asInstanceOf[JsObject]
         json1 \ "name" === JsString("A 1")
-        json1 \ "facebookId" === JsString("111")
-        json1 \ "provider" === JsString("facebook")
         json1 \ "userId" === JsString(user.externalId.id)
         json1 \ "installationId" === JsString(kifiInstallation1.externalId.id)
         json1 \ "rules" \ "version" must beAnInstanceOf[JsString]


### PR DESCRIPTION
A search of the extension shows that they're not being used.
