### PR TITLE
Hacky stop gap fix for the browsing history tracker race condition

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/BrowsingHistoryTrackerImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/BrowsingHistoryTrackerImpl.scala
@@ -15,7 +15,8 @@ import com.keepit.model.BrowsingHistory
 class BrowsingHistoryTrackerImpl (tableSize: Int, numHashFuncs: Int, minHits: Int,
     browsingHistoryRepo: BrowsingHistoryRepo, db: Database) extends BrowsingHistoryTracker with Logging {
 
-  def add(userId: Id[User], uriId: Id[NormalizedURI]) = {
+
+  def add(userId: Id[User], uriId: Id[NormalizedURI]) = Symbol("User Browsing History Lock for " + userId.toString).synchronized {
     val filter = getMultiHashFilter(userId)
     filter.put(uriId.id)
 


### PR DESCRIPTION
This won't help any more once we run multiple machines. We probably need to rethink the database access pattern here a little.
