### PR TITLE
JSON support for username password provider

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/social/providers/UsernamePasswordProvider.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/providers/UsernamePasswordProvider.scala
@@ -3,30 +3,36 @@ package com.keepit.social.providers
 import com.keepit.social.UserIdentityProvider
 
 import play.api.Application
-import play.api.mvc.Request
+import play.api.mvc.{Results, Request, PlainResult, Result}
 import play.api.mvc.Results.Redirect
-import play.api.mvc.{PlainResult, Result}
 import securesocial.core.providers.{UsernamePasswordProvider => UPP}
 import securesocial.core.{Registry, UserService, IdentityId, SocialUser}
+import play.api.libs.json.Json
 
 class UsernamePasswordProvider(application: Application)
   extends UPP(application) with UserIdentityProvider {
   override def doAuth[A]()(implicit request: Request[A]): Either[Result, SocialUser] = {
     UPP.loginForm.bindFromRequest().fold(
-      errors => Left(error()),
+      errors => Left(error(request, "bad_form", "Invalid email or password")),
       credentials => {
-        val result = for {
-          user <- UserService.find(IdentityId(credentials._1, id))
-          pinfo <- user.passwordInfo
-          hasher <- Registry.hashers.get(pinfo.hasher) if hasher.matches(pinfo, credentials._2)
-        } yield Right(SocialUser(user))
-        result getOrElse Left(error())
+        UserService.find(IdentityId(credentials._1, id)) match {
+          case Some(identity) =>
+            val result = for {
+              pinfo <- identity.passwordInfo
+              hasher <- Registry.hashers.get(pinfo.hasher) if hasher.matches(pinfo, credentials._2)
+            } yield Right(SocialUser(identity))
+            result getOrElse Left(error(request, "bad_password", "Wrong password."))
+          case None => Left(error(request, "no_user_exists", "No user with that email address exists."))
+        }
       }
     )
   }
 
-  private def error[A](): PlainResult = {
-    Redirect("/").flashing("error" ->
-        "Invalid email and password. Try with different credentials, or create an account if you don't have one yet.")
+  private def error[A](request: Request[A], errorCode: String, errorString: String): PlainResult = {
+    request.tags.get("format") match {
+      case Some("json") =>
+        Results.Forbidden(Json.obj("error" -> errorCode)).as("application/json")
+      case _ => Redirect("/").flashing("error" -> errorString)
+    }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
@@ -69,6 +69,10 @@ class HomeController @Inject() (db: Database,
       Ok(views.html.website.welcome(newSignup = newSignup, msg = request.flash.get("error")))
   })
 
+  def curtainHome = Action {
+    Ok.stream(Enumerator.fromStream(Play.resourceAsStream("public/curtain.html").get)) as HTML
+  }
+
   def kifiSiteRedirect(path: String) = Action {
     MovedPermanently(s"/$path")
   }

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -1,4 +1,6 @@
 
+GET     /curtain                    @com.keepit.controllers.website.HomeController.curtainHome()
+
 GET     /login                      securesocial.controllers.LoginPage.login
 GET     /logout                     securesocial.controllers.LoginPage.logout
 
@@ -15,18 +17,30 @@ POST    /signupWithPassword         @com.keepit.controllers.core.AuthController.
 # OAuth provider entry points (e.g. "facebook")
 GET     /authenticate/:provider     securesocial.controllers.ProviderController.authenticate(provider)
 POST    /authenticate/:provider     securesocial.controllers.ProviderController.authenticateByPost(provider)
+
 # custom auth routes which set some session state
-GET     /login/:provider            @com.keepit.controllers.core.AuthController.login(provider)
-POST    /login/:provider            @com.keepit.controllers.core.AuthController.loginByPost(provider)
+
+# Standalone login page
+GET     /login/:provider            @com.keepit.controllers.core.AuthController.login(provider, format: String ?= "html")
+POST    /login/:provider            @com.keepit.controllers.core.AuthController.loginByPost(provider, format: String ?= "html")
+POST    /login                      @com.keepit.controllers.core.AuthController.loginWithUserPass(format: String ?= "json")
+
 GET     /link/:provider             @com.keepit.controllers.core.AuthController.link(provider)
 POST    /link/:provider             @com.keepit.controllers.core.AuthController.linkByPost(provider)
+
+# Initial signup using provider pages
 GET     /signup/:provider           @com.keepit.controllers.core.AuthController.signup(provider)
 POST    /signup/:provider           @com.keepit.controllers.core.AuthController.signupByPost(provider)
+
 POST    /loginAndLink/:provider     @com.keepit.controllers.core.AuthController.passwordLoginAndLink(provider)
+
 POST    /mobileauth/:provider       @com.keepit.controllers.core.AuthController.mobileAuth(provider)
+
 GET     /verify/:code               @com.keepit.controllers.core.AuthController.verifyEmail(code)
+
 GET     /resetPassword              @com.keepit.controllers.core.AuthController.resetPasswordPage()
 POST    /resetPassword              @com.keepit.controllers.core.AuthController.resetPassword()
+
 GET     /setPassword/:code          @com.keepit.controllers.core.AuthController.setNewPasswordPage(code: String)
 POST    /setPassword/:code          @com.keepit.controllers.core.AuthController.setNewPassword(code: String)
 


### PR DESCRIPTION
@2is10 

This adds the route you wanted `POST /login`, which speaks JSON and will redirect to `/` on success, or return json on failure.
