### PR TITLE
Since normalizedUris change so often now, added some resilience to them changing

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -399,8 +399,8 @@ const socketHandlers = {
   unread_notifications_count: function(count) {
     // see comment in syncNumNotificationsNotVisited() :(
     if (numNotificationsNotVisited != count) {
-      numNotificationsNotVisited = count;
       reportError("numNotificationsNotVisited count incorrect: " + numNotificationsNotVisited + " != " + count);
+      numNotificationsNotVisited = count;
       tellTabsNoticeCountIfChanged();
     }
   }
@@ -623,7 +623,8 @@ api.port.on({
     socket.send(["get_networks", friendId], respond);
   },
   open_deep_link: function(data, _, tab) {
-    var uriData = pageData[data.nUri];
+    var uriData = pageData[data.nUri] || pageData[(n = api.tabs.anyAt(data.nUri)) && n.nUri];
+
     if (uriData) {
       var tab = tab.nUri == data.nUri ? tab : uriData.tabs[0];
       if (tab.ready) {
@@ -707,8 +708,10 @@ function markNoticesVisited(category, id, timeStr, locator) {
   notifications && notifications.forEach(function(n, i) {
     if ((!locator || n.locator == locator) &&
         (n.id == id || new Date(n.time) <= time)) {
-      n.unread = false;
-      decrementNumNotificationsNotVisited(n);
+      if (n.unread) {
+        n.unread = false;
+        decrementNumNotificationsNotVisited(n);
+      }
     }
   });
   tabsShowingNotificationsPane.forEach(function(tab) {

--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -51,7 +51,7 @@ noticesPane = function() {
           if(this.dataset.locator) {
             api.port.emit("open_deep_link", {nUri: this.dataset.uri, locator: this.dataset.locator});
           } else if(this.dataset.category == "global") {
-            markVisited("global", undefined, undefined, undefined, this.dataset.id);
+            markVisited("global", undefined, undefined, this.dataset.id);
             api.port.emit("set_global_read", {noticeId: this.dataset.id});
             if (this.dataset.uri) {
               window.open(this.dataset.uri, "_blank")
@@ -91,7 +91,7 @@ noticesPane = function() {
           break;
         case "markOneVisited":
           console.log("marking one", a)
-          markVisited(a.category, a.nUri, a.time, a.locator, a.id);
+          markVisited(a.category, a.time, a.locator, a.id);
           $markAll.toggle(a.numNotVisited > 0);
           break;
         case "markAllVisited":
@@ -136,14 +136,13 @@ noticesPane = function() {
     api.port.emit("notifications_read", notices[0].time);
   }
 
-  function markVisited(category, nUri, timeStr, locator, id) {
+  function markVisited(category, timeStr, locator, id) {
     var time = new Date(timeStr);  // event time, not notification time
     $notices.find(".kifi-notice-" + category + ":not(.kifi-notice-visited)").each(function() {
       console.log("trying",id, this.dataset.id )
       if(id && id == this.dataset.id) {
         this.classList.add("kifi-notice-visited");
-      } else if (this.dataset.uri == nUri &&
-          dateWithoutMs(this.dataset.createdAt) <= time &&
+      } else if (dateWithoutMs(this.dataset.createdAt) <= time &&
           (!locator || this.dataset.locator == locator)) {
         this.classList.add("kifi-notice-visited");
       }


### PR DESCRIPTION
1) No longer require nUri to match when marking a notification as read. When an id or locator is the same, then it is enough.
2) `message_read` searches all pages for threads with that ID, and updates them.

@2is10 Mind reviewing? 
