### PR TITLE
dropping user_thread.notification_last_seen

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/123.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/123.sql
@@ -1,0 +1,10 @@
+# ELIZA
+
+# --- !Ups
+
+alter table user_thread
+  drop column notification_last_seen;
+
+insert into evolutions (name, description) values('123.sql', 'dropping user_thread.notification_last_seen');
+
+# --- !Downs

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/ExtMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/ExtMessagingController.scala
@@ -217,16 +217,10 @@ class ExtMessagingController @Inject() (
       val lastModified = messagingController.setAllNotificationsReadBefore(socket.userId, messageId)
       socket.channel.push(Json.arr("all_notifications_visited", notifId, lastModified))
     },
-    "get_last_notify_read_time" -> { _ =>
-      val tOpt = messagingController.getNotificationLastSeen(socket.userId)
-      tOpt.map { t =>
-        socket.channel.push(Json.arr("last_notify_read_time", t.toStandardTimeString))
-      }
+    "get_last_notify_read_time" -> { _ =>  // DEPRECATED remove after all extensions reach 2.6.42 or later
+      socket.channel.push(Json.arr("last_notify_read_time", clock.get.toStandardTimeString))
     },
-    "set_last_notify_read_time" -> { case JsString(time) +: _ =>
-      val t = parseStandardTime(time)
-      messagingController.setNotificationLastSeen(socket.userId, t)
-      socket.channel.push(Json.arr("last_notify_read_time", t.toStandardTimeString))
+    "set_last_notify_read_time" -> { case JsString(time) +: _ =>  // DEPRECATED no longer called by 2.6.42 or later
     },
     "get_notifications" -> { case JsNumber(howMany) +: _ =>
       val notices = messagingController.getLatestSendableNotifications(socket.userId, howMany.toInt)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/MessageRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/MessageRepo.scala
@@ -54,8 +54,7 @@ object Message {
     )(Message.apply, unlift(Message.unapply))
 }
 
-case class MessagesForThread(val thread:Id[MessageThread], val messages:Seq[Message])
-{
+case class MessagesForThread(val thread:Id[MessageThread], val messages:Seq[Message]) {
   override def equals(other:Any):Boolean = other match {
     case mft: MessagesForThread => (thread.id == mft.thread.id && messages.size == mft.messages.size)
     case _ => false
@@ -112,8 +111,7 @@ trait MessageRepo extends Repo[Message] with ExternalIdColumnFunction[Message] {
 class MessageRepoImpl @Inject() (
     val clock: Clock,
     val db: DataBaseComponent,
-    val messagesForThreadIdCache: MessagesForThreadIdCache
-  )
+    val messagesForThreadIdCache: MessagesForThreadIdCache)
   extends DbRepo[Message] with MessageRepo with ExternalIdColumnDbFunction[Message] with Logging {
 
   import db.Driver.Implicit._
@@ -176,17 +174,17 @@ class MessageRepoImpl @Inject() (
   }
 
   def getAfter(threadId: Id[MessageThread], after: DateTime)(implicit session: RSession): Seq[Message] = {
-    (for (row <- table if row.thread===threadId && row.createdAt>after) yield row).sortBy(row => row.createdAt desc).list
+    (for (row <- table if row.thread === threadId && row.createdAt > after) yield row).sortBy(row => row.createdAt desc).list
   }
 
   def updateUriIds(updates: Seq[(Id[NormalizedURI], Id[NormalizedURI])])(implicit session: RWSession) : Unit = { //Note: There is potentially a race condition here with updateUriId. Need to investigate.
-    updates.foreach{ case (oldId, newId) =>
-      (for (row <- table if row.sentOnUriId===oldId) yield row.sentOnUriId).update(newId)
+    updates.foreach { case (oldId, newId) =>
+      (for (row <- table if row.sentOnUriId === oldId) yield row.sentOnUriId).update(newId)
     }
   }
 
   def getFromIdToId(fromId: Id[Message], toId: Id[Message])(implicit session: RSession): Seq[Message] = {
-    (for (row <- table if row.id>=fromId && row.id<=toId) yield row).list
+    (for (row <- table if row.id >= fromId && row.id <= toId) yield row).list
   }
 
   def getMaxId()(implicit session: RSession): Id[Message] = {
@@ -203,10 +201,4 @@ class MessageRepoImpl @Inject() (
     results
   }
 
-
-
 }
-
-
-
-

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/MessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/MessagingController.scala
@@ -96,7 +96,6 @@ class MessagingController @Inject() (
       userThreadRepo.setNotification(userId, thread.id.get, lastMsgFromOther, notifJson, false)
       userThreadRepo.clearNotification(userId)
       userThreadRepo.setLastSeen(userId, thread.id.get, currentDateTime)
-      userThreadRepo.setNotificationLastSeen(userId, currentDateTime)
     }
   }
 
@@ -468,7 +467,7 @@ class MessagingController @Inject() (
         sentOnUriId = thread.uriId
       ))
     }
-    SafeFuture { 
+    SafeFuture {
       setLastSeen(from, thread.id.get, Some(message.createdAt))
       db.readOnly { implicit session => messageRepo.refreshCache(thread.id.get) }
     }
@@ -750,18 +749,6 @@ class MessagingController @Inject() (
   def getPendingNotifications(userId: Id[User]) : Seq[Notification] = {
     db.readOnly{ implicit session =>
       userThreadRepo.getPendingNotifications(userId)
-    }
-  }
-
-  def setNotificationLastSeen(userId: Id[User], timestamp: DateTime) : Unit = {
-    db.readWrite(attempts=2){ implicit session =>
-      userThreadRepo.setNotificationLastSeen(userId, timestamp)
-    }
-  }
-
-  def getNotificationLastSeen(userId: Id[User]): Option[DateTime] = {
-    db.readOnly{ implicit session =>
-      userThreadRepo.getNotificationLastSeen(userId)
     }
   }
 


### PR DESCRIPTION
Looks like this may result in more email notifications going out because we’ll no longer suppress them if the user opens the notifications pane. We’ll only suppress them if the user click the notification or marks it read.

We decided that we should eventually track notification read state with a new `SEEN` state on `UserNotification` (between `DELIVERED` and `READ`) instead of passing a single timestamp from the extension that represents the user having seen all notifications.

@stkem, please review. Thanks.
