### PR TITLE
2.5.27: you dreamt it

### DIFF
--- a/packrat/adapters/chrome/main.html
+++ b/packrat/adapters/chrome/main.html
@@ -3,5 +3,5 @@
 <script src="deps.js"></script>
 <script src="listeners.js"></script>
 <script src="api.js"></script>
-<script src="scripts/lib/reconnecting-websocket.js"></script>
+<script src="reconnecting-websocket.js"></script>
 <script src="main.js"></script>

--- a/packrat/adapters/chrome/manifest.json
+++ b/packrat/adapters/chrome/manifest.json
@@ -18,7 +18,55 @@
   "background": {
     "page": "main.html"
   },
-  "content_scripts": [],
+  "content_scripts": [
+    {
+      "js": [
+        "scripts/api.js",
+        "scripts/deep_link_redirect.js"
+      ],
+      "matches": [
+        "*://www.kifi.com/r/*",
+        "*://kifi.com/r/*",
+        "*://www.keepitfindit.com/r/*",
+        "*://keepitfindit.com/r/*",
+        "*://dev.ezkeep.com/r/*"
+      ],
+      "run_at": "document_start"
+    },
+    {
+      "js": [
+        "scripts/api.js",
+        "scripts/lib/jquery.js",
+        "scripts/lib/jquery-bindhover.js",
+        "scripts/lib/mustache.js",
+        "scripts/render.js",
+        "scripts/html/search/google.js",
+        "scripts/html/search/google_hits.js",
+        "scripts/html/search/google_hit.js",
+        "scripts/google_inject.js"
+      ],
+      "css": [
+        "styles/google_inject.css",
+        "styles/friend_card.css"
+      ],
+      "matches": ["<all_urls>"],
+      "include_globs": [
+        "*://www.google.c??/",
+        "*://www.google.c??/search*",
+        "*://www.google.c??/webhp*",
+        "*://www.google.com.??/",
+        "*://www.google.com.??/search*",
+        "*://www.google.com.??/webhp*",
+        "*://www.google.co.??/",
+        "*://www.google.co.??/search*",
+        "*://www.google.co.??/webhp*",
+        "*://www.google.??/",
+        "*://www.google.??/search*",
+        "*://www.google.??/webhp*"
+      ],
+      "run_at": "document_start"
+    }
+  ],
   "permissions": [
     "tabs",
     "bookmarks",

--- a/packrat/adapters/firefox/data/scripts/api.js
+++ b/packrat/adapters/firefox/data/scripts/api.js
@@ -38,6 +38,7 @@ api = function() {
       }
       console.log("'" + ds.substr(0,2) + ds.substr(15,9) + "." + String(+d).substr(10) + "'", args.join(" "));
     },
+    mutationsFirePromptly: false,
     noop: function() {},
     onEnd: [],  // TODO: find an event that will allows us to invoke these
     port: {

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -503,7 +503,7 @@ timers.setTimeout(function() {  // async to allow main.js to complete (so portHa
       include: urlRe,
       contentStyleFile: o.styles.map(url),
       contentScriptFile: o.scripts.map(url),
-      contentScriptWhen: "ready",
+      contentScriptWhen: arr[2] ? "start" : "ready",
       contentScriptOptions: {dataUriPrefix: url(""), dev: prefs.env == "development"},
       attachTo: ["existing", "top"],
       onAttach: function(worker) {

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.5.26
+version=2.5.27

--- a/packrat/scripts/deep_link_redirect.js
+++ b/packrat/scripts/deep_link_redirect.js
@@ -1,13 +1,17 @@
 // @match /^https?:\/\/(dev\.ezkeep\.com:9000|(www\.)?(kifi|keepitfindit)\.com)\/r\/.*/
 // @require scripts/api.js
+// @asap
 
-!function(json) {
-  if (json) {  // in case injected into wrong page
-    document.querySelector(".kifi-deep-link-no-extension").style.display = "none";
+!function run(json, e) {
+  var msg = document.getElementsByClassName('kifi-deep-link-no-extension')[0];
+  if (msg) {
+    msg.style.display = "none";
     var link = JSON.parse(json);
     api.port.emit("add_deep_link_listener", link.locator);
     if (link.uri) {
       window.location = link.uri;
     }
+  } else {
+    document.addEventListener("DOMContentLoaded", run.bind(null, json));
   }
 }(document.documentElement.dataset.kifiDeepLink);

--- a/packrat/scripts/deep_link_site.js
+++ b/packrat/scripts/deep_link_site.js
@@ -1,7 +1,6 @@
 // @match /^https?:\/\/(dev\.ezkeep\.com:8080|(www\.)?(kifi|keepitfindit)\.com)\/(?!r\/).*/
 // @require scripts/api.js
 
-
 document.addEventListener('click', function(e) {
   var uri, loc;
   if (!e.button && (uri = e.target.href) && (loc = e.target.dataset.locator)) {

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -1,16 +1,21 @@
 // @match /^https?:\/\/www\.google\.(com|com\.(a[fgiru]|b[dhnorz]|c[ouy]|do|e[cgt]|fj|g[hit]|hk|jm|k[hw]|l[by]|m[txy]|n[afgip]|om|p[aehkry]|qa|s[abglv]|t[jrw]|u[ay]|v[cn])|co\.(ao|bw|c[kr]|i[dln]|jp|k[er]|ls|m[az]|nz|t[hz]|u[gkz]|v[ei]|z[amw])|a[demstz]|b[aefgijsy]|cat|c[adfghilmnvz]|d[ejkmz]|e[es]|f[imr]|g[aeglmpry]|h[nrtu]|i[emqst]|j[eo]|k[giz]|l[aiktuv]|m[degklnsuvw]|n[eloru]|p[lnstosuw]|s[cehikmnot]|t[dgklmnot]|v[gu]|ws)\/(|search|webhp)([?#].*)?$/
+// @asap
 // @require styles/google_inject.css
 // @require styles/friend_card.css
+// @require scripts/api.js
 // @require scripts/lib/jquery.js
 // @require scripts/lib/jquery-bindhover.js
 // @require scripts/lib/mustache.js
-// @require scripts/api.js
 // @require scripts/render.js
 // @require scripts/html/search/google.js
 // @require scripts/html/search/google_hits.js
 // @require scripts/html/search/google_hit.js
 
-var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test(location.host) && function() {  // idempotent for Chrome
+// (same as match pattern above)
+const searchUrlRe = /^https?:\/\/www\.google\.(com|com\.(a[fgiru]|b[dhnorz]|c[ouy]|do|e[cgt]|fj|g[hit]|hk|jm|k[hw]|l[by]|m[txy]|n[afgip]|om|p[aehkry]|qa|s[abglv]|t[jrw]|u[ay]|v[cn])|co\.(ao|bw|c[kr]|i[dln]|jp|k[er]|ls|m[az]|nz|t[hz]|u[gkz]|v[ei]|z[amw])|a[demstz]|b[aefgijsy]|cat|c[adfghilmnvz]|d[ejkmz]|e[es]|f[imr]|g[aeglmpry]|h[nrtu]|i[emqst]|j[eo]|k[giz]|l[aiktuv]|m[degklnsuvw]|n[eloru]|p[lnstosuw]|s[cehikmnot]|t[dgklmnot]|v[gu]|ws)\/(|search|webhp)([?#].*)?$/;
+
+// We check the pattern because Chrome match/glob patterns aren't powerful enough. crbug.com/289057
+if (searchUrlRe.test(document.URL)) !function() {
   api.log("[google_inject]");
 
   function logEvent() {  // parameters defined in main.js
@@ -18,7 +23,6 @@ var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test
   }
 
   var $res = $(render("html/search/google", {})).hide();   // a reference to our search results (kept so that we can reinsert when removed)
-  bindHandlers();
 
   var filter;             // current search filter (null or {[who: "m"|"f"|dot-delimited user ids]?, [when: "t"|"y"|"w"|"m"]?})
   var query = "";         // latest search query
@@ -26,46 +30,24 @@ var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test
   var showMoreOnArrival;
   var clicks = {kifi: [], google: []};  // clicked result link hrefs
 
-  // "main" div seems to always stay in the page, so only need to bind listener once.
-  // TODO: move this code lower, so it runs after we initiate the first search
-  // TODO: also detect result selection via keyboard
-  $("#main").on("mousedown", "#search h3.r a", function logSearchEvent() {
-    var href = this.href, $li = $(this).closest("li.g");
-    var $kifiRes = $("#kifi-res-list"), $kifiLi = $kifiRes.children("li.g");
-    var resIdx = $li.parent().children("li.g").index($li);
-    var isKifi = $li[0].parentNode === $kifiRes[0];
+  // stuff for timing
+  var keyTimer, idleTimer, tQuery = Date.now(), tGoogleResultsShown = tQuery, tKifiResultsReceived, tKifiResultsShown;
 
-    clicks[isKifi ? "kifi" : "google"].push(href);
-
-    if (href && resIdx >= 0) {
-      logEvent("search", isKifi ? "kifiResultClicked" : "googleResultClicked",
-        {"url": href, "whichResult": resIdx, "query": response.query, "experimentId": response.experimentId, "kifiResultsCount": $kifiLi.length});
-    }
+  var $q = $(), $qf = $q, $qp = $q;
+  $(function() {
+    $q = $("#gbqfq,#lst-ib").on("input", onInput);  // stable identifier: "Google Bar Query Form Query"
+    $qf = $("#gbqf,#tsf").submit(onSubmit);  // stable identifier: "Google Bar Query Form"
+    $qp = $("#gs_taif0");  // stable identifier: "Google Search Type-Ahead Input Field"
   });
-
-  var keyTimer, idleTimer, tQuery = +new Date, tGoogleResultsShown = tQuery, tKifiResultsReceived, tKifiResultsShown;
-  var $q = $("#gbqfq,#lst-ib").on("input", onInput);  // stable identifier: "Google Bar Query Form Query"
   function onInput() {
-    tQuery = +new Date;
+    tQuery = Date.now();
     clearTimeout(keyTimer);
     keyTimer = setTimeout(search, 250);  // enough of a delay that we won't search after *every* keystroke (similar to Google's behavior)
   }
-  var $qf = $("#gbqf,#tsf").submit(onSubmit);  // stable identifier: "Google Bar Query Form"
   function onSubmit() {
-    tQuery = +new Date;
+    tQuery = Date.now();
     clearTimeout(keyTimer);
     search();  // immediate search
-  }
-  var $qp = $(document.getElementById("gs_taif0"));  // stable identifier: "Google Search Type-Ahead Input Field"
-
-  function onIdle() {
-    logEvent("search", "dustSettled", {
-      "query": query,
-      "experimentId": response.experimentId,
-      "kifiHadResults": response.hits && response.hits.length > 0,
-      "kifiReceivedAt": tKifiResultsReceived - tQuery,
-      "kifiShownAt": tKifiResultsShown - tQuery,
-      "googleShownAt": tGoogleResultsShown - tQuery});
   }
 
   checkSearchType();
@@ -84,7 +66,7 @@ var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test
   function search(fallbackQuery, newFilter, isFirst) {
     if (isVertical) return;
 
-    var q = ($qp.val() || $q.val() || fallbackQuery || "").trim().replace(/\s+/, " ");  // TODO: also detect "Showing results for" and prefer that
+    var q = ($qp.val() || $q.val() || fallbackQuery || "").trim().replace(/\s+/g, " ");  // TODO: also detect "Showing results for" and prefer that
     var f = arguments.length > 1 ? newFilter : filter;
     if (q == query && areSameFilter(f, filter)) {
       api.log("[search] nothing new, query:", q, "filter:", f);
@@ -100,7 +82,7 @@ var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test
 
     clearTimeout(idleTimer);
     idleTimer = setTimeout(onIdle, 1200);
-    var t1 = +new Date;
+    var t1 = Date.now();
     api.port.emit("get_keeps", {query: q, filter: f, first: isFirst}, function results(resp) {
       if (q != query || !areSameFilter(f, filter)) {
         api.log("[results] ignoring for query:", q, "filter:", f);
@@ -120,7 +102,7 @@ var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test
       response = resp;
       if (isFirst && resp.filter) {  // restoring previous filter (user navigated back)
         filter = f = newFilter = resp.filter;
-        $(".kifi-filter-btn").addClass("kifi-expanded");
+        $res.find(".kifi-filter-btn").addClass("kifi-expanded");
         $res.find(".kifi-filters").show().each(function() {
           if (f.who) {
             $(this).find(".kifi-filter[data-name=who]").find(".kifi-filter-val")
@@ -132,25 +114,17 @@ var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test
           }
         });
       }
-      response.hits.forEach(processHit);
-
-      var ires = document.getElementById("ires");
-      if (ires) {
-        resp.shown = true;
-        tKifiResultsShown = +new Date;
-      }
 
       if (resp.hits.length || f) {  // we show a "no results match filter" message if filtering
+        response.hits.forEach(processHit);
         appendResults();
         if ($res[0].style.display == "none") {  // check to avoid disrupting transition
-          $res.show();
-        }
-        if ($res[0].nextElementSibling !== ires) {
-          $res.insertBefore(ires);
+          $res[0].style.display = "block";
         }
       } else {
-        $res.hide();
+        $res[0].style.display = "none";
       }
+      attachKifiRes();
 
       logEvent("search", "kifiLoaded", {"query": q, "filter": f, "queryUUID": resp.uuid});
       if (resp.hits.length) {
@@ -173,7 +147,17 @@ var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test
 
   function parseQuery(hash) {
     var m = /[?#&]q=[^&]*/.exec(hash);
-    return m && unescape(m[0].substr(3).replace("+", " ")).trim() || "";
+    return m && unescape(m[0].substr(3).replace(/\+/g, " ")).trim() || "";
+  }
+
+  function onIdle() {
+    logEvent("search", "dustSettled", {
+      "query": query,
+      "experimentId": response.experimentId,
+      "kifiHadResults": response.hits && response.hits.length > 0,
+      "kifiReceivedAt": tKifiResultsReceived - tQuery,
+      "kifiShownAt": tKifiResultsShown - tQuery,
+      "googleShownAt": tGoogleResultsShown - tQuery});
   }
 
   $(window).on("hashchange", function() {
@@ -181,7 +165,7 @@ var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test
     checkSearchType();
     search();  // needed for switch from shopping to web search, for example
   }).on("beforeunload", function(e) {
-    if (response.query === query && new Date - tKifiResultsShown > 2000) {
+    if (response.query === query && Date.now() - tKifiResultsShown > 2000) {
       logEvent("search", "searchUnload", {
         "query": response.query,
         "queryUUID": response.uuid,
@@ -193,30 +177,68 @@ var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test
     }
   });
 
-  var MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
-  var observer = new MutationObserver(function onMutation(mutations) {
+  var observer = new MutationObserver(withMutations);
+  function withMutations(mutations) {
     if (isVertical) return;
     for (var i = 0; i < mutations.length; i++) {
       for (var j = 0, nodes = mutations[i].addedNodes; j < nodes.length; j++) {
         if (nodes[j].id === "ires") {
-          tGoogleResultsShown = +new Date;
-          api.log("[onMutation] Google results inserted");
-          $res.insertBefore(nodes[j]);  // reattach
-          if (!response.shown) {
-            response.shown = true;
-            tKifiResultsShown = +new Date;
-          }
-          search();  // prediction may have changed
+          tGoogleResultsShown = Date.now();
+          api.log("[withMutations] Google results inserted");
+          attachKifiRes(0, nodes[j]);
+          $(setTimeout.bind(null, search));  // prediction may have changed
         }
       }
     }
     if (!$q.length || !document.contains($q[0])) {  // for #lst-ib (e.g. google.co.il)
-      $q.remove(); $qf.remove();
+      $q.remove(), $qf.remove();
       $q = $($q.selector).on("input", onInput);
       $qf = $($qf.selector).submit(onSubmit);
     }
+  }
+  var whatToObserve = {childList: true, subtree: true};  // TODO: optimize away subtree
+  observer.observe(document, whatToObserve);
+  $(function() {
+    withMutations(observer.takeRecords());
+    observer.disconnect();
+    observer.observe(document.getElementById('main'), whatToObserve);
+    attachKifiRes();
   });
-  observer.observe(document.getElementById("main"), {childList: true, subtree: true});  // TODO: optimize away subtree
+
+  function attachKifiRes(_, ires) {
+    if ($res[0].parentElement) {
+      return true;
+    } else if ((ires = ires || document.getElementById('ires'))) {
+      $res.insertBefore(ires);
+      if (!response.shown && response.hits) {
+        response.shown = true;
+        tKifiResultsShown = Date.now();
+      }
+      setTimeout(bindResHandlers);
+      return true;
+    }
+  }
+
+  if (!api.mutationsFirePromptly) {
+    setTimeout(function tryAttach() {
+      attachKifiRes() || setTimeout(tryAttach, 1);
+    }, 1);
+  }
+
+  // TODO: also detect result selection via keyboard
+  $(document).on("mousedown", "#search h3.r a", function logSearchEvent() {
+    var href = this.href, $li = $(this).closest("li.g");
+    var $kifiRes = $("#kifi-res-list"), $kifiLi = $kifiRes.children("li.g");
+    var resIdx = $li.parent().children("li.g").index($li);
+    var isKifi = $li[0].parentNode === $kifiRes[0];
+
+    clicks[isKifi ? "kifi" : "google"].push(href);
+
+    if (href && resIdx >= 0) {
+      logEvent("search", isKifi ? "kifiResultClicked" : "googleResultClicked",
+        {"url": href, "whichResult": resIdx, "query": response.query, "experimentId": response.experimentId, "kifiResultsCount": $kifiLi.length});
+    }
+  });
 
   api.onEnd.push(function() {
     api.log("[google_inject:onEnd]");
@@ -277,7 +299,7 @@ var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test
     return boldSearchTerms(url, matches);
   }
 
-  function bindHandlers() {
+  var bindResHandlers = function() {
     $res.on("mouseover", ".kifi-res-more-a", function() {
       $(this).closest(".kifi-res-more").addClass("kifi-over");
     }).on("mouseout", ".kifi-res-more-a", function() {
@@ -423,11 +445,12 @@ var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test
       api.port.emit("add_deep_link_listener", $(this).data("locator"));
       location.href = $(this).closest("li.g").find("h3.r a")[0].href;
     });
+    bindResHandlers = $.noop;
   }
 
   function appendResults() {
     $res.find(".kifi-res-title").toggleClass("kifi-collapsed", !response.show);
-    $res.find(".kifi-filter-btn")[response.show ? "show" : "hide"]();
+    $res.find(".kifi-filter-btn")[0].style.display = response.show ? "block" : "none";
     $res.append(render(
       "html/search/google_hits", {
         show: response.show,
@@ -614,7 +637,7 @@ var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test
               var who = filter.who.length > 1 ? filter.who + "." + friend.id : friend.id;
               search(null, $.extend({}, filter, {who: who}));
               $in.nextAll(".kifi-filter-detail-clear").addClass("kifi-visible");
-              addTime = +new Date;
+              addTime = Date.now();
             },
             onDelete: function(friend) {
               api.log("[onDelete]", friend.id, friend.name);
@@ -642,6 +665,4 @@ var googleInject = googleInject || /^www\.google\.[a-z]{2,3}(\.[a-z]{2})?$/.test
       }
     }).prev(".kifi-filter-detail-notch").addBack().removeClass("kifi-visible");
   }
-
-  return true;
 }();

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -7,7 +7,7 @@ function logEvent() {  // parameters defined in main.js
 }
 
 var tile = tile || function() {  // idempotent for Chrome
-  api.log("[scout]", location.hostname);
+  api.log("[keeper_scout]", location.hostname);
 
   window.onerror = function(message, url, lineNo) {
     if (!/https?\:/.test(url)) {  // this is probably from extension code, not from the website we're running this on

--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -1,9 +1,9 @@
 // @require styles/metro/notices.css
+// @require scripts/api.js
 // @require scripts/html/metro/notices.js
 // @require scripts/html/metro/notice_global.js
 // @require scripts/html/metro/notice_message.js
 // @require scripts/formatting.js
-// @require scripts/api.js
 // @require scripts/lib/jquery.timeago.js
 // @require scripts/lib/antiscroll.min.js
 // @require scripts/scrollable.js

--- a/packrat/scripts/notifier.js
+++ b/packrat/scripts/notifier.js
@@ -1,7 +1,7 @@
 // @require styles/notifier.css
+// @require scripts/api.js
 // @require scripts/lib/jquery.js
 // @require scripts/lib/mustache.js
-// @require scripts/api.js
 // @require scripts/formatting.js
 // @require scripts/render.js
 


### PR DESCRIPTION
Inserting Kifi results in the Google search results page with no flicker. This relies on a `MutationObserver` in Chrome to detect when Google’s results are inserted into the page. In Firefox, the MutationObserver doesn’t fire promptly enough to avoid flicker, so we poll the DOM using `document.getElementById('ires')` and `setTimeout`. Using these techniques, we can add the Kifi results to the page nearly instantly after Google’s are added (which typically happens 20-100ms before `DOMContentLoaded`) and before their initial rendering. Waa-la! No flicker.

TODO: If Kifi results are not yet available when Google’s results are inserted into the page, show just the Kifi bar initially and keep the Kifi results collapsed when they _do_ arrive.

Note that we’re injecting google_inject.js and its dependencies at `"document_start"`using Chrome’s manifest.json. This is a faster method of injecting, since we declare all of our JS and CSS files up front and how Chrome should decide which pages to inject them in, whereas the `chrome.tabs.executeScript` and `chrome.tabs.insertCSS` methods are triggered by our background page script and only operate on one file at a time. We don’t use manifest.json for injecting all of our content scripts because 1) that results in repeated injection of common dependencies ([crbug.com/248627](http://crbug.com/248627)) and 2) the match  patterns/globs available in manifest.json are not as powerful as the regular expressions we use to match URLs in Firefox. A third reason we didn’t use manifest.json for injection before now was that there would be no easy way to know which content script files had been injected already when it came time to dynamically inject more, but that has been addressed in this pull request by having our build script append a line to each content script file for tracking purposes.
