### PR TITLE
New goodies

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/admin/ServiceController.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/admin/ServiceController.scala
@@ -8,6 +8,9 @@ import com.google.inject.Inject
 import views.html
 import com.keepit.common.logging.Logging
 import play.api.mvc._
+import scala.util.{Failure, Success, Try}
+import scala.util.matching.Regex
+import scala.collection.JavaConversions._
 
 class ServiceController @Inject() (
     serviceDiscovery: ServiceDiscovery) extends Controller with Logging {
@@ -23,6 +26,60 @@ class ServiceController @Inject() (
 
     def topology = Action { implicit request =>
         Ok(serviceDiscovery.toString)
+    }
+
+
+    def threadDetails(name: String = "", state: String = "", stack: String = "") = Action { request =>
+      val onlyShowUs = request.queryString.get("us").nonEmpty
+
+      val allThreads = Thread.getAllStackTraces.map { case (thread, stackTrace) =>
+        val threadName = thread.getName
+        val isOurCodeInThisStack = stackTrace.filter(s => (s.getClassName + s.getMethodName).toLowerCase.contains("com.keepit")).nonEmpty
+
+        if (!onlyShowUs || isOurCodeInThisStack) {
+          if (threadName.toLowerCase.contains(name.toLowerCase) && thread.getState.toString.toLowerCase.contains(state.toLowerCase)) {
+            if (stack.isEmpty || stackTrace.filter(s => (s.getClassName + s.getMethodName).toLowerCase.contains(stack.toLowerCase)).nonEmpty) {
+              val header = s"${thread.getName}\t(${thread.getState.toString})"
+              val stackStr = stackTrace.map { st =>
+                val matchName = (st.getClassName + st.getMethodName).toLowerCase
+                val comKeepitMatch = if (matchName.contains("com.keepit.")) "*" else ""
+                val stackMatch = if (stack.nonEmpty && matchName.contains(stack.toLowerCase)) "*"
+                else ""
+                s"$comKeepitMatch\t$stackMatch\t${st.getClassName}.${st.getMethodName}:${st.getLineNumber}"
+              } mkString("\n")
+              Some(header + "\n" + stackStr)
+            } else {
+              None
+            }
+          } else {
+            None
+          }
+        } else {
+          None
+        }
+      }.flatten.mkString("\n\n")
+      Ok(allThreads)
+    }
+
+    def threadSummary = Action { request =>
+      val poolRe = "(.*)-\\d*".r
+      val ioRe = "(.*) #\\d*".r
+      val allThreads = Thread.getAllStackTraces.map { th =>
+        val threadName = th._1.getName
+        threadName match {
+          case poolRe(shortName) => shortName
+          case ioRe(shortName) => shortName
+          case s => s
+        }
+      }
+      val displayOut = allThreads
+        .map(th => (th, allThreads.count(_ == th)))
+        .toSet.toSeq
+        .sortWith((a,b) => a._2 > b._2)
+        .map(th => s"${th._2}\t${th._1}")
+        .mkString("\n")
+
+      Ok(displayOut)
     }
 
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/admin/ServiceController.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/admin/ServiceController.scala
@@ -36,20 +36,20 @@ class ServiceController @Inject() (
         val threadName = thread.getName
         val isOurCodeInThisStack = stackTrace.filter(s => (s.getClassName + s.getMethodName).toLowerCase.contains("com.keepit")).nonEmpty
 
-        if (!onlyShowUs || isOurCodeInThisStack) {
-          if (threadName.toLowerCase.contains(name.toLowerCase) && thread.getState.toString.toLowerCase.contains(state.toLowerCase)) {
-            if (stack.isEmpty || stackTrace.filter(s => (s.getClassName + s.getMethodName).toLowerCase.contains(stack.toLowerCase)).nonEmpty) {
-              val header = s"${thread.getName}\t(${thread.getState.toString})"
-              val stackStr = stackTrace.map { st =>
-                val matchName = (st.getClassName + st.getMethodName).toLowerCase
-                val comKeepitMatch = if (matchName.contains("com.keepit.")) "*" else ""
-                val stackMatch = if (stack.nonEmpty && matchName.contains(stack.toLowerCase)) "*"
-                else ""
-                s"$comKeepitMatch\t$stackMatch\t${st.getClassName}.${st.getMethodName}:${st.getLineNumber}"
-              } mkString("\n")
-              Some(header + "\n" + stackStr)
-            } else None
-          } else None
+        if ((!onlyShowUs || isOurCodeInThisStack)
+          && (threadName.toLowerCase.contains(name.toLowerCase) && thread.getState.toString.toLowerCase.contains(state.toLowerCase))
+          && (stack.isEmpty || stackTrace.filter(s => (s.getClassName + s.getMethodName).toLowerCase.contains(stack.toLowerCase)).nonEmpty)) {
+
+          val header = s"${thread.getName}\t(${thread.getState.toString})"
+          val stackStr = stackTrace.map { st =>
+            val matchName = (st.getClassName + st.getMethodName).toLowerCase
+            val comKeepitMatch = if (matchName.contains("com.keepit.")) "*" else ""
+            val stackMatch = if (stack.nonEmpty && matchName.contains(stack.toLowerCase)) "*"
+            else ""
+            s"$comKeepitMatch\t$stackMatch\t${st.getClassName}.${st.getMethodName}:${st.getLineNumber}"
+          } mkString("\n")
+          Some(header + "\n" + stackStr)
+          
         } else None
       }.flatten.mkString("\n\n")
       Ok(allThreads)

--- a/kifi-backend/modules/common/app/com/keepit/common/admin/ServiceController.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/admin/ServiceController.scala
@@ -48,15 +48,9 @@ class ServiceController @Inject() (
                 s"$comKeepitMatch\t$stackMatch\t${st.getClassName}.${st.getMethodName}:${st.getLineNumber}"
               } mkString("\n")
               Some(header + "\n" + stackStr)
-            } else {
-              None
-            }
-          } else {
-            None
-          }
-        } else {
-          None
-        }
+            } else None
+          } else None
+        } else None
       }.flatten.mkString("\n\n")
       Ok(allThreads)
     }

--- a/kifi-backend/modules/common/app/com/keepit/common/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/package.scala
@@ -18,4 +18,11 @@ package object common {
     def withSideEffect(fun: A => Unit): A = { fun(a); a }
     def tap(fun: A => Unit): A = withSideEffect(fun)
   }
+
+  implicit class SpiltCombinator[A, B](val a: A) extends AnyVal {
+    def split(t: A => Boolean)(y: A => B, z: A => B) = {
+      if (t(a)) y(a)
+      else z(a)
+    }
+  }
 }

--- a/kifi-backend/modules/common/conf/common.routes
+++ b/kifi-backend/modules/common/conf/common.routes
@@ -13,5 +13,7 @@ GET     /assets/*file               controllers.Assets.at(path="/public", file)
 GET     /internal/benchmark                   @com.keepit.common.healthcheck.CommonBenchmarkController.benchmarksResults()
 GET     /internal/version                     @com.keepit.common.healthcheck.CommonBenchmarkController.version()
 GET     /internal/clusters/refresh            @com.keepit.common.admin.ServiceController.forceRefresh()
-GET		/internal/clusters/mystatus			  @com.keepit.common.admin.ServiceController.myStatus
-GET		/internal/clusters/topology			  @com.keepit.common.admin.ServiceController.topology
+GET		  /internal/clusters/mystatus			      @com.keepit.common.admin.ServiceController.myStatus
+GET		  /internal/clusters/topology			      @com.keepit.common.admin.ServiceController.topology
+GET     /internal/common/threadSummary        @com.keepit.common.admin.ServiceController.threadSummary
+GET     /internal/common/threadDetails        @com.keepit.common.admin.ServiceController.threadDetails(name: String ?= "", state: String ?= "", stack ?= "")


### PR DESCRIPTION
This lets us easily (on all services, no YourKit overhead):
- See how many threads are allocated in each pool
- Query threads / states / stack traces and see what is happening

Example usages:

```
curl http://localhost:9000/internal/common/threadSummary
curl http://localhost:9000/internal/common/threadDetails?name=dispatcher
curl http://localhost:9000/internal/common/threadDetails?state=running
curl http://localhost:9000/internal/common/threadDetails?name=iteratee&stack=MessagingController
curl http://localhost:9000/internal/common/threadDetails?us
```

During free time I'll continue to tweak this, clean it up, and give it more features.
