### PR TITLE
including the total number of messages in the thread in message notification JSON

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/126.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/126.sql
@@ -3,6 +3,7 @@
 # --- !Ups
 
 CREATE INDEX message_i_thread_id_created_at ON message (thread_id, created_at);
+DROP INDEX message_i_my_thread ON message;
 
 INSERT INTO evolutions (name, description) VALUES ('126.sql', 'add index on thread id and creation time in message table');
 

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/126.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/126.sql
@@ -1,0 +1,11 @@
+# ELIZA
+
+# --- !Ups
+
+CREATE INDEX message_i_thread_id_created_at ON message (thread_id, created_at);
+
+INSERT INTO evolutions (name, description) VALUES ('126.sql', 'add index on thread id and creation time in message table');
+
+# --- !Downs
+
+DROP INDEX message_i_thread_id_created_at ON message;

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/MessageRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/MessageRepo.scala
@@ -18,7 +18,7 @@ import play.api.libs.json._
 import play.api.libs.json.util._
 import play.api.libs.functional.syntax._
 import scala.slick.lifted.Query
-import scala.slick.jdbc.{StaticQuery => Q}
+import scala.slick.jdbc.StaticQuery
 
 case class Message(
     id: Option[Id[Message]] = None,
@@ -196,7 +196,7 @@ class MessageRepoImpl @Inject() (
 
   def getMessageCounts(threadId: Id[MessageThread], afterOpt: Option[DateTime])(implicit session: RSession): (Int, Int) = {
     afterOpt.map{ after =>
-      Q.queryNA[(Int, Int)](s"select count(*), sum(created_at > '$after') from message where thread_id = $threadId").first
+      StaticQuery.queryNA[(Int, Int)](s"select count(*), sum(created_at > '$after') from message where thread_id = $threadId").first
     } getOrElse {
       val n = Query(table.filter(row => row.thread === threadId).length).first
       (n, n)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/MessageRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/MessageRepo.scala
@@ -18,6 +18,7 @@ import play.api.libs.json._
 import play.api.libs.json.util._
 import play.api.libs.functional.syntax._
 import scala.slick.lifted.Query
+import scala.slick.jdbc.{StaticQuery => Q}
 
 case class Message(
     id: Option[Id[Message]] = None,
@@ -104,7 +105,7 @@ trait MessageRepo extends Repo[Message] with ExternalIdColumnFunction[Message] {
 
   def getMaxId()(implicit session: RSession): Id[Message]
 
-  def getNumMessagesAfter(threadId: Id[MessageThread], afterOpt: Option[DateTime])(implicit session: RSession): Int
+  def getMessageCounts(threadId: Id[MessageThread], afterOpt: Option[DateTime])(implicit session: RSession): (Int, Int)
 
 }
 
@@ -193,16 +194,13 @@ class MessageRepoImpl @Inject() (
     Query(table.map(_.id).max).first.getOrElse(Id[Message](0))
   }
 
-  def getNumMessagesAfter(threadId: Id[MessageThread], afterOpt: Option[DateTime])(implicit session: RSession): Int = {
-    afterOpt.map{ after => 
-      Query(table.filter(row => row.thread===threadId && row.createdAt > after).length).first
+  def getMessageCounts(threadId: Id[MessageThread], afterOpt: Option[DateTime])(implicit session: RSession): (Int, Int) = {
+    afterOpt.map{ after =>
+      Q.queryNA[(Int, Int)](s"select count(*), sum(created_at > '$after') from message where thread_id = $threadId").first
     } getOrElse {
-      Query(table.filter(row => row.thread===threadId).length).first
+      val n = Query(table.filter(row => row.thread === threadId).length).first
+      (n, n)
     }
   }
 
 }
-
-
-
-

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/MessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/MessagingController.scala
@@ -92,7 +92,7 @@ class MessagingController @Inject() (
         participantSet.toSeq.map(id2BasicUser(_))
       )
 
-      val notifJson = buildMessageNotificationJson(lastMsgFromOther, thread, messageWithBasicUser, locator, false, 0, 0, 0, 0, false)
+      val notifJson = buildMessageNotificationJson(lastMsgFromOther, thread, messageWithBasicUser, locator, false, 0, 0, 0, 0, 0, false)
 
       userThreadRepo.setNotification(userId, thread.id.get, lastMsgFromOther, notifJson, false)
       userThreadRepo.markRead(userId)
@@ -324,6 +324,7 @@ class MessagingController @Inject() (
       originalAuthorIdx: Int,
       unseenAuthors: Int,
       numAuthors: Int,
+      numMessages: Int,
       numUnread: Int,
       muted: Boolean
     ) : JsValue = {
@@ -341,7 +342,8 @@ class MessagingController @Inject() (
       "category"      -> "message",
       "firstAuthor"   -> originalAuthorIdx,
       "authors"       -> numAuthors, //number of people who have sent messages in this conversation
-      "unreadAuthors" -> unseenAuthors, //number of people in 'particiapnts' who's messages you haven't seen yet
+      "messages"      -> numMessages, //total number of messages in this conversation
+      "unreadAuthors" -> unseenAuthors, //number of people in 'participants' whose messages user hasn't seen yet
       "unreadMessages"-> numUnread,
       "muted"         -> muted
     )
@@ -367,8 +369,10 @@ class MessagingController @Inject() (
         case Some(lastSeen) => authorActivityInfos.filter(_.lastActive.get.isAfter(lastSeen)).length
         case None => authorActivityInfos.length
       }
-      val (numUnread: Int, muted: Boolean) = db.readOnly { implicit session =>
-        (messageRepo.getNumMessagesAfter(thread.id.get, lastSeenOpt), userThreadRepo.isMuted(userId, thread.id.get))
+      val (numMessages: Int, numUnread: Int, muted: Boolean) = db.readOnly { implicit session =>
+        val (numMessages, numUnread) = messageRepo.getMessageCounts(thread.id.get, lastSeenOpt)
+        val muted = userThreadRepo.isMuted(userId, thread.id.get)
+        (numMessages, numUnread, muted)
       }
 
       val notifJson = buildMessageNotificationJson(
@@ -380,6 +384,7 @@ class MessagingController @Inject() (
         originalAuthorIdx = authorActivityInfos.filter(_.started).zipWithIndex.head._2,
         unseenAuthors = if (muted) 0 else unseenAuthors,  // TODO: see TODO above
         numAuthors = authorActivityInfos.length,
+        numMessages = numMessages,
         numUnread = numUnread,
         muted = muted)
 
@@ -526,14 +531,11 @@ class MessagingController @Inject() (
     setLastSeen(from, thread.id.get, Some(message.createdAt))
     db.readWrite { implicit session => userThreadRepo.setLastActive(from, thread.id.get, message.createdAt) }
 
-    val threadActivity = db.readOnly{ implicit session =>
-      userThreadRepo.getThreadActivity(thread.id.get)
-    } sortWith { case (first, second) =>
-      first.id.id < second.id.id
-    } sortWith { case (first, second) =>
-      first.lastActive.isDefined && (second.lastActive.isEmpty || first.lastActive.get.isBefore(second.lastActive.get))
+    val (numMessages: Int, numUnread: Int, threadActivity: Seq[UserThreadActivity]) = db.readOnly { implicit session =>
+      val (numMessages, numUnread) = messageRepo.getMessageCounts(thread.id.get, Some(message.createdAt))
+      val activity = userThreadRepo.getThreadActivity(thread.id.get).sortBy { a => (a.lastActive.getOrElse(END_OF_TIME), a.id.id) }
+      (numMessages, numUnread, activity)
     }
-
 
     val originalAuthor = threadActivity.filter(_.started).zipWithIndex.head._2
     val numAuthors = threadActivity.filter(_.lastActive.isDefined).length
@@ -555,7 +557,8 @@ class MessagingController @Inject() (
         originalAuthorIdx = originalAuthor,
         unseenAuthors = 0,
         numAuthors = numAuthors,
-        numUnread = 0,
+        numMessages = numMessages,
+        numUnread = numUnread,
         muted = false)
       if (userExperiments.contains(ExperimentType.INBOX)){
         db.readWrite(attempts=2){ implicit session =>


### PR DESCRIPTION
This will allow us to stop using `ElizaThreadInfo` soon. We’ll start using the "notification" JSON to populate the "conversations on this page" list instead for all users, regardless of whether they have the `inbox` experiment.

@stkem 
cc @andrewconner 
