### PR TITLE
get_oauth2_token_null_check

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/abook/ABookServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/abook/ABookServiceClient.scala
@@ -117,7 +117,8 @@ class ABookServiceClientImpl @Inject() (
 
   def getOAuth2Token(userId: Id[User], abookId: Id[ABookInfo]): Future[Option[OAuth2Token]] = {
     call(ABook.internal.getOAuth2Token(userId, abookId)).map { r =>
-      r.json.as[Option[OAuth2Token]]
+      if (r.json == null) None // TODO: revisit
+      else r.json.as[Option[OAuth2Token]]
     }
   }
 }


### PR DESCRIPTION
Adding null checks here for now, but I tend to think that we should ensure ClientResponse.json returns JsNull in such cases -- will send in another pull request.

cc: @eishay 
cc: @ymatsuda 
