### PR TITLE
fixing an apparent typo

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/UserThreadRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/UserThreadRepo.scala
@@ -30,7 +30,7 @@ case class UserThread(
     lastNotification: JsValue,
     notificationUpdatedAt: DateTime = currentDateTime,
     notificationLastSeen: Option[DateTime] = None,
-    notoficationEmailed: Boolean = false,
+    notificationEmailed: Boolean = false,
     replyable: Boolean = true
   )
   extends Model[UserThread] {


### PR DESCRIPTION
why didn’t slick catch this?
