### PR TITLE
deactivate user connections when we merge users

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -80,6 +80,8 @@ class AdminUserController @Inject() (
       }
       userRepo.save(toUser.withState(UserStates.ACTIVE))
       userRepo.save(fromUser.withState(UserStates.INACTIVE))
+
+      userConnectionRepo.deactivateAllConnections(fromUserId)
     }
 
     for (su <- db.readOnly { implicit s => socialUserInfoRepo.getByUser(toUserId) }) {


### PR DESCRIPTION
This is meant to fix a bug Leo has with an inactive user showing up for a friend that had his two user accounts merged.
