### PR TITLE
logging remote host to know which node in the cluster did we actually hit, remote response time as the other server saw it and the "wait time" (gap between overall time it took to time it took the other service to process the request)

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/controller/LoggingFilter.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/LoggingFilter.scala
@@ -23,6 +23,7 @@ object LoggingFilter extends EssentialFilter {
           s"[HTTP-IN] #${trackingId} [${rh.method}] ${rh.uri} from ${rh.remoteAddress} to ${rh.host} took [${time}ms] and returned ${result.header.status}")
         result.withHeaders(
           CommonHeaders.ResponseTime -> time.toString,
+          //todo(eishay): the interesting part is the local service type and node id, to be sent
           CommonHeaders.LocalHost -> host)
       }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/net/HttpClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/HttpClient.scala
@@ -170,7 +170,7 @@ private[net] class Request(req: WSRequestHolder, headers: List[(String, String)]
     val start = System.currentTimeMillis
     val res = wsRequest.get()
     res.onComplete { resTry =>
-      logResponse(start, "GET", resTry.isSuccess, trackingId)
+      logResponse(start, "GET", resTry.isSuccess, trackingId, resTry.toOption)
     }
     res
   }
@@ -179,7 +179,7 @@ private[net] class Request(req: WSRequestHolder, headers: List[(String, String)]
     val start = System.currentTimeMillis
     val res = wsRequest.put(body)
     res.onComplete { resTry =>
-      logResponse(start, "PUT", resTry.isSuccess, trackingId)
+      logResponse(start, "PUT", resTry.isSuccess, trackingId, resTry.toOption)
     }
     res
   }
@@ -188,7 +188,7 @@ private[net] class Request(req: WSRequestHolder, headers: List[(String, String)]
     val start = System.currentTimeMillis
     val res = wsRequest.post(body)
     res.onComplete { resTry =>
-      logResponse(start, "POST", resTry.isSuccess, trackingId)
+      logResponse(start, "POST", resTry.isSuccess, trackingId, resTry.toOption)
     }
     res
   }
@@ -197,7 +197,7 @@ private[net] class Request(req: WSRequestHolder, headers: List[(String, String)]
     val start = System.currentTimeMillis
     val res = wsRequest.post(body)
     res.onComplete { resTry =>
-      logResponse(start, "POST", resTry.isSuccess, trackingId)
+      logResponse(start, "POST", resTry.isSuccess, trackingId, resTry.toOption)
     }
     res
   }
@@ -206,17 +206,24 @@ private[net] class Request(req: WSRequestHolder, headers: List[(String, String)]
     val start = System.currentTimeMillis
     val res = wsRequest.delete()
     res.onComplete { resTry =>
-      logResponse(start, "DELETE", resTry.isSuccess, trackingId)
+      logResponse(start, "DELETE", resTry.isSuccess, trackingId, resTry.toOption)
     }
     res
   }
 
   private val accessLog = Logger("com.keepit.access")
 
-  private def logResponse(startTime: Long, method: String, isSuccess: Boolean, trackingId: String) = {
+  private def logResponse(startTime: Long, method: String, isSuccess: Boolean, trackingId: String, resOpt: Option[Response]) = {
     val time = System.currentTimeMillis - startTime
+    //todo(eishay): the interesting part is the remote service and node id, to be logged
+    val remoteHost = resOpt.map(_.header(CommonHeaders.LocalHost)).flatten.getOrElse("NA")
+    val remoteTime = resOpt.map(_.header(CommonHeaders.ResponseTime)).flatten.map(_.toInt)
+    val waitTime = remoteTime map {rt => rt - time}
     val queryString = wsRequest.queryString map {case (k, v) => s"$k=$v"} mkString "&"
-    accessLog.info(s"""[OUT] #${trackingId} [$method] ${wsRequest.url} took [${time}ms] with params [${queryString}] (success = $isSuccess)""")
+    accessLog.info(
+      s"[OUT] #${trackingId} [$method] ${wsRequest.url} from $remoteHost timing " +
+      s"[local:${time}ms,remote:${remoteTime.getOrElse("NA")},wait:${waitTime.getOrElse("NA")}] " +
+      s"with params [${queryString}] (success = $isSuccess)")
   }
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/net/HttpClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/HttpClient.scala
@@ -218,7 +218,7 @@ private[net] class Request(req: WSRequestHolder, headers: List[(String, String)]
     //todo(eishay): the interesting part is the remote service and node id, to be logged
     val remoteHost = resOpt.map(_.header(CommonHeaders.LocalHost)).flatten.getOrElse("NA")
     val remoteTime = resOpt.map(_.header(CommonHeaders.ResponseTime)).flatten.map(_.toInt)
-    val waitTime = remoteTime map {rt => rt - time}
+    val waitTime = remoteTime map {rt => time - rt}
     val queryString = wsRequest.queryString map {case (k, v) => s"$k=$v"} mkString "&"
     accessLog.info(
       s"[OUT] #${trackingId} [$method] ${wsRequest.url} from $remoteHost timing " +


### PR DESCRIPTION
Wait time would include network latency and thread starvations
