### PR TITLE
2.6.58: working around Chrome (up to v33 at least) rendering glitch...

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.6.57
+version=2.6.58

--- a/packrat/scripts/pane.js
+++ b/packrat/scripts/pane.js
@@ -84,7 +84,7 @@ var pane = pane || function () {  // idempotent for Chrome
     if ($pane) {
       var left = back || toPaneIdx(name) < toPaneIdx(toPaneName(paneHistory[0]));
       keeper.onPaneChange(locator);
-      var $cubby = $pane.find(".kifi-pane-cubby").css("overflow", "hidden");
+      var $cubby = $pane.find(".kifi-pane-cubby").css("overflow", "hidden").layout();
       var $cart = $cubby.find(".kifi-pane-box-cart").addClass(left ? "kifi-back" : "kifi-forward");
       var $old = $cart.find(".kifi-pane-box");
       var $new = $(render('html/keeper/pane_' + name, params))[left ? "prependTo" : "appendTo"]($cart).layout();


### PR DESCRIPTION
...that majorly disrupts pane transitions

To reproduce, click a page thread, click Back, and click a page thread again.
