### PR TITLE
2.4.31: using Visibility API to guide when we mark messages read

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -568,14 +568,6 @@ api = function() {
       get: function(tabId) {
         return pages[tabId];
       },
-      isSelected: function(tab) {
-        for (var winId in selectedTabIds) {
-          if (selectedTabIds[winId] === tab.id) {
-            return true;
-          }
-        }
-        return false;
-      },
       isFocused: function(tab) {
         return selectedTabIds[focusedWinId] === tab.id;
       },

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -353,10 +353,6 @@ exports.tabs = {
     var tab = tabsById[page.id], win = tab.window;
     return win === windows.activeWindow && tab === win.tabs.activeTab;
   },
-  isSelected: function(page) {
-    var tab = tabsById[page.id], win = tab.window;
-    return tab === win.tabs.activeTab;
-  },
   navigate: function(tabId, url) {
     var tab = tabsById[tabId], win;
     if (tab) {

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.4.30
+version=2.4.31

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -332,9 +332,7 @@ const socketHandlers = {
         }
       }
       d.tabs.forEach(function(tab) {
-        whenTabSelected(tab, function (tab) {
-          api.tabs.emit(tab, "message", {thread: th, message: message, read: d.lastMessageRead[th.id], userId: session.userId});
-        });
+        api.tabs.emit(tab, "message", {thread: th, message: message, read: d.lastMessageRead[th.id], userId: session.userId});
       });
       tellTabsIfCountChanged(d, "m", messageCount(d));
     }
@@ -910,21 +908,10 @@ function clone(o) {
   return c;
 }
 
-function whenTabSelected(tab, callback) {
-  if (api.tabs.isSelected(tab)) {
-    callback(tab);
-  } else {
-    (tab.focusCallbacks = tab.focusCallbacks || []).push(callback);
-  }
-}
 // ===== Browser event listeners
 
 api.tabs.on.focus.add(function(tab) {
   api.log("#b8a", "[tabs.on.focus] %i %o", tab.id, tab);
-  for (var cb; tab.focusCallbacks && (cb = tab.focusCallbacks.shift());) {
-    cb(tab);
-  }
-  delete tab.focusCallbacks;
   subscribe(tab);
   if (tab.autoShowSec != null && !tab.autoShowTimer) {
     scheduleAutoShow(tab);

--- a/packrat/scripts/thread.js
+++ b/packrat/scripts/thread.js
@@ -136,6 +136,12 @@ threadPane = function() {
   }
 
   function emitRead(threadId, m) {
-    api.port.emit("set_message_read", {threadId: threadId, messageId: m.id, time: m.createdAt});
+    var hidden = 'hidden' in document ? 'hidden' : 'webkitHidden';
+    if (document[hidden]) {
+      api.log("[emitRead] waiting (hidden)", m.id);
+      $(document).off('.thread').one('visibilitychange.thread webkitvisibilitychange.thread', emitRead.bind(this, threadId, m));
+    } else {
+      api.port.emit("set_message_read", {threadId: threadId, messageId: m.id, time: m.createdAt});
+    }
   }
 }();


### PR DESCRIPTION
This has the advantage that we won't mark messages read if the browser window is minified, even if the page getting the messages is on the selected tab in that minified window.

Another advantage (or difference) compared to the other approach is that we still render the message immediately this way. If we were to decide to animate message arrival, this would ensure that the animation wouldn't be run when someone switches to a tab that has received messages while the tab was hidden (which might give the false impression that they had just arrived).
