### PR TITLE
2.6.42: extension will assume first participant is latest author if missing

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.6.41
+version=2.6.42

--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -124,6 +124,7 @@ panes.notices = function () {
     notice.cdnBase = cdnBase;
     switch (notice.category) {
     case 'message':
+      notice.author = notice.author || notice.participants[0];
       var nParticipants = notice.participants.length;
       notice.oneParticipant = nParticipants === 1;
       notice.twoParticipants = nParticipants === 2;

--- a/packrat/scripts/notifier.js
+++ b/packrat/scripts/notifier.js
@@ -29,6 +29,7 @@ var notifier = function() {
     switch (o.category) {
       case "message":
         removeByAssociatedId(o.thread, {fade: false});
+        o.author = o.author || o.participants[0];
         add({
           title: o.author.firstName + " " + o.author.lastName,
           subtitle: "Sent you a new Kifi Message",


### PR DESCRIPTION
cc @stkem 

This is so that we can remove the author field from notifications when (or soon after) we begin ordering the participants.
