### PR TITLE
preserving non-breaking space for now when there is no user desc to reserve height

### DIFF
--- a/kifi-backend/modules/common/public/site/js/main.js
+++ b/kifi-backend/modules/common/public/site/js/main.js
@@ -1220,7 +1220,7 @@ $(function() {
 		me = data;
 		$(".my-pic").css("background-image", "url(" + formatPicUrl(data.id, data.pictureName, 200) + ")");
 		$(".my-name").text(data.firstName + ' ' + data.lastName);
-		$(".my-description").text(data.description);
+		$(".my-description").text(data.description || '\u00A0'); // nbsp
 	}
 
 	$.getJSON(urlNetworks, function (data) {


### PR DESCRIPTION
Otherwise, if the user has no description, when this response comes in, the upper left column shrinks by about 20px and a gap is introduced above the collections list, which previously measured its `offsetTop`.
