### PR TITLE
Not duplicating the URI string in "thread" WebsSocket messages

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/ExtMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/ExtMessagingController.scala
@@ -120,9 +120,7 @@ class ExtMessagingController @Inject() (
       log.info(s"[get_thread] user ${socket.userId} requesting thread extId $threadId")
       messagingController.getThreadMessagesWithBasicUser(ExternalId[MessageThread](threadId), None) map { msgs =>
         log.info(s"[get_thread] got messages: $msgs")
-        val url = msgs.headOption.map(_.nUrl).getOrElse("")  // needs to change when we have detached threads
-        socket.channel.push(
-          Json.arr("thread", Json.obj("id" -> threadId, "uri" -> url, "messages" -> msgs.reverse)))
+        socket.channel.push(Json.arr("thread", Json.obj("id" -> threadId, "messages" -> msgs.reverse)))
       }
     },
     "set_all_notifications_visited" -> { case JsString(notifId) +: _ =>


### PR DESCRIPTION
ok with you @ebfaed ?

The kifi extension is not using the `"uri"` field. If needed, it can be obtained on the receiving end the same way it is here.
