### PR TITLE
Make the S3 backed flower filter the default

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
@@ -37,7 +37,7 @@ object SearchConfig {
       "dampingHalfDecayMine" -> "7.0",
       "dampingHalfDecayFriends" -> "5.0",
       "dampingHalfDecayOthers" -> "2.0",
-      "useS3FlowerFilter" -> "false"
+      "useS3FlowerFilter" -> "true"
     )
   private[this] val descriptions =
     Map[String, String](


### PR DESCRIPTION
The old file backed one will still be there, so we can switch back with
just a settings change if something goes wrong in the multi machine
setup. We'll remove it in week or two once everything is running
smoothly.
