### PR TITLE
In memory cache for social users is causing issues with connecting/disconnecting

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -64,13 +64,13 @@ ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends CacheModule(c
 
   @Singleton
   @Provides
-  def socialUserInfoUserCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new SocialUserInfoUserCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
+  def socialUserInfoUserCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
+    new SocialUserInfoUserCache(stats, accessLog, (outerRepo, 30 days))
 
   @Singleton
   @Provides
-  def socialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new SocialUserInfoNetworkCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
+  def socialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
+    new SocialUserInfoNetworkCache(stats, accessLog, (outerRepo, 30 days))
 
   @Singleton
   @Provides
@@ -164,8 +164,8 @@ ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends CacheModule(c
 
   @Singleton
   @Provides
-  def socialUserConnectionsCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new SocialUserConnectionsCache(stats, accessLog, (innerRepo, 1 minute), (outerRepo, 6 hours))
+  def socialUserConnectionsCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
+    new SocialUserConnectionsCache(stats, accessLog, (outerRepo, 6 hours))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -433,7 +433,7 @@ class UserController @Inject() (
       socialUserRepo.getByUser(request.userId).find(_.networkType.name == network)
     } match {
       case Some(sui) =>
-        val firstResponse = Enumerator.enumerate(check().map(script).toSeq :+ domain)
+        val firstResponse = Enumerator.enumerate(domain +: check().map(script).toSeq)
         val returnEnumerator = Enumerator.generateM(poller)
         Ok.stream(firstResponse andThen returnEnumerator &> Comet(callback = callback) andThen Enumerator(script(JsString("end"))) andThen Enumerator.eof )
       case None =>


### PR DESCRIPTION
@eishay This could feasibly slow things down that need to look up the social users by userId. However, we're having issues with clients talking to two different shoebox servers, and getting a different list of networks. This is apparent when connecting/disconnecting networks.

We may need to come up with another solution.
