### PR TITLE
Make sure we add new threads to pageData if they aren't there

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.5.25
+version=2.5.26

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -356,6 +356,10 @@ const socketHandlers = {
         }
       }
 
+      if (i == n) {
+        socket.send(["get_threads_by_url", message.url]);
+      }
+
       // ensure marked read if from this user
       if (message.user.id == session.userId) {
         if (new Date(message.createdAt) > new Date(d.lastMessageRead[threadId] || 0)) {


### PR DESCRIPTION
This appears to fix a bug in which new threads don't show up in the thread list if you're already on the page.
