### PR TITLE
Better CSS specificity

### DIFF
--- a/packrat/html/metro/pane.html
+++ b/packrat/html/metro/pane.html
@@ -1,7 +1,7 @@
 <div class="kifi-pane">
   <div class="kifi-pane-head">
     <div class="kifi-pane-head-settings">
-      <a href="javascript:" style="background-image:url({{cdnBase}}/users/{{session.userId}}/pics/100/0.jpg)"></a>
+      <a href="javascript:" class="kifi-pane-head-settings-picture" style="background-image:url({{cdnBase}}/users/{{session.userId}}/pics/100/0.jpg)"></a>
     </div>
     <div class="kifi-pane-head-settings-menu">
       <div class="kifi-pane-settings-menu-no-select">Logged in as {{session.name}}</div>

--- a/packrat/styles/metro/pane.css
+++ b/packrat/styles/metro/pane.css
@@ -103,7 +103,7 @@ div.kifi-pane-head-settings {
   position: relative;
   z-index: 1;
 }
-div.kifi-pane-head-settings a {
+div.kifi-pane-head-settings .kifi-pane-head-settings-picture {
   width: 30px;
   height: 30px;
   background-size: 30px;
@@ -145,11 +145,13 @@ div.kifi-pane-head-settings-menu {
   -webkit-user-select: none;
   -moz-user-select: none;
 }
-.kifi-pane-head-settings-menu div {
+.kifi-pane-settings-menu-item, .kifi-pane-settings-menu-no-select {
   padding: 6px 10px 6px 6px;
   border: 1px solid transparent;
 }
 .kifi-pane-settings-menu-no-select {
+  user-select: none;
+  cursor: default;
   margin-left: 12px;
 }
 .kifi-pane-settings-menu-item:hover,


### PR DESCRIPTION
@2is10 removed selecting on `div` and `a`. Left the `div` wrapper around the settings head because of backgrounds. If I'm missing another way to do it, let me know.
