### PR TITLE
Faster bookmark imports

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeError.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeError.scala
@@ -45,7 +45,7 @@ case class AirbrakeError(
 
   lazy val trimmedMessage = message.map(_.toString.abbreviate(AirbrakeError.MaxMessageSize))
   override def toString(): String = {
-    s"${super.toString()}\n${rootException.getStackTrace mkString "\nat \t"}"
+    s"${rootException.toString()}\nat \t${rootException.getStackTrace mkString "\nat \t"}"
   }
 
   private val maxCauseDepth = 5

--- a/kifi-backend/modules/common/conf/prod/shoebox.conf
+++ b/kifi-backend/modules/common/conf/prod/shoebox.conf
@@ -24,7 +24,7 @@ db.shoebox {
   connectionTestStatement="SELECT 1"
   maxConnectionAge=0
   partitionCount=4
-  maxConnectionsPerPartition=6
+  maxConnectionsPerPartition=12
   minConnectionsPerPartition=4
   setLogStatementsEnabled=true
   acquireRetryAttempts=10

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
@@ -51,7 +51,7 @@ class AdminBookmarksController @Inject() (
 
   def rescrape = AdminJsonAction { request =>
     val id = Id[Bookmark]((request.body.asJson.get \ "id").as[Int])
-    db.readOnly { implicit session =>
+    db.readWrite { implicit session =>
       val bookmark = bookmarkRepo.get(id)
       val uri = uriRepo.get(bookmark.uriId)
       scraper.scheduleScrape(uri)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/BookmarksCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/BookmarksCommander.scala
@@ -67,7 +67,7 @@ class BookmarksCommander @Inject() (
  ) extends Logging {
 
   def keepMultiple(keepInfosWithCollection: KeepInfosWithCollection, user: User, experiments: Set[ExperimentType], contextBuilder: EventContextBuilder, source: String):
-                  (List[KeepInfo], Option[Int]) = {
+                  (Seq[KeepInfo], Option[Int]) = {
     val tStart = currentDateTime
     val KeepInfosWithCollection(collection, keepInfos) = keepInfosWithCollection
     val keeps = bookmarkInterner.internBookmarks(Json.toJson(keepInfos), user, experiments, source).map(KeepInfo.fromBookmark)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/BookmarkInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/BookmarkInterner.scala
@@ -9,6 +9,7 @@ import com.keepit.model._
 import com.keepit.scraper.ScraperPlugin
 import com.keepit.common.logging.Logging
 import com.keepit.common.healthcheck.{AirbrakeNotifier, AirbrakeError}
+import com.keepit.common.KestrelCombinator
 
 import play.api.libs.json._
 
@@ -17,6 +18,9 @@ import com.keepit.common.service.FortyTwoServices
 
 import com.google.inject.{Inject, Singleton}
 import com.keepit.normalizer.NormalizationCandidate
+import scala.util.Try
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.UUID
 
 @Singleton
 class BookmarkInterner @Inject() (
@@ -31,49 +35,77 @@ class BookmarkInterner @Inject() (
   implicit private val fortyTwoServices: FortyTwoServices)
     extends Logging {
 
-  def internBookmarks(value: JsValue, user: User, experiments: Set[ExperimentType], source: BookmarkSource, installationId: Option[ExternalId[KifiInstallation]] = None): List[Bookmark] = {
-    log.info(s"[internBookmarks] user=(${user.id} ${user.firstName} ${user.lastName}) source=$source installId=$installationId value=$value] ")
+  def internBookmarks(value: JsValue, user: User, experiments: Set[ExperimentType], source: BookmarkSource, installationId: Option[ExternalId[KifiInstallation]] = None): Seq[Bookmark] = {
+    val referenceId = UUID.randomUUID
+    log.info(s"[internBookmarks] user=(${user.id} ${user.firstName} ${user.lastName}) source=$source installId=$installationId value=$value $referenceId ")
+    val parseStart = System.currentTimeMillis()
+    val bookmarks = getBookmarksFromJson(value)
+    log.info(s"[internBookmarks-$referenceId] Parsing took: ${System.currentTimeMillis - parseStart}ms")
+
+    var count = new AtomicInteger(0)
+    val total = bookmarks.size
+    val batchSize = 100
+    val persistedBookmarksWithUris = bookmarks.grouped(batchSize).map { bms =>
+      val startTime = System.currentTimeMillis
+      log.info(s"[internBookmarks-$referenceId] Persisting $batchSize bookmarks: ${count.get}/$total")
+      val persisted = db.readWrite(attempts = 2) { implicit session =>
+        bms.map { bm => internUriAndBookmark(bm, user, experiments, source) }.flatten
+      }
+      log.info(s"[internBookmarks-$referenceId] Done with ${count.addAndGet(bms.size)}/$total. Took ${System.currentTimeMillis - startTime}ms")
+      persisted
+    }
+
+    log.info(s"[internBookmarks-$referenceId] Requesting scrapes")
+    val persistedBookmarks = persistedBookmarksWithUris.flatten.toSeq.map { case (bm, uri) =>
+      db.readWrite { implicit session =>
+        if (uri.state == NormalizedURIStates.SCRAPE_WANTED) {
+          Try(scraper.scheduleScrape(uri))
+        }
+        bm
+      }
+    }
+    log.info(s"[internBookmarks-$referenceId] Done!")
+    persistedBookmarks
+  }
+
+  private def getBookmarksFromJson(value: JsValue): Seq[JsObject] = {
     value match {
-      case JsArray(elements) => (elements map {e => internBookmarks(e, user, experiments, source, installationId)} flatten).toList
-      case json: JsObject if(json.keys.contains("children")) => internBookmarks(json \ "children" , user, experiments, source)
-      case json: JsObject => List(internBookmark(json, user, experiments, source)).flatten
-      case e: Throwable => throw new Exception("can't figure what to do with %s".format(e))
+      case JsArray(elements) => elements.map(getBookmarksFromJson).flatten
+      case json: JsObject if json.keys.contains("children") => getBookmarksFromJson(json \ "children")
+      case json: JsObject => Seq(json)
+      case e => throw new Exception("can't figure what to do with %s".format(e)) // bad! ruins an import!
     }
   }
 
   def internBookmark(uri: NormalizedURI, user: User, isPrivate: Boolean, experiments: Set[ExperimentType],
-      installationId: Option[ExternalId[KifiInstallation]], source: BookmarkSource, title: Option[String], url: String) = {
-    db.readWrite(attempts = 2) { implicit s =>
-      bookmarkRepo.getByUriAndUser(uri.id.get, user.id.get, excludeState = None) match {
-        case Some(bookmark) if bookmark.isActive => Some(bookmark.withPrivate(isPrivate = isPrivate))
-        case Some(bookmark) => Some(bookmarkRepo.save(bookmark.withActive(true).withPrivate(isPrivate).withTitle(title orElse(uri.title)).withUrl(url)))
-        case None =>
-          Events.userEvent(EventFamilies.SLIDER, "newKeep", user, experiments, installationId.map(_.id).getOrElse(""), JsObject(Seq("source" -> JsString(source.value))))
-          val urlObj = urlRepo.get(url).getOrElse(urlRepo.save(URLFactory(url = url, normalizedUriId = uri.id.get)))
-          Some(bookmarkRepo.save(BookmarkFactory(uri, user.id.get, title orElse uri.title, urlObj, source, isPrivate, installationId)))
-      }
+      installationId: Option[ExternalId[KifiInstallation]], source: BookmarkSource, title: Option[String], url: String)(implicit session: RWSession) = {
+    val startTime = System.currentTimeMillis
+    bookmarkRepo.getByUriAndUser(uri.id.get, user.id.get, excludeState = None) match {
+      case Some(bookmark) if bookmark.isActive => bookmark.withPrivate(isPrivate = isPrivate)
+      case Some(bookmark) => bookmarkRepo.save(bookmark.withActive(true).withPrivate(isPrivate).withTitle(title orElse(uri.title)).withUrl(url))
+      case None =>
+        Events.userEvent(EventFamilies.SLIDER, "newKeep", user, experiments, installationId.map(_.id).getOrElse(""), JsObject(Seq("source" -> JsString(source.value))))
+        val urlObj = urlRepo.get(url).getOrElse(urlRepo.save(URLFactory(url = url, normalizedUriId = uri.id.get)))
+        bookmarkRepo.save(BookmarkFactory(uri, user.id.get, title orElse uri.title, urlObj, source, isPrivate, installationId))
     }
   }
 
-  private def internBookmark(json: JsObject, user: User, experiments: Set[ExperimentType], source: BookmarkSource, installationId: Option[ExternalId[KifiInstallation]] = None): Option[Bookmark] = try {
+  private def internUriAndBookmark(json: JsObject, user: User, experiments: Set[ExperimentType], source: BookmarkSource, installationId: Option[ExternalId[KifiInstallation]] = None)(implicit session: RWSession): Option[(Bookmark, NormalizedURI)] = try {
+    val startTime = System.currentTimeMillis
     val title = (json \ "title").asOpt[String]
     val url = (json \ "url").as[String]
     val isPrivate = (json \ "isPrivate").asOpt[Boolean].getOrElse(true)
     if (!url.toLowerCase.startsWith("javascript:")) {
       log.debug("interning bookmark %s with title [%s]".format(json, title))
 
-      val uri = db.readWrite(attempts = 2) { implicit s =>
+      val uri = {
         val initialURI = uriRepo.internByUri(url, NormalizationCandidate(json):_*)
         if (initialURI.state == NormalizedURIStates.ACTIVE | initialURI.state == NormalizedURIStates.INACTIVE)
           uriRepo.save(initialURI.withState(NormalizedURIStates.SCRAPE_WANTED))
         else initialURI
       }
 
-      if (uri.state == NormalizedURIStates.SCRAPE_WANTED) {
-        scraper.scheduleScrape(uri)
-      }
-      internBookmark(uri, user, isPrivate, experiments, installationId, source, title, url)
-
+      Some((internBookmark(uri, user, isPrivate, experiments, installationId, source, title, url), uri))
     } else {
       None
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/BookmarkInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/BookmarkInterner.scala
@@ -63,12 +63,7 @@ class BookmarkInterner @Inject() (
       if (isNewBookmark) {
         Events.userEvent(EventFamilies.SLIDER, "newKeep", user, experiments, installationId.map(_.id).getOrElse(""), JsObject(Seq("source" -> JsString(source.value))))
       }
-      db.readWrite { implicit session =>
-        if (uri.state == NormalizedURIStates.SCRAPE_WANTED) {
-          Try(scraper.scheduleScrape(uri))
-        }
-        bm
-      }
+      bm
     }.toList
     log.info(s"[internBookmarks-$referenceId] Done!")
     persistedBookmarks
@@ -110,6 +105,11 @@ class BookmarkInterner @Inject() (
         else initialURI
       }
       val (isNewKeep, bookmark) = internBookmark(uri, user, isPrivate, experiments, installationId, source, title, url)
+
+      if (uri.state == NormalizedURIStates.SCRAPE_WANTED) {
+        Try(scraper.scheduleScrape(uri))
+      }
+
       Some((bookmark, uri, isNewKeep))
     } else {
       None

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperPlugin.scala
@@ -5,9 +5,10 @@ import scala.concurrent.Future
 import com.keepit.model.NormalizedURI
 import com.keepit.search.Article
 import com.keepit.scraper.extractor.Extractor
+import com.keepit.common.db.slick.DBSession.RWSession
 
 trait ScraperPlugin extends Plugin {
   def scrapePending(): Future[Seq[(NormalizedURI, Option[Article])]]
-  def scheduleScrape(uri: NormalizedURI): Unit
+  def scheduleScrape(uri: NormalizedURI)(implicit session: RWSession): Unit
   def scrapeBasicArticle(url: String, customExtractor: Option[Extractor] = None): Future[Option[BasicArticle]]
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperPluginImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperPluginImpl.scala
@@ -19,6 +19,7 @@ import com.keepit.common.akka.{FortyTwoActor, UnsupportedActorMessage}
 import com.keepit.common.plugin.{SchedulingPlugin, SchedulingProperties}
 import com.keepit.scraper.extractor.Extractor
 import com.keepit.common.db.slick.Database
+import com.keepit.common.db.slick.DBSession.RWSession
 
 case object Scrape
 case class ScrapeInstance(uri: NormalizedURI)
@@ -82,26 +83,20 @@ class ScraperPluginImpl @Inject() (
   override def scrapePending(): Future[Seq[(NormalizedURI, Option[Article])]] =
     actor.ref.ask(Scrape)(1 minutes).mapTo[Seq[(NormalizedURI, Option[Article])]]
 
-  def scheduleScrape(uri: NormalizedURI): Unit = {
+  def scheduleScrape(uri: NormalizedURI)(implicit session: RWSession): Unit = {
     if (scraperConfig.disableScraperService) {
       actor.ref.ask(ScrapeInstance(uri))(1 minutes).mapTo[(NormalizedURI, Option[Article])]
     } else {
       val uriId = uri.id.get
-      val (info, proxyOpt) = db.readOnly { implicit s =>
-        val info = scrapeInfoRepo.getByUriId(uriId)
-        val proxyOpt = urlPatternRuleRepo.getProxy(uri.url)
-        (info, proxyOpt)
-      }
+      val info = scrapeInfoRepo.getByUriId(uriId)
+      val proxyOpt = urlPatternRuleRepo.getProxy(uri.url)
+
       val toSave = info match {
         case Some(s) => s.withState(ScrapeInfoStates.PENDING)
         case None => ScrapeInfo(uriId = uriId, state = ScrapeInfoStates.PENDING)
       }
-      val saved = db.readWrite { implicit s =>
-        scrapeInfoRepo.save(toSave)
-      }
-      log.info(s"[scheduleScrape-WithRequest] invoke (remote) Scraper service; uri=(${uri.id}, ${uri.state}, ${uri.url}, proxy=$proxyOpt)")
-      val f = scraperClient.scheduleScrapeWithRequest(ScrapeRequest(uri, saved, proxyOpt))
-      Await.result(f, 5 seconds) // should be really quick
+      val saved = scrapeInfoRepo.save(toSave)
+      // todo: It may be nice to force trigger a scrape directly
     }
   }
 

--- a/kifi-backend/modules/shoebox/public/css/main.css
+++ b/kifi-backend/modules/shoebox/public/css/main.css
@@ -479,12 +479,12 @@ body[data-view=search] .main-keeps {top: 108px}
 .keep-hover-button-wrapper {display: none; position: absolute; right: 0; top: 0; height: 100%; width: 1px}
 .keep-hover-button-table {display: table; width: 100%; height: 100%}
 .keep-hover-button-cell {display: table-cell; vertical-align: middle}
-.keep-hover-button {font-size: 11px; color: #9ea3ad; background: #eff2f7; padding: 7px 12px; border: 1px solid #f4f6f9; border-radius: 9px; position: absolute; right: 16px; cursor: pointer; -webkit-user-select: none; -moz-user-select: -moz-none; -ms-user-select: none}
+.keep-hover-button {font-size: 11px; color: #fff; background: #67829c; padding: 7px 12px; border: 1px solid #f4f6f9; border-radius: 9px; position: absolute; right: 16px; cursor: pointer; -webkit-user-select: none; -moz-user-select: -moz-none; -ms-user-select: none}
 .keep .keep-button-close {display: none}
 .keep:hover .keep-hover-button-wrapper {display: block}
 .keep.detailed .keep-button-preview {display: none}
 .keep.detailed .keep-button-close {display: block}
-.keep.detailed .keep-hover-button {background: #e3e6ee;}
+.keep.detailed .keep-hover-button {background: #67829c;}
 .keep>.handle {cursor: move; position: absolute; top: 0; bottom: 0; left: 0; width: 21px; display: none; background: url(../img/drag-handle.png) center/10px no-repeat}
 .keep>.handle:hover,
 .keep.detailed>.handle,

--- a/kifi-backend/modules/shoebox/test/com/keepit/scraper/FakeScraperModule.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/scraper/FakeScraperModule.scala
@@ -15,7 +15,7 @@ case class FakeScraperModule(fakeArticles: Option[PartialFunction[(String, Optio
 
 class FakeScraperPlugin(fakeArticles: Option[PartialFunction[(String, Option[Extractor]), BasicArticle]]) extends ScraperPlugin {
   def scrapePending() = Future.successful(Seq())
-  def scheduleScrape(uri: NormalizedURI)(implicit session: RWSession: Unit = {}
+  def scheduleScrape(uri: NormalizedURI)(implicit session: RWSession): Unit = {}
   def scrapeBasicArticle(url: String, customExtractor: Option[Extractor] = None): Future[Option[BasicArticle]] =
     Future.successful(fakeArticles.map(_.apply((url, customExtractor))))
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/scraper/FakeScraperModule.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/scraper/FakeScraperModule.scala
@@ -4,6 +4,7 @@ import scala.concurrent._
 import com.keepit.model.NormalizedURI
 import com.google.inject.{Provides, Singleton}
 import com.keepit.scraper.extractor.Extractor
+import com.keepit.common.db.slick.DBSession.RWSession
 
 case class FakeScraperModule(fakeArticles: Option[PartialFunction[(String, Option[Extractor]), BasicArticle]] = None) extends ScraperModule {
   override def configure() {}
@@ -14,7 +15,7 @@ case class FakeScraperModule(fakeArticles: Option[PartialFunction[(String, Optio
 
 class FakeScraperPlugin(fakeArticles: Option[PartialFunction[(String, Option[Extractor]), BasicArticle]]) extends ScraperPlugin {
   def scrapePending() = Future.successful(Seq())
-  def scheduleScrape(uri: NormalizedURI): Unit = {}
+  def scheduleScrape(uri: NormalizedURI)(implicit session: RWSession: Unit = {}
   def scrapeBasicArticle(url: String, customExtractor: Option[Extractor] = None): Future[Option[BasicArticle]] =
     Future.successful(fakeArticles.map(_.apply((url, customExtractor))))
 }


### PR DESCRIPTION
We discovered that bookmarks were importing roughly 2 per second (1000 bookmarks could take over 10 minutes). These changes improve the performance significantly.

The biggest slowdowns were using multiple separate db sessions per bookmark, and blocking on the Scraper acknowledging our scrape requests. We are now batching and importing in parallel, and letting the scraper plugin pick up bookmark imports implicitly through it's scheduled plugin.

We may want to still let the scraper know directly about new bookmark imports, but Ray and I agreed that it's not a super high priority.

cc: @raymondng @Effifuks @eishay 
