### PR TITLE
adding "use strict" in most of our scripts + a wee bit of code re-formatting

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -1,7 +1,8 @@
 // API for main.js
 
-const hexRe = /^#[0-9a-f]{3}$/i;
+var hexRe = /^#[0-9a-f]{3}$/i;
 function log() {
+  'use strict';
   var d = new Date, ds = d.toString(), t = "[" + ds.substr(0, 2) + ds.substr(15,9) + "." + String(+d).substr(10) + "] ", args = arguments, a0 = args[0];
   if (hexRe.test(a0)) {
     args[0] = "%c" + t + args[1];
@@ -13,7 +14,8 @@ function log() {
 }
 
 var api = function() {
-  const httpRe = /^https?:/;
+  'use strict';
+  var httpRe = /^https?:/;
 
   function dispatch() {
     var args = arguments;
@@ -91,9 +93,9 @@ var api = function() {
     }
   });
 
-  const stripHashRe = /^[^#]*/;
-  const googleSearchRe = /^https?:\/\/www\.google\.[a-z]{2,3}(?:\.[a-z]{2})?\/(?:|search|webhp)\?(?:.*&)?q=([^&#]*)/;
-  const plusRe = /\+/g;
+  var stripHashRe = /^[^#]*/;
+  var googleSearchRe = /^https?:\/\/www\.google\.[a-z]{2,3}(?:\.[a-z]{2})?\/(?:|search|webhp)\?(?:.*&)?q=([^&#]*)/;
+  var plusRe = /\+/g;
 
   chrome.webNavigation.onBeforeNavigate.addListener(function(details) {
     var match = details.url.match(googleSearchRe);
@@ -216,9 +218,9 @@ var api = function() {
     }
   });
 
-  const pages = {};  // by tab.id in "normal" windows only
-  const normalTab = {};  // by tab.id (true if tab is in a "normal" window)
-  const selectedTabIds = {};  // by window.id in "normal" windows only
+  var pages = {};  // by tab.id in "normal" windows only
+  var normalTab = {};  // by tab.id (true if tab is in a "normal" window)
+  var selectedTabIds = {};  // by window.id in "normal" windows only
   chrome.tabs.query({windowType: "normal"}, function(tabs) {
     tabs.forEach(function(tab) {
       normalTab[tab.id] = true;
@@ -231,7 +233,7 @@ var api = function() {
     });
   });
 
-  const ports = {}, portHandlers = {
+  var ports = {}, portHandlers = {
     "api:handling": function(data, _, page, port) {
       for (var i = 0; i < data.length; i++) {
         port.handling[data[i]] = true;
@@ -356,7 +358,7 @@ var api = function() {
     }
   }
 
-  const hostRe = /^https?:\/\/[^\/]*/;
+  var hostRe = /^https?:\/\/[^\/]*/;
   return {
     bookmarks: {
       create: function(parentId, name, url, callback) {

--- a/packrat/adapters/chrome/options.js
+++ b/packrat/adapters/chrome/options.js
@@ -1,4 +1,5 @@
 $(function() {
+  'use strict';
   var main = chrome.extension.getBackgroundPage(), api = main.api, env = api.prefs.get("env");
 
   $(api.isPackaged() ? null : "select").show()

--- a/packrat/adapters/chrome/scripts/api.js
+++ b/packrat/adapters/chrome/scripts/api.js
@@ -1,6 +1,7 @@
 // API for content scripts
 
 var api = api || function() {  // idempotent for Chrome
+  'use strict';
   var msgHandlers = [], callbacks = {}, nextCallbackId = 1, port;
 
   function createPort() {
@@ -115,6 +116,7 @@ var api = api || function() {  // idempotent for Chrome
 }();
 
 var log = log || function() {
+  'use strict';
   var d = new Date, ds = d.toString();
   arguments[0] = "[" + ds.substr(0, 2) + ds.substr(15,9) + "." + String(+d).substr(10) + "] " + arguments[0];
   return console.log.apply.bind(console.log, console, arguments);

--- a/packrat/adapters/firefox/data/scripts/api.js
+++ b/packrat/adapters/firefox/data/scripts/api.js
@@ -1,6 +1,7 @@
 // API for content scripts
 
 const api = function() {
+  // TODO: 'use strict'; after working around global definitions in eval’d scripts below
   var nextCallbackId = 1, callbacks = {};
 
   function invokeCallback(callbackId, response) {
@@ -58,6 +59,7 @@ const api = function() {
 }();
 
 function log() {
+  'use strict';
   var d = new Date, ds = d.toString();
   for (var args = Array.slice(arguments), i = 0; i < args.length; i++) {
     var arg = args[i];

--- a/packrat/adapters/firefox/data/scripts/workers/socket.js
+++ b/packrat/adapters/firefox/data/scripts/workers/socket.js
@@ -1,4 +1,5 @@
 function log() {
+  'use strict';
   var d = new Date, ds = d.toString(), a = Array.slice(arguments);
   for (var i = 0; i < a.length; i++) {
     var v = a[i];

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -1,4 +1,6 @@
 // API for main.js
+/*jshint globalstrict:true */
+"use strict";
 
 function dispatch() {
   var args = arguments;

--- a/packrat/adapters/firefox/lib/bookmarks.js
+++ b/packrat/adapters/firefox/lib/bookmarks.js
@@ -1,4 +1,6 @@
 // see https://developer.mozilla.org/en-US/docs/Places_Developer_Guide
+/*jshint globalstrict:true */
+'use strict';
 
 var { Cc, Ci } = require('chrome')
 var bookmarks = Cc["@mozilla.org/browser/nav-bookmarks-service;1"].getService(Ci.nsINavBookmarksService);

--- a/packrat/adapters/firefox/lib/icon.js
+++ b/packrat/adapters/firefox/lib/icon.js
@@ -1,4 +1,5 @@
-//
+/*jshint globalstrict:true */
+'use strict';
 
 const { Ci, Cc } = require("chrome");
 const WM = Cc["@mozilla.org/appshell/window-mediator;1"].getService(Ci.nsIWindowMediator);

--- a/packrat/adapters/firefox/lib/location.js
+++ b/packrat/adapters/firefox/lib/location.js
@@ -1,3 +1,6 @@
+/*jshint globalstrict:true */
+'use strict';
+
 const {Ci} = require('chrome');
 const {browserWindows, BrowserWindow} = require('sdk/windows');
 const tabs = require('sdk/tabs');

--- a/packrat/adapters/shared/deps.js
+++ b/packrat/adapters/shared/deps.js
@@ -1,4 +1,5 @@
 !function(exports, meta) {
+	'use strict';
 	exports.deps = function(paths, injected) {
 		paths = typeof paths == 'string' ? [paths] : paths;
 		var scripts = [], styles = {};

--- a/packrat/adapters/shared/listeners.js
+++ b/packrat/adapters/shared/listeners.js
@@ -3,8 +3,8 @@ Listeners.prototype = [];
 Listeners.prototype.constructor = Listeners;
 Listeners.prototype.add = Listeners.prototype.push;
 Listeners.prototype.remove = function(f) {
-  var i;
-  while ((i = this.indexOf(f)) >= 0) {
+  'use strict';
+  for (var i; ~(i = this.indexOf(f));) {
     this.splice(i, 1);
   }
 };

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1,11 +1,14 @@
+/*jshint globalstrict:true */
+"use strict";
+
 var api = api || require("./api");
 var log = log || api.log;
 
-const NOTIFICATION_BATCH_SIZE = 10;
+var NOTIFICATION_BATCH_SIZE = 10;
 
 //                            | sub |    |------- country domain -------|-- generic domain --|           |-- port? --|
-const domainRe = /^https?:\/\/[^\/]*?((?:[^.\/]+\.[^.\/]{2,3}\.[^.\/]{2}|[^.\/]+\.[^.\/]{2,6}|localhost))(?::\d{2,5})?(?:$|\/)/;
-const hostRe = /^https?:\/\/([^\/]+)/;
+var domainRe = /^https?:\/\/[^\/]*?((?:[^.\/]+\.[^.\/]{2,3}\.[^.\/]{2}|[^.\/]+\.[^.\/]{2,6}|localhost))(?::\d{2,5})?(?:$|\/)/;
+var hostRe = /^https?:\/\/([^\/]+)/;
 
 var tabsByLocator = {};
 var notificationsCallbacks = [];
@@ -85,7 +88,7 @@ function ajax(service, method, uri, data, done, fail) {  // method and uri are r
 
 // ===== Event logging
 
-const eventFamilies = {slider:1, search:1, extension:1, account:1, notification:1};
+var eventFamilies = {slider:1, search:1, extension:1, account:1, notification:1};
 
 function logEvent(eventFamily, eventName, metaData, prevEvents) {
   if (!eventFamilies[eventFamily]) {
@@ -126,7 +129,7 @@ logEvent.catchUp = function() {
 
 // ===== WebSocket handlers
 
-const socketHandlers = {
+var socketHandlers = {
   denied: function() {
     log("[socket:denied]")();
     socket.close();
@@ -359,7 +362,7 @@ api.port.on({
       api.tabs.emit(tab, "kept", {kept: data.private ? "private" : "public"});
     });
   },
-  keeper_shown: function(_, _, tab) {
+  keeper_shown: function(_, __, tab) {
     (pageData[tab.nUri] || {}).shown = true;  // server already notified via event log
   },
   suppress_on_site: function(data, _, tab) {
@@ -1113,8 +1116,8 @@ api.tabs.on.loading.add(function(tab) {
   logEvent("extension", "pageLoad");
 });
 
-const searchPrefetchCache = {};  // for searching before the results page is ready
-const searchFilterCache = {};    // for restoring filter if user navigates back to results
+var searchPrefetchCache = {};  // for searching before the results page is ready
+var searchFilterCache = {};    // for restoring filter if user navigates back to results
 api.on.search.add(function prefetchResults(query) {
   log('[prefetchResults] prefetching for query:', query)();
   searchOnServer({query: query, filter: (searchFilterCache[query] || {}).filter}, function(response) {

--- a/packrat/scripts/compose.js
+++ b/packrat/scripts/compose.js
@@ -1,6 +1,7 @@
 // @require scripts/scrollable.js
 
 function attachComposeBindings($c, composeTypeName, enterToSend) {
+  'use strict';
   var $f = $c.find(".kifi-compose");
   var $t = $f.find(".kifi-compose-to");
   var $d = $f.find(".kifi-compose-draft");

--- a/packrat/scripts/deep_link_redirect.js
+++ b/packrat/scripts/deep_link_redirect.js
@@ -3,6 +3,7 @@
 // @asap
 
 !function run(json, e) {
+  'use strict';
   var msg = document.getElementsByClassName('kifi-deep-link-no-extension')[0];
   if (msg) {
     msg.style.display = "none";

--- a/packrat/scripts/deep_link_site.js
+++ b/packrat/scripts/deep_link_site.js
@@ -2,6 +2,7 @@
 // @require scripts/api.js
 
 document.addEventListener('click', function(e) {
+  'use strict';
   var uri, loc;
   if (!e.button && (uri = e.target.href) && (loc = e.target.dataset.locator)) {
     log('[deep_link_site:click]', uri, loc)();

--- a/packrat/scripts/dialog.js
+++ b/packrat/scripts/dialog.js
@@ -7,8 +7,9 @@ $.fn.layout = $.fn.layout || function() {
   return this.each(function() {this.clientHeight});  // forces layout
 };
 
-kifiDialog = function() {
-  
+var kifiDialog = function() {
+  'use strict';
+  return {toggleLoginDialog: toggleLoginDialog};
   function toggleLoginDialog() {
     render("html/login_dialog", {
       logo: api.url("images/kifi_logo_medium.png")
@@ -59,16 +60,11 @@ kifiDialog = function() {
 
       document.addEventListener("keydown", onKeyDown, true);
       function onKeyDown(e) {
-        if (e.keyCode == 27 && !e.metaKey && !e.ctrlKey && !e.shiftKey) { 
+        if (e.keyCode === 27 && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
           removeDialog();
           return false;
         }
       }
     });
   }
-  return {
-    toggleLoginDialog: function() {
-      toggleLoginDialog();
-    }
-  };
 }();

--- a/packrat/scripts/formatting.js
+++ b/packrat/scripts/formatting.js
@@ -1,4 +1,5 @@
 function getTextFormatter() {
+ 'use strict';
   return function(text, render) {
     // Careful... this is raw text (necessary for URL detection). Be sure to Mustache.escape untrusted portions!
     text = render(text);
@@ -29,6 +30,7 @@ function getTextFormatter() {
 }
 
 function getSnippetFormatter() {
+ 'use strict';
   return function(text, render) {
     // Careful... this is raw text (necessary for URL detection). Be sure to Mustache.escape untrusted portions!
     text = render(text);
@@ -45,6 +47,7 @@ function getSnippetFormatter() {
 }
 
 function getLocalDateFormatter() {
+ 'use strict';
   return function(text, render) {
     try {
       return new Date(render(text)).toString();
@@ -55,6 +58,7 @@ function getLocalDateFormatter() {
 }
 
 function convertDraftToText(html) {
+ 'use strict';
   html = html
     .replace(/<div><br\s*[\/]?><\/div>/gi, '\n')
     .replace(/<br\s*[\/]?>/gi, '\n')

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -12,7 +12,7 @@
 // @require scripts/html/search/google_hit.js
 
 // (same as match pattern above)
-const searchUrlRe = /^https?:\/\/www\.google\.(?:com|com\.(?:a[fgiru]|b[dhnorz]|c[ouy]|do|e[cgt]|fj|g[hit]|hk|jm|k[hw]|l[by]|m[txy]|n[afgip]|om|p[aehkry]|qa|s[abglv]|t[jrw]|u[ay]|v[cn])|co\.(?:ao|bw|c[kr]|i[dln]|jp|k[er]|ls|m[az]|nz|t[hz]|u[gkz]|v[ei]|z[amw])|a[demstz]|b[aefgijsy]|cat|c[adfghilmnvz]|d[ejkmz]|e[es]|f[imr]|g[aeglmpry]|h[nrtu]|i[emqst]|j[eo]|k[giz]|l[aiktuv]|m[degklnsuvw]|n[eloru]|p[lnstosuw]|s[cehikmnot]|t[dgklmnot]|v[gu]|ws)\/(?:|search|webhp)(?:[?#].*)?$/;
+var searchUrlRe = /^https?:\/\/www\.google\.(?:com|com\.(?:a[fgiru]|b[dhnorz]|c[ouy]|do|e[cgt]|fj|g[hit]|hk|jm|k[hw]|l[by]|m[txy]|n[afgip]|om|p[aehkry]|qa|s[abglv]|t[jrw]|u[ay]|v[cn])|co\.(?:ao|bw|c[kr]|i[dln]|jp|k[er]|ls|m[az]|nz|t[hz]|u[gkz]|v[ei]|z[amw])|a[demstz]|b[aefgijsy]|cat|c[adfghilmnvz]|d[ejkmz]|e[es]|f[imr]|g[aeglmpry]|h[nrtu]|i[emqst]|j[eo]|k[giz]|l[aiktuv]|m[degklnsuvw]|n[eloru]|p[lnstosuw]|s[cehikmnot]|t[dgklmnot]|v[gu]|ws)\/(?:|search|webhp)(?:[?#].*)?$/;
 
 $.fn.layout = function() {
   return this.each(function() {this.clientHeight});  // forces layout
@@ -20,6 +20,7 @@ $.fn.layout = function() {
 
 // We check the pattern because Chrome match/glob patterns aren't powerful enough. crbug.com/289057
 if (searchUrlRe.test(document.URL)) !function() {
+  'use strict';
   log("[google_inject]")();
 
   function logEvent() {  // parameters defined in main.js

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -7,6 +7,7 @@ function logEvent() {  // parameters defined in main.js
 }
 
 var tile = tile || function() {  // idempotent for Chrome
+  'use strict';
   log("[keeper_scout]", location.hostname)();
 
   window.onerror = function(message, url, lineNo) {
@@ -247,8 +248,9 @@ var tile = tile || function() {  // idempotent for Chrome
   return tile;
 }();
 
-const linkedInProfileRe = /^https?:\/\/[a-z]{2,3}.linkedin.com\/profile\/view\?/;
+var linkedInProfileRe = /^https?:\/\/[a-z]{2,3}.linkedin.com\/profile\/view\?/;
 function withUrls(o) {
+  'use strict';
   o.url = document.URL;
   var el, cUrl = ~o.url.search(linkedInProfileRe) ?
     (el = document.querySelector('.public-profile>dd>:first-child')) && 'http://' + el.textContent :

--- a/packrat/scripts/lib/jquery-bindhover.js
+++ b/packrat/scripts/lib/jquery-bindhover.js
@@ -10,6 +10,7 @@ home-grown at FortyTwo, not intended for distribution (yet)
 // recovery period during which clicks are ignored.
 
 !function($) {
+  'use strict';
   $.fn.bindHover = function(selector, create) {
     if (selector == "destroy") {
       return this.each(function() {

--- a/packrat/scripts/lib/rwsocket.js
+++ b/packrat/scripts/lib/rwsocket.js
@@ -1,5 +1,6 @@
 function ReconnectingWebSocket(opts) {
-  const wordRe = /\w+/, minRetryConnectDelayMs = 300, maxRetryConnectDelayMs = 5000, idlePingDelayMs = 10000;
+  'use strict';
+  var wordRe = /\w+/, minRetryConnectDelayMs = 300, maxRetryConnectDelayMs = 5000, idlePingDelayMs = 10000;
   var ws, self = this, buffer = [], disTimeout, pingTimeout, lastRecOrPingTime, retryConnectDelayMs = minRetryConnectDelayMs;
 
   this.send = function(data) {

--- a/packrat/scripts/look.js
+++ b/packrat/scripts/look.js
@@ -1,4 +1,5 @@
 function lookMouseDown(e) {
+  'use strict';
   if (e.which != 1) return;
   e.preventDefault();
   var el = snapshot.fuzzyFind(this.href.substr(11));

--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -21,11 +21,13 @@
 // (TBD whether focus is also required).
 
 panes.notices = function() {
-  const PIXELS_FROM_BOTTOM = 40; // load more notifications when this many pixels from the bottom
-  const NEW_FADE_TIMEOUT = 1000; // number of ms to wait before starting to fade
-  const NEW_FADE_DURATION = 3000; // length of the fade
+  'use strict';
 
-  const handlers = {
+  var PIXELS_FROM_BOTTOM = 40; // load more notifications when this many pixels from the bottom
+  var NEW_FADE_TIMEOUT = 1000; // number of ms to wait before starting to fade
+  var NEW_FADE_DURATION = 3000; // length of the fade
+
+  var handlers = {
     new_notification: function(n) {
       log("[new_notification]", n)();
       showNew([n]);

--- a/packrat/scripts/notifier_scout.js
+++ b/packrat/scripts/notifier_scout.js
@@ -2,6 +2,7 @@
 // @require scripts/api.js
 
 var notifierScout = notifierScout || function() {  // idempotent for Chrome
+  'use strict';
   api.port.on({
     session_change: function(s) {
       if (!s) {

--- a/packrat/scripts/prevent_ancestor_scroll.js
+++ b/packrat/scripts/prevent_ancestor_scroll.js
@@ -1,5 +1,6 @@
 // A jQuery plugin to prevent scrolling of ancestor elements while scrolling inside this element
 $.fn.preventAncestorScroll = function() {
+  'use strict';
   return this.on('wheel mousewheel', function(e) {
     var sT = this.scrollTop, sT2, delta = e.type === 'wheel' ? e.originalEvent.deltaY : -e.originalEvent.wheelDelta;
     if (delta > 0 && sT + delta > (sT2 = this.scrollHeight - this.clientHeight)) {

--- a/packrat/scripts/render.js
+++ b/packrat/scripts/render.js
@@ -3,6 +3,7 @@ var cdnBase = api.dev ?
   "//djty7jcqog9qu.cloudfront.net";
 
 var render = function() {
+  'use strict';
   return function(path, params, partials, callback) {  // partials and callback are both optional
     if (!callback && typeof partials == "function") {
       callback = partials, partials = null;

--- a/packrat/scripts/scrollable.js
+++ b/packrat/scripts/scrollable.js
@@ -1,6 +1,7 @@
 // @require scripts/throttle.js
 
 !function() {
+  'use strict';
   $.fn.scrollable = function(o) {
     return this.each(function() {
       o.$above.addClass("kifi-scrollable-above");

--- a/packrat/scripts/snapshot.js
+++ b/packrat/scripts/snapshot.js
@@ -1,5 +1,6 @@
-var snapshot = {
-
+var snapshot = function () {
+  'use strict';
+  return {
   // Characters that must not be considered part of names/tokens.
   delim: /[#\.:> ]/,
 
@@ -211,4 +212,5 @@ var snapshot = {
       }
     }
   }
+}
 };

--- a/packrat/scripts/thread.js
+++ b/packrat/scripts/thread.js
@@ -13,7 +13,8 @@
 // @require scripts/prevent_ancestor_scroll.js
 
 panes.thread = function() {
-  const handlers = {
+  'use strict';
+  var handlers = {
     message: function(o) {
       update(o.threadId, o.message, o.userId);
     },

--- a/packrat/scripts/threads.js
+++ b/packrat/scripts/threads.js
@@ -14,7 +14,8 @@
 // @require scripts/prevent_ancestor_scroll.js
 
 panes.threads = function() {
-  const handlers = {
+  'use strict';
+  var handlers = {
     thread_info: function(o) {
       update(o.thread, o.read);
     },

--- a/packrat/scripts/throttle.js
+++ b/packrat/scripts/throttle.js
@@ -1,5 +1,6 @@
 // from underscore.js (w/minor tweaks)
 function throttle(func, wait) {
+	'use strict';
 	var context, args, result, timeout, previous = 0;
 	function later() {
 		previous = Date.now();


### PR DESCRIPTION
- sad to see `const` go in the Chrome code (kept it in Firefox-only code)
- couldn’t add `"use strict"` to Firefox content script api.js yet b/c it currently uses window.eval to dynamically inject required content scripts that define global vars
- not always adding an extra level of indentation yet, to keep the diff clean here
