### PR TITLE
Add API for updating user data from website

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/social/BasicUser.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/BasicUser.scala
@@ -42,6 +42,3 @@ case class BasicUserUserIdKey(userId: Id[User]) extends Key[BasicUser] {
 
 class BasicUserUserIdCache(innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
   extends JsonCacheImpl[BasicUserUserIdKey, BasicUser](innermostPluginSettings, innerToOuterPluginSettings:_*)
-
-// TODO(andrew): Invalidate cache. More tricky on this multi-object cache. Right now, the data doesn't change. When we go multi-network, it will.
-// Also affected: CommentWithBasicUser

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -100,6 +100,8 @@ POST    /site/collections/:id/setKeeps @com.keepit.controllers.website.Bookmarks
 POST    /site/chatter               @com.keepit.controllers.website.CommentController.getChatter
 
 GET     /site/user/me               @com.keepit.controllers.website.UserController.currentUser()
+POST    /site/user/me               @com.keepit.controllers.website.UserController.updateCurrentUser()
+
 GET     /site/user/connections      @com.keepit.controllers.website.UserController.connections()
 GET     /site/user/all-connections  @com.keepit.controllers.website.UserController.getAllConnections()
 POST    /site/user/update-email     @com.keepit.controllers.website.UserController.updateEmail


### PR DESCRIPTION
@2is10

To do this I had to add proper cache invalidation for BasicUser and CommentWithBasicUser as well.

I also changed the format of the user info in /site/user/me to include a description to display on the user's profile.
