### PR TITLE
pageData reliability improvements

### DIFF
--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -58,16 +58,11 @@ var tile = tile || function() {  // idempotent for Chrome
       setTimeout(keeper.bind(null, "showKeepers", o.keepers, o.otherKeeps), 3000);
     },
     counts: function(counts) {
-      if (!tile || !tile.parentNode) return;
-
-      var n = Math.max(counts.m, counts.n);
-      if (n) {
-        tileCount.textContent = n;
-        tile.insertBefore(tileCount, tileCard.nextSibling);
-      } else if (tileCount.parentNode) {
-        tileCount.remove();
+      if (!tile || !tile.parentNode) {
+        whenSessionKnown.push(updateCounts.bind(this, counts));
+        return;
       }
-      tile.dataset.counts = JSON.stringify(counts);
+      updateCounts(counts);
     },
     scroll_rule: function(r) {
       if (!onScroll) {
@@ -120,6 +115,17 @@ var tile = tile || function() {  // idempotent for Chrome
         break;
       }
     }
+  }
+
+  function updateCounts(counts) {
+    var n = Math.max(counts.m, counts.n);
+    if (n) {
+      tileCount.textContent = n;
+      tile.insertBefore(tileCount, tileCard.nextSibling);
+    } else if (tileCount.parentNode) {
+      tileCount.remove();
+    }
+    tile.dataset.counts = JSON.stringify(counts);
   }
 
   function toggleLoginDialog() {

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -58,8 +58,7 @@ var tile = tile || function() {  // idempotent for Chrome
       setTimeout(keeper.bind(null, "showKeepers", o.keepers, o.otherKeeps), 3000);
     },
     counts: function(counts) {
-      if (!tile || !tile.parentNode) {
-        whenSessionKnown.push(updateCounts.bind(this, counts));
+      if (!tile) {
         return;
       }
       updateCounts(counts);


### PR DESCRIPTION
This introduces a `pageData` boolean field called `cacheIsDirty`. Whenever the socket disconnects, we cannot trust the `pageData` for reliability. If we simply reset it, the user may experience odd interruptions.

So, we mark the `pageData` cache as dirty, but a content page can still use it until refreshed. When refreshed, it is no longer dirty. Also, on socket re-connect, we sync other things as well now.

Also did some future proofing, with us removing `uri_1` and `uri_2`. 
