### PR TITLE
Remove utf8 directive (will fix param set)

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/107.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/107.sql
@@ -9,11 +9,11 @@ CREATE TABLE contact_info (
 
 	user_id bigint(20) NOT NULL,
 	abook_id bigint(20) NOT NULL,
-	email varchar(512) character set utf8 NOT NULL,
+	email varchar(512)  NOT NULL,
 	origin varchar(128) NOT NULL,
-  	name varchar(1024) character set utf8,
-	first_name varchar(512) character set utf8,
-	last_name varchar(512) character set utf8,
+  	name varchar(1024),
+	first_name varchar(512),
+	last_name varchar(512),
 	picture_url varchar(2048),
   	parent_id bigint(20),                   -- for contacts with multiple emails
 


### PR DESCRIPTION
H2 does not like this syntax, but with the right parameter group for MySQL 5.6 this can be addressed correctly.
