### PR TITLE
handling equiv-terms in proximity query

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
@@ -12,8 +12,7 @@ import scala.concurrent.duration._
 object SearchConfig {
   private[search] val defaultParams =
     Map[String, String](
-      "phraseProximityBoost" -> "0.0",     // disabled
-      "phraseBoost" -> "0.5",
+      "phraseBoost" -> "0.33",
       "siteBoost" -> "1.0",
       "similarity" -> "default",
       "svWeightMyBookMarks" -> "1",
@@ -41,8 +40,7 @@ object SearchConfig {
     )
   private[this] val descriptions =
     Map[String, String](
-      "phraseProximityBoost" -> "boost value for phrase proximity",
-      "phraseBoost" -> "boost value for the detected phrase",
+      "phraseBoost" -> "boost value for the detected phrase [0f,1f]",
       "siteBoost" -> "boost value for matching website names and domains",
       "similarity" -> "similarity characteristics",
       "svWeightMyBookMarks" -> "semantics vector weight for my bookmarks",

--- a/kifi-backend/modules/common/app/com/keepit/search/query/parser/QueryParser.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/query/parser/QueryParser.scala
@@ -23,7 +23,7 @@ abstract class QueryParser(protected val defaultAnalyzer: Analyzer, protected va
 
   def getStemmedTermArray(length: Int = -1) = if (length < 0) stemmedTerms.toArray else stemmedTerms.take(length).toArray
 
-  def getStemmedTerms(field: String) = stemmedTerms.map(t => new Term(field, t.text()))
+  def getStemmedTerms = stemmedTerms
 
   def parse(queryText: CharSequence): Option[Query]
 
@@ -46,7 +46,7 @@ abstract class QueryParser(protected val defaultAnalyzer: Analyzer, protected va
   def getStemmedFieldQuery(field: String, queryText: String): Option[Query] = {
     val it = new TermIterator(field, queryText, stemmingAnalyzer) with Position with TermInterceptor {
       def process(t: Term): Term = {
-        stemmedTerms += t
+        if (field == "") stemmedTerms += t
         t
       }
     }

--- a/kifi-backend/modules/search/app/com/keepit/search/MainQueryParser.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/MainQueryParser.scala
@@ -33,11 +33,9 @@ class MainQueryParser(
   lang: Lang,
   analyzer: Analyzer,
   stemmingAnalyzer: Analyzer,
-  baseBoost: Float,
   proximityBoost: Float,
   semanticBoost: Float,
   phraseBoost: Float,
-  phraseProximityBoost: Float,
   override val siteBoost: Float,
   phraseDetector: PhraseDetector
 ) extends QueryParser(analyzer, stemmingAnalyzer) with DefaultSyntax with PercentMatch with QueryExpansion {
@@ -68,16 +66,9 @@ class MainQueryParser(
     super.parse(queryText).map{ query =>
       if (numStemmedTerms <= 0) query
       else {
-        query.setBoost(baseBoost)
-
-        val phrases = if (numStemmedTerms > 1 && (phraseBoost > 0.0f || phraseProximityBoost > 0.0f)) {
-          val p = if (phraseProximityBoost > 0.0f) {
-            phraseDetector.detect(getStemmedTermArray(ProximityQuery.maxLength))
-          } else {
-            phraseDetector.detectAll(getStemmedTermArray(ProximityQuery.maxLength))
-          }
-          if (p.size > 0) p
-          else NlpPhraseDetector.detectAll(queryText.toString, stemmingAnalyzer, lang)
+        val phrases = if (numStemmedTerms > 1 && phraseBoost > 0.0f) {
+          val p = phraseDetector.detectAll(getStemmedTermArray(ProximityQuery.maxLength))
+          if (p.size > 0) p else NlpPhraseDetector.detectAll(queryText.toString, stemmingAnalyzer, lang)
         } else {
           Set.empty[(Int, Int)]
         }
@@ -86,23 +77,16 @@ class MainQueryParser(
         val auxStrengths = ArrayBuffer.empty[Float]
 
         if (semanticBoost > 0.0f) {
-          val svq = SemanticVectorQuery(getStemmedTerms("sv"), fallbackField = "title_stemmed")
+          val svq = SemanticVectorQuery(svTerms, fallbackField = "title_stemmed")
           auxQueries += namedQuery("semantic vector", svq)
           auxStrengths += semanticBoost
         }
 
-        if (phraseProximityBoost > 0.0f && phrases.nonEmpty) {
-          val phraseProxQ = new DisjunctionMaxQuery(0.0f)
-          phraseProxQ.add( PhraseProximityQuery(getStemmedTerms("cs"), phrases))
-          phraseProxQ.add( PhraseProximityQuery(getStemmedTerms("ts"), phrases))
-          phraseProxQ.add( PhraseProximityQuery(getStemmedTerms("title_stemmed"), phrases))
-          auxQueries += namedQuery("proximity", phraseProxQ)
-          auxStrengths += phraseProximityBoost
-        } else if (proximityBoost > 0.0f && numStemmedTerms > 1) {
+        if (proximityBoost > 0.0f && numStemmedTerms > 1) {
           val proxQ = new DisjunctionMaxQuery(0.0f)
-          proxQ.add(ProximityQuery(getStemmedTerms("cs"), phrases, phraseBoost))
-          proxQ.add(ProximityQuery(getStemmedTerms("ts"), phrases, phraseBoost))
-          proxQ.add(ProximityQuery(getStemmedTerms("title_stemmed"), phrases, phraseBoost))
+          proxQ.add(ProximityQuery(proxTermsFor("cs"), phrases, phraseBoost))
+          proxQ.add(ProximityQuery(proxTermsFor("ts"), phrases, phraseBoost))
+          proxQ.add(ProximityQuery(proxTermsFor("title_stemmed"), phrases, phraseBoost))
           auxQueries += namedQuery("proximity", proxQ)
           auxStrengths += proximityBoost
         }
@@ -114,5 +98,13 @@ class MainQueryParser(
         }
       }
     }
+  }
+
+  private[this] def proxTermsFor(field: String): Seq[Seq[Term]] = {
+    getStemmedTerms.map{ t => new Term(field, t.text()) }.map{ Seq(_) }
+  }
+
+  private[this] def svTerms: Seq[Term] = {
+    getStemmedTerms.map{ t => new Term("sv", t.text()) }
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/MainQueryParserFactory.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/MainQueryParserFactory.scala
@@ -8,17 +8,14 @@ import com.keepit.inject._
 @Singleton
 class MainQueryParserFactory @Inject() (phraseDetector: PhraseDetector) {
   def apply(lang: Lang, proximityBoost: Float = 0.0f, semanticBoost: Float = 0.0f, phraseBoost: Float = 0.0f,
-      phraseProximityBoost: Float = 0.0f, siteBoost: Float = 0.0f): MainQueryParser = {
-    val total = 1.0f + phraseBoost
+            siteBoost: Float = 0.0f): MainQueryParser = {
     new MainQueryParser(
       lang,
       DefaultAnalyzer.forParsing(lang),
       DefaultAnalyzer.forParsingWithStemmer(lang),
-      1.0f/total,
       proximityBoost,
       semanticBoost,
-      phraseBoost/total,
-      phraseProximityBoost,
+      phraseBoost,
       siteBoost,
       phraseDetector
     )

--- a/kifi-backend/modules/search/app/com/keepit/search/MainSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/MainSearcher.scala
@@ -93,7 +93,6 @@ class MainSearcher(
   val svWeightClickHistory = config.asInt("svWeightClickHistory")
   val similarity = Similarity(config.asString("similarity"))
   val phraseBoost = config.asFloat("phraseBoost")
-  val phraseProximityBoost = config.asFloat("phraseProximityBoost")
   val siteBoost = config.asFloat("siteBoost")
   val minMyBookmarks = config.asInt("minMyBookmarks")
   val myBookmarkBoost = config.asFloat("myBookmarkBoost")
@@ -192,7 +191,7 @@ class MainSearcher(
     lang = LangDetector.detectShortText(queryString, langProbabilities)
 
     val hotDocs = new HotDocSetFilter()
-    val parser = parserFactory(lang, proximityBoost, semanticBoost, phraseBoost, phraseProximityBoost, siteBoost)
+    val parser = parserFactory(lang, proximityBoost, semanticBoost, phraseBoost, siteBoost)
     parser.setPercentMatch(percentMatch)
     parser.setPercentMatchForHotDocs(percentMatchForHotDocs, hotDocs)
 
@@ -447,7 +446,7 @@ class MainSearcher(
     // TODO: use user profile info as a bias
     lang = LangDetector.detectShortText(queryString, langProbabilities)
     val hotDocs = new HotDocSetFilter()
-    val parser = parserFactory(lang, proximityBoost, semanticBoost, phraseBoost, phraseProximityBoost, siteBoost)
+    val parser = parserFactory(lang, proximityBoost, semanticBoost, phraseBoost, siteBoost)
     parser.setPercentMatch(percentMatch)
     parser.setPercentMatchForHotDocs(percentMatchForHotDocs, hotDocs)
 

--- a/kifi-backend/modules/search/app/com/keepit/search/query/ProximityQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/ProximityQuery.scala
@@ -23,6 +23,7 @@ import org.apache.lucene.util.ToStringUtils
 import java.lang.{Float => JFloat}
 import java.util.{Set => JSet}
 import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
 import scala.math._
 
 object ProximityQuery {
@@ -30,7 +31,7 @@ object ProximityQuery {
   val maxLength = 64  // we use first 64 terms (enough?)
   val gapPenalty = 0.05f
 
-  def apply(terms: Seq[Term], phrases: Set[(Int, Int)] = Set(), phraseBoost: Float = 0.0f) = new ProximityQuery(terms, phrases, phraseBoost)
+  def apply(terms: Seq[Seq[Term]], phrases: Set[(Int, Int)] = Set(), phraseBoost: Float = 0.0f) = new ProximityQuery(terms, phrases, phraseBoost)
 
   def buildPhraseDict(termIds: Array[Int], phrases: Set[(Int, Int)]) = {
     val notInPhrase = termIds.clone
@@ -45,15 +46,18 @@ object ProximityQuery {
   }
 }
 
-class ProximityQuery(val terms: Seq[Term], val phrases: Set[(Int, Int)] = Set(), val phraseBoost: Float) extends Query {
+class ProximityQuery(val terms: Seq[Seq[Term]], val phrases: Set[(Int, Int)] = Set(), val phraseBoost: Float) extends Query {
 
   override def createWeight(searcher: IndexSearcher): Weight = new ProximityWeight(this)
 
   override def rewrite(reader: IndexReader): Query = this
 
-  override def extractTerms(out: JSet[Term]): Unit = out.addAll(terms)
+  override def extractTerms(out: JSet[Term]): Unit = terms.foreach{ ts => out.addAll(ts) }
 
-  override def toString(s: String) = "proximity(%s)%s".format(terms.mkString(","), ToStringUtils.boost(getBoost()))
+  override def toString(s: String) = {
+    val termsString = terms.map{ t => if (t.size == 1) t.head.toString else t.mkString("(", ",", ")") }.mkString(",")
+    s"proximity(${termsString})${ToStringUtils.boost(getBoost())}"
+  }
 
   override def equals(obj: Any): Boolean = obj match {
     case prox: ProximityQuery => (terms == prox.terms && getBoost() == prox.getBoost())
@@ -69,7 +73,7 @@ class ProximityWeight(query: ProximityQuery) extends Weight {
 
   private[this] val termIdMap = {
     var id = -1
-    query.terms.take(ProximityQuery.maxLength).foldLeft(Map.empty[Term, Int]){ (m, term) =>
+    query.terms.take(ProximityQuery.maxLength).foldLeft(Map.empty[Seq[Term], Int]){ (m, term) =>
       if (m.contains(term)) m
       else {
         id += 1
@@ -106,7 +110,7 @@ class ProximityWeight(query: ProximityQuery) extends Weight {
       val phrasesOpt = if (query.phrases.isEmpty) {
         None
       } else {
-        Some(query.phrases.map{ case (pos, len) => query.terms.slice(pos , pos + len).map(_.text).mkString(" ") }.mkString("[", " ; ", "]"))
+        Some(query.phrases.map{ case (pos, len) => query.terms.slice(pos , pos + len).map(_.head.text).mkString(" ") }.mkString("[", " ; ", "]"))
       }
 
       result.setDescription("proximity(%s), product of:".format(query.terms.mkString(",") + phrasesOpt.getOrElse("")))
@@ -126,24 +130,15 @@ class ProximityWeight(query: ProximityQuery) extends Weight {
   def getQuery() = query
 
   override def scorer(context: AtomicReaderContext, scoreDocsInOrder: Boolean, topScorer: Boolean, acceptDocs: Bits): Scorer = {
-    if (query.terms.size > 0) {
-      val tps = termIdMap.map{ case (term, id) =>
-        val termText = term.text()
-        makePositionAndId(context, term, id, acceptDocs)
-      }.toArray
-      new ProximityScorer(this, tps, termIds, phraseMatcher, query.phraseBoost)
-    } else {
-      null
+    val buf = new ArrayBuffer[PositionAndId](termIdMap.size)
+    termIdMap.foreach{ case (equivTerms, id) =>
+      equivTerms.foreach{ term =>
+        val enum = termPositionsEnum(context, term, acceptDocs)
+        if (enum != null) buf += new PositionAndId(enum, term.text(), id)
+      }
     }
-  }
 
-  private def makePositionAndId(context: AtomicReaderContext, term: Term, id: Int, acceptDocs: Bits) = {
-    val enum = termPositionsEnum(context, term, acceptDocs)
-    if (enum == null) {
-      new PositionAndId(EmptyDocsAndPositionsEnum, term.text(), id)
-    } else {
-      new PositionAndId(enum, term.text(), id)
-    }
+    if (buf.isEmpty) null else new ProximityScorer(this, buf.toArray, termIds, phraseMatcher, query.phraseBoost)
   }
 }
 
@@ -189,7 +184,7 @@ class ProximityScorer(weight: ProximityWeight, tps: Array[PositionAndId], termId
   private[this] var scoredDoc = -1
   private[this] val weightVal = weight.getWeightValue
 
-  private[this] val pq = new PriorityQueue[PositionAndId](termIds.length) {
+  private[this] val pq = new PriorityQueue[PositionAndId](tps.length) {
     override def lessThan(nodeA: PositionAndId, nodeB: PositionAndId) = {
       if (nodeA.doc == nodeB.doc) nodeA.pos < nodeB.pos
       else nodeA.doc < nodeB.doc

--- a/kifi-backend/modules/search/test/com/keepit/search/query/ProximityQueryTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/query/ProximityQueryTest.scala
@@ -67,12 +67,16 @@ class ProximityQueryTest extends Specification {
 
   val searcher = new IndexSearcher(reader)
 
+  private def mkProxTerms(terms: Term*): Seq[Seq[Term]] = {
+    terms.map{Seq(_)}
+  }
+
   "ProximityQuery" should {
 
     "score using proximity (two terms)" in {
       readerContextLeaves.size === 1
 
-      var q = ProximityQuery(Seq(new Term("B", "abc"), new Term("B", "def")))
+      var q = ProximityQuery(mkProxTerms(new Term("B", "abc"), new Term("B", "def")))
       var weight = searcher.createNormalizedWeight(q)
 
       var scorer = weight.scorer(readerContext, true, true, reader.getLiveDocs)
@@ -86,7 +90,7 @@ class ProximityQueryTest extends Specification {
       buf.size === 10
       buf.sortBy(_._2).map(_._1) === Seq(9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
 
-      q = ProximityQuery(Seq(new Term("B", "def"), new Term("B", "ghi")))
+      q = ProximityQuery(mkProxTerms(new Term("B", "def"), new Term("B", "ghi")))
       weight = searcher.createNormalizedWeight(q)
 
       (weight != null) === true
@@ -103,7 +107,7 @@ class ProximityQueryTest extends Specification {
     }
 
     "score using proximity (two phrases)" in {
-      var q = ProximityQuery(Seq(new Term("B", "aaa"), new Term("B", "bbb"), new Term("B", "ccc"), new Term("B", "ddd")))
+      var q = ProximityQuery(mkProxTerms(new Term("B", "aaa"), new Term("B", "bbb"), new Term("B", "ccc"), new Term("B", "ddd")))
       var weight = searcher.createNormalizedWeight(q)
 
       var scorer = weight.scorer(readerContext, true, true, reader.getLiveDocs)
@@ -117,7 +121,7 @@ class ProximityQueryTest extends Specification {
       buf.size === 10
       buf.sortBy(_._2).map(_._1) === Seq(19, 18, 17, 16, 15, 14, 13, 12, 11, 10)
 
-      q = ProximityQuery(Seq(new Term("B", "eee"), new Term("B", "fff"), new Term("B", "ggg"), new Term("B", "hhh")))
+      q = ProximityQuery(mkProxTerms(new Term("B", "eee"), new Term("B", "fff"), new Term("B", "ggg"), new Term("B", "hhh")))
       weight = searcher.createNormalizedWeight(q)
 
       (weight != null) === true
@@ -134,7 +138,7 @@ class ProximityQueryTest extends Specification {
     }
 
     "score using proximity (four terms)" in {
-      var q = ProximityQuery(Seq(new Term("B", "aaa"), new Term("B", "bbb"), new Term("B", "ccc"), new Term("B", "ddd")))
+      var q = ProximityQuery(mkProxTerms(new Term("B", "aaa"), new Term("B", "bbb"), new Term("B", "ccc"), new Term("B", "ddd")))
       var weight = searcher.createNormalizedWeight(q)
 
       var scorer = weight.scorer(readerContext, true, true, reader.getLiveDocs)
@@ -148,7 +152,7 @@ class ProximityQueryTest extends Specification {
       buf.size === 10
       buf.sortBy(_._2).map(_._1) === Seq(19, 18, 17, 16, 15, 14, 13, 12, 11, 10)
 
-      q = ProximityQuery(Seq(new Term("B", "aaa"), new Term("B", "ccc"), new Term("B", "bbb"), new Term("B", "ddd")))
+      q = ProximityQuery(mkProxTerms(new Term("B", "aaa"), new Term("B", "ccc"), new Term("B", "bbb"), new Term("B", "ddd")))
       weight = searcher.createNormalizedWeight(q)
 
       scorer = weight.scorer(readerContext, true, true, reader.getLiveDocs)
@@ -166,7 +170,7 @@ class ProximityQueryTest extends Specification {
     "score using proximity with repeating terms" in {
       readerContextLeaves.size === 1
 
-      var q = ProximityQuery(Seq(new Term("B", "abc"), new Term("B", "abc"), new Term("B", "def")))
+      var q = ProximityQuery(mkProxTerms(new Term("B", "abc"), new Term("B", "abc"), new Term("B", "def")))
       var weight = searcher.createNormalizedWeight(q)
 
       var scorer = weight.scorer(readerContext, true, true, reader.getLiveDocs)
@@ -180,7 +184,7 @@ class ProximityQueryTest extends Specification {
       buf.size === 10
       buf.sortBy(_._2).map(_._1) === Seq(9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
 
-      q = ProximityQuery(Seq(new Term("B", "def"), new Term("B", "def"), new Term("B", "ghi"), new Term("B", "ghi")))
+      q = ProximityQuery(mkProxTerms(new Term("B", "def"), new Term("B", "def"), new Term("B", "ghi"), new Term("B", "ghi")))
       weight = searcher.createNormalizedWeight(q)
 
       (weight != null) === true
@@ -196,8 +200,41 @@ class ProximityQueryTest extends Specification {
       buf.sortBy(_._2).map(_._1) === Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
     }
 
+    "score using proximity (equiv terms)" in {
+      readerContextLeaves.size === 1
+
+      var q = ProximityQuery(Seq(Seq(new Term("B", "abc"), new Term("B", "aaa")), Seq(new Term("B", "def"))))
+      var weight = searcher.createNormalizedWeight(q)
+
+      var scorer = weight.scorer(readerContext, true, true, reader.getLiveDocs)
+      val buf = new ArrayBuffer[(Int, Float)]()
+      var doc = scorer.nextDoc()
+      while (doc < DocIdSetIterator.NO_MORE_DOCS) {
+        buf += ((doc, scorer.score()))
+        doc = scorer.nextDoc()
+      }
+      indexReader.numDocs() === 30
+      buf.size === 20
+      buf.sortBy(h => (h._2, h._1)).map(_._1) === Seq(10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+
+      q = ProximityQuery(Seq(Seq(new Term("B", "def"), new Term("B", "aaa")), Seq(new Term("B", "ccc"), new Term("B", "ghi"))))
+      weight = searcher.createNormalizedWeight(q)
+
+      (weight != null) === true
+
+      scorer = weight.scorer(readerContext, true, true, reader.getLiveDocs)
+      buf.clear
+      doc = scorer.nextDoc()
+      while (doc < DocIdSetIterator.NO_MORE_DOCS) {
+        buf += ((doc, scorer.score()))
+        doc = scorer.nextDoc()
+      }
+      buf.size === 20
+      buf.sortBy(_._2).map(_._1) === Seq(0, 19, 1, 18, 2, 17, 3, 16, 4, 15, 5, 14, 6, 13, 7, 12, 8, 11, 9, 10)
+    }
+
     "not return hits when no term" in {
-      val q = ProximityQuery(Seq.empty[Term])
+      val q = ProximityQuery(mkProxTerms())
       val weight = searcher.createNormalizedWeight(q)
       (weight != null) === true
 


### PR DESCRIPTION
ProximityQuery now takes Seq[Seq[Term] rather than Seq[Term]. It take a group of terms in inner Seq[Term] as equivalent terms. This is a preparation for concatenated words support (ex. "face book" vs "facebook"). This can be used for simple cases of synonyms, too.
