### PR TITLE
fix clipping of enter to send menu

### DIFF
--- a/packrat/styles/metro/pane.css
+++ b/packrat/styles/metro/pane.css
@@ -296,6 +296,8 @@ a.kifi-pane-back::after {
   right: 0;
   bottom: 0;
   background: #fafafa;
+}
+.kifi-pane-notices>.kifi-pane-tall {
   overflow: hidden;
 }
 .kifi-pane-tall .kifi-scroll-inner {


### PR DESCRIPTION
Removing this CSS rule doesn't seem to affect anything else in the UI.
