### PR TITLE
Fix annoying style leak

### DIFF
--- a/packrat/styles/metro/thread.css
+++ b/packrat/styles/metro/thread.css
@@ -48,6 +48,9 @@ img.kifi-message-pic.kifi-self {
   margin-left: 45px;
   word-wrap: break-word;
 }
+.kifi-message-body p {
+  clear: none;
+}
 .kifi-message-name {
   position: relative;
   top: -2px;


### PR DESCRIPTION
This happens on stack overflow and some other sites. I think having `p { clear: both }` is pretty common so it's worth doing.
