### PR TITLE
sending canonical URL(s) along with user actions associated with a page

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/ExtMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/ExtMessagingController.scala
@@ -47,7 +47,6 @@ class ExtMessagingController @Inject() (
       (o \ "text").as[String].trim,
       (o \ "recipients").as[Seq[String]])
 
-    // TODO: factor out NormalizedURI interning so that it's only done once instead of once per recipient
     val responseFuture = messagingController.constructRecipientSet(recipients.map(ExternalId[User](_))).map{ recipientSet =>
       // TODO: propagate "canonical" & "og" to shoebox along with "url" to intern the NormalizedURI
       val message : Message = messagingController.sendNewMessage(request.user.id.get, recipientSet, Some(urlStr), title, text)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
@@ -42,6 +42,7 @@ class ExtBookmarksController @Inject() (
   def remove() = AuthenticatedJsonToJsonAction { request =>
     val url = (request.body \ "url").as[String]
     val bookmark = db.readWrite { implicit s =>
+      // TODO: use uriRepo.internByUri(url, NormalizationCandidate(json):_*) to utilize "canonical" & "og"
       uriRepo.getByUri(url).flatMap { uri =>
         bookmarkRepo.getByUriAndUser(uri.id.get, request.userId).map { b =>
           bookmarkRepo.save(b.withActive(false))
@@ -59,6 +60,7 @@ class ExtBookmarksController @Inject() (
     val json = request.body
     val (url, priv) = ((json \ "url").as[String], (json \ "private").as[Boolean])
     db.readWrite { implicit s =>
+      // TODO: use uriRepo.internByUri(url, NormalizationCandidate(json):_*) to utilize "canonical" & "og"
       uriRepo.getByUri(url).flatMap { uri =>
         bookmarkRepo.getByUriAndUser(uri.id.get, request.userId).filter(_.isPrivate != priv).map {b =>
           bookmarkRepo.save(b.withPrivate(priv))

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -410,6 +410,8 @@ api.port.on({
     var bm = {
       title: data.title,
       url: data.url,
+      canonical: data.canonical,
+      og: data.og,
       isPrivate: data.how == "private"};
     postBookmarks(function(f) {f([bm])}, "HOVER_KEEP");
     pageData[tab.nUri].tabs.forEach(function(tab) {
@@ -417,10 +419,10 @@ api.port.on({
       api.tabs.emit(tab, "kept", {kept: data.how});
     });
   },
-  unkeep: function(_, _, tab) {
-    api.log("[unkeep]", tab.url);
+  unkeep: function(data, _, tab) {
+    api.log("[unkeep]", data);
     delete (pageData[tab.nUri] || {}).kept;
-    ajax("POST", "/bookmarks/remove", {url: tab.url}, function(o) {
+    ajax("POST", "/bookmarks/remove", data, function(o) {
       api.log("[unkeep] response:", o);
     });
     pageData[tab.nUri].tabs.forEach(function(tab) {
@@ -428,13 +430,13 @@ api.port.on({
       api.tabs.emit(tab, "kept", {kept: null});
     });
   },
-  set_private: function(priv, _, tab) {
-    api.log("[setPrivate]", tab.url, priv);
-    ajax("POST", "/bookmarks/private", {url: tab.url, private: priv}, function(o) {
+  set_private: function(data, _, tab) {
+    api.log("[setPrivate]", data);
+    ajax("POST", "/bookmarks/private", data, function(o) {
       api.log("[setPrivate] response:", o);
     });
     pageData[tab.nUri].tabs.forEach(function(tab) {
-      api.tabs.emit(tab, "kept", {kept: priv ? "private" : "public"});
+      api.tabs.emit(tab, "kept", {kept: data.private ? "private" : "public"});
     });
   },
   keeper_shown: function(_, _, tab) {
@@ -491,7 +493,7 @@ api.port.on({
         unreadNotification = true;
       }
     }
-    
+
     if (unreadNotification || (!d || !d.lastMessageRead || new Date(o.time) > new Date(d.lastMessageRead[o.threadId] || 0))) {
       markNoticesVisited("message", tab.nUri, o.messageId, o.time, "/messages/" + o.threadId);
       if (d && d.lastMessageRead) {

--- a/packrat/scripts/slider2.js
+++ b/packrat/scripts/slider2.js
@@ -251,7 +251,7 @@ slider2 = function() {
     createSlider(function() {
       $slider.prependTo(tile);
 
-      logEvent("slider", "sliderShown", {trigger: trigger, onPageMs: String(lastShownAt - tile.dataset.t0), url: document.URL});
+      logEvent("slider", "sliderShown", withUrls({trigger: trigger, onPageMs: String(lastShownAt - tile.dataset.t0)}));
       api.port.emit("keeper_shown");
 
       callback && callback();
@@ -356,21 +356,21 @@ slider2 = function() {
   function keepPage(how) {
     api.log("[keepPage]", how);
     updateKeptDom(how);
-    api.port.emit("keep", {url: document.URL, title: document.title, how: how});
+    api.port.emit("keep", withUrls({title: document.title, how: how}));
     logEvent("slider", "keep", {isPrivate: how == "private"});
   }
 
   function unkeepPage() {
     api.log("[unkeepPage]", document.URL);
     updateKeptDom("");
-    api.port.emit("unkeep");
+    api.port.emit("unkeep", withUrls({}));
     logEvent("slider", "unkeep");
   }
 
   function toggleKeep(how) {
     api.log("[toggleKeep]", how);
     updateKeptDom(how);
-    api.port.emit("set_private", how == "private");
+    api.port.emit("set_private", withUrls({private: how == "private"}));
   }
 
   function updateKeptDom(how) {

--- a/packrat/scripts/threads.js
+++ b/packrat/scripts/threads.js
@@ -103,11 +103,10 @@ threadsPane = function() {
 
   function sendMessage($container, e, text, recipientIds) {
     // logEvent("slider", "message");
-    api.port.emit("send_message", {
-        url: document.URL,
+    api.port.emit("send_message", withUrls({
         title: document.title,
         text: text,
-        recipients: recipientIds},
+        recipients: recipientIds}),
       function(resp) {
         api.log("[sendMessage] resp:", resp);
         var friends = $container.find(".kifi-compose-to").data("friends").reduce(function(o, f) {


### PR DESCRIPTION
@leogrim @yingjieMiao @stkem 

Also no longer posting canonical URLs to `/ext/canonical` on every applicable page load.

Note that there is a `TODO` in eliza to propagate canonical URLs to shoebox. (I updated shoebox to optionally accept them from eliza.)
