### PR TITLE
You can log in with a verified email address that is not your SUI email.

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/social/providers/UsernamePasswordProvider.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/providers/UsernamePasswordProvider.scala
@@ -23,7 +23,8 @@ class UsernamePasswordProvider(application: Application)
               hasher <- Registry.hashers.get(pinfo.hasher) if hasher.matches(pinfo, credentials._2)
             } yield Right(SocialUser(identity))
             result getOrElse Left(error(request, "wrong_password", "Wrong password."))
-          case None => Left(error(request, "no_such_user", "No user with that email address exists."))
+          case None =>
+            Left(error(request, "no_such_user", "No user with that email address exists."))
         }
       }
     )

--- a/kifi-backend/modules/shoebox/app/com/keepit/social/ProdShoeboxSecureSocialModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/social/ProdShoeboxSecureSocialModule.scala
@@ -9,6 +9,7 @@ import com.keepit.common.healthcheck.{AirbrakeNotifier, AirbrakeError}
 import com.keepit.common.store.S3ImageStore
 import com.keepit.common.controller.{ShoeboxActionAuthenticator, ActionAuthenticator}
 import com.keepit.heimdal.{HeimdalServiceClient, UserEventContextBuilderFactory}
+import com.keepit.common.time.Clock
 
 
 trait ShoeboxSecureSocialModule extends SecureSocialModule {
@@ -40,9 +41,10 @@ trait ShoeboxSecureSocialModule extends SecureSocialModule {
     emailRepo: EmailAddressRepo,
     socialGraphPlugin: SocialGraphPlugin,
     userEventContextBuilder: UserEventContextBuilderFactory,
-    heimdal: HeimdalServiceClient
+    heimdal: HeimdalServiceClient,
+    clock: Clock
   ): SecureSocialUserPlugin = new SecureSocialUserPluginImpl(
-    db, socialUserInfoRepo, userRepo, userCredRepo, imageStore, airbrake, emailRepo, socialGraphPlugin, userEventContextBuilder, heimdal
+    db, socialUserInfoRepo, userRepo, userCredRepo, imageStore, airbrake, emailRepo, socialGraphPlugin, userEventContextBuilder, heimdal, clock
   )
 }
 


### PR DESCRIPTION
We have a slight architectural problem where the (email) login details of a user are stored (in `SocialUserInfo`) by the email address (text). So the login email address is static, and may _not_ be their preferred / active Kifi email address. This change lets users log in with any verified email address associated with their account.
