### PR TITLE
Access log

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/controller/LoggingFilter.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/LoggingFilter.scala
@@ -17,7 +17,7 @@ object LoggingFilter extends EssentialFilter {
 
       def logTime(result: PlainResult): Result = {
         val time = System.currentTimeMillis - start
-        Logger.info(s"${rh.method} ${rh.uri} took ${time}ms and returned ${result.header.status}")
+        Logger("com.keepit.access").info(s"[IN] ${rh.method} ${rh.uri} took [${time}ms] and returned ${result.header.status}")
         result.withHeaders("Request-Time" -> time.toString, "Spaceship" -> host)
       }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/net/HttpClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/HttpClient.scala
@@ -16,6 +16,8 @@ import com.keepit.common.logging.Logging
 import com.keepit.common.healthcheck.{AirbrakeNotifier, AirbrakeError, HealthcheckPlugin}
 import scala.xml._
 
+import play.api.Logger
+
 case class NonOKResponseException(url: String, response: ClientResponse, requestBody: Option[Any] = None)
     extends Exception(s"Requesting $url ${requestBody.map{b => b.toString}}, got a ${response.status}. Body: ${response.body}")
 
@@ -204,8 +206,13 @@ private[net] class Request(wsRequest: WSRequestHolder) extends Logging {
     res
   }
 
-  private def logResponse(startTime: Long, method: String, isSuccess: Boolean) =
-    log.info(s"""[${System.currentTimeMillis - startTime}ms] [$method] ${wsRequest.url} [${wsRequest.queryString map {case (k, v) => s"$k=$v"} mkString "&"}] (success = $isSuccess)""")
+  private val accessLog = Logger("com.keepit.access")
+
+  private def logResponse(startTime: Long, method: String, isSuccess: Boolean) = {
+    val time = System.currentTimeMillis - startTime
+    val queryString = wsRequest.queryString map {case (k, v) => s"$k=$v"} mkString "&"
+    accessLog.info(s"""[OUT] [$method] ${wsRequest.url} took [${time}ms] with params [${queryString}] (success = $isSuccess)""")
+  }
 }
 
 trait ClientResponse {

--- a/kifi-backend/modules/common/app/com/keepit/common/store/S3ObjectStore.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/S3ObjectStore.scala
@@ -51,7 +51,7 @@ trait S3ObjectStore[A, B]  extends ObjectStore[A, B] with Logging {
       throw ex
   }
 
-  private val accessLog = Logger("com.keepit.access")
+  private lazy val accessLog = Logger("com.keepit.access")
 
   def += (kv: (A, B)) = {
     val startTime = System.currentTimeMillis

--- a/kifi-backend/modules/common/conf/prod/logger.prod.xml
+++ b/kifi-backend/modules/common/conf/prod/logger.prod.xml
@@ -4,7 +4,7 @@
   <!-- always a good activate OnConsoleStatusListener -->
   <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
 
-  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+  <appender name="app_log" class="ch.qos.logback.core.rolling.RollingFileAppender">
    <file>log/app.log</file>
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <fileNamePattern>log/app.%d{yyyy-MM-dd}.log.zip</fileNamePattern>
@@ -13,9 +13,32 @@
      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
    </encoder>
   </appender>
-  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
-    <appender-ref ref="FILE" />
+
+  <appender name="async_app_log" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="app_log" />
   </appender>
+
+  <!-- ================================ -->
+
+  <appender name="access" class="ch.qos.logback.core.rolling.RollingFileAppender">
+   <file>log/access.log</file>
+   <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+     <fileNamePattern>log/access.%d{yyyy-MM-dd}.log.zip</fileNamePattern>
+   </rollingPolicy>
+   <encoder>
+     <pattern>%d{HH:mm:ss.SSS} - %msg%n</pattern>
+   </encoder>
+  </appender>
+
+  <appender name="async_access" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="access" />
+  </appender>
+
+  <logger name="com.keepit.access" level="DEBUG">
+    <appender-ref ref="async_access" />
+  </logger>
+
+  <!-- ================================ -->
 
   <logger name="com.mysql" level="ERROR"/>
   <logger name="com.jolbox.bonecp" level="INFO"/>
@@ -23,6 +46,7 @@
   <logger name="securesocial.core" level="DEBUG"/>
 
   <root level="INFO">
-    <appender-ref ref="ASYNC" />
+    <appender-ref ref="async_app_log" />
   </root>
+
 </configuration>

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminHealthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminHealthController.scala
@@ -2,7 +2,7 @@ package com.keepit.controllers.admin
 
 import com.keepit.common.time.RichDateTime
 import com.keepit.common.service.FortyTwoServices
-import com.keepit.common.cache.CacheStatistics
+import com.keepit.common.cache.GlobalCacheStatistics
 import com.keepit.common.healthcheck._
 
 import scala.util.Random
@@ -27,7 +27,7 @@ class AdminHealthController @Inject() (
   def serviceView = AdminHtmlAction { implicit request =>
     val errorCount = healthcheckPlugin.errorCount
     val recentErrors = healthcheckPlugin.errors()
-    val cacheStats = CacheStatistics.getStatistics
+    val cacheStats = GlobalCacheStatistics.getStatistics
     val (totalHits, totalMisses, totalSets) = (cacheStats.map(_._2).sum, cacheStats.map(_._3).sum, cacheStats.map(_._4).sum)
     Ok(html.admin.serverInfo(services.currentService, services.currentVersion, services.compilationTime.toStandardTimeString,
         services.started.toStandardTimeString, errorCount, recentErrors, cacheStats, totalHits, totalMisses, totalSets))

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DBSession.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DBSession.scala
@@ -6,15 +6,19 @@ import scala.slick.session.{Session, ResultSetConcurrency, ResultSetType, Result
 import scala.concurrent._
 import scala.util.Try
 
+import play.api.Logger
+
 object DBSession {
-  abstract class SessionWrapper(_session: => Session) extends Session {
+  abstract class SessionWrapper(name: String, _session: => Session) extends Session {
     private var open = false
     private var doRollback = false
     private var transaction: Option[Promise[Unit]] = None
+    private var startTime: Long = -1
     lazy val session = {
       val s = _session
       if (inTransaction) s.conn.setAutoCommit(false)
       open = true
+      startTime = System.currentTimeMillis
       s
     }
 
@@ -29,7 +33,15 @@ object DBSession {
     override def resultSetType = session.resultSetType
     override def resultSetConcurrency = session.resultSetConcurrency
     override def resultSetHoldability = session.resultSetHoldability
-    def close() { if (open) session.close() }
+
+    private val accessLog = Logger("com.keepit.access")
+
+    def close(): Unit = if (open) {
+      session.close()
+      val time = System.currentTimeMillis - startTime
+      accessLog.info(s"""[DB] [$name] took [${time}ms]""")
+    }
+
     def rollback() { doRollback = true }
     def inTransaction = transaction.nonEmpty
 
@@ -66,9 +78,9 @@ object DBSession {
       rsHoldability: ResultSetHoldability = resultSetHoldability) = throw new UnsupportedOperationException
   }
 
-  abstract class RSession(roSession: => Session) extends SessionWrapper(roSession)
-  class ROSession(roSession: => Session) extends RSession(roSession)
-  class RWSession(rwSession: => Session) extends RSession(rwSession)
+  abstract class RSession(name: String, roSession: => Session) extends SessionWrapper(name, roSession)
+  class ROSession(roSession: => Session) extends RSession("RO", roSession)
+  class RWSession(rwSession: => Session) extends RSession("RW", rwSession)
 
   implicit def roToSession(roSession: ROSession): Session = roSession.session
   implicit def rwToSession(rwSession: RWSession): Session = rwSession.session


### PR DESCRIPTION
adding a new access log file that will have timing for IO operations we're doing:
- HTTP-IN - incoming HTTP traffic + timing
- OUT - outgoing traffic using the http client + timing
- CACHE - HIT/MISS/SET + timing
- DB - RO/RW sessions + timing
- S3 - GET/PUT/DEL

Missing websockets IN/OUT traffic/timing log
