### PR TITLE
Increasing the frequency with which data for the Result Clicked flower filter gets synced to Disk/S3

### DIFF
--- a/kifi-backend/modules/common/conf/prod/prod.conf
+++ b/kifi-backend/modules/common/conf/prod/prod.conf
@@ -108,7 +108,7 @@ index.config = "../../index/config"
 result-click-tracker = {
   dir = "../../index/resultClickTracker"
   numHashFuncs = 10
-  syncEvery = 100
+  syncEvery = 50
 }
 
 # click history tracker


### PR DESCRIPTION
We can increase the threshold for this again later, but with the current load and config, sync seem to happen only once or twice per day, which is a bit low.
