### PR TITLE
Separate calls for all friends and search friends

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -83,6 +83,7 @@ trait ShoeboxServiceClient extends ServiceClient {
   def uriChannelCountFanout(): Seq[Future[Int]]
   def suggestExperts(urisAndKeepers: Seq[(Id[NormalizedURI], Seq[Id[User]])]): Future[Seq[Id[User]]]
   def getSearchFriends(userId: Id[User]): Future[Set[Id[User]]]
+  def getFriends(userId: Id[User]): Future[Set[Id[User]]]
 }
 
 case class ShoeboxCacheProvider @Inject() (
@@ -98,6 +99,7 @@ case class ShoeboxCacheProvider @Inject() (
     socialUserNetworkCache: SocialUserInfoNetworkCache,
     socialUserCache: SocialUserInfoUserCache,
     userSessionExternalIdCache: UserSessionExternalIdCache,
+    userConnectionsCache: UserConnectionIdCache,
     searchFriendsCache: SearchFriendsCache)
 
 class ShoeboxServiceClientImpl @Inject() (
@@ -110,6 +112,7 @@ class ShoeboxServiceClientImpl @Inject() (
 
   // request consolidation
   private[this] val consolidateSearchFriendsReq = new RequestConsolidator[SearchFriendsKey, Set[Id[User]]](ttl = 3 seconds)
+  private[this] val consolidateUserConnectionsReq = new RequestConsolidator[UserConnectionIdKey, Set[Id[User]]](ttl = 3 seconds)
   private[this] val consolidateClickHistoryReq = new RequestConsolidator[ClickHistoryUserIdKey, Array[Byte]](ttl = 3 seconds)
   private[this] val consolidateBrowsingHistoryReq = new RequestConsolidator[BrowsingHistoryUserIdKey, Array[Byte]](ttl = 3 seconds)
   private[this] val consolidateGetExperimentsReq = new RequestConsolidator[String, Seq[SearchConfigExperiment]](ttl = 30 seconds)
@@ -229,6 +232,14 @@ class ShoeboxServiceClientImpl @Inject() (
   def getSearchFriends(userId: Id[User]): Future[Set[Id[User]]] = consolidateSearchFriendsReq(SearchFriendsKey(userId)){ key=>
     cacheProvider.searchFriendsCache.getOrElseFuture(key) {
       call(Shoebox.internal.getSearchFriends(userId)).map {r =>
+        r.json.as[JsArray].value.map(jsv => Id[User](jsv.as[Long])).toSet
+      }
+    }
+  }
+
+  def getFriends(userId: Id[User]): Future[Set[Id[User]]] = consolidateUserConnectionsReq(UserConnectionIdKey(userId)){ key=>
+    cacheProvider.userConnectionsCache.getOrElseFuture(key) {
+      call(Shoebox.internal.getConnectedUsers(userId)).map {r =>
         r.json.as[JsArray].value.map(jsv => Id[User](jsv.as[Long])).toSet
       }
     }

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -342,6 +342,10 @@ class FakeShoeboxServiceClientImpl(
   def getSearchFriends(userId: Id[User]): Future[Set[Id[User]]] = {
     Future.successful(allUserConnections.getOrElse(userId, Set.empty))
   }
+
+  def getFriends(userId: Id[User]): Future[Set[Id[User]]] = {
+    Future.successful(allUserConnections.getOrElse(userId, Set.empty))
+  }
 }
 
 class FakeClickHistoryTrackerImpl (tableSize: Int, numHashFuncs: Int, minHits: Int) extends ClickHistoryTracker with Logging {

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/ShoeboxServiceClientTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/ShoeboxServiceClientTest.scala
@@ -46,10 +46,10 @@ class ShoeboxServiceClientTest extends Specification with ApplicationInjector {
       }
     }
 
-    "get connected users' ids" in {
+    "get friends' ids" in {
       running(new TestApplication(shoeboxServiceClientTestModules:_*)) {
         val shoeboxServiceClient = inject[ShoeboxServiceClient]
-        val userIdsFuture = shoeboxServiceClient.getSearchFriends(user1965.id.get)
+        val userIdsFuture = shoeboxServiceClient.getFriends(user1965.id.get)
         Await.result(userIdsFuture, Duration(5, SECONDS)) ===  Set(1933,1935,1927,1921).map(Id[User](_))
 
       }

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphSearcher.scala
@@ -60,7 +60,7 @@ class URIGraphSearcher(searcher: Searcher, storeSearcher: Searcher) extends Base
 class URIGraphSearcherWithUser(searcher: Searcher, storeSearcher: Searcher, myUserId: Id[User], shoeboxClient: ShoeboxServiceClient, monitoredAwait: MonitoredAwait)
   extends URIGraphSearcher(searcher, storeSearcher) {
 
-  private[this] val friendIdsFuture = shoeboxClient.getSearchFriends(myUserId)
+  private[this] val friendIdsFuture = shoeboxClient.getFriends(myUserId)
 
   private[this] lazy val myInfo: UserInfo = {
     val docid = reader.getIdMapper.getDocId(myUserId.id)


### PR DESCRIPTION
@ymatsuda Let me know if I changed things in the right places. I standardized the naming of the methods to be getFriends and getSearchFriends.
