### PR TITLE
Notification race condition

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -485,7 +485,14 @@ api.port.on({
   },
   set_message_read: function(o, _, tab) {
     var d = pageData[tab.nUri];
-    if (!d || !d.lastMessageRead || new Date(o.time) > new Date(d.lastMessageRead[o.threadId] || 0)) {
+    var unreadNotification = false;
+    for (var i = 0; i < notifications.length; i++) {
+      if (notifications[i].messageId == o.id && notifications[i].unread) {
+        unreadNotification = true;
+      }
+    }
+    
+    if (unreadNotification || (!d || !d.lastMessageRead || new Date(o.time) > new Date(d.lastMessageRead[o.threadId] || 0))) {
       markNoticesVisited("message", tab.nUri, o.messageId, o.time, "/messages/" + o.threadId);
       if (d && d.lastMessageRead) {
         d.lastMessageRead[o.threadId] = o.time;


### PR DESCRIPTION
There's a race condition for when the last message seen is the latest message, but the notification is still marked as unread on the server. This sends the set_message_read message in that case.
