### PR TITLE
using tuple instead of string for secondary sort

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -264,7 +264,7 @@ class UserController @Inject() (
           }
           (suc, status)
         }
-      }) sortBy { case (sui, status) => s"$status ${sui.fullName}" }
+      }) sortBy { case (sui, status) => (status, sui.fullName) }
     }
 
     Ok(JsArray(connections.map { conn =>


### PR DESCRIPTION
(Didn't know about this before today, but knew Scala's vast standard library had to provide a better way.)
