### PR TITLE
avoiding hairline font-weight on small fonts b/c unreadable in Max OS X 10.7.x

### DIFF
--- a/packrat/styles/keeper/message_mute.css
+++ b/packrat/styles/keeper/message_mute.css
@@ -28,8 +28,8 @@
 }
 .kifi-message-mute-option-description {
   font-size: 13px;
-  font-weight: 100;
-  letter-spacing: .4px;
+  font-weight: 200;
+  -webkit-font-smoothing: antialiased;
   margin-top: 4px;
 }
 .kifi-message-header-muted {

--- a/packrat/styles/keeper/message_mute.less
+++ b/packrat/styles/keeper/message_mute.less
@@ -42,8 +42,8 @@
 
 .kifi-message-mute-option-description {
   font-size: 13px;
-  font-weight: 100;
-  letter-spacing: .4px;
+  font-weight: 200;
+  -webkit-font-smoothing: antialiased;
   margin-top: 4px;
 }
 

--- a/packrat/styles/keeper/message_participants.css
+++ b/packrat/styles/keeper/message_participants.css
@@ -289,15 +289,15 @@
   display: block;
 }
 .kifi-message-participant-dialog-title {
-  font-weight: 100;
-  letter-spacing: .5px;
+  font-weight: 200;
+  -webkit-font-smoothing: antialiased;
   margin-bottom: 6px;
 }
 .kifi-message-participant-dialog-button {
   float: right;
   font-size: 13px;
-  font-weight: 100;
-  letter-spacing: .5px;
+  font-weight: 200;
+  -webkit-font-smoothing: antialiased;
   padding: 7px 16px;
   border-radius: 2px;
   margin-top: 8px;

--- a/packrat/styles/keeper/message_participants.less
+++ b/packrat/styles/keeper/message_participants.less
@@ -350,16 +350,16 @@
 }
 
 .kifi-message-participant-dialog-title {
-  font-weight: 100;
-  letter-spacing: .5px;
+  font-weight: 200;
+  -webkit-font-smoothing: antialiased;
   margin-bottom: 6px;
 }
 
 .kifi-message-participant-dialog-button {
   float: right;
   font-size: 13px;
-  font-weight: 100;
-  letter-spacing: .5px;
+  font-weight: 200;
+  -webkit-font-smoothing: antialiased;
   padding: 7px 16px;
   border-radius: 2px;
   margin-top: 8px;


### PR DESCRIPTION
cc @joonho1101 

See Jenny’s computer for an example. The text looks gray instead of white and almost disappears entirely into the background. `font-weight: 100` is really only safe for large font sizes, like, say, 36px and up.
