### PR TITLE
making slider2.js idempotent for Chrome

### DIFF
--- a/packrat/scripts/slider2.js
+++ b/packrat/scripts/slider2.js
@@ -26,9 +26,9 @@ $.fn.scrollToBottom = function () {
 };
 
 var CO_KEY = /^Mac/.test(navigator.platform) ? '⌘' : 'Ctrl';
-var panes = {};
+var panes = panes || {};  // idempotent for Chrome
 
-var slider2 = function () {
+var slider2 = slider2 || function () {  // idempotent for Chrome
   'use strict';
   var $slider, $pane, paneHistory, lastShownAt;
 


### PR DESCRIPTION
I think it’s conceivable that a tab navigation could happen just before or during a `chrome.tabs.executeScript` call, which could result in this script being injected multiple times in an page. An error would probably occur, preventing it from marking itself injected. It’s unclear what exactly could happen, so I’m being conservative here.
