### PR TITLE
for firefox: handling in-page navigation and bfcache (instant back/forward) navigation better

### DIFF
--- a/packrat/adapters/firefox/data/scripts/start.js
+++ b/packrat/adapters/firefox/data/scripts/start.js
@@ -1,7 +1,0 @@
-if (document.readyState === "loading") {
-  self.port.emit("api:start");
-}
-
-addEventListener("hashchange", function() {
-  self.port.emit("api:nav");
-});

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -18,19 +18,25 @@ function markInjected(inj, o) {
 const self = require("sdk/self"), data = self.data, load = data.load.bind(data), url = data.url.bind(url);
 const timers = require("sdk/timers");
 const { Ci, Cc } = require("chrome");
-const WM = Cc["@mozilla.org/appshell/window-mediator;1"].getService(Ci.nsIWindowMediator);
 const {deps} = require("./deps");
 const {Listeners} = require("./listeners");
 const icon = require("./icon");
 const windows = require("sdk/windows").browserWindows;
 const tabs = require("sdk/tabs");
-const googleSearchPattern = /^https?:\/\/www\.google\.[a-z]{2,3}(\.[a-z]{2})?\/(|search|webhp)\?(|.*&)q=([^&]*)/;
+const workerNs = require('sdk/core/namespace').ns();
 
-const pages = {}, workers = {}, tabsById = {};  // all by tab.id
+const googleSearchPattern = /^https?:\/\/www\.google\.[a-z]{2,3}(\.[a-z]{2})?\/(|search|webhp)\?(|.*&)q=([^&]*)/;
+const httpRe = /^https?:/;
+const hostRe = /^https?:\/\/[^\/]*/;
+const stripHashRe = /^[^#]*/;
+
+const pages = {}, tabsById = {};
 function createPage(tab) {
   if (!tab || !tab.id) throw Error(tab ? "tab without id" : "tab required");
-  (workers[tab.id] || (workers[tab.id] = [])).length = 0;
-  return pages[tab.id] = {id: tab.id, url: tab.url};
+  exports.log('[createPage]', tab.id, tab.url);
+  var page = pages[tab.id] = {id: tab.id, url: tab.url};
+  workerNs(page).workers = [];
+  return page;
 }
 
 exports.bookmarks = require("./bookmarks");
@@ -40,7 +46,7 @@ exports.icon = {
   set: function(page, path) {
     if (page === pages[page.id]) {
       page.icon = path;
-      exports.log("page:", page);
+      exports.log("[api.icon.set]", page.id, path);
       var tab = tabsById[page.id], win = tab.window;
       if (tab === win.tabs.activeTab) {
         icon.show(win, url(path));
@@ -303,7 +309,6 @@ function onSocketMessage(socketId, data) {
 
 exports.storage = require("sdk/simple-storage").storage;
 
-const hostRe = /^https?:\/\/[^\/]*/;
 exports.tabs = {
   anyAt: function(url) {
     for each (let page in pages) {
@@ -327,20 +332,20 @@ exports.tabs = {
   },
   each: function(callback) {
     for each (let page in pages) {
-      if (/^https?:/.test(page.url)) callback(page);
+      if (httpRe.test(page.url)) callback(page);
     }
   },
   eachSelected: function(callback) {
     for each (let win in windows) {
       var page = pages[win.tabs.activeTab.id];
-      if (page && /^https?:/.test(page.url)) callback(page);
+      if (page && httpRe.test(page.url)) callback(page);
     }
   },
   emit: function(tab, type, data, opts) {
-    var page = pages[tab.id];
-    if (page && (page === tab || page.url.match(hostRe)[0] == tab.url.match(hostRe)[0])) {
-      for (var emitted, arr = workers[tab.id], i = 0; i < arr.length; i++) {
-        var worker = arr[i];
+    var emitted;
+    const page = pages[tab.id];
+    if (page === tab) {
+      for (let worker of workerNs(page).workers) {
         if (worker.handling[type]) {
           worker.port.emit(type, data);
           if (!emitted) {
@@ -349,7 +354,9 @@ exports.tabs = {
           }
         }
       }
-      if (!emitted && opts && opts.queue) {
+    }
+    if (!emitted) {
+      if (opts && opts.queue) {
         if (page.toEmit) {
           if (opts.queue === 1) {
             for (var i = 0; i < page.toEmit.length; i++) {
@@ -363,9 +370,9 @@ exports.tabs = {
         } else {
           page.toEmit = [[type, data]];
         }
+      } else {
+        exports.log("[api.tabs.emit]", tab.id, "type:", type, "neither emitted nor queued for:", tab.url);
       }
-    } else {
-      exports.log("[api.tabs.emit] SUPPRESSED tab:", tab.id, "type:", type, "navigated:", tab.url, "->", page && page.url);
     }
   },
   get: function(pageId) {
@@ -402,13 +409,8 @@ tabs
 })
 .on("close", function(tab) {
   exports.log("[tabs.close]", tab.id, tab.url);
-  var page = pages[tab.id];
-  delete pages[tab.id];
-  delete workers[tab.id];
+  onPageHide(tab.id);
   delete tabsById[tab.id];
-  if (/^https?:/.test(page.url)) {
-    dispatch.call(exports.tabs.on.unload, page);
-  }
 })
 .on("activate", function(tab) {
   var page = pages[tab.id];
@@ -424,7 +426,7 @@ tabs
       } else {
         page = createPage(tab);
       }
-      if (tab.window === windows.activeWindow && /^https?:/.test(page.url)) {
+      if (tab.window === windows.activeWindow && httpRe.test(page.url)) {
         dispatch.call(exports.tabs.on.focus, page);
       }
     }
@@ -434,7 +436,7 @@ tabs
   exports.log("[tabs.deactivate]", tab.id, tab.url);
   if (tab.window === windows.activeWindow) {
     var page = pages[tab.id];
-    if (page && /^https?:/.test(page.url)) {
+    if (page && httpRe.test(page.url)) {
       dispatch.call(exports.tabs.on.blur, page);
     }
   }
@@ -454,13 +456,13 @@ windows
 })
 .on("activate", function(win) {
   var page = pages[win.tabs.activeTab.id];
-  if (page && /^https?:/.test(page.url)) {
+  if (page && httpRe.test(page.url)) {
     dispatch.call(exports.tabs.on.focus, page);
   }
 })
 .on("deactivate", function(win) {
   var page = pages[win.tabs.activeTab.id];
-  if (page && /^https?:/.test(page.url)) {
+  if (page && httpRe.test(page.url)) {
     dispatch.call(exports.tabs.on.blur, page);
   }
 });
@@ -475,44 +477,59 @@ for each (let win in windows) {
     tabsById[tab.id] = tab;
     pages[tab.id] || createPage(tab);
   }
-};
+}
+
+// navigation handling
+
+require('./location').onChange(function(tabId, newPage) {
+  const tab = tabsById[tabId];
+  exports.log('[location:change]', tabId, 'newPage:', newPage, tab.url);
+  if (newPage) {
+    onPageHide(tab.id);
+
+    // Note: It’s possible that this page shouldn’t actually be created, since Firefox will grab the actual
+    // page from the bfcache. If we detect that in the PageMod pageshow handler below, we discard this page.
+    // TODO: Find a way to detect at this point whether the page will be coming from the bfcache and recover
+    // our old page object if it is.
+    let page = createPage(tab);
+
+    let match = googleSearchPattern.exec(tab.url);
+    if (match) {
+      let query = decodeURIComponent(match[4].replace(/\+/g, ' '));
+      if (query) dispatch.call(exports.on.search, query);
+    }
+    dispatch.call(exports.tabs.on.loading, page);
+  } else {
+    let page = pages[tabId];
+    if (page.url.match(stripHashRe)[0] === tab.url.match(stripHashRe)[0]) {  // fragment-only change
+      page.url = tab.url;
+    } else if (page.url != tab.url) {
+      if (httpRe.test(page.url)) {
+        dispatch.call(api.tabs.on.unload, page);
+        page.url = tab.url;
+        dispatch.call(api.tabs.on.loading, page);
+      } else {
+        page.url = tab.url;
+      }
+    }
+  }
+});
+
+function onPageHide(tabId) {
+  const page = pages[tabId];
+  if (page) {
+    delete pages[tabId];
+    if (httpRe.test(page.url)) {
+      dispatch.call(exports.tabs.on.unload, page);
+    }
+  }
+}
 
 // attaching content scripts
-
-let {PageMod} = require("sdk/page-mod");
-PageMod({
-  include: /^https?:.*/,
-  contentScriptFile: url("scripts/start.js"),
-  contentScriptWhen: "start",
-  attachTo: ["existing", "top"],
-  onAttach: function(worker) {
-    var tab = worker.tab;
-    exports.log("[onAttach]", tab.id, "start.js", tab.url);
-    worker.port.on("api:start", function() {
-      exports.log("[api:start]", tab.id, tab.url);
-      var oldPage = pages[tab.id];
-      if (oldPage && /^https?:/.test(oldPage.url)) {
-        dispatch.call(exports.tabs.on.unload, oldPage);
-      }
-      var page = createPage(tab);
-      var searchQuery = decodeURIComponent(((page.url.match(googleSearchPattern) || [])[4] || '').replace(/\+/g, ' '));
-      if (searchQuery) dispatch.call(exports.on.search, searchQuery);
-      dispatch.call(exports.tabs.on.loading, page);
-    });
-    worker.port.on("api:nav", function() {
-      exports.log("[api:nav]", tab.id, tab.url);
-      var oldPage = pages[tab.id];
-      if (oldPage) {
-        dispatch.call(exports.tabs.on.unload, oldPage);
-      }
-      dispatch.call(exports.tabs.on.loading, createPage(tab));
-    });
-  }});
-
 timers.setTimeout(function() {  // async to allow main.js to complete (so portHandlers can be defined)
+  const {PageMod} = require("sdk/page-mod");
   require("./meta").contentScripts.forEach(function(arr) {
-    var path = arr[0], urlRe = arr[1];
-    var o = deps(path);
+    const path = arr[0], urlRe = arr[1], o = deps(path);
     exports.log("defining PageMod:", path, "deps:", o);
     PageMod({
       include: urlRe,
@@ -522,15 +539,25 @@ timers.setTimeout(function() {  // async to allow main.js to complete (so portHa
       contentScriptOptions: {dataUriPrefix: url(""), dev: prefs.env == "development"},
       attachTo: ["existing", "top"],
       onAttach: function(worker) {
-        let tab = worker.tab, page = pages[tab.id];
+        const tab = worker.tab, page = pages[tab.id];
         exports.log("[onAttach]", tab.id, this.contentScriptFile, tab.url, page);
-        let injected = markInjected({}, o);
-        workers[tab.id].push(worker);
-        worker.on("pageshow", function() {  // navigated forward or back to page. https://bugzilla.mozilla.org/show_bug.cgi?id=766088#c2
-          exports.log("[pageshow] tab:", tab.id, "url:", tab.url);
+        const injected = markInjected({}, o);
+        const workers = workerNs(page).workers;
+        workers.push(worker);
+        worker.on("pageshow", function() {  // pageshow/pagehide discussion at bugzil.la/766088#c2
+          if (pages[tab.id] !== page) {  // bfcache used
+            exports.log("[api:pageshow] tab:", tab.id, "updating:", pages[tab.id], "->", page);
+            pages[tab.id] = page;
+          } else if (page.url !== tab.url) {  // shouldn’t happen
+            exports.log("[api:pageshow] tab:", tab.id, "updating:", page.url, "->", tab.url);
+            page.url = tab.url;
+          } else {
+            exports.log("[api:pageshow] tab:", tab.id, "url:", tab.url);
+          }
           emitQueuedMessages(page, worker);
         }).on("pagehide", function() {
           exports.log("[pagehide] tab:", tab.id);
+          onPageHide(tab.id);
         });
         Object.keys(portHandlers).forEach(function(type) {
           worker.port.on(type, function(data, callbackId) {

--- a/packrat/adapters/firefox/lib/location.js
+++ b/packrat/adapters/firefox/lib/location.js
@@ -1,0 +1,48 @@
+const {Ci} = require('chrome');
+const {browserWindows, BrowserWindow} = require('sdk/windows');
+const tabs = require('sdk/tabs');
+const {getTabId} = require('sdk/tabs/utils');
+const {windows} = require('sdk/window/utils');
+const browserNs = require('sdk/core/namespace').ns();
+
+function getTabIdForBrowser(gBrowser, browser) {
+  for (let tab of gBrowser.tabs) {
+    if (tab.linkedBrowser === browser) {
+      return getTabId(tab);
+    }
+  }
+}
+
+function getBrowser(win) {
+  for (let w of windows('navigator:browser')) {
+    if (BrowserWindow({window: w}) === win) {
+      return w.gBrowser;
+    }
+  }
+}
+
+function on(gBrowser, callback) {
+  gBrowser.addTabsProgressListener(
+    browserNs(gBrowser).listener = {onLocationChange: change.bind(gBrowser, callback)});
+}
+
+function off(gBrowser) {
+  gBrowser.removeTabsProgressListener(browserNs(gBrowser).listener);
+}
+
+function change(callback, browser, progress, req, loc, flags) {
+  callback(getTabIdForBrowser(this, browser), !(flags & Ci.nsIWebProgressListener.LOCATION_CHANGE_SAME_DOCUMENT));
+}
+
+exports.onChange = function(callback) {
+  for (let win of windows('navigator:browser')) {
+    on(win.gBrowser, callback);
+  }
+
+  browserWindows.on('open', function(win) {
+    on(getBrowser(win), callback);
+  });
+  browserWindows.on('close', function(win) {
+    off(getBrowser(win));
+  });
+};


### PR DESCRIPTION
Also detecting Google search queries earlier (akin to how we do it in Chrome) by listening for an event in the main extension instead of waiting for a content script to be injected into the results page and then notifying the main extension.
