### PR TITLE
airbraking more and verifying error message size

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/abook/ABookServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/abook/ABookServiceClient.scala
@@ -6,7 +6,7 @@ import com.keepit.model.{ABookInfo => ABookInfo, ABookRawInfo, ABookOriginType, 
 import com.keepit.common.db.Id
 import com.keepit.common.service.{ServiceClient, ServiceType}
 import com.keepit.common.logging.Logging
-import com.keepit.common.healthcheck.HealthcheckPlugin
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.net.HttpClient
 import com.keepit.common.zookeeper.ServiceCluster
 
@@ -28,7 +28,7 @@ trait ABookServiceClient extends ServiceClient {
 
 
 class ABookServiceClientImpl @Inject() (
-  val healthcheck: HealthcheckPlugin,
+  val airbrakeNotifier: AirbrakeNotifier,
   val httpClient: HttpClient,
   val serviceCluster: ServiceCluster
 )
@@ -57,7 +57,7 @@ class ABookServiceClientImpl @Inject() (
   }
 }
 
-class FakeABookServiceClientImpl(val healthcheck: HealthcheckPlugin) extends ABookServiceClient {
+class FakeABookServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) extends ABookServiceClient {
 
   val serviceCluster: ServiceCluster = new ServiceCluster(ServiceType.TEST_MODE)
 

--- a/kifi-backend/modules/common/app/com/keepit/abook/ABookServiceClientModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/abook/ABookServiceClientModule.scala
@@ -1,7 +1,7 @@
 package com.keepit.abook
 
 import com.google.inject.{Provides, Singleton}
-import com.keepit.common.healthcheck.HealthcheckPlugin
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.net.HttpClient
 import com.keepit.common.zookeeper.ServiceDiscovery
 import com.keepit.common.service.ServiceType
@@ -17,9 +17,9 @@ case class ProdABookServiceClientModule() extends ABookServiceClientModule {
   @Provides
   def ABookServiceClient(client: HttpClient,
                          serviceDiscovery: ServiceDiscovery,
-                         healthcheck: HealthcheckPlugin): ABookServiceClient = {
+                         airbrakeNotifier: AirbrakeNotifier): ABookServiceClient = {
     new ABookServiceClientImpl(
-      healthcheck,
+      airbrakeNotifier,
       client,
       serviceDiscovery.serviceCluster(ServiceType.ABOOK)
     )
@@ -33,8 +33,8 @@ case class TestABookServiceClientModule() extends ABookServiceClientModule {
 
   @Singleton
   @Provides
-  def ABookServiceClient(healthcheck: HealthcheckPlugin): ABookServiceClient = {
-    new FakeABookServiceClientImpl(healthcheck)
+  def ABookServiceClient(airbrakeNotifier: AirbrakeNotifier): ABookServiceClient = {
+    new FakeABookServiceClientImpl(airbrakeNotifier)
   }
 
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeError.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeError.scala
@@ -20,20 +20,21 @@ case class AirbrakeError(
     id: ExternalId[AirbrakeError] = ExternalId())
 
 object AirbrakeError {
-  def apply(request: Request[_], exception: Throwable): AirbrakeError =
+  val MaxStringSize = 1024 * 1024 //1MB
+  def apply(request: RequestHeader, exception: Throwable): AirbrakeError =
     new AirbrakeError(
           exception = exception,
-          url = Some(request.uri),
-          params = request.queryString,
+          url = Some(request.uri.take(MaxStringSize)),
+          params = request.queryString.take(MaxStringSize),
           method = Some(request.method),
           headers = request.headers.toMap)
 
-  def apply(request: Request[_], exception: Throwable, message: String): AirbrakeError =
+  def apply(request: RequestHeader, exception: Throwable, message: String): AirbrakeError =
     new AirbrakeError(
           exception = exception,
-          message = Some(message),
-          url = Some(request.uri),
-          params = request.queryString,
+          message = Some(message.take(MaxStringSize)),
+          url = Some(request.uri.take(MaxStringSize)),
+          params = request.queryString.take(MaxStringSize),
           method = Some(request.method),
           headers = request.headers.toMap)
 

--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeFormatter.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeFormatter.scala
@@ -19,8 +19,10 @@ import scala.xml._
 
 import play.api.mvc._
 
+import AirbrakeError.MaxStringSize
+
 case class ErrorWithStack(error: Throwable, stack: Seq[StackTraceElement]) {
-  override def toString(): String = error.toString
+  override def toString(): String = error.toString.take(MaxStringSize)
   val cause: Option[ErrorWithStack] = Option(error.getCause).map(e => ErrorWithStack(e))
   val rootCause: ErrorWithStack = cause.map(c => c.rootCause).getOrElse(this)
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/HealthcheckError.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/HealthcheckError.scala
@@ -31,9 +31,11 @@ case class HealthcheckError(
   id: ExternalId[HealthcheckError] = ExternalId(),
   createdAt: DateTime = currentDateTime) {
 
+  val Max8M = 8 * 1024 * 1024
+
   lazy val signature: HealthcheckErrorSignature = {
     val permText: String =
-      causeStacktraceHead(4).getOrElse(errorMessage.map(_.message).getOrElse("")) +
+      causeStacktraceHead(4).getOrElse(errorMessage.map(_.message.take(Max8M)).getOrElse("")) +
         path.getOrElse("") +
         method.getOrElse("") +
         callType.toString
@@ -95,7 +97,7 @@ case class HealthcheckError(
         .replaceAll("\\d", "*").take(60)
     error match {
       case None =>
-        val message = errorMessage.map(_.message).getOrElse(path.getOrElse(callType.toString()))
+        val message = errorMessage.map(_.message.take(Max8M)).getOrElse(path.getOrElse(callType.toString()))
         displayMessage(message)
       case Some(t) =>
         val source = cause(t)

--- a/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
@@ -1,12 +1,11 @@
 package com.keepit.eliza
 
-
 import com.keepit.model.User
 import com.keepit.common.db.Id
 import com.keepit.common.service.{ServiceClient, ServiceType}
 import com.keepit.common.logging.Logging
 import com.keepit.common.routes.Eliza
-import com.keepit.common.healthcheck.HealthcheckPlugin
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.net.HttpClient
 import com.keepit.common.zookeeper.ServiceCluster
 
@@ -33,10 +32,10 @@ trait ElizaServiceClient extends ServiceClient {
 
 
 class ElizaServiceClientImpl @Inject() (
-    val healthcheck: HealthcheckPlugin,
+    val airbrakeNotifier: AirbrakeNotifier,
     val httpClient: HttpClient,
     val serviceCluster: ServiceCluster
-  ) 
+  )
   extends ElizaServiceClient with Logging {
 
   def sendToUserNoBroadcast(userId: Id[User], data: JsArray): Unit = {
@@ -79,13 +78,12 @@ class ElizaServiceClientImpl @Inject() (
   def importThread(data: JsObject): Unit = {
     call(Eliza.internal.importThread, data)
   }
-
 }
 
-class FakeElizaServiceClientImpl(val healthcheck: HealthcheckPlugin) extends ElizaServiceClient{
+class FakeElizaServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) extends ElizaServiceClient{
   val serviceCluster: ServiceCluster = new ServiceCluster(ServiceType.TEST_MODE)
   protected def httpClient: com.keepit.common.net.HttpClient = ???
-  
+
   def sendToUserNoBroadcast(userId: Id[User], data: JsArray): Unit = {}
 
   def sendToUser(userId: Id[User], data: JsArray): Unit = {}

--- a/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClientModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClientModule.scala
@@ -1,7 +1,7 @@
 package com.keepit.eliza
 
 import com.google.inject.{Provides, Singleton}
-import com.keepit.common.healthcheck.HealthcheckPlugin
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.net.HttpClient
 import com.keepit.common.zookeeper.ServiceDiscovery
 import com.keepit.common.service.ServiceType
@@ -18,24 +18,22 @@ case class ProdElizaServiceClientModule() extends ElizaServiceClientModule {
   def elizaServiceClient (
     client: HttpClient,
     serviceDiscovery: ServiceDiscovery,
-    healthcheck: HealthcheckPlugin): ElizaServiceClient = {
+    airbrakeNotifier: AirbrakeNotifier): ElizaServiceClient = {
     new ElizaServiceClientImpl(
-      healthcheck,
+      airbrakeNotifier,
       client,
       serviceDiscovery.serviceCluster(ServiceType.ELIZA)
       )
   }
-
 }
-
 
 case class TestElizaServiceClientModule() extends ElizaServiceClientModule {
   def configure() {}
 
   @Singleton
   @Provides
-  def elizaServiceClient(healthcheck: HealthcheckPlugin): ElizaServiceClient = {
-    new FakeElizaServiceClientImpl(healthcheck)
+  def elizaServiceClient(airbrakeNotifier: AirbrakeNotifier): ElizaServiceClient = {
+    new FakeElizaServiceClientImpl(airbrakeNotifier)
   }
 
 }

--- a/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalServiceClient.scala
@@ -1,12 +1,11 @@
 package com.keepit.heimdal
 
-
 import com.keepit.model.User
 import com.keepit.common.db.Id
 import com.keepit.common.service.{ServiceClient, ServiceType}
 import com.keepit.common.logging.Logging
 import com.keepit.common.routes.Heimdal
-import com.keepit.common.healthcheck.HealthcheckPlugin
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.net.HttpClient
 import com.keepit.common.zookeeper.ServiceCluster
 
@@ -22,24 +21,21 @@ trait HeimdalServiceClient extends ServiceClient {
   def trackEvent(event: UserEvent): Unit
 }
 
-
 class HeimdalServiceClientImpl @Inject() (
-    val healthcheck: HealthcheckPlugin,
+    val airbrakeNotifier: AirbrakeNotifier,
     val httpClient: HttpClient,
     val serviceCluster: ServiceCluster
-  ) 
+  )
   extends HeimdalServiceClient with Logging {
 
   def trackEvent(event: UserEvent) : Unit = {
     call(Heimdal.internal.trackEvent, Json.toJson(event))
   }
-
 }
 
-class FakeHeimdalServiceClientImpl(val healthcheck: HealthcheckPlugin) extends HeimdalServiceClient{
+class FakeHeimdalServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) extends HeimdalServiceClient{
   val serviceCluster: ServiceCluster = new ServiceCluster(ServiceType.TEST_MODE)
   protected def httpClient: com.keepit.common.net.HttpClient = ???
 
   def trackEvent(event: UserEvent) : Unit = {}
-
 }

--- a/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalServiceClientModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalServiceClientModule.scala
@@ -1,7 +1,7 @@
 package com.keepit.heimdal
 
 import com.google.inject.{Provides, Singleton}
-import com.keepit.common.healthcheck.HealthcheckPlugin
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.net.HttpClient
 import com.keepit.common.zookeeper.ServiceDiscovery
 import com.keepit.common.service.ServiceType
@@ -18,9 +18,9 @@ case class ProdHeimdalServiceClientModule() extends HeimdalServiceClientModule {
   def heimdalServiceClient (
     client: HttpClient,
     serviceDiscovery: ServiceDiscovery,
-    healthcheck: HealthcheckPlugin): HeimdalServiceClient = {
+    airbrakeNotifier: AirbrakeNotifier): HeimdalServiceClient = {
     new HeimdalServiceClientImpl(
-      healthcheck,
+      airbrakeNotifier,
       client,
       serviceDiscovery.serviceCluster(ServiceType.HEIMDAL)
       )
@@ -34,8 +34,8 @@ case class TestHeimdalServiceClientModule() extends HeimdalServiceClientModule {
 
   @Singleton
   @Provides
-  def heimdalServiceClient(healthcheck: HealthcheckPlugin): HeimdalServiceClient = {
-    new FakeHeimdalServiceClientImpl(healthcheck)
+  def heimdalServiceClient(airbrakeNotifier: AirbrakeNotifier): HeimdalServiceClient = {
+    new FakeHeimdalServiceClientImpl(airbrakeNotifier)
   }
 
 }

--- a/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClient.scala
@@ -2,6 +2,7 @@ package com.keepit.search
 
 import com.keepit.common.zookeeper._
 import com.keepit.common.healthcheck.BenchmarkResultsJson._
+import com.keepit.common.healthcheck.{AirbrakeNotifier, BenchmarkResults}
 import com.keepit.common.service.{ServiceClient, ServiceType}
 import com.keepit.common.db.Id
 import com.keepit.common.net.HttpClient
@@ -14,7 +15,6 @@ import scala.concurrent.Future
 import com.keepit.common.routes.Search
 import com.keepit.common.routes.Common
 import scala.concurrent.Promise
-import com.keepit.common.healthcheck.{HealthcheckPlugin, BenchmarkResults}
 import play.api.libs.json.JsArray
 import com.keepit.model.NormalizedURI
 import com.keepit.model.User
@@ -61,13 +61,11 @@ trait SearchServiceClient extends ServiceClient {
   def version(): Future[String]
 }
 
-
-
 class SearchServiceClientImpl(
     override val serviceCluster: ServiceCluster,
     override val port: Int,
     override val httpClient: HttpClient,
-    val healthcheck: HealthcheckPlugin)
+    val airbrakeNotifier: AirbrakeNotifier)
   extends SearchServiceClient() {
 
   def logResultClicked(userId: Id[User], query: String, uriId: Id[NormalizedURI], rank: Int, isKeep: Boolean): Unit = {

--- a/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClientModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClientModule.scala
@@ -2,7 +2,7 @@ package com.keepit.search
 
 import net.codingwell.scalaguice.ScalaModule
 import com.google.inject.{Provides, Singleton}
-import com.keepit.common.healthcheck.HealthcheckPlugin
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.net.HttpClient
 import com.keepit.common.zookeeper.ServiceDiscovery
 import com.keepit.common.service.ServiceType
@@ -19,12 +19,12 @@ case class ProdSearchServiceClientModule() extends SearchServiceClientModule {
   def searchServiceClient(
     client: HttpClient,
     serviceDiscovery: ServiceDiscovery,
-    healthcheck: HealthcheckPlugin): SearchServiceClient = {
+    airbrakeNotifier: AirbrakeNotifier): SearchServiceClient = {
     new SearchServiceClientImpl(
       serviceDiscovery.serviceCluster(ServiceType.SEARCH),
       current.configuration.getInt("service.search.port").get,
       client,
-      healthcheck)
+      airbrakeNotifier)
   }
 
 }

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -11,7 +11,6 @@ import com.keepit.common.db.ExternalId
 import com.keepit.common.db.Id
 import com.keepit.common.db.SequenceNumber
 import com.keepit.common.db.State
-import com.keepit.common.healthcheck.HealthcheckPlugin
 import com.keepit.common.logging.Logging
 import com.keepit.common.mail.ElectronicMail
 import com.keepit.common.net.HttpClient
@@ -38,6 +37,7 @@ import com.keepit.search.ArticleSearchResult
 import com.keepit.model.BrowsingHistoryUserIdKey
 import com.keepit.social.SocialId
 import com.keepit.model.NormalizedURIKey
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.model.UserConnectionIdKey
 import play.api.libs.json.JsObject
 import com.keepit.model.SocialUserInfoNetworkKey
@@ -113,8 +113,8 @@ class ShoeboxServiceClientImpl @Inject() (
   override val serviceCluster: ServiceCluster,
   override val port: Int,
   override val httpClient: HttpClient,
-  cacheProvider: ShoeboxCacheProvider,
-  val healthcheck: HealthcheckPlugin)
+  val airbrakeNotifier: AirbrakeNotifier,
+  cacheProvider: ShoeboxCacheProvider)
     extends ShoeboxServiceClient with Logging{
 
   // request consolidation
@@ -178,7 +178,6 @@ class ShoeboxServiceClientImpl @Inject() (
       Json.fromJson[Seq[Long]](r.json).get.map(Id[User](_))
     }
   }
-
 
   def sendMail(email: ElectronicMail): Future[Boolean] = {
     call(Shoebox.internal.sendMail(), Json.toJson(email)).map(r => r.body.toBoolean)

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClientModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClientModule.scala
@@ -1,7 +1,7 @@
 package com.keepit.shoebox
 
 import com.google.inject.{Provides, Singleton}
-import com.keepit.common.healthcheck.HealthcheckPlugin
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.net.HttpClient
 import com.keepit.common.zookeeper.ServiceDiscovery
 import com.keepit.common.service.ServiceType
@@ -19,11 +19,11 @@ case class ProdShoeboxServiceClientModule() extends ShoeboxServiceClientModule {
     client: HttpClient,
     cacheProvider: ShoeboxCacheProvider,
     serviceDiscovery: ServiceDiscovery,
-    healthcheck: HealthcheckPlugin): ShoeboxServiceClient = {
+    airbrakeNotifier: AirbrakeNotifier): ShoeboxServiceClient = {
     new ShoeboxServiceClientImpl(
       serviceDiscovery.serviceCluster(ServiceType.SHOEBOX),
       current.configuration.getInt("service.shoebox.port").get,
-      client, cacheProvider, healthcheck)
+      client, airbrakeNotifier, cacheProvider)
   }
 
 }

--- a/kifi-backend/modules/common/test/com/keepit/common/net/FakeHttpClientModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/net/FakeHttpClientModule.scala
@@ -3,10 +3,12 @@ package com.keepit.common.net
 import net.codingwell.scalaguice.ScalaModule
 import com.google.inject.{Provides, Singleton}
 import com.keepit.common.controller.FortyTwoCookies.{ImpersonateCookie, KifiInstallationCookie}
+import com.keepit.common.healthcheck._
 
 case class FakeHttpClientModule(requestToResponse: PartialFunction[String, FakeClientResponse] = FakeClientResponse.emptyFakeHttpClient) extends ScalaModule {
 
   def configure(): Unit = {
+    install(FakeAirbrakeModule())
     val fakeClient = new FakeHttpClient(Some(requestToResponse))
     bind[HttpClient].toInstance(fakeClient)
     bind[FakeHttpClient].toInstance(fakeClient)

--- a/kifi-backend/modules/common/test/com/keepit/search/TestSearchServiceClientModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/search/TestSearchServiceClientModule.scala
@@ -1,7 +1,7 @@
 package com.keepit.search
 
 import com.google.inject.{Singleton, Provides}
-import com.keepit.common.healthcheck.HealthcheckPlugin
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.zookeeper.ServiceCluster
 
 case class TestSearchServiceClientModule() extends SearchServiceClientModule {
@@ -10,8 +10,7 @@ case class TestSearchServiceClientModule() extends SearchServiceClientModule {
 
   @Provides
   @Singleton
-  def searchServiceClient(serviceCluster: ServiceCluster, healthcheck: HealthcheckPlugin): SearchServiceClient = {
-    new SearchServiceClientImpl(serviceCluster, -1, null, healthcheck)
+  def searchServiceClient(serviceCluster: ServiceCluster, airbrakeNotifier: AirbrakeNotifier): SearchServiceClient = {
+    new SearchServiceClientImpl(serviceCluster, -1, null, airbrakeNotifier)
   }
-
 }

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -1,6 +1,6 @@
 package com.keepit.shoebox
 
-import com.keepit.common.healthcheck.HealthcheckPlugin
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.service.ServiceType
 import com.keepit.common.zookeeper.ServiceCluster
 import com.keepit.common.logging.Logging
@@ -30,7 +30,7 @@ import play.api.libs.json.JsObject
 class FakeShoeboxServiceClientImpl(
     clickHistoryTracker: ClickHistoryTracker,
     browsingHistoryTracker: BrowsingHistoryTracker,
-    val healthcheck: HealthcheckPlugin
+    val airbrakeNotifier: AirbrakeNotifier
   ) extends ShoeboxServiceClient {
   val serviceCluster: ServiceCluster = new ServiceCluster(ServiceType.TEST_MODE)
   protected def httpClient: com.keepit.common.net.HttpClient = ???

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/TestShoeboxServiceClientModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/TestShoeboxServiceClientModule.scala
@@ -1,7 +1,7 @@
 package com.keepit.shoebox
 
 import com.google.inject.{Provides, Singleton}
-import com.keepit.common.healthcheck.HealthcheckPlugin
+import com.keepit.common.healthcheck._
 import com.keepit.common.net.HttpClient
 import com.keepit.common.zookeeper.ServiceCluster
 
@@ -15,21 +15,22 @@ case class TestShoeboxServiceClientModule() extends ShoeboxServiceClientModule {
       shoeboxCacheProvided: ShoeboxCacheProvider,
       httpClient: HttpClient,
       serviceCluster: ServiceCluster,
-      healthcheck: HealthcheckPlugin): ShoeboxServiceClient =
-    new ShoeboxServiceClientImpl(serviceCluster, -1, httpClient,shoeboxCacheProvided, healthcheck)
-
+      airbrakeNotifier: AirbrakeNotifier): ShoeboxServiceClient =
+    new ShoeboxServiceClientImpl(serviceCluster, -1, httpClient, airbrakeNotifier, shoeboxCacheProvided)
 }
 
 case class FakeShoeboxServiceModule() extends ShoeboxServiceClientModule {
-  def configure(): Unit = {}
+  def configure(): Unit = {
+    install(FakeAirbrakeModule())
+  }
 
   @Singleton
   @Provides
   def fakeShoeboxServiceClient(
       clickHistoryTracker: ClickHistoryTracker,
       browsingHistoryTracker: BrowsingHistoryTracker,
-      healthcheck: HealthcheckPlugin): ShoeboxServiceClient =
-    new FakeShoeboxServiceClientImpl(clickHistoryTracker, browsingHistoryTracker, healthcheck)
+      airbrakeNotifier: AirbrakeNotifier): ShoeboxServiceClient =
+    new FakeShoeboxServiceClientImpl(clickHistoryTracker, browsingHistoryTracker, airbrakeNotifier)
 
   @Provides
   @Singleton

--- a/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
@@ -99,7 +99,7 @@ case class ElizaCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Provides
   def activeExperimentsCache(innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new ActiveExperimentsCache((innerRepo, 5 minutes), (outerRepo, 7 days))
-  
+
   @Singleton
   @Provides
   def normalizedURIUrlHashCache(innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
@@ -67,15 +67,14 @@ class MessagingTest extends Specification with DbTestInjector {
     "merge and notify correctly" in {
       withDb(ElizaCacheModule(), FakeShoeboxServiceModule(), TestElizaServiceClientModule(), StandaloneTestActorSystemModule()) { implicit injector =>
 
-
         val (messagingController, user1, user2, user3, user2n3Set, notificationRouter) = setup()
 
-        var notified = scala.collection.concurrent.TrieMap[Id[User], Int]()  
+        var notified = scala.collection.concurrent.TrieMap[Id[User], Int]()
 
         notificationRouter.onNotification{ (userId, notification) =>
           // println(s"Got Notification $notification for $userId")
           if (notified.isDefinedAt(userId.get)) {
-            notified(userId.get) = notified(userId.get) + 1 
+            notified(userId.get) = notified(userId.get) + 1
           } else {
             notified(userId.get) = 1
           }
@@ -83,8 +82,8 @@ class MessagingTest extends Specification with DbTestInjector {
 
         val (thread1, msg1) = messagingController.sendNewMessage(user1, user2n3Set, Json.obj("url" -> "http://kifi.com"), Some("title"), "Hello Chat")
         val (thread2, msg2) = messagingController.sendNewMessage(user1, user2n3Set, Json.obj("url" -> "http://kifi.com"), Some("title"), "Hello Chat again!")
-        
-        
+
+
         notified.isDefinedAt(user1)===false
         notified(user2)===2
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/LocalPostOffice.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/LocalPostOffice.scala
@@ -16,8 +16,10 @@ class ShoeboxPostOfficeImpl @Inject() (mailRepo: ElectronicMailRepo)
       if (mail.htmlBody.value.size > PostOffice.BODY_MAX_SIZE ||
         mail.textBody.isDefined && mail.textBody.get.value.size > PostOffice.BODY_MAX_SIZE) {
         log.warn(s"PostOffice attempted to send an email (${mail.externalId}) longer than ${PostOffice.BODY_MAX_SIZE} bytes. Too big!")
-        mailRepo.save(mail.copy(
-          htmlBody = mail.htmlBody.value.take(PostOffice.BODY_MAX_SIZE - 20) + "<br>\n<br>\n(snip)").prepareToSend())
+        val prepMail = mail.copy(
+          htmlBody = mail.htmlBody.value.take(PostOffice.BODY_MAX_SIZE - 20) + "<br>\n<br>\n(snip)",
+          textBody = mail.textBody.map(_.value.take(PostOffice.BODY_MAX_SIZE - 20) + "\n(snip)")).prepareToSend()
+        mailRepo.save(prepMail)
       } else {
         mailRepo.save(mail.prepareToSend())
       }


### PR DESCRIPTION
- more checks to make sure that error messages are caped in size.
- using airbrake as the top level exception catching so we we'll send less error messages to shoebox and persist them in the db.
- airbraking in the httpclient layer instead of healthchecking
