### PR TITLE
Implements a generic LinkProcessingExtractor

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/net/URI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/URI.scala
@@ -37,6 +37,24 @@ object URI extends Logging {
     val uri = URIParser.parseAll(URIParser.uri, uriString.trim).get
     (uri.scheme, uri.userInfo, uri.host, uri.port, uri.path, uri.query, uri.fragment)
   }
+
+  def isRelative(uriString: String): Boolean = uriString.startsWith("/")
+  def isAbsolute(uriString : String): Boolean = !isRelative(uriString)
+
+  def url(baseUri: URI, targetUrl: String): String =
+    if (isRelative(targetUrl)) {
+      val absoluteTargetUrl = for {
+        scheme <- baseUri.scheme
+        host <- baseUri.host }
+      yield scheme + "://" + host.name + targetUrl
+      absoluteTargetUrl getOrElse targetUrl
+    }
+    else targetUrl
+
+  def url(baseUrl: String, targetUrl: String): String =
+    if (isRelative(targetUrl) && isAbsolute(baseUrl))
+      safelyParse(baseUrl).map(url(_, targetUrl)) getOrElse targetUrl
+    else targetUrl
 }
 
 class URI(val raw: Option[String], val scheme: Option[String], val userInfo: Option[String], val host: Option[Host], val port: Int, val path: Option[String], val query: Option[Query], val fragment: Option[String]) {

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/HttpFetcher.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/HttpFetcher.scala
@@ -184,18 +184,10 @@ case class HttpFetchStatus(statusCode: Int, message: Option[String], context: Ht
 
 case class HttpRedirect(statusCode: Int, currentLocation: String, newDestination: String) {
   def isPermanent = (statusCode == HttpStatus.SC_MOVED_PERMANENTLY)
-  def isAbsolute = HttpRedirect.isAbsolute(currentLocation) && HttpRedirect.isAbsolute(newDestination)
+  def isAbsolute = URI.isAbsolute(currentLocation) && URI.isAbsolute(newDestination)
   def isLocatedAt(url: String) = (currentLocation == url)
 }
 
 object HttpRedirect {
-  def isAbsolute(url: String) = url.toLowerCase.startsWith("http")
-  def withStandardizationEffort(statusCode: Int, currentLocation: String, newDestination: String): HttpRedirect = {
-    val standardizedOption = for {
-      uri <- URI.safelyParse(currentLocation) if isAbsolute(currentLocation) && !isAbsolute(newDestination)
-      scheme <- uri.scheme
-      host <- uri.host
-    } yield HttpRedirect(statusCode, currentLocation, scheme + "://" + host.name + newDestination)
-    standardizedOption.getOrElse(HttpRedirect(statusCode, currentLocation, newDestination))
-  }
+  def withStandardizationEffort(statusCode: Int, currentLocation: String, newDestination: String): HttpRedirect = HttpRedirect(statusCode, currentLocation, URI.url(currentLocation, newDestination))
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/DefaultExtractor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/DefaultExtractor.scala
@@ -17,7 +17,7 @@ object DefaultExtractorProvider extends ExtractorProvider {
   def apply(uri: URI) = apply(uri.toString)
   def apply(url: String) = new DefaultExtractor(url, Scraper.maxContentChars, htmlMapper)
 
-  private val htmlMapper = Some(new DefaultHtmlMapper {
+  val htmlMapper = Some(new DefaultHtmlMapper {
     override def mapSafeElement(name: String) = {
       name.toLowerCase match {
         case "option" => "option"

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/Extractor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/Extractor.scala
@@ -17,13 +17,13 @@ trait Extractor {
 trait ExtractorFactory extends Function[String, Extractor]
 
 @Singleton
-class ExtractorFactoryImpl @Inject() (youtubeExtractorProvider: YoutubeExtractorProvider) extends ExtractorFactory with Logging {
+class ExtractorFactoryImpl @Inject() (youtubeExtractorProvider: YoutubeExtractorProvider, linkProcessingExtractorProvider: LinkProcessingExtractorProvider) extends ExtractorFactory with Logging {
 
   val all = Seq(
     youtubeExtractorProvider,
     GithubExtractorProvider,
     LinkedInExtractorProvider,
-    DefaultExtractorProvider
+    linkProcessingExtractorProvider
   )
 
   def apply(url: String): Extractor = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/LinkProcessingExtractor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/LinkProcessingExtractor.scala
@@ -1,0 +1,70 @@
+package com.keepit.scraper.extractor
+
+import org.apache.tika.parser.html.HtmlMapper
+import com.keepit.scraper.{Scraper, HttpFetcher}
+import com.keepit.common.db.slick.Database
+import com.keepit.model.UrlPatternRuleRepo
+import com.google.inject.{Inject, Singleton}
+import com.keepit.common.net.URI
+import org.apache.tika.sax.{Link, LinkContentHandler, TeeContentHandler}
+import org.xml.sax.ContentHandler
+import scala.collection.JavaConversions._
+
+class LinkProcessingExtractor(
+  url: String,
+  maxContentChars: Int,
+  htmlMapper: Option[HtmlMapper],
+  processLink: Link => Option[String],
+  httpFetcher: HttpFetcher,
+  db: Database,
+  urlPatternRuleRepo: UrlPatternRuleRepo)
+extends DefaultExtractor(url, maxContentChars, htmlMapper) {
+
+  private val linkHandler = new LinkContentHandler()
+  private val handler = new TeeContentHandler(super.getContentHandler, linkHandler)
+  override def getContentHandler: ContentHandler = handler
+  def getLinks(): Seq[Link] = linkHandler.getLinks
+
+  private lazy val (linkedContent, linkedKeywords): (Seq[String], Seq[Option[String]]) = {
+    val linkedContentWithKeywords = for {
+      link <- getLinks()
+      linkUrl <- processLink(link)
+    } yield {
+      log.info(s"Scraping additional content from link ${linkUrl} for url ${url}")
+      val extractor = new DefaultExtractor(linkUrl, maxContentChars, htmlMapper)
+      val proxy = db.readOnly {implicit session => urlPatternRuleRepo.getProxy(linkUrl) }
+      httpFetcher.fetch(linkUrl, proxy = proxy)(extractor.process)
+      (extractor.getContent(), extractor.getKeywords())
+    }
+    linkedContentWithKeywords.unzip
+  }
+
+  override def getContent(): String = (super.getContent() +: linkedContent).mkString("\n").take(maxContentChars)
+  override def getKeywords(): Option[String] = {
+    val keywords = (super.getKeywords() +: linkedKeywords).flatten.mkString(" | ")
+    if (keywords.isEmpty) None else Some(keywords)
+  }
+}
+
+@Singleton
+class LinkProcessingExtractorProvider @Inject() (httpFetcher: HttpFetcher, db: Database, urlPatternRuleRepo: UrlPatternRuleRepo) extends ExtractorProvider {
+  def isDefinedAt(uri: URI) = true
+  def apply(uri: URI) = new LinkProcessingExtractor(uri.toString, Scraper.maxContentChars, DefaultExtractorProvider.htmlMapper, processLink(uri), httpFetcher, db, urlPatternRuleRepo)
+
+  private def processLink(uri: URI): Link => Option[String] = {
+    val url = uri.toString()
+    link: Link => {
+      val absoluteLinkUrl = URI.url(uri, link.getUri)
+      link match {
+        case _ if isAbout(url, absoluteLinkUrl) => Some(absoluteLinkUrl)
+        case _ => None
+      }
+    }
+  }
+
+  private def isAbout(baseUrl: String, aboutUrl: String): Boolean = {
+    val aboutPages = Seq("about", "aboutus", "about-us", "about_us", "apropos", "a-propos", "a_propos")
+    val aboutSuffix = ("/(" + aboutPages.mkString("|") + """)(\.[a-z]{2,4})?/?$""").r
+    aboutUrl.startsWith(baseUrl) && aboutSuffix.pattern.matcher(aboutUrl).find
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/LinkProcessingExtractor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/extractor/LinkProcessingExtractor.scala
@@ -51,14 +51,12 @@ class LinkProcessingExtractorProvider @Inject() (httpFetcher: HttpFetcher, db: D
   def isDefinedAt(uri: URI) = true
   def apply(uri: URI) = new LinkProcessingExtractor(uri.toString, Scraper.maxContentChars, DefaultExtractorProvider.htmlMapper, processLink(uri), httpFetcher, db, urlPatternRuleRepo)
 
-  private def processLink(uri: URI): Link => Option[String] = {
+  private def processLink(uri: URI)(link: Link): Option[String] = {
     val url = uri.toString()
-    link: Link => {
-      val absoluteLinkUrl = URI.url(uri, link.getUri)
-      link match {
-        case _ if isAbout(url, absoluteLinkUrl) => Some(absoluteLinkUrl)
-        case _ => None
-      }
+    val absoluteLinkUrl = URI.url(uri, link.getUri)
+    link match {
+      case _ if isAbout(url, absoluteLinkUrl) => Some(absoluteLinkUrl)
+      case _ => None
     }
   }
 


### PR DESCRIPTION
@ymatsuda @stkem @yingjieMiao 

This extractor builds upon DefaultExtractor to process the links found within a scraped page, both for side effects (e.g. report a canonical url) or to aggregate their content with the main page's (e.g. fetch "About" page). It becomes the new default extractor.

Right now, the only links being processed are the "About" links (aggregate with main content) but I have tried to build it so that other heuristics (e.g. report canonical urls or fetch menu for a restaurant page) can easily be added to LinkProcessingExtractorProvider
