### PR TITLE
Very aggressive message caching in Eliza

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
@@ -14,12 +14,12 @@ case class ElizaCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Singleton
   @Provides
   def messageThreadExternalIdCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new MessageThreadExternalIdCache(stats, accessLog, (outerRepo, 7 days))
+    new MessageThreadExternalIdCache(stats, accessLog, (outerRepo, Duration.Inf))
 
   @Singleton
   @Provides
   def messagesForThreadIdCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new MessagesForThreadIdCache(stats, accessLog, (outerRepo, 24 hours))
+    new MessagesForThreadIdCache(stats, accessLog, (outerRepo, Duration.Inf))
 
   @Singleton
   @Provides


### PR DESCRIPTION
We're going to need to make this cache smarter when dealing with long and/or very active threads at some point, but this should solve the latency problem.
