### PR TITLE
modifying bootstrap to stop overriding the height attribute

### DIFF
--- a/kifi-backend/modules/common/public/bootstrap/css/bootstrap.css
+++ b/kifi-backend/modules/common/public/bootstrap/css/bootstrap.css
@@ -68,11 +68,13 @@ sub {
 
 img {
   width: auto\9;
-  height: auto;
   max-width: 100%;
   vertical-align: middle;
   border: 0;
   -ms-interpolation-mode: bicubic;
+}
+img:not([height]) {
+  height: auto;
 }
 
 #map_canvas img,


### PR DESCRIPTION
This should help the graphite charts reserve space for themselves, as intended.
