### PR TITLE
Notification consistency improvements

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/DeepLink.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/DeepLink.scala
@@ -21,7 +21,7 @@ case class DeepLink(
   id: Option[Id[DeepLink]] = None,
   createdAt: DateTime = currentDateTime,
   updatedAt: DateTime = currentDateTime,
-  initatorUserId: Option[Id[User]],
+  initiatorUserId: Option[Id[User]],
   recipientUserId: Option[Id[User]],
   uriId: Option[Id[NormalizedURI]],
   urlId: Option[Id[URL]] = None, // todo(Andrew): remove Option after grandfathering process

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -651,6 +651,9 @@ function insertNewNotification(n) {
         return false;
       }
       break;
+    } else if (notifications[i].details.locator == n.details.locator) {
+      // there is already a more recent notification for this thread
+      return false;
     }
   }
   notifications.splice(i, 0, n);
@@ -664,16 +667,14 @@ function insertNewNotification(n) {
     }
   }
 
-  if (n.details.subsumes) {
-    for (i++; i < notifications.length; i++) {
-      var n2 = notifications[i];
-      if (n2.id == n.details.subsumes) {
-        notifications.splice(i, 1);
-        if (notificationNotVisited.test(n2.state)) {
-          decrementNumNotificationsNotVisited(n2);
-        }
-        break;
+  while(++i < notifications.length) {
+    var n2 = notifications[i];
+    if (n2.id == n.details.subsumes || n.details.locator == n2.details.locator) {
+      notifications.splice(i, 1);
+      if (notificationNotVisited.test(n2.state)) {
+        decrementNumNotificationsNotVisited(n2);
       }
+      break;
     }
   }
   return true;


### PR DESCRIPTION
This seems to fix some, but not all, of the problems we have with subsuming notifications. There are two main parts to this change:
- We now use the threadId on the extension to decide whether to subsume the notification. This deals with cases where we may have missed a "notification" message due to a disconnect. In this case we can get notifications through "missed_notifications", but those may reference subsumed notifications we don't have.
- Since we generate notifications asynchronously, the order in which the notifications are created can be different from the order of their corresponding messages. We should avoid sending notifications in this case, since they would be immediately subsumed anyway.

I think there are still a few possible race conditions here. I think if we can use "SELECT...FOR UPDATE" we can eliminate some of them. We could also consider using an actor or some other method to serialize creation of notifications.
