### PR TITLE
Making service self check return a future

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/service/Service.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/service/Service.scala
@@ -10,13 +10,14 @@ import java.util.Locale
 import play.api.Mode
 import play.api.Mode._
 import play.api.libs.json._
+import scala.concurrent.{Future, promise}
 
 case class ServiceVersion(val value: String) {
   override def toString(): String = value
 }
 
 sealed abstract class ServiceType(val name: String) {
-  def selfCheck : Boolean = true
+  def selfCheck() : Future[Boolean] = promise[Boolean].success(true).future
 }
 
 object ServiceType {

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
@@ -8,6 +8,7 @@ import com.keepit.common.amazon._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 import scala.collection.concurrent.TrieMap
+import scala.util.{Try, Success, Failure}
 
 import play.api.libs.json._
 
@@ -129,8 +130,10 @@ class ServiceDiscoveryImpl @Inject() (
 
   def startSelfCheck(): Unit = future {
     log.info("Running self check")
-    if(services.currentService.selfCheck) changeStatus(ServiceStatus.UP)
-    else changeStatus(ServiceStatus.SELFCHECK_FAIL)
+    services.currentService.selfCheck().onComplete{
+      case Success(passed) => if (passed) changeStatus(ServiceStatus.UP) else changeStatus(ServiceStatus.SELFCHECK_FAIL)
+      case Failure(e) => changeStatus(ServiceStatus.SELFCHECK_FAIL)
+    }
   }
   
 


### PR DESCRIPTION
To facilitate longer running self checks that migth just be waiting for
something (i.e. index update) and not doing any computation
