### PR TITLE
Graphite - Sets fixed min/max for the Total Search Time axis of the engineering

### DIFF
--- a/shoebox/modules/common/app/views/admin/engineeringDashboard.scala.html
+++ b/shoebox/modules/common/app/views/admin/engineeringDashboard.scala.html
@@ -37,7 +37,9 @@
   height: 400,
   hideGrid: "true",
   from: $("#timerange").val(),
-  lineWidth: 2
+  lineWidth: 2,
+  yMinRight: 0,
+  yMaxRight: 400
   };
 
   var baseTargets = ["drawAsInfinite(stats.counters.*.deploys.count)"];


### PR DESCRIPTION
@eishay The total search time has been consistently in the 100-300ms range for most of the day, this is why I have fixed the axis to 0-400ms. Using 0-50ms would make the most recent graphs crash by lack of any point to plot.
