### PR TITLE
do not create a new ReconnectingWebSocket if we already have one

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1263,6 +1263,9 @@ function startSession(callback, retryMs) {
 
     session = data;
     session.prefs = {}; // to come via socket
+    if (socket) {
+      socket.close();
+    }
     socket = api.socket.open(elizaBaseUri().replace(/^http/, "ws") + "/eliza/ext/ws", socketHandlers, function onConnect() {
       for (var nUri in pageData) {
         pageData[nUri].threadDataIsStale = true;

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -619,7 +619,7 @@ function syncNumNotificationsNotVisited() {
   // much worse lately. I've had dificulty consistantly reproducing, so am adding this
   // sync in until we can identify the real issue counts get off. Could be related to
   // spotty internet, or some logic error above. -Andrew
-  if(socket && socket.send) {
+  if (socket) {
     socket.send(["get_unread_notifications_count"]);
   }
 }
@@ -1263,10 +1263,7 @@ function startSession(callback, retryMs) {
 
     session = data;
     session.prefs = {}; // to come via socket
-    if (socket) {
-      socket.close();
-    }
-    socket = api.socket.open(elizaBaseUri().replace(/^http/, "ws") + "/eliza/ext/ws", socketHandlers, function onConnect() {
+    socket = socket || api.socket.open(elizaBaseUri().replace(/^http/, "ws") + "/eliza/ext/ws", socketHandlers, function onConnect() {
       for (var nUri in pageData) {
         pageData[nUri].threadDataIsStale = true;
       }

--- a/packrat/scripts/lib/reconnecting-websocket.js
+++ b/packrat/scripts/lib/reconnecting-websocket.js
@@ -5,7 +5,7 @@ function ReconnectingWebSocket(opts) {
   this.send = function(data) {
     if (ws && ws.readyState == WebSocket.OPEN && !disTimeout) {
       ws.send(data);
-      if (new Date - lastRecOrPingTime > idlePingDelayMs) {  // a way to recover from timeout failure/unreliability
+      if (Date.now() - lastRecOrPingTime > idlePingDelayMs) {  // a way to recover from timeout failure/unreliability
         ping();
       }
     } else {
@@ -99,7 +99,7 @@ function ReconnectingWebSocket(opts) {
   function sendBuffer() {
     while (buffer.length) {
       var a = buffer.shift();
-      api.log("#0bf", "[RWS] sending, buffered for %i ms: %s", new Date - a[1], (wordRe.exec(a[0]) || a)[0]);
+      api.log("#0bf", "[RWS] sending, buffered for %i ms: %s", Date.now() - a[1], (wordRe.exec(a[0]) || a)[0]);
       ws.send(a[0]);
     }
   }


### PR DESCRIPTION
I saw two sockets open simultaneously on my kifi tonight, both pinging consistently. I used the debugger to verify that they had different `ReconnectingWebSocket` wrapper objects. This is the only place in the code where we create them, so I’m adding code to ensure that we don’t create a new one if we already have an existing good socket.

I think we should also try to understand how/why we get into `startSession` with an open/live/functioning socket. It appears the only place such a call could originate is the `/ext/authed` calllback near main.js:860.

cc @andrewconner @ebfaed 
