### PR TITLE
Adding url endpoint to query the status of a service

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/admin/ServiceController.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/admin/ServiceController.scala
@@ -20,4 +20,8 @@ class ServiceController @Inject() (
         Ok("Alright, alright! I've refreshed.")
     }
 
+    def myStatus = Action { implicit request =>
+        Ok(serviceDiscovery.myStatus.map(_.name).getOrElse("none"))
+    }
+
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/admin/ServiceController.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/admin/ServiceController.scala
@@ -24,4 +24,8 @@ class ServiceController @Inject() (
         Ok(serviceDiscovery.myStatus.map(_.name).getOrElse("none"))
     }
 
+    def topology = Action { implicit request =>
+        Ok(serviceDiscovery.toString)
+    }
+
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/DiscoveryModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/DiscoveryModule.scala
@@ -86,6 +86,7 @@ abstract class LocalDiscoveryModule(serviceType: ServiceType) extends DiscoveryM
       def changeStatus(newStatus: ServiceStatus): Unit = {}
       def startSelfCheck(): Unit = {}
       def forceUpdate(): Unit = {}
+      def myStatus: Option[ServiceStatus] = Some(ServiceStatus.UP)
     }
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
@@ -24,6 +24,7 @@ trait ServiceDiscovery {
   def startSelfCheck(): Unit
   def changeStatus(newStatus: ServiceStatus): Unit
   def forceUpdate(): Unit
+  def myStatus: Option[ServiceStatus]
 }
 
 @Singleton
@@ -114,6 +115,13 @@ class ServiceDiscoveryImpl @Inject() (
         serviceInstance.remoteService.status = newStatus
         zk.set(node, RemoteService.toJson(serviceInstance.remoteService))
       }
+    }
+  }
+
+  def myStatus : Option[ServiceStatus] = {
+    myNode.flatMap { node =>
+      val thisServiceInstance = clusters(services.currentService).instanceForNode(node)
+      thisServiceInstance.map(_.remoteService.status)
     }
   }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
@@ -70,6 +70,8 @@ class ServiceDiscoveryImpl @Inject() (
     }
   }
 
+  override def toString(): String = clusters.map(kv => kv._1.toString + ":" + kv._2.toString).mkString("\n")
+
   implicit val amazonInstanceInfoFormat = AmazonInstanceInfo.format
 
   override def myClusterSize: Int = clusters.get(services.currentService) map {c => c.size} getOrElse 0

--- a/kifi-backend/modules/common/conf/common.routes
+++ b/kifi-backend/modules/common/conf/common.routes
@@ -13,3 +13,4 @@ GET     /assets/*file               controllers.Assets.at(path="/public", file)
 GET     /internal/benchmark                   @com.keepit.common.healthcheck.CommonBenchmarkController.benchmarksResults()
 GET     /internal/version                     @com.keepit.common.healthcheck.CommonBenchmarkController.version()
 GET     /internal/clusters/refresh            @com.keepit.common.admin.ServiceController.forceRefresh()
+GET		/internal/clusters/mystatus			  @com.keepit.common.admin.ServiceController.myStatus

--- a/kifi-backend/modules/common/conf/common.routes
+++ b/kifi-backend/modules/common/conf/common.routes
@@ -14,3 +14,4 @@ GET     /internal/benchmark                   @com.keepit.common.healthcheck.Com
 GET     /internal/version                     @com.keepit.common.healthcheck.CommonBenchmarkController.version()
 GET     /internal/clusters/refresh            @com.keepit.common.admin.ServiceController.forceRefresh()
 GET		/internal/clusters/mystatus			  @com.keepit.common.admin.ServiceController.myStatus
+GET		/internal/clusters/topology			  @com.keepit.common.admin.ServiceController.topology


### PR DESCRIPTION
for use by the deployment script so we don't deploy the second instance until the first one is fully up.
Also includes simple endpoint to query a service for what it thinks the clusters topology is currently, currently just for human consumption.
