### PR TITLE
indicating when an account is already finalized instead of the reverse

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -163,10 +163,10 @@ class AuthController @Inject() (
               Authenticator.create(identity).fold(
                 error => Status(500)("0"),
                 authenticator => {
-                  val needsToFinalize = db.readOnly { implicit session =>
-                    userRepo.get(sui.userId.get).state == UserStates.INCOMPLETE_SIGNUP
+                  val finalized = db.readOnly { implicit session =>
+                    userRepo.get(sui.userId.get).state != UserStates.INCOMPLETE_SIGNUP
                   }
-                  Ok(Json.obj("success"-> true, "email" -> email, "new_account" -> false, "needsToFinalize" -> needsToFinalize))
+                  Ok(Json.obj("success"-> true, "email" -> email, "new_account" -> false, "finalized" -> finalized))
                     .withNewSession
                     .withCookies(authenticator.toCookie)
                 }

--- a/kifi-backend/modules/shoebox/public/js/auth.js
+++ b/kifi-backend/modules/shoebox/public/js/auth.js
@@ -120,7 +120,7 @@
         email: email,
         password: password
       }).done(function(data) {
-        if (data.needsToFinalize) {
+        if (!data.finalized) {
           transitionTitle($('.signup-2').data('title'));
           $('body').addClass('finalizing droppable');
           setTimeout(function () {


### PR DESCRIPTION
@andrewconner 
This fixes an issue where the JS code was incorrectly assuming the account was already finalized because the server was not responding with `"needsToFinalize": true` (see the alternate response formatting code path a little further down at AuthController.scala:183).
