### PR TITLE
proximity query: factored out local alignment, phrase aware local alignmend

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/MainQueryParser.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/MainQueryParser.scala
@@ -104,9 +104,9 @@ class MainQueryParser(
           auxStrengths += phraseProximityBoost
         } else if (proximityBoost > 0.0f && numStemmedTerms > 1) {
           val proxQ = new DisjunctionMaxQuery(0.0f)
-          proxQ.add(ProximityQuery(getStemmedTerms("cs")))
-          proxQ.add(ProximityQuery(getStemmedTerms("ts")))
-          proxQ.add(ProximityQuery(getStemmedTerms("title_stemmed")))
+          proxQ.add(ProximityQuery(getStemmedTerms("cs"), phrases))
+          proxQ.add(ProximityQuery(getStemmedTerms("ts"), phrases))
+          proxQ.add(ProximityQuery(getStemmedTerms("title_stemmed"), phrases))
           auxQueries += namedQuery("proximity", proxQ)
           auxStrengths += proximityBoost
         }

--- a/kifi-backend/modules/search/app/com/keepit/search/query/ProximityQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/ProximityQuery.scala
@@ -1,11 +1,13 @@
 package com.keepit.search.query
 
 import com.keepit.search.index.Searcher
+import com.keepit.search.query.QueryUtil._
+import com.keepit.search.util.AhoCorasick
+import com.keepit.search.util.LocalAlignment
 import org.apache.lucene.index.AtomicReaderContext
 import org.apache.lucene.index.DocsAndPositionsEnum
 import org.apache.lucene.index.IndexReader
 import org.apache.lucene.index.Term
-import com.keepit.search.query.QueryUtil._
 import org.apache.lucene.search.Query
 import org.apache.lucene.search.Scorer
 import org.apache.lucene.search.Weight
@@ -14,22 +16,30 @@ import org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS
 import org.apache.lucene.search.Explanation
 import org.apache.lucene.search.IndexSearcher
 import org.apache.lucene.search.similarities.Similarity
+import org.apache.lucene.util.Bits
 import org.apache.lucene.util.PriorityQueue
 import org.apache.lucene.util.ToStringUtils
 import java.lang.{Float => JFloat}
 import java.util.{Set => JSet}
 import scala.collection.JavaConversions._
 import scala.math._
-import java.util.Arrays
-import org.apache.lucene.util.Bits
 
 object ProximityQuery {
-  def apply(terms: Seq[Term]) = new ProximityQuery(terms)
+  def apply(terms: Seq[Term], phrases: Set[(Int, Int)] = Set()) = new ProximityQuery(terms, phrases)
+
+  def buildPhraseDict(termIds: Array[Int], phrases: Set[(Int, Int)]) = {
+    val notInPhrase = termIds.clone
+    phrases.foreach{ case (pos, len) =>
+      (pos until (pos + len)).foreach{ idx => notInPhrase(idx) = -1 }
+    }
+
+    notInPhrase.filter{ _ >= 0 }.map{ id => (Seq(id), 1) } ++ phrases.map{ case (pos, len) => (termIds.slice(pos, pos + len).toSeq, len) }
+  }
 
   val gapPenalty = 0.05f
 }
 
-class ProximityQuery(val terms: Seq[Term]) extends Query {
+class ProximityQuery(val terms: Seq[Term], val phrases: Set[(Int, Int)] = Set()) extends Query {
 
   override def createWeight(searcher: IndexSearcher): Weight = new ProximityWeight(this)
 
@@ -48,12 +58,24 @@ class ProximityQuery(val terms: Seq[Term]) extends Query {
 }
 
 class ProximityWeight(query: ProximityQuery) extends Weight {
+  // we use first 64 terms (enough?)
+
   private[this] var value = 0.0f
-  private[this] val maxRawScore = {
-    val n = query.terms.size.toFloat
-    // max possible proximity score
-    ((n * (n + 1.0f) / 2.0f) - (ProximityQuery.gapPenalty * n * (n - 1.0f) / 2.0f))
+
+  private[this] val termIdMap = {
+    var id = -1
+    query.terms.take(64).foldLeft(Map.empty[Term, Int]){ (m, term) =>
+      if (m.contains(term)) m
+      else {
+        id += 1
+        m + (term -> id)
+      }
+    }
   }
+  private[this] val termIds = query.terms.take(64).map(termIdMap).toArray
+  private[this] val ac: Option[AhoCorasick[Int, Int]] = if (query.phrases.isEmpty) None else Some(AhoCorasick(ProximityQuery.buildPhraseDict(termIds, query.phrases)))
+
+  private[this] val maxRawScore = LocalAlignment(termIds, ac, ProximityQuery.gapPenalty).maxScore
 
   def getWeightValue = value / maxRawScore
 
@@ -74,7 +96,13 @@ class ProximityWeight(query: ProximityQuery) extends Weight {
 
     val result = new ComplexExplanation()
     if (exists) {
-      result.setDescription("proximity(%s), product of:".format(query.terms.mkString(",")))
+      val phrasesOpt = if (query.phrases.isEmpty) {
+        None
+      } else {
+        Some(query.phrases.map{ case (pos, len) => query.terms.slice(pos , pos + len).mkString(" ") }.mkString("[", " ; ", "]"))
+      }
+
+      result.setDescription("proximity(%s), product of:".format(query.terms.mkString(",") + phrasesOpt.getOrElse("")))
       val proxScore = sc.score
       result.setValue(proxScore)
       result.setMatch(true)
@@ -92,25 +120,22 @@ class ProximityWeight(query: ProximityQuery) extends Weight {
 
   override def scorer(context: AtomicReaderContext, scoreDocsInOrder: Boolean, topScorer: Boolean, acceptDocs: Bits): Scorer = {
     if (query.terms.size > 0) {
-      var i = -1
-      // uses first 64 terms (enough?)
-      val tps = query.terms.take(64).foldLeft(Map.empty[String, PositionAndMask]){ (tps, term) =>
-        i += 1
+      val tps = termIdMap.map{ case (term, id) =>
         val termText = term.text()
-        tps + (termText -> (tps.getOrElse(termText, makePositionAndMask(context, term, acceptDocs)).setBit(i)))
-      }
-      new ProximityScorer(this, tps.values.toArray)
+        makePositionAndId(context, term, id, acceptDocs)
+      }.toArray
+      new ProximityScorer(this, tps, termIds, ac)
     } else {
       null
     }
   }
 
-  private def makePositionAndMask(context: AtomicReaderContext, term: Term, acceptDocs: Bits) = {
+  private def makePositionAndId(context: AtomicReaderContext, term: Term, id: Int, acceptDocs: Bits) = {
     val enum = termPositionsEnum(context, term, acceptDocs)
     if (enum == null) {
-      new PositionAndMask(EmptyDocsAndPositionsEnum, term.text())
+      new PositionAndId(EmptyDocsAndPositionsEnum, term.text(), id)
     } else {
-      new PositionAndMask(enum, term.text())
+      new PositionAndId(enum, term.text(), id)
     }
   }
 }
@@ -124,18 +149,11 @@ class ProximityWeight(query: ProximityQuery) extends Weight {
  * posLeft = number of unvisited term positions in current document
  * mask : reflects the position of the term in query.
  */
-private[query] final class PositionAndMask(val tp: DocsAndPositionsEnum, val termText: String) {
+private[query] final class PositionAndId(val tp: DocsAndPositionsEnum, val termText: String, val id: Int) {
   var doc = -1
   var pos = -1
 
-  private[this] var mask: Long = 0L
   private[this] var posLeft = 0
-
-  def getMask = mask
-  def setBit(index: Int) = {
-    mask = (mask | (1L << index))
-    this
-  }
 
   def fetchDoc(target: Int) {
     pos = -1
@@ -158,76 +176,44 @@ private[query] final class PositionAndMask(val tp: DocsAndPositionsEnum, val ter
   }
 }
 
-class ProximityScorer(weight: ProximityWeight, tps: Array[PositionAndMask]) extends Scorer(weight) {
+class ProximityScorer(weight: ProximityWeight, tps: Array[PositionAndId], termIds: Array[Int], ac: Option[AhoCorasick[Int, Int]]) extends Scorer(weight) {
   private[this] var curDoc = -1
   private[this] var proximityScore = 0.0f
   private[this] var scoredDoc = -1
-  private[this] val numTerms = tps.length
-  private[this] val rl = new Array[Float](numTerms + 1) // run lengths
-  private[this] val ls = new Array[Float](numTerms + 1) // local scores
   private[this] val weightVal = weight.getWeightValue
 
-  private[this] def gapPenalty(distance: Int) = ProximityQuery.gapPenalty * distance.toFloat
-
-  private[this] val pq = new PriorityQueue[PositionAndMask](numTerms) {
-    override def lessThan(nodeA: PositionAndMask, nodeB: PositionAndMask) = {
+  private[this] val pq = new PriorityQueue[PositionAndId](termIds.length) {
+    override def lessThan(nodeA: PositionAndId, nodeB: PositionAndId) = {
       if (nodeA.doc == nodeB.doc) nodeA.pos < nodeB.pos
       else nodeA.doc < nodeB.doc
     }
   }
-  tps.foreach{ tp => pq.insertWithOverflow(tp)}
+  tps.foreach{ tp => pq.insertWithOverflow(tp) }
+
+  private[this] val localAlignment = LocalAlignment(termIds, ac, ProximityQuery.gapPenalty)
 
   override def score(): Float = {
     // compute edit distance based proximity score
-    val insertCost = 1.0f
-    val baseEditCost = 1.0f
     val doc = curDoc
     if (scoredDoc != doc) {
+      // start fetching position for all terms at this doc
+      // in fact, it only fetches the first position (if exists) for each term
       var top = pq.top
-      var maxScore = 0.0f
-      // if term still have positions left in this doc
-      if (top.pos < Int.MaxValue) {
-        var i = 0
-        Arrays.fill(rl, 0.0f) // clear the run lengths
-        Arrays.fill(ls, 0.0f) // clear the local scores
-
-        // start fetching position for all terms
-        // in fact, it only fetches the first position (if exists) for each term
-        while (top.doc == doc && top.pos == -1) {
-          top.nextPos()
-          top = pq.updateTop()
-        }
-
-        // Find all partial sequence matches (possible phrases) using the dynamic programming.
-        // This is similar to a local alignment matching in bioinformatics, but we disallow gaps.
-        // We give a weight to each term occurrence using a local alignment score, thus, a term in a
-        // a matching sequence gets a high weight. A weight is diffused to following positions with a constant decay.
-        // A local score at a position is the sum of weights of all terms.
-        // The max local score + the base score is the score of the current document.
-        var prevPos = -1
-        while (top.doc == doc && top.pos < Int.MaxValue) {       // while doc still have term positions left
-          val curPos = top.pos                                  // note: doc is fixed, earlier term position fetched first, the associated term also changes
-          val mask = top.getMask
-          var i = 1
-          // update run lengths and local scores
-          var prevRun = 0.0f
-          var localScoreSum = 0.0f
-          while (i <= numTerms) {
-            val runLen = if (((1L << (i - 1)) & mask) != 0) prevRun + 1.0f else 0.0f
-            val localScore = max(ls(i) - (gapPenalty(curPos - prevPos)), 0.0f)
-            prevRun = rl(i) // store the run length of previous round
-            rl(i) = runLen
-            ls(i) = if (localScore < runLen) runLen else localScore
-            localScoreSum += ls(i)
-            i += 1
-          }
-          maxScore = max(maxScore, localScoreSum)
-          top.nextPos()
-          top = pq.updateTop()
-          if (top.pos > curPos) prevPos = curPos
-        }
-        proximityScore = maxScore * weightVal
+      while (top.doc == doc && top.pos == -1) {
+        top.nextPos()
+        top = pq.updateTop()
       }
+
+      // go through all positions
+      localAlignment.begin()
+      while (top.doc == doc && top.pos < Int.MaxValue) { // doc still have term positions left
+        localAlignment.update(top.id, top.pos) // note: doc is fixed, earlier term position fetched first, the associated term also changes
+        top.nextPos()
+        top = pq.updateTop()
+      }
+      localAlignment.end()
+
+      proximityScore = weightVal * localAlignment.score
       scoredDoc = doc
     }
     proximityScore
@@ -241,7 +227,7 @@ class ProximityScorer(weight: ProximityWeight, tps: Array[PositionAndMask]) exte
     var top = pq.top
     val doc = if (target <= curDoc && curDoc < NO_MORE_DOCS) curDoc + 1 else target
     while (top.doc < doc) {
-      top.fetchDoc(doc)           // note: this modifies top.doc, need to reheapify.
+      top.fetchDoc(doc) // note: this modifies top.doc, need to reheapify.
       top = pq.updateTop()
     }
     curDoc = top.doc

--- a/kifi-backend/modules/search/app/com/keepit/search/util/AhoCorasick.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/util/AhoCorasick.scala
@@ -1,0 +1,106 @@
+package com.keepit.search.util
+
+import scala.collection.mutable.Queue
+import scala.annotation.tailrec
+import scala.math._
+
+object AhoCorasick {
+
+  trait State[D] {
+    def check(position: Int, onMatch: (Int, D)=>Unit): Unit
+    def reset(): State[D]
+  }
+
+  def apply[I, D](dict: Seq[(Seq[I], D)]) = new AhoCorasick(dict)
+}
+
+class AhoCorasick[I, D](dict: Seq[(Seq[I], D)]) {
+  import AhoCorasick.State
+
+  private class StateImpl(fail: StateImpl) extends State[D] {
+    var nextStates: Map[I, StateImpl] = Map()
+    var failState: StateImpl = _root
+    var hasMatch = false
+    var data: Option[D] = None
+
+    def next(item: I): Option[StateImpl] = nextStates.get(item)
+
+    private[AhoCorasick] def nextOrCreate(item: I): StateImpl = {
+      nextStates.get(item) match {
+        case Some(nextState) =>
+          nextState
+        case _ =>
+          val nextState = new StateImpl(_root)
+          nextStates += (item -> nextState)
+          nextState
+      }
+    }
+
+    private[AhoCorasick] def set(d: D) = {
+      hasMatch = true
+      data = Some(d)
+    }
+
+    private[AhoCorasick] def setFailState(state: StateImpl) = {
+      hasMatch |= state.hasMatch
+      failState = state
+    }
+
+    def check(position: Int, onMatch: (Int, D)=>Unit): Unit = {
+      if (hasMatch) {
+        data.foreach(data => onMatch(position, data))
+        failState.check(position, onMatch)
+      }
+    }
+
+    def reset(): State[D] = _root
+  }
+
+  private val _root: StateImpl = new StateImpl(null)
+  def root: State[D] = _root
+
+  val maxLength: Int = makeTrie(dict)
+  makeFailureLinks()
+
+  private def makeTrie(dict: Seq[(Seq[I], D)]): Int = {
+    var maxLen: Int = 0
+    dict.foreach{ case (sequence, data)  =>
+      maxLen = max(maxLen , sequence.size)
+      sequence.foldLeft(_root){ (state, item) => state.nextOrCreate(item) }.set(data)
+    }
+    maxLen
+  }
+
+  private def makeFailureLinks() {
+    val queue: Queue[StateImpl] = Queue()
+    _root.nextStates.foreach{ case (_, s) => queue += s }
+
+    while (queue.nonEmpty) {
+      val s = queue.dequeue()
+      s.nextStates.foreach{ case (item, next) =>
+        queue += next
+        s.failState.next(item).foreach(next.setFailState(_))
+      }
+    }
+  }
+
+  def scan(iter: Iterator[I])(onMatch: (Int, D)=>Unit): Unit = {
+    var position = -1
+    iter.foldLeft(_root){ (s, item) =>
+      position += 1
+      val next = _next(item, s)
+      next.check(position, onMatch)
+      next
+    }
+  }
+
+  def next(item: I, s: State[D]): State[D] = _next(item, s.asInstanceOf[StateImpl])
+
+  @tailrec private def _next(item: I, s: StateImpl): StateImpl = {
+    s.next(item) match {
+      case Some(next) => next
+      case _ => if (s eq root) _root else _next(item, s.failState)
+    }
+  }
+}
+

--- a/kifi-backend/modules/search/app/com/keepit/search/util/LocalAlignment.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/util/LocalAlignment.scala
@@ -1,0 +1,133 @@
+package com.keepit.search.util
+
+import AhoCorasick.State
+import scala.math._
+
+import java.util.Arrays
+
+trait LocalAlignment {
+  def begin(): Unit
+  def end(): Unit
+  def update(id: Int, position: Int): Unit
+  def score: Float
+  def maxScore: Float
+}
+
+object LocalAlignment {
+  def apply(termIds: Array[Int], ac: Option[AhoCorasick[Int, Int]], gapPenalty: Float): LocalAlignment = {
+    val localAlignment = new BasicLocalAlignment(termIds, gapPenalty)
+    ac match {
+      case Some(ac) => new PhraseAwareLocalAlignment(ac, localAlignment)
+      case _ => localAlignment
+    }
+  }
+}
+
+class BasicLocalAlignment(termIds: Array[Int], gapPenalty: Float) extends LocalAlignment {
+  // Find all partial sequence matches (possible phrases) using the dynamic programming.
+  // This is similar to a local alignment matching in bioinformatics, but we disallow gaps.
+  // We give a weight to each term occurrence using a local alignment score, thus, a term in a
+  // a matching sequence gets a high weight. A weight is diffused to following positions with a constant decay.
+  // A local score at a position is the sum of weights of all terms.
+  // The max local score + the base score is the score of the current document.
+  private[this] val numTerms = termIds.length
+  private[this] val rl = new Array[Float](numTerms) // run lengths
+  private[this] val ls = new Array[Float](numTerms) // local scores
+  private[this] var alignmentScore = 0.0f
+  private[this] var lastPos = -1
+  private[this] var dist = 1
+
+  private[this] def getGapPenalty(distance: Int): Float = gapPenalty * distance.toFloat
+
+  def maxScore: Float = {
+     // max possible local alignment score
+    val n = termIds.length.toFloat
+    ((n * (n + 1.0f) / 2.0f) - (gapPenalty * n * (n - 1.0f) / 2.0f))
+  }
+
+  def begin(): Unit = {
+    Arrays.fill(rl, 0.0f) // clear the run lengths
+    Arrays.fill(ls, 0.0f) // clear the local scores
+    alignmentScore = 0.0f
+    lastPos = -1
+  }
+
+  def update(termId: Int, curPos: Int): Unit = {
+    if (lastPos < curPos) dist = curPos - lastPos
+    // update run lengths and local scores
+    var prevRun = 0.0f
+    var localScoreSum = 0.0f
+    var i = 0
+    while (i < numTerms) {
+      val runLen = if (termIds(i) == termId) prevRun + 1.0f else 0.0f
+      val localScore = max(ls(i) - (getGapPenalty(dist)), 0.0f)
+      prevRun = rl(i) // store the run length of previous round
+      rl(i) = runLen
+      ls(i) = if (localScore < runLen) runLen else localScore
+      localScoreSum += ls(i)
+      i += 1
+    }
+    lastPos = curPos
+    alignmentScore = max(alignmentScore, localScoreSum)
+  }
+
+  def end(): Unit = {}
+
+  def score: Float = alignmentScore
+}
+
+class PhraseAwareLocalAlignment(ac: AhoCorasick[Int, Int], localAlignment: LocalAlignment) extends LocalAlignment {
+  private[this] val bufSize = ac.maxLength
+  private[this] var bufferedPos = -1
+  private[this] var processedPos = -1
+  private[this] val ids = new Array[Int](bufSize)
+  private[this] val matching = new Array[Boolean](bufSize)
+  private[this] var state: State[Int] = ac.root
+
+  private def flush(): Unit = {
+    while (processedPos < bufferedPos) { processOnePosition() }
+  }
+
+  private def processOnePosition(): Unit = {
+    processedPos += 1
+    if (matching(processedPos % bufSize)) localAlignment.update(ids(processedPos % bufSize), processedPos)
+  }
+
+  def begin(): Unit = {
+    bufferedPos = -1
+    processedPos = -1
+    state = ac.root
+    localAlignment.begin()
+  }
+
+  def update(id: Int, pos: Int): Unit = {
+    if (pos - bufferedPos > 1) { // found a gap, flush buffer
+      flush()
+      processedPos = pos - 1
+      state = ac.root
+    } else if (bufferedPos - processedPos >= bufSize) { // buffer full
+      processOnePosition()
+    }
+    bufferedPos = pos
+    ids(pos % bufSize) = id
+    matching(pos % bufSize) = false
+
+    state = ac.next(id, state)
+    state.check(pos, onMatch = { (curPos, len) =>
+      var i = curPos - min(bufSize, len)
+      while (i < curPos) {
+        i += 1
+        matching(i % bufSize) = true
+      }
+    })
+  }
+
+  def end(): Unit = {
+    flush() // flush remaining ids in the buffer
+    localAlignment.end()
+  }
+
+  def score: Float = localAlignment.score
+  def maxScore = localAlignment.maxScore
+}
+

--- a/kifi-backend/modules/search/test/com/keepit/search/query/ProximityQueryTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/query/ProximityQueryTest.scala
@@ -162,6 +162,39 @@ class ProximityQueryTest extends Specification {
       buf.sortBy(_._2).map(_._1) === Seq(19, 18, 17, 16, 15, 14, 13, 12, 11, 10)
     }
 
+    "score using proximity with repeating terms" in {
+      readerContextLeaves.size === 1
+
+      var q = ProximityQuery(Seq(new Term("B", "abc"), new Term("B", "abc"), new Term("B", "def")))
+      var weight = searcher.createNormalizedWeight(q)
+
+      var scorer = weight.scorer(readerContext, true, true, reader.getLiveDocs)
+      val buf = new ArrayBuffer[(Int, Float)]()
+      var doc = scorer.nextDoc()
+      while (doc < DocIdSetIterator.NO_MORE_DOCS) {
+        buf += ((doc, scorer.score()))
+        doc = scorer.nextDoc()
+      }
+      indexReader.numDocs() === 30
+      buf.size === 10
+      buf.sortBy(_._2).map(_._1) === Seq(9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+
+      q = ProximityQuery(Seq(new Term("B", "def"), new Term("B", "def"), new Term("B", "ghi"), new Term("B", "ghi")))
+      weight = searcher.createNormalizedWeight(q)
+
+      (weight != null) === true
+
+      scorer = weight.scorer(readerContext, true, true, reader.getLiveDocs)
+      buf.clear
+      doc = scorer.nextDoc()
+      while (doc < DocIdSetIterator.NO_MORE_DOCS) {
+        buf += ((doc, scorer.score()))
+        doc = scorer.nextDoc()
+      }
+      buf.size === 10
+      buf.sortBy(_._2).map(_._1) === Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    }
+
     "not return hits when no term" in {
       val q = ProximityQuery(Seq.empty[Term])
       val weight = searcher.createNormalizedWeight(q)
@@ -169,6 +202,20 @@ class ProximityQueryTest extends Specification {
 
       val scorer = weight.scorer(readerContext, true, true, reader.getLiveDocs)
       scorer === null
+    }
+    "make a phrase dictionary correctly" in {
+      val termIds = Array(0,1,2,3,4,5,6,1,2)
+      val phrases1 = Set((1, 3), (5, 2))
+      ProximityQuery.buildPhraseDict(termIds, phrases1).toSet === Set((Seq(0), 1), (Seq(1), 1), (Seq(2), 1), (Seq(4), 1), (Seq(1,2,3), 3), (Seq(5,6), 2))
+
+      val phrases2 = Set((1, 3), (5, 2), (6, 2))
+      ProximityQuery.buildPhraseDict(termIds, phrases2).toSet === Set((Seq(0), 1), (Seq(2), 1), (Seq(4), 1), (Seq(1,2,3), 3), (Seq(5,6), 2), (Seq(6,1), 2))
+
+      val phrases3 = Set((1, 3), (5, 2), (0, 1), (5, 1))
+      ProximityQuery.buildPhraseDict(termIds, phrases3).toSet === Set((Seq(0), 1), (Seq(1), 1), (Seq(2), 1), (Seq(4), 1), (Seq(1,2,3), 3), (Seq(5,6), 2), (Seq(5), 1))
+
+      val phrases4 = Set((0, 3), (3, 3), (6, 3))
+      ProximityQuery.buildPhraseDict(termIds, phrases4).toSet === Set((Seq(0,1,2), 3), (Seq(3,4,5), 3), (Seq(6,1,2), 3))
     }
   }
 }

--- a/kifi-backend/modules/search/test/com/keepit/search/util/AhoCorasickTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/util/AhoCorasickTest.scala
@@ -1,0 +1,44 @@
+package com.keepit.search.util
+
+import org.specs2.mutable._
+import play.api.test._
+import play.api.test.Helpers._
+import scala.util.Random
+
+class AhoCorasickTest extends Specification {
+  val dict1 = Seq(
+    (Seq( "a", "b" ), "a b"),
+    (Seq( "b", "c" ), "b c"),
+    (Seq( "b", "a", "b"), "b a b"),
+    (Seq( "d" ), "d"),
+    (Seq( "a", "b", "c"), "a b c"),
+    (Seq( "b", "c", "d", "e" ), "b c d e"),
+    (Seq( "d", "e" ), "d e"),
+    (Seq( "a", "b", "c", "d", "e" ), "a b c d e")
+  )
+  val dict2 = Seq(
+    (Seq("a"), "a"),
+    (Seq("b", "c", "d"), "b c d"),
+    (Seq("c"), "c")
+  )
+
+  val ac1 = new AhoCorasick[String, String](dict1)
+  val ac2 = new AhoCorasick[String, String](dict2)
+
+  "AhoCorasick" should {
+    "find phrases" in {
+      var res = Set.empty[(Int, String)]
+      ac1.scan(Seq( "x", "b", "a", "b", "c", "d", "e", "x" ).iterator){ (pos, data) => res +=  ((pos, data)) }
+      res === Set((3, "b a b"), (3, "a b"), (4, "a b c"), (4, "b c"), (5, "d"), (6, "a b c d e"), (6, "b c d e"), (6, "d e"))
+
+      res = Set.empty[(Int, String)]
+      ac1.scan(Seq( "a", "b", "c" ).iterator){ (pos, data) => res +=  ((pos, data)) }
+      res === Set((1, "a b"), (2, "a b c"), (2, "b c"))
+
+      res = Set.empty[(Int, String)]
+      ac2.scan(Seq( "a", "b", "c", "a", "d" ).iterator){ (pos, data) => res +=  ((pos, data)) }
+      res === Set((0, "a"), (2, "c"), (3, "a"))
+    }
+  }
+}
+

--- a/kifi-backend/modules/search/test/com/keepit/search/util/PhraseAwareLocalAlignmentTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/util/PhraseAwareLocalAlignmentTest.scala
@@ -1,0 +1,74 @@
+package com.keepit.search.util
+
+import org.specs2.mutable._
+import play.api.test._
+import play.api.test.Helpers._
+import scala.util.Random
+
+class PhraseAwareLocalAlignmentTest extends Specification {
+  val toId: Map[String, Int] = Map("a"->10, "b"->20, "c"->30, "d"->40, "e"->50)
+
+  val dict0 = Seq(
+    (Seq("b", "c") map toId, 2),
+    (Seq("c", "d") map toId, 2)
+  )
+  val dict1 = Seq(
+    (Seq("b", "c") map toId, 2),
+    (Seq("d", "e") map toId, 2)
+  )
+  val dict2 = Seq(
+    (Seq("a", "b") map toId, 2),
+    (Seq("d", "e") map toId, 2)
+  )
+  val dict3 = Seq(
+    (Seq("b", "c", "d") map toId, 3),
+    (Seq("c", "d", "e") map toId, 3)
+  )
+
+  val ac0 = new AhoCorasick[Int, Int](dict0)
+  val ac1 = new AhoCorasick[Int, Int](dict1)
+  val ac2 = new AhoCorasick[Int, Int](dict2)
+  val ac3 = new AhoCorasick[Int, Int](dict3)
+
+  class DummyLocalAlignment extends LocalAlignment {
+    var positions = Set.empty[(Int, Int)]
+    def begin(): Unit = { positions = Set.empty[(Int, Int)] }
+    def update(id: Int, pos: Int): Unit = { positions += ((id, pos)) }
+    def end(): Unit = {}
+    def score: Float = 0.0f
+    def maxScore: Float = 1.0f
+  }
+
+  "PhraseAwareLocalAlignment" should {
+    "emit positions only when included in phrases" in {
+      val dummy = new DummyLocalAlignment
+      val doc = Seq("b", "a", "b", "c", "d", "e")
+
+      var localAlignment = new PhraseAwareLocalAlignment(ac0, dummy)
+      localAlignment.begin()
+      doc.zipWithIndex.foreach{ case (t, i) => localAlignment.update(toId(t), i) }
+      localAlignment.end()
+      dummy.positions === Set((toId("b"), 2), (toId("c"), 3), (toId("d"), 4))
+
+      localAlignment = new PhraseAwareLocalAlignment(ac1, dummy)
+      localAlignment.begin()
+      doc.zipWithIndex.foreach{ case (t, i) => localAlignment.update(toId(t), i) }
+      localAlignment.end()
+      dummy.positions === Set((toId("b"), 2), (toId("c"), 3), (toId("d"), 4), (toId("e"), 5))
+
+      localAlignment = new PhraseAwareLocalAlignment(ac2, dummy)
+      localAlignment.begin()
+      doc.zipWithIndex.foreach{ case (t, i) => localAlignment.update(toId(t), i) }
+      localAlignment.end()
+      dummy.positions === Set((toId("a"), 1), (toId("b"), 2), (toId("d"), 4), (toId("e"), 5))
+
+      localAlignment = new PhraseAwareLocalAlignment(ac3, dummy)
+      localAlignment.begin()
+      doc.zipWithIndex.foreach{ case (t, i) => localAlignment.update(toId(t), i) }
+      localAlignment.end()
+      dummy.positions === Set((toId("b"), 2), (toId("c"), 3), (toId("d"), 4), (toId("e"), 5))
+
+    }
+  }
+}
+


### PR DESCRIPTION
- factored out the local alignment computation from ProximityQuery ( the code is less cluttered)
- and created LocalAlignment trait, BasicLocalAlignment class and PhraseAwareLocalAlignment class
- PhraseAwareLocalAlignment uses Aho-Corasick state machine to find phrases in a token stream in one pass
- The Aho-Corasick state machine is implemented in AhoCorasick class.
- current PhraseProximityQuery is still in use. PhraseAwareLocalAlignment will be turned on by disabling PhraseProximityQuery.
