### PR TITLE
Switch LinkedIn to OAuth2

### DIFF
--- a/kifi-backend/conf/dev-securesocial.conf
+++ b/kifi-backend/conf/dev-securesocial.conf
@@ -56,10 +56,10 @@ securesocial {
   }
 
   linkedin {
-      requestTokenUrl="https://api.linkedin.com/uas/oauth/requestToken"
-      accessTokenUrl="https://api.linkedin.com/uas/oauth/accessToken"
-      authorizationUrl="https://api.linkedin.com/uas/oauth/authenticate"
-      consumerKey="ovlhms1y0fjr"
-      consumerSecret="5nz8568RERDuTNpu"
+    authorizationUrl="https://www.linkedin.com/uas/oauth2/authorization"
+    accessTokenUrl="https://www.linkedin.com/uas/oauth2/accessToken"
+    clientId=ovlhms1y0fjr
+    clientSecret=5nz8568RERDuTNpu
+    scope="r_basicprofile,r_fullprofile,r_emailaddress,r_network,r_contactinfo,w_messages"
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/social/providers/LinkedInProvider.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/providers/LinkedInProvider.scala
@@ -2,10 +2,72 @@ package com.keepit.social.providers
 
 import com.keepit.social.UserIdentityProvider
 
-import play.api.Application
+import LinkedInProvider._
+import play.api.libs.ws.WS
+import play.api.{Logger, Application}
+import securesocial.core.{UserId, AuthenticationException, SocialUser}
 
 /**
- * A LinkedIn Provider
+ * A LinkedIn Provider (OAuth2)
  */
 class LinkedInProvider(application: Application)
-    extends securesocial.core.providers.LinkedInProvider(application) with UserIdentityProvider
+    extends securesocial.core.OAuth2Provider(application) with UserIdentityProvider {
+
+  override def id = LinkedInProvider.LinkedIn
+
+  override def fillProfile(user: SocialUser): SocialUser = {
+    val accessToken = user.oAuth2Info.get.accessToken
+    val promise = WS.url(LinkedInProvider.Api + accessToken).get()
+
+    try {
+      val response = awaitResult(promise)
+      val me = response.json
+      (me \ ErrorCode).asOpt[Int] match {
+        case Some(error) => {
+          val message = (me \ Message).asOpt[String]
+          val requestId = (me \ RequestId).asOpt[String]
+          val timestamp = (me \ Timestamp).asOpt[String]
+          Logger.error(
+            "Error retrieving information from LinkedIn. Error code: %s, requestId: %s, message: %s, timestamp: %s"
+                format(error, message, requestId, timestamp)
+          )
+          throw new AuthenticationException()
+        }
+        case _ => {
+          val userId = (me \ Id).as[String]
+          val firstName = (me \ FirstName).asOpt[String].getOrElse("")
+          val lastName = (me \ LastName).asOpt[String].getOrElse("")
+          val fullName = (me \ FormattedName).asOpt[String].getOrElse("")
+          val avatarUrl = (me \ PictureUrl).asOpt[String]
+
+          SocialUser(user).copy(
+            id = UserId(userId, id),
+            firstName = firstName,
+            lastName = lastName,
+            fullName= fullName,
+            avatarUrl = avatarUrl
+          )
+        }
+      }
+    } catch {
+      case e: Exception => {
+        Logger.error("[securesocial] error retrieving profile information from LinkedIn", e)
+        throw new AuthenticationException()
+      }
+    }
+  }
+}
+
+object LinkedInProvider {
+  val Api = "https://api.linkedin.com/v1/people/~:(id,first-name,last-name,formatted-name,picture-url)?format=json&oauth2_access_token="
+  val LinkedIn = "linkedin"
+  val ErrorCode = "errorCode"
+  val Message = "message"
+  val RequestId = "requestId"
+  val Timestamp = "timestamp"
+  val Id = "id"
+  val FirstName = "firstName"
+  val LastName = "lastName"
+  val FormattedName = "formattedName"
+  val PictureUrl = "pictureUrl"
+}

--- a/kifi-backend/modules/common/conf/dev-securesocial.conf
+++ b/kifi-backend/modules/common/conf/dev-securesocial.conf
@@ -56,10 +56,10 @@ securesocial {
   }
 
   linkedin {
-      requestTokenUrl="https://api.linkedin.com/uas/oauth/requestToken"
-      accessTokenUrl="https://api.linkedin.com/uas/oauth/accessToken"
-      authorizationUrl="https://api.linkedin.com/uas/oauth/authenticate"
-      consumerKey="ovlhms1y0fjr"
-      consumerSecret="5nz8568RERDuTNpu"
+    authorizationUrl="https://www.linkedin.com/uas/oauth2/authorization"
+    accessTokenUrl="https://www.linkedin.com/uas/oauth2/accessToken"
+    clientId=ovlhms1y0fjr
+    clientSecret=5nz8568RERDuTNpu
+    scope="r_basicprofile,r_fullprofile,r_emailaddress,r_network,r_contactinfo,w_messages"
   }
 }

--- a/kifi-backend/modules/common/conf/prod/prod-securesocial.conf
+++ b/kifi-backend/modules/common/conf/prod/prod-securesocial.conf
@@ -56,10 +56,10 @@ securesocial {
   }
 
   linkedin {
-      requestTokenUrl="https://api.linkedin.com/uas/oauth/requestToken"
-      accessTokenUrl="https://api.linkedin.com/uas/oauth/accessToken"
-      authorizationUrl="https://api.linkedin.com/uas/oauth/authenticate"
-      consumerKey="r11loldy9zlg"
-      consumerSecret="6XsgSLw60c0W2cId"
+    authorizationUrl="https://www.linkedin.com/uas/oauth2/authorization"
+    accessTokenUrl="https://www.linkedin.com/uas/oauth2/accessToken"
+    clientId="r11loldy9zlg"
+    clientSecret="6XsgSLw60c0W2cId"
+    scope="r_basicprofile,r_fullprofile,r_emailaddress,r_network,r_contactinfo,w_messages"
   }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/social/LinkedInSocialGraphTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/social/LinkedInSocialGraphTest.scala
@@ -16,13 +16,12 @@ import com.keepit.social.{SocialNetworks, SocialId}
 class LinkedInSocialGraphTest extends Specification with ShoeboxApplicationInjector {
 
   private def urlIsConnections(url: String): Boolean = {
-    url.startsWith("http://api.linkedin.com/v1/people/rFOBMp35vZ/connections:(id,firstName,lastName,pictureUrl,publicProfileUrl)?format=json") &&
-      url.contains("oauth_consumer_key=ovlhms1y0fjr") &&
-      url.contains("oauth_token=a27da99f-3e1f-4fb6-9261-944b3d1a8464")
+    url.startsWith("https://api.linkedin.com/v1/people/rFOBMp35vZ/connections:(id,firstName,lastName,pictureUrl,publicProfileUrl)?format=json") &&
+      url.contains("oauth2_access_token=this_is_my_token")
   }
 
   private def urlIsProfile(url: String): Boolean = {
-    url.startsWith("http://api.linkedin.com/v1/people/rFOBMp35vZ:(id,firstName,lastName,emailAddress,pictureUrl)?format=json")
+    url.startsWith("https://api.linkedin.com/v1/people/rFOBMp35vZ:(id,firstName,lastName,emailAddress,pictureUrl)?format=json")
   }
 
   private val fakeLinkedInResponse: PartialFunction[String, FakeClientResponse] = {
@@ -34,9 +33,9 @@ class LinkedInSocialGraphTest extends Specification with ShoeboxApplicationInjec
     "fetch from linkedin" in {
       running(new ShoeboxApplication(FakeHttpClientModule(fakeLinkedInResponse))) {
 
-        val oAuth1Info = OAuth1Info("a27da99f-3e1f-4fb6-9261-944b3d1a8464", "9e3a1cfe-36c4-406f-903a-13c04d41e42b")
+        val oAuth2Info = OAuth2Info("this_is_my_token")
         val socialUser = SocialUser(UserId("rFOBMp35vZ", "linkedin"), "Greg", "Methvin", "Greg Methvin",
-          None, None, AuthenticationMethod.OAuth1, Some(oAuth1Info), None, None)
+          None, None, AuthenticationMethod.OAuth2, None, Some(oAuth2Info), None)
 
         val user = inject[Database].readWrite { implicit s =>
           userRepo.save(User(firstName = "Greg", lastName = "Methvin"))


### PR DESCRIPTION
This upgrades the LinkedIn authentication to use OAuth2. This will make it easy for our mobile app to authenticate using the same method we use for Facebook. The existing kifi sessions will not be affected, but in order to continue fetching users' social graphs, those users will need to reauth with linkedin.

I also plan to contribute the LinkedIn OAuth2Provider back to SecureSocial.
