### PR TITLE
avoiding missing keeper background (occurs when tile.css added after slider2.css

### DIFF
--- a/packrat/scripts/slider2.js
+++ b/packrat/scripts/slider2.js
@@ -1,3 +1,4 @@
+// @require styles/metro/tile.css
 // @require styles/metro/slider2.css
 // @require styles/friend_card.css
 // @require scripts/lib/jquery.js


### PR DESCRIPTION
I observed this happen as a result of `open_to` arriving in a page with a new message before the `init` message.
