### PR TITLE
factoring out height maintenance of pane content from compose.js

### DIFF
--- a/packrat/html/snapshot_bar.html
+++ b/packrat/html/snapshot_bar.html
@@ -1,6 +1,6 @@
 <kifi class="kifi-root kifi-snapshot-bar-wrap">
   <div class="kifi-snapshot-bar">
-    Click part of this page to reference it in your {{type}}. 
+    Click part of this page to reference it in your message. 
     <button class="kifi-snapshot-cancel">Cancel</button>
   </div>
 </kifi>

--- a/packrat/scripts/maintain_height.js
+++ b/packrat/scripts/maintain_height.js
@@ -1,0 +1,35 @@
+function maintainHeight(elMaxHeight, elScrollTop, elContainer, otherEls) {
+  'use strict';
+
+  var hOld;
+  var $win = $(window).on('resize', update);
+
+  var observer = new MutationObserver(update);
+  var whatToObserve = {childList: true, subtree: true, characterData: true};
+  for (var i = otherEls.length; i--;) {
+    observer.observe(otherEls[i], whatToObserve);
+  }
+
+  update();
+
+  return {
+    destroy: function () {
+      $win.off('resize', update);
+      observer.disconnect();
+    }};
+
+  function update() {
+    var hNew = elContainer.offsetHeight;
+    for (var i = otherEls.length; i--;) {
+      hNew -= otherEls[i].offsetHeight;
+    }
+    hNew = Math.max(0, hNew);
+    if (hNew !== hOld) {
+      log('[maxHeight:update]', hOld, '->', hNew)();
+      var scrollTop = elScrollTop.scrollTop;
+      elMaxHeight.style.maxHeight = hNew + 'px';
+      elScrollTop.scrollTop = hOld == null ? 99999 : Math.max(0, scrollTop + hOld - hNew);
+      hOld = hNew;
+    }
+  }
+}

--- a/packrat/scripts/snapshot.js
+++ b/packrat/scripts/snapshot.js
@@ -135,7 +135,7 @@ var snapshot = function () {
     return null;
   },
 
-  take: function(composeTypeName, onExit) {
+  take: function(onExit) {
     document.documentElement.classList.add("kifi-snapshot-mode");
     document.body.classList.add("kifi-snapshot-root");
 
@@ -148,7 +148,7 @@ var snapshot = function () {
     var $selectable = $shades.add($glass).appendTo("body").on("mousemove", function(e) {
       updateSelection(cX = e.clientX, cY = e.clientY, e.pageX - e.clientX, e.pageY - e.clientY);
     });
-    render("html/snapshot_bar", {"type": composeTypeName}, function(html) {
+    render("html/snapshot_bar", function(html) {
       api.require("scripts/lib/jquery-ui-draggable.min.js", function() {  // for draggable
         $(html).appendTo("body")
           .draggable({cursor: "move", distance: 10, handle: ".kifi-snapshot-bar", scroll: false})

--- a/packrat/scripts/threads.js
+++ b/packrat/scripts/threads.js
@@ -11,6 +11,7 @@
 // @require scripts/compose.js
 // @require scripts/snapshot.js
 // @require scripts/lib/antiscroll.min.js
+// @require scripts/maintain_height.js
 // @require scripts/prevent_ancestor_scroll.js
 
 panes.threads = function () {
@@ -68,17 +69,27 @@ panes.threads = function () {
     .on('kifi:compose-submit', sendMessage.bind(null, $container))
     .find('time').timeago();
 
-    attachComposeBindings($container, 'message', prefs.enterToSend);
-
     $list = $container.find('.kifi-threads-list').preventAncestorScroll();
-    var scroller = $list.parent().antiscroll({x: false}).data('antiscroll');
+    var $scroll = $list.parent();
+    var compose = initCompose($container, prefs.enterToSend);
+    var heighter = maintainHeight($scroll[0], $list[0], $container[0], [compose.form()]);
+
+    $scroll.antiscroll({x: false});
+    var scroller = $scroll.data('antiscroll');
     $(window).on('resize.threads', scroller.refresh.bind(scroller));
 
-    $container.closest('.kifi-pane-box').on('kifi:remove', function () {
+    var $box = $container.closest('.kifi-pane-box').on('kifi:remove', function () {
       $list.length = 0;
       $(window).off('resize.threads');
+      compose.destroy();
+      heighter.destroy();
       api.port.off(handlers);
     });
+    if ($box.data('shown')) {
+      compose.focus();
+    } else {
+      $box.on('kifi:shown', compose.focus);
+    }
   }
 
   function update(thread) {

--- a/packrat/styles/keeper/compose.css
+++ b/packrat/styles/keeper/compose.css
@@ -16,14 +16,29 @@ form.kifi-compose {
   outline: none;
   box-shadow: none;
   cursor: text; /* ff */
-  transition: 160ms cubic-bezier(.405,-.375,.630,1.260) min-height;
+}
+.kifi-compose.kifi-empty .kifi-compose-draft:focus {
+  -webkit-animation: paddingLeft10 .16s ease-out;
+  animation: paddingLeft10 .16s ease-out;
+}
+@-webkit-keyframes paddingLeft10 {
+  50% {padding-left: 10px}
+}
+@keyframes paddingLeft10 {
+  50% {padding-left: 10px}
+}
+.kifi-ti-token-input:only-child>#token-input-kifi-compose-to:focus {
+  -webkit-animation: paddingLeft5 .16s ease-out;
+  animation: paddingLeft5 .16s ease-out;
+}
+@-webkit-keyframes paddingLeft5 {
+  50% {padding-left: 5px}
+}
+@keyframes paddingLeft5 {
+  50% {padding-left: 5px}
 }
 .kifi-compose-draft:first-child {
   border-radius: 3px 3px 0 0;
-}
-.kifi-compose-draft:focus,
-.kifi-compose:not(.kifi-empty) .kifi-compose-draft {
-  min-height: 40px;
 }
 .kifi-compose.kifi-empty .kifi-compose-draft::after {
   content: attr(data-placeholder);


### PR DESCRIPTION
This makes the code easier to reason about and paves the way for using compose.js in a toaster-style overlay.

Also using a MutationObserver now to maintain the max-height of the pane content instead of listening for specific events.

Also changing the small animation of the compose area from a vertical size increase to a horizontal text movement animation to avoid shifting the entire content of the pane above, which can be quite distracting.
