### PR TITLE
fixing esc key to close a message thread

### DIFF
--- a/packrat/scripts/message_header.js
+++ b/packrat/scripts/message_header.js
@@ -46,28 +46,22 @@ var messageHeader = this.messageHeader = (function ($, win) {
 
 		participants: null,
 
-		prevEscHandler: null,
+		escHandler: null,
 
 		onDocClick: null,
 
 		/**
-		 * Renders and initializes a message header box if not already.
+		 * Renders and initializes a message header box.
 		 */
-		construct: function ($parent, threadId, participants) {
-			if (!this.initialized) {
-				this.threadId = threadId;
-				this.participants = participants;
-				this.constructPlugins();
-				this.init($parent);
+		init: function ($parent, threadId, participants) {
+			if (this.initialized) {
+				this.destroy();
 			}
-		},
-
-		/**
-		 * Renders and initializes a Message Header.
-		 */
-		init: function ($parent) {
+			this.threadId = threadId;
+			this.participants = participants;
 			this.initialized = true;
 			this.status = {};
+			this.claimPlugins();
 			this.$el = $(this.render()).appendTo($parent);
 			this.initPlugins();
 			this.initEvents();
@@ -86,9 +80,8 @@ var messageHeader = this.messageHeader = (function ($, win) {
 
 			function addDocListeners() {
 				if (this.initialized) {
-					var $doc = $(document);
-					this.prevEscHandler = $doc.data('esc');
-					$doc.data('esc', this.handleEsc.bind(this));
+					this.escHandler = this.handleEsc.bind(this);
+					$(document).data('esc').add(this.escHandler);
 
 					var onDocClick = this.onDocClick = onClick.bind(this);
 					document.addEventListener('click', onDocClick, true);
@@ -143,13 +136,8 @@ var messageHeader = this.messageHeader = (function ($, win) {
 
 		handleEsc: function (e) {
 			if (this.isOptionExpanded()) {
-				e.preventDefault();
-				e.stopPropagation();
-				e.stopImmediatePropagation();
 				this.hideOptions();
-			}
-			else if (this.prevEscHandler) {
-				this.prevEscHandler.call(e.target, e);
+				return false;
 			}
 		},
 
@@ -158,15 +146,17 @@ var messageHeader = this.messageHeader = (function ($, win) {
 		 * It removes all event listeners and caches to elements.
 		 */
 		destroy: function () {
+			log('[message_header:destroy]', this.initialized, this.threadId)();
 			if (this.initialized) {
 				this.initialized = false;
+				this.threadId = null;
 
 				this.unshadePane();
 
 				this.destroyPlugins();
 
-				$(document).data('esc', this.prevEscHandler);
-				this.prevEscHandler = null;
+				$(document).data('esc').remove(this.escHandler);
+				this.escHandler = null;
 
 				var onDocClick = this.onDocClick;
 				if (onDocClick) {
@@ -174,16 +164,11 @@ var messageHeader = this.messageHeader = (function ($, win) {
 					this.onDocClick = null;
 				}
 
-				'$el'.split(',').forEach(function (name) {
-					var $el = this[name];
-					if ($el) {
-						$el.remove();
-						this[name] = null;
-					}
-				}, this);
+				// this.$el.remove() not called because it would disrupt a farewell transition
+				// parent should call it later (e.g. by being removed itself)
 
 				this.status = null;
-				this.$pane = null;
+				this.$el = null;
 				this.participants = null;
 			}
 		},
@@ -246,10 +231,9 @@ var messageHeader = this.messageHeader = (function ($, win) {
 			});
 		},
 
-		constructPlugins: function () {
+		claimPlugins: function () {
 			this.plugins.forEach(function (plugin) {
 				plugin.parent = this;
-				plugin.construct();
 			}, this);
 		},
 
@@ -261,15 +245,15 @@ var messageHeader = this.messageHeader = (function ($, win) {
 		},
 
 		initPlugins: function () {
-			return this.plugins.map(function (plugin) {
+			this.plugins.forEach(function (plugin) {
 				plugin.init();
 			});
 		},
 
 		destroyPlugins: function () {
 			this.plugins.forEach(function (plugin) {
-				return plugin.destroy();
-			}, this);
+				plugin.destroy();
+			});
 		}
 	};
 

--- a/packrat/scripts/message_muter.js
+++ b/packrat/scripts/message_muter.js
@@ -19,16 +19,14 @@ var messageMuter = this.messageMuter = (function ($, win) {
 
 	var kifiUtil = win.kifiUtil;
 
-	api.port.on({
+	var portHandlers = {
 		muted: function (muted) {
-			if (messageMuter.initialized) {
-				messageMuter.updateMuted(muted);
-			}
+			messageMuter.updateMuted(muted);
 		}
-	});
+	};
 
 	api.onEnd.push(function () {
-		messageMuter.destroy('api:onEnd');
+		messageMuter.destroy();
 		messageMuter = win.messageMuter = null;
 	});
 
@@ -49,19 +47,12 @@ var messageMuter = this.messageMuter = (function ($, win) {
 		parent: null,
 
 		/**
-		 * A constructor of Message Muter
-		 *
-		 * @constructor
-		 *
-		 * @param {string} trigger - A triggering user action
-		 */
-		construct: function (trigger) {},
-
-		/**
 		 * Initializes a Message Muter.
 		 */
 		init: function () {
 			this.initialized = true;
+
+			api.port.on(portHandlers);
 
 			this.initEvents();
 
@@ -73,11 +64,10 @@ var messageMuter = this.messageMuter = (function ($, win) {
 		 * Initializes event listeners.
 		 */
 		initEvents: function () {
-			var $parent = this.getParent$();
-			$parent.on('click', '.kifi-message-header-unmute-button', this.unmute.bind(this));
-
-			$parent.on('click', '.kifi-message-mute-option-mute', this.mute.bind(this));
-			$parent.on('click', '.kifi-message-mute-option-unmute', this.unmute.bind(this));
+			this.parent.$el
+				.on('click', '.kifi-message-header-unmute-button', this.unmute.bind(this))
+				.on('click', '.kifi-message-mute-option-mute', this.mute.bind(this))
+				.on('click', '.kifi-message-mute-option-unmute', this.unmute.bind(this));
 		},
 
 		/**
@@ -172,35 +162,12 @@ var messageMuter = this.messageMuter = (function ($, win) {
 		},
 
 		/**
-		 * Returns a jQuery wrapper object for the parent module.
-		 *
-		 * @return {jQuery} A jQuery wrapper object
-		 */
-		getParent$: function () {
-			return this.parent.$el;
-		},
-
-		/**
-		 * Destroys a tag box.
 		 * It removes all event listeners and caches to elements.
 		 */
 		destroy: function () {
-			if (this.initialized) {
-				this.initialized = false;
-				this.parent = null;
-
-				if (win.slider2) {
-					win.slider2.unshadePane();
-				}
-
-				['$input', '$list', '$el'].forEach(function (name) {
-					var $el = this[name];
-					if ($el) {
-						$el.remove();
-						this[name] = null;
-					}
-				}, this);
-			}
+			this.initialized = false;
+			this.parent = null;
+			api.port.off(portHandlers);
 		}
 	};
 

--- a/packrat/scripts/snapshot.js
+++ b/packrat/scripts/snapshot.js
@@ -154,7 +154,7 @@ var snapshot = function () {
           .draggable({cursor: "move", distance: 10, handle: ".kifi-snapshot-bar", scroll: false})
           .on("click", ".kifi-snapshot-cancel", exitSnapshotMode)
           .add($shades).css("opacity", 0).animate({opacity: 1}, 300);
-        $(document).data("esc", exitSnapshotMode);
+        $(document).data('esc').add(exitSnapshotMode);
       });
     });
     $(window).scroll(function() {
@@ -169,7 +169,7 @@ var snapshot = function () {
         $(this).remove();
         document.body.classList.remove("kifi-snapshot-root");
       });
-      $(document).removeData("esc");
+      $(document).data('esc').remove(exitSnapshotMode);
       setTimeout(onExit.bind(null, selector));
     }
     function updateSelection(clientX, clientY, scrollLeft, scrollTop) {

--- a/packrat/scripts/tagbox.js
+++ b/packrat/scripts/tagbox.js
@@ -223,9 +223,8 @@ this.tagbox = (function ($, win) {
 
 			function addDocListeners() {
 				if (this.active) {
-					var $doc = $(document);
-					this.prevEscHandler = $doc.data('esc');
-					$doc.data('esc', this.handleEsc.bind(this));
+					this.escHandler = this.handleEsc.bind(this);
+					$(document).data('esc').add(this.escHandler);
 
 					var onDocClick = this.onDocClick = onClick.bind(this);
 					document.addEventListener('click', onDocClick, true);
@@ -278,7 +277,6 @@ this.tagbox = (function ($, win) {
 			var KEY_UP = 38,
 				KEY_DOWN = 40,
 				KEY_ENTER = 13,
-				KEY_ESC = 27,
 				KEY_TAB = 9;
 
 			function onInput(e) {
@@ -294,34 +292,25 @@ this.tagbox = (function ($, win) {
 			}
 
 			function onKeydown(e) {
-				var preventDefault = false;
 				if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) {
-					// not handling any special keys
 					return;
 				}
 
 				switch (e.which) {
 				case KEY_UP:
 					this.navigate('up');
-					preventDefault = true;
+					e.preventDefault();
 					break;
 				case KEY_DOWN:
 					this.navigate('down');
-					preventDefault = true;
+					e.preventDefault();
 					break;
 				case KEY_ENTER:
 				case KEY_TAB:
 					this.select(null, 'key:' + (e.which === KEY_ENTER ? 'enter' : 'tab'));
 					this.setInputValue();
-					preventDefault = true;
-					break;
-				case KEY_ESC:
-					this.handleEsc(e);
-					return;
-				}
-
-				if (preventDefault) {
 					e.preventDefault();
+					break;
 				}
 			}
 
@@ -334,10 +323,7 @@ this.tagbox = (function ($, win) {
 			};
 		})(),
 
-		handleEsc: function (e) {
-			e.preventDefault();
-			e.stopPropagation();
-			e.stopImmediatePropagation();
+		handleEsc: function () {
 			log('esc');
 
 			if (this.currentSuggestion) {
@@ -346,6 +332,7 @@ this.tagbox = (function ($, win) {
 			else {
 				this.hide('key:esc');
 			}
+			return false;
 		},
 
 		/**
@@ -488,8 +475,8 @@ this.tagbox = (function ($, win) {
 					}
 				}, this);
 
-				$(document).data('esc', this.prevEscHandler);
-				this.prevEscHandler = null;
+				$(document).data('esc').remove(this.escHandler);
+				this.escHandler = null;
 
 				var onDocClick = this.onDocClick;
 				if (onDocClick) {

--- a/packrat/scripts/thread.js
+++ b/packrat/scripts/thread.js
@@ -32,7 +32,7 @@ panes.thread = function () {
         renderThread($container, th.id, th.messages, session);
         api.port.emit('participants', th.id, function (participants) {
           var $who = $container.closest('.kifi-pane-box').find('.kifi-thread-who');
-          window.messageHeader.construct($who, th.id, participants);
+          window.messageHeader.init($who, th.id, participants);
           $container.css('margin-top', $who.outerHeight());
         });
         api.port.on(handlers);
@@ -78,6 +78,7 @@ panes.thread = function () {
 
     $container.closest('.kifi-pane-box').on('kifi:remove', function () {
       if ($holder.length && this.contains($holder[0])) {
+        window.messageHeader.destroy();
         $holder = $();
         $(window).off('resize.thread');
         api.port.off(handlers);


### PR DESCRIPTION
cc @joonho1101 

Note that this changes the lifecycle of the `messageHeader` component a bit. Now `.destroy()` is called when the thread pane is removed from the page (the `kifi:remove` event) or when `.init(...)` is called for the next thread pane, whichever comes first.

Also, we no longer need to check whether a component is initialized before handling a message from the main extension because now we only listen to messages while initialized.
