### PR TITLE
removing cache invalidation for global bookmark count

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/BookmarkRepo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/BookmarkRepo.scala
@@ -59,7 +59,6 @@ class BookmarkRepoImpl @Inject() (
 
   override def invalidateCache(bookmark: Bookmark)(implicit session: RSession) = {
     bookmarkUriUserCache.set(BookmarkUriUserKey(bookmark.uriId, bookmark.userId), bookmark)
-    countCache.remove(BookmarkCountKey())
     countCache.remove(BookmarkCountKey(Some(bookmark.userId)))
     bookmark
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -97,7 +97,7 @@ class ShoeboxCacheModule extends ScalaModule {
   @Singleton
   @Provides
   def bookmarkCountCache(outerRepo: FortyTwoCachePlugin) =
-    new BookmarkCountCache((outerRepo, 1 hour))
+    new BookmarkCountCache((outerRepo, 1 day))
 
   @Singleton
   @Provides


### PR DESCRIPTION
The reason for the timeouts bookmarks count we're getting in prod is that we reset the cache of global bookmark count whenever we add a new bookmark. Counting from the db is taking a very long time and we don't really have to have the most accurate number.

I'm going to have a one day ttl on the global counter cache and not invalidate it so the count of bookmarks is going to be at most one day old and once a day we'll have a slow query. 
If we'll see that more accurate numbers are important we can maintain a count approximation in memcached. 
Let me know if you have a simpler/better solution.

[fortytwo@b01 log]$ grep "count bookmarks" app.log
00:40:37.167 [play-akka.actor.default-dispatcher-104] INFO  c.k.c.performance.package$Stopwatch - [count bookmarks] elapsed milliseconds: 45376.699348
00:45:15.155 [play-akka.actor.default-dispatcher-121] INFO  c.k.c.performance.package$Stopwatch - [count bookmarks] elapsed milliseconds: 1.919791
01:34:15.771 [play-akka.actor.default-dispatcher-250] INFO  c.k.c.performance.package$Stopwatch - [count bookmarks] elapsed milliseconds: 31254.075501
01:38:10.078 [play-akka.actor.default-dispatcher-254] INFO  c.k.c.performance.package$Stopwatch - [count bookmarks] elapsed milliseconds: 37775.47149
01:38:48.205 [play-akka.actor.default-dispatcher-261] INFO  c.k.c.performance.package$Stopwatch - [count bookmarks] elapsed milliseconds: 1.845231
01:38:48.216 [play-akka.actor.default-dispatcher-265] INFO  c.k.c.performance.package$Stopwatch - [count bookmarks] elapsed milliseconds: 1.886363
01:39:05.385 [play-akka.actor.default-dispatcher-260] INFO  c.k.c.performance.package$Stopwatch - [count bookmarks] elapsed milliseconds: 60550.180193
02:43:52.902 [play-akka.actor.default-dispatcher-446] INFO  c.k.c.performance.package$Stopwatch - [count bookmarks] elapsed milliseconds: 28376.271887
02:55:50.942 [play-akka.actor.default-dispatcher-486] INFO  c.k.c.performance.package$Stopwatch - [count bookmarks] elapsed milliseconds: 1.977794
03:31:03.957 [play-akka.actor.default-dispatcher-582] INFO  c.k.c.performance.package$Stopwatch - [count bookmarks] elapsed milliseconds: 43022.322606
03:32:34.265 [play-akka.actor.default-dispatcher-586] INFO  c.k.c.performance.package$Stopwatch - [count bookmarks] elapsed milliseconds: 1.869838
