### PR TITLE
excluding muted threads from the unread thread count

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/UserThreadRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/UserThreadRepo.scala
@@ -272,7 +272,7 @@ class UserThreadRepoImpl @Inject() (
   }
 
   def getPendingNotificationCount(userId: Id[User])(implicit session: RSession): Int = {
-    Query((for (row <- table if row.user===userId && row.notificationPending===true) yield row).length).first
+    Query((for (row <- table if row.user === userId && !row.notificationPending && !row.muted) yield row).length).first
   }
 
   def getSendableNotificationsAfter(userId: Id[User], after: DateTime)(implicit session: RSession): Seq[JsObject] = {


### PR DESCRIPTION
This is part of [this Asana task](https://app.asana.com/0/5510510565844/8848957475508). This should make no difference now, but in a week or two, we’ll stop automatically marking new messages on muted threads as read, and you’ll begin to notice the difference.

Heads up @ebfaed.

cc @stkem @andrewconner 
