### PR TITLE
clear uri redirct field during split

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
@@ -138,6 +138,7 @@ class UriIntegrityActor @Inject()(
     val toBeScraped = db.readWrite { implicit s =>
       urlRepo.save(url.withNormUriId(newUriId).withHistory(URLHistory(clock.now, newUriId, URLHistoryCause.SPLIT)))
       val (oldUri, newUri) = (uriRepo.get(url.normalizedUriId), uriRepo.get(newUriId))
+      if (newUri.redirect.isDefined) uriRepo.save(newUri.copy(redirect = None, redirectTime = None))
       val toBeScraped = if (oldUri.state != NormalizedURIStates.ACTIVE && oldUri.state != NormalizedURIStates.INACTIVE && (newUri.state == NormalizedURIStates.ACTIVE || newUri.state == NormalizedURIStates.INACTIVE)) {
         Some(uriRepo.save(uriRepo.get(newUriId).withState(NormalizedURIStates.SCRAPE_WANTED)))
       } else None


### PR DESCRIPTION
@ymatsuda  @leogrim

We do two things in handleSplit function:
1. Make sure any thing associated with the url now refer to the new uri
2. if the new uri already exists and has a redirect field, clear that field, so that the uri gets has a fresh state.

TODO:
1. better naming of "split"
2. create a change repo, so that Eliza get notified. 
