### PR TITLE
use correct table in slider history (+ retries and db calls with race potential)

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/73.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/73.sql
@@ -1,0 +1,20 @@
+# --- !Ups
+
+CREATE TABLE slider_history (
+    id bigint(20) NOT NULL AUTO_INCREMENT,
+    user_id bigint(20) NOT NULL,
+    table_size SMALLINT UNSIGNED NOT NULL,
+    filter BLOB NOT NULL,
+    num_hash_funcs SMALLINT UNSIGNED NOT NULL,
+    min_hits SMALLINT UNSIGNED NOT NULL,
+    state varchar(20) NOT NULL,
+    created_at datetime NOT NULL,
+    updated_at datetime NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT slider_history_user_id FOREIGN KEY (user_id) REFERENCES user(id),
+    UNIQUE INDEX slider_history_i_user_id(user_id)
+);
+
+insert into evolutions (name, description) values('73.sql', 'adding slider_history table again');
+
+# --- !Downs

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/BrowsingHistoryTrackerImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/BrowsingHistoryTrackerImpl.scala
@@ -16,11 +16,11 @@ class BrowsingHistoryTrackerImpl (tableSize: Int, numHashFuncs: Int, minHits: In
     browsingHistoryRepo: BrowsingHistoryRepo, db: Database) extends BrowsingHistoryTracker with Logging {
 
 
-  def add(userId: Id[User], uriId: Id[NormalizedURI]) = Symbol("User Browsing History Lock for " + userId.toString).synchronized {
+  def add(userId: Id[User], uriId: Id[NormalizedURI]) = {
     val filter = getMultiHashFilter(userId)
     filter.put(uriId.id)
 
-    db.readWrite { implicit session =>
+    db.readWrite(attempts=3) { implicit session =>
       browsingHistoryRepo.save(browsingHistoryRepo.getByUserId(userId) match {
         case Some(bh) =>
           bh.withFilter(filter.getFilter)


### PR DESCRIPTION
-Add the "slider_history" table back and make SliderHistoryRepo use it
-3 attempts on slider history and browsing history db call with race
condition failure potential
