### PR TITLE
always sending notification to extension after a sent message

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/MessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/MessagingController.scala
@@ -500,12 +500,12 @@ class MessagingController @Inject() (
         db.readWrite(attempts=2){ implicit session =>
           userThreadRepo.setNotification(from, thread.id.get, message, notifJson, false)
         }
-        notificationRouter.sendToUser(from, Json.arr("notification", notifJson))
       } else {
         db.readWrite(attempts=2){ implicit session =>
           userThreadRepo.setNotificationJsonIfNotPresent(from, thread.id.get, notifJson, message)
         }
       }
+      notificationRouter.sendToUser(from, Json.arr("notification", notifJson))
     }
     //=== END
 


### PR DESCRIPTION
@stkem 
@ebfaed, will notifying about a user’s own sent messages break the iPhone app? The `"notification"` will already be marked as read.
