### PR TITLE
2.6.40: splitting the kifi pane out into its own script

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.6.39
+version=2.6.40

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -6,8 +6,7 @@ function logEvent() {  // parameters defined in main.js
   api.port.emit("log_event", Array.prototype.slice.call(arguments));
 }
 
-var session,
-  tags = [];
+var session, tags = [];
 var tile = tile || function() {  // idempotent for Chrome
   'use strict';
   log("[keeper_scout]", location.hostname)();
@@ -23,10 +22,10 @@ var tile = tile || function() {  // idempotent for Chrome
   api.port.on({
     session_change: onSessionChange,
     open_to: function(o) {
-      keeper("showPane", o.trigger, o.locator, o.redirected);
+      loadAndDo('pane', 'show', o.trigger, o.locator, o.redirected);
     },
-    button_click: keeper.bind(null, "togglePane", "button"),
-    auto_show: keeper.bind(null, "show", "auto"),
+    button_click: loadAndDo.bind(null, 'pane', 'toggle', 'button'),
+    auto_show: loadAndDo.bind(null, 'slider2', 'show', 'auto'),
     init: function(o) {
       var pos = o.position;
       if (pos) {
@@ -59,7 +58,7 @@ var tile = tile || function() {  // idempotent for Chrome
       }
     },
     keepers: function(o) {
-      setTimeout(keeper.bind(null, "showKeepers", o.keepers, o.otherKeeps), 3000);
+      setTimeout(loadAndDo.bind(null, 'slider2', 'showKeepers', o.keepers, o.otherKeeps), 3000);
     },
     counts: function(counts) {
       tile && updateCounts(counts);
@@ -77,7 +76,7 @@ var tile = tile || function() {  // idempotent for Chrome
             log("[onScroll]", Math.round(hSeen / hPage * 10000) / 100, ">", r[1], "% and", hPage, ">", r[0] * hViewport, "?")();
             if (hPage > r[0] * hViewport && hSeen > (r[1] / 100) * hPage) {
               log("[onScroll] showing")();
-              keeper("show", "scroll");
+              loadAndDo('slider2', 'show', 'scroll');
             }
           }
         });
@@ -108,11 +107,11 @@ var tile = tile || function() {  // idempotent for Chrome
         e.preventDefault();
         break;
       case 77: // m
-        keeper("togglePane", "key", "/messages");
+        loadAndDo('pane', 'toggle', 'key', '/messages');
         e.preventDefault();
         break;
       case 79: // o
-        keeper("togglePane", "key", "/notices");
+        loadAndDo('pane', 'toggle', 'key', '/notices');
         e.preventDefault();
         break;
       }
@@ -136,20 +135,22 @@ var tile = tile || function() {  // idempotent for Chrome
     });
   }
 
-  function keeper() {  // gateway to slider2.js
-    var args = Array.prototype.slice.apply(arguments);
+  function loadAndDo(name, methodName) {  // gateway to slider2.js
     if (session === undefined) {  // not yet initialized
+      var args = Array.prototype.slice.call(arguments);
       args.unshift(null);
-      whenSessionKnown.push(Function.bind.apply(keeper, args));
+      whenSessionKnown.push(Function.bind.apply(loadAndDo, args));
     } else if (!session) {
       toggleLoginDialog();
     } else {
-      api.require("scripts/slider2.js", function() {
-        if (onScroll && name != "showKeepers") {
-          document.removeEventListener("scroll", onScroll);
+      var args = Array.prototype.slice.call(arguments, 2);
+      api.require('scripts/' + name + '.js', function() {
+        if (onScroll && name !== 'showKeepers') {
+          document.removeEventListener('scroll', onScroll);
           onScroll = null;
         }
-        slider2[args.shift()].apply(slider2, args);
+        var o = window[name];
+        o[methodName].apply(o, args);
       });
     }
   }
@@ -184,7 +185,7 @@ var tile = tile || function() {  // idempotent for Chrome
   tile["kifi:position"] = positionTile;
   tile.addEventListener("mouseover", function(e) {
     if (e.target === tileCount || tileCard.contains(e.target)) {
-      keeper("show", "tile");
+      loadAndDo('slider2', 'show', 'tile');
     }
   });
 
@@ -194,7 +195,7 @@ var tile = tile || function() {  // idempotent for Chrome
   document.addEventListener("keydown", onKeyDown, true);
 
   function onResize() {
-    if (document.documentElement.classList.contains("kifi-with-pane")) return;
+    if (paneCall('showing')) return;
     clearTimeout(onResize.t);  // throttling tile repositioning
     onResize.t = setTimeout(positionTile, 50);
   }
@@ -228,8 +229,13 @@ var tile = tile || function() {  // idempotent for Chrome
         tile.remove();
       }
     }
-    if (window.slider2) {
-      slider2.hidePane();
+    paneCall('hide');
+  }
+
+  function paneCall(methodName) {
+    var pane = window.pane;
+    if (pane) {
+      return pane[methodName]();
     }
   }
 

--- a/packrat/scripts/message_header.js
+++ b/packrat/scripts/message_header.js
@@ -109,16 +109,16 @@ var messageHeader = this.messageHeader = (function ($, win) {
 		},
 
 		shadePane: function () {
-			if (win.slider2) {
+			if (win.pane) {
 				this.$el.closest('.kifi-thread-who').addClass('kifi-active');
-				win.slider2.shadePane();
+				win.pane.shade();
 			}
 		},
 
 		unshadePane: function () {
-			if (win.slider2) {
+			if (win.pane) {
 				this.$el.closest('.kifi-thread-who').removeClass('kifi-active');
-				win.slider2.unshadePane();
+				win.pane.unshade();
 			}
 		},
 

--- a/packrat/scripts/pane.js
+++ b/packrat/scripts/pane.js
@@ -1,0 +1,344 @@
+// @require styles/keeper/pane.css
+// @require scripts/slider2.js
+// @require scripts/html/keeper/pane.js
+// @require scripts/html/keeper/pane_notices.js
+// @require scripts/html/keeper/pane_threads.js
+// @require scripts/html/keeper/pane_thread.js
+
+$.fn.scrollToBottom = function () {
+  'use strict';
+  return this.each(function () {
+    var cH = this.clientHeight, sH = this.scrollHeight;
+    if (cH < sH) {
+      var sT = this.scrollTop, d = sH - sT - cH;
+      if (d > 0) {
+        $(this).animate({scrollTop: sT + d}, 40 * Math.log(d));
+      }
+    }
+  });
+};
+
+var panes = panes || {};  // idempotent for Chrome
+
+var pane = pane || function () {  // idempotent for Chrome
+  'use strict';
+  var $pane, paneHistory;
+
+  $(document).data('esc').add(function (e) {
+    if ($pane) {
+      hidePane();
+      return false;
+    }
+  });
+
+  api.onEnd.push(function () {
+    log('[pane:onEnd]')();
+    $pane && $pane.remove();
+    $('html').removeClass('kifi-with-pane kifi-pane-parent');
+  });
+
+  function toPaneName(locator) {
+    var name = locator.match(/[a-z]+\/?/)[0];
+    return {messages: "threads", "messages/": "thread"}[name] || name;
+  }
+
+  var paneIdxs = ["notices","threads","thread"];
+  function toPaneIdx(name) {
+    return paneIdxs.indexOf(name);
+  }
+
+  var createPaneParams = {
+    thread: function (cb, locator, participants) {
+      if (participants) {
+        respond(participants);
+      } else {
+        var id = locator.substr(10);
+        log("[createPaneParams.thread] need participants", id)();
+        api.port.emit("participants", id, respond);
+      }
+      function respond(p) {
+        cb({participants: p, numParticipants: p.length > 1 ? p.length : null});
+      }
+    }};
+
+  function showPane(locator, back, paramsArg, redirected) {
+    log("[showPane]", locator, back ? "back" : "")();
+    if (locator !== (paneHistory && paneHistory[0])) {
+      var name = toPaneName(locator);
+      (createPaneParams[name] || function (cb) {cb({backButton: paneHistory && paneHistory[back ? 2 : 0]})})(function (params) {
+        params.redirected = redirected;
+        showPane2(locator, back, name, params);
+      }, locator, paramsArg);
+    }
+  }
+
+  function showPane2(locator, back, name, params) {  // only called by showPane
+    log("[showPane2]", locator, name)();
+    if ($pane) {
+      var left = back || toPaneIdx(name) < toPaneIdx(toPaneName(paneHistory[0]));
+      slider2.onPaneChange(locator);
+      var $cubby = $pane.find(".kifi-pane-cubby").css("overflow", "hidden");
+      var $cart = $cubby.find(".kifi-pane-box-cart").addClass(left ? "kifi-back" : "kifi-forward");
+      var $old = $cart.find(".kifi-pane-box");
+      var $new = $(render('html/keeper/pane_' + name, params))[left ? "prependTo" : "appendTo"]($cart).layout();
+      $cart.addClass("kifi-animated").layout().addClass("kifi-roll")
+      .on("transitionend", function end(e) {
+        if (e.target !== this) return;
+        if (!left) $cart.removeClass("kifi-animated kifi-back kifi-forward");
+        $old.triggerHandler("kifi:remove");
+        $old.remove();
+        $new.data("shown", true).triggerHandler("kifi:shown");
+        $cart.removeClass("kifi-roll kifi-animated kifi-back kifi-forward")
+          .off("transitionend", end);
+        $cubby.css("overflow", "");
+        window.dispatchEvent(new Event("resize"));  // for other page scripts
+      });
+      if (back) {
+        paneHistory.shift();
+        paneHistory[0] = locator;  // usually unnecessary (already the same)
+      } else {
+        paneHistory.unshift(locator);
+      }
+      api.port.emit("pane", {old: $pane[0].dataset.locator, new: locator});
+      $pane[0].dataset.locator = locator;
+      populatePane($new, name, locator);
+    } else {
+      paneHistory = [locator];
+      $('html').addClass('kifi-pane-parent');
+      $pane = $(render('html/keeper/pane',
+        $.extend(params, {
+          site: location.hostname,
+          user: session.user
+        }), {
+          pane: 'pane_' + name
+        }));
+      $pane[0].dataset.locator = locator;
+      api.port.emit("pane", {new: locator});
+      var bringSlider = !slider2.showing();
+      if (bringSlider) {
+        $pane.append(slider2.create(locator)).appendTo(tile.parentNode);
+      } else {
+        slider2.onPaneChange(locator);
+        $pane.insertBefore(tile);
+        $(tile).css("transform", "translate(0," + (window.innerHeight - tile.getBoundingClientRect().bottom) + "px)");
+      }
+      $pane.layout()
+      .on("transitionend", function onPaneShown(e) {
+        if (e.target !== this) return;
+        $pane.off("transitionend", onPaneShown);
+        if (bringSlider) {
+          tile.style.display = "block"; // in case sensitive
+        } else {
+          slider2.appendTo($pane);
+          $pane.before(tile);
+        }
+        $box.data("shown", true).triggerHandler("kifi:shown");
+      })
+      .hoverfu('.kifi-pane-head-logo', function(configureHover) {
+        configureHover({
+          mustHoverFor: 700, hideAfter: 2500, click: 'hide',
+          position: {my: 'center top+10', at: 'center bottom', of: this, collision: 'none'}
+        });
+      })
+      .hoverfu(".kifi-pane-head-feedback", function (configureHover) {
+        var btn = this;
+        render("html/keeper/titled_tip", {
+          dir: "below",
+          title: "Give Us Feedback",
+          html: "Tell us your ideas for Kifi<br>or report an issue."
+        }, function (html) {
+          configureHover(html, {
+            mustHoverFor: 700, hideAfter: 4000, click: "hide",
+            position: {my: 'center top+16', at: 'center bottom', of: btn, collision: 'none'}
+          });
+        });
+      })
+      .on("click", ".kifi-pane-head-feedback", function (e) {
+        e.preventDefault();
+        var width = 700;
+        var height = 400;
+        var left = (screen.width - width) / 2;
+        var top = (screen.height - height) / 2;
+        window.open(
+          "https://www.kifi.com/feedback/form",
+          "kifi-feedback",
+          "width="+width+",height="+height+",resizable,top="+top+",left="+left);
+      })
+      .hoverfu('.kifi-pane-head-settings:not(.kifi-active)', function (configureHover) {
+        var btn = this;
+        render("html/keeper/titled_tip", {
+          dir: "below",
+          cssClass: 'kifi-pane-head-settings-tip',
+          title: "Settings",
+          html: "Customize your Kifi<br>experience."
+        }, function (html) {
+          configureHover(html, {
+            mustHoverFor: 700, hideAfter: 3000, click: "hide",
+            position: {my: 'right top+10', at: 'right bottom', of: btn, collision: 'none'}
+          });
+        });
+      })
+      .on("mousedown", ".kifi-pane-head-settings", function (e) {
+        e.preventDefault();
+        var $sett = $(this).addClass("kifi-active");
+        var $menu = $sett.next(".kifi-pane-head-settings-menu").fadeIn(50);
+        var $hide = $menu.find(".kifi-pane-settings-hide")
+          .on("mouseenter", enterItem)
+          .on("mouseleave", leaveItem);
+        document.addEventListener("mousedown", docMouseDown, true);
+        $menu.on("kifi:hide", hide);
+        // .kifi-hover class needed because :hover does not work during drag
+        function enterItem() { $(this).addClass("kifi-hover"); }
+        function leaveItem() { $(this).removeClass("kifi-hover"); }
+        function docMouseDown(e) {
+          if (!$menu[0].contains(e.target)) {
+            $menu.triggerHandler("kifi:hide");
+            if ($sett[0] === e.target) {
+              e.stopPropagation();
+            }
+          }
+        }
+        function hide() {
+          document.removeEventListener("mousedown", docMouseDown, true);
+          $sett.removeClass("kifi-active");
+          $hide.off("mouseenter", enterItem)
+              .off("mouseleave", leaveItem);
+          $menu.off("kifi:hide", hide).fadeOut(50, function () {
+            $menu.find(".kifi-hover").removeClass("kifi-hover");
+          });
+        }
+        api.port.emit("get_suppressed", function (suppressed) {
+          $hide.toggleClass("kifi-checked", !!suppressed);
+        });
+      })
+      .on("mouseup", ".kifi-pane-settings-hide", function (e) {
+        e.preventDefault();
+        var $hide = $(this).toggleClass("kifi-checked");
+        var checked = $hide.hasClass("kifi-checked");
+        $(tile).toggle(!checked);
+        api.port.emit("suppress_on_site", checked);
+        setTimeout(function () {
+          if (checked) {
+            hidePane();
+          } else {
+            $hide.closest(".kifi-pane-head-settings-menu").triggerHandler("kifi:hide");
+          }
+        }, 150);
+      })
+      .on("mouseup", ".kifi-pane-settings-sign-out", function (e) {
+        e.preventDefault();
+        api.port.emit("deauthenticate");
+        $(tile).hide();
+        setTimeout(function () {
+          hidePane();
+          $('<kifi class="kifi-root kifi-signed-out-tooltip"><b>Logged out</b><br>To log back in to Kifi, click the <img class="kifi-signed-out-icon" src="' + api.url('images/keep.faint.png') + '"> button above.</kifi>')
+            .appendTo('body').delay(6000).fadeOut(1000, function () { $(this).remove(); });
+        }, 150);
+        return;
+      })
+      .on("keydown", ".kifi-pane-search", function (e) {
+        var q;
+        if (e.which == 13 && (q = this.value.trim())) {
+          this.value = '';
+          window.open('https://www.kifi.com/find?q=' + encodeURIComponent(q).replace(/%20/g, "+"));
+        }
+      })
+      .on("click", ".kifi-pane-back", function () {
+        var loc = paneHistory[1] || this.dataset.loc;
+        if (loc) {
+          showPane(loc, true);
+        }
+      })
+      .on("kifi:show-pane", function (e, loc, paramsArg) {
+        showPane(loc, false, paramsArg);
+      })
+      .on("mousedown click keydown keypress keyup", function (e) {
+        e.stopPropagation();
+      });
+      $("html").addClass("kifi-with-pane");
+      var $box = $pane.find(".kifi-pane-box");
+      populatePane($box, name, locator);
+    }
+  }
+
+  function hidePane(leaveSlider) {
+    log('[hidePane]', leaveSlider ? 'leaving slider' : '')();
+    if (leaveSlider) {
+      $(tile).css({top: "", bottom: "", transform: ""}).insertAfter($pane);
+      slider2.onPaneChange();
+      // $slider.find(".kifi-slider2-x").css("overflow", "");
+    } else {
+      $(tile).css("transform", "");
+      slider2.discard();
+    }
+    $pane
+    .off("transitionend") // onPaneShown
+    .on("transitionend", function (e) {
+      if (e.target === this) {
+        var $pane = $(this);
+        $pane.find(".kifi-pane-box").triggerHandler("kifi:remove");
+        $pane.remove();
+        $("html").removeClass("kifi-pane-parent");
+        window.dispatchEvent(new Event("resize"));  // for other page scripts
+      }
+    });
+    api.port.emit("pane", {old: $pane[0].dataset.locator});
+    $pane = paneHistory = null;
+    $("html").removeClass("kifi-with-pane");
+  }
+
+  function populatePane($box, name, locator) {
+    var $tall = $box.find(".kifi-pane-tall");
+    if (name == "thread") {
+      $tall.css("margin-top", $box.find(".kifi-thread-who").outerHeight());
+    }
+    api.require("scripts/" + name + ".js", function () {
+      panes[name].render($tall, locator);
+    });
+  };
+
+  // the pane API
+  return {
+    showing: function () {
+      return !!$pane;
+    },
+    show: function (trigger, locator, redirected) {
+      log("[pane.show]", trigger, locator, redirected || '')();
+      showPane(locator, false, null, redirected);
+    },
+    hide: function (leaveSlider) {
+      if ($pane) {
+        hidePane(leaveSlider);
+      }
+    },
+    toggle: function (trigger, locator) {
+      locator = locator || '/notices';
+      if ($pane) {
+        if (locator == paneHistory[0]) {
+          hidePane(trigger === 'keeper');
+        } else {
+          showPane(locator);
+        }
+      } else if (!$('html').hasClass('kifi-pane-parent')) { // ensure it's finished hiding
+        showPane(locator);
+      }
+    },
+    shade: function () {
+      if ($pane) {
+        $pane.addClass('kifi-shaded');
+      }
+    },
+    unshade: function () {
+      if ($pane) {
+        $pane.removeClass('kifi-shaded');
+      }
+    },
+    getLocator: function () {
+      return $pane && $pane[0].dataset.locator || null;
+    },
+    getThreadId: function () {
+      var locator = this.getLocator();
+      return locator && locator.split('/')[2];
+    }
+  };
+}();

--- a/packrat/scripts/tagbox.js
+++ b/packrat/scripts/tagbox.js
@@ -462,7 +462,9 @@ this.tagbox = (function ($, win) {
 			if (this.active) {
 				this.active = false;
 
-				win.slider2.unshadePane();
+				if (win.pane) {
+					win.pane.unshade();
+				}
 				$(win.tile).css('transform', '');
 
 				$(win).off('resize.kifi-tagbox-suggest', this.winResizeListener);
@@ -763,7 +765,9 @@ this.tagbox = (function ($, win) {
 		 */
 		setLoaded: function () {
 			this.removeClass('kifi-loading');
-			win.slider2.shadePane();
+			if (win.pane) {
+				win.pane.shade();
+			}
 		},
 
 		/**


### PR DESCRIPTION
This is mostly code movement from slider2.js to pane.js, plus the definition of simple APIs between them.

This has long been needed from a code organization standpoint, but I think it will also make it easier to work on the new pane design.

Also rendering both the keeper and the pane synchronously now.
