### PR TITLE
Maybe fixing all the integrity constriant violations

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
@@ -84,7 +84,7 @@ case class NormalizedURIKey(id: Id[NormalizedURI]) extends Key[NormalizedURI] {
 }
 
 case class NormalizedURIUrlHashKey(urlHash: UrlHash) extends Key[NormalizedURI] {
-  override val version = 0
+  override val version = 1
   val namespace = "uri_by_hash"
   def toKey(): String = urlHash.hash
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -28,7 +28,7 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Singleton
   @Provides
   def normalizedURIUrlHashCache(innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new NormalizedURIUrlHashCache((innerRepo, 1 second), (outerRepo, 7 days))
+    new NormalizedURIUrlHashCache((outerRepo, 7 days))
 
   @Provides @Singleton
   def prepUrlHashToMappedUrlCache(innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =


### PR DESCRIPTION
Did some digging and found a few things:
-The extensions causes (at least) two calls to internByUri on each page load. One through Eliza when looking up threads (the first) and one through /ext/canonical, as far as I can tell. There is a 50% chance that those will go to different machines, so the locking won't help at all.
-The cache for NormaliedUri by hash has an in memory inner cache! This explains why reties didn't help: The inner cache (correctly) contained a None and the retries
-I checked the cache for a few of the offending hashes and found some oddities. There was at least one stale None and several entirely missing entries. Not sure yet how that happened.

This removes the inner cache and increases the cache version to get rid of incorrect data.
@eishay @leogrim @yingjieMiao 
