### PR TITLE
first admin page to view domain-wise normalization rule

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
@@ -173,6 +173,26 @@ class SliderAdminController @Inject() (
     }
     Ok(JsObject(domainSensitiveMap map { case (s, b) => s -> JsBoolean(b) } toSeq))
   }
+  
+  def normSchemePageView(page: Int = 0) = AdminHtmlAction { implicit request =>
+    val PAGE_SIZE = 50
+    val (domains, totalCount) = db.readOnly{ implicit s =>
+      domainRepo.normSchemePage(page, PAGE_SIZE)
+    }
+    val pageCount = (totalCount * 1.0 / PAGE_SIZE).ceil.toInt
+    Ok(html.admin.domainNormalization(domains, page, totalCount, pageCount, PAGE_SIZE, None))
+  }
+  
+  def searchDomainNormalization() = AdminHtmlAction{ implicit request =>
+    val form = request.request.body.asFormUrlEncoded.map{ req => req.map(r => (r._1 -> r._2.head)) }
+    val searchTerm = form.flatMap{ _.get("searchTerm") }
+    searchTerm match {
+      case None => Redirect(routes.SliderAdminController.normSchemePageView(0))
+      case Some(term) =>
+        val domains = db.readOnly{implicit s => domainRepo.getByPrefix(term) }
+        Ok(html.admin.domainNormalization(domains, 0, domains.size, 1, domains.size, searchTerm))
+    }
+  }
 
   def refetchClassifications = /* TODO: AdminJson */Action { implicit request =>
     domainTagImporter.refetchClassifications()

--- a/kifi-backend/modules/shoebox/app/views/admin/admin.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/admin.scala.html
@@ -104,7 +104,9 @@
                     <a class="dropdown-toggle" data-toggle="dropdown"  href="@com.keepit.controllers.admin.routes.AdminHealthController.serviceView">Data Integrity</a>
                     <ul class="dropdown-menu" role="menu">
                         <li><a href="@com.keepit.controllers.admin.routes.UrlController.normalizationView(0)">Normalization</a>
+                          <li><a href="@com.keepit.controllers.admin.routes.SliderAdminController.normSchemePageView(0)">Domain Normalization</a>
                     </ul>
+                    
                 </li>
 
 		    </ul>

--- a/kifi-backend/modules/shoebox/app/views/admin/domainNormalization.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/domainNormalization.scala.html
@@ -1,0 +1,76 @@
+@(domains: Seq[com.keepit.classify.Domain], page: Int, totalCount: Int, pageCount: Int, maxPageSize: Int, searchTerm: Option[String])
+
+@pagination(page: Int, pageCount: Int) = {
+  <div class="pagination pagination-centered pagination-mini">
+    <ul>
+      <li>
+        @if(page > 0) {
+          <a href="@com.keepit.controllers.admin.routes.SliderAdminController.normSchemePageView(page - 1)">
+        } else {
+         <a href="#">
+        }
+        Prev
+        </a>
+      </li>
+      @for(i <- 0 to (pageCount - 1)) {
+        @if(i == page) {
+          <li class="disabled">
+            <a href="com.keepit.controllers.admin.routes.SliderAdminController.normSchemePageView(i)">@{i + 1}</a>
+          </li>
+        } else {
+          <li class="active">
+            <a href="com.keepit.controllers.admin.routes.SliderAdminController.normSchemePageView(i)">@{i + 1}</a>
+          </li>
+        }
+      }
+      <li>
+        @if(domains.size > 0) {
+          <a href="com.keepit.controllers.admin.routes.SliderAdminController.normSchemePageView(page + 1)">
+        } else {
+         <a href="#">
+        }
+        Next
+        </a>
+      </li>
+    </ul>
+  </div>
+}
+
+@admin(totalCount + " domains with normalization scheme") {
+  <h2>Showing @domains.size (page @{page + 1})</h2>
+  @pagination(page, pageCount)
+  <form class="form-inline" action="@com.keepit.controllers.admin.routes.SliderAdminController.searchDomainNormalization()" method="POST">
+    @if(searchTerm.isDefined){
+      <input type="text" name="searchTerm" value="@{searchTerm.get}"/>
+    } else {
+      <input type="text" name="searchTerm" placeholder="type prefix of hostname here"/>
+    }
+    <input type="submit" value="Search"/></br>
+    @if(searchTerm.isDefined){
+      <a href="@com.keepit.controllers.admin.routes.SliderAdminController.normSchemePageView(0)">Clear search</a>
+    }
+  </form>
+
+  <table class = "table table-bordered">
+    <tr>
+      <th>#</th>
+      <th>domain id</th>
+      <th>hostname</th>
+      <th>state</th>
+      <th>scheme</th>
+    </tr>
+  
+  @for((domain, i) <- domains.zipWithIndex) {
+    <tr>
+      <td>@{i + 1 + page*maxPageSize}</td>
+      <td>@domain.id.get</td>
+      <td>@domain.hostname</td>
+      <td>@domain.state</td>
+      <td>@domain.normalizationScheme.getOrElse("None")</td>
+    </tr>
+  }
+
+  </table>
+  @pagination(page, pageCount) 
+
+}

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -260,6 +260,8 @@ POST    /admin/slider/domains/fetch @com.keepit.controllers.admin.SliderAdminCon
 GET     /admin/slider/importEvents  @com.keepit.controllers.admin.SliderAdminController.getImportEvents
 GET     /admin/slider/version       @com.keepit.controllers.admin.SliderAdminController.getVersionForm
 POST    /admin/slider/version       @com.keepit.controllers.admin.SliderAdminController.broadcastLatestVersion(ver: String)
+GET     /admin/slider/domainNormSchemeView @com.keepit.controllers.admin.SliderAdminController.normSchemePageView(page: Int ?= 0)
+POST     /admin/slider/searchDomainNormalization @com.keepit.controllers.admin.SliderAdminController.searchDomainNormalization()
 
 GET     /admin/phrases              @com.keepit.controllers.admin.PhraseController.displayPhrases(page: Int ?= 0)
 POST    /admin/phrases/add          @com.keepit.controllers.admin.PhraseController.addPhrase


### PR DESCRIPTION
1. able to view domain wise normalization rule (only showing domains that have normalization schemes. Otherwise 7M is too much)
2. one can search domain by prefix. This will retrieve all domains matching the prefix (regardless of the normalization schemes). 
3. still need to make it nicely editable. 
