### PR TITLE
Explicitly provide DateTime string JSON formatter

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/mail/ElectronicMail.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/ElectronicMail.scala
@@ -77,19 +77,19 @@ object ElectronicMail {
   implicit val userExternalIdFormat = ExternalId.format[User]
   implicit val emailExternalIdFormat = ExternalId.format[ElectronicMail]
   implicit val idFormat = Id.format[ElectronicMail]
-  implicit val fromFormat: Format[SystemEmailAddress] = 
+  implicit val fromFormat: Format[SystemEmailAddress] =
     Format(__.read[String].map(s => EmailAddresses(s)), new Writes[SystemEmailAddress]{ def writes(o: SystemEmailAddress) = JsString(o.address) })
-  implicit val emailAddressHolderFormat: Format[EmailAddressHolder] = 
+  implicit val emailAddressHolderFormat: Format[EmailAddressHolder] =
     Format(__.read[String].map(s => GenericEmailAddress(s)), new Writes[EmailAddressHolder]{ def writes(o: EmailAddressHolder) = JsString(o.address) })
-  implicit val emailMessageIdFormat: Format[ElectronicMailMessageId] = 
+  implicit val emailMessageIdFormat: Format[ElectronicMailMessageId] =
     Format(__.read[String].map(s => ElectronicMailMessageId(s)), new Writes[ElectronicMailMessageId]{ def writes(o: ElectronicMailMessageId) = JsString(o.id) })
-  implicit val emailCategoryFormat: Format[ElectronicMailCategory] = 
+  implicit val emailCategoryFormat: Format[ElectronicMailCategory] =
     Format(__.read[String].map(s => ElectronicMailCategory(s)), new Writes[ElectronicMailCategory]{ def writes(o: ElectronicMailCategory) = JsString(o.category) })
 
   implicit val emailFormat = (
       (__ \ 'id).formatNullable(Id.format[ElectronicMail]) and
-      (__ \ 'createdAt).format[DateTime] and
-      (__ \ 'updatedAt).format[DateTime] and
+      (__ \ 'createdAt).format(DateTimeJsonFormat) and
+      (__ \ 'updatedAt).format(DateTimeJsonFormat) and
       (__ \ 'externalId).format(ExternalId.format[ElectronicMail]) and
       (__ \ 'senderUserId).formatNullable(Id.format[User]) and
       (__ \ 'from).format[SystemEmailAddress] and

--- a/kifi-backend/modules/common/app/com/keepit/common/social/CommentWithBasicUser.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/social/CommentWithBasicUser.scala
@@ -24,7 +24,7 @@ case class CommentWithBasicUser(
 object CommentWithBasicUser {
   implicit val format = (
     (__ \ 'id ).format(ExternalId.format[Comment]) and
-    (__ \ 'createdAt).format[DateTime] and
+    (__ \ 'createdAt).format(DateTimeJsonFormat) and
     (__ \ 'text).format[String] and
     (__ \ 'user).format[BasicUser] and
     (__ \ 'permissions).format(State.format[CommentPermission]) and

--- a/kifi-backend/modules/common/app/com/keepit/common/time/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/time/package.scala
@@ -46,7 +46,7 @@ package object time {
   val UTC_DATETIME_FORMAT = STANDARD_DATETIME_FORMAT.withLocale(Locale.ENGLISH).withZone(zones.UTC)
   val STANDARD_DATE_FORMAT = ISODateTimeFormat.date.withLocale(Locale.ENGLISH).withZone(zones.PT)
 
-  implicit val DateTimeJsonFormat: Format[DateTime] = new Format[DateTime] {
+  implicit object DateTimeJsonFormat extends Format[DateTime] {
     def reads(json: JsValue) = try {
       json.asOpt[String] match {
         case Some(timeStr) => JsSuccess(parseStandardTime(timeStr))

--- a/kifi-backend/modules/common/app/com/keepit/model/Bookmark.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Bookmark.scala
@@ -49,8 +49,8 @@ case class Bookmark(
 object Bookmark {
   implicit def bookmarkFormat = (
     (__ \ 'id).formatNullable(Id.format[Bookmark]) and
-    (__ \ 'createdAt).format[DateTime] and
-    (__ \ 'updatedAt).format[DateTime] and
+    (__ \ 'createdAt).format(DateTimeJsonFormat) and
+    (__ \ 'updatedAt).format(DateTimeJsonFormat) and
     (__ \ 'externalId).format(ExternalId.format[Bookmark]) and
     (__ \ 'title).formatNullable[String] and
     (__ \ 'uriId).format(Id.format[NormalizedURI]) and

--- a/kifi-backend/modules/common/app/com/keepit/model/Collection.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Collection.scala
@@ -35,8 +35,8 @@ object Collection {
     (__ \ 'userId).format(Id.format[User]) and
     (__ \ 'name).format[String] and
     (__ \ 'state).format(State.format[Collection]) and
-    (__ \ 'createdAt).format[DateTime] and
-    (__ \ 'updatedAt).format[DateTime] and
+    (__ \ 'createdAt).format(DateTimeJsonFormat) and
+    (__ \ 'updatedAt).format(DateTimeJsonFormat) and
     (__ \ 'lastKeptTo).formatNullable[DateTime] and
     (__ \ 'seq).format(SequenceNumber.sequenceNumberFormat)
   )(Collection.apply, unlift(Collection.unapply))

--- a/kifi-backend/modules/common/app/com/keepit/model/Comment.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Comment.scala
@@ -1,11 +1,12 @@
 package com.keepit.model
 
-import org.joda.time.DateTime
-import com.keepit.common.db._
-import com.keepit.common.time.DEFAULT_DATE_TIME_ZONE
-import com.keepit.common.time.currentDateTime
-import com.keepit.common.cache._
 import scala.concurrent.duration._
+
+import org.joda.time.DateTime
+
+import com.keepit.common.cache._
+import com.keepit.common.db._
+import com.keepit.common.time._
 
 case class Comment(
   id: Option[Id[Comment]] = None,
@@ -41,8 +42,8 @@ object Comment {
 
   implicit val commentFormat = (
       (__ \ 'id).formatNullable(Id.format[Comment]) and
-      (__ \ 'createdAt).format[DateTime] and
-      (__ \ 'updatedAt).format[DateTime] and
+      (__ \ 'createdAt).format(DateTimeJsonFormat) and
+      (__ \ 'updatedAt).format(DateTimeJsonFormat) and
       (__ \ 'externalId).format(ExternalId.format[Comment]) and
       (__ \ 'uriId).format(Id.format[NormalizedURI]) and
       (__ \ 'urlId).formatNullable(Id.format[URL]) and
@@ -57,7 +58,7 @@ object Comment {
 }
 
 case class CommentCountUriIdKey(normUriId: Id[NormalizedURI]) extends Key[Int] {
-  override val version = 2
+  override val version = 3
   val namespace = "comment_by_normuriid"
   def toKey(): String = normUriId.id.toString
 }

--- a/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
@@ -41,8 +41,8 @@ case class NormalizedURI (
 object NormalizedURI {
   implicit def format = (
     (__ \ 'id).formatNullable(Id.format[NormalizedURI]) and
-    (__ \ 'createdAt).format[DateTime] and
-    (__ \ 'updatedAt).format[DateTime] and
+    (__ \ 'createdAt).format(DateTimeJsonFormat) and
+    (__ \ 'updatedAt).format(DateTimeJsonFormat) and
     (__ \ 'externalId).format(ExternalId.format[NormalizedURI]) and
     (__ \ 'title).formatNullable[String] and
     (__ \ 'url).format[String] and

--- a/kifi-backend/modules/common/app/com/keepit/model/Phrase.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Phrase.scala
@@ -26,8 +26,8 @@ case class Phrase (
 object Phrase {
   implicit val format = (
     (__ \ 'id).formatNullable(Id.format[Phrase]) and
-    (__ \ 'createdAt).format[DateTime] and
-    (__ \ 'updatedAt).format[DateTime] and
+    (__ \ 'createdAt).format(DateTimeJsonFormat) and
+    (__ \ 'updatedAt).format(DateTimeJsonFormat) and
     (__ \ 'phrase).format[String] and
     (__ \ 'lang).format[String].inmap(Lang.apply, unlift(Lang.unapply)) and
     (__ \ 'source).format[String] and

--- a/kifi-backend/modules/common/app/com/keepit/model/SocialUserInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/SocialUserInfo.scala
@@ -49,8 +49,8 @@ object SocialUserInfo {
   import com.keepit.serializer.SocialUserSerializer._
   implicit val format = (
     (__ \ 'id).formatNullable(Id.format[SocialUserInfo]) and
-    (__ \ 'createdAt).format[DateTime] and
-    (__ \ 'updatedAt).format[DateTime] and
+    (__ \ 'createdAt).format(DateTimeJsonFormat) and
+    (__ \ 'updatedAt).format(DateTimeJsonFormat) and
     (__ \ 'userId).formatNullable(Id.format[User]) and
     (__ \ 'fullName).format[String] and
     (__ \ 'pictureUrl).formatNullable[String] and

--- a/kifi-backend/modules/common/app/com/keepit/model/URL.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/URL.scala
@@ -19,7 +19,7 @@ case class URLHistory(date: DateTime, id: Id[NormalizedURI], cause: URLHistoryCa
 
 object URLHistory {
   implicit val format = (
-    (__ \ 'date).format[DateTime] and
+    (__ \ 'date).format(DateTimeJsonFormat) and
     (__ \ 'id).format(Id.format[NormalizedURI]) and
     (__ \ 'cause).format[String].inmap(URLHistoryCause.apply, unlift(URLHistoryCause.unapply))
   )(URLHistory.apply _, unlift(URLHistory.unapply))

--- a/kifi-backend/modules/common/app/com/keepit/model/User.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/User.scala
@@ -30,8 +30,8 @@ case class User(
 object User {
   implicit val format = (
     (__ \ 'id).formatNullable(Id.format[User]) and
-    (__ \ 'createdAt).format[DateTime] and
-    (__ \ 'updatedAt).format[DateTime] and
+    (__ \ 'createdAt).format(DateTimeJsonFormat) and
+    (__ \ 'updatedAt).format(DateTimeJsonFormat) and
     (__ \ 'externalId).format(ExternalId.format[User]) and
     (__ \ 'firstName).format[String] and
     (__ \ 'lastName).format[String] and

--- a/kifi-backend/modules/common/app/com/keepit/model/UserSession.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserSession.scala
@@ -37,10 +37,10 @@ object UserSession {
     (__ \ 'externalId).format[ExternalId[UserSession]] and
     (__ \ 'socialId).format[String].inmap(SocialId.apply, unlift(SocialId.unapply)) and
     (__ \ 'provider).format[String].inmap(SocialNetworkType.apply, unlift(SocialNetworkType.unapply)) and
-    (__ \ 'expires).format[DateTime] and
+    (__ \ 'expires).format(DateTimeJsonFormat) and
     (__ \ 'state).format[State[UserSession]] and
-    (__ \ 'createdAt).format[DateTime] and
-    (__ \ 'updatedAt).format[DateTime]
+    (__ \ 'createdAt).format(DateTimeJsonFormat) and
+    (__ \ 'updatedAt).format(DateTimeJsonFormat)
   )(UserSession.apply, unlift(UserSession.unapply))
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/search/ArticleSearchResultRef.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/ArticleSearchResultRef.scala
@@ -30,11 +30,11 @@ case class ArticleSearchResultRef (
 object ArticleSearchResultRef {
   import play.api.libs.functional.syntax._
   import play.api.libs.json._
-  
+
   implicit def articleSearchResultRefFormat = (
     (__ \ 'id).formatNullable(Id.format[ArticleSearchResultRef]) and
-    (__ \ 'createdAt).format[DateTime] and
-    (__ \ 'updatedAt).format[DateTime] and
+    (__ \ 'createdAt).format(DateTimeJsonFormat) and
+    (__ \ 'updatedAt).format(DateTimeJsonFormat) and
     (__ \ 'externalId).format(ExternalId.format[ArticleSearchResultRef]) and
     (__ \ 'state).format(State.format[ArticleSearchResultRef]) and
     (__ \ 'last).formatNullable(ExternalId.format[ArticleSearchResultRef]) and

--- a/kifi-backend/modules/common/app/com/keepit/search/SearchConfigExperiment.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchConfigExperiment.scala
@@ -52,8 +52,8 @@ object SearchConfigExperiment {
     (__ \ 'config).format[SearchConfig] and
     (__ \ 'startedAt).formatNullable[DateTime] and
     (__ \ 'state).format[State[SearchConfigExperiment]] and
-    (__ \ 'createdAt).format[DateTime] and
-    (__ \ 'updatedAt).format[DateTime]
+    (__ \ 'createdAt).format(DateTimeJsonFormat) and
+    (__ \ 'updatedAt).format(DateTimeJsonFormat)
   )(SearchConfigExperiment.apply, unlift(SearchConfigExperiment.unapply))
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserTopic.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserTopic.scala
@@ -69,8 +69,8 @@ object UserTopic {
     (__ \'id).formatNullable(Id.format[UserTopic]) and
     (__ \'userId).format(Id.format[User]) and
     (__ \'topic).format(new TopicByteArrayFormat) and
-    (__ \'createdAt).format[DateTime] and
-    (__ \'updatedAt).format[DateTime]
+    (__ \'createdAt).format(DateTimeJsonFormat) and
+    (__ \'updatedAt).format(DateTimeJsonFormat)
   )(UserTopic.apply, unlift(UserTopic.unapply))
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/realtime/UserNotifier.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/realtime/UserNotifier.scala
@@ -74,7 +74,7 @@ case class SendableNotification(
 object SendableNotification {
   implicit val format = (
     (__ \ 'id).format(ExternalId.format[UserNotification]) and
-    (__ \ 'time).format[DateTime] and
+    (__ \ 'time).format(DateTimeJsonFormat) and
     (__ \ 'category).format[String].inmap(UserNotificationCategory.apply, unlift(UserNotificationCategory.unapply)) and
     (__ \ 'details).format[JsValue].inmap(UserNotificationDetails.apply, unlift(UserNotificationDetails.unapply)) and
     (__ \ 'state).format(State.format[UserNotification])


### PR DESCRIPTION
This will help us avoid bugs where we use the wrong implicit DateTime serializer.
