### PR TITLE
2.6.55: avoiding a Firefox bug resulting in duplicate content script injection

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.6.54
+version=2.6.55

--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -4,7 +4,7 @@
 // @require scripts/html/keeper/notice_global.js
 // @require scripts/html/keeper/notice_message.js
 // @require scripts/lib/jquery-ui-position.min.js
-// @require scripts/lib/jquery.hoverfu.js
+// @require scripts/lib/jquery-hoverfu.js
 // @require scripts/lib/jquery.timeago.js
 // @require scripts/lib/antiscroll.min.js
 // @require scripts/formatting.js


### PR DESCRIPTION
... by eliminating the `setTimeout` before defining `PageMod`s.

Also fixing jquery-hoverfu.js filename.
