### PR TITLE
bump up the error report threshold on wait time on http client from 100m...

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/net/HttpClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/HttpClient.scala
@@ -262,7 +262,7 @@ private[net] class Request(val req: WSRequestHolder, headers: List[(String, Stri
             statusCode = res.status))
 
         e.waitTime map {waitTime =>
-          if (waitTime > 100) {//ms
+          if (waitTime > 200) {//ms
             val exception = tracer.withCause(LongWaitException(req.url, res, waitTime))
             airbrake.get.notify(
               AirbrakeError.outgoing(


### PR DESCRIPTION
...s to 200ms

we will turn it back down as we get better understandings of how to solve the problem
