### PR TITLE
macro based MonitoredAwait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,11 @@ kifi-backend/modules/securesocial/bin/*
 kifi-backend/kifi-backend.sublime-project
 kifi-backend/kifi-backend.sublime-workspace
 *.swp
+kifi-backend/modules/macros/.target/*
+kifi-backend/modules/macros/.classpath
+kifi-backend/modules/macros/.project
+kifi-backend/modules/macros/.settings/*
+kifi-backend/modules/macros/.cache
 kifi-backend/modules/common/.target/*
 kifi-backend/modules/common/.classpath
 kifi-backend/modules/common/.project

--- a/kifi-backend/modules/common/app/com/keepit/common/akka/MonitoredAwait.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/akka/MonitoredAwait.scala
@@ -1,46 +1,28 @@
 package com.keepit.common.akka
 
+import com.keepit.common.healthcheck.{AirbrakeNotifier, AirbrakeError, HealthcheckPlugin}
+import com.keepit.common.logging.Logging
 import com.keepit.common.performance._
 import scala.concurrent.Await
 import scala.concurrent.Awaitable
 import scala.concurrent.duration._
 import com.google.inject.Inject
-import com.keepit.common.healthcheck.{AirbrakeNotifier, AirbrakeError, HealthcheckPlugin}
 
-class MonitoredAwait @Inject() (airbrake: AirbrakeNotifier, healthcheckPlugin: HealthcheckPlugin) {
+class MonitoredAwait @Inject() (airbrake: AirbrakeNotifier, healthcheckPlugin: HealthcheckPlugin) extends com.keepit.macros.MonitoredAwait {
 
-  def result[T](awaitable: Awaitable[T], atMost: Duration, errorMessage: String, valueFailureHandler: T): T = {
-    val caller = Thread.currentThread().getStackTrace()(2)
-    val tag = s"Await: ${caller.getClassName()}.${caller.getMethodName()}:${caller.getLineNumber()}"
+  def onError(tag: String, ex: Throwable, errorMessage: String) = airbrake.notify(AirbrakeError(ex, Some(s"$tag [$errorMessage]")))
 
-    val sw = new Stopwatch(tag)
-    try {
-      Await.result(awaitable, atMost)
-    } catch {
-      case ex: Throwable =>
-        airbrake.notify(AirbrakeError(ex, Some(s"[$errorMessage]")))
-        valueFailureHandler
-    } finally {
-      sw.stop()
-      sw.logTime()
-    }
-  }
+  def logTime(tag: String, elapsedTimeNano: Long): Unit = {}
 
-  def result[T](awaitable: Awaitable[T], atMost: Duration, errorMessage: String) = {
-    val caller = Thread.currentThread().getStackTrace()(2)
-    val tag = s"Await: ${caller.getClassName()}.${caller.getMethodName()}:${caller.getLineNumber()}"
-
-    val sw = new Stopwatch(tag)
-    try {
-      Await.result(awaitable, atMost)
-    } catch {
-      case ex: Throwable =>
-        if (healthcheckPlugin.isWarm)
-          airbrake.notify(AirbrakeError(ex, Some(s"[$errorMessage]")))
-        throw ex
-    } finally {
-      sw.stop()
-      sw.logTime()
-    }
-  }
+  lazy val logging: MonitoredAwait = new MonitoredAwaitLogging(airbrake, healthcheckPlugin)
 }
+
+class MonitoredAwaitLogging(airbrake: AirbrakeNotifier, healthcheckPlugin: HealthcheckPlugin) extends MonitoredAwait(airbrake, healthcheckPlugin) with Logging {
+
+  override def logTime(tag: String, elapsedTimeNano: Long): Unit = {
+    log.info(s"$tag elapsed milliseconds: ${(elapsedTimeNano/1000000d)}")
+  }
+
+  override lazy val logging: MonitoredAwait = this
+}
+

--- a/kifi-backend/modules/macros/app/com/keepit/macros/MonitoredAwaitMacro.scala
+++ b/kifi-backend/modules/macros/app/com/keepit/macros/MonitoredAwaitMacro.scala
@@ -4,7 +4,6 @@ import scala.concurrent.Await
 import scala.concurrent.Awaitable
 import scala.concurrent.duration._
 import scala.reflect.macros.Context
-import play.api.Logger
 
 trait MonitoredAwait {
 

--- a/kifi-backend/modules/macros/app/com/keepit/macros/MonitoredAwaitMacro.scala
+++ b/kifi-backend/modules/macros/app/com/keepit/macros/MonitoredAwaitMacro.scala
@@ -1,0 +1,78 @@
+package com.keepit.macros
+
+import scala.concurrent.Await
+import scala.concurrent.Awaitable
+import scala.concurrent.duration._
+import scala.reflect.macros.Context
+import play.api.Logger
+
+trait MonitoredAwait {
+
+  def result[T](awaitable: Awaitable[T], atMost: Duration, errorMessage: String, valueFailureHandler: T): T  = macro MonitoredAwaitMacro.resultWithDefault[T]
+  def result[T](awaitable: Awaitable[T], atMost: Duration, errorMessage: String): T  = macro MonitoredAwaitMacro.result[T]
+
+  def result[T](awaitable: Awaitable[T], atMost: Duration, errorMessage: String, valueFailureHandler: T, position: String): T = {
+    val startTime = System.nanoTime()
+    try {
+      Await.result(awaitable, atMost)
+    } catch {
+      case ex: Throwable =>
+        onError(position, ex, errorMessage)
+        valueFailureHandler
+    } finally {
+      logTime(position, (System.nanoTime() - startTime))
+    }
+  }
+
+  def result[T](awaitable: Awaitable[T], atMost: Duration, errorMessage: String, position: String): T = {
+    val startTime = System.nanoTime()
+    try {
+      Await.result(awaitable, atMost)
+    } catch {
+      case ex: Throwable =>
+        onError(position, ex, errorMessage)
+        throw ex
+    } finally {
+      logTime(position, (System.nanoTime() - startTime))
+    }
+  }
+
+  def onError(position: String, ex: Throwable, msg: String): Unit
+
+  def logTime(tag: String, elapsedTimeNano: Long): Unit
+}
+
+object MonitoredAwaitMacro {
+
+  type MonitoredAwaitContext = Context { type PrefixType =  MonitoredAwait }
+
+  private[this] def getPosition(x: MonitoredAwaitContext) = {
+    val className = Option(x.enclosingClass).map(_.symbol.toString).getOrElse("")
+    val methodName = Option(x.enclosingMethod).map(_.symbol.toString).getOrElse("")
+    val line = x.enclosingPosition.line
+
+    s"Await[${className}][${methodName}]:${line}"
+  }
+
+  def resultWithDefault[T](x: MonitoredAwaitContext)(
+      awaitable: x.Expr[Awaitable[T]],
+      atMost: x.Expr[Duration],
+      errorMessage: x.Expr[String],
+      valueFailureHandler: x.Expr[T]
+  ):  x.Expr[T] = {
+    import x.universe._
+    val position = getPosition(x)
+    reify(x.prefix.splice.result(awaitable.splice, atMost.splice, errorMessage.splice, valueFailureHandler.splice, x.literal(position).splice))
+  }
+
+  def result[T](x: MonitoredAwaitContext)(
+      awaitable: x.Expr[Awaitable[T]],
+      atMost: x.Expr[Duration],
+      errorMessage: x.Expr[String]
+  ):  x.Expr[T] = {
+    import x.universe._
+    val position = getPosition(x)
+    reify(x.prefix.splice.result(awaitable.splice, atMost.splice, errorMessage.splice, x.literal(position).splice))
+  }
+}
+

--- a/kifi-backend/project/Build.scala
+++ b/kifi-backend/project/Build.scala
@@ -159,9 +159,13 @@ object ApplicationBuild extends Build {
       Keys.fork := false
     )
 
-    lazy val common = play.Project("common", appVersion, commonDependencies, path = file("modules/common")).settings(
+    lazy val macros = play.Project("macros", appVersion, commonDependencies, path = file("modules/macros")).settings(
       commonSettings: _*
     )
+
+    lazy val common = play.Project("common", appVersion, commonDependencies, path = file("modules/common")).settings(
+      commonSettings: _*
+    ).dependsOn(macros)
 
     lazy val sqldb = play.Project("sqldb", appVersion, sqldbDependencies, path = file("modules/sqldb")).settings(
       commonSettings: _*


### PR DESCRIPTION
- My first scala macro :)
- Created new module "macros" to compile the macro definition before anything else
- MonitoredAwait gets the class/method name of the caller at compile time. It no longer inspects the stack trace. This should be faster and generate less garbages.
- Added the class/method name to airbrake messages
- Timing log is disabled. do monitoredAwait.logging.result(...) if you want to log the timing.

@eishay , @andrewconner, please review. Thanks!
