### PR TITLE
Separate login from signup

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/controller/ActionAuthenticator.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/ActionAuthenticator.scala
@@ -1,6 +1,10 @@
 package com.keepit.common.controller
 
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
 import com.google.inject.{Inject, Singleton}
+import com.keepit.common.akka.MonitoredAwait
 import com.keepit.common.controller.FortyTwoCookies.{ImpersonateCookie, KifiInstallationCookie}
 import com.keepit.common.db._
 import com.keepit.common.healthcheck.{AirbrakeNotifier, AirbrakeError}
@@ -8,15 +12,13 @@ import com.keepit.common.logging.Logging
 import com.keepit.common.net.URI
 import com.keepit.common.service.FortyTwoServices
 import com.keepit.model._
+import com.keepit.shoebox.ShoeboxServiceClient
+import com.keepit.social.{SocialNetworkType, SocialId}
+
 import play.api.i18n.Messages
 import play.api.libs.json.JsNumber
 import play.api.mvc._
 import securesocial.core._
-import com.keepit.common.akka.MonitoredAwait
-import scala.concurrent.duration._
-import com.keepit.shoebox.ShoeboxServiceClient
-import scala.concurrent.Future
-import com.keepit.social.{SocialNetworkType, SocialId}
 
 case class ReportedException(val id: ExternalId[AirbrakeError], val cause: Throwable) extends Exception(id.toString, cause)
 
@@ -41,27 +43,46 @@ trait ActionAuthenticator extends SecureSocial {
       allowPending: Boolean,
       bodyParser: BodyParser[T],
       onAuthenticated: AuthenticatedRequest[T] => Result,
+      onSocialAuthenticated: SecuredRequest[T] => Result,
       onUnauthenticated: Request[T] => Result): Action[T]
 
   private[controller] def authenticatedAction[T](
       apiClient: Boolean,
       allowPending: Boolean,
       bodyParser: BodyParser[T],
-      onAuthenticated: AuthenticatedRequest[T] => Result): Action[T] =
+      onAuthenticated: AuthenticatedRequest[T] => Result,
+      onUnauthenticated: Request[T] => Result): Action[T] = {
+    authenticatedAction(
+      apiClient = apiClient,
+      allowPending = allowPending,
+      bodyParser = bodyParser,
+      onAuthenticated = onAuthenticated,
+      onSocialAuthenticated = onUnauthenticated,
+      onUnauthenticated = onUnauthenticated)
+  }
+
+  private[controller] def authenticatedAction[T](
+      apiClient: Boolean,
+      allowPending: Boolean,
+      bodyParser: BodyParser[T],
+      onAuthenticated: AuthenticatedRequest[T] => Result): Action[T] = {
+        val onUnauthenticated = { implicit request: Request[_] =>
+          if (apiClient) {
+            Forbidden(JsNumber(0))
+          } else {
+            Redirect("/login")
+                .flashing("error" -> Messages("securesocial.loginRequired"))
+                .withSession(session + (SecureSocial.OriginalUrlKey -> request.uri))
+          }
+        }
         authenticatedAction(
           apiClient = apiClient,
           allowPending = allowPending,
           bodyParser = bodyParser,
           onAuthenticated = onAuthenticated,
-          onUnauthenticated = { implicit request =>
-            if (apiClient) {
-              Forbidden(JsNumber(0))
-            } else {
-              Redirect("/login")
-                .flashing("error" -> Messages("securesocial.loginRequired"))
-                .withSession(session + (SecureSocial.OriginalUrlKey -> request.uri))
-            }
-          })
+          onSocialAuthenticated = onUnauthenticated,
+          onUnauthenticated = onUnauthenticated)
+  }
 }
 
 @Singleton
@@ -78,13 +99,7 @@ class RemoteActionAuthenticator @Inject() (
 
   private def getExperiments(userId: Id[User]): Future[Seq[State[ExperimentType]]] = shoeboxClient.getUserExperiments(userId)
 
-  private def authenticatedHandler[T](apiClient: Boolean, allowPending: Boolean)(authAction: AuthenticatedRequest[T] => Result) = { implicit request: SecuredRequest[T] => /* onAuthenticated */
-      val userId = request.session.get(ActionAuthenticator.FORTYTWO_USER_ID).map(id => Id[User](id.toLong)).getOrElse {
-        // If this fails, then SecureSocial says they're authenticated, but they're not.
-        monitoredAwait.result(shoeboxClient.getSocialUserInfoByNetworkAndSocialId(
-          SocialId(request.user.identityId.userId), SocialNetworkType(request.user.identityId.providerId)),
-          3 seconds, s"on social user id $request.user.id.id").get.userId.get
-      }
+  private def authenticatedHandler[T](userId: Id[User], apiClient: Boolean, allowPending: Boolean)(authAction: AuthenticatedRequest[T] => Result) = { implicit request: SecuredRequest[T] => /* onAuthenticated */
       val experimentsFuture = getExperiments(userId).map(_.toSet)
       val impersonatedUserIdOpt: Option[ExternalId[User]] = impersonateCookie.decodeFromCookie(request.cookies.get(impersonateCookie.COOKIE_NAME))
       val kifiInstallationId: Option[ExternalId[KifiInstallation]] = kifiInstallationCookie.decodeFromCookie(request.cookies.get(kifiInstallationCookie.COOKIE_NAME))
@@ -111,10 +126,21 @@ class RemoteActionAuthenticator @Inject() (
       allowPending: Boolean,
       bodyParser: BodyParser[T],
       onAuthenticated: AuthenticatedRequest[T] => Result,
+      onSocialAuthenticated: SecuredRequest[T] => Result,
       onUnauthenticated: Request[T] => Result): Action[T] = UserAwareAction(bodyParser) { request =>
     val result = request.user match {
-      case Some(user) =>
-        authenticatedHandler(apiClient, allowPending)(onAuthenticated)(SecuredRequest(user, request))
+      case Some(socialUser) =>
+        val uidOpt = request.session.get(ActionAuthenticator.FORTYTWO_USER_ID).map(id => Id[User](id.toLong)).orElse {
+          monitoredAwait.result(shoeboxClient.getSocialUserInfoByNetworkAndSocialId(
+            SocialId(socialUser.identityId.userId), SocialNetworkType(socialUser.identityId.providerId)),
+            3 seconds, s"on social user id $request.user.id.id").flatMap(_.userId)
+        }
+        uidOpt match {
+          case Some(userId) =>
+            authenticatedHandler(userId, apiClient, allowPending)(onAuthenticated)(SecuredRequest(socialUser, request))
+          case None =>
+            onSocialAuthenticated(SecuredRequest(socialUser, request))
+        }
       case None =>
         onUnauthenticated(request)
     }
@@ -138,7 +164,6 @@ class RemoteActionAuthenticator @Inject() (
       experiments: Set[State[ExperimentType]], kifiInstallationId: Option[ExternalId[KifiInstallation]],
       newSession: Session, request: Request[T], adminUserId: Option[Id[User]] = None, allowPending: Boolean) = {
     val user = shoeboxClient.getUsers(Seq(userId)).map(_.head)
-    val cleanedSesison = newSession - IdentityProvider.SessionId + ("server_version" -> fortyTwoServices.currentVersion.value)
     try {
       action(AuthenticatedRequest[T](identity, userId, monitoredAwait.result(user, 3 seconds, s"getting user $userId"), request, experiments, kifiInstallationId, adminUserId)) match {
         case r: PlainResult => r.withSession(newSession)

--- a/kifi-backend/modules/common/app/com/keepit/social/UserIdentity.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/UserIdentity.scala
@@ -5,7 +5,10 @@ import com.keepit.model.User
 
 import securesocial.core.{Identity, SocialUser}
 
-case class UserIdentity(userId: Option[Id[User]], socialUser: SocialUser) extends Identity {
+case class UserIdentity(
+  userId: Option[Id[User]],
+  socialUser: SocialUser,
+  allowSignup: Boolean = false) extends Identity {
   def identityId = socialUser.identityId
   def firstName = socialUser.firstName
   def lastName = socialUser.lastName

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
@@ -15,6 +15,7 @@ import play.api.Play.current
 import play.api._
 import play.api.libs.iteratee.Enumerator
 import play.api.mvc._
+import securesocial.core.{SocialUser, SecuredRequest}
 
 class HomeController @Inject() (db: Database,
   userRepo: UserRepo,
@@ -52,7 +53,11 @@ class HomeController @Inject() (db: Database,
       Ok.stream(Enumerator.fromStream(Play.resourceAsStream("public/index.html").get)) as HTML
     }
   }, unauthenticatedAction = { implicit request =>
-    Ok(views.html.website.welcome(passwordAuth = Play.isDev))
+    request match {
+      case SecuredRequest(identity, request) =>
+        Ok(views.html.website.welcome(passwordAuth = Play.isDev, authenticatedAs = Some(SocialUser(identity))))
+      case _ => Ok(views.html.website.welcome(passwordAuth = Play.isDev))
+    }
   })
 
   def kifiSiteRedirect(path: String) = Action {

--- a/kifi-backend/modules/shoebox/app/com/keepit/social/SecureSocialUserServiceImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/social/SecureSocialUserServiceImpl.scala
@@ -1,23 +1,20 @@
 package com.keepit.social
 
 import com.google.inject.{Inject, Singleton}
-import com.keepit.common.db.slick.{DBSession, Database}
-import com.keepit.model._
-import com.keepit.common.store.S3ImageStore
-import com.keepit.common.healthcheck.{Healthcheck, HealthcheckPlugin}
-import securesocial.core._
-import com.keepit.common.logging.Logging
+import com.keepit.common.db.slick.DBSession.RWSession
+import com.keepit.common.db.slick.Database
 import com.keepit.common.db.{ExternalId, Id}
-import play.api.{Application, Play}
-import Play.current
-import com.keepit.common.db.slick.DBSession.{RSession, RWSession}
-import com.keepit.inject.AppScoped
-import securesocial.core.providers.{UsernamePasswordProvider, Token}
-import scala.Some
-import com.keepit.model.User
 import com.keepit.common.healthcheck.HealthcheckError
-import securesocial.core.IdentityId
-import com.keepit.model.SocialUserInfo
+import com.keepit.common.healthcheck.{Healthcheck, HealthcheckPlugin}
+import com.keepit.common.logging.Logging
+import com.keepit.common.store.S3ImageStore
+import com.keepit.inject.AppScoped
+import com.keepit.model._
+
+import play.api.Play.current
+import play.api.{Application, Play}
+import securesocial.core._
+import securesocial.core.providers.{UsernamePasswordProvider, Token}
 
 @Singleton
 class SecureSocialUserPluginImpl @Inject() (
@@ -53,15 +50,15 @@ class SecureSocialUserPluginImpl @Inject() (
 
   def save(identity: Identity): SocialUser = reportExceptions {
     db.readWrite { implicit s =>
-      val (userId, socialUser) = getUserIdAndSocialUser(identity)
+      val (userId, socialUser, allowSignup) = getUserIdAndSocialUser(identity)
       log.info(s"[save] persisting (social|42) user $socialUser")
       val socialUserInfo = internUser(
         SocialId(socialUser.identityId.userId),
         SocialNetworkType(socialUser.identityId.providerId),
         socialUser,
-        userId)
+        userId,
+        allowSignup)
       require(socialUserInfo.credentials.isDefined, "social user info's credentials is not defined: %s".format(socialUserInfo))
-      require(socialUserInfo.userId.isDefined, "social user id  is not defined: %s".format(socialUserInfo))
       if (!socialUser.identityId.providerId.equals("userpass")) // FIXME
         socialGraphPlugin.asyncFetch(socialUserInfo)
       log.info("[save] persisting %s into %s".format(socialUser, socialUserInfo))
@@ -69,9 +66,9 @@ class SecureSocialUserPluginImpl @Inject() (
     }
   }
 
-  private def getUserIdAndSocialUser(identity: Identity): (Option[Id[User]], SocialUser) = identity match {
-    case UserIdentity(userId, socialUser) => (userId, socialUser)
-    case ident => (None, SocialUser(ident))
+  private def getUserIdAndSocialUser(identity: Identity): (Option[Id[User]], SocialUser, Boolean) = identity match {
+    case UserIdentity(userId, socialUser, allowSignup) => (userId, socialUser, allowSignup)
+    case ident => (None, SocialUser(ident), false)
   }
 
   private def createUser(identity: Identity): User = {
@@ -84,11 +81,15 @@ class SecureSocialUserPluginImpl @Inject() (
   }
 
   private def internUser(
-      socialId: SocialId, socialNetworkType: SocialNetworkType,
-      socialUser: SocialUser, userId: Option[Id[User]])(implicit session: RWSession): SocialUserInfo = {
+      socialId: SocialId, socialNetworkType: SocialNetworkType, socialUser: SocialUser,
+      userId: Option[Id[User]], allowSignup: Boolean)(implicit session: RWSession): SocialUserInfo = {
     log.info(s"[internUser] socialId=$socialId snType=$socialNetworkType socialUser=$socialUser userId=$userId")
+    def makeUser(): Option[User] = {
+      if (allowSignup) Some(userRepo.save(createUser(socialUser))) else None
+    }
+
     val suiOpt = socialUserInfoRepo.getOpt(socialId, socialNetworkType)
-    val userOpt = userId orElse {
+    val existingUserOpt = userId orElse {
       // TODO: better way of dealing with emails that already exist; for now just link accounts
       socialUser.email flatMap (emailRepo.getByAddressOpt(_)) map (_.userId)
     } flatMap userRepo.getOpt
@@ -98,42 +99,43 @@ class SecureSocialUserPluginImpl @Inject() (
         // TODO(greg): handle case where user id in socialUserInfo is different from the one in the session
         if (suiOpt == Some(socialUserInfo)) socialUserInfo else socialUserInfoRepo.save(socialUserInfo)
       case Some(socialUserInfo) if socialUserInfo.userId.isEmpty =>
-        val user = userOpt getOrElse userRepo.save(createUser(socialUser))
+        val userOpt = existingUserOpt orElse makeUser()
 
         //social user info with user must be FETCHED_USING_SELF, so setting user should trigger a pull
         //todo(eishay): send a direct fetch request
 
-        for (su <- socialUserInfoRepo.getByUser(user.id.get)
+        for (user <- userOpt; su <- socialUserInfoRepo.getByUser(user.id.get)
             if su.networkType == socialUserInfo.networkType && su.id.get != socialUserInfo.id.get) {
           throw new IllegalStateException(s"Social user for ${su.networkType} is already connected: $su")
         }
 
-        val sui = socialUserInfoRepo.save(socialUserInfo.withUser(user))
-        if (userOpt.isEmpty) imageStore.updatePicture(sui, user.externalId)
+        val sui = socialUserInfoRepo.save(userOpt map socialUserInfo.withUser getOrElse socialUserInfo)
+        for (user <- userOpt if existingUserOpt.isEmpty) imageStore.updatePicture(sui, user.externalId)
         sui
       case None =>
-        val user = userOpt getOrElse userRepo.save(createUser(socialUser))
-        log.info("creating new SocialUserInfo for %s".format(user))
+        val userOpt = existingUserOpt orElse makeUser()
+        log.info("creating new SocialUserInfo for %s".format(userOpt))
 
-        val userInfo = SocialUserInfo(userId = Some(user.id.get),//verify saved
+        val userInfo = SocialUserInfo(userId = userOpt.flatMap(_.id),//verify saved
           socialId = socialId, networkType = socialNetworkType, pictureUrl = socialUser.avatarUrl,
           fullName = socialUser.fullName, credentials = Some(socialUser))
         log.info("SocialUserInfo created is %s".format(userInfo))
         val sui = socialUserInfoRepo.save(userInfo)
 
-        if (socialUser.authMethod == AuthenticationMethod.UserPassword) {
-          val cred =
-            UserCred(
-              userId = user.id.get,
-              loginName = socialUser.email.getOrElse(throw new Exception),
-              provider = "bcrypt" /* hard-coded */,
-              credentials = socialUser.passwordInfo.get.password,
-              salt = socialUser.passwordInfo.get.salt.getOrElse(""))
-          val savedCred = userCredRepo.save(cred)
-          log.info(s"[save(userpass)] Persisted $cred into userCredRepo as $savedCred")
+        for (user <- userOpt) {
+          if (socialUser.authMethod == AuthenticationMethod.UserPassword) {
+            val cred =
+              UserCred(
+                userId = user.id.get,
+                loginName = socialUser.email.getOrElse(throw new Exception),
+                provider = "bcrypt" /* hard-coded */,
+                credentials = socialUser.passwordInfo.get.password,
+                salt = socialUser.passwordInfo.get.salt.getOrElse(""))
+            val savedCred = userCredRepo.save(cred)
+            log.info(s"[save(userpass)] Persisted $cred into userCredRepo as $savedCred")
+          }
+          if (existingUserOpt.isEmpty) imageStore.updatePicture(sui, user.externalId)
         }
-
-        if (userOpt.isEmpty) imageStore.updatePicture(sui, user.externalId)
         sui
     }
   }
@@ -269,4 +271,3 @@ class SecureSocialAuthenticatorPluginImpl @Inject()(
     }
   }
 }
-

--- a/kifi-backend/modules/shoebox/app/views/website/welcome.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/website/welcome.scala.html
@@ -1,5 +1,6 @@
-@(id: Option[ExternalId[Invitation]] = None, socialUser: Option[SocialUserInfo] = None,
-    msg: Option[String] = None, skipLetMeIn: Boolean = false, passwordAuth: Boolean = false)
+@(id: Option[ExternalId[Invitation]] = None, socialUser: Option[SocialUserInfo] = None, msg: Option[String] = None,
+    skipLetMeIn: Boolean = false, passwordAuth: Boolean = false,
+    authenticatedAs: Option[securesocial.core.SocialUser] = None)
 
 @helper.main(title = "Welcome to Kifi!", hiddenElements = Seq("header"), head = Html(s"""
     <meta property="og:url" content="https://www.kifi.com${id map (com.keepit.controllers.website.routes.InviteController.acceptInvite(_).url) getOrElse com.keepit.controllers.website.routes.HomeController.home()}">
@@ -10,6 +11,14 @@
     """)) {
   <section class="content clearfix text_center welcome">
     <h1>Welcome to the <img src="@routes.Assets.at("images/logo2.png")" width="103" height="58" class="logo2"> private beta!</h1>
+
+    @authenticatedAs.map { socialUser =>
+      <p class="authenticated-as">
+        Hi @socialUser.firstName!
+        You are currently logged in with @{SocialNetworkType(socialUser.identityId.providerId).displayName}.
+        <a href="@com.keepit.controllers.core.routes.AuthController.signup()">Create an account.</a>
+       </p>
+    }.getOrElse("")
 
     @msg.map { m =>
       <p class="error-message">@m</p>


### PR DESCRIPTION
These are preliminary changes to separate login and signup. The main goal here is to allow you to log in as just a social user (eventually this will be the "log in" feature; now the auto-signup is still enabled). This way when you "log in" with a social network, we can ask again about what you want to do before making any changes. We can orchestrate this process from our own code and just use SecureSocial for the social authentication part.
