### PR TITLE
Singleton actor

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/actor/ActorFactory.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/actor/ActorFactory.scala
@@ -2,16 +2,17 @@ package com.keepit.common.actor
 
 import akka.actor._
 import akka.testkit.TestActorRef
-import com.google.inject.{ImplementedBy, Provider, Inject}
+import com.google.inject.{ImplementedBy, Provider, Inject, Singleton}
 import com.keepit.common.akka.AlertingActor
 
+@Singleton
 class ActorFactory[T <: Actor] @Inject() (
     systemProvider: Provider[ActorSystem],
     builder: ActorBuilder,
     provider: Provider[T]) {
 
-  def system: ActorSystem = systemProvider.get
-  def get(): ActorRef = builder(system, provider)
+  lazy val system: ActorSystem = systemProvider.get
+  lazy val actor: ActorRef = builder(system, provider)
 }
 
 @ImplementedBy(classOf[ActorBuilderImpl])

--- a/kifi-backend/modules/common/app/com/keepit/common/actor/ActorWrapper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/actor/ActorWrapper.scala
@@ -6,7 +6,7 @@ import com.google.inject.{ImplementedBy, Provider, Inject, Singleton}
 import com.keepit.common.akka.AlertingActor
 
 @Singleton
-class ActorWrapper[T <: Actor] @Inject() (
+class ActorProvider[T <: Actor] @Inject() (
     systemProvider: Provider[ActorSystem],
     builder: ActorBuilder,
     provider: Provider[T]) {

--- a/kifi-backend/modules/common/app/com/keepit/common/actor/ActorWrapper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/actor/ActorWrapper.scala
@@ -6,7 +6,7 @@ import com.google.inject.{ImplementedBy, Provider, Inject, Singleton}
 import com.keepit.common.akka.AlertingActor
 
 @Singleton
-class ActorFactory[T <: Actor] @Inject() (
+class ActorWrapper[T <: Actor] @Inject() (
     systemProvider: Provider[ActorSystem],
     builder: ActorBuilder,
     provider: Provider[T]) {

--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/HealthCheckModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/HealthCheckModule.scala
@@ -4,7 +4,7 @@ import net.codingwell.scalaguice.ScalaModule
 import com.google.inject.Provides
 import com.keepit.inject.AppScoped
 import java.net.InetAddress
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.service.FortyTwoServices
 import com.keepit.common.plugin.SchedulingProperties
 
@@ -20,8 +20,8 @@ case class ProdHealthCheckModule() extends HealthCheckModule {
 
   @Provides
   @AppScoped
-  def healthcheckProvider(actorWrapper: ActorWrapper[HealthcheckActor],
+  def healthcheckProvider(actorProvider: ActorProvider[HealthcheckActor],
     services: FortyTwoServices, host: HealthcheckHost): HealthcheckPlugin = {
-    new HealthcheckPluginImpl(actorWrapper, services, host)
+    new HealthcheckPluginImpl(actorProvider, services, host)
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/HealthCheckModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/HealthCheckModule.scala
@@ -4,7 +4,7 @@ import net.codingwell.scalaguice.ScalaModule
 import com.google.inject.Provides
 import com.keepit.inject.AppScoped
 import java.net.InetAddress
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.service.FortyTwoServices
 import com.keepit.common.plugin.SchedulingProperties
 
@@ -20,8 +20,8 @@ case class ProdHealthCheckModule() extends HealthCheckModule {
 
   @Provides
   @AppScoped
-  def healthcheckProvider(actorFactory: ActorFactory[HealthcheckActor],
+  def healthcheckProvider(actorWrapper: ActorWrapper[HealthcheckActor],
     services: FortyTwoServices, host: HealthcheckHost): HealthcheckPlugin = {
-    new HealthcheckPluginImpl(actorFactory, services, host)
+    new HealthcheckPluginImpl(actorWrapper, services, host)
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/Healthcheck.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/Healthcheck.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration._
 
 import com.google.inject.Inject
 import com.google.inject.ImplementedBy
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.akka.AlertingActor
 import com.keepit.common.logging.Logging
 import com.keepit.common.mail.ElectronicMail
@@ -154,7 +154,7 @@ trait HealthcheckPlugin extends Plugin {
 }
 
 class HealthcheckPluginImpl @Inject() (
-    actorFactory: ActorFactory[HealthcheckActor],
+    actorWrapper: ActorWrapper[HealthcheckActor],
     services: FortyTwoServices,
     host: HealthcheckHost)
   extends HealthcheckPlugin
@@ -163,25 +163,23 @@ class HealthcheckPluginImpl @Inject() (
   val schedulingProperties = SchedulingProperties.AlwaysEnabled
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.actor
-
   // plugin lifecycle methods
   override def enabled: Boolean = true
   override def onStart() {
-    scheduleTask(actorFactory.system, 0 seconds, 10 minutes, actor, ReportErrorsAction)
+    scheduleTask(actorWrapper.system, 0 seconds, 10 minutes, actorWrapper.actor, ReportErrorsAction)
   }
 
-  def errorCount(): Int = Await.result((actor ? ErrorCount).mapTo[Int], 1 seconds)
+  def errorCount(): Int = Await.result((actorWrapper.actor ? ErrorCount).mapTo[Int], 1 seconds)
 
-  def errors(): Seq[HealthcheckError] = Await.result((actor ? GetErrors).mapTo[List[HealthcheckError]], 1 seconds)
+  def errors(): Seq[HealthcheckError] = Await.result((actorWrapper.actor ? GetErrors).mapTo[List[HealthcheckError]], 1 seconds)
 
-  def resetErrorCount(): Unit = actor ! ResetErrorCount
+  def resetErrorCount(): Unit = actorWrapper.actor ! ResetErrorCount
 
-  def reportErrors(): Unit = actor ! ReportErrorsAction
+  def reportErrors(): Unit = actorWrapper.actor ! ReportErrorsAction
 
   def addError(error: HealthcheckError): HealthcheckError = {
     log.error(s"Healthcheck logged error: ${error}")
-    actor ! error
+    actorWrapper.actor ! error
     error
   }
 
@@ -191,7 +189,7 @@ class HealthcheckPluginImpl @Inject() (
     val email = (ElectronicMail(from = EmailAddresses.ENG, to = List(EmailAddresses.ENG),
         subject = subject, htmlBody = message.body,
         category = PostOffice.Categories.HEALTHCHECK))
-    actor ! email
+    actorWrapper.actor ! email
     email
   }
 
@@ -201,9 +199,9 @@ class HealthcheckPluginImpl @Inject() (
     val email = (ElectronicMail(from = EmailAddresses.ENG, to = List(EmailAddresses.ENG),
         subject = subject, htmlBody = message.body,
         category = PostOffice.Categories.HEALTHCHECK))
-    actor ! email
+    actorWrapper.actor ! email
     email
   }
 
-  override def warmUp() = scheduleTaskOnce(actorFactory.system, 3 minutes, "Healthcheck: consider service warm") {super.warmUp()}
+  override def warmUp() = scheduleTaskOnce(actorWrapper.system, 3 minutes, "Healthcheck: consider service warm") {super.warmUp()}
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/Healthcheck.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/Healthcheck.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration._
 
 import com.google.inject.Inject
 import com.google.inject.ImplementedBy
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.akka.AlertingActor
 import com.keepit.common.logging.Logging
 import com.keepit.common.mail.ElectronicMail
@@ -154,7 +154,7 @@ trait HealthcheckPlugin extends Plugin {
 }
 
 class HealthcheckPluginImpl @Inject() (
-    actorWrapper: ActorWrapper[HealthcheckActor],
+    actorProvider: ActorProvider[HealthcheckActor],
     services: FortyTwoServices,
     host: HealthcheckHost)
   extends HealthcheckPlugin
@@ -166,20 +166,20 @@ class HealthcheckPluginImpl @Inject() (
   // plugin lifecycle methods
   override def enabled: Boolean = true
   override def onStart() {
-    scheduleTask(actorWrapper.system, 0 seconds, 10 minutes, actorWrapper.actor, ReportErrorsAction)
+    scheduleTask(actorProvider.system, 0 seconds, 10 minutes, actorProvider.actor, ReportErrorsAction)
   }
 
-  def errorCount(): Int = Await.result((actorWrapper.actor ? ErrorCount).mapTo[Int], 1 seconds)
+  def errorCount(): Int = Await.result((actorProvider.actor ? ErrorCount).mapTo[Int], 1 seconds)
 
-  def errors(): Seq[HealthcheckError] = Await.result((actorWrapper.actor ? GetErrors).mapTo[List[HealthcheckError]], 1 seconds)
+  def errors(): Seq[HealthcheckError] = Await.result((actorProvider.actor ? GetErrors).mapTo[List[HealthcheckError]], 1 seconds)
 
-  def resetErrorCount(): Unit = actorWrapper.actor ! ResetErrorCount
+  def resetErrorCount(): Unit = actorProvider.actor ! ResetErrorCount
 
-  def reportErrors(): Unit = actorWrapper.actor ! ReportErrorsAction
+  def reportErrors(): Unit = actorProvider.actor ! ReportErrorsAction
 
   def addError(error: HealthcheckError): HealthcheckError = {
     log.error(s"Healthcheck logged error: ${error}")
-    actorWrapper.actor ! error
+    actorProvider.actor ! error
     error
   }
 
@@ -189,7 +189,7 @@ class HealthcheckPluginImpl @Inject() (
     val email = (ElectronicMail(from = EmailAddresses.ENG, to = List(EmailAddresses.ENG),
         subject = subject, htmlBody = message.body,
         category = PostOffice.Categories.HEALTHCHECK))
-    actorWrapper.actor ! email
+    actorProvider.actor ! email
     email
   }
 
@@ -199,9 +199,9 @@ class HealthcheckPluginImpl @Inject() (
     val email = (ElectronicMail(from = EmailAddresses.ENG, to = List(EmailAddresses.ENG),
         subject = subject, htmlBody = message.body,
         category = PostOffice.Categories.HEALTHCHECK))
-    actorWrapper.actor ! email
+    actorProvider.actor ! email
     email
   }
 
-  override def warmUp() = scheduleTaskOnce(actorWrapper.system, 3 minutes, "Healthcheck: consider service warm") {super.warmUp()}
+  override def warmUp() = scheduleTaskOnce(actorProvider.system, 3 minutes, "Healthcheck: consider service warm") {super.warmUp()}
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/Healthcheck.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/Healthcheck.scala
@@ -163,7 +163,7 @@ class HealthcheckPluginImpl @Inject() (
   val schedulingProperties = SchedulingProperties.AlwaysEnabled
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   // plugin lifecycle methods
   override def enabled: Boolean = true

--- a/kifi-backend/modules/common/app/com/keepit/common/mail/PostOffice.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/PostOffice.scala
@@ -7,7 +7,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.mutable.Queue
 import akka.actor.Actor
 import scala.util.{Success, Failure}
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.plugin.{SchedulingPlugin, SchedulingProperties}
 import scala.concurrent.duration._
 import akka.util.Timeout
@@ -64,7 +64,7 @@ trait RemotePostOfficePlugin extends Plugin {
 }
 
 class RemotePostOfficePluginImpl @Inject() (
-    actorWrapper: ActorWrapper[RemotePostOfficeActor])
+    actorProvider: ActorProvider[RemotePostOfficeActor])
   extends RemotePostOfficePlugin with SchedulingPlugin {
 
   val schedulingProperties = SchedulingProperties.AlwaysEnabled
@@ -72,9 +72,9 @@ class RemotePostOfficePluginImpl @Inject() (
   implicit val actorTimeout = Timeout(5 seconds)
   override def enabled: Boolean = true
   override def onStart() {
-     scheduleTask(actorWrapper.system, 30 seconds, 3 minutes, actorWrapper.actor, SendQueuedEmails)
+     scheduleTask(actorProvider.system, 30 seconds, 3 minutes, actorProvider.actor, SendQueuedEmails)
   }
-  def sendMail(mail: ElectronicMail) = actorWrapper.actor ! SendEmail(mail)
+  def sendMail(mail: ElectronicMail) = actorProvider.actor ! SendEmail(mail)
 }
 
 class RemotePostOfficeImpl @Inject() (

--- a/kifi-backend/modules/common/app/com/keepit/common/mail/PostOffice.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/PostOffice.scala
@@ -70,7 +70,7 @@ class RemotePostOfficePluginImpl @Inject() (
   val schedulingProperties = SchedulingProperties.AlwaysEnabled
 
   implicit val actorTimeout = Timeout(5 seconds)
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   override def enabled: Boolean = true
   override def onStart() {

--- a/kifi-backend/modules/common/app/com/keepit/common/mail/PostOffice.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/PostOffice.scala
@@ -7,7 +7,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.mutable.Queue
 import akka.actor.Actor
 import scala.util.{Success, Failure}
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.plugin.{SchedulingPlugin, SchedulingProperties}
 import scala.concurrent.duration._
 import akka.util.Timeout
@@ -64,19 +64,17 @@ trait RemotePostOfficePlugin extends Plugin {
 }
 
 class RemotePostOfficePluginImpl @Inject() (
-    actorFactory: ActorFactory[RemotePostOfficeActor])
+    actorWrapper: ActorWrapper[RemotePostOfficeActor])
   extends RemotePostOfficePlugin with SchedulingPlugin {
 
   val schedulingProperties = SchedulingProperties.AlwaysEnabled
 
   implicit val actorTimeout = Timeout(5 seconds)
-  private lazy val actor = actorFactory.actor
-
   override def enabled: Boolean = true
   override def onStart() {
-     scheduleTask(actorFactory.system, 30 seconds, 3 minutes, actor, SendQueuedEmails)
+     scheduleTask(actorWrapper.system, 30 seconds, 3 minutes, actorWrapper.actor, SendQueuedEmails)
   }
-  def sendMail(mail: ElectronicMail) = actor ! SendEmail(mail)
+  def sendMail(mail: ElectronicMail) = actorWrapper.actor ! SendEmail(mail)
 }
 
 class RemotePostOfficeImpl @Inject() (

--- a/kifi-backend/modules/common/test/com/keepit/common/actor/ActorFactoryTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/actor/ActorFactoryTest.scala
@@ -1,0 +1,41 @@
+package com.keepit.common.actor
+
+import com.keepit.test._
+import akka.actor._
+import org.specs2.mutable.Specification
+import com.google.inject.{Singleton, Provides}
+import play.api.Play.current
+import akka.testkit.TestKit
+
+class MyTestActorA extends Actor {
+  def receive = {
+  	case a => sender ! a
+  }
+}
+
+class MyTestActorB extends Actor {
+  def receive = {
+  	case a => sender ! a
+  }
+}
+
+class ActorFactoryTest extends Specification with TestInjector {
+
+  "ActorFactory" should {
+    "provide singletons" in {
+      withInjector(StandaloneTestActorSystemModule()) { implicit injector =>
+      	val actorA = inject[ActorFactory[MyTestActorA]].actor
+      	val actorB = inject[ActorFactory[MyTestActorB]].actor
+      	//checking we're not getting the same reference fo rdiferant actor types
+      	actorA !== actorB
+      	val factoryA = inject[ActorFactory[MyTestActorA]]
+      	factoryA.actor === factoryA.actor
+      	//making sure the actor factory is a singleton
+      	factoryA.actor === actorA
+      	val factoryB = inject[ActorFactory[MyTestActorB]]
+      	factoryB.actor === factoryB.actor
+      	factoryB.actor === actorB
+      }
+    }   
+  }
+}

--- a/kifi-backend/modules/common/test/com/keepit/common/actor/ActorFactoryTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/actor/ActorFactoryTest.scala
@@ -19,20 +19,20 @@ class MyTestActorB extends Actor {
   }
 }
 
-class ActorWrapperTest extends Specification with TestInjector {
+class ActorProviderTest extends Specification with TestInjector {
 
-  "ActorWrapper" should {
+  "ActorProvider" should {
     "provide singletons" in {
       withInjector(StandaloneTestActorSystemModule()) { implicit injector =>
-      	val actorA = inject[ActorWrapper[MyTestActorA]].actor
-      	val actorB = inject[ActorWrapper[MyTestActorB]].actor
+      	val actorA = inject[ActorProvider[MyTestActorA]].actor
+      	val actorB = inject[ActorProvider[MyTestActorB]].actor
       	//checking we're not getting the same reference fo rdiferant actor types
       	actorA !== actorB
-      	val factoryA = inject[ActorWrapper[MyTestActorA]]
+      	val factoryA = inject[ActorProvider[MyTestActorA]]
       	factoryA.actor === factoryA.actor
       	//making sure the actor factory is a singleton
       	factoryA.actor === actorA
-      	val factoryB = inject[ActorWrapper[MyTestActorB]]
+      	val factoryB = inject[ActorProvider[MyTestActorB]]
       	factoryB.actor === factoryB.actor
       	factoryB.actor === actorB
       }

--- a/kifi-backend/modules/common/test/com/keepit/common/actor/ActorFactoryTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/actor/ActorFactoryTest.scala
@@ -19,20 +19,20 @@ class MyTestActorB extends Actor {
   }
 }
 
-class ActorFactoryTest extends Specification with TestInjector {
+class ActorWrapperTest extends Specification with TestInjector {
 
-  "ActorFactory" should {
+  "ActorWrapper" should {
     "provide singletons" in {
       withInjector(StandaloneTestActorSystemModule()) { implicit injector =>
-      	val actorA = inject[ActorFactory[MyTestActorA]].actor
-      	val actorB = inject[ActorFactory[MyTestActorB]].actor
+      	val actorA = inject[ActorWrapper[MyTestActorA]].actor
+      	val actorB = inject[ActorWrapper[MyTestActorB]].actor
       	//checking we're not getting the same reference fo rdiferant actor types
       	actorA !== actorB
-      	val factoryA = inject[ActorFactory[MyTestActorA]]
+      	val factoryA = inject[ActorWrapper[MyTestActorA]]
       	factoryA.actor === factoryA.actor
       	//making sure the actor factory is a singleton
       	factoryA.actor === actorA
-      	val factoryB = inject[ActorFactory[MyTestActorB]]
+      	val factoryB = inject[ActorWrapper[MyTestActorB]]
       	factoryB.actor === factoryB.actor
       	factoryB.actor === actorB
       }

--- a/kifi-backend/modules/search/app/com/keepit/controllers/search/SearchStatisticsController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/search/SearchStatisticsController.scala
@@ -1,7 +1,7 @@
 package com.keepit.controllers.search
 
 import com.keepit.common.controller.SearchServiceController
-import com.keepit.search.{ArticleSearchResultRef, SearchStatisticsExtractorFactory, UriLabel}
+import com.keepit.search.{ArticleSearchResultRef, SearchStatisticsExtractorWrapper, UriLabel}
 import com.google.inject.Inject
 import com.google.inject.Provider
 import com.keepit.common.db.ExternalId
@@ -15,7 +15,7 @@ import com.keepit.common.logging.Logging
 import play.api.libs.json.JsArray
 import com.keepit.serializer.UriLabelSerializer
 
-class SearchStatisticsController @Inject() (sseFactory: Provider[SearchStatisticsExtractorFactory])
+class SearchStatisticsController @Inject() (sseFactory: Provider[SearchStatisticsExtractorWrapper])
   extends SearchServiceController with Logging{
 
   def getSearchStatistics() = Action(parse.json) { request =>

--- a/kifi-backend/modules/search/app/com/keepit/controllers/search/SearchStatisticsController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/search/SearchStatisticsController.scala
@@ -1,7 +1,7 @@
 package com.keepit.controllers.search
 
 import com.keepit.common.controller.SearchServiceController
-import com.keepit.search.{ArticleSearchResultRef, SearchStatisticsExtractorWrapper, UriLabel}
+import com.keepit.search.{ArticleSearchResultRef, SearchStatisticsExtractorProvider, UriLabel}
 import com.google.inject.Inject
 import com.google.inject.Provider
 import com.keepit.common.db.ExternalId
@@ -15,7 +15,7 @@ import com.keepit.common.logging.Logging
 import play.api.libs.json.JsArray
 import com.keepit.serializer.UriLabelSerializer
 
-class SearchStatisticsController @Inject() (sseFactory: Provider[SearchStatisticsExtractorWrapper])
+class SearchStatisticsController @Inject() (sseFactory: Provider[SearchStatisticsExtractorProvider])
   extends SearchServiceController with Logging{
 
   def getSearchStatistics() = Action(parse.json) { request =>

--- a/kifi-backend/modules/search/app/com/keepit/search/SearchStatisticsExtractor.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/SearchStatisticsExtractor.scala
@@ -29,7 +29,7 @@ import com.keepit.common.akka.MonitoredAwait
 import scala.concurrent.duration._
 
 @Singleton
-class SearchStatisticsExtractorFactory @Inject() (
+class SearchStatisticsExtractorWrapper @Inject() (
   uriGraph: URIGraph,
   articleIndexer: ArticleIndexer, searchConfigManager: SearchConfigManager, mainSearcherFactory: MainSearcherFactory, parserFactory: MainQueryParserFactory,
   browsingHistoryBuilder: BrowsingHistoryBuilder, clickHistoryBuilder: ClickHistoryBuilder, resultClickTracker: ResultClickTracker, store: MongoEventStore,

--- a/kifi-backend/modules/search/app/com/keepit/search/SearchStatisticsExtractor.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/SearchStatisticsExtractor.scala
@@ -29,7 +29,7 @@ import com.keepit.common.akka.MonitoredAwait
 import scala.concurrent.duration._
 
 @Singleton
-class SearchStatisticsExtractorWrapper @Inject() (
+class SearchStatisticsExtractorProvider @Inject() (
   uriGraph: URIGraph,
   articleIndexer: ArticleIndexer, searchConfigManager: SearchConfigManager, mainSearcherFactory: MainSearcherFactory, parserFactory: MainQueryParserFactory,
   browsingHistoryBuilder: BrowsingHistoryBuilder, clickHistoryBuilder: ClickHistoryBuilder, resultClickTracker: ResultClickTracker, store: MongoEventStore,

--- a/kifi-backend/modules/search/app/com/keepit/search/comment/CommentIndexerPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/comment/CommentIndexerPlugin.scala
@@ -48,7 +48,7 @@ class CommentIndexerPluginImpl @Inject() (
   val schedulingProperties = SchedulingProperties.AlwaysEnabled
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   override def enabled: Boolean = true
   override def onStart() {

--- a/kifi-backend/modules/search/app/com/keepit/search/comment/CommentIndexerPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/comment/CommentIndexerPlugin.scala
@@ -9,7 +9,7 @@ import com.keepit.common.db.SequenceNumber
 import com.keepit.common.healthcheck.{Healthcheck, HealthcheckPlugin, HealthcheckError}
 import com.keepit.common.logging.Logging
 import com.keepit.common.plugin.{SchedulingPlugin, SchedulingProperties}
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.inject._
 import play.api.Play.current
 import scala.concurrent.Future
@@ -41,7 +41,7 @@ trait CommentIndexerPlugin extends SchedulingPlugin {
 }
 
 class CommentIndexerPluginImpl @Inject() (
-    actorWrapper: ActorWrapper[CommentIndexerActor],
+    actorProvider: ActorProvider[CommentIndexerActor],
     commentIndexer: CommentIndexer)
   extends CommentIndexerPlugin with Logging {
 
@@ -50,7 +50,7 @@ class CommentIndexerPluginImpl @Inject() (
 
   override def enabled: Boolean = true
   override def onStart() {
-    scheduleTask(actorWrapper.system, 30 seconds, 1 minute, actorWrapper.actor, Update)
+    scheduleTask(actorProvider.system, 30 seconds, 1 minute, actorProvider.actor, Update)
     log.info("starting CommentIndexerPluginImpl")
   }
   override def onStop() {
@@ -59,10 +59,10 @@ class CommentIndexerPluginImpl @Inject() (
     commentIndexer.close()
   }
 
-  override def update(): Future[Int] = actorWrapper.actor.ask(Update)(1 minutes).mapTo[Int]
+  override def update(): Future[Int] = actorProvider.actor.ask(Update)(1 minutes).mapTo[Int]
 
   override def reindex() {
     commentIndexer.reindex()
-    actorWrapper.actor ! Update
+    actorProvider.actor ! Update
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphPlugin.scala
@@ -49,7 +49,7 @@ class URIGraphPluginImpl @Inject() (
   val schedulingProperties = SchedulingProperties.AlwaysEnabled
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   override def enabled: Boolean = true
   override def onStart() {

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphPlugin.scala
@@ -9,7 +9,7 @@ import com.keepit.common.db.SequenceNumber
 import com.keepit.common.healthcheck.{Healthcheck, HealthcheckPlugin, HealthcheckError}
 import com.keepit.common.logging.Logging
 import com.keepit.common.plugin.{SchedulingPlugin, SchedulingProperties}
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.inject._
 import play.api.Play.current
 import scala.concurrent.Future
@@ -42,7 +42,7 @@ trait URIGraphPlugin extends SchedulingPlugin {
 }
 
 class URIGraphPluginImpl @Inject() (
-    actorWrapper: ActorWrapper[URIGraphActor],
+    actorProvider: ActorProvider[URIGraphActor],
     uriGraph: URIGraph)
   extends URIGraphPlugin with Logging {
 
@@ -51,7 +51,7 @@ class URIGraphPluginImpl @Inject() (
 
   override def enabled: Boolean = true
   override def onStart() {
-    scheduleTask(actorWrapper.system, 30 seconds, 1 minute, actorWrapper.actor, Update)
+    scheduleTask(actorProvider.system, 30 seconds, 1 minute, actorProvider.actor, Update)
     log.info("starting URIGraphPluginImpl")
   }
   override def onStop() {
@@ -60,15 +60,15 @@ class URIGraphPluginImpl @Inject() (
     uriGraph.close()
   }
 
-  override def update(): Future[Int] = actorWrapper.actor.ask(Update)(1 minutes).mapTo[Int]
+  override def update(): Future[Int] = actorProvider.actor.ask(Update)(1 minutes).mapTo[Int]
 
   override def reindex() {
     uriGraph.reindex()
-    actorWrapper.actor ! Update
+    actorProvider.actor ! Update
   }
 
   override def reindexCollection() {
     uriGraph.reindexCollection()
-    actorWrapper.actor ! Update
+    actorProvider.actor ! Update
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphPlugin.scala
@@ -9,7 +9,7 @@ import com.keepit.common.db.SequenceNumber
 import com.keepit.common.healthcheck.{Healthcheck, HealthcheckPlugin, HealthcheckError}
 import com.keepit.common.logging.Logging
 import com.keepit.common.plugin.{SchedulingPlugin, SchedulingProperties}
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.inject._
 import play.api.Play.current
 import scala.concurrent.Future
@@ -42,18 +42,16 @@ trait URIGraphPlugin extends SchedulingPlugin {
 }
 
 class URIGraphPluginImpl @Inject() (
-    actorFactory: ActorFactory[URIGraphActor],
+    actorWrapper: ActorWrapper[URIGraphActor],
     uriGraph: URIGraph)
   extends URIGraphPlugin with Logging {
 
   val schedulingProperties = SchedulingProperties.AlwaysEnabled
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.actor
-
   override def enabled: Boolean = true
   override def onStart() {
-    scheduleTask(actorFactory.system, 30 seconds, 1 minute, actor, Update)
+    scheduleTask(actorWrapper.system, 30 seconds, 1 minute, actorWrapper.actor, Update)
     log.info("starting URIGraphPluginImpl")
   }
   override def onStop() {
@@ -62,15 +60,15 @@ class URIGraphPluginImpl @Inject() (
     uriGraph.close()
   }
 
-  override def update(): Future[Int] = actor.ask(Update)(1 minutes).mapTo[Int]
+  override def update(): Future[Int] = actorWrapper.actor.ask(Update)(1 minutes).mapTo[Int]
 
   override def reindex() {
     uriGraph.reindex()
-    actor ! Update
+    actorWrapper.actor ! Update
   }
 
   override def reindexCollection() {
     uriGraph.reindexCollection()
-    actor ! Update
+    actorWrapper.actor ! Update
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/index/ArticleIndexerPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/ArticleIndexerPlugin.scala
@@ -52,7 +52,7 @@ class ArticleIndexerPluginImpl @Inject() (
   val schedulingProperties = SchedulingProperties.AlwaysEnabled
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   // plugin lifecycle methods
   override def enabled: Boolean = true

--- a/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainClassifier.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainClassifier.scala
@@ -122,7 +122,7 @@ class DomainClassifierImpl @Inject()(
   updater: SensitivityUpdater)
     extends DomainClassifier {
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   private val splitPattern = """\.""".r
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainTagImporter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainTagImporter.scala
@@ -312,7 +312,7 @@ class DomainTagImporterImpl @Inject() (
   actorFactory: ActorFactory[DomainTagImportActor])
     extends DomainTagImporter {
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   def refetchClassifications() {
     actor ! RefetchAll

--- a/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainTagImporter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainTagImporter.scala
@@ -18,7 +18,7 @@ import org.joda.time.format.DateTimeFormat
 import com.google.inject.{Provides, ImplementedBy, Inject, Singleton}
 
 import com.keepit.common.service.FortyTwoServices
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.analytics.{EventFamilies, Events, EventPersister}
 import com.keepit.common.db.Id
@@ -309,18 +309,18 @@ trait DomainTagImporter {
 }
 
 class DomainTagImporterImpl @Inject() (
-  actorWrapper: ActorWrapper[DomainTagImportActor])
+  actorProvider: ActorProvider[DomainTagImportActor])
     extends DomainTagImporter {
 
   def refetchClassifications() {
-    actorWrapper.actor ! RefetchAll
+    actorProvider.actor ! RefetchAll
   }
 
   def removeTag(tagName: DomainTagName): Future[Option[DomainTag]] = {
-    actorWrapper.actor.ask(RemoveTag(tagName))(1 minute).mapTo[Option[DomainTag]]
+    actorProvider.actor.ask(RemoveTag(tagName))(1 minute).mapTo[Option[DomainTag]]
   }
 
   def applyTagToDomains(tagName: DomainTagName, domainNames: Seq[String]): Future[DomainTag] = {
-    actorWrapper.actor.ask(ApplyTag(tagName, domainNames))(1 minute).mapTo[DomainTag]
+    actorProvider.actor.ask(ApplyTag(tagName, domainNames))(1 minute).mapTo[DomainTag]
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainTagImporter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainTagImporter.scala
@@ -18,7 +18,7 @@ import org.joda.time.format.DateTimeFormat
 import com.google.inject.{Provides, ImplementedBy, Inject, Singleton}
 
 import com.keepit.common.service.FortyTwoServices
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.analytics.{EventFamilies, Events, EventPersister}
 import com.keepit.common.db.Id
@@ -309,20 +309,18 @@ trait DomainTagImporter {
 }
 
 class DomainTagImporterImpl @Inject() (
-  actorFactory: ActorFactory[DomainTagImportActor])
+  actorWrapper: ActorWrapper[DomainTagImportActor])
     extends DomainTagImporter {
 
-  private lazy val actor = actorFactory.actor
-
   def refetchClassifications() {
-    actor ! RefetchAll
+    actorWrapper.actor ! RefetchAll
   }
 
   def removeTag(tagName: DomainTagName): Future[Option[DomainTag]] = {
-    actor.ask(RemoveTag(tagName))(1 minute).mapTo[Option[DomainTag]]
+    actorWrapper.actor.ask(RemoveTag(tagName))(1 minute).mapTo[Option[DomainTag]]
   }
 
   def applyTagToDomains(tagName: DomainTagName, domainNames: Seq[String]): Future[DomainTag] = {
-    actor.ask(ApplyTag(tagName, domainNames))(1 minute).mapTo[DomainTag]
+    actorWrapper.actor.ask(ApplyTag(tagName, domainNames))(1 minute).mapTo[DomainTag]
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventListener.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventListener.scala
@@ -2,7 +2,7 @@ package com.keepit.common.analytics
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import com.google.inject.{ Inject, Singleton, Provider }
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.db._
 import com.keepit.common.db.slick.DBSession._
@@ -84,11 +84,9 @@ object SearchEventName {
 
 @Singleton
 class EventHelper @Inject() (
-  actorFactory: ActorFactory[EventHelperActor],
+  actorWrapper: ActorWrapper[EventHelperActor],
   listeners: Set[EventListener]) {
-  private lazy val actor = actorFactory.actor
-
-  def newEvent(event: Event): Unit = actor ! event
+  def newEvent(event: Event): Unit = actorWrapper.actor ! event
 
   def matchEvent(event: Event): Seq[String] =
     listeners.filter(_.onEvent.isDefinedAt(event)).map(_.getClass.getSimpleName.replaceAll("\\$", "")).toSeq

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventListener.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventListener.scala
@@ -2,7 +2,7 @@ package com.keepit.common.analytics
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import com.google.inject.{ Inject, Singleton, Provider }
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.db._
 import com.keepit.common.db.slick.DBSession._
@@ -84,9 +84,9 @@ object SearchEventName {
 
 @Singleton
 class EventHelper @Inject() (
-  actorWrapper: ActorWrapper[EventHelperActor],
+  actorProvider: ActorProvider[EventHelperActor],
   listeners: Set[EventListener]) {
-  def newEvent(event: Event): Unit = actorWrapper.actor ! event
+  def newEvent(event: Event): Unit = actorProvider.actor ! event
 
   def matchEvent(event: Event): Seq[String] =
     listeners.filter(_.onEvent.isDefinedAt(event)).map(_.getClass.getSimpleName.replaceAll("\\$", "")).toSeq

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventListener.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventListener.scala
@@ -86,7 +86,7 @@ object SearchEventName {
 class EventHelper @Inject() (
   actorFactory: ActorFactory[EventHelperActor],
   listeners: Set[EventListener]) {
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   def newEvent(event: Event): Unit = actor ! event
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventStream.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventStream.scala
@@ -27,7 +27,7 @@ class EventStream @Inject() (
     eventWriter: EventWriter) {
   implicit val timeout = Timeout(1 second)
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   def newStream(): Future[(Iteratee[JsValue,_],Enumerator[JsValue])] = {
     (actor ? NewStream).map {

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventStream.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventStream.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration._
 import org.joda.time.DateTime
 
 import com.google.inject.{Inject, Singleton}
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.HealthcheckPlugin
@@ -23,17 +23,15 @@ import play.api.libs.json._
 
 @Singleton
 class EventStream @Inject() (
-    actorFactory: ActorFactory[EventStreamActor],
+    actorWrapper: ActorWrapper[EventStreamActor],
     eventWriter: EventWriter) {
   implicit val timeout = Timeout(1 second)
 
-  private lazy val actor = actorFactory.actor
-
   def newStream(): Future[(Iteratee[JsValue,_],Enumerator[JsValue])] = {
-    (actor ? NewStream).map {
+    (actorWrapper.actor ? NewStream).map {
       case Connected(enumerator) =>
         // Since we're expecting no input from the client, just consume and discard the input
-        val iteratee = Iteratee.foreach[JsValue]{ s => actor ! ReplyEcho }
+        val iteratee = Iteratee.foreach[JsValue]{ s => actorWrapper.actor ! ReplyEcho }
         (iteratee, enumerator)
     }
   }
@@ -43,7 +41,7 @@ class EventStream @Inject() (
     eventWriter.wrapEvent(event).map { wrappedEvent =>
       // Todo(Andrew): Wire up to new WS
       //adminEvent.broadcast("event", Json.toJson(wrappedEvent))
-      actor ! BroadcastEvent(Json.toJson(wrappedEvent))
+      actorWrapper.actor ! BroadcastEvent(Json.toJson(wrappedEvent))
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/PersistEvent.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/PersistEvent.scala
@@ -9,7 +9,7 @@ import org.joda.time._
 
 import com.google.inject.Inject
 
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.db.Id
 import com.keepit.common.healthcheck._
 import com.keepit.common.logging.Logging
@@ -65,11 +65,11 @@ trait EventPersister {
 }
 
 class EventPersisterImpl @Inject() (
-    actorWrapper: ActorWrapper[PersistEventActor])
+    actorProvider: ActorProvider[PersistEventActor])
   extends EventPersister with Logging {
 
-  def persist(event: Event): Unit = actorWrapper.actor ! Persist(event, currentDateTime)
-  def persist(events: Seq[Event]): Unit = actorWrapper.actor ! PersistMany(events, currentDateTime)
+  def persist(event: Event): Unit = actorProvider.actor ! Persist(event, currentDateTime)
+  def persist(events: Seq[Event]): Unit = actorProvider.actor ! PersistMany(events, currentDateTime)
 }
 
 class FakeEventPersisterImpl @Inject() (

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/PersistEvent.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/PersistEvent.scala
@@ -68,7 +68,7 @@ class EventPersisterImpl @Inject() (
     actorFactory: ActorFactory[PersistEventActor])
   extends EventPersister with Logging {
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   def persist(event: Event): Unit = actor ! Persist(event, currentDateTime)
   def persist(events: Seq[Event]): Unit = actor ! PersistMany(events, currentDateTime)

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/PersistEvent.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/PersistEvent.scala
@@ -9,7 +9,7 @@ import org.joda.time._
 
 import com.google.inject.Inject
 
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.db.Id
 import com.keepit.common.healthcheck._
 import com.keepit.common.logging.Logging
@@ -65,13 +65,11 @@ trait EventPersister {
 }
 
 class EventPersisterImpl @Inject() (
-    actorFactory: ActorFactory[PersistEventActor])
+    actorWrapper: ActorWrapper[PersistEventActor])
   extends EventPersister with Logging {
 
-  private lazy val actor = actorFactory.actor
-
-  def persist(event: Event): Unit = actor ! Persist(event, currentDateTime)
-  def persist(events: Seq[Event]): Unit = actor ! PersistMany(events, currentDateTime)
+  def persist(event: Event): Unit = actorWrapper.actor ! Persist(event, currentDateTime)
+  def persist(events: Seq[Event]): Unit = actorWrapper.actor ! PersistMany(events, currentDateTime)
 }
 
 class FakeEventPersisterImpl @Inject() (

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/reports/ReportBuilder.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/reports/ReportBuilder.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.joda.time.DateTime
 import com.keepit.common.healthcheck.HealthcheckPlugin
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.google.inject.Inject
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.logging.Logging
@@ -124,7 +124,7 @@ trait ReportBuilderPlugin extends Plugin {
 }
 
 class ReportBuilderPluginImpl @Inject() (
-  actorWrapper: ActorWrapper[ReportBuilderActor],
+  actorProvider: ActorProvider[ReportBuilderActor],
   db: Database,
   searchConfigExperimentRepo: SearchConfigExperimentRepo,
   reportStore: ReportStore,
@@ -133,21 +133,21 @@ class ReportBuilderPluginImpl @Inject() (
   val schedulingProperties: SchedulingProperties) //only on leader
     extends Logging with ReportBuilderPlugin with SchedulingPlugin {
 
-  def buildReport(startDate: DateTime, endDate: DateTime, report: ReportRepo): Unit = actorWrapper.actor ! BuildReport(startDate, endDate, report)
-  def buildReports(startDate: DateTime, endDate: DateTime, reportGroup: ReportGroup): Unit = actorWrapper.actor ! BuildReports(startDate, endDate, reportGroup)
+  def buildReport(startDate: DateTime, endDate: DateTime, report: ReportRepo): Unit = actorProvider.actor ! BuildReport(startDate, endDate, report)
+  def buildReports(startDate: DateTime, endDate: DateTime, reportGroup: ReportGroup): Unit = actorProvider.actor ! BuildReports(startDate, endDate, reportGroup)
 
-  private lazy val actor = actorWrapper.actor
+  private lazy val actor = actorProvider.actor
   // plugin lifecycle methods
   override def enabled: Boolean = true
   override def onStart() {
-    scheduleTask(actorWrapper.system, 10 seconds, 1 hour, actorWrapper.actor, ReportCron(this))
+    scheduleTask(actorProvider.system, 10 seconds, 1 hour, actorProvider.actor, ReportCron(this))
   }
 
   override def reportCron(): Unit = {
     if (currentDateTime.hourOfDay().get() == 3) {// 3am PST
-      actorWrapper.actor ! BuildReports(defaultStartTime, defaultEndTime,
+      actorProvider.actor ! BuildReports(defaultStartTime, defaultEndTime,
          searchExperimentReports(db.readOnly { implicit s => searchConfigExperimentRepo.getActive() }))
-      actorWrapper.actor ! BuildReports(defaultStartTime, defaultEndTime, dailyReports)
+      actorProvider.actor ! BuildReports(defaultStartTime, defaultEndTime, dailyReports)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/reports/ReportBuilder.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/reports/ReportBuilder.scala
@@ -136,7 +136,7 @@ class ReportBuilderPluginImpl @Inject() (
   def buildReport(startDate: DateTime, endDate: DateTime, report: ReportRepo): Unit = actor ! BuildReport(startDate, endDate, report)
   def buildReports(startDate: DateTime, endDate: DateTime, reportGroup: ReportGroup): Unit = actor ! BuildReports(startDate, endDate, reportGroup)
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
   // plugin lifecycle methods
   override def enabled: Boolean = true
   override def onStart() {

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/InvitationMailPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/InvitationMailPlugin.scala
@@ -7,7 +7,7 @@ import org.joda.time.Days
 import com.google.inject.{ImplementedBy, Inject}
 import play.api.Plugin
 
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
@@ -84,22 +84,20 @@ trait InvitationMailPlugin extends Plugin {
 }
 
 class InvitationMailPluginImpl @Inject()(
-    actorFactory: ActorFactory[InvitationMailActor],
+    actorWrapper: ActorWrapper[InvitationMailActor],
     val schedulingProperties: SchedulingProperties //only on leader
     ) extends InvitationMailPlugin with SchedulingPlugin with Logging {
 
   override def enabled: Boolean = true
 
-  private lazy val actor = actorFactory.actor
-
   def resendNotifications() {
-    actor ! ResendNotifications
+    actorWrapper.actor ! ResendNotifications
   }
   def notifyAcceptedUser(userId: Id[User]) {
-    actor ! NotifyAcceptedUser(userId)
+    actorWrapper.actor ! NotifyAcceptedUser(userId)
   }
   override def onStart() {
     log.info("Starting InvitationMailPluginImpl")
-    scheduleTask(actorFactory.system, 10 seconds, 12 hours, actor, ResendNotifications)
+    scheduleTask(actorWrapper.system, 10 seconds, 12 hours, actorWrapper.actor, ResendNotifications)
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/InvitationMailPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/InvitationMailPlugin.scala
@@ -90,7 +90,7 @@ class InvitationMailPluginImpl @Inject()(
 
   override def enabled: Boolean = true
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   def resendNotifications() {
     actor ! ResendNotifications

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/InvitationMailPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/InvitationMailPlugin.scala
@@ -7,7 +7,7 @@ import org.joda.time.Days
 import com.google.inject.{ImplementedBy, Inject}
 import play.api.Plugin
 
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
@@ -84,20 +84,20 @@ trait InvitationMailPlugin extends Plugin {
 }
 
 class InvitationMailPluginImpl @Inject()(
-    actorWrapper: ActorWrapper[InvitationMailActor],
+    actorProvider: ActorProvider[InvitationMailActor],
     val schedulingProperties: SchedulingProperties //only on leader
     ) extends InvitationMailPlugin with SchedulingPlugin with Logging {
 
   override def enabled: Boolean = true
 
   def resendNotifications() {
-    actorWrapper.actor ! ResendNotifications
+    actorProvider.actor ! ResendNotifications
   }
   def notifyAcceptedUser(userId: Id[User]) {
-    actorWrapper.actor ! NotifyAcceptedUser(userId)
+    actorProvider.actor ! NotifyAcceptedUser(userId)
   }
   override def onStart() {
     log.info("Starting InvitationMailPluginImpl")
-    scheduleTask(actorWrapper.system, 10 seconds, 12 hours, actorWrapper.actor, ResendNotifications)
+    scheduleTask(actorProvider.system, 10 seconds, 12 hours, actorProvider.actor, ResendNotifications)
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailModule.scala
@@ -6,7 +6,7 @@ import com.keepit.inject.AppScoped
 import com.keepit.common.healthcheck.{HealthcheckMailSender, LocalHealthcheckMailSender}
 import net.codingwell.scalaguice.ScalaModule
 import com.keepit.common.plugin.SchedulingProperties
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 
 trait MailModule extends ScalaModule
 
@@ -49,12 +49,12 @@ case class DevMailModule() extends MailModule {
   @AppScoped
   @Provides
   def mailToKeepPlugin(
-    actorWrapper: ActorWrapper[MailToKeepActor],
+    actorProvider: ActorProvider[MailToKeepActor],
     mailToKeepServerSettings: Option[MailToKeepServerSettings],
     schedulingProperties: SchedulingProperties): MailToKeepPlugin = {
     mailToKeepServerSettingsOpt match {
       case None => new FakeMailToKeepPlugin()
-      case _ => new MailToKeepPluginImpl(actorWrapper, schedulingProperties)
+      case _ => new MailToKeepPluginImpl(actorProvider, schedulingProperties)
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailModule.scala
@@ -6,7 +6,7 @@ import com.keepit.inject.AppScoped
 import com.keepit.common.healthcheck.{HealthcheckMailSender, LocalHealthcheckMailSender}
 import net.codingwell.scalaguice.ScalaModule
 import com.keepit.common.plugin.SchedulingProperties
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 
 trait MailModule extends ScalaModule
 
@@ -49,12 +49,12 @@ case class DevMailModule() extends MailModule {
   @AppScoped
   @Provides
   def mailToKeepPlugin(
-    actorFactory: ActorFactory[MailToKeepActor],
+    actorWrapper: ActorWrapper[MailToKeepActor],
     mailToKeepServerSettings: Option[MailToKeepServerSettings],
     schedulingProperties: SchedulingProperties): MailToKeepPlugin = {
     mailToKeepServerSettingsOpt match {
       case None => new FakeMailToKeepPlugin()
-      case _ => new MailToKeepPluginImpl(actorFactory, schedulingProperties)
+      case _ => new MailToKeepPluginImpl(actorWrapper, schedulingProperties)
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailSender.scala
@@ -21,7 +21,7 @@ class MailSenderPluginImpl @Inject() (
     val schedulingProperties: SchedulingProperties) //only on leader
   extends Logging with MailSenderPlugin with SchedulingPlugin {
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   // plugin lifecycle methods
   override def enabled: Boolean = true

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailSender.scala
@@ -3,7 +3,7 @@ package com.keepit.common.mail
 import scala.concurrent.duration._
 
 import com.google.inject.Inject
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.db.slick._
 import com.keepit.common.healthcheck.HealthcheckPlugin
@@ -17,20 +17,18 @@ trait MailSenderPlugin extends Plugin {
 }
 
 class MailSenderPluginImpl @Inject() (
-    actorFactory: ActorFactory[MailSenderActor],
+    actorWrapper: ActorWrapper[MailSenderActor],
     val schedulingProperties: SchedulingProperties) //only on leader
   extends Logging with MailSenderPlugin with SchedulingPlugin {
-
-  private lazy val actor = actorFactory.actor
 
   // plugin lifecycle methods
   override def enabled: Boolean = true
   override def onStart() {
-    scheduleTask(actorFactory.system, 5 seconds, 5 seconds, actor, ProcessOutbox)
+    scheduleTask(actorWrapper.system, 5 seconds, 5 seconds, actorWrapper.actor, ProcessOutbox)
   }
 
-  override def processOutbox() { actor ! ProcessOutbox }
-  override def processMail(mail: ElectronicMail) { actor ! ProcessMail(mail) }
+  override def processOutbox() { actorWrapper.actor ! ProcessOutbox }
+  override def processMail(mail: ElectronicMail) { actorWrapper.actor ! ProcessMail(mail) }
 }
 
 private[mail] case class ProcessOutbox()

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailSender.scala
@@ -3,7 +3,7 @@ package com.keepit.common.mail
 import scala.concurrent.duration._
 
 import com.google.inject.Inject
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.db.slick._
 import com.keepit.common.healthcheck.HealthcheckPlugin
@@ -17,18 +17,18 @@ trait MailSenderPlugin extends Plugin {
 }
 
 class MailSenderPluginImpl @Inject() (
-    actorWrapper: ActorWrapper[MailSenderActor],
+    actorProvider: ActorProvider[MailSenderActor],
     val schedulingProperties: SchedulingProperties) //only on leader
   extends Logging with MailSenderPlugin with SchedulingPlugin {
 
   // plugin lifecycle methods
   override def enabled: Boolean = true
   override def onStart() {
-    scheduleTask(actorWrapper.system, 5 seconds, 5 seconds, actorWrapper.actor, ProcessOutbox)
+    scheduleTask(actorProvider.system, 5 seconds, 5 seconds, actorProvider.actor, ProcessOutbox)
   }
 
-  override def processOutbox() { actorWrapper.actor ! ProcessOutbox }
-  override def processMail(mail: ElectronicMail) { actorWrapper.actor ! ProcessMail(mail) }
+  override def processOutbox() { actorProvider.actor ! ProcessOutbox }
+  override def processMail(mail: ElectronicMail) { actorProvider.actor ! ProcessMail(mail) }
 }
 
 private[mail] case class ProcessOutbox()

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailToKeepPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailToKeepPlugin.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration._
 import org.jsoup.Jsoup
 
 import com.google.inject.{ImplementedBy, Inject}
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.analytics.{EventFamilies, Events, EventPersister}
 import com.keepit.common.db.slick.Database
@@ -207,17 +207,17 @@ trait MailToKeepPlugin extends Plugin {
 }
 
 class MailToKeepPluginImpl @Inject()(
-  actorWrapper: ActorWrapper[MailToKeepActor],
+  actorProvider: ActorProvider[MailToKeepActor],
   val schedulingProperties: SchedulingProperties //only on leader
 ) extends MailToKeepPlugin with SchedulingPlugin {
 
   override def enabled: Boolean = true
 
   def fetchNewKeeps() {
-    actorWrapper.actor ! FetchNewKeeps
+    actorProvider.actor ! FetchNewKeeps
   }
   override def onStart() {
-    scheduleTask(actorWrapper.system, 10 seconds, 1 minute, actorWrapper.actor, FetchNewKeeps)
+    scheduleTask(actorProvider.system, 10 seconds, 1 minute, actorProvider.actor, FetchNewKeeps)
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailToKeepPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailToKeepPlugin.scala
@@ -213,7 +213,7 @@ class MailToKeepPluginImpl @Inject()(
 
   override def enabled: Boolean = true
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   def fetchNewKeeps() {
     actor ! FetchNewKeeps

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailToKeepPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailToKeepPlugin.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration._
 import org.jsoup.Jsoup
 
 import com.google.inject.{ImplementedBy, Inject}
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.analytics.{EventFamilies, Events, EventPersister}
 import com.keepit.common.db.slick.Database
@@ -207,19 +207,17 @@ trait MailToKeepPlugin extends Plugin {
 }
 
 class MailToKeepPluginImpl @Inject()(
-  actorFactory: ActorFactory[MailToKeepActor],
+  actorWrapper: ActorWrapper[MailToKeepActor],
   val schedulingProperties: SchedulingProperties //only on leader
 ) extends MailToKeepPlugin with SchedulingPlugin {
 
   override def enabled: Boolean = true
 
-  private lazy val actor = actorFactory.actor
-
   def fetchNewKeeps() {
-    actor ! FetchNewKeeps
+    actorWrapper.actor ! FetchNewKeeps
   }
   override def onStart() {
-    scheduleTask(actorFactory.system, 10 seconds, 1 minute, actor, FetchNewKeeps)
+    scheduleTask(actorWrapper.system, 10 seconds, 1 minute, actorWrapper.actor, FetchNewKeeps)
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphPluginImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphPluginImpl.scala
@@ -6,7 +6,7 @@ import com.keepit.common.healthcheck.HealthcheckPlugin
 import com.keepit.common.db.slick.Database
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.logging.Logging
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.plugin.{SchedulingPlugin, SchedulingProperties}
 import akka.util.Timeout
 import scala.concurrent.Future
@@ -83,7 +83,7 @@ private[social] class SocialGraphActor @Inject() (
 
 class SocialGraphPluginImpl @Inject() (
   graphs: Set[SocialGraph],
-  actorWrapper: ActorWrapper[SocialGraphActor],
+  actorProvider: ActorProvider[SocialGraphActor],
   val schedulingProperties: SchedulingProperties) //only on leader
   extends SocialGraphPlugin with Logging with SchedulingPlugin {
 
@@ -93,7 +93,7 @@ class SocialGraphPluginImpl @Inject() (
   override def enabled: Boolean = true
   override def onStart() {
     log.info("starting SocialGraphPluginImpl")
-    scheduleTask(actorWrapper.system, 10 seconds, 1 minutes, actorWrapper.actor, FetchAll)
+    scheduleTask(actorProvider.system, 10 seconds, 1 minutes, actorProvider.actor, FetchAll)
   }
   override def onStop() {
     log.info("stopping SocialGraphPluginImpl")
@@ -106,6 +106,6 @@ class SocialGraphPluginImpl @Inject() (
   override def asyncFetch(socialUserInfo: SocialUserInfo): Future[Seq[SocialConnection]] = {
     require(socialUserInfo.credentials.isDefined,
       "social user info's credentials are not defined: %s".format(socialUserInfo))
-    actorWrapper.actor.ask(FetchUserInfo(socialUserInfo))(5 minutes).mapTo[Seq[SocialConnection]]
+    actorProvider.actor.ask(FetchUserInfo(socialUserInfo))(5 minutes).mapTo[Seq[SocialConnection]]
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphPluginImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphPluginImpl.scala
@@ -89,7 +89,7 @@ class SocialGraphPluginImpl @Inject() (
 
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   // plugin lifecycle methods
   override def enabled: Boolean = true

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphRefresherPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphRefresherPlugin.scala
@@ -49,7 +49,7 @@ class SocialGraphRefresherImpl @Inject() (
 
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   // plugin lifecycle methods
   override def enabled: Boolean = true

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphRefresherPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphRefresherPlugin.scala
@@ -10,7 +10,7 @@ import com.keepit.common.db.slick._
 import scala.concurrent.duration._
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.plugin._
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import play.api.Plugin
 import com.keepit.social.SocialGraphPlugin
 
@@ -43,17 +43,15 @@ private[social] class SocialGraphRefresherActor @Inject() (
 trait SocialGraphRefresher extends Plugin {}
 
 class SocialGraphRefresherImpl @Inject() (
-    actorFactory: ActorFactory[SocialGraphRefresherActor],
+    actorWrapper: ActorWrapper[SocialGraphRefresherActor],
     val schedulingProperties: SchedulingProperties) //only on leader
   extends SocialGraphRefresher with SchedulingPlugin {
 
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.actor
-
   // plugin lifecycle methods
   override def enabled: Boolean = true
   override def onStart() {
-    scheduleTask(actorFactory.system, 90 seconds, 5 minutes, actor, RefreshAll)
+    scheduleTask(actorWrapper.system, 90 seconds, 5 minutes, actorWrapper.actor, RefreshAll)
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphRefresherPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphRefresherPlugin.scala
@@ -10,7 +10,7 @@ import com.keepit.common.db.slick._
 import scala.concurrent.duration._
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.plugin._
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import play.api.Plugin
 import com.keepit.social.SocialGraphPlugin
 
@@ -43,7 +43,7 @@ private[social] class SocialGraphRefresherActor @Inject() (
 trait SocialGraphRefresher extends Plugin {}
 
 class SocialGraphRefresherImpl @Inject() (
-    actorWrapper: ActorWrapper[SocialGraphRefresherActor],
+    actorProvider: ActorProvider[SocialGraphRefresherActor],
     val schedulingProperties: SchedulingProperties) //only on leader
   extends SocialGraphRefresher with SchedulingPlugin {
 
@@ -52,6 +52,6 @@ class SocialGraphRefresherImpl @Inject() (
   // plugin lifecycle methods
   override def enabled: Boolean = true
   override def onStart() {
-    scheduleTask(actorWrapper.system, 90 seconds, 5 minutes, actorWrapper.actor, RefreshAll)
+    scheduleTask(actorProvider.system, 90 seconds, 5 minutes, actorProvider.actor, RefreshAll)
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/store/ImageDataIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/store/ImageDataIntegrityPlugin.scala
@@ -2,7 +2,7 @@ package com.keepit.common.store
 
 import scala.concurrent.duration._
 import com.google.inject.Inject
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.db.ExternalId
 import com.keepit.common.db.slick.Database
@@ -87,17 +87,15 @@ trait ImageDataIntegrityPlugin extends Plugin {
 
 class ImageDataIntegrityPluginImpl @Inject()(
     system: ActorSystem,
-    actorFactory: ActorFactory[ImageDataIntegrityActor],
+    actorWrapper: ActorWrapper[ImageDataIntegrityActor],
     val schedulingProperties: SchedulingProperties //only on leader
   ) extends SchedulingPlugin with ImageDataIntegrityPlugin {
-  private lazy val actor = actorFactory.actor
-
   def verifyAll() {
-    actor ! VerifyAllPictures
+    actorWrapper.actor ! VerifyAllPictures
   }
 
   override def onStart() {
-    scheduleTask(system, 2 minutes, 1 hour, actor, VerifyAllPictures)
+    scheduleTask(system, 2 minutes, 1 hour, actorWrapper.actor, VerifyAllPictures)
     super.onStart()
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/store/ImageDataIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/store/ImageDataIntegrityPlugin.scala
@@ -90,7 +90,7 @@ class ImageDataIntegrityPluginImpl @Inject()(
     actorFactory: ActorFactory[ImageDataIntegrityActor],
     val schedulingProperties: SchedulingProperties //only on leader
   ) extends SchedulingPlugin with ImageDataIntegrityPlugin {
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   def verifyAll() {
     actor ! VerifyAllPictures

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/store/ImageDataIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/store/ImageDataIntegrityPlugin.scala
@@ -2,7 +2,7 @@ package com.keepit.common.store
 
 import scala.concurrent.duration._
 import com.google.inject.Inject
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.db.ExternalId
 import com.keepit.common.db.slick.Database
@@ -87,15 +87,15 @@ trait ImageDataIntegrityPlugin extends Plugin {
 
 class ImageDataIntegrityPluginImpl @Inject()(
     system: ActorSystem,
-    actorWrapper: ActorWrapper[ImageDataIntegrityActor],
+    actorProvider: ActorProvider[ImageDataIntegrityActor],
     val schedulingProperties: SchedulingProperties //only on leader
   ) extends SchedulingPlugin with ImageDataIntegrityPlugin {
   def verifyAll() {
-    actorWrapper.actor ! VerifyAllPictures
+    actorProvider.actor ! VerifyAllPictures
   }
 
   override def onStart() {
-    scheduleTask(system, 2 minutes, 1 hour, actorWrapper.actor, VerifyAllPictures)
+    scheduleTask(system, 2 minutes, 1 hour, actorProvider.actor, VerifyAllPictures)
     super.onStart()
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/learning/topicmodel/TopicUpdaterPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/learning/topicmodel/TopicUpdaterPlugin.scala
@@ -9,7 +9,7 @@ import com.keepit.common.db.SequenceNumber
 import com.keepit.common.healthcheck.{Healthcheck, HealthcheckPlugin, HealthcheckError}
 import com.keepit.common.logging.Logging
 import com.keepit.common.plugin.{SchedulingPlugin, SchedulingProperties}
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.inject._
 import play.api.Play.current
 import scala.concurrent.Future
@@ -76,20 +76,18 @@ trait TopicUpdaterPlugin extends SchedulingPlugin {
 
 @Singleton
 class TopicUpdaterPluginImpl @Inject() (
-    actorFactory: ActorFactory[TopicUpdaterActor],
+    actorWrapper: ActorWrapper[TopicUpdaterActor],
     centralConfig: CentralConfig,
     val schedulingProperties: SchedulingProperties //only on leader
 ) extends TopicUpdaterPlugin with Logging{
 
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.actor
-
   override def enabled: Boolean = true
   override def onStart() {
      log.info("starting TopicUpdaterPluginImpl")
-     scheduleTask(actorFactory.system, 10 minutes, 2 minutes, actor, UpdateTopic)
-     scheduleTask(actorFactory.system, 30 seconds, 3650 days, "check remodel status")(watchRemodelStatus)
+     scheduleTask(actorWrapper.system, 10 minutes, 2 minutes, actorWrapper.actor, UpdateTopic)
+     scheduleTask(actorWrapper.system, 30 seconds, 3650 days, "check remodel status")(watchRemodelStatus)
   }
   override def onStop() {
      log.info("stopping TopicUpdaterPluginImpl")
@@ -114,12 +112,12 @@ class TopicUpdaterPluginImpl @Inject() (
     }
 
     if (remodelStat == RemodelState.STARTED){
-      actor ! ContinueRemodel
+      actorWrapper.actor ! ContinueRemodel
     }
 
     centralConfig.onChange(remodelKey){ flagOpt =>
       if (flagOpt.isDefined && (flagOpt.get == RemodelState.NEEDED)){
-        actor ! Remodel
+        actorWrapper.actor ! Remodel
       }
     }
   }
@@ -136,12 +134,10 @@ trait TopicModelSwitcherPlugin extends Plugin
 
 @Singleton
 class TopicModelSwitcherPluginImpl @Inject() (
-  actorFactory: ActorFactory[TopicUpdaterActor],
+  actorWrapper: ActorWrapper[TopicUpdaterActor],
   centralConfig: CentralConfig
 ) extends TopicModelSwitcherPlugin with Logging {
   implicit val actorTimeout = Timeout(5 seconds)
-
-  private lazy val actor = actorFactory.actor
 
   override def enabled: Boolean = true
 
@@ -158,7 +154,7 @@ class TopicModelSwitcherPluginImpl @Inject() (
     val flagKey = new TopicModelFlagKey()
     centralConfig.onChange(flagKey){ flagOpt =>
       log.info("topic model flag may have changed. Send a msg to TopicUpdater actor. ")
-      actor ! SwitchModel
+      actorWrapper.actor ! SwitchModel
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/learning/topicmodel/TopicUpdaterPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/learning/topicmodel/TopicUpdaterPlugin.scala
@@ -83,7 +83,7 @@ class TopicUpdaterPluginImpl @Inject() (
 
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   override def enabled: Boolean = true
   override def onStart() {
@@ -141,7 +141,7 @@ class TopicModelSwitcherPluginImpl @Inject() (
 ) extends TopicModelSwitcherPlugin with Logging {
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   override def enabled: Boolean = true
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/realtime/NotificationConsistencyChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/realtime/NotificationConsistencyChecker.scala
@@ -3,7 +3,7 @@ package com.keepit.realtime
 import scala.concurrent.duration._
 
 import com.google.inject.{ImplementedBy, Inject}
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.{Healthcheck, HealthcheckError, HealthcheckPlugin}
@@ -45,18 +45,16 @@ trait NotificationConsistencyChecker extends Plugin {
 
 class NotificationConsistencyCheckerImpl @Inject()(
     system: ActorSystem,
-    actorFactory: ActorFactory[NotificationConsistencyActor],
+    actorWrapper: ActorWrapper[NotificationConsistencyActor],
     val schedulingProperties: SchedulingProperties) //only on leader
   extends SchedulingPlugin with NotificationConsistencyChecker {
 
-  private lazy val actor = actorFactory.actor
-
   def verifyVisited() {
-    actor ! VerifyVisited
+    actorWrapper.actor ! VerifyVisited
   }
 
   override def onStart() {
-    scheduleTask(system, 2 minutes, 1 hour, actor, VerifyVisited)
+    scheduleTask(system, 2 minutes, 1 hour, actorWrapper.actor, VerifyVisited)
     super.onStart()
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/realtime/NotificationConsistencyChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/realtime/NotificationConsistencyChecker.scala
@@ -3,7 +3,7 @@ package com.keepit.realtime
 import scala.concurrent.duration._
 
 import com.google.inject.{ImplementedBy, Inject}
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.{Healthcheck, HealthcheckError, HealthcheckPlugin}
@@ -45,16 +45,16 @@ trait NotificationConsistencyChecker extends Plugin {
 
 class NotificationConsistencyCheckerImpl @Inject()(
     system: ActorSystem,
-    actorWrapper: ActorWrapper[NotificationConsistencyActor],
+    actorProvider: ActorProvider[NotificationConsistencyActor],
     val schedulingProperties: SchedulingProperties) //only on leader
   extends SchedulingPlugin with NotificationConsistencyChecker {
 
   def verifyVisited() {
-    actorWrapper.actor ! VerifyVisited
+    actorProvider.actor ! VerifyVisited
   }
 
   override def onStart() {
-    scheduleTask(system, 2 minutes, 1 hour, actorWrapper.actor, VerifyVisited)
+    scheduleTask(system, 2 minutes, 1 hour, actorProvider.actor, VerifyVisited)
     super.onStart()
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/realtime/NotificationConsistencyChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/realtime/NotificationConsistencyChecker.scala
@@ -49,7 +49,7 @@ class NotificationConsistencyCheckerImpl @Inject()(
     val schedulingProperties: SchedulingProperties) //only on leader
   extends SchedulingPlugin with NotificationConsistencyChecker {
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   def verifyVisited() {
     actor ! VerifyVisited

--- a/kifi-backend/modules/shoebox/app/com/keepit/realtime/UserEmailNotifier.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/realtime/UserEmailNotifier.scala
@@ -159,7 +159,7 @@ class UserEmailNotifierPluginImpl @Inject() (
 
   implicit val actorTimeout = Timeout(5 second)
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   override def enabled: Boolean = true
   override def onStart() {

--- a/kifi-backend/modules/shoebox/app/com/keepit/realtime/UserEmailNotifier.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/realtime/UserEmailNotifier.scala
@@ -3,7 +3,7 @@ package com.keepit.realtime
 import scala.concurrent.duration._
 
 import com.google.inject.Inject
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.akka._
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
@@ -153,22 +153,20 @@ trait UserEmailNotifierPlugin extends SchedulingPlugin {
 }
 
 class UserEmailNotifierPluginImpl @Inject() (
-    actorFactory: ActorFactory[UserEmailNotifierActor],
+    actorWrapper: ActorWrapper[UserEmailNotifierActor],
     val schedulingProperties: SchedulingProperties) //only on leader
   extends UserEmailNotifierPlugin with Logging {
 
   implicit val actorTimeout = Timeout(5 second)
 
-  private lazy val actor = actorFactory.actor
-
   override def enabled: Boolean = true
   override def onStart() {
     log.info("starting UserEmailNotifierPluginImpl")
-    scheduleTask(actorFactory.system, 30 seconds, 2 minutes, actor, SendEmails)
+    scheduleTask(actorWrapper.system, 30 seconds, 2 minutes, actorWrapper.actor, SendEmails)
   }
 
   override def sendEmails() {
-    actor ! SendEmails
+    actorWrapper.actor ! SendEmails
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/realtime/UserEmailNotifier.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/realtime/UserEmailNotifier.scala
@@ -3,7 +3,7 @@ package com.keepit.realtime
 import scala.concurrent.duration._
 
 import com.google.inject.Inject
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.akka._
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
@@ -153,7 +153,7 @@ trait UserEmailNotifierPlugin extends SchedulingPlugin {
 }
 
 class UserEmailNotifierPluginImpl @Inject() (
-    actorWrapper: ActorWrapper[UserEmailNotifierActor],
+    actorProvider: ActorProvider[UserEmailNotifierActor],
     val schedulingProperties: SchedulingProperties) //only on leader
   extends UserEmailNotifierPlugin with Logging {
 
@@ -162,11 +162,11 @@ class UserEmailNotifierPluginImpl @Inject() (
   override def enabled: Boolean = true
   override def onStart() {
     log.info("starting UserEmailNotifierPluginImpl")
-    scheduleTask(actorWrapper.system, 30 seconds, 2 minutes, actorWrapper.actor, SendEmails)
+    scheduleTask(actorProvider.system, 30 seconds, 2 minutes, actorProvider.actor, SendEmails)
   }
 
   override def sendEmails() {
-    actorWrapper.actor ! SendEmails
+    actorProvider.actor ! SendEmails
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/DataIntegrity.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/DataIntegrity.scala
@@ -30,7 +30,7 @@ class DataIntegrityPluginImpl @Inject() (
     val schedulingProperties: SchedulingProperties) //only on leader
   extends Logging with DataIntegrityPlugin {
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
   // plugin lifecycle methods
   override def enabled: Boolean = true
   override def onStart() {

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/DataIntegrity.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/DataIntegrity.scala
@@ -3,7 +3,7 @@ package com.keepit.scraper
 import com.keepit.common.logging.Logging
 import com.google.inject.{Inject, ImplementedBy, Singleton}
 import com.keepit.common.healthcheck.HealthcheckPlugin
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.common.db._
 import com.keepit.common.db.slick._
 import com.keepit.common.db.slick.DBSession._
@@ -26,15 +26,15 @@ import com.keepit.common.plugin.{SchedulingPlugin, SchedulingProperties}
 trait DataIntegrityPlugin extends SchedulingPlugin
 
 class DataIntegrityPluginImpl @Inject() (
-    actorFactory: ActorFactory[DataIntegrityActor],
+    actorWrapper: ActorWrapper[DataIntegrityActor],
     val schedulingProperties: SchedulingProperties) //only on leader
   extends Logging with DataIntegrityPlugin {
 
-  private lazy val actor = actorFactory.actor
+  private lazy val actor = actorWrapper.actor
   // plugin lifecycle methods
   override def enabled: Boolean = true
   override def onStart() {
-    scheduleTask(actorFactory.system, 5 minutes, 1 hour, actor, Cron)
+    scheduleTask(actorWrapper.system, 5 minutes, 1 hour, actorWrapper.actor, Cron)
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/DataIntegrity.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/DataIntegrity.scala
@@ -3,7 +3,7 @@ package com.keepit.scraper
 import com.keepit.common.logging.Logging
 import com.google.inject.{Inject, ImplementedBy, Singleton}
 import com.keepit.common.healthcheck.HealthcheckPlugin
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.common.db._
 import com.keepit.common.db.slick._
 import com.keepit.common.db.slick.DBSession._
@@ -26,15 +26,15 @@ import com.keepit.common.plugin.{SchedulingPlugin, SchedulingProperties}
 trait DataIntegrityPlugin extends SchedulingPlugin
 
 class DataIntegrityPluginImpl @Inject() (
-    actorWrapper: ActorWrapper[DataIntegrityActor],
+    actorProvider: ActorProvider[DataIntegrityActor],
     val schedulingProperties: SchedulingProperties) //only on leader
   extends Logging with DataIntegrityPlugin {
 
-  private lazy val actor = actorWrapper.actor
+  private lazy val actor = actorProvider.actor
   // plugin lifecycle methods
   override def enabled: Boolean = true
   override def onStart() {
-    scheduleTask(actorWrapper.system, 5 minutes, 1 hour, actorWrapper.actor, Cron)
+    scheduleTask(actorProvider.system, 5 minutes, 1 hour, actorProvider.actor, Cron)
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/Scraper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/Scraper.scala
@@ -7,7 +7,7 @@ import com.keepit.common.time._
 import com.keepit.common.net.URI
 import com.keepit.search.ArticleStore
 import com.keepit.model._
-import com.keepit.scraper.extractor.DefaultExtractorFactory
+import com.keepit.scraper.extractor.DefaultExtractorWrapper
 import com.keepit.scraper.extractor.Extractor
 import com.keepit.scraper.mediatypes.MediaTypes
 import com.keepit.search.LangDetector
@@ -170,12 +170,12 @@ class Scraper @Inject() (
           }.getOrElse(throw new Exception("failed to find an extractor factory"))
         case Failure(_) =>
           log.warn("uri parsing failed: [%s]".format(url))
-          DefaultExtractorFactory(url)
+          DefaultExtractorWrapper(url)
       }
     } catch {
       case e: Throwable =>
           log.warn("uri parsing failed: [%s][%s]".format(url, e.toString))
-          DefaultExtractorFactory(url)
+          DefaultExtractorWrapper(url)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/Scraper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/Scraper.scala
@@ -7,7 +7,7 @@ import com.keepit.common.time._
 import com.keepit.common.net.URI
 import com.keepit.search.ArticleStore
 import com.keepit.model._
-import com.keepit.scraper.extractor.DefaultExtractorWrapper
+import com.keepit.scraper.extractor.DefaultExtractorProvider
 import com.keepit.scraper.extractor.Extractor
 import com.keepit.scraper.mediatypes.MediaTypes
 import com.keepit.search.LangDetector
@@ -170,12 +170,12 @@ class Scraper @Inject() (
           }.getOrElse(throw new Exception("failed to find an extractor factory"))
         case Failure(_) =>
           log.warn("uri parsing failed: [%s]".format(url))
-          DefaultExtractorWrapper(url)
+          DefaultExtractorProvider(url)
       }
     } catch {
       case e: Throwable =>
           log.warn("uri parsing failed: [%s][%s]".format(url, e.toString))
-          DefaultExtractorWrapper(url)
+          DefaultExtractorProvider(url)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperPlugin.scala
@@ -1,7 +1,7 @@
 package com.keepit.scraper
 
 import com.keepit.common.healthcheck.HealthcheckPlugin
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.google.inject.Inject
 import com.keepit.common.logging.Logging
 import com.keepit.model.NormalizedURI
@@ -44,20 +44,18 @@ trait ScraperPlugin extends Plugin {
 }
 
 class ScraperPluginImpl @Inject() (
-    actorFactory: ActorFactory[ScraperActor],
+    actorWrapper: ActorWrapper[ScraperActor],
     scraper: Scraper,
     val schedulingProperties: SchedulingProperties) //only on leader
   extends ScraperPlugin with SchedulingPlugin with Logging {
 
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.actor
-
   // plugin lifecycle methods
   override def enabled: Boolean = true
   override def onStart() {
     log.info("starting ScraperPluginImpl")
-    scheduleTask(actorFactory.system, 30 seconds, 1 minutes, actor, Scrape)
+    scheduleTask(actorWrapper.system, 30 seconds, 1 minutes, actorWrapper.actor, Scrape)
   }
   override def onStop() {
     log.info("stopping ScraperPluginImpl")
@@ -65,11 +63,11 @@ class ScraperPluginImpl @Inject() (
   }
 
   override def scrape(): Seq[(NormalizedURI, Option[Article])] = {
-    val future = actor.ask(Scrape)(1 minutes).mapTo[Seq[(NormalizedURI, Option[Article])]]
+    val future = actorWrapper.actor.ask(Scrape)(1 minutes).mapTo[Seq[(NormalizedURI, Option[Article])]]
     Await.result(future, 1 minutes)
   }
 
   override def asyncScrape(uri: NormalizedURI): Future[(NormalizedURI, Option[Article])] = {
-    actor.ask(ScrapeInstance(uri))(1 minutes).mapTo[(NormalizedURI, Option[Article])]
+    actorWrapper.actor.ask(ScrapeInstance(uri))(1 minutes).mapTo[(NormalizedURI, Option[Article])]
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperPlugin.scala
@@ -51,7 +51,7 @@ class ScraperPluginImpl @Inject() (
 
   implicit val actorTimeout = Timeout(5 seconds)
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   // plugin lifecycle methods
   override def enabled: Boolean = true

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperPlugin.scala
@@ -1,7 +1,7 @@
 package com.keepit.scraper
 
 import com.keepit.common.healthcheck.HealthcheckPlugin
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.google.inject.Inject
 import com.keepit.common.logging.Logging
 import com.keepit.model.NormalizedURI
@@ -44,7 +44,7 @@ trait ScraperPlugin extends Plugin {
 }
 
 class ScraperPluginImpl @Inject() (
-    actorWrapper: ActorWrapper[ScraperActor],
+    actorProvider: ActorProvider[ScraperActor],
     scraper: Scraper,
     val schedulingProperties: SchedulingProperties) //only on leader
   extends ScraperPlugin with SchedulingPlugin with Logging {
@@ -55,7 +55,7 @@ class ScraperPluginImpl @Inject() (
   override def enabled: Boolean = true
   override def onStart() {
     log.info("starting ScraperPluginImpl")
-    scheduleTask(actorWrapper.system, 30 seconds, 1 minutes, actorWrapper.actor, Scrape)
+    scheduleTask(actorProvider.system, 30 seconds, 1 minutes, actorProvider.actor, Scrape)
   }
   override def onStop() {
     log.info("stopping ScraperPluginImpl")
@@ -63,11 +63,11 @@ class ScraperPluginImpl @Inject() (
   }
 
   override def scrape(): Seq[(NormalizedURI, Option[Article])] = {
-    val future = actorWrapper.actor.ask(Scrape)(1 minutes).mapTo[Seq[(NormalizedURI, Option[Article])]]
+    val future = actorProvider.actor.ask(Scrape)(1 minutes).mapTo[Seq[(NormalizedURI, Option[Article])]]
     Await.result(future, 1 minutes)
   }
 
   override def asyncScrape(uri: NormalizedURI): Future[(NormalizedURI, Option[Article])] = {
-    actorWrapper.actor.ask(ScrapeInstance(uri))(1 minutes).mapTo[(NormalizedURI, Option[Article])]
+    actorProvider.actor.ask(ScrapeInstance(uri))(1 minutes).mapTo[(NormalizedURI, Option[Article])]
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/DefaultExtractor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/DefaultExtractor.scala
@@ -13,7 +13,7 @@ import org.xml.sax.ContentHandler
 import play.api.http.MimeTypes
 
 
-object DefaultExtractorFactory extends ExtractorFactory {
+object DefaultExtractorWrapper extends ExtractorWrapper {
   def isDefinedAt(uri: URI) = true
   def apply(uri: URI) = new DefaultExtractor(uri.toString, Scraper.maxContentChars, htmlMapper)
   def apply(url: String) = new DefaultExtractor(url, Scraper.maxContentChars, htmlMapper)

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/DefaultExtractor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/DefaultExtractor.scala
@@ -13,7 +13,7 @@ import org.xml.sax.ContentHandler
 import play.api.http.MimeTypes
 
 
-object DefaultExtractorWrapper extends ExtractorWrapper {
+object DefaultExtractorProvider extends ExtractorProvider {
   def isDefinedAt(uri: URI) = true
   def apply(uri: URI) = new DefaultExtractor(uri.toString, Scraper.maxContentChars, htmlMapper)
   def apply(url: String) = new DefaultExtractor(url, Scraper.maxContentChars, htmlMapper)

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/Extractor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/Extractor.scala
@@ -5,9 +5,9 @@ import com.keepit.scraper.HttpInputStream
 
 object Extractor {
   val factories = Seq(
-    YoutubeExtractorFactory,
-    GithubExtractorFactory,
-    DefaultExtractorFactory
+    YoutubeExtractorWrapper,
+    GithubExtractorWrapper,
+    DefaultExtractorWrapper
   )
 }
 trait Extractor {
@@ -16,5 +16,5 @@ trait Extractor {
   def getMetadata(name: String): Option[String]
 }
 
-abstract class ExtractorFactory extends PartialFunction[URI, Extractor]
+abstract class ExtractorWrapper extends PartialFunction[URI, Extractor]
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/Extractor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/Extractor.scala
@@ -5,9 +5,9 @@ import com.keepit.scraper.HttpInputStream
 
 object Extractor {
   val factories = Seq(
-    YoutubeExtractorWrapper,
-    GithubExtractorWrapper,
-    DefaultExtractorWrapper
+    YoutubeExtractorProvider,
+    GithubExtractorProvider,
+    DefaultExtractorProvider
   )
 }
 trait Extractor {
@@ -16,5 +16,5 @@ trait Extractor {
   def getMetadata(name: String): Option[String]
 }
 
-abstract class ExtractorWrapper extends PartialFunction[URI, Extractor]
+abstract class ExtractorProvider extends PartialFunction[URI, Extractor]
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/GithubExtractor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/GithubExtractor.scala
@@ -10,7 +10,7 @@ import org.xml.sax.Attributes
 import org.xml.sax.ContentHandler
 import org.jsoup.nodes.Document
 
-object GithubExtractorFactory extends ExtractorFactory {
+object GithubExtractorWrapper extends ExtractorWrapper {
   def isDefinedAt(uri: URI) = {
     uri match {
       case URI(_, _, Some(Host("com", "github", _*)), _, Some(path), Some(query), _) =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/GithubExtractor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/GithubExtractor.scala
@@ -10,7 +10,7 @@ import org.xml.sax.Attributes
 import org.xml.sax.ContentHandler
 import org.jsoup.nodes.Document
 
-object GithubExtractorWrapper extends ExtractorWrapper {
+object GithubExtractorProvider extends ExtractorProvider {
   def isDefinedAt(uri: URI) = {
     uri match {
       case URI(_, _, Some(Host("com", "github", _*)), _, Some(path), Some(query), _) =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/YoutubeExtractor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/YoutubeExtractor.scala
@@ -10,7 +10,7 @@ import org.apache.tika.parser.html.HtmlMapper
 import org.xml.sax.Attributes
 import org.xml.sax.ContentHandler
 
-object YoutubeExtractorWrapper extends ExtractorWrapper {
+object YoutubeExtractorProvider extends ExtractorProvider {
   def isDefinedAt(uri: URI) = {
     uri match {
       case URI(_, _, Some(Host("com", "youtube", _*)), _, Some(path), Some(query), _) =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/YoutubeExtractor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/YoutubeExtractor.scala
@@ -10,7 +10,7 @@ import org.apache.tika.parser.html.HtmlMapper
 import org.xml.sax.Attributes
 import org.xml.sax.ContentHandler
 
-object YoutubeExtractorFactory extends ExtractorFactory {
+object YoutubeExtractorWrapper extends ExtractorWrapper {
   def isDefinedAt(uri: URI) = {
     uri match {
       case URI(_, _, Some(Host("com", "youtube", _*)), _, Some(path), Some(query), _) =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/PhraseImporter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/PhraseImporter.scala
@@ -3,7 +3,7 @@ package com.keepit.shoebox
 import java.io._
 import com.keepit.common.healthcheck.HealthcheckPlugin
 import com.keepit.common.akka.FortyTwoActor
-import com.keepit.common.actor.ActorWrapper
+import com.keepit.common.actor.ActorProvider
 import com.keepit.search.Lang
 import com.keepit.common.db.Id
 import com.keepit.common.logging.Logging
@@ -94,12 +94,12 @@ trait PhraseImporter {
 }
 
 class PhraseImporterImpl @Inject()(
-    actorWrapper: ActorWrapper[PhraseImporterActor],
+    actorProvider: ActorProvider[PhraseImporterActor],
     EventPersister: EventPersister)
   extends PhraseImporter {
 
   def importFile(file: File): Unit = {
-    actorWrapper.actor ! ImportFile(file)
+    actorProvider.actor ! ImportFile(file)
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/PhraseImporter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/PhraseImporter.scala
@@ -98,7 +98,7 @@ class PhraseImporterImpl @Inject()(
     EventPersister: EventPersister)
   extends PhraseImporter {
 
-  private lazy val actor = actorFactory.get()
+  private lazy val actor = actorFactory.actor
 
   def importFile(file: File): Unit = {
     actor ! ImportFile(file)

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/PhraseImporter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/PhraseImporter.scala
@@ -3,7 +3,7 @@ package com.keepit.shoebox
 import java.io._
 import com.keepit.common.healthcheck.HealthcheckPlugin
 import com.keepit.common.akka.FortyTwoActor
-import com.keepit.common.actor.ActorFactory
+import com.keepit.common.actor.ActorWrapper
 import com.keepit.search.Lang
 import com.keepit.common.db.Id
 import com.keepit.common.logging.Logging
@@ -94,14 +94,12 @@ trait PhraseImporter {
 }
 
 class PhraseImporterImpl @Inject()(
-    actorFactory: ActorFactory[PhraseImporterActor],
+    actorWrapper: ActorWrapper[PhraseImporterActor],
     EventPersister: EventPersister)
   extends PhraseImporter {
 
-  private lazy val actor = actorFactory.actor
-
   def importFile(file: File): Unit = {
-    actor ! ImportFile(file)
+    actorWrapper.actor ! ImportFile(file)
   }
 }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/scraper/extractor/GithubExtractorTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/scraper/extractor/GithubExtractorTest.scala
@@ -11,7 +11,7 @@ class GithubExtractorTest extends Specification {
   def setup(url: String, file: String): String = {
     val uri = URI.parse(url).get
     val stream = new FileInputStream("modules/shoebox/test/com/keepit/scraper/extractor/" + file)
-    val extractor = GithubExtractorWrapper(uri)
+    val extractor = GithubExtractorProvider(uri)
     extractor.process(new HttpInputStream(stream))
 
     extractor.getContent()

--- a/kifi-backend/modules/shoebox/test/com/keepit/scraper/extractor/GithubExtractorTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/scraper/extractor/GithubExtractorTest.scala
@@ -11,7 +11,7 @@ class GithubExtractorTest extends Specification {
   def setup(url: String, file: String): String = {
     val uri = URI.parse(url).get
     val stream = new FileInputStream("modules/shoebox/test/com/keepit/scraper/extractor/" + file)
-    val extractor = GithubExtractorFactory(uri)
+    val extractor = GithubExtractorWrapper(uri)
     extractor.process(new HttpInputStream(stream))
 
     extractor.getContent()


### PR DESCRIPTION
I noticed that its not clear that all the classes that holds a ref to an actor are singletons which may lead to creation of few actor instances of the same type which is exactly what we don't want to happen.
- This change makes the actor factory a singleton (per actor type) and stores a singleton instance of the actor within it. I.e. it does not trust the wrapper class to hold the actor ref.
- in addition, no need to store a ref to the actor anymore. 
- renaming factory to wrapper since we're not creating a new actor on every access

/cc @andrewconner  & @gmethvin for actors foo
