### PR TITLE
Fixing mark as read when notifications are not in order.

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
@@ -88,6 +88,7 @@ class ServiceDiscoveryImpl @Inject() (
 
   private def keepAlive() : Unit = {
     scheduler.scheduleOnce(2 minutes){
+      forceUpdate()
       if (stillRegistered) {
         keepAlive()
       } else {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/MessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/MessagingController.scala
@@ -647,11 +647,11 @@ class MessagingController @Inject() (
 
   def connectedSockets: Int  = notificationRouter.connectedSockets
 
-  def setNotificationReadForMessage(userId: Id[User], msgExtId: ExternalId[Message]) : Unit = {
+  def setNotificationReadForMessage(userId: Id[User], msgExtId: ExternalId[Message]): Unit = {
     val message = db.readOnly{ implicit session => messageRepo.get(msgExtId) }
     val thread  = db.readOnly{ implicit session => threadRepo.get(message.thread) } //TODO: This needs to change when we have detached threads
-    val nUrl : String = thread.nUrl.getOrElse("")
-    if (message.from != userId) db.readWrite{ implicit session => userThreadRepo.clearNotificationForMessage(userId, thread.id.get, message) }
+    val nUrl: String = thread.nUrl.getOrElse("")
+    if (message.from.isDefined && message.from.get != userId) db.readWrite{ implicit session => userThreadRepo.clearNotificationForMessage(userId, thread.id.get, message) }
     notificationRouter.sendToUser(userId, Json.arr("message_read", nUrl, message.threadExtId.id, message.createdAt, message.externalId.id))
     notificationRouter.sendToUser(userId, Json.arr("unread_notifications_count", getPendingNotificationCount(userId)))
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/MessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/MessagingController.scala
@@ -651,7 +651,11 @@ class MessagingController @Inject() (
     val message = db.readOnly{ implicit session => messageRepo.get(msgExtId) }
     val thread  = db.readOnly{ implicit session => threadRepo.get(message.thread) } //TODO: This needs to change when we have detached threads
     val nUrl: String = thread.nUrl.getOrElse("")
-    if (message.from.isDefined && message.from.get != userId) db.readWrite{ implicit session => userThreadRepo.clearNotificationForMessage(userId, thread.id.get, message) }
+    if (message.from.isDefined && message.from.get != userId) {
+      db.readWrite { implicit session =>
+        userThreadRepo.clearNotificationForMessage(userId, thread.id.get, message)
+      }
+    }
     notificationRouter.sendToUser(userId, Json.arr("message_read", nUrl, message.threadExtId.id, message.createdAt, message.externalId.id))
     notificationRouter.sendToUser(userId, Json.arr("unread_notifications_count", getPendingNotificationCount(userId)))
   }

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -612,9 +612,9 @@ api.port.on({
       socket.send(["set_last_notify_read_time", t]);
     }
   },
-  all_notifications_visited: function(id, time) {
-    markAllNoticesVisited(id, time);
-    socket.send(["set_all_notifications_visited", id]);
+  all_notifications_visited: function(o) {
+    markAllNoticesVisited(o.id, o.time);
+    socket.send(["set_all_notifications_visited", o.id]);
   },
   session: function(_, respond) {
     respond(session);

--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -70,8 +70,10 @@ noticesPane = function() {
         api.port.emit("notifications_pane", true);
 
         $markAll = $box.find(".kifi-pane-mark-notices-read").click(function() {
-          var data = $notices.find(".kifi-notice").data();
-          api.port.emit("all_notifications_visited", data.id, data.createdAt);
+          var data = $notices.find(".kifi-notice").toArray().sort(function(a, b) {
+             return new Date(b.dataset.createdAt) - new Date(a.dataset.createdAt);
+          })[0].dataset;
+          api.port.emit("all_notifications_visited", {id: data.id, time: data.createdAt});
           // not updating DOM until response received due to bulk nature of action
         }).toggle(numNotVisited > 0);
 

--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -70,10 +70,11 @@ noticesPane = function() {
         api.port.emit("notifications_pane", true);
 
         $markAll = $box.find(".kifi-pane-mark-notices-read").click(function() {
-          var data = $notices.find(".kifi-notice").toArray().sort(function(a, b) {
-             return new Date(b.dataset.createdAt) - new Date(a.dataset.createdAt);
-          })[0].dataset;
-          api.port.emit("all_notifications_visited", {id: data.id, time: data.createdAt});
+          var o = $notices.find(".kifi-notice").toArray().reduce(function(o, el) {
+            var t = new Date(el.dataset.createdAt);
+            return t > o.time ? {time: t, id: el.dataset.id} : o;
+          }, {time: 0});
+          api.port.emit("all_notifications_visited", o);
           // not updating DOM until response received due to bulk nature of action
         }).toggle(numNotVisited > 0);
 


### PR DESCRIPTION
~~Currently, there's a server-side bug that is updating notification records when the user replies to a message. Thus, notifications are sorted by the last time _anyone_ replied to a thread, not _someone other than the current user_. Because of this, when notifications are marked as read, we potentially send an older ID, which leaves some threads as unread.~~

~~Ideally, this is temporary, but @stkem and I couldn't find how these records are being updated after looking for a while.~~ **_Unless_ you like the added resiliency.**

edit: Server side bug fixed. @2is10 do we want this (the `thread.js` change) for resiliency, or can it?

edit2: Stephen raises a good point: there's many notifications with wrong timestamps. Leaving this for now is probably a good thing.

Also (in `main.js`), the first parameter for port messages is the payload. The 2nd is the response, 3rd is the tab. So not sure how this ever worked.
