### PR TITLE
doc: utf8mb4

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/107.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/107.sql
@@ -20,7 +20,8 @@ CREATE TABLE contact_info (
 	PRIMARY KEY (id)
 
 	-- CONSTRAINT contact_info_abook_id FOREIGN KEY (abook_id) REFERENCES abook_info(id)
-);
+) -- DEFAULT CHARSET=utf8mb4
+;
 
 # --- !Downs
 

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/108.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/108.sql
@@ -13,7 +13,8 @@ CREATE TABLE abook_info (
 	raw_info_loc varchar(512),
 
 	PRIMARY KEY (id)
-);
+) -- DEFAULT CHARSET=utf8mb4
+;
 
 # --- !Downs
 


### PR DESCRIPTION
Documenting the fact that abook tables now default to utf8mb4
