### PR TITLE
Don't throw exceptions for expired tokens

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/FacebookSocialGraph.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/FacebookSocialGraph.scala
@@ -16,6 +16,7 @@ object FacebookSocialGraph {
 
   object ErrorSubcodes {
     val AppNotInstalled = 458
+    val Expired = 463
   }
 }
 
@@ -44,6 +45,12 @@ class FacebookSocialGraph @Inject() (
             log.warn(s"App not authorized for social user $socialUserInfo; not fetching connections.")
             db.readWrite { implicit s =>
               socialRepo.save(socialUserInfo.withState(SocialUserInfoStates.APP_NOT_AUTHORIZED).withLastGraphRefresh())
+            }
+            Seq()
+          case (_, Some(Expired)) =>
+            log.warn(s"Token expired for social user $socialUserInfo; not fetching connections.")
+            db.readWrite { implicit s =>
+              socialRepo.save(socialUserInfo.withState(SocialUserInfoStates.FETCH_FAIL).withLastGraphRefresh())
             }
             Seq()
           case _ =>


### PR DESCRIPTION
Currently it seems like this only happens for pending users (or, presumably, users that haven't logged in for a long time) so I don't think we care much about seeing these errors from facebook.

Does it also make sense to set credentials to None in cases like this where we know the credentials aren't useful anymore?
