### PR TITLE
avoiding array copy in binary serializer

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/cache/PlayCachePlugin.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/PlayCachePlugin.scala
@@ -46,11 +46,15 @@ case class PlayCacheKey(key: String) extends Key[Any] {
 }
 
 private object PlayBinaryFormat extends BinaryFormat[Any] {
-  def reads(obj: Array[Byte]): Any = {
-    new ObjectInputStream(new ByteArrayInputStream(obj)).readObject()
+
+  protected def reads(obj: Array[Byte], offset: Int, length: Int): Any = {
+    new ObjectInputStream(new ByteArrayInputStream(obj, offset, length)).readObject()
   }
-  def writes(value: Any): Array[Byte] = {
+  protected def writes(value: Any): Array[Byte] = {
     val out = new ByteArrayOutputStream()
+
+    out.write(1) // we have something
+
     new ObjectOutputStream(out).writeObject(value)
     out.toByteArray
   }

--- a/kifi-backend/modules/common/test/com/keepit/common/cache/FortyTwoCacheTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/cache/FortyTwoCacheTest.scala
@@ -28,8 +28,8 @@ case class TestBinaryCacheKey(id: String) extends Key[Array[Byte]] {
 }
 
 object DummyBinarySerializer extends BinaryFormat[Array[Byte]] {
-  def writes(x: Array[Byte]) = x
-  def reads(x: Array[Byte]) = x
+  protected def writes(x: Array[Byte]) = x
+  protected def reads(x: Array[Byte], offset: Int, length: Int) = x
 }
 
 class TestBinaryCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)

--- a/kifi-backend/modules/common/test/com/keepit/serializer/BrowsingHistorySerializerTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/serializer/BrowsingHistorySerializerTest.scala
@@ -27,9 +27,9 @@ class BrowsingHistorySerializerTest extends Specification {
       )
 
       val serializer = BrowsingHistoryBinarySerializer.browsingHistoryBinarySerializer
-      val serializedHistory = serializer.writes(browsingHistory)
+      val serializedHistory = serializer.writes(Some(browsingHistory))
 
-      val deserializedHistory = serializer.reads(serializedHistory)
+      val deserializedHistory = serializer.reads(serializedHistory).get
 
       deserializedHistory.filter.deep === filter.deep
       deserializedHistory.copy(filter = filter) === browsingHistory
@@ -48,8 +48,8 @@ class BrowsingHistorySerializerTest extends Specification {
         updatesCount = 42
       )
       val serializer = BrowsingHistoryBinarySerializer.browsingHistoryBinarySerializer
-      val serializedHistory = serializer.writes(browsingHistory)
-      serializer.reads(serializedHistory) must throwA[AssertionError]
+      val serializedHistory = serializer.writes(Some(browsingHistory))
+      serializer.reads(serializedHistory).get must throwA[AssertionError]
     }
     "Fail appropriately" in {
 
@@ -65,7 +65,7 @@ class BrowsingHistorySerializerTest extends Specification {
         updatesCount = 42
       )
       val serializer = BrowsingHistoryBinarySerializer.browsingHistoryBinarySerializer
-      serializer.writes(browsingHistory) must throwA[AssertionError]
+      serializer.writes(Some(browsingHistory)) must throwA[AssertionError]
     }
   }
 

--- a/kifi-backend/modules/common/test/com/keepit/serializer/ClickHistoryBinarySerializerTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/serializer/ClickHistoryBinarySerializerTest.scala
@@ -25,11 +25,11 @@ class ClickHistorySerializerTest extends Specification {
         minHits = 1,
         updatesCount = 42
       )
-      
-      val serializer = ClickHistoryBinarySerializer.clickHistoryBinarySerializer
-      val serializedHistory = serializer.writes(clickHistory)
 
-      val deserializedHistory = serializer.reads(serializedHistory)
+      val serializer = ClickHistoryBinarySerializer.clickHistoryBinarySerializer
+      val serializedHistory = serializer.writes(Some(clickHistory))
+
+      val deserializedHistory = serializer.reads(serializedHistory).get
 
       deserializedHistory.filter.deep === filter.deep
       deserializedHistory.copy(filter = filter) === clickHistory
@@ -48,8 +48,8 @@ class ClickHistorySerializerTest extends Specification {
         updatesCount = 42
       )
       val serializer = ClickHistoryBinarySerializer.clickHistoryBinarySerializer
-      val serializedHistory = serializer.writes(clickHistory)
-      serializer.reads(serializedHistory) must throwA[AssertionError]
+      val serializedHistory = serializer.writes(Some(clickHistory))
+      serializer.reads(serializedHistory).get must throwA[AssertionError]
     }
     "Fail appropriately" in {
 
@@ -65,7 +65,7 @@ class ClickHistorySerializerTest extends Specification {
         updatesCount = 42
       )
       val serializer = ClickHistoryBinarySerializer.clickHistoryBinarySerializer
-      serializer.writes(clickHistory) must throwA[AssertionError]
+      serializer.writes(Some(clickHistory)) must throwA[AssertionError]
     }
   }
 

--- a/kifi-backend/modules/search/app/com/keepit/search/ProbablisticLRUChunkCache.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/ProbablisticLRUChunkCache.scala
@@ -12,16 +12,17 @@ import java.nio.{IntBuffer, ByteBuffer}
 
 object IntArrayBinarySerializer extends BinaryFormat[Array[Int]] {
 
-  def reads(data: Array[Byte]): Array[Int] = {
-    val intBuffer = ByteBuffer.wrap(data).asIntBuffer
-    val outArray = new Array[Int](data.length/4)
+  protected def reads(data: Array[Byte], offset: Int, length: Int): Array[Int] = {
+    val intBuffer = ByteBuffer.wrap(data, offset, length).asIntBuffer
+    val outArray = new Array[Int]((data.length - 1)/4)
     intBuffer.get(outArray)
     outArray
   }
 
-  def writes(value: Array[Int]): Array[Byte] = {
-    val byteBuffer = ByteBuffer.allocate(value.size*4)
-    byteBuffer.asIntBuffer.put(value.array)
+  protected def writes(value: Array[Int]): Array[Byte] = {
+    val byteBuffer = ByteBuffer.allocate(1 + value.size*4)
+    byteBuffer.put(1.toByte) // we have something
+    byteBuffer.asIntBuffer.put(value)
     byteBuffer.array
   }
 


### PR DESCRIPTION
The definition/implementation of BinaryFormat is changed to avoid array copy in serialization/deserialization. 
