### PR TITLE
Create new controller for authentication and account linking

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -1,0 +1,52 @@
+package com.keepit.controllers.core
+
+import com.keepit.common.controller.{ActionAuthenticator, ShoeboxServiceController}
+
+import play.api.libs.json.Json
+import play.api.mvc._
+import securesocial.controllers.ProviderController
+import securesocial.core._
+
+class AuthController extends ShoeboxServiceController {
+
+  // Some of this is copied from ProviderController in SecureSocial
+  // We might be able to do this better but I'm just trying to get it working for now
+  def mobileAuth(providerName: String) = Action(parse.json) { implicit request =>
+  // e.g. { "accessToken": "..." }
+    val oauth2Info = Json.fromJson(request.body)(Json.reads[OAuth2Info]).asOpt
+    val provider = Registry.providers.get(providerName).get
+    val authMethod = provider.authMethod
+    val filledUser = provider.fillProfile(
+      SocialUser(UserId("", providerName), "", "", "", None, None, authMethod, oAuth2Info = oauth2Info))
+    UserService.find(filledUser.id) map { user =>
+      val withSession = Events.fire(new LoginEvent(user)).getOrElse(session)
+      Authenticator.create(user) match {
+        case Right(authenticator) =>
+          Ok(Json.obj("sessionId" -> authenticator.id)).withSession(
+            withSession - SecureSocial.OriginalUrlKey - IdentityProvider.SessionId - OAuth1Provider.CacheKey)
+              .withCookies(authenticator.toCookie)
+        case Left(error) => throw error
+      }
+    } getOrElse {
+      NotFound(Json.obj("error" -> "user not found"))
+    }
+  }
+
+  // These methods are nice wrappers for the SecureSocial authentication methods.
+  // Logout is still handled by SecureSocial directly.
+
+  def login(provider: String) = getAuthAction(provider, isLogin = true)
+  def loginByPost(provider: String) = getAuthAction(provider, isLogin = true)
+  def link(provider: String) = getAuthAction(provider, isLogin = false)
+  def linkByPost(provider: String) = getAuthAction(provider, isLogin = false)
+
+  private def getAuthAction(provider: String, isLogin: Boolean): Action[AnyContent] = Action { implicit request =>
+    ProviderController.authenticate(provider)(request) match {
+      case res: SimpleResult[_] if isLogin =>
+        val sesh = Session.decodeFromCookie(
+          res.header.headers.get(SET_COOKIE).flatMap(Cookies.decode(_).find(_.name == Session.COOKIE_NAME)))
+        res.withSession(sesh - ActionAuthenticator.FORTYTWO_USER_ID)
+      case res => res
+    }
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
@@ -10,8 +10,6 @@ import com.keepit.common.net._
 import com.keepit.model._
 
 import play.api.libs.json.Json
-import play.api.mvc.Action
-import securesocial.core._
 
 @Singleton
 class ExtAuthController @Inject() (
@@ -25,29 +23,6 @@ class ExtAuthController @Inject() (
   userExperimentRepo: UserExperimentRepo,
   kifiInstallationCookie: KifiInstallationCookie)
   extends BrowserExtensionController(actionAuthenticator) with ShoeboxServiceController {
-
-  // Some of this is copied from ProviderController in SecureSocial
-  // We might be able to do this better but I'm just trying to get it working for now
-  def mobileAuth(providerName: String) = Action(parse.json) { implicit request =>
-    // e.g. { "accessToken": "..." }
-    val oauth2Info = Json.fromJson(request.body)(Json.reads[OAuth2Info]).asOpt
-    val provider = Registry.providers.get(providerName).get
-    val authMethod = provider.authMethod
-    val filledUser = provider.fillProfile(
-      SocialUser(UserId("", providerName), "", "", "", None, None, authMethod, oAuth2Info = oauth2Info))
-    UserService.find(filledUser.id) map { user =>
-      val withSession = Events.fire(new LoginEvent(user)).getOrElse(session)
-      Authenticator.create(user) match {
-        case Right(authenticator) =>
-          Ok(Json.obj("sessionId" -> authenticator.id)).withSession(
-              withSession - SecureSocial.OriginalUrlKey - IdentityProvider.SessionId - OAuth1Provider.CacheKey)
-            .withCookies(authenticator.toCookie)
-        case Left(error) => throw error
-      }
-    } getOrElse {
-      NotFound(Json.obj("error" -> "user not found"))
-    }
-  }
 
   def start = AuthenticatedJsonToJsonAction { implicit request =>
     val userId = request.userId

--- a/kifi-backend/modules/shoebox/app/views/website/userHome.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/website/userHome.scala.html
@@ -37,7 +37,7 @@
             }
           } else {
             not connected.
-            <form action="@securesocial.controllers.routes.ProviderController.authenticate(network.name)"
+            <form action="@com.keepit.controllers.core.routes.AuthController.link(network.name)"
               style="display:inline" method="post">
               <button type="submit" class="btn-link">Connect with @network.displayName</button>
             </form>

--- a/kifi-backend/modules/shoebox/app/views/website/welcome.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/website/welcome.scala.html
@@ -22,12 +22,12 @@
       <div class="networks">
       @for(network <- SocialNetworks.ALL.sortBy(network => !socialUser.exists(_.networkType == network))) {
         @if(socialUser.isEmpty || socialUser.get.networkType == network) {
-          <a href="@securesocial.controllers.routes.ProviderController.authenticate(network.name)" class="big blue btn">
+          <a href="@com.keepit.controllers.core.routes.AuthController.login(network.name)" class="big blue btn">
             Log in with @network.displayName
           </a>
         } else {
           <br>
-          <a href="@securesocial.controllers.routes.ProviderController.authenticate(network.name)" class="btn">
+          <a href="@com.keepit.controllers.core.routes.AuthController.login(network.name)" class="btn">
             I want to log in with @network.displayName instead
           </a>
         }

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -9,7 +9,12 @@ POST    /register                   securesocial.controllers.Registration.handle
 # OAuth provider entry points (e.g. "facebook")
 GET     /authenticate/:provider     securesocial.controllers.ProviderController.authenticate(provider)
 POST    /authenticate/:provider     securesocial.controllers.ProviderController.authenticateByPost(provider)
-POST    /mobileauth/:provider      @com.keepit.controllers.ext.ExtAuthController.mobileAuth(provider)
+# custom auth routes which set some session state
+GET     /login/:provider            @com.keepit.controllers.core.AuthController.login(provider)
+POST    /login/:provider            @com.keepit.controllers.core.AuthController.loginByPost(provider)
+GET     /link/:provider             @com.keepit.controllers.core.AuthController.link(provider)
+POST    /link/:provider             @com.keepit.controllers.core.AuthController.linkByPost(provider)
+POST    /mobileauth/:provider       @com.keepit.controllers.core.AuthController.mobileAuth(provider)
 
 POST    /disconnect/:provider       @com.keepit.controllers.website.HomeController.disconnect(provider)
 


### PR DESCRIPTION
This creates a new controller, AuthController, to deal with authentication. I moved the mobile authentication code there and also created specific wrappers for the SecureSocial authentication code to use for account linking and normal authentication.

I think this might fix the problem in dev mode where we link two separate accounts to the same user in dev mode. Now whenever we are logging in (instead of linking accounts) we remove the user from the session so it looks like a new login.
