### PR TITLE
Mixpanel kifi.com tweaks

### DIFF
--- a/kifi-backend/modules/shoebox/public/js/main.js
+++ b/kifi-backend/modules/shoebox/public/js/main.js
@@ -2758,7 +2758,7 @@ $(function () {
 
 	function updateMe(data) {
 		me = data;
-		mixpanel.identify(me.id);
+		mixpanel.alias(me.id);
 		$('.my-pic').css('background-image', 'url(' + formatPicUrl(data.id, data.pictureName, 200) + ')');
 		$('.my-name').text(data.firstName + ' ' + data.lastName);
 		$('.my-description').text(data.description || '\u00A0'); // nbsp

--- a/kifi-backend/modules/shoebox/public/js/track.js
+++ b/kifi-backend/modules/shoebox/public/js/track.js
@@ -67,7 +67,7 @@
   }
 
   function defaultClickHandler(action) {
-    mixpanel.track('clicked_internal_page',{
+    mixpanel.track('user_clicked_internal_page',{
       type: getLocation(),
       action: action,
       origin: window.location.origin
@@ -75,7 +75,7 @@
   }
 
   function defaultViewHandler(path) {
-    mixpanel.track('viewed_internal_page',{
+    mixpanel.track('user_viewed_internal_page',{
       type: getLocation(path),
       origin: window.location.origin
     });


### PR DESCRIPTION
-Using “user” prefix for all events, just like the server
-Aliasing the external id, so we can track new signups end to end
