### PR TITLE
warp speed for everybody

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
@@ -15,7 +15,7 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 object SearchConfig {
   private[search] val defaultParams =
     Map[String, String](
-      "enableWarp" -> "false",
+      "enableWarp" -> "true",
       "phraseBoost" -> "0.33",
       "siteBoost" -> "1.0",
       "concatBoost" -> "0.8",


### PR DESCRIPTION
This skips Lucene search execution when a user has a heavily boosted keep for the query, thus the query returns faster.
