### PR TITLE
JSON support for user/pass signups, logic changes

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/controller/WebsiteController.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/WebsiteController.scala
@@ -27,6 +27,9 @@ class WebsiteController(actionAuthenticator: ActionAuthenticator) extends Contro
     }
   }
 
+  def JsonToJsonAction(allowPending: Boolean)(authenticatedAction: AuthenticatedRequest[JsValue] => Result, unauthenticatedAction: Request[JsValue] => Result): Action[JsValue] =
+    actionAuthenticator.authenticatedAction(true, allowPending, parse.tolerantJson, authenticatedAction, unauthenticatedAction)
+
   def AuthenticatedHtmlAction(action: AuthenticatedRequest[AnyContent] => Result): Action[AnyContent] =
     actionAuthenticator.authenticatedAction(false, false, parse.anyContent, action)
 

--- a/kifi-backend/modules/common/app/com/keepit/social/providers/UsernamePasswordProvider.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/providers/UsernamePasswordProvider.scala
@@ -8,6 +8,7 @@ import play.api.mvc.Results.Redirect
 import securesocial.core.providers.{UsernamePasswordProvider => UPP}
 import securesocial.core.{Registry, UserService, IdentityId, SocialUser}
 import play.api.libs.json.Json
+import play.api.http.ContentTypes
 
 class UsernamePasswordProvider(application: Application)
   extends UPP(application) with UserIdentityProvider {
@@ -31,7 +32,7 @@ class UsernamePasswordProvider(application: Application)
   private def error[A](request: Request[A], errorCode: String, errorString: String): PlainResult = {
     request.tags.get("format") match {
       case Some("json") =>
-        Results.Forbidden(Json.obj("error" -> errorCode)).as("application/json")
+        Results.Forbidden(Json.obj("error" -> errorCode)).as(ContentTypes.JSON)
       case _ => Redirect("/").flashing("error" -> errorString)
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -91,7 +91,7 @@ class AuthController @Inject() (
     originalUrlOpt map { url => sesh + (SecureSocial.OriginalUrlKey -> url) } getOrElse sesh
   }
 
-  private def getAuthAction(provider: String, authType: AuthType, format: String = "json"): Action[AnyContent] = Action { request =>
+  private def getAuthAction(provider: String, authType: AuthType, format: String = "html"): Action[AnyContent] = Action { request =>
     val augmentedRequest = augmentRequestWithTag(request, "format" -> format)
 
     val actualProvider = if (authType == AuthType.LoginAndLink) SocialNetworks.FORTYTWO.authProvider else provider

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -14,6 +14,8 @@ GET     /signup                     @com.keepit.controllers.core.AuthController.
 POST    /signup                     @com.keepit.controllers.core.AuthController.handleSignup()
 POST    /signupWithPassword         @com.keepit.controllers.core.AuthController.handleUsernamePasswordSignup()
 
+POST    /auth/signup                @com.keepit.controllers.core.AuthController.userPasswordSignup()
+
 # OAuth provider entry points (e.g. "facebook")
 GET     /authenticate/:provider     securesocial.controllers.ProviderController.authenticate(provider)
 POST    /authenticate/:provider     securesocial.controllers.ProviderController.authenticateByPost(provider)
@@ -24,6 +26,7 @@ POST    /authenticate/:provider     securesocial.controllers.ProviderController.
 GET     /login/:provider            @com.keepit.controllers.core.AuthController.login(provider, format: String ?= "html")
 POST    /login/:provider            @com.keepit.controllers.core.AuthController.loginByPost(provider, format: String ?= "html")
 POST    /login                      @com.keepit.controllers.core.AuthController.loginWithUserPass(format: String ?= "json")
+POST    /auth/login                  @com.keepit.controllers.core.AuthController.loginWithUserPass(format: String ?= "json")
 
 GET     /link/:provider             @com.keepit.controllers.core.AuthController.link(provider)
 POST    /link/:provider             @com.keepit.controllers.core.AuthController.linkByPost(provider)


### PR DESCRIPTION
@2is10 

Current API:

``` javascript
// signup
$.postJson("/auth/signup",{"email": "werdna3@andrewconner.org", "password": "asdfasdf"})
// on success, 200 with success json
// on fail, {"error": "error_code"}
// codes: password_too_short, user_exists_failed_auth
// when account exists, logs user in, success json contains {"new_account": false}
// when logged in and account does not exists, success json contains {"new_account": true}
```
