### PR TITLE
Fix for notification for muted conversation

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -929,7 +929,6 @@ function removeNotificationPopups(associatedId) {
 
 function standardizeNotification(n) {
   n.category = (n.category || "message").toLowerCase();
-  n.unread = n.unread || (n.unreadAuthors > 0);
   if (!session || session.experiments.indexOf('inbox') < 0) {
     for (var i = n.participants ? n.participants.length : 0; i--;) {
       if (n.participants[i].id == session.user.id) {


### PR DESCRIPTION
@2is10 @andrewconner 

I am not sure why `(n.unreadAuthors > 0)` is necessary, but the line is the source of the bug. Tested with and without the code and confirmed.
