### PR TITLE
2.4.10: making content script injection idempotent for Chrome

### DIFF
--- a/packrat/adapters/chrome/scripts/api.js
+++ b/packrat/adapters/chrome/scripts/api.js
@@ -1,6 +1,6 @@
-// API for content scripts
+// API for content scripts (idempotent b/c Chrome sometimes injects twice)
 
-var api = function() {
+var api = api || function() {
   var msgHandlers = [], callbacks = {}, nextCallbackId = 1, port;
   function createPort() {
     port = chrome.runtime.connect({name: ""});

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.4.9
+version=2.4.10

--- a/packrat/scripts/deeplink.js
+++ b/packrat/scripts/deeplink.js
@@ -1,11 +1,13 @@
 // @match /^https?:\/\/(dev\.ezkeep\.com:9000|(www\.)?(kifi|keepitfindit)\.com)\/r\/.*/
 // @require scripts/api.js
 
-!function() {
-  document.querySelector(".kifi-deep-link-no-extension").style.display = "none";
-  var deepLink = JSON.parse(document.documentElement.dataset.kifiDeepLink);
-  api.port.emit("add_deep_link_listener", deepLink.locator);
-  if (deepLink.uri) {
-    window.location = deepLink.uri;
+!function(json) {
+  if (json) {  // in case injected into wrong page
+    document.querySelector(".kifi-deep-link-no-extension").style.display = "none";
+    var link = JSON.parse(json);
+    api.port.emit("add_deep_link_listener", link.locator);
+    if (link.uri) {
+      window.location = link.uri;
+    }
   }
-}();
+}(document.documentElement.dataset.kifiDeepLink);

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -7,9 +7,10 @@
 // @require scripts/api.js
 // @require scripts/render.js
 
-api.log("[google_inject]");
 
-!function() {
+var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test(location.host) && function() {  // idempotent for Chrome
+  api.log("[google_inject]");
+
   function logEvent() {  // parameters defined in main.js
     api.port.emit("log_event", Array.prototype.slice.call(arguments));
   }
@@ -617,4 +618,6 @@ api.log("[google_inject]");
       }
     }).prev(".kifi-filter-detail-notch").addBack().removeClass("kifi-visible");
   }
+
+  return true;
 }();

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -6,14 +6,14 @@ function logEvent() {  // parameters defined in main.js
   api.port.emit("log_event", Array.prototype.slice.call(arguments));
 }
 
-window.onerror = function (message, url, lineNo) {
+window.onerror = function(message, url, lineNo) {
   if (!/https?\:/.test(url)) {
     // this is probably from extension code, not from the website we're running this on
     api.port.emit("report_error", { message: message, url: url, lineNo: lineNo });
   }
 };
 
-var t0 = +new Date, tile, root = document.querySelector("body") || document.documentElement;
+var t0 = +new Date, tile;
 
 !function() {
   api.log("[scout]", location.hostname);
@@ -146,7 +146,7 @@ var t0 = +new Date, tile, root = document.querySelector("body") || document.docu
     tileCard = tile.firstChild;
     tileCount = document.createElement("span");
     tileCount.className = "kifi-count";
-    root.appendChild(tile);
+    (document.querySelector("body") || document.documentElement).appendChild(tile);
     tile.addEventListener("mouseover", function(e) {
       if (e.target === tileCount || tileCard.contains(e.target)) {
         keeper("show", "tile");

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -6,17 +6,14 @@ function logEvent() {  // parameters defined in main.js
   api.port.emit("log_event", Array.prototype.slice.call(arguments));
 }
 
-window.onerror = function(message, url, lineNo) {
-  if (!/https?\:/.test(url)) {
-    // this is probably from extension code, not from the website we're running this on
-    api.port.emit("report_error", { message: message, url: url, lineNo: lineNo });
-  }
-};
-
-var t0 = +new Date, tile;
-
-!function() {
+var tile = tile || function() {  // idempotent for Chrome
   api.log("[scout]", location.hostname);
+  window.onerror = function(message, url, lineNo) {
+    if (!/https?\:/.test(url)) {  // this is probably from extension code, not from the website we're running this on
+      api.port.emit("report_error", { message: message, url: url, lineNo: lineNo });
+    }
+  };
+
   var tileCard, tileCount, onScroll;
   api.port.on({
     open_to: function(o) {
@@ -132,28 +129,27 @@ var t0 = +new Date, tile;
     });
   }
 
-  !function insertTile() {
-    while (tile = document.getElementById("kifi-tile")) {
-      tile.parentNode.removeChild(tile);
+  while (tile = document.getElementById("kifi-tile")) {
+    tile.parentNode.removeChild(tile);
+  }
+  tile = document.createElement("div");
+  tile.dataset.t0 = +new Date;
+  tile.id = tile.className = "kifi-tile";
+  tile.style.display = "none";
+  tile.innerHTML =
+    "<div class=kifi-tile-card>" +
+    "<div class=kifi-tile-keep style='background-image:url(" + api.url("images/metro/tile_logo.png") + ")'></div>" +
+    "<div class=kifi-tile-kept></div></div>";
+  tileCard = tile.firstChild;
+  tileCount = document.createElement("span");
+  tileCount.className = "kifi-count";
+  (document.querySelector("body") || document.documentElement).appendChild(tile);
+  tile.addEventListener("mouseover", function(e) {
+    if (e.target === tileCount || tileCard.contains(e.target)) {
+      keeper("show", "tile");
     }
-    tile = document.createElement("div");
-    tile.id = tile.className = "kifi-tile";
-    tile.style.display = "none";
-    tile.innerHTML =
-      "<div class=kifi-tile-card>" +
-      "<div class=kifi-tile-keep style='background-image:url(" + api.url("images/metro/tile_logo.png") + ")'></div>" +
-      "<div class=kifi-tile-kept></div></div>";
-    tileCard = tile.firstChild;
-    tileCount = document.createElement("span");
-    tileCount.className = "kifi-count";
-    (document.querySelector("body") || document.documentElement).appendChild(tile);
-    tile.addEventListener("mouseover", function(e) {
-      if (e.target === tileCount || tileCard.contains(e.target)) {
-        keeper("show", "tile");
-      }
-    });
-    tile["kifi:position"] = positionTile;
-  }();
+  });
+  tile["kifi:position"] = positionTile;
 
   function onResize() {
     if (document.documentElement.classList.contains("kifi-with-pane")) return;
@@ -196,4 +192,6 @@ var t0 = +new Date, tile;
       tile = tileCount = null;
     }
   });
+
+  return tile;
 }();

--- a/packrat/scripts/notifier.js
+++ b/packrat/scripts/notifier.js
@@ -78,10 +78,6 @@ var KifiNotification = {
   add: function(params) {
     params = $.extend(KifiNotification.defaultParams, params);
 
-    if ($("#kifi-notify-notice-wrapper").length == 0) {
-      $(root).append("<div id=kifi-notify-notice-wrapper>");
-    }
-
     render("html/notify_box.html", {
       formatSnippet: getSnippetFormatter,
       title: params.title,
@@ -94,7 +90,11 @@ var KifiNotification = {
     }, function(html) {
       var $item = $(html);
 
-      $("#kifi-notify-notice-wrapper").addClass(params.wrapperClass).append($item);
+      var $wrap = $("#kifi-notify-notice-wrapper");
+      if (!$wrap.length) {
+        $wrap = $("<div id=kifi-notify-notice-wrapper>").appendTo($("body")[0] || "html");
+      }
+      $wrap.addClass(params.wrapperClass).append($item);
 
       ["beforeOpen", "afterOpen", "beforeClose", "afterClose"].forEach(function(val) {
         $item.data(val, $.isFunction(params[val]) ? params[val] : $.noop);
@@ -155,9 +155,7 @@ var KifiNotification = {
     function removeItem() {
       $item.data("afterClose")($item, manualClose);
       $item.remove();
-      if ($(".kifi-notify-item-wrapper").length == 0) {
-        $("#kifi-notify-notice-wrapper").remove();
-      }
+      $("#kifi-notify-notice-wrapper").not(":has(.kifi-notify-item-wrapper)").remove();
     }
   },
 
@@ -175,7 +173,7 @@ var KifiNotification = {
     var $wrap = $("#kifi-notify-notice-wrapper");
     (params.beforeClose || $.noop)($wrap);
     $wrap.fadeOut(function() {
-      $(this).remove();
+      $wrap.remove();
       (params.afterClose || $.noop)();
     });
   }

--- a/packrat/scripts/notifier_scout.js
+++ b/packrat/scripts/notifier_scout.js
@@ -1,13 +1,16 @@
 // @match /^https?:\/\/[^\/]*\/.*$/
 // @require scripts/api.js
 
-api.port.on({
-  new_notification: function(n) {
-    if (n.state == "visited") return;
-    var p = document.querySelector(".kifi-pane"), loc = p && p.dataset.locator;
-    if (loc !== "/notices" && loc !== n.details.locator) {
-      api.require("scripts/notifier.js", function() {
-        notifier.show(n);
-      });
-    }
-  }});
+var notifierScout = notifierScout || function() {  // idempotent for Chrome
+  api.port.on({
+    new_notification: function(n) {
+      if (n.state == "visited") return;
+      var p = document.querySelector(".kifi-pane"), loc = p && p.dataset.locator;
+      if (loc !== "/notices" && loc !== n.details.locator) {
+        api.require("scripts/notifier.js", function() {
+          notifier.show(n);
+        });
+      }
+    }});
+  return true;
+})();

--- a/packrat/scripts/notifier_scout.js
+++ b/packrat/scripts/notifier_scout.js
@@ -13,4 +13,4 @@ var notifierScout = notifierScout || function() {  // idempotent for Chrome
       }
     }});
   return true;
-})();
+}();

--- a/packrat/scripts/slider2.js
+++ b/packrat/scripts/slider2.js
@@ -306,7 +306,7 @@ slider2 = function() {
       if (data.dragStarting) {
         delete data.dragStarting;
         api.log("[startDrag] installing draggable");
-        data.$dragGlass = $("<div class=kifi-slider2-drag-glass>").mouseup(stopDrag).appendTo(root);
+        data.$dragGlass = $("<div class=kifi-slider2-drag-glass>").mouseup(stopDrag).appendTo(tile.parentNode);
         $(tile).draggable({axis: "y", containment: "window", scroll: false, stop: stopDrag})[0]
           .dispatchEvent(data.mousedownEvent); // starts drag
       }
@@ -477,7 +477,7 @@ slider2 = function() {
           $pane = $(html);
           $pane[0].dataset.locator = locator;
           if (bringSlider) {
-            $pane.append($slider).appendTo(root);
+            $pane.append($slider).appendTo(tile.parentNode);
           } else {
             $pane.insertBefore(tile);
             $(tile).css("transform", "translate(0," + (window.innerHeight - tile.getBoundingClientRect().bottom) + "px)");

--- a/packrat/scripts/slider2.js
+++ b/packrat/scripts/slider2.js
@@ -255,7 +255,7 @@ slider2 = function() {
     createSlider(function() {
       $slider.prependTo(tile);
 
-      logEvent("slider", "sliderShown", {trigger: trigger, onPageMs: String(lastShownAt - t0), url: document.URL});
+      logEvent("slider", "sliderShown", {trigger: trigger, onPageMs: String(lastShownAt - tile.dataset.t0), url: document.URL});
       api.port.emit("keeper_shown");
 
       callback && callback();


### PR DESCRIPTION
fixes issue where kifi would sometimes not work after an automatic redirect (e.g. from a Google search result click or a URL shortener like t.co)
