### PR TITLE
no side effects

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/query/SemanticVectorExtractorQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/SemanticVectorExtractorQuery.scala
@@ -70,11 +70,7 @@ class SemanticVectorExtractorWeight(query: SemanticVectorExtractorQuery, semanti
   override def getQuery() = query
   override def scoresDocsOutOfOrder() = false
 
-  override def getValueForNormalization(): Float = {
-    semanticWeights.foreach{ _.getValueForNormalization() } // for side effect
-    personalWeight.foreach{ _.getValueForNormalization() } // for side effect
-    1.0f
-  }
+  override def getValueForNormalization(): Float = 1f
 
   override def normalize(norm: Float, topLevelBoost: Float): Unit = {
     semanticWeights.foreach{ _.normalize(1.0f, 1.0f) } // for side effect


### PR DESCRIPTION
@ymatsuda 

`getValueForNormalization` should have no side effects ? 

Instead of returning 1, we may also return sum of normalization values from each sub weight. But that may change the final score quite a bit. It won't affect ranking, but the to-show/not-to-show behavior may change. 
