### PR TITLE
add renormalization_check field to url table

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/URL.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/URL.scala
@@ -33,7 +33,8 @@ case class URL (
   domain: Option[String],
   normalizedUriId: Id[NormalizedURI],
   history: Seq[URLHistory] = Seq(),
-  state: State[URL] = URLStates.ACTIVE
+  state: State[URL] = URLStates.ACTIVE,
+  renormalizationCheck: Option[Boolean] = None
 ) extends Model[URL] {
   def withId(id: Id[URL]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/103.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/103.sql
@@ -1,0 +1,11 @@
+#SHOEBOX
+
+# --- !Ups
+alter table url
+	add column renormalization_check boolean;
+
+create index url_renormalization_check url(renormalization_check);
+
+insert into evolutions (name, description) values('103.sql', 'add column renormalization_check to url');
+
+# --- !Downs


### PR DESCRIPTION
Add a renormalization_check field to url table. 

This helps to batch process url renormalization: we only retrieve the next N urls whose renormalization_check field is None (or false). Once they are processed by the manual renormalization procedure, we mark them as true. 
Without this type of marking, the renormalization will have a very long database write-lock. 

We also support domain wise renormalization. 

With this in place, we can go ahead and deploy the renormalization code. 

@ymatsuda 
@leogrim  
