### PR TITLE
enabled the percent match threshold for hot documents

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
@@ -25,7 +25,7 @@ object SearchConfig {
       "sharingBoostInNetwork" -> "0.5",
       "sharingBoostOutOfNetwork" -> "0.1",
       "percentMatch" -> "75",
-      "percentMatchForHotDocs" -> "100",
+      "percentMatchForHotDocs" -> "60",
       "halfDecayHours" -> "24",
       "recencyBoost" -> "1.0",
       "newContentBoost" -> "1.0",


### PR DESCRIPTION
Documents are hot when they are useful pages (now useful pages include recent keeps) or are result click boosted.
We use a lower percent match threshold then the regular one so that there will be more chance that hot documents pass it.
