### PR TITLE
Don't include empty notifications in counting the client requests

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/UserThreadRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/UserThreadRepo.scala
@@ -181,7 +181,7 @@ class UserThreadRepoImpl @Inject() (
   }
 
   def getLatestSendableNotifications(userId: Id[User], howMany: Int)(implicit session: RSession): Seq[JsObject] = {
-    val rawNotifications = (for (row <- table if row.user === userId) yield row)
+    val rawNotifications = (for (row <- table if row.user === userId && row.lastNotification=!=JsNull.asInstanceOf[JsValue] && row.lastNotification=!=null.asInstanceOf[JsValue]) yield row)
                             .sortBy(row => (row.notificationUpdatedAt) desc)
                             .take(howMany).map(row => row.lastNotification ~ row.notificationPending)
                             .list
@@ -193,7 +193,7 @@ class UserThreadRepoImpl @Inject() (
   }
 
   def getSendableNotificationsAfter(userId: Id[User], after: DateTime)(implicit session: RSession): Seq[JsObject] = {
-    val rawNotifications = (for (row <- table if row.user===userId && row.notificationUpdatedAt > after) yield row)
+    val rawNotifications = (for (row <- table if row.user===userId && row.notificationUpdatedAt > after && row.lastNotification=!=JsNull.asInstanceOf[JsValue] && row.lastNotification=!=null.asInstanceOf[JsValue]) yield row)
                             .sortBy(row => (row.notificationUpdatedAt) desc)
                             .map(row => row.lastNotification ~ row.notificationPending) 
                             .list
@@ -201,7 +201,7 @@ class UserThreadRepoImpl @Inject() (
   }
 
   def getSendableNotificationsBefore(userId: Id[User], before: DateTime, howMany: Int)(implicit session: RSession): Seq[JsObject] = {
-    val rawNotifications = (for (row <- table if row.user===userId && row.notificationUpdatedAt < before) yield row)
+    val rawNotifications = (for (row <- table if row.user===userId && row.notificationUpdatedAt < before && row.lastNotification=!=JsNull.asInstanceOf[JsValue] &&row.lastNotification=!=null.asInstanceOf[JsValue]) yield row)
                             .sortBy(row => (row.notificationUpdatedAt) desc)
                             .map(row => row.lastNotification ~ row.notificationPending)
                             .take(howMany) 

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
@@ -83,10 +83,12 @@ class MessagingTest extends Specification with DbTestInjector {
         notified.isDefinedAt(user1)===false
         notified(user2)===2
 
+        messagingController.getLatestSendableNotifications(user3, 10)
 
         messagingController.getPendingNotifications(user3).length===1 //there was only one thread created due to merging
         messagingController.setAllNotificationsRead(user3)
         messagingController.getPendingNotifications(user3).length===0
+
       }
     }
 


### PR DESCRIPTION
Unnecessarily complicated due to the json null deserialization bug in play
