### PR TITLE
fix test

### DIFF
--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
@@ -42,11 +42,12 @@ class UriIntegrityPluginTest extends Specification with ShoeboxApplicationInject
             val url2 = urlRepo.save(URLFactory("http://www.fakebing.com/index", nuri2.id.get))        // to be splitted, to be pointing to
             
             val user = userRepo.save(User(firstName = "foo", lastName = "bar"))
+            val user2 = userRepo.save(User(firstName = "abc", lastName = "xyz"))
             
             val hover = BookmarkSource("HOVER_KEEP")
             val bm1 = bmRepo.save(Bookmark(title = Some("google"), userId = user.id.get, url = url0.url, urlId = url0.id,  uriId = nuri0.id.get, source = hover))
             val bm2 = bmRepo.save(Bookmark(title = Some("bing"), userId = user.id.get, url = url1.url, urlId = url1.id, uriId = nuri2.id.get, source = hover))
-            val bm3 = bmRepo.save(Bookmark(title = Some("bing"), userId = user.id.get, url = url2.url, urlId = url2.id, uriId = nuri2.id.get, source = hover))
+            val bm3 = bmRepo.save(Bookmark(title = Some("bing"), userId = user2.id.get, url = url2.url, urlId = url2.id, uriId = nuri2.id.get, source = hover))
 
             (Array(nuri0, nuri1, nuri2, nuri3), Array(url0, url1, url2), Array(bm1, bm2, bm3))
           }

--- a/kifi-backend/modules/shoebox/test/com/keepit/reports/GeckoboardBookmarkWidgetsTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/reports/GeckoboardBookmarkWidgetsTest.scala
@@ -49,9 +49,9 @@ GeckoboardBookmarkWidgetsTest extends Specification with ShoeboxApplicationInjec
 
       bookmarkRepo.save(Bookmark(title = Some("G1"), userId = user1.id.get, url = url1.url, urlId = url1.id,
         uriId = uri1.id.get, source = hover, createdAt = t1.plusMinutes(3)))
-      bookmarkRepo.save(Bookmark(title = Some("B1"), userId = user1.id.get, url = url1.url, urlId = url1.id,
-        uriId = uri1.id.get, source = hover, createdAt = t1.plusMinutes(3)))
-      bookmarkRepo.save(Bookmark(title = Some("A1"), userId = user1.id.get, url = url2.url, urlId = url2.id,
+      bookmarkRepo.save(Bookmark(title = Some("B1"), userId = user1.id.get, url = url2.url, urlId = url2.id,
+        uriId = uri2.id.get, source = hover, createdAt = t1.plusMinutes(3)))
+      bookmarkRepo.save(Bookmark(title = Some("A1"), userId = user2.id.get, url = url2.url, urlId = url2.id,
         uriId = uri2.id.get, source = initLoad, createdAt = t1.plusHours(50)))
       bookmarkRepo.save(Bookmark(title = None, userId = user2.id.get, url = url1.url, urlId = url1.id,
         uriId = uri1.id.get, source = hover, createdAt = t2.plusDays(1)))
@@ -69,13 +69,13 @@ GeckoboardBookmarkWidgetsTest extends Specification with ShoeboxApplicationInjec
         inject[KeepersPerWeek].data === NumberAndSecondaryStat(1, 0)
         inject[KeepersPerMonth].data === NumberAndSecondaryStat(1, 0)
 
-        inject[TotalKeepsPerHour].data === NumberAndSecondaryStat(3, 0)
+        inject[TotalKeepsPerHour].data === NumberAndSecondaryStat(2, 0)
         inject[UIKeepsPerHour].data === NumberAndSecondaryStat(2, 0)
-        inject[TotalKeepsPerDay].data === NumberAndSecondaryStat(3, 0)
+        inject[TotalKeepsPerDay].data === NumberAndSecondaryStat(2, 0)
         inject[UIKeepsPerDay].data === NumberAndSecondaryStat(2, 0)
-        inject[TotalKeepsPerWeek].data === NumberAndSecondaryStat(3, 0)
+        inject[TotalKeepsPerWeek].data === NumberAndSecondaryStat(2, 0)
         inject[UIKeepsPerWeek].data === NumberAndSecondaryStat(2, 0)
-        inject[TotalKeepsPerMonth].data === NumberAndSecondaryStat(3, 0)
+        inject[TotalKeepsPerMonth].data === NumberAndSecondaryStat(2, 0)
         inject[UIKeepsPerMonth].data === NumberAndSecondaryStat(2, 0)
       }
     }


### PR DESCRIPTION
@eishay 

The new bookmark repo has a constrain: (user_id, uri_id) is a unique key. These two tests violated the rule.
I modified the GeckoboardBookmarkWidgetsTest a little bit to make it pass. 

Please make sure it still makes sense and do its job. 
