### PR TITLE
Sanity checking notifications

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -228,7 +228,6 @@ const socketHandlers = {
   },
   all_notifications_visited: function(id, time) {
     api.log("[socket:all_notifications_visited]", id, time);
-    syncNumNotificationsNotVisited();
     markAllNoticesVisited(id, time);
   },
   thread: function(th) {
@@ -749,8 +748,6 @@ function markNoticesVisited(category, id, timeStr, locator) {
       id: id,
       numNotVisited: numNotificationsNotVisited});
   });
-
-  syncNumNotificationsNotVisited(); // see comment in function :(
 }
 
 function markAllNoticesVisited(id, timeStr) {  // id and time of most recent notification to mark

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -397,6 +397,7 @@ const socketHandlers = {
   unread_notifications_count: function(count) {
     // see comment in syncNumNotificationsNotVisited() :(
     if (numNotificationsNotVisited != count) {
+      socket.send(["get_missed_notifications", notifications.length ? notifications[0].time : new Date(0).toISOString()]);
       reportError("numNotificationsNotVisited count incorrect: " + numNotificationsNotVisited + " != " + count);
       numNotificationsNotVisited = count;
       tellTabsNoticeCountIfChanged();
@@ -556,6 +557,7 @@ api.port.on({
       notificationsCallbacks.push(reply);
     }
     function reply() {
+      syncNumNotificationsNotVisited(); // sanity checking
       respond({
         notifications: notifications.slice(0, NOTIFICATION_BATCH_SIZE),
         timeLastSeen: timeNotificationsLastSeen.toISOString(),


### PR DESCRIPTION
We've noticed several times where the client misses messages and notifications. Fortunately, I was able to watch it live, and I noticed _nothing_ came down the socket, yet pings continued to work.

There's a chance it was a server side issue (@stkem has a commit exploring that), but I want to be resilient against these types of problems.

Whenever the count is off, we ask for missed notifications. Additionally, every time the user opens the notifications pane, we sync the count (which will sync missed notifications if it's wrong).
