### PR TITLE
added in-mem cache to UserExperimentCache, no wait in SearchConfigManager

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/common/cache/ABookCacheModule.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/common/cache/ABookCacheModule.scala
@@ -62,8 +62,8 @@ case class ABookCacheModule(cachePluginModules: CachePluginModule*) extends Cach
 
   @Singleton
   @Provides
-  def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
-    new UserExperimentCache(stats, accessLog, (outerRepo, 7 days))
+  def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserExperimentCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/CommonHealthcheckController.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/CommonHealthcheckController.scala
@@ -4,18 +4,16 @@ import scala.util.Random
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent._
 import scala.concurrent.duration._
-
 import play.api.libs.json._
 import play.api.Play.current
 import play.api.mvc.Action
 import play.api.mvc.Controller
 import securesocial.core.SecureSocial
-
 import com.keepit.search._
 import com.keepit.common.service._
 import com.keepit.model._
 import com.keepit.common.db.Id
-
+import com.keepit.common.cache.FortyTwoCachePlugin
 import com.keepit.common.controller.{AdminController, ActionAuthenticator}
 import com.google.inject.Inject
 
@@ -41,7 +39,7 @@ class CommonBenchmarkController @Inject() (
   }
 }
 
-class BenchmarkRunner @Inject() (cache: UserExperimentCache) {
+class BenchmarkRunner @Inject() (cache: FortyTwoCachePlugin) {
   def runBenchmark() = BenchmarkResults(cpuBenchmarkTime(), cpuParBenchmarkTime(), memcachedBenchmarkTime())
 
   private def cpuBenchmarkTime(): Long = {
@@ -64,7 +62,7 @@ class BenchmarkRunner @Inject() (cache: UserExperimentCache) {
   private def memcachedBenchmarkTime(): Double = {
     val iterations = 1000
     val start = System.currentTimeMillis
-    for (i <- 0 to iterations) { cache.get(UserExperimentUserIdKey(Id[User](1))) }
+    for (i <- 0 to iterations) { cache.get(UserExperimentUserIdKey(Id[User](1)).toString) }
     (System.currentTimeMillis - start).toDouble / iterations.toDouble
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -125,7 +125,6 @@ class ShoeboxServiceClientImpl @Inject() (
   private[this] val consolidateUserConnectionsReq = new RequestConsolidator[UserConnectionIdKey, Set[Id[User]]](ttl = 3 seconds)
   private[this] val consolidateClickHistoryReq = new RequestConsolidator[ClickHistoryUserIdKey, Array[Byte]](ttl = 3 seconds)
   private[this] val consolidateBrowsingHistoryReq = new RequestConsolidator[BrowsingHistoryUserIdKey, Array[Byte]](ttl = 3 seconds)
-  private[this] val consolidateGetExperimentsReq = new RequestConsolidator[String, Seq[SearchConfigExperiment]](ttl = 30 seconds)
 
   def getUserOpt(id: ExternalId[User]): Future[Option[User]] = {
     cacheProvider.userExternalIdCache.getOrElseFutureOpt(UserExternalIdKey(id)) {
@@ -331,7 +330,7 @@ class ShoeboxServiceClientImpl @Inject() (
     }
   }
 
-  def getActiveExperiments: Future[Seq[SearchConfigExperiment]] = consolidateGetExperimentsReq("active") { t =>
+  def getActiveExperiments: Future[Seq[SearchConfigExperiment]] = {
     cacheProvider.activeSearchConfigExperimentsCache.getOrElseFuture(ActiveExperimentsKey) {
       call(Shoebox.internal.getActiveExperiments).map { r =>
         Json.fromJson[Seq[SearchConfigExperiment]](r.json).get

--- a/kifi-backend/modules/common/test/com/keepit/common/cache/TestCacheModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/cache/TestCacheModule.scala
@@ -87,8 +87,8 @@ case class TestCacheModule() extends CacheModule(HashMapMemoryCacheModule()) {
 
   @Singleton
   @Provides
-  def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
-    new UserExperimentCache(stats, accessLog, (outerRepo, 7 days))
+  def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserExperimentCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
@@ -73,8 +73,8 @@ case class ElizaCacheModule(cachePluginModules: CachePluginModule*) extends Cach
 
   @Singleton
   @Provides
-  def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
-    new UserExperimentCache(stats, accessLog, (outerRepo, 7 days))
+  def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserExperimentCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/heimdal/app/com/keepit/common/cache/HeimdalCacheModule.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/common/cache/HeimdalCacheModule.scala
@@ -62,8 +62,8 @@ case class HeimdalCacheModule(cachePluginModules: CachePluginModule*) extends Ca
 
   @Singleton
   @Provides
-  def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
-    new UserExperimentCache(stats, accessLog, (outerRepo, 7 days))
+  def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserExperimentCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/search/app/com/keepit/common/cache/SearchCacheModule.scala
+++ b/kifi-backend/modules/search/app/com/keepit/common/cache/SearchCacheModule.scala
@@ -67,8 +67,8 @@ case class SearchCacheModule(cachePluginModules: CachePluginModule*) extends Cac
 
   @Singleton
   @Provides
-  def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
-    new UserExperimentCache(stats, accessLog, (outerRepo, 7 days))
+  def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserExperimentCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
 
   @Singleton
   @Provides
@@ -83,7 +83,7 @@ case class SearchCacheModule(cachePluginModules: CachePluginModule*) extends Cac
   @Singleton
   @Provides
   def activeExperimentsCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new ActiveExperimentsCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 7 days))
+    new ActiveExperimentsCache(stats, accessLog, (outerRepo, 7 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/search/test/com/keepit/search/SearchConfigTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/SearchConfigTest.scala
@@ -47,6 +47,7 @@ class SearchConfigTest extends Specification with TestInjector {
           ), weight = 0.5, state = SearchConfigExperimentStates.ACTIVE
         )))
 
+        searchConfigManager.syncActiveExperiments
         val (c1, e1) = searchConfigManager.getConfig(andrew.id.get, "andrew conner")
         val (c2, e2) = searchConfigManager.getConfig(andrew.id.get, "Andrew  Conner")
         c1 === c2
@@ -82,6 +83,7 @@ class SearchConfigTest extends Specification with TestInjector {
         ), weight = 1000, state = SearchConfigExperimentStates.ACTIVE
         ))
 
+        searchConfigManager.syncActiveExperiments
         val (c1, _) = searchConfigManager.getConfig(andrew.id.get, "andrew conner")
         val (c2, _) = searchConfigManager.getConfig(andrew.id.get, "software engineer")
         val (c3, _) = searchConfigManager.getConfig(andrew.id.get, "fortytwo inc")
@@ -105,12 +107,14 @@ class SearchConfigTest extends Specification with TestInjector {
         ), weight = 1, state = SearchConfigExperimentStates.ACTIVE
         )))
 
+        searchConfigManager.syncActiveExperiments
         val (c1, _) = searchConfigManager.getConfig(greg.id.get, "turtles")
         c1.asInt("percentMatch") === 700
         c1.asDouble("phraseBoost") === 500.0
 
         fakeShoeboxServiceClient.saveExperiment(ex.withState(SearchConfigExperimentStates.INACTIVE))
 
+        searchConfigManager.syncActiveExperiments
         val (c2, _) = searchConfigManager.getConfig(greg.id.get, "turtles")
         c2.asInt("percentMatch") !== 700
         c2.asDouble("phraseBoost") !== 500.0
@@ -129,6 +133,7 @@ class SearchConfigTest extends Specification with TestInjector {
         ), weight = 1, state = SearchConfigExperimentStates.ACTIVE
         ))
 
+        searchConfigManager.syncActiveExperiments
         val (c1, _) = searchConfigManager.getConfig(greg.id.get, "turtles")
         c1.asInt("percentMatch") === 9000
         c1.asDouble("phraseBoost") === 10000.0

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -104,8 +104,8 @@ ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends CacheModule(c
 
   @Singleton
   @Provides
-  def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
-    new UserExperimentCache(stats, accessLog, (outerRepo, 7 days))
+  def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserExperimentCache(stats, accessLog, (innerRepo, 1 minutes), (outerRepo, 7 days))
 
   @Singleton
   @Provides


### PR DESCRIPTION
in-mem cache ttls are
- 10 min. for search/eliza/heimdal/abook
- 1 min. for shoebox (I made this short for now since showbox deals with admin)
