### PR TITLE
Handle empty friend names better (workaround for LinkedIn bug)

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialUserImportFriends.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialUserImportFriends.scala
@@ -40,7 +40,8 @@ class SocialUserImportFriends @Inject() (
   private def getIfUpdateNeeded(friend: SocialUserInfo)(implicit s: RSession): Option[SocialUserInfo] = {
     repo.getOpt(friend.socialId, friend.networkType) match {
       case Some(existing) if existing.copy(
-        fullName = friend.fullName, pictureUrl = friend.pictureUrl, profileUrl = friend.profileUrl) != existing =>
+          fullName = friend.fullName, pictureUrl = friend.pictureUrl, profileUrl = friend.profileUrl) != existing &&
+          friend.fullName.nonEmpty /* LinkedIn API sometimes sends us bad data... */ =>
         Some(existing.copy(
           fullName = friend.fullName,
           pictureUrl = friend.pictureUrl,

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/UserConnectionCreator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/UserConnectionCreator.scala
@@ -65,7 +65,9 @@ class UserConnectionCreator @Inject() (
       userConnectionRepo.removeConnections(userId, existingConnections diff updatedConnections)
 
       val newConnections = updatedConnections diff existingConnections
-      if (newConnections.nonEmpty) userChannel.push(userId, Json.arr("new_friends", newConnections.map(basicUserRepo.load)))
+      if (newConnections.nonEmpty) {
+        userChannel.push(userId, Json.arr("new_friends", newConnections.map(basicUserRepo.load)))
+      }
       newConnections.foreach { connId =>
         log.info(s"Sending new connection to user $connId (to $userId)")
         userChannel.push(connId, Json.arr("new_friends", Set(basicUserRepo.load(userId))))
@@ -79,10 +81,11 @@ class UserConnectionCreator @Inject() (
       network: SocialNetworkType): Seq[(SocialUserInfo, Option[SocialConnection])] = {
     implicit val timeout = BabysitterTimeout(30 seconds, 2 minutes)
     db.readOnly { implicit s =>
-      socialIds map {
-        socialRepo.get(_, network)
-      } map { sui =>
-        (sui, socialConnectionRepo.getConnectionOpt(socialUserInfo.id.get, sui.id.get))
+      for {
+        socialId <- socialIds
+        sui <- socialRepo.getOpt(socialId, network)
+      } yield {
+        sui -> socialConnectionRepo.getConnectionOpt(socialUserInfo.id.get, sui.id.get)
       }
     }
   }
@@ -91,17 +94,14 @@ class UserConnectionCreator @Inject() (
       network: SocialNetworkType): Seq[SocialConnection] = {
     log.info(s"looking for new (or reactive) connections for user ${socialUserInfo.fullName}")
     extractFriendsWithConnections(socialUserInfo, socialIds, network) map {
+      case (_, Some(c)) if c.state == SocialConnectionStates.ACTIVE => c
       case (friend, Some(c)) =>
-        c.state match {
-          case SocialConnectionStates.ACTIVE => c
-          case _ =>
-            log.info(s"activate connection between ${c.socialUser1} and ${c.socialUser2}")
-            db.readWrite { implicit s =>
-              socialConnectionRepo.save(c.withState(SocialConnectionStates.ACTIVE))
-            }
+        log.info(s"activate connection between ${c.socialUser1} and ${c.socialUser2}")
+        db.readWrite { implicit s =>
+          socialConnectionRepo.save(c.withState(SocialConnectionStates.ACTIVE))
         }
       case (friend, None) =>
-        log.info(s"a new connection was created between ${socialUserInfo} and ${friend.id.get}")
+        log.info(s"a new connection was created between $socialUserInfo and ${friend.id.get}")
         db.readWrite { implicit s =>
           socialConnectionRepo.save(SocialConnection(socialUser1 = socialUserInfo.id.get, socialUser2 = friend.id.get))
         }
@@ -110,31 +110,27 @@ class UserConnectionCreator @Inject() (
 
   def disableOldConnections(socialUserInfo: SocialUserInfo, socialIds: Seq[SocialId],
       network: SocialNetworkType): Seq[SocialConnection] = {
-    log.info("looking for connections to disable for user %s".format(socialUserInfo.fullName))
+    log.info(s"looking for connections to disable for ${socialUserInfo.fullName}")
     db.readWrite { implicit s =>
       val existingSocialUserInfoIds = socialConnectionRepo.getUserConnections(socialUserInfo.userId.get) collect {
         case sui if sui.networkType == network => sui.socialId
       }
-      log.debug("socialUserInfoForAllFriendsIds = %s".format(socialIds))
-      log.debug("existingSocialUserInfoIds = %s".format(existingSocialUserInfoIds))
-      log.info("size of diff =%s".format((existingSocialUserInfoIds diff socialIds).length))
-      existingSocialUserInfoIds diff socialIds map {
-        socialId => {
-          val friendSocialUserInfoId = socialRepo.get(socialId, network).id.get
-          log.info("about to disbale connection between %s and for socialId = %s".format(socialUserInfo.id.get,friendSocialUserInfoId ));
-          socialConnectionRepo.getConnectionOpt(socialUserInfo.id.get, friendSocialUserInfoId) match {
-            case Some(c) => {
-              if (c.state != SocialConnectionStates.INACTIVE){
-                log.info("connection is disabled")
-                socialConnectionRepo.save(c.withState(SocialConnectionStates.INACTIVE))
-              }
-              else {
-                log.info("connection is already disabled")
-                c
-              }
-            }
-            case _ => throw new Exception("could not find the SocialConnection between %s and for socialId = %s".format(socialUserInfo.id.get,friendSocialUserInfoId ));
-          }
+      val diff = existingSocialUserInfoIds diff socialIds
+      log.debug(s"socialUserInfoForAllFriendsIds = $socialIds")
+      log.debug(s"existingSocialUserInfoIds = $existingSocialUserInfoIds")
+      log.info(s"size of diff = ${diff.length}")
+      diff map { socialId =>
+        val friendSocialUserInfoId = socialRepo.get(socialId, network).id.get
+        log.info(s"about to disable connection to ${socialUserInfo.id.get} for $friendSocialUserInfoId")
+        socialConnectionRepo.getConnectionOpt(socialUserInfo.id.get, friendSocialUserInfoId) match {
+          case Some(c) if c.state != SocialConnectionStates.INACTIVE =>
+            log.info("connection is disabled")
+            socialConnectionRepo.save(c.withState(SocialConnectionStates.INACTIVE))
+          case Some(c) =>
+            log.info("connection is already disabled")
+            c
+          case None =>
+            throw new Exception(s"could not find connection to ${socialUserInfo.id.get} for $friendSocialUserInfoId")
         }
       }
     }


### PR DESCRIPTION
We don't add or edit the SocialUserInfo if it has no name, but we still update the connections if there's an existing SocialUserInfo in the database with that ID.
