### PR TITLE
language detection for query with a strong influence by the browser setting

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/controllers/ext/ExtSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/ext/ExtSearchController.scala
@@ -142,9 +142,7 @@ class ExtSearchController @Inject() (
       println(s"accept-langauge ===>>> $code")
       val lang = code.substring(0,2)
       if (lang == "zh") Set("zh-cn", "zh-tw") else Set(lang)
-    }
-
-    println(s"langauges ===>>> ${langs}")
+    } + "en" // always include English
 
     val size = langs.size
     if (size == 0) {

--- a/kifi-backend/modules/search/test/com/keepit/search/MainSearcherTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/MainSearcherTest.scala
@@ -147,7 +147,7 @@ class MainSearcherTest extends Specification with ApplicationInjector {
             mainSearcherFactory.clear
             val mainSearcher = mainSearcherFactory(userId, SearchFilter.default(), allHitsConfig)
             val graphSearcher = mainSearcher.uriGraphSearcher
-            val (myHits, friendsHits, othersHits, _) = mainSearcher.searchText("alldocs", numHitsPerCategory, clickBoosts)
+            val (myHits, friendsHits, othersHits, _) = mainSearcher.searchText("alldocs", numHitsPerCategory, clickBoosts, Map(Lang("en") -> 0.9d))
 
             //println("----")
             val myUriIds = graphSearcher.getUserToUriEdgeSet(userId).destIdSet.map(_.id)


### PR DESCRIPTION
- we give a (very) high prior probability to languages in Accept-Languages HTTP header field (this comes from the browser setting)
- if a single language is in the field, we give it 0.9. 0.1 are equally distributed among other languages.
- if multiple languages are in the field. we gives (1.0 - 0.1/num_of_langs) to specified languages in total and equally distribute among them. (0.1/num_of_langs) is equally distributed remaining languages.
- English is aways included for now.
- why this strong bias?
  - it is very difficult to detect language from a short text like a query, and the detector often makes a mistake. For example, the detector returns Hungarian for "amazon" if we use the uniform distribution.
  - a wrong language leads to a wrong stemming and to wrong or no semantic vectors.
  - I tested manually, and 0.9 seems to be strong enough to bias toward one language. If we have multiple languages, 0.9 is not enough, so I came up with the formula above.
- TODO: we need to use users keeps and click/browsing histories for better prior probabilities.
