### PR TITLE
Escape name and email into db

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/User.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/User.scala
@@ -43,6 +43,9 @@ object User {
     (__ \ 'pictureName).formatNullable[String] and
     (__ \ 'userPictureId).formatNullable[Id[UserPicture]]
   )(User.apply, unlift(User.unapply))
+
+  val brackets = "[<>]".r
+  def stripBadChars(str: String) = brackets.replaceAllIn(str, "")
 }
 
 case class UserExternalIdKey(externalId: ExternalId[User]) extends Key[User] {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -232,9 +232,9 @@ class AuthController @Inject() (
       case (None, Some(identity)) =>
         // No user exists, so is social
         Ok(views.html.signup.finalizeSocial(
-          firstName = identity.firstName,
-          lastName = identity.lastName,
-          email = identity.email.getOrElse(""),
+          firstName = xml.Utility.escape(identity.firstName),
+          lastName = xml.Utility.escape(identity.lastName),
+          email = xml.Utility.escape(identity.email.getOrElse("")),
           picturePath = identity.avatarUrl.getOrElse("")
         ))
       case (None, None) =>
@@ -332,10 +332,10 @@ class AuthController @Inject() (
       userId = userIdOpt,
       socialUser = SocialUser(
         identityId = IdentityId(email, SocialNetworks.FORTYTWO.authProvider),
-        firstName = if (isComplete || firstName.nonEmpty) firstName else email,
-        lastName = lastName,
-        fullName = s"$firstName $lastName",
-        email = Some(email),
+        firstName = xml.Utility.escape(if (isComplete || firstName.nonEmpty) firstName else email),
+        lastName = xml.Utility.escape(lastName),
+        fullName = xml.Utility.escape(s"$firstName $lastName"),
+        email = Some(xml.Utility.escape(email)),
         avatarUrl = GravatarHelper.avatarFor(email),
         authMethod = AuthenticationMethod.UserPassword,
         passwordInfo = Some(passwordInfo)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -217,9 +217,9 @@ class AuthController @Inject() (
       case (None, Some(identity)) =>
         // No user exists, so is social
         Ok(views.html.signup.finalizeSocial(
-          firstName = xml.Utility.escape(identity.firstName),
-          lastName = xml.Utility.escape(identity.lastName),
-          email = xml.Utility.escape(identity.email.getOrElse("")),
+          firstName = User.stripBadChars(identity.firstName),
+          lastName = User.stripBadChars(identity.lastName),
+          email = identity.email.getOrElse(""),
           picturePath = identity.avatarUrl.getOrElse("")
         ))
       case (None, None) =>
@@ -309,9 +309,6 @@ class AuthController @Inject() (
 
   private val url = current.configuration.getString("application.baseUrl").get
 
-  @inline private def stripBadChars(str: String) =
-    str.filterNot("<>" contains _)
-
   private def saveUserPasswordIdentity(userIdOpt: Option[Id[User]], identityOpt: Option[Identity],
       email: String, passwordInfo: PasswordInfo,
       firstName: String = "", lastName: String = "", isComplete: Boolean = true): UserIdentity = {
@@ -319,9 +316,9 @@ class AuthController @Inject() (
       userId = userIdOpt,
       socialUser = SocialUser(
         identityId = IdentityId(email, SocialNetworks.FORTYTWO.authProvider),
-        firstName = stripBadChars(if (isComplete || firstName.nonEmpty) firstName else email),
-        lastName = stripBadChars(lastName),
-        fullName = stripBadChars(s"$firstName $lastName"),
+        firstName = User.stripBadChars(if (isComplete || firstName.nonEmpty) firstName else email),
+        lastName = User.stripBadChars(lastName),
+        fullName = User.stripBadChars(s"$firstName $lastName"),
         email = Some(email),
         avatarUrl = GravatarHelper.avatarFor(email),
         authMethod = AuthenticationMethod.UserPassword,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -183,14 +183,17 @@ class UserController @Inject() (
       firstName: Option[String] = None, lastName: Option[String] = None)
   private implicit val updatableUserDataFormat = Json.format[UpdatableUserInfo]
 
+  @inline private def stripBadChars(str: String) =
+    str.filterNot("<>" contains _)
+
   def updateCurrentUser() = AuthenticatedJsonToJsonAction(true) { implicit request =>
     request.body.asOpt[UpdatableUserInfo] map { userData =>
       db.readWrite { implicit session =>
         userData.description foreach { userValueRepo.setValue(request.userId, "user_description", _) }
         if (userData.firstName.isDefined || userData.lastName.isDefined) {
           val user = userRepo.get(request.userId)
-          val cleanFirst = xml.Utility.escape(userData.firstName getOrElse user.firstName)
-          val cleanLast = xml.Utility.escape(userData.lastName getOrElse user.lastName)
+          val cleanFirst = stripBadChars(userData.firstName getOrElse user.firstName)
+          val cleanLast = stripBadChars(userData.lastName getOrElse user.lastName)
           userRepo.save(user.copy(
             firstName = cleanFirst,
             lastName = cleanLast

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -189,6 +189,8 @@ class UserController @Inject() (
         userData.description foreach { userValueRepo.setValue(request.userId, "user_description", _) }
         if (userData.firstName.isDefined || userData.lastName.isDefined) {
           val user = userRepo.get(request.userId)
+          val cleanFirst = xml.Utility.escape(userData.firstName getOrElse user.firstName)
+          val cleanLast = xml.Utility.escape(userData.lastName getOrElse user.lastName)
           userRepo.save(user.copy(
             firstName = userData.firstName getOrElse user.firstName,
             lastName = userData.lastName getOrElse user.lastName

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -192,8 +192,8 @@ class UserController @Inject() (
           val cleanFirst = xml.Utility.escape(userData.firstName getOrElse user.firstName)
           val cleanLast = xml.Utility.escape(userData.lastName getOrElse user.lastName)
           userRepo.save(user.copy(
-            firstName = userData.firstName getOrElse user.firstName,
-            lastName = userData.lastName getOrElse user.lastName
+            firstName = cleanFirst,
+            lastName = cleanLast
           ))
         }
         for (emails <- userData.emails) {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -192,8 +192,8 @@ class UserController @Inject() (
         userData.description foreach { userValueRepo.setValue(request.userId, "user_description", _) }
         if (userData.firstName.isDefined || userData.lastName.isDefined) {
           val user = userRepo.get(request.userId)
-          val cleanFirst = stripBadChars(userData.firstName getOrElse user.firstName)
-          val cleanLast = stripBadChars(userData.lastName getOrElse user.lastName)
+          val cleanFirst = User.stripBadChars(userData.firstName getOrElse user.firstName)
+          val cleanLast = User.stripBadChars(userData.lastName getOrElse user.lastName)
           userRepo.save(user.copy(
             firstName = cleanFirst,
             lastName = cleanLast


### PR DESCRIPTION
@2is10 @joonho1101 These are the two places we accept user input for names. It's probably best we escape these (even if we make it standard to use client-side escaping). Thoughts?
