### PR TITLE
avoiding style leaks

### DIFF
--- a/packrat/html/metro/thread.html
+++ b/packrat/html/metro/thread.html
@@ -9,5 +9,5 @@
   <p class="kifi-thread-snippet">
     {{#formatSnippet}}{{{digest}}}{{/formatSnippet}}
   </p>
-  <span class="kifi-thread-arrow"></span>
+  <span class="kifi-thread-arr"></span>
 </div>

--- a/packrat/styles/metro/slider2.css
+++ b/packrat/styles/metro/slider2.css
@@ -16,6 +16,7 @@
   font-weight: inherit;
   font-style: inherit;
   text-transform: none;
+  text-shadow: none;
   text-indent: 0;
   background: transparent;
   color: inherit;

--- a/packrat/styles/metro/slider2.css
+++ b/packrat/styles/metro/slider2.css
@@ -78,6 +78,16 @@
 .kifi-pane ::-webkit-input-placeholder {
   font-style: inherit;
 }
+.kifi-slider2 ::selection,
+.kifi-pane ::selection {
+  background-color: initial;
+  color: initial;
+}
+.kifi-slider2 ::-moz-selection,
+.kifi-pane ::-moz-selection {
+  background-color: -moz-html-CellHighlight;
+  color: -moz-html-CellHighlightText;
+}
 
 .kifi-tile>.kifi-slider2-tip {
   right: 0;

--- a/packrat/styles/metro/slider2.css
+++ b/packrat/styles/metro/slider2.css
@@ -16,6 +16,7 @@
   font-weight: inherit;
   font-style: inherit;
   text-transform: none;
+  text-indent: 0;
   background: transparent;
   color: inherit;
   border: none;

--- a/packrat/styles/metro/threads.css
+++ b/packrat/styles/metro/threads.css
@@ -67,7 +67,7 @@ span.kifi-thread-msg-count {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.kifi-thread-arrow {
+.kifi-thread-arr {
   position: absolute;
   top: 21px;
   right: 11px;
@@ -75,7 +75,7 @@ span.kifi-thread-msg-count {
   height: 9px;
   overflow: hidden;
 }
-.kifi-thread-arrow::before {
+.kifi-thread-arr::before {
   content: "\21e7";
   position: absolute;
   top: -10px;

--- a/packrat/styles/metro/tile.css
+++ b/packrat/styles/metro/tile.css
@@ -18,6 +18,7 @@
   text-align: center;
   font-family: "Helvetica Neue",arial,sans-serif;
   text-transform: none;
+  text-shadow: none;
   transition: -webkit-transform 90ms ease-in-out;
   transition: transform 90ms ease-in-out;
   -webkit-perspective: 200px;


### PR DESCRIPTION
Note that its seems that the system default selection color behavior is not quite possible to restore in Firefox. This just changes the colors to fixed system highlight colors (not quite what Firefox normally uses).
