### PR TITLE
Include total keeps in collection info and update it periodically

### DIFF
--- a/kifi-backend/modules/shoebox/public/js/main.js
+++ b/kifi-backend/modules/shoebox/public/js/main.js
@@ -986,16 +986,13 @@ $(function() {
 		}
 	}
 
-	function updateNumKeeps() {
-		$.getJSON(xhrBase + '/keeps/count', function(data) {
-			$('.left-col .my-keeps .nav-count').text(myKeepsCount = data.numKeeps);
-		});
-	}
-
 	function updateCollections() {
 		promise.collections = $.getJSON(xhrBase + '/collections/all', {sort: "user"}, function(data) {
-			collTmpl.render(data.collections);
 			collections = data.collections.reduce(function(o, c) {o[c.id] = c; return o}, {});
+			if ($collList.find('.renaming, .showing').length === 0) {
+				collTmpl.render(data.collections);
+			}
+			$('.left-col .my-keeps .nav-count').text(myKeepsCount = data.keeps);
 		}).promise();
 	}
 
@@ -1771,7 +1768,6 @@ $(function() {
 		$('#invite-friends-link').toggle(canInvite());
 	});
 	updateCollections();
-	updateNumKeeps();
 	$.getJSON(xhrBase + '/user/friends/count', function(data) {
 		updateFriendRequests(data.requests);
 	});
@@ -1781,7 +1777,7 @@ $(function() {
 
 	// auto-update my keeps
 	setTimeout(function refresh() {
-		updateNumKeeps();
+		updateCollections();
 		addNewKeeps();
 		setTimeout(refresh, 25000 + 5000 * Math.random());
 	}, 30000);


### PR DESCRIPTION
@2is10 

I'm open suggestions regarding renaming of this route and the related functions. You could argue that since all the keeps is kind of a "collection" that it's not unreasonable to put the total keeps in /collections/all but I'm not sure if that's confusing.
