### PR TITLE
2.6.15: refactoring of messaging code in the extension

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.6.14
+version=2.6.15

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -70,8 +70,12 @@ ThreadData.prototype = {
   getThread: function (threadId) {
     return this.threads.filter(hasId(threadId))[0];
   },
-  addThread: function (thread) {
-    insertUpdateChronologically(this.threads, thread, 'lastCommentedAt');
+  addThread: function (th) {
+    th.participants = th.participants.filter(idIsNot(session.userId));
+    var old = insertUpdateChronologically(this.threads, th, 'lastCommentedAt');
+    if (old && old.lastMessageRead && new Date(old.lastMessageRead) > new Date(th.lastMessageRead || 0)) {
+      th.lastMessageRead = old.lastMessageRead;
+    }
   },
   getUnreadThreads: function() {
     var arr = [];
@@ -101,7 +105,7 @@ ThreadData.prototype = {
 };
 
 function insertUpdateChronologically(arr, o, time) {
-  var date = new Date(o[time]);
+  var date = new Date(o[time]), old;
   for (var i = arr.length; i--;) {
     var el = arr[i];
     if (date > new Date(el[time])) {
@@ -110,11 +114,13 @@ function insertUpdateChronologically(arr, o, time) {
     }
     if (o.id === el.id) {
       arr.splice(i, 1);
+      old = el;
     }
   }
   if (date) {
     arr.unshift(o);
   }
+  return old;
 }
 
 // ===== Server requests

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -65,6 +65,7 @@ ThreadData.prototype = {
       }
     });
     this.threads = threads;
+    delete this.stale;
   },
   getThread: function (threadId) {
     return this.threads.filter(hasId(threadId))[0];

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -312,12 +312,12 @@ var socketHandlers = {
         td.addThread(thread);
       } else if (td) {
         // this is probably the first message of a new thread
-        socket.send(["get_thread_info", id], td.addThread.bind(td));
+        socket.send(["get_thread_info", threadId], td.addThread.bind(td));
       }
 
       // ensure marked read if from this user
       if (message.user.id == session.userId) {
-        td.markRead(thread.id, message.createdAt);
+        td.markRead(threadId, message.createdAt);
       }
 
       forEachTabAt(message.url, message.nUrl, function(tab) {

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -10,13 +10,16 @@ var NOTIFICATION_BATCH_SIZE = 10;
 var domainRe = /^https?:\/\/[^\/]*?((?:[^.\/]+\.[^.\/]{2,3}\.[^.\/]{2}|[^.\/]+\.[^.\/]{2,6}|localhost))(?::\d{2,5})?(?:$|\/)/;
 var hostRe = /^https?:\/\/([^\/]+)/;
 
+var tabsByUrl = {}; // by normalized url
 var tabsByLocator = {};
 var notificationsCallbacks = [];
-var threadCallbacks = {};
+var threadDataCallbacks = {}; // by normalized url
+var threadCallbacks = {}; // by thread ID
 
 // ===== Cached data from server
 
 var pageData = {}; // keyed by normalized url
+var pageThreadData = {}; // keyed by normalized url
 var messageData = {}; // keyed by thread id; todo: evict old threads from memory
 var notifications;  // [] would mean user has none
 var timeNotificationsLastSeen = new Date(0);
@@ -30,6 +33,7 @@ var urlPatterns = [];
 function clearDataCache() {
   log("[clearDataCache]")();
   pageData = {};
+  pageThreadData = {};
   messageData = {};
   notifications = null;
   timeNotificationsLastSeen = new Date(0);
@@ -42,22 +46,75 @@ function clearDataCache() {
 }
 
 function PageData() {
-  this.tabs = [];
 }
-PageData.prototype = {
-  withThreadData: function(cb) {
-    if (this.threadDataReceived) {
-      cb();
-    } else {
-      (this.threadDataCallbacks || (this.threadDataCallbacks = [])).push(cb);
-    }
+
+function ThreadData() {
+}
+ThreadData.prototype = {
+  init: function (threads) {
+    var oldReadTimes = this.threads ? this.threads.reduce(function(o, th) {
+      o[th.id] = th.lastMessageRead;
+      return o;
+    }, {}) : {};
+    threads.forEach(function(th) {
+      th.participants = th.participants.filter(idIsNot(session.userId));
+      // avoid overwriting newer read-state information
+      var oldTimeStr = oldReadTimes[th.id];
+      if (oldTimeStr && new Date(oldTimeStr) > new Date(th.lastMessageRead || 0)) {
+        th.lastMessageRead = oldTimeStr;
+      }
+    });
+    this.threads = threads;
   },
-  dispatchThreadData: function() {
-    for (var arr = this.threadDataCallbacks; arr && arr.length;) {
-      arr.shift()();
+  getThread: function (threadId) {
+    return this.threads.filter(hasId(threadId))[0];
+  },
+  addThread: function (thread) {
+    insertUpdateChronologically(this.threads, thread, 'lastCommentedAt');
+  },
+  getUnreadThreads: function() {
+    var arr = [];
+    for (var i = this.threads.length; i--;) {
+      var th = this.threads[i];
+      var readAt = th.lastMessageRead;
+      if (!readAt || new Date(readAt) < new Date(th.lastCommentedAt)) {
+        arr.push(th);
+      }
     }
-    delete this.threadDataCallbacks;
-  }};
+    return arr;
+  },
+  countUnreadThreads: function() {
+    return this.getUnreadThreads().length;
+  },
+  getUnreadLocator: function () {
+    var unread = this.getUnreadThreads();
+    return unread.length === 1 ? '/messages/' + unread[0].id : (unread.length ? '/messages' : null);
+  },
+  markRead: function (threadId, timeStr) {
+    var th = this.getThread(threadId);
+    if (th && (!th.lastMessageRead || new Date(timeStr) > new Date(th.lastMessageRead))) {
+      th.lastMessageRead = timeStr;
+      return true;
+    }
+  }
+};
+
+function insertUpdateChronologically(arr, o, time) {
+  var date = new Date(o[time]);
+  for (var i = arr.length; i--;) {
+    var el = arr[i];
+    if (date > new Date(el[time])) {
+      arr.splice(i + 1, 0, o);
+      date = null;
+    }
+    if (o.id === el.id) {
+      arr.splice(i, 1);
+    }
+  }
+  if (date) {
+    arr.unshift(o);
+  }
+}
 
 // ===== Server requests
 
@@ -132,10 +189,7 @@ logEvent.catchUp = function() {
 var socketHandlers = {
   denied: function() {
     log("[socket:denied]")();
-    socket.close();
-    socket = null;
-    session = null;
-    clearDataCache();
+    clearSession();
   },
   version: function(v) {
     log("[socket:version]", v)();
@@ -174,7 +228,7 @@ var socketHandlers = {
       while (notificationsCallbacks.length) {
         notificationsCallbacks.shift()();
       }
-      tellTabsNoticeCountIfChanged();
+      tellVisibleTabsNoticeCountIfChanged();
     }
   },
   notification: function(n) {  // a new notification (real-time)
@@ -186,27 +240,35 @@ var socketHandlers = {
   },
   missed_notifications: function(arr, serverTime) {
     log("[socket:missed_notifications]", arr, serverTime)();
-    for (var i = arr.length - 1; ~i; i--) {
+    var threadIds = {};
+    for (var i = arr.length; i--;) {
       var n = arr[i];
       standardizeNotification(n);
-
-      if (pageData[n.url]) {
-        // One ThreadInfo in d.threads and messageData[threadId] may be outdated.
-        // Really only need to load the ThreadInfo and any new messages on the thread.
-        loadThreadData(n.url);
-      }
 
       if (!insertNewNotification(n)) {
         arr.splice(i, 1);
       } else if ((new Date(serverTime) - new Date(notifications[0].time)) < 1000*60) {
         sendNotificationToTabs(n);
       }
+
+      threadIds[n.threadId] = n.url;
     }
     if (arr.length) {
-      (tabsByLocator['/notices'] || []).forEach(function(tab) {
+      forEachTabAtLocator('/notices', function(tab) {
         api.tabs.emit(tab, "missed_notifications", arr);
       });
-      tellTabsNoticeCountIfChanged();
+      tellVisibleTabsNoticeCountIfChanged();
+    }
+    for (var id in threadIds) {
+      var nUri = threadIds[id];
+      var td = pageThreadData[nUri];
+      if (td) {
+        socket.send(["get_thread_info", id], td.addThread.bind(td));
+      }
+      if (messageData[id] && !threadCallbacks[id]) {
+        socket.send(["get_thread", id]);  // TODO: "get_thread_since" (don't need messages already loaded)
+        threadCallbacks[id] = [];
+      }
     }
   },
   last_notify_read_time: function(t) {
@@ -224,81 +286,60 @@ var socketHandlers = {
     log("[socket:thread]", th)();
     messageData[th.id] = th.messages;
     for (var arr = threadCallbacks[th.id]; arr && arr.length;) {
-      arr.shift()({id: th.id, messages: th.messages, participants: th.messages[0].participants});
+      arr.shift()({id: th.id, messages: th.messages});
     }
     delete threadCallbacks[th.id];
   },
   message: function(threadId, message) {
     log("[socket:message]", threadId, message, message.nUrl)();
-    var d = pageData[message.nUrl] || pageData[message.url];
-    if (d && !(messageData[threadId] || []).some(hasId(message.id))) {
-      var thread = (d.threads || []).filter(hasId(threadId))[0];
+    var messages = messageData[threadId];
+    if (messages) {
+      insertUpdateChronologically(messages, message, "createdAt");
+    }
+    var td = pageThreadData[message.nUrl] || pageThreadData[message.url];
+    if (td) {
+      var thread = td.getThread(threadId);
       if (thread) {
-          var messages;
-          if (thread.messageCount >= 1) {
-            messages = messageData[threadId];
-            if (messages) {
-              // insert message in chronological order
-              var t = new Date(message.createdAt);
-              for (var i = messages.length; i > 0 && new Date(messages[i-1].createdAt) > t; i--);
-              messages.splice(i, 0, message);
-            }
-          } else {
-            messageData[threadId] = messages = [message];
-          }
-
-          var lastMessage = messages[messages.length-1];
-          // until we have the updated threadinfos, do a best attempt at updating the thread
-          if (!thread.createdAt) thread.createdAt = lastMessage.createdAt;
-          thread.digest = lastMessage.text;
-          thread.lastAuthor = lastMessage.user.id;
-          thread.lastCommentedAt = lastMessage.createdAt;
-          thread.messageCount = messages.length;
-          messages.forEach(function(m) { thread.messageTimes[m.id] = m.createdAt; });
-          thread.participants = lastMessage.participants.filter(idIsNot(session.userId));
-
-          // keep thread in chronological order
-          //var t = new Date(thread.lastCommmentedAt);
-          //for (i = d.threads.length; i > 0 && new Date(d.threads[i-1].lastCommentedAt) > t; i--);
-          //d.threads.splice(i, 0, thread);
-      } else {
-        // this is the first message of a new thread, so we should fetch its thread data
-        loadThreadData(message.nUrl);
+        // until we have the updated threadinfo, do a best attempt at updating the thread
+        var m = messages && messages[messages.length - 1] || message;
+        thread.digest = m.text;
+        thread.lastAuthor = m.user.id;
+        thread.lastCommentedAt = m.createdAt;
+        thread.messageCount = messages ? messages.length : (thread.messageCount + 1);
+        thread.messageTimes[message.id] = message.createdAt;
+        //thread.participants = lastMessage.participants.filter(idIsNot(session.userId)); // not yet needed
+        td.addThread(thread);
+      } else if (td) {
+        // this is probably the first message of a new thread
+        socket.send(["get_thread_info", id], td.addThread.bind(td));
       }
 
       // ensure marked read if from this user
       if (message.user.id == session.userId) {
-        if (new Date(message.createdAt) > new Date(d.lastMessageRead[threadId] || 0)) {
-          d.lastMessageRead[threadId] = message.createdAt;
-        }
+        td.markRead(thread.id, message.createdAt);
       }
 
-      d.tabs.forEach(function(tab) {
-        api.tabs.emit(tab, "message", {threadId: threadId, thread: thread, message: message, read: d.lastMessageRead[threadId], userId: session.userId});
+      forEachTabAt(message.url, message.nUrl, function(tab) {
+        api.tabs.emit(tab, "message", {thread: thread, message: message, userId: session.userId});
       });
-      tellTabsIfCountChanged(d, "m", messageCount(d));
+      tellTabsUnreadThreadCountIfChanged(td, message.nUrl, message.url);
     }
   },
   message_read: function(nUri, threadId, time, messageId) {
     log("[socket:message_read]", nUri, threadId, time)();
-
     removeNotificationPopups(threadId);
-
-    var hasThreadId = hasId(threadId);
-    for (var page in pageData) {
-      var d = pageData[page];
-      if (d.threads.filter(hasThreadId).length > 0) {
-        d.lastMessageRead[threadId] = time;
-        var thread = d.threads.filter(hasId(threadId))[0];
-        d.tabs.forEach(function(tab) {
-          api.tabs.emit(tab, "thread_info", {thread: thread, read: d.lastMessageRead[threadId]});
+    markNoticesVisited("message", messageId, time, "/messages/" + threadId);
+    for (var uri in pageThreadData) {
+      var td = pageThreadData[uri];
+      var thread = td.getThread(threadId);
+      if (thread && td.markRead(threadId, time)) {
+        forEachTabAt(uri, function(tab) {
+          api.tabs.emit(tab, "thread_info", thread);
         });
-        tellTabsIfCountChanged(d, "m", messageCount(d));
+        tellTabsUnreadThreadCountIfChanged(td, uri);
       }
     }
-    markNoticesVisited("message", messageId, time, "/messages/" + threadId);
-
-    tellTabsNoticeCountIfChanged();
+    tellVisibleTabsNoticeCountIfChanged();
   },
   unread_notifications_count: function(count) {
     // see comment in syncNumNotificationsNotVisited() :(
@@ -308,7 +349,7 @@ var socketHandlers = {
         reportError("numNotificationsNotVisited count incorrect: " + numNotificationsNotVisited + " != " + count);
       }
       numNotificationsNotVisited = count;
-      tellTabsNoticeCountIfChanged();
+      tellVisibleTabsNoticeCountIfChanged();
     }
   }
 };
@@ -337,7 +378,7 @@ api.port.on({
       og: data.og,
       isPrivate: data.how == "private"};
     postBookmarks(function(f) {f([bm])}, "HOVER_KEEP");
-    pageData[tab.nUri].tabs.forEach(function(tab) {
+    forEachTabAt(tab.url, tab.nUri, function(tab) {
       setIcon(tab, data.how);
       api.tabs.emit(tab, "kept", {kept: data.how});
     });
@@ -348,7 +389,7 @@ api.port.on({
     ajax("POST", "/bookmarks/remove", data, function(o) {
       log("[unkeep] response:", o)();
     });
-    pageData[tab.nUri].tabs.forEach(function(tab) {
+    forEachTabAt(tab.url, tab.nUri, function(tab) {
       setIcon(tab, false);
       api.tabs.emit(tab, "kept", {kept: null});
     });
@@ -358,7 +399,7 @@ api.port.on({
     ajax("POST", "/bookmarks/private", data, function(o) {
       log("[setPrivate] response:", o)();
     });
-    pageData[tab.nUri].tabs.forEach(function(tab) {
+    forEachTabAt(tab.url, tab.nUri, function(tab) {
       api.tabs.emit(tab, "kept", {kept: data.private ? "private" : "public"});
     });
   },
@@ -391,30 +432,22 @@ api.port.on({
     logEvent.apply(null, data);
   },
   send_message: function(data, respond, tab) {
-    log("[send_message]", data)();
     var nUri = tab.nUri || data.url;
     data.extVersion = api.version;
     ajax("eliza", "POST", "/eliza/messages", data, function(o) {
       log("[send_message] resp:", o)();
 
-      var d = pageData[nUri];
       var thread = o.threadInfo;
-      messageData[thread.id] = o.messages;
-      if (d) {
-        thread.participants = thread.participants.filter(idIsNot(session.userId));
-        d.threads = d.threads.filter(idIsNot(thread.id));
-        d.threads.push(thread);  // maintaining chronological order
-
-        var lastMessage = o.messages[o.messages.length - 1];
-        if (new Date(lastMessage.createdAt) > new Date(d.lastMessageRead[thread.id] || 0)) {
-          d.lastMessageRead[thread.id] = lastMessage.createdAt;
-        }
+      var td = pageThreadData[nUri];
+      if (td) {
+        td.addThread(thread);
+        td.markRead(thread.id, o.messages[o.messages.length - 1].createdAt);
       }
+      messageData[thread.id] = o.messages;
       respond(o);
     });
   },
   send_reply: function(data, respond) {
-    log("[send_reply]", data)();
     var id = data.threadId;
     delete data.threadId;
     data.extVersion = api.version;
@@ -425,53 +458,82 @@ api.port.on({
   },
   message_rendered: function(o, _, tab) {
     whenTabFocused(tab, o.threadId, function (tab) {
-      var d = pageData[tab.nUri];
-      var unreadNotification = false;
+      var unreadNotification;
       for (var i = 0; i < notifications.length; i++) {
-        if (notifications[i].unread && (notifications[i].thread == o.threadId || notifications[i].id == o.messageId)) {
+        var n = notifications[i];
+        if (n.unread && (n.thread === o.threadId || n.id === o.messageId)) {
           unreadNotification = true;
-          o.messageId = notifications[i].id;
+          o.messageId = n.id;
         }
       }
 
-      if (o.forceSend || unreadNotification || (!d || !d.lastMessageRead || new Date(o.time) >= new Date(d.lastMessageRead[o.threadId] || 0))) {
+      var td = pageThreadData[tab.nUri];
+      if (o.forceSend || unreadNotification || !td || td.markRead(o.threadId, o.time)) {
         markNoticesVisited("message", o.messageId, o.time, "/messages/" + o.threadId);
-        if (d && d.lastMessageRead) {
-          d.lastMessageRead[o.threadId] = o.time;
-          tellTabsIfCountChanged(d, "m", messageCount(d));  // tabs at this uri
+        if (td) {
+          tellTabsUnreadThreadCountIfChanged(td, tab.nUri);
         }
-        tellTabsNoticeCountIfChanged();  // visible tabs
+        tellVisibleTabsNoticeCountIfChanged();
         socket.send(["set_message_read", o.messageId]);
       }
     });
   },
+  participants: function(id, respond, tab) {
+    var td = pageThreadData[tab.nUri];
+    var th = td && td.getThread(id);
+    if (th) {
+      respond(th.participants);
+    } else {
+      var msgs = messageData[id];
+      if (msgs) {
+        reply({messages: msgs});
+      } else {
+        var tc = threadCallbacks[id];
+        if (tc) {
+          tc.push(reply);
+        } else {
+          socket.send(["get_thread", id]);
+          threadCallbacks[id] = [reply];
+        }
+      }
+    }
+    function reply(th) {
+      respond(th.messages[0].participants.filter(idIsNot(session.userId)));
+    }
+  },
   set_global_read: function(o, _, tab) {
     markNoticesVisited("global", o.noticeId);
-    tellTabsNoticeCountIfChanged();  // visible tabs
+    tellVisibleTabsNoticeCountIfChanged();
     socket.send(["set_global_read", o.noticeId]);
   },
   threads: function(_, respond, tab) {
-    var d = pageData[tab.nUri];
-    if (d) d.withThreadData(function() {
-      respond({threads: d.threads, read: d.lastMessageRead});
-    });
+    var td = pageThreadData[tab.nUri];
+    if (td) {
+      reply(td);
+    } else {
+      (threadDataCallbacks[tab.nUri] || (threadDataCallbacks[tab.nUri] = [])).push(reply);
+    }
+    function reply(td) {
+      respond(td.threads);
+    }
   },
   thread: function(data, respond, tab) {
-    var d = pageData[tab.nUri];
-    if (d) d.withThreadData(function() {
-      var th = d.threads.filter(function(t) {return t.id == data.id || t.messageTimes[data.id]})[0];
-      if (th && messageData[th.id]) {
+    var msgs = messageData[data.id];
+    if (msgs) {
+      if (data.respond) {
+        respond({id: data.id, messages: msgs});
+      }
+    } else {
+      var tc = threadCallbacks[data.id];
+      if (tc) {
         if (data.respond) {
-          respond({id: th.id, messages: messageData[th.id], participants: th.participants || []});
+          tc.push(respond);
         }
       } else {
-        var id = (th || data).id;
-        socket.send(["get_thread", id]);
-        if (data.respond) {
-          (threadCallbacks[id] || (threadCallbacks[id] = [])).push(respond);
-        }
+        socket.send(["get_thread", data.id]);
+        threadCallbacks[data.id] = data.respond ? [respond] : [];
       }
-    });
+    }
   },
   notifications: function(_, respond) {
     if (notifications) {
@@ -544,11 +606,11 @@ api.port.on({
     socket.send(["get_networks", friendId], respond);
   },
   open_deep_link: function(link, _, tab) {
-    if (tab.nUri == link.nUri) {
+    if (tab.nUri === link.nUri) {
       awaitDeepLink(link, tab.id);
     } else {
-      var d = pageData[link.nUri];
-      if ((tab = d ? d.tabs[0] : api.tabs.anyAt(link.nUri))) {  // page’s normalized URI may have changed
+      var tabs = tabsByUrl[link.nUri];
+      if ((tab = tabs ? tabs[0] : api.tabs.anyAt(link.nUri))) {  // page’s normalized URI may have changed
         awaitDeepLink(link, tab.id);
         api.tabs.select(tab.id);
       } else {
@@ -609,8 +671,8 @@ function standardizeNotification(n) {
 function sendNotificationToTabs(n) {
   var told = {};
   api.tabs.eachSelected(tellTab);
-  (tabsByLocator['/notices'] || []).forEach(tellTab);
-  tellTabsNoticeCountIfChanged();
+  forEachTabAtLocator('/notices', tellTab);
+  tellVisibleTabsNoticeCountIfChanged();
   api.play("media/notification.mp3");
 
   function tellTab(tab) {
@@ -637,8 +699,11 @@ function insertNewNotification(n) {
   notifications.splice(i, 0, n);
 
   if (n.unread) {  // may have been visited before arrival
-    var d = pageData[n.url];
-    if (d && new Date(n.time) <= getTimeLastRead(n, d)) {
+    var td, th;
+    if (n.category === 'message' &&
+        (td = pageThreadData[n.url]) &&
+        (th = td.getThread(n.locator.substr(10))) &&
+        new Date(th.lastMessageRead || 0) > new Date(n.time)) {
       n.unread = false;
     } else {
       numNotificationsNotVisited++;
@@ -684,7 +749,7 @@ function markNoticesVisited(category, id, timeStr, locator) {
       }
     }
   });
-  (tabsByLocator['/notices'] || []).forEach(function(tab) {
+  forEachTabAtLocator('/notices', function(tab) {
     api.tabs.emit(tab, "notifications_visited", {
       category: category,
       time: timeStr,
@@ -698,15 +763,12 @@ function markAllNoticesVisited(id, timeStr) {  // id and time of most recent not
   var time = new Date(timeStr);
   for (var i = 0; i < notifications.length; i++) {
     var n = notifications[i];
-    if ((n.id == id || new Date(n.time) <= time) && n.unread) {
+    if (n.unread && (n.id === id || new Date(n.time) <= time)) {
       n.unread = false;
-      var d = pageData[n.url];
-      if (d && new Date(n.time) > getTimeLastRead(n, d)) {
-        switch (n.category) {
-          case "message":
-            d.lastMessageRead[n.locator.split("/")[2]] = n.time;
-            tellTabsIfCountChanged(d, "m", messageCount(d));  // tabs at this uri
-            break;
+      if (n.category === 'message') {
+        var td = pageThreadData[n.url];
+        if (td && td.markRead(n.locator.substr(10), n.time)) {
+          tellTabsUnreadThreadCountIfChanged(td, n.url);
         }
       }
     }
@@ -714,14 +776,14 @@ function markAllNoticesVisited(id, timeStr) {  // id and time of most recent not
   numNotificationsNotVisited = notifications.filter(function(n) {
     return n.unread;
   }).length;
-  (tabsByLocator['/notices'] || []).forEach(function(tab) {
+  forEachTabAtLocator('/notices', function(tab) {
     api.tabs.emit(tab, "all_notifications_visited", {
       id: id,
       time: timeStr,
       numNotVisited: numNotificationsNotVisited});
   });
 
-  tellTabsNoticeCountIfChanged();  // visible tabs
+  tellVisibleTabsNoticeCountIfChanged();
 }
 
 function decrementNumNotificationsNotVisited(n) {
@@ -731,11 +793,6 @@ function decrementNumNotificationsNotVisited(n) {
   if (numNotificationsNotVisited > 0 || ~session.experiments.indexOf("admin")) {  // exposing -1 to admins to help debug
     numNotificationsNotVisited--;
   }
-}
-
-function getTimeLastRead(n, d) {
-  return new Date(
-    n.category == "message" && d.lastMessageRead ? (d.lastMessageRead[n.locator.split("/")[2]] || 0) : 0);
 }
 
 function awaitDeepLink(link, tabId, retrySec) {
@@ -753,89 +810,66 @@ function awaitDeepLink(link, tabId, retrySec) {
   }
 }
 
-function initTab(tab, d) {  // d is pageData[tab.nUri]
-  log("[initTab]", tab.id, "inited:", tab.inited)();
-
-  d.counts.n = numNotificationsNotVisited;
-  api.tabs.emit(tab, "counts", d.counts, {queue: 1});
-  if (tab.inited) return;
-  tab.inited = true;
-
-  if (ruleSet.rules.message && d.counts.m) {  // open immediately to unread message(s)
-    var ids = unreadThreadIds(d.threads, d.lastMessageRead);
-    api.tabs.emit(tab, "open_to", {trigger: "message", locator: "/messages" + (ids.length > 1 ? "" : "/" + ids[0])}, {queue: 1});
-    ids.forEach(function(id) {
-      socket.send(["get_thread", id]);
-    });
-  } else if (!d.kept && !d.neverOnSite && (!d.sensitive || !ruleSet.rules.sensitive)) {  // auto-engagement
-    var url = tab.url;
-    if (ruleSet.rules.url && urlPatterns.some(function(re) {return re.test(url)})) {
-      log("[initTab]", tab.id, "restricted")();
-    } else if (ruleSet.rules.shown && d.shown) {
-      log("[initTab]", tab.id, "shown before")();
-    } else {
-      if (api.prefs.get("showSlider")) {
-        api.tabs.emit(tab, "scroll_rule", ruleSet.rules.scroll, {queue: 1});
-      }
-      tab.autoShowSec = (ruleSet.rules.focus || [])[0];
-      if (tab.autoShowSec != null && api.tabs.isFocused(tab)) {
-        scheduleAutoShow(tab);
-      }
-      if (d.keepers.length) {
-        api.tabs.emit(tab, "keepers", {keepers: d.keepers, otherKeeps: d.otherKeeps}, {queue: 1});
-      }
-    }
-  }
-}
-
 function dateWithoutMs(t) { // until db has ms precision
   var d = new Date(t);
   d.setMilliseconds(0);
   return d;
 }
 
-function messageCount(d) {
-  var n = 0;
-  for (var i = 0; i < d.threads.length; i++) {
-    var th = d.threads[i], thReadTime = new Date(d.lastMessageRead[th.id] || 0);
-    for (var id in th.messageTimes) {
-      if (new Date(th.messageTimes[id]) > thReadTime) {
-        n++; break;
+function forEachTabAt() { // (url[, url]..., f)
+  var done = {};
+  var f = arguments[arguments.length - 1];
+  for (var i = arguments.length - 1; i--;) {
+    var url = arguments[i];
+    if (!done[url]) {
+      done[url] = true;
+      var tabs = tabsByUrl[url];
+      if (tabs) {
+        tabs.forEach(f);
       }
     }
   }
-  return n;
 }
 
-function unreadThreadIds(threads, readTimes) {
-  return threads.filter(function(th) {
-    var readTime = new Date(readTimes[th.id] || 0);
-    for (var id in th.messageTimes) {
-      if (new Date(th.messageTimes[id]) > readTime) {
-        return true;
+function forEachTabAtLocator(loc, f) {
+  var tabs = tabsByLocator[loc];
+  if (tabs) {
+    tabs.forEach(f);
+  }
+}
+
+function forEachTabAtUriAndLocator(nUri, loc, f) {
+  var arr1, arr2;
+  if ((arr1 = tabsByUrl[nUri]) && (arr2 = tabsByLocator[loc])) {
+    for (var i = arr1.length; i--;) {
+      var tab = arr1[i];
+      if (~arr2.indexOf(tab)) {
+        f(tab);
       }
     }
-  }).map(getId);
+  }
 }
 
-function tellTabsNoticeCountIfChanged() {
+function tellVisibleTabsNoticeCountIfChanged() {
   api.tabs.eachSelected(function(tab) {
-    var d = pageData[tab.nUri];
-    if (d && d.counts && d.counts.n != numNotificationsNotVisited) {
-      d.counts.n = numNotificationsNotVisited;
-      api.tabs.emit(tab, "counts", d.counts, {queue: 1});
+    if (tab.counts && tab.counts.n !== numNotificationsNotVisited) {
+      tab.counts.n = numNotificationsNotVisited;
+      api.tabs.emit(tab, "counts", tab.counts, {queue: 1});
     }
   });
 }
 
-function tellTabsIfCountChanged(d, key, count) {
-  if (d.counts[key] != count) {
-    d.counts[key] = count;
-    d.counts.n = numNotificationsNotVisited;
-    d.tabs.forEach(function(tab) {
-      api.tabs.emit(tab, "counts", d.counts, {queue: 1});
-    });
-  }
+function tellTabsUnreadThreadCountIfChanged(td) { // (td, url[, url]...)
+  var m = td.countUnreadThreads();
+  var args = Array.prototype.slice.call(arguments, 1);
+  args.push(function(tab) {
+    if (tab.counts.m !== m) {
+      tab.counts.m = m;
+      tab.counts.n = numNotificationsNotVisited;
+      api.tabs.emit(tab, "counts", tab.counts, {queue: 1});
+    }
+  });
+  forEachTabAt.apply(null, args);
 }
 
 function searchOnServer(request, respond) {
@@ -891,175 +925,207 @@ api.icon.on.click.add(function(tab) {
   api.tabs.emit(tab, "button_click", null, {queue: 1});
 });
 
-function subscribe(tab) {
-  log("[subscribe] %i %s %s %s", tab.id, tab.url, tab.icon, tab.nUri)();
+function kifify(tab) {
+  log("[kifify]", tab.id, tab.url, tab.icon || '', tab.nUri || '', session ? '' : 'no session')();
   if (!tab.icon) {
     api.icon.set(tab, "icons/keep.faint.png");
   }
 
-  if (session == null) {
-    log("[subscribe] user not logged in")();
-    if (!getStored("user_logout")) { // user did not explicitly log out using our logout process
-      ajax("GET", "/ext/authed", function userIsLoggedIn() {
-        // user is now logged in
+  if (!session) {
+    if (!getStored("user_logout")) { // user did not explicitly log out
+      ajax("GET", "/ext/authed", function() {
+        // user is logged in; need to fetch session data
         authenticate(function() {
-          subscribe(tab);
+          if (api.tabs.get(tab.id) === tab) {  // tab still at same page
+            kifify(tab);
+          }
         });
       });
     }
     return;
   }
 
-  var d = pageData[tab.nUri || tab.url];
+  var url = tab.url;
+  var uri = tab.nUri || url;
 
-  if (d) {  // no need to ask server again
-    if (d.threadDataIsStale) {
-      loadThreadData(d.nUri || tab.nUri || tab.url);
-      d.threadDataIsStale = false;
-    }
-    if (tab.nUri) {  // tab is already initialized
-      if (d.counts) {
-        d.counts.n = numNotificationsNotVisited;
-        api.tabs.emit(tab, "counts", d.counts);
-      }
-    } else {
-      finish(tab.url);
-      if (d.hasOwnProperty("kept")) {
-        setIcon(tab, d.kept);
-        sendInit(tab, d);
-        initTab(tab, d);
-      } // else wait for page data
+  // page data
+  var d = pageData[uri];
+  if (d) {
+    if (!tab.nUri) {
+      stashTab(tab, uri);
+      kififyWithPageData(tab, d);
     }
   } else {
-    ajax("POST", "/ext/pageDetails", {url: tab.url}, function success(resp) {
-      log("[subscribe] pageDetails:", resp)();
-
-      var uri = resp.normalized;
-
-      // the initial load of the page’s thread data. probably want to prefetch threads
-      // that have any unread messages, but only in that case.
-      loadThreadData(uri);
-
-      if ((api.tabs.get(tab.id) || {}).url != tab.url) return;
-      d = pageData[uri] = pageData[uri] || new PageData;
-      finish(uri);
-
-      d.kept = resp.kept;
-      d.position = resp.position;
-      d.neverOnSite = resp.neverOnSite;
-      d.sensitive = resp.sensitive;
-      d.shown = resp.shown;
-      d.keepers = resp.keepers || [];
-      d.keeps = resp.keeps || 0;
-      d.otherKeeps = d.keeps - d.keepers.length - (d.kept === "public");
-      d.pageDetailsReceived = true;
-
-      // TODO: don’t initialize this thread data here as if it were known
-      d.threads = d.threads || [];
-      d.counts = d.counts || {m:0, n:0};
-      d.lastMessageRead = d.lastMessageRead || {};
-
-      d.tabs.forEach(function(tab) {
-        setIcon(tab, d.kept);
-        sendInit(tab, d);
-      });
-
-      if (d.threadDataReceived) {
-        d.tabs.forEach(function(tab) {
-          initTab(tab, d);
-        });
-      }
-    }, function fail(xhr) {
+    ajax("POST", "/ext/pageDetails", {url: url}, gotPageDetailsFor.bind(null, url, tab), function fail(xhr) {
       if (xhr.status == 403) {
-        session = null;
-        if (socket) {
-          socket.close();
-          socket = null;
-        }
-        clearDataCache();
+        clearSession();
       }
     });
   }
-  function finish(uri) {
-    tab.nUri = uri;
-    for (var i = 0; i < d.tabs.length; i++) {
-      if (d.tabs[i].id == tab.id) {
-        d.tabs.splice(i--, 1);
-      }
-    }
-    d.tabs.push(tab);
-    log("[subscribe:finish]", tab.id)();
+
+  // thread data
+  var td = pageThreadData[uri];
+  if (td && !td.stale) {
+    tab.counts = {n: numNotificationsNotVisited, m: td.countUnreadThreads()};
+    api.tabs.emit(tab, "counts", tab.counts, {queue: 1});
+  } else {
+    socket.send(["get_threads", url], gotThreadDataFor.bind(null, url, tab));
   }
 }
 
-function loadThreadData(url) {
-  socket.send(["get_threads", url], function(threads) {
-    var d = pageData[url] || pageData[threads.length ? threads[0].nUrl : ''];
-    if (!d) return;
-
-    var oldMessageCounts = !d.threads ? {} : d.threads.reduce(function(o, th) {
-      o[th.id] = th.messageCount;
-      return o;
-    }, {});
-
-    d.threads = threads;
-    d.lastMessageRead = d.lastMessageRead || {};
-    threads.forEach(function(t) {
-      t.participants = t.participants.filter(idIsNot(session.userId));
-      d.lastMessageRead[t.id] = t.lastMessageRead;  // TODO: make sure we do not clobber greater/later timestamp
-    });
-    d.counts = {n: 0, m: messageCount(d)};
-    d.dispatchThreadData();
-
-    if (!d.threadDataReceived) {
-      d.threadDataReceived = true;
-      if (d.pageDetailsReceived) {
-        d.tabs.forEach(function(tab) {
-          initTab(tab, d);
-        });
+function stashTab(tab, uri) {
+  tab.nUri = uri;
+  var tabs = tabsByUrl[uri];
+  if (tabs) {
+    for (var i = tabs.length; i--;) {
+      if (tabs[i].id == tab.id) {
+        tabs.splice(i, 1);
       }
     }
+    tabs.push(tab);
+  } else {
+    tabsByUrl[uri] = [tab];
+  }
+  log("[stashTab]", tab.id)();
+}
 
-    // Push threads with any new messages to relevant tabs and load+push their messages too.
+function kififyWithPageData(tab, d) {
+  log("[kififyWithPageData]", tab.id, tab.engaged ? 'already engaged' : '')();
+  setIcon(tab, d.kept);
 
+  api.tabs.emit(tab, "init", {  // harmless if sent to same page more than once
+    kept: d.kept,
+    position: d.position,
+    hide: d.neverOnSite || ruleSet.rules.sensitive && d.sensitive
+  }, {queue: 1});
+
+  // consider triggering automatic keeper behavior on page to engage user (only once)
+  if (!tab.engaged) {
+    tab.engaged = true;
+    if (!d.kept && !d.neverOnSite && (!d.sensitive || !ruleSet.rules.sensitive)) {
+      if (ruleSet.rules.url && urlPatterns.some(reTest(tab.url))) {
+        log("[initTab]", tab.id, "restricted")();
+      } else if (ruleSet.rules.shown && d.shown) {
+        log("[initTab]", tab.id, "shown before")();
+      } else {
+        if (api.prefs.get("showSlider")) {
+          api.tabs.emit(tab, "scroll_rule", ruleSet.rules.scroll, {queue: 1});
+        }
+        tab.autoShowSec = (ruleSet.rules.focus || [])[0];
+        if (tab.autoShowSec != null && api.tabs.isFocused(tab)) {
+          scheduleAutoShow(tab);
+        }
+        if (d.keepers.length) {
+          api.tabs.emit(tab, "keepers", {keepers: d.keepers, otherKeeps: d.otherKeeps}, {queue: 1});
+        }
+      }
+    }
+  }
+}
+
+function gotPageDetailsFor(url, tab, resp) {
+  var tabIsOld = api.tabs.get(tab.id) !== tab || url.split('#', 1)[0] !== tab.url.split('#', 1)[0];
+
+  log("[gotPageDetailsFor]", tab.id, tabIsOld ? 'OLD' : '', url, resp)();
+
+  var nUri = resp.normalized;
+  var d = pageData[nUri] || new PageData;
+
+  d.kept = resp.kept;
+  d.position = resp.position;
+  d.neverOnSite = resp.neverOnSite;
+  d.sensitive = resp.sensitive;
+  d.shown = resp.shown;
+  d.keepers = resp.keepers || [];
+  d.keeps = resp.keeps || 0;
+  d.otherKeeps = d.keeps - d.keepers.length - (d.kept === "public");
+
+  if (!tabIsOld) {
+    pageData[nUri] = d;
+    stashTab(tab, nUri);
+    kififyWithPageData(tab, d);
+  }
+}
+
+function gotThreadDataFor(url, tab, threads, nUri) {
+  var tabIsOld = api.tabs.get(tab.id) !== tab || url.split('#', 1)[0] !== tab.url.split('#', 1)[0];
+  log("[gotThreadDataFor]", tab.id, tabIsOld ? 'OLD' : '', url, nUri === url ? '' : nUri, threads)();
+
+  var td = pageThreadData[nUri] || pageThreadData[threads.length ? threads[0].nUrl : ''] || new ThreadData;
+  var oldMessageCounts = td.threads && td.threads.reduce(function(o, th) {
+    o[th.id] = th.messageCount;
+    return o;
+  }, {});
+
+  td.init(threads);
+
+  if (!tabIsOld) {
+    pageThreadData[nUri] = td;
+
+    tab.counts = {n: numNotificationsNotVisited, m: td.countUnreadThreads()};
+    api.tabs.emit(tab, "counts", tab.counts, {queue: 1});
+
+    if (ruleSet.rules.message && tab.counts.m) {  // open immediately to unread message(s)
+      api.tabs.emit(tab, "open_to", {trigger: "message", locator: td.getUnreadLocator()}, {queue: 1});
+      td.getUnreadThreads().forEach(function(th) {
+        socket.send(["get_thread", th.id]);  // prefetch
+        if (!threadCallbacks[th.id]) {
+          threadCallbacks[th.id] = [];
+        }
+      });
+    }
+  }
+
+  for (var callbacks = threadDataCallbacks[nUri]; callbacks && callbacks.length;) {
+    callbacks.shift()(td);
+  }
+  delete threadDataCallbacks[nUri];
+
+  if (oldMessageCounts) {
+    tellTabsUnreadThreadCountIfChanged(td, nUri);
+
+    // Push threads with any new messages to relevant tabs
     var threadsWithNewMessages = [];
-    threads.forEach(function(th) {
-      var numNew = th.messageCount - (oldMessageCounts[th.id] || 0);
-      if (numNew) {
-        socket.send(["get_thread", th.id]);
-        (threadCallbacks[th.id] || (threadCallbacks[th.id] = [])).push(function(th) {
-          d.tabs.forEach(function(tab) {
-            // TODO: may want to special case (numNew == 1) for an animation
-            api.tabs.emit(tab, "thread", {id: th.id, messages: th.messages, userId: session.userId});
-          });
-        });
+    td.threads.forEach(function(th) {
+      var oldMessageCount = oldMessageCounts[th.id] || 0;
+      if (oldMessageCount < th.messageCount) {
         threadsWithNewMessages.push(th);
+        if (threadCallbacks[th.id]) {
+          threadCallbacks[th.id].push(tellTabs);
+        } else {
+          socket.send(['get_thread', th.id]);
+          threadCallbacks[th.id] = [tellTabs];
+        }
+      }
+      function tellTabs(o) {
+        forEachTabAtLocator('/messages/' + o.id, function(tab) {
+          if (o.messages.length - oldMessageCount === 1) {
+            api.tabs.emit(tab, 'message', {
+              thread: th,
+              message: o.messages.length[o.messages.length - 1],
+              userId: session.userId});
+          } else {
+            api.tabs.emit(tab, 'thread', {id: o.id, messages: o.messages, userId: session.userId});
+          }
+        });
       }
     });
-    if (threadsWithNewMessages.length == 1) {  // special cased to trigger an animation
+    if (threadsWithNewMessages.length === 1) {  // special cased to trigger an animation
       var th = threadsWithNewMessages[0];
-      d.tabs.forEach(function(tab) {
-        api.tabs.emit(tab, "thread_info", {thread: th, read: d.lastMessageRead[th.id]});
+      forEachTabAtUriAndLocator(nUri, '/messages', function(tab) {
+        api.tabs.emit(tab, 'thread_info', th);
       });
     } else if (threadsWithNewMessages.length > 1) {
-      d.tabs.forEach(function(tab) {
-        api.tabs.emit(tab, "threads", {threads: d.threads, readTimes: d.lastMessageRead, userId: session.userId});
+      forEachTabAtUriAndLocator(nUri, '/messages', function(tab) {
+        api.tabs.emit(tab, 'threads', td.threads);
       });
     }
-  });
+  }
 }
 
 function setIcon(tab, kept) {
   log("[setIcon] tab:", tab.id, "kept:", kept)();
   api.icon.set(tab, kept ? "icons/kept.png" : "icons/keep.png");
-}
-
-function sendInit(tab, d) {
-  api.tabs.emit(tab, "init", {
-      kept: d.kept,
-      position: d.position,
-      hide: d.neverOnSite || ruleSet.rules.sensitive && d.sensitive
-    }, {queue: 1});
 }
 
 function postBookmarks(supplyBookmarks, bookmarkSource) {
@@ -1100,7 +1166,7 @@ api.tabs.on.focus.add(function(tab) {
   }
 
   delete tab.focusCallbacks;
-  subscribe(tab);
+  kifify(tab);
   if (tab.autoShowSec != null && !tab.autoShowTimer) {
     scheduleAutoShow(tab);
   }
@@ -1114,7 +1180,7 @@ api.tabs.on.blur.add(function(tab) {
 
 api.tabs.on.loading.add(function(tab) {
   log("#b8a", "[tabs.on.loading] %i %o", tab.id, tab)();
-  subscribe(tab);
+  kifify(tab);
   logEvent("extension", "pageLoad");
 });
 
@@ -1149,21 +1215,22 @@ function getPrefetched(request, cb) {
 
 api.tabs.on.unload.add(function(tab, historyApi) {
   log("#b8a", "[tabs.on.unload] %i %o", tab.id, tab)();
-  var d = pageData[tab.nUri];
-  if (d) {
-    for (var i = 0; i < d.tabs.length; i++) {
-      if (d.tabs[i].id == tab.id) {
-        d.tabs.splice(i--, 1);
-      }
+  var tabs = tabsByUrl[tab.nUri];
+  for (var i = tabs && tabs.length; i--;) {
+    if (tabs[i].id === tab.id) {
+      tabs.splice(i, 1);
     }
-    if (!d.tabs.length) {
-      delete pageData[tab.nUri];
-    }
+  }
+  if (!tabs || !tabs.length) {
+    delete tabsByUrl[tab.nUri];
+    delete pageData[tab.nUri];
+    delete pageThreadData[tab.nUri];
   }
   api.timers.clearTimeout(tab.autoShowTimer);
   delete tab.autoShowTimer;
   delete tab.nUri;
-  delete tab.inited;
+  delete tab.counts;
+  delete tab.engaged;
   delete tab.focusCallbacks;
   if (historyApi) {
     api.tabs.emit(tab, "reset");
@@ -1192,14 +1259,15 @@ function compilePatterns(arr) {
   return arr;
 }
 
+function reTest(s) {
+  return function(re) {return re.test(s)};
+}
 function hasId(id) {
   return function(o) {return o.id === id};
 }
-
 function idIsNot(id) {
   return function(o) {return o.id !== id};
 }
-
 function getId(o) {
   return o.id;
 }
@@ -1310,8 +1378,8 @@ function startSession(callback, retryMs) {
     session = data;
     session.prefs = {}; // to come via socket
     socket = socket || api.socket.open(elizaBaseUri().replace(/^http/, "ws") + "/eliza/ext/ws", socketHandlers, function onConnect() {
-      for (var nUri in pageData) {
-        pageData[nUri].threadDataIsStale = true;
+      for (var uri in pageThreadData) {
+        pageThreadData[uri].stale = true;
       }
       socket.send(["get_last_notify_read_time"]);
       connectSync();
@@ -1321,7 +1389,7 @@ function startSession(callback, retryMs) {
         socket.send(["get_missed_notifications", notifications.length ? notifications[0].time : new Date(0).toISOString()]);
       }
       syncNumNotificationsNotVisited();
-      api.tabs.eachSelected(subscribe);
+      api.tabs.eachSelected(kifify);
     }, function onDisconnect(why) {
       reportError("socket disconnect (" + why + ")");
     });
@@ -1383,14 +1451,18 @@ function openLogin(callback, retryMs) {
     }});
 }
 
-function deauthenticate() {
-  log("[deauthenticate]")();
+function clearSession() {
   session = null;
   if (socket) {
     socket.close();
     socket = null;
   }
   clearDataCache();
+}
+
+function deauthenticate() {
+  log("[deauthenticate]")();
+  endSession();
   api.popup.open({
     name: "kifi-deauthenticate",
     url: webBaseUri() + "/logout#_=_",

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -59,13 +59,10 @@ var tile = tile || function() {  // idempotent for Chrome
       setTimeout(keeper.bind(null, "showKeepers", o.keepers, o.otherKeeps), 3000);
     },
     counts: function(counts) {
-      if (!tile) {
-        return;
-      }
-      updateCounts(counts);
+      tile && updateCounts(counts);
     },
     scroll_rule: function(r) {
-      if (!onScroll) {
+      if (!onScroll && !window.slider2) {
         var lastScrollTime = 0;
         document.addEventListener("scroll", onScroll = function(e) {
           var t = e.timeStamp || Date.now();
@@ -143,11 +140,11 @@ var tile = tile || function() {  // idempotent for Chrome
     } else if (!session) {
       toggleLoginDialog();
     } else {
-      if (onScroll && name != "showKeepers") {
-        document.removeEventListener("scroll", onScroll);
-        onScroll = null;
-      }
       api.require("scripts/slider2.js", function() {
+        if (onScroll && name != "showKeepers") {
+          document.removeEventListener("scroll", onScroll);
+          onScroll = null;
+        }
         slider2[args.shift()].apply(slider2, args);
       });
     }

--- a/packrat/scripts/slider2.js
+++ b/packrat/scripts/slider2.js
@@ -375,31 +375,28 @@ var slider2 = function () {
     return paneIdxs.indexOf(name);
   }
 
-  var createTemplateParams = {
+  var createPaneParams = {
     thread: function (cb, locator, participants) {
-      var id = locator.split("/")[2];
       if (participants) {
-        respond(participants, locator);
+        respond(participants);
       } else {
-        log("[createTemplateParams] getting thread for participants")();
-        api.port.emit("thread", {id: id, respond: true}, function (th) {
-          respond(th.participants, "/messages/" + th.id);
-        });
+        var id = locator.substr(10);
+        log("[createPaneParams.thread] need participants", id)();
+        api.port.emit("participants", id, respond);
       }
-      function respond(p, canonicalLocator) {
-        cb({participants: p, numParticipants: p.length > 1 ? p.length : null}, canonicalLocator);
+      function respond(p) {
+        cb({participants: p, numParticipants: p.length > 1 ? p.length : null});
       }
     }};
 
   function showPane(locator, back, paramsArg) {
     log("[showPane]", locator, back ? "back" : "")();
-    var pane = toPaneName(locator);
-    (createTemplateParams[pane] || function (cb) {cb({backButton: paneHistory && paneHistory[back ? 2 : 0]})})(function (params, canonicalLocator) {
-      var loc = canonicalLocator || locator;
-      if (loc !== (paneHistory && paneHistory[0])) {
-        showPane2(loc, back, pane, params);
-      }
-    }, locator, paramsArg);
+    if (locator !== (paneHistory && paneHistory[0])) {
+      var pane = toPaneName(locator);
+      (createPaneParams[pane] || function (cb) {cb({backButton: paneHistory && paneHistory[back ? 2 : 0]})})(function (params) {
+        showPane2(locator, back, pane, params);
+      }, locator, paramsArg);
+    }
   }
 
   function showPane2(locator, back, pane, params) {  // only called by showPane

--- a/packrat/scripts/thread.js
+++ b/packrat/scripts/thread.js
@@ -16,7 +16,7 @@ panes.thread = function() {
   'use strict';
   var handlers = {
     message: function(o) {
-      update(o.threadId, o.message, o.userId);
+      update(o.thread.id, o.message, o.userId);
     },
     thread: function(o) {
       updateAll(o.id, o.messages, o.userId);

--- a/packrat/scripts/threads.js
+++ b/packrat/scripts/threads.js
@@ -16,33 +16,29 @@
 panes.threads = function() {
   'use strict';
   var handlers = {
-    thread_info: function(o) {
-      update(o.thread, o.read);
-    },
+    thread_info: update,
     message: function(o) {
-      update(o.thread, o.read);
+      update(o.thread);
     },
-    threads: function(o) {
-      updateAll(o.threads, o.readTimes, o.userId);
-    }};
+    threads: updateAll};
 
   var $list = $();
   return {
     render: function($container) {
-      api.port.emit("threads", function(o) {
+      api.port.emit("threads", function(threads) {
         api.port.emit("session", function(session) {
-          renderThreads($container, o, session.prefs);
+          renderThreads($container, threads, session.prefs);
           api.port.on(handlers);
-          o.threads.forEach(function(th) {
+          threads.forEach(function(th) {
             api.port.emit("thread", {id: th.id});  // preloading
           });
         });
       });
     }};
 
-  function renderThreads($container, o, prefs) {
-      o.threads.forEach(function(t) {
-        var n = messageCount(t, new Date(o.read[t.id] || 0));
+  function renderThreads($container, threads, prefs) {
+      threads.forEach(function(t) {
+        var n = messageCount(t);
         t.messageCount = n < -9 ? "9+" : Math.abs(n);
         t.messagesUnread = n < 0;
         t.participantsPictured = t.participants.slice(0, 4);
@@ -51,7 +47,7 @@ panes.threads = function() {
         formatSnippet: getSnippetFormatter,
         formatLocalDate: getLocalDateFormatter,
         emptyUri: api.url("images/metro/bg_messages.png"),
-        threads: o.threads,
+        threads: threads,
         showTo: true,
         draftPlaceholder: "Type a message…",
         draftDefault: "Check this out.",
@@ -70,7 +66,7 @@ panes.threads = function() {
         .on("click", ".kifi-thread", function() {
           var $th = $(this), id = $th.data("id");
           var participants = $th.data("recipients") ||
-            o.threads.filter(function(t) {return t.id == id})[0].participants;
+            threads.filter(function(t) {return t.id === id})[0].participants;
           $th.closest(".kifi-pane").triggerHandler("kifi:show-pane", ["/messages/" + id, participants])
         })
         .on("kifi:compose-submit", sendMessage.bind(null, $container))
@@ -89,9 +85,9 @@ panes.threads = function() {
         });
   }
 
-  function update(thread, readTime) {
+  function update(thread) {
       if ($list.length && thread) {
-        renderThread(thread, readTime, function($th) {
+        renderThread(thread, function($th) {
           var $old = $list.children("[data-id=" + thread.id + "],[data-id=]").first();
           if ($old.length) {
             var $thBelow = $old.nextAll(".kifi-thread");  // TODO: compare timestamps
@@ -114,10 +110,10 @@ panes.threads = function() {
       }
   }
 
-  function updateAll(threads, readTimes, userId) {
+  function updateAll(threads) {
       var arr = new Array(threads.length), n = 0;
       threads.forEach(function(th, i) {
-        renderThread(th, readTimes[th.id], function($th) {
+        renderThread(th, function($th) {
           arr[i] = $th;
           if (++n == arr.length) {
             $list.children(".kifi-thread").remove().end()
@@ -145,8 +141,8 @@ panes.threads = function() {
       });
   }
 
-  function renderThread(th, readTime, callback) {
-    var n = messageCount(th, new Date(readTime || 0));
+  function renderThread(th, callback) {
+    var n = messageCount(th);
     th.messageCount = n < -9 ? "9+" : Math.abs(n);
     th.messagesUnread = n < 0;
     th.participantsPictured = th.participants.slice(0, 4);
@@ -157,10 +153,10 @@ panes.threads = function() {
     });
   }
 
-  function messageCount(th, readTime) {
-    var nUnr = 0;
+  function messageCount(th) {
+    var nUnr = 0, readAt = new Date(th.lastMessageRead || 0);
     for (var id in th.messageTimes) {
-      if (new Date(th.messageTimes[id]) > readTime) {
+      if (new Date(th.messageTimes[id]) > readAt) {
         nUnr++;
       }
     }


### PR DESCRIPTION
I’m hoping this will clarify the code a bit and fix more border-case consistency issues than it introduces.

Changes:
- `pageData` now only contains actual page data from shoebox (e.g. kept status).
  - The thread summary data is now in `pageThreadData`.
  - The list of tabs currently at each normalized URI is now kept in `tabsByUrl`.
- No longer waiting until page data from shoebox returns before requesting a page’s thread summaries.
- No longer waiting until both page data from shoebox and thread data from eliza arrive before initializing pages.
  - Instead, we initialize pages with data from each service independently, as it arrives.
- The objects in `pageThreadData` are instances of `ThreadData`, which have methods for convenience and to help maintain data consistency/constraints.
- Utilizing the `lastMessageRead` field inside the JSON of each `ThreadInfo` to track read state instead of the separate map we were using since pre-eliza.
- Using `threadDataCallbacks` both to hold callbacks for when a page’s thread summaries arrive and to signal that there is an outstanding request for a page’s thread summaries.
- Using `threadCallbacks` in a similar manner for specific threads.
- Leveraging our knowledge of which pane is currently open on each tab to decide which messaging/notification updates to send them (see `forEachTabAtLocator`).
- Introduced a new `participants` extension message for requesting a thread’s participants.
  - It responds faster than `thread` b/c it can use either the thread summary or the thread’s first message.
- Renamed the `subscribe` method to `kifify` since we no longer have page subscriptions and the method’s main job is to make sure the browser tab is properly kifified™.
- Renamed the `tab.inited` flag to `tab.engaged` to try be clearer that it represents initialization of a page’s auto-engagement behavior (showing the tile and auto-expanding the keeper).
