### PR TITLE
added .jshintrc

### DIFF
--- a/packrat/.jshintrc
+++ b/packrat/.jshintrc
@@ -62,11 +62,11 @@
 	"validthis": true,
 
 	// Environments
-	"browser": false,
+	"browser": true,
 	"couch": false,
 	"devel": false,
 	"dojo": false,
-	"jquery": false,
+	"jquery": true,
 	"mootools": false,
 	"node": false,
 	"nonstandard": false,

--- a/packrat/.jshintrc
+++ b/packrat/.jshintrc
@@ -1,0 +1,88 @@
+{
+	// http://www.jshint.com/docs/options
+
+	// Enforcing options
+	"bitwise": true,
+	"camelcase": true,
+	"curly": true,
+	"eqeqeq": true,
+	"es3": true,
+	"forin": true,
+	"immed": true,
+	"indent": 2,
+	"latedef": true,
+	"newcap": true,
+	"noarg": true,
+	"noempty": true,
+	"nonew": true,
+	"plusplus": false,
+  // true, single, double
+	"quotmark": true,
+	"regexp": true,
+	// This option prohibits the use of unsafe . in regular expressions.
+	"undef": true,
+	"unused": true,
+	"strict": true,
+	"trailing": true,
+	"maxparams": 4,
+	"maxdepth": 3,
+	"maxstatements": 25,
+	"maxcomplexity": 10,
+	"maxlen": 160,
+
+	// Relaxing options
+	"asi": false,
+	"boss": false,
+	"debug": false,
+	"eqnull": true,
+	"es5": false,
+	// This option tells JSHint that your code uses ECMAScript 5 specific features such as getters and setters. Note that not all browsers implement these features.
+	"esnext": false,
+	"evil": false,
+	"expr": false,
+	"funcscope": false,
+	"globalstrict": false,
+	"iterator": false,
+	"lastsemic": false,
+	"laxbreak": false,
+	"laxcomma": false,
+	"loopfunc": false,
+	"moz": false,
+	"multistr": false,
+	"onecase": false,
+	// This option suppresses warnings about switches with just one case. Most of the time you want to use if instead of switch if there is only one case. However, some code generators prefer to generate switch statements.
+	"proto": false,
+	"regexdash": false,
+	// This option suppresses warnings about unescaped - in the end of regular expressions.
+	"scripturl": false,
+	"smarttabs": false,
+	"shadow": false,
+	"sub": false,
+	"supernew": false,
+	"validthis": true,
+
+	// Environments
+	"browser": false,
+	"couch": false,
+	"devel": false,
+	"dojo": false,
+	"jquery": false,
+	"mootools": false,
+	"node": false,
+	"nonstandard": false,
+	"phantom": false,
+	"prototypejs": false,
+	"rhino": false,
+	"worker": false,
+	"wsh": false,
+	"yui": false,
+
+	// Legacy
+	"nomen": true,
+	"onevar": false,
+	"passfail": false,
+	"white": true,
+
+	// Globals
+	"globals": {}
+}


### PR DESCRIPTION
It is good to have a .jshintrc per project to lint javascript sources on build time.

Right now, its options are somewhat strict as I always use very strict option values (helps me to reduce errors).
It can be configured for the team.

It is going to be much more useful once grunt build is complete.
