### PR TITLE
Firefox selection color fix for pull request 3928

### DIFF
--- a/packrat/styles/insulate.css
+++ b/packrat/styles/insulate.css
@@ -282,7 +282,7 @@
   text-shadow: initial;
 }
 .kifi-root.kifi-root ::-moz-selection {
-  background: initial;
-  color: initial;
+  background-color: -moz-html-CellHighlight;
+  color: -moz-html-CellHighlightText;
   text-shadow: initial;
 }


### PR DESCRIPTION
In Firefox, initial color and background color are black and transparent, respectively, which doesn’t do much to identify the selection.
