### PR TITLE
2.6.3: no more tab.ready

### DIFF
--- a/packrat/adapters/chrome/scripts/api.js
+++ b/packrat/adapters/chrome/scripts/api.js
@@ -98,7 +98,7 @@ var api = api || function() {  // idempotent for Chrome
       },
       on: function(handlers) {
         msgHandlers.push(handlers);
-        port || createPort();
+        api.port.emit('api:handling', Object.keys(handlers));
       }},
     require: function(paths, callback) {
       if (requireQueue) {

--- a/packrat/adapters/firefox/data/scripts/api.js
+++ b/packrat/adapters/firefox/data/scripts/api.js
@@ -54,10 +54,9 @@ api = function() {
       },
       on: function(handlers) {
         for (var type in handlers) {
-          if (handlers.hasOwnProperty(type)) {
-            self.port.on(type, handlers[type]);
-          }
+          self.port.on(type, handlers[type]);
         }
+        self.port.emit("api:handling", Object.keys(handlers));
       }},
     require: function(paths, callback) {
       var callbackId = nextCallbackId++;

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -321,7 +321,7 @@ exports.tabs = {
     tabs.open({
       url: url,
       onOpen: function(tab) {
-        callback && callback(pages[tab.id] || createPage(tab));
+        callback && callback(tab.id);
       }
     });
   },
@@ -441,8 +441,6 @@ tabs
 })
 .on("ready", function(tab) {
   exports.log("[tabs.ready]", tab.id, tab.url);
-  // createPage is already called when first message ("api:start") arrives
-  // pages[tab.id] || createPage(tab);
 });
 
 windows

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -321,7 +321,7 @@ exports.tabs = {
     tabs.open({
       url: url,
       onOpen: function(tab) {
-        callback && callback(tab.id);
+        callback && callback(pages[tab.id] || createPage(tab));
       }
     });
   },
@@ -336,19 +336,36 @@ exports.tabs = {
       if (page && /^https?:/.test(page.url)) callback(page);
     }
   },
-  emit: function(tab, type, data) {
-    var currTab = pages[tab.id];
-    if (tab === currTab || currTab && currTab.url.match(hostRe)[0] == tab.url.match(hostRe)[0]) {
-      if (currTab.ready) {
-        exports.log("[api.tabs.emit] tab:", tab.id, "type:", type, "data:", data, "url:", tab.url);
-        workers[tab.id].forEach(function(worker) {
+  emit: function(tab, type, data, opts) {
+    var page = pages[tab.id];
+    if (page && (page === tab || page.url.match(hostRe)[0] == tab.url.match(hostRe)[0])) {
+      for (var emitted, arr = workers[tab.id], i = 0; i < arr.length; i++) {
+        var worker = arr[i];
+        if (worker.handling[type]) {
           worker.port.emit(type, data);
-        });
-      } else {
-        (currTab.toEmit || (currTab.toEmit = [])).push([type, data]);
+          if (!emitted) {
+            emitted = true;
+            exports.log("[api.tabs.emit]", tab.id, "type:", type, "data:", data, "url:", tab.url);
+          }
+        }
+      }
+      if (!emitted && opts && opts.queue) {
+        if (page.toEmit) {
+          if (opts.queue === 1) {
+            for (var i = 0; i < page.toEmit.length; i++) {
+              if (page.toEmit[i][0] === type) {
+                page.toEmit[i][1] = data;
+                return;
+              }
+            }
+          }
+          page.toEmit.push([type, data]);
+        } else {
+          page.toEmit = [[type, data]];
+        }
       }
     } else {
-      exports.log("[api.tabs.emit] SUPPRESSED tab:", tab.id, "type:", type, "navigated:", tab.url, "->", currTab && currTab.url);
+      exports.log("[api.tabs.emit] SUPPRESSED tab:", tab.id, "type:", type, "navigated:", tab.url, "->", page && page.url);
     }
   },
   get: function(pageId) {
@@ -371,7 +388,6 @@ exports.tabs = {
     focus: new Listeners,
     blur: new Listeners,
     loading: new Listeners,
-    ready: new Listeners,
     unload: new Listeners}};
 
 exports.timers = timers;
@@ -425,7 +441,8 @@ tabs
 })
 .on("ready", function(tab) {
   exports.log("[tabs.ready]", tab.id, tab.url);
-  pages[tab.id] || createPage(tab);
+  // createPage is already called when first message ("api:start") arrives
+  // pages[tab.id] || createPage(tab);
 });
 
 windows
@@ -510,31 +527,12 @@ timers.setTimeout(function() {  // async to allow main.js to complete (so portHa
         let tab = worker.tab, page = pages[tab.id];
         exports.log("[onAttach]", tab.id, this.contentScriptFile, tab.url, page);
         let injected = markInjected({}, o);
-        let pw = workers[tab.id];
-        pw.push(worker);
-        worker.on("pageshow", function() {
-          if (!page.ready && /^https?:/.test(page.url)) {
-            exports.log("[pageshow] tab:", tab.id, "url:", tab.url);
-            // marking and dispatching ready here instead of when tabs "ready" fires because:
-            //  1. content scripts are not necessarily attached yet when tabs "ready" fires
-            //  2. certain calls from content scripts fail if page is not yet visible
-            //     (see https://bugzilla.mozilla.org/show_bug.cgi?id=766088#c2)
-            page.ready = true;
-
-            (page.toEmit || []).forEach(function emit(m) {
-              exports.log("[pageshow:emit]", tab.id, m[0], m[1] != null ? m[1] : "");
-              worker.port.emit.apply(worker.port, m);
-            });
-            delete page.toEmit;
-
-            dispatch.call(exports.tabs.on.ready, page);  // must run only once per page, not per content script on page
-          }
+        workers[tab.id].push(worker);
+        worker.on("pageshow", function() {  // navigated forward or back to page. https://bugzilla.mozilla.org/show_bug.cgi?id=766088#c2
+          exports.log("[pageshow] tab:", tab.id, "url:", tab.url);
+          emitQueuedMessages(page, worker);
         }).on("pagehide", function() {
           exports.log("[pagehide] tab:", tab.id);
-          pw.length = 0;
-        }).on("detach", function() {
-          exports.log("[detach] tab:", tab.id);
-          pw.length = 0;
         });
         Object.keys(portHandlers).forEach(function(type) {
           worker.port.on(type, function(data, callbackId) {
@@ -543,6 +541,14 @@ timers.setTimeout(function() {  // async to allow main.js to complete (so portHa
                 worker.port.emit("api:respond", callbackId, response);
               }, page);
           });
+        });
+        worker.handling = {};
+        worker.port.on("api:handling", function(types) {
+          exports.log("[api:handling]", types);
+          for each (let type in types) {
+            worker.handling[type] = true;
+          }
+          emitQueuedMessages(page, worker);
         });
         worker.port.on("api:require", function(paths, callbackId) {
           var o = deps(paths, injected);
@@ -553,6 +559,24 @@ timers.setTimeout(function() {  // async to allow main.js to complete (so portHa
       }});
   });
 }, 0);
+
+function emitQueuedMessages(page, worker) {
+  if (page.toEmit) {
+    for (var i = 0; i < page.toEmit.length;) {
+      var m = page.toEmit[i];
+      if (worker.handling[m[0]]) {
+        exports.log("[emitQueuedMessages]", page.id, m[0], m[1] != null ? m[1] : "");
+        worker.port.emit.apply(worker.port, m);
+        page.toEmit.splice(i, 1);
+      } else {
+        i++;
+      }
+    }
+    if (!page.toEmit.length) {
+      delete page.toEmit;
+    }
+  }
+}
 
 function removeFromWindow(win) {
   if (win.removeIcon) {

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.6.2
+version=2.6.3

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1,6 +1,7 @@
 var api = api || require("./api");
 
 const NOTIFICATION_BATCH_SIZE = 10;
+const hostRe = /^https?:\/\/([^\/]*)/;
 
 var tabsShowingNotificationsPane = [];
 var notificationsCallbacks = [];
@@ -469,7 +470,6 @@ api.port.on({
     }
   },
   set_keeper_pos: function(o, _, tab) {
-    const hostRe = /^https?:\/\/([^\/]*)/;
     for (var nUri in pageData) {
       if (nUri.match(hostRe)[1] == o.host) {
         pageData[nUri].position = o.pos;
@@ -626,31 +626,33 @@ api.port.on({
     socket.send(["get_networks", friendId], respond);
   },
   open_deep_link: function(data, _, tab) {
-    var n;
-                                      // on a tab that is the old normalized URI, and we know about the new normalization
-    var uriData = pageData[data.nUri] || pageData[(n = api.tabs.anyAt(data.nUri)) && n.nUri];
-
-    if (uriData) {
-      var tab = tab.nUri == data.nUri ? tab : uriData.tabs[0];
-      if (tab.ready) {
-        api.tabs.emit(tab, "open_to", {trigger: "deepLink", locator: data.locator});
-      } else {
-        createDeepLinkListener(data.locator, tab.id);
+    var tabAtNewNormUri, d =
+      pageData[data.nUri] ||
+      pageData[(tabAtNewNormUri = api.tabs.anyAt(data.nUri)) && tabAtNewNormUri.nUri];  // data associated with old URI normalization
+    if (d) {
+      goToDeepLink(tab.nUri == data.nUri ? tab : d.tabs[0]);
+    } else {
+      api.tabs.open(data.nUri, goToDeepLink);
+    }
+    function goToDeepLink(tab) {
+      if (data.locator) {
+        api.tabs.emit(tab, "open_to", {trigger: "deepLink", locator: data.locator}, {queue: 1});
       }
       api.tabs.select(tab.id);
-    } else {
-      api.tabs.open(data.nUri, function(tabId) {
-        if (data.locator) {
-          createDeepLinkListener(data.locator, tabId);
-        }
-      });
     }
   },
   remove_notification: function(o) {
     removeNotificationPopups(o.associatedId);
   },
-  add_deep_link_listener: function(locator, _, tab) {
-    createDeepLinkListener(locator, tab.id);
+  handle_deep_link: function handleDeepLink(o, _, tab, retrySec) {
+    tab = api.tabs.get(tab.id);
+    if (tab && o.uri.match(hostRe)[1] == tab.url.match(hostRe)[1]) {
+      api.log("[handleDeepLink]", tab.id, o);
+      api.tabs.emit(tab, "open_to", {trigger: "deepLink", locator: o.locator}, {queue: 1});
+    } else if ((retrySec = retrySec || .5) < 5) {
+      api.log("[handleDeepLink]", tab.id, "retrying in", retrySec, "sec");
+      setTimeout(handleDeepLink.bind(null, o, null, tab, retrySec + .5), retrySec * 1000);
+    }
   },
   report_error: function(data, _, tag) {
     // TODO: filter errors and improve fidelity/completeness of information
@@ -674,7 +676,7 @@ function sendNotificationToTabs(n) {
   function tellTab(tab) {
     if (told[tab.id]) return;
     told[tab.id] = true;
-    api.tabs.emit(tab, "new_notification", n);
+    api.tabs.emit(tab, "new_notification", n, {queue: true});
   }
 }
 
@@ -796,37 +798,17 @@ function getTimeLastRead(n, d) {
     n.category == "message" && d.lastMessageRead ? (d.lastMessageRead[n.locator.split("/")[2]] || 0) : 0);
 }
 
-function createDeepLinkListener(locator, tabId) {
-  var createdTime = Date.now();
-  api.tabs.on.ready.add(function deepLinkListener(tab) {
-    if (Date.now() - createdTime > 15000) {
-      api.tabs.on.ready.remove(deepLinkListener);
-      api.log("[createDeepLinkListener] Listener timed out.");
-      return;
-    }
-    if (tab.id == tabId) {
-      // uncomment second clause below to develop /r/ page using production deep links
-      var hasForwarded = !(new RegExp("^" + webBaseUri() + "/r/", "").test(tab.url)) /* && tab.url.indexOf("dev.ezkeep.com") < 0 */;
-      if (hasForwarded) {
-        api.log("[createDeepLinkListener] Sending deep link to tab " + tab.id, locator);
-        api.tabs.emit(tab, "open_to", {trigger: "deepLink", locator: locator});
-        api.tabs.on.ready.remove(deepLinkListener);
-      }
-    }
-  });
-}
-
 function initTab(tab, d) {  // d is pageData[tab.nUri]
   api.log("[initTab]", tab.id, "inited:", tab.inited);
 
   d.counts.n = numNotificationsNotVisited;
-  api.tabs.emit(tab, "counts", d.counts);
+  api.tabs.emit(tab, "counts", d.counts, {queue: 1});
   if (tab.inited) return;
   tab.inited = true;
 
   if (ruleSet.rules.message && d.counts.m) {  // open immediately to unread message(s)
     var ids = unreadThreadIds(d.threads, d.lastMessageRead);
-    api.tabs.emit(tab, "open_to", {trigger: "message", locator: "/messages" + (ids.length > 1 ? "" : "/" + ids[0])});
+    api.tabs.emit(tab, "open_to", {trigger: "message", locator: "/messages" + (ids.length > 1 ? "" : "/" + ids[0])}, {queue: 1});
     ids.forEach(function(id) {
       socket.send(["get_thread", id]);
     });
@@ -838,15 +820,14 @@ function initTab(tab, d) {  // d is pageData[tab.nUri]
       api.log("[initTab]", tab.id, "shown before");
     } else {
       if (api.prefs.get("showSlider")) {
-        api.tabs.emit(tab, "scroll_rule", ruleSet.rules.scroll);
+        api.tabs.emit(tab, "scroll_rule", ruleSet.rules.scroll, {queue: 1});
       }
       tab.autoShowSec = (ruleSet.rules.focus || [])[0];
       if (tab.autoShowSec != null && api.tabs.isFocused(tab)) {
         scheduleAutoShow(tab);
       }
-
       if (d.keepers.length) {
-        api.tabs.emit(tab, "keepers", {keepers: d.keepers, otherKeeps: d.otherKeeps});
+        api.tabs.emit(tab, "keepers", {keepers: d.keepers, otherKeeps: d.otherKeeps}, {queue: 1});
       }
     }
   }
@@ -887,7 +868,7 @@ function tellTabsNoticeCountIfChanged() {
     var d = pageData[tab.nUri];
     if (d && d.counts && d.counts.n != numNotificationsNotVisited) {
       d.counts.n = numNotificationsNotVisited;
-      api.tabs.emit(tab, "counts", d.counts);
+      api.tabs.emit(tab, "counts", d.counts, {queue: 1});
     }
   });
 }
@@ -897,7 +878,7 @@ function tellTabsIfCountChanged(d, key, count) {
     d.counts[key] = count;
     d.counts.n = numNotificationsNotVisited;
     d.tabs.forEach(function(tab) {
-      api.tabs.emit(tab, "counts", d.counts);
+      api.tabs.emit(tab, "counts", d.counts, {queue: 1});
     });
   }
 }
@@ -952,7 +933,7 @@ function ymd(d) {  // yyyy-mm-dd local date
 
 // kifi icon in location bar
 api.icon.on.click.add(function(tab) {
-  api.tabs.emit(tab, "button_click");
+  api.tabs.emit(tab, "button_click", null, {queue: 1});
 });
 
 function subscribe(tab) {
@@ -1064,9 +1045,10 @@ function setIcon(tab, kept) {
 
 function sendInit(tab, d) {
   api.tabs.emit(tab, "init", {
-    kept: d.kept,
-    position: d.position,
-    hide: d.neverOnSite || ruleSet.rules.sensitive && d.sensitive});
+      kept: d.kept,
+      position: d.position,
+      hide: d.neverOnSite || ruleSet.rules.sensitive && d.sensitive
+    }, {queue: 1});
 }
 
 function postBookmarks(supplyBookmarks, bookmarkSource) {
@@ -1122,6 +1104,7 @@ api.tabs.on.blur.add(function(tab) {
 api.tabs.on.loading.add(function(tab) {
   api.log("#b8a", "[tabs.on.loading] %i %o", tab.id, tab);
   subscribe(tab);
+  logEvent("extension", "pageLoad");
 });
 
 const searchPrefetchCache = {};  // for searching before the results page is ready
@@ -1153,11 +1136,6 @@ function getPrefetched(request, cb) {
   }
 }
 
-api.tabs.on.ready.add(function(tab) {
-  api.log("#b8a", "[tabs.on.ready] %i %o", tab.id, tab);
-  logEvent("extension", "pageLoad");
-});
-
 api.tabs.on.unload.add(function(tab) {
   api.log("#b8a", "[tabs.on.unload] %i %o", tab.id, tab);
   api.timers.clearTimeout(tab.autoShowTimer);
@@ -1184,7 +1162,7 @@ function scheduleAutoShow(tab) {
       delete tab.autoShowTimer;
       if (api.prefs.get("showSlider")) {
         api.log("[autoShow]", tab.id);
-        api.tabs.emit(tab, "auto_show");
+        api.tabs.emit(tab, "auto_show", null, {queue: 1});
       }
     }, tab.autoShowSec * 1000);
   }
@@ -1284,7 +1262,7 @@ function getRules() {
 
 // ===== Session management
 
-var session, socket, onReadyTemp;
+var session, socket, onLoadingTemp;
 
 function connectSync() {
   getRules();
@@ -1335,7 +1313,7 @@ function startSession(callback, retryMs) {
     delete session.patterns;
     delete session.installationId;
 
-    api.tabs.on.ready.remove(onReadyTemp), onReadyTemp = null;
+    api.tabs.on.loading.remove(onLoadingTemp), onLoadingTemp = null;
     api.tabs.each(function(page) {
       api.tabs.emit(page, "session_change", session);
     });
@@ -1356,10 +1334,10 @@ function startSession(callback, retryMs) {
       } else {
         api.tabs.open(webBaseUri());
       }
-      api.tabs.on.ready.add(onReadyTemp = function(tab) {
+      api.tabs.on.loading.add(onLoadingTemp = function(tab) {
         // if kifi.com home page, retry first authentication
         if (tab.url.replace(/\/#.*$/, "") === webBaseUri()) {
-          api.tabs.on.ready.remove(onReadyTemp), onReadyTemp = null;
+          api.tabs.on.loading.remove(onLoadingTemp), onLoadingTemp = null;
           startSession(callback, retryMs);
         }
       });
@@ -1404,7 +1382,7 @@ function deauthenticate() {
       }
       api.tabs.each(function(tab) {
         api.icon.set(tab, "icons/keep.faint.png");
-        api.tabs.emit(tab, "session_change", undefined);
+        api.tabs.emit(tab, "session_change", null);
       });
     }
   })

--- a/packrat/scripts/deep_link_redirect.js
+++ b/packrat/scripts/deep_link_redirect.js
@@ -5,11 +5,10 @@
 !function run(json, e) {
   var msg = document.getElementsByClassName('kifi-deep-link-no-extension')[0];
   if (msg) {
-    debugger;
     msg.style.display = "none";
     var link = JSON.parse(json);
     if (link.url) {
-      api.port.emit("handle_deep_link", link);
+      api.port.emit("await_deep_link", link);
       window.location = link.url;
     }
   } else {

--- a/packrat/scripts/deep_link_redirect.js
+++ b/packrat/scripts/deep_link_redirect.js
@@ -5,11 +5,12 @@
 !function run(json, e) {
   var msg = document.getElementsByClassName('kifi-deep-link-no-extension')[0];
   if (msg) {
+    debugger;
     msg.style.display = "none";
     var link = JSON.parse(json);
-    api.port.emit("add_deep_link_listener", link.locator);
-    if (link.uri) {
-      window.location = link.uri;
+    if (link.url) {
+      api.port.emit("handle_deep_link", link);
+      window.location = link.url;
     }
   } else {
     document.addEventListener("DOMContentLoaded", run.bind(null, json));

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -466,8 +466,9 @@ if (searchUrlRe.test(document.URL)) !function() {
         configureHover(html, {canLeaveFor: 600, click: "toggle"});
       });
     }).on("click", ".kifi-chatter-deeplink", function() {
-      api.port.emit("add_deep_link_listener", $(this).data("locator"));
-      location.href = $(this).closest("li.g").find("h3.r a")[0].href;
+      var url = $(this).closest("li.g").find("h3.r a")[0].href;
+      api.port.emit("handle_deep_link", {url: url, locator: $(this).data("locator")});
+      location.href = url;
     });
   }
 

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -467,7 +467,7 @@ if (searchUrlRe.test(document.URL)) !function() {
       });
     }).on("click", ".kifi-chatter-deeplink", function() {
       var url = $(this).closest("li.g").find("h3.r a")[0].href;
-      api.port.emit("handle_deep_link", {url: url, locator: $(this).data("locator")});
+      api.port.emit("await_deep_link", {url: url, locator: $(this).data("locator")});
       location.href = url;
     });
   }


### PR DESCRIPTION
Eliminating the `tab.ready` flag and `on.ready` event, which we were using to indicate both that the page’s document was ready and that its initial content scripts had been injected (and thus that it had most likely registered its message handlers). We now track in the extension which messages each content script port has registered handlers for and queue critical messages in the extension until a page’s relevant content script port reports that it has a registered handler for that type of message.

When using `api.tabs.emit` to send a tab a message, pass a new fourth argument `{queue: true}` to queue the message if necessary until the tab has a handler ready, or pass `{queue: 1}` to queue the message if necessary ensuring that only one message of this type will ever be queued for the tab at at time. `{queue: 1}` is helpful for `"counts"` messages, for example, where the tab will only actually care about the most recent counts.
