### PR TITLE
Fixing bug when we have pageData, but no registered tabs because the extension was reloaded.

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -614,7 +614,7 @@ api.port.on({
   },
   open_deep_link: function(data, _, tab) {
     var uriData = pageData[data.nUri];
-    if (uriData) {
+    if (uriData && uriData.tabs[0]) {
       var tab = tab.nUri == data.nUri ? tab : uriData.tabs[0];
       if (tab.ready) {
         api.tabs.emit(tab, "open_to", {trigger: "deepLink", locator: data.locator});


### PR DESCRIPTION
This can happen when the user has two of the same site open in their browser, the extension is reloaded, they close one of the tabs, and never select the other tab. We have pageData, but no known tabs.
