### PR TITLE
new pane locators for the new Message Box

### DIFF
--- a/packrat/html/keeper/keeper.html
+++ b/packrat/html/keeper/keeper.html
@@ -13,8 +13,8 @@
     </span>
   </span>
   <span class="kifi-dock">
-    <span class="kifi-dock-btn kifi-dock-inbox{{#atNotices}} kifi-at{{/atNotices}}" data-loc="/notices" data-tip="i">
-      <span class="kifi-count"{{^inboxCount}} style="display:none"{{/inboxCount}}>{{inboxCount}}</span>
+    <span class="kifi-dock-btn kifi-dock-inbox{{#boxOpen}} kifi-at{{/boxOpen}}" data-loc="/box" data-tip="i">
+      <span class="kifi-count"{{^boxCount}} style="display:none"{{/boxCount}}>{{boxCount}}</span>
     </span>
     <span class="kifi-dock-sep"></span>
     <span class="kifi-dock-btn kifi-dock-compose" data-tip="c"></span>

--- a/packrat/html/keeper/keeper.html
+++ b/packrat/html/keeper/keeper.html
@@ -13,7 +13,7 @@
     </span>
   </span>
   <span class="kifi-dock">
-    <span class="kifi-dock-btn kifi-dock-inbox{{#boxOpen}} kifi-at{{/boxOpen}}" data-loc="/box" data-tip="i">
+    <span class="kifi-dock-btn kifi-dock-inbox{{#boxOpen}} kifi-at{{/boxOpen}}" data-loc="/messages#all" data-tip="i">
       <span class="kifi-count"{{^boxCount}} style="display:none"{{/boxCount}}>{{boxCount}}</span>
     </span>
     <span class="kifi-dock-sep"></span>

--- a/packrat/html/keeper/keeper.html
+++ b/packrat/html/keeper/keeper.html
@@ -13,7 +13,7 @@
     </span>
   </span>
   <span class="kifi-dock">
-    <span class="kifi-dock-btn kifi-dock-inbox{{#boxOpen}} kifi-at{{/boxOpen}}" data-loc="/messages#all" data-tip="i">
+    <span class="kifi-dock-btn kifi-dock-inbox{{#boxOpen}} kifi-at{{/boxOpen}}" data-loc="/messages:all" data-tip="i">
       <span class="kifi-count"{{^boxCount}} style="display:none"{{/boxCount}}>{{boxCount}}</span>
     </span>
     <span class="kifi-dock-sep"></span>

--- a/packrat/html/keeper/notices.html
+++ b/packrat/html/keeper/notices.html
@@ -1,5 +1,3 @@
-<div class="kifi-notices kifi-scroll-inner">
-  <div class="kifi-notices-none">
-    Ho, hum... Nothing’s happened yet!
-  </div>
+<div class="kifi-notices-box">
+  <div class="kifi-notices-list kifi-scroll-inner"></div>
 </div>

--- a/packrat/html/keeper/pane_notices.html
+++ b/packrat/html/keeper/pane_notices.html
@@ -1,13 +1,14 @@
 <div class="kifi-pane-box kifi-pane-notices">
-  {{#backButton}}
-  {{!<a class="kifi-pane-back" href="javascript:"></a>}}
-  {{/backButton}}
+  {{!<a class="kifi-pane-mark-notices-read" href="javascript:">Mark all read</a>}}
   <div class="kifi-notices-head">
     <input class="kifi-notices-query" type="text" placeholder="Search your messages">
-    <a class="kifi-notices-filter kifi-notices-filter-all">All</a>{{!
-  }}<a class="kifi-notices-filter kifi-notices-filter-sent" href="javascript:">Sent</a>{{!
-  }}<a class="kifi-notices-filter kifi-notices-filter-unread" href="javascript:">Unread</a>{{!
-  }}<a class="kifi-notices-filter kifi-notices-filter-page" href="javascript:">This Page</a>
+    <a class="kifi-notices-filter kifi-notices-filter-all" data-hash="all">All</a>{{!
+  }}<a class="kifi-notices-filter kifi-notices-filter-sent" data-hash="sent" href="javascript:">Sent</a>{{!
+  }}<a class="kifi-notices-filter kifi-notices-filter-unread" data-hash="unread" href="javascript:">Unread</a>{{!
+  }}<a class="kifi-notices-filter kifi-notices-filter-page" data-hash="page" href="javascript:">This Page</a>
   </div>
-  <div class="kifi-pane-tall"></div>
+  <div class="kifi-pane-tall">
+    <div class="kifi-notices-cart">
+    </div>
+  </div>
 </div>

--- a/packrat/html/keeper/pane_notices.html
+++ b/packrat/html/keeper/pane_notices.html
@@ -2,10 +2,10 @@
   {{!<a class="kifi-pane-mark-notices-read" href="javascript:">Mark all read</a>}}
   <div class="kifi-notices-head">
     <input class="kifi-notices-query" type="text" placeholder="Search your messages">
-    <a class="kifi-notices-filter kifi-notices-filter-all" data-hash="all">All</a>{{!
-  }}<a class="kifi-notices-filter kifi-notices-filter-sent" data-hash="sent" href="javascript:">Sent</a>{{!
-  }}<a class="kifi-notices-filter kifi-notices-filter-unread" data-hash="unread" href="javascript:">Unread</a>{{!
-  }}<a class="kifi-notices-filter kifi-notices-filter-page" data-hash="page" href="javascript:">This Page</a>
+    <a class="kifi-notices-filter kifi-notices-filter-all" data-sub="all">All</a>{{!
+  }}<a class="kifi-notices-filter kifi-notices-filter-sent" data-sub="sent" href="javascript:">Sent</a>{{!
+  }}<a class="kifi-notices-filter kifi-notices-filter-unread" data-sub="unread" href="javascript:">Unread</a>{{!
+  }}<a class="kifi-notices-filter kifi-notices-filter-page" data-sub="page" href="javascript:">This Page</a>
   </div>
   <div class="kifi-pane-tall">
     <div class="kifi-notices-cart">

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -241,7 +241,7 @@ var socketHandlers = {
       handleRealTimeNotification(n);
       var tl = pageThreads[n.url];
       if (tl) {
-        // TODO: update tabs at n.url and /box
+        // TODO: update tabs at n.url and /messages
       }
       tellVisibleTabsNoticeCountIfChanged();
     }
@@ -268,7 +268,7 @@ var socketHandlers = {
       }
     }
     if (arr.length) {
-      forEachTabAtLocator('/box', function(tab) {
+      forEachTabAtLocator('/messages', function(tab) {
         api.tabs.emit(tab, 'missed_notifications', arr);
       });
     }
@@ -790,7 +790,7 @@ function standardizeNotification(n) {
 function handleRealTimeNotification(n) {
   var tabsTold = {};
   api.tabs.eachSelected(tellTab);
-  forEachTabAtLocator('/box', tellTab);
+  forEachTabAtLocator('/messages', tellTab);
 
   if (n.unread && !n.muted) {
     api.play('media/notification.mp3');
@@ -855,7 +855,7 @@ function markRead(category, threadId, messageId, timeStr) {
       allThreads.decNumUnreadUnmuted();
     }
 
-    forEachTabAtLocator('/box', function(tab) {
+    forEachTabAtLocator('/messages', function(tab) {
       api.tabs.emit(tab, 'notifications_visited', {
         category: category,
         time: timeStr,
@@ -882,7 +882,7 @@ function markAllNoticesVisited(id, timeStr) {  // id and time of most recent not
   });
   // TODO: update numUnreadUnmuted for each ThreadList in pageThreads?
 
-  forEachTabAtLocator('/box', function(tab) {
+  forEachTabAtLocator('/messages', function(tab) {
     api.tabs.emit(tab, "all_notifications_visited", {
       id: id,
       time: timeStr,
@@ -1220,10 +1220,10 @@ function gotPageThreads(uri, nUri, threads) {
   }
   delete pageThreadsCallbacks[uri];
 
-  // sending new page threads (or just the count) to tabs at '/box' on this page
+  // sending new page threads (or just the count) to tabs at '/messages' on this page
   if (numNewThreads) {
-    forEachTabAtUriAndLocator(uri, nUri, '/box', function(tab) {
-      // should send all threads if at /box/page; otherwise, just the count
+    forEachTabAtUriAndLocator(uri, nUri, '/messages', function(tab) {
+      // should send all threads if at /messages#page; otherwise, just the count
       api.tabs.emit(tab, 'page_threads', pt.ids.map(idToThread));  // TODO: write handler
       api.tabs.emit(tab, 'page_thread_count', pt.ids.length);  // TODO: write handler
     });
@@ -1259,7 +1259,7 @@ function gotPageThreadsFor(url, tab, pt, nUri) {
     pageThreads[nUri] = pt;
     if (ruleSet.rules.message && pt.numUnreadUnmuted) {  // open immediately to unread message(s)
       api.tabs.emit(tab, 'open_to', {
-        locator: pt.numUnreadUnmuted === 1 ? '/messages/' + pt.firstUnreadUnmuted() : '/box#page',
+        locator: pt.numUnreadUnmuted === 1 ? '/messages/' + pt.firstUnreadUnmuted() : '/messages',
         trigger: 'message'
       }, {queue: 1});
       pt.forEachUnread(function(threadId) {

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1223,7 +1223,7 @@ function gotPageThreads(uri, nUri, threads) {
   // sending new page threads (or just the count) to tabs at '/messages' on this page
   if (numNewThreads) {
     forEachTabAtUriAndLocator(uri, nUri, '/messages', function(tab) {
-      // should send all threads if at /messages#page; otherwise, just the count
+      // should send all threads if at /messages:page; otherwise, just the count
       api.tabs.emit(tab, 'page_threads', pt.ids.map(idToThread));  // TODO: write handler
       api.tabs.emit(tab, 'page_thread_count', pt.ids.length);  // TODO: write handler
     });

--- a/packrat/scripts/keeper.js
+++ b/packrat/scripts/keeper.js
@@ -85,7 +85,7 @@ var keeper = keeper || function () {  // idempotent for Chrome
       'isKept': kept,
       'isPrivate': kept === 'private',
       'boxCount': count,
-      'boxOpen': /^\/messages(?:#|$)/.test(locator),
+      'boxOpen': /^\/messages(?:$|:)/.test(locator),
       'isTagged': tags.length
     }));
       // TODO: unindent below

--- a/packrat/scripts/keeper.js
+++ b/packrat/scripts/keeper.js
@@ -85,7 +85,7 @@ var keeper = keeper || function () {  // idempotent for Chrome
       'isKept': kept,
       'isPrivate': kept === 'private',
       'boxCount': count,
-      'boxOpen': /^\/box(?:#|$)/.test(locator),
+      'boxOpen': /^\/messages(?:#|$)/.test(locator),
       'isTagged': tags.length
     }));
       // TODO: unindent below

--- a/packrat/scripts/keeper.js
+++ b/packrat/scripts/keeper.js
@@ -84,9 +84,8 @@ var keeper = keeper || function () {  // idempotent for Chrome
       'bgDir': api.url('images/keeper'),
       'isKept': kept,
       'isPrivate': kept === 'private',
-      'inboxCount': count,
-      'atNotices': '/notices' === locator,
-      'atMessages': /^\/messages/.test(locator),
+      'boxCount': count,
+      'boxOpen': /^\/box(?:#|$)/.test(locator),
       'isTagged': tags.length
     }));
       // TODO: unindent below

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -101,11 +101,11 @@ var tile = tile || function() {  // idempotent for Chrome
         e.preventDefault();
         break;
       case 77: // m
-        loadAndDo('pane', 'toggle', 'key', '/box#page');
+        loadAndDo('pane', 'toggle', 'key', '/messages');
         e.preventDefault();
         break;
       case 79: // o
-        loadAndDo('pane', 'toggle', 'key', '/box');
+        loadAndDo('pane', 'toggle', 'key', '/messages#all');
         e.preventDefault();
         break;
       case 83: // s

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -101,11 +101,11 @@ var tile = tile || function() {  // idempotent for Chrome
         e.preventDefault();
         break;
       case 77: // m
-        loadAndDo('pane', 'toggle', 'key', '/messages');
+        loadAndDo('pane', 'toggle', 'key', '/box#page');
         e.preventDefault();
         break;
       case 79: // o
-        loadAndDo('pane', 'toggle', 'key', '/notices');
+        loadAndDo('pane', 'toggle', 'key', '/box');
         e.preventDefault();
         break;
       case 83: // s

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -105,7 +105,7 @@ var tile = tile || function() {  // idempotent for Chrome
         e.preventDefault();
         break;
       case 79: // o
-        loadAndDo('pane', 'toggle', 'key', '/messages#all');
+        loadAndDo('pane', 'toggle', 'key', '/messages:all');
         e.preventDefault();
         break;
       case 83: // s

--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -290,7 +290,7 @@ panes.notices = function () {
   }
 
   function formatLocator(hash) {
-    return hash && hash !== 'all' ? '/box#' + hash : '/box';
+    return hash && hash !== 'page' ? '/messages#' + hash : '/messages';
   }
 }();
 

--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -254,8 +254,8 @@ panes.notices = function () {
     });
     $list = $new.find('.kifi-notices-list');
     api.port.emit('pane', {
-      old: formatLocator($aOld.data('hash')),
-      new: formatLocator($aNew.data('hash'))
+      old: formatLocator($aOld.data('sub')),
+      new: formatLocator($aNew.data('sub'))
     });
   }
 
@@ -289,8 +289,8 @@ panes.notices = function () {
     return user.firstName + ' ' + user.lastName;
   }
 
-  function formatLocator(hash) {
-    return hash && hash !== 'page' ? '/messages#' + hash : '/messages';
+  function formatLocator(sub) {
+    return sub && sub !== 'page' ? '/messages:' + sub : '/messages';
   }
 }();
 

--- a/packrat/scripts/pane.js
+++ b/packrat/scripts/pane.js
@@ -39,13 +39,8 @@ var pane = pane || function () {  // idempotent for Chrome
     $('html').removeClass('kifi-with-pane kifi-pane-parent');
   });
 
-  function canonicalize(locator) {  // kifi.com chatter link uses /messages
-    return locator === '/messages' ? '/box#page' : (locator || '/box');
-  }
-
   function toPaneName(locator) {
-    var name = locator.match(/[a-z]+/)[0];
-    return {box: 'notices', messages: 'thread'}[name] || name;
+    return /^\/messages\//.test(locator) ? 'thread' : 'notices';
   }
 
   var paneIdxs = ['notices', 'thread'];
@@ -312,7 +307,7 @@ var pane = pane || function () {  // idempotent for Chrome
       }
     },
     toggle: function (trigger, locator) {
-      locator = canonicalize(locator);
+      locator = locator || '/messages#all';
       if ($pane) {
         if (locator === paneHistory[0]) {
           hidePane(trigger === 'keeper');
@@ -329,7 +324,7 @@ var pane = pane || function () {  // idempotent for Chrome
         if ($pane) {
           toggleToaster();
         } else {
-          showPane('/box').then(toggleToaster);
+          showPane('/messages#all').then(toggleToaster);
         }
         function toggleToaster() {
           toaster.toggleIn($pane).done(function (compose) {

--- a/packrat/scripts/pane.js
+++ b/packrat/scripts/pane.js
@@ -39,9 +39,13 @@ var pane = pane || function () {  // idempotent for Chrome
     $('html').removeClass('kifi-with-pane kifi-pane-parent');
   });
 
+  function canonicalize(locator) {  // kifi.com chatter link uses /messages
+    return locator === '/messages' ? '/box#page' : (locator || '/box');
+  }
+
   function toPaneName(locator) {
-    var name = locator.match(/[a-z]+\/?/)[0];
-    return {messages: 'notices', 'messages/': 'thread'}[name] || name;
+    var name = locator.match(/[a-z]+/)[0];
+    return {box: 'notices', messages: 'thread'}[name] || name;
   }
 
   var paneIdxs = ['notices', 'thread'];
@@ -68,7 +72,7 @@ var pane = pane || function () {  // idempotent for Chrome
     var deferred = Q.defer();
     if (locator !== (paneHistory && paneHistory[0])) {
       var name = toPaneName(locator);
-      (createPaneParams[name] || function (cb) {cb({backButton: paneHistory && paneHistory[back ? 2 : 0]})})(function (params) {
+      (createPaneParams[name] || function (cb) {cb({})})(function (params) {
         params.redirected = redirected;
         showPaneContinued(locator, back, name, params);
         deferred.resolve();
@@ -244,19 +248,6 @@ var pane = pane || function () {  // idempotent for Chrome
         }, 150);
         return;
       })
-      .on("keydown", ".kifi-pane-search", function (e) {
-        var q;
-        if (e.which == 13 && (q = this.value.trim())) {
-          this.value = '';
-          window.open('https://www.kifi.com/find?q=' + encodeURIComponent(q).replace(/%20/g, "+"));
-        }
-      })
-      .on("click", ".kifi-pane-back", function () {
-        var loc = paneHistory[1] || this.dataset.loc;
-        if (loc) {
-          showPane(loc, true);
-        }
-      })
       .on("kifi:show-pane", function (e, loc, paramsArg) {
         showPane(loc, false, paramsArg);
       })
@@ -298,10 +289,10 @@ var pane = pane || function () {  // idempotent for Chrome
 
   function populatePane($box, name, locator) {
     var $tall = $box.find(".kifi-pane-tall");
-    if (name == "thread") {
+    if (name === 'thread') {
       $tall.css("margin-top", $box.find(".kifi-thread-who").outerHeight());
     }
-    api.require("scripts/" + name + ".js", function () {
+    api.require('scripts/' + name + '.js', function () {
       panes[name].render($tall, locator);
     });
   };
@@ -321,11 +312,9 @@ var pane = pane || function () {  // idempotent for Chrome
       }
     },
     toggle: function (trigger, locator) {
-      if (!locator) {
-        locator = '/notices';
-      }
+      locator = canonicalize(locator);
       if ($pane) {
-        if (locator == paneHistory[0]) {
+        if (locator === paneHistory[0]) {
           hidePane(trigger === 'keeper');
         } else {
           showPane(locator);
@@ -340,7 +329,7 @@ var pane = pane || function () {  // idempotent for Chrome
         if ($pane) {
           toggleToaster();
         } else {
-          showPane('/notices').then(toggleToaster);
+          showPane('/box').then(toggleToaster);
         }
         function toggleToaster() {
           toaster.toggleIn($pane).done(function (compose) {

--- a/packrat/scripts/pane.js
+++ b/packrat/scripts/pane.js
@@ -307,7 +307,7 @@ var pane = pane || function () {  // idempotent for Chrome
       }
     },
     toggle: function (trigger, locator) {
-      locator = locator || '/messages#all';
+      locator = locator || '/messages:all';
       if ($pane) {
         if (locator === paneHistory[0]) {
           hidePane(trigger === 'keeper');
@@ -324,7 +324,7 @@ var pane = pane || function () {  // idempotent for Chrome
         if ($pane) {
           toggleToaster();
         } else {
-          showPane('/messages#all').then(toggleToaster);
+          showPane('/messages:all').then(toggleToaster);
         }
         function toggleToaster() {
           toaster.toggleIn($pane).done(function (compose) {

--- a/packrat/styles/keeper/notices.css
+++ b/packrat/styles/keeper/notices.css
@@ -1,4 +1,4 @@
-.kifi-pane a.kifi-pane-mark-notices-read[href] {
+.kifi-pane-mark-notices-read {
   position: absolute;
   top: 8px;
   right: 0;
@@ -7,26 +7,57 @@
   font-size: 12px;
   line-height: 26px;
   color: #fff !important;
-  display: none !important;
+  text-decoration: none !important;
+  display: none;
 }
-a.kifi-pane-mark-notices-read:hover {
-  text-decoration: none;
+.kifi-pane-mark-notices-read:hover {
   background-color: #67829c;
 }
-a.kifi-pane-mark-notices-read:active {
+.kifi-pane-mark-notices-read:active {
   background-color: #607991;
 }
-.kifi-notices {
+.kifi-notices-cart {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+}
+.kifi-notices-cart.kifi-forward,
+.kifi-notices-cart.kifi-back {
+  width: 626px; /* 310 + 6 + 310 */
+}
+.kifi-notices-cart.kifi-animated {
+  transition: -webkit-transform .2s ease-in-out;
+  transition: transform .2s ease-in-out;
+}
+.kifi-notices-cart.kifi-back:not(.kifi-roll),
+.kifi-notices-cart.kifi-roll.kifi-forward {
+  -webkit-transform: translate(-316px,0);
+  transform: translate(-316px,0);
+}
+.kifi-notices-box {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 310px;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.kifi-notices-cart.kifi-back .kifi-notices-box:last-child,
+.kifi-notices-cart.kifi-forward .kifi-notices-box:nth-child(2) {
+  left: 316px;
+}
+.kifi-notices-list {
   max-height: 100%;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
-div.kifi-notices-none {
-  margin: 10px 12px;
-  display: none;
-}
-div.kifi-notices-none:only-child {
+.kifi-notices-list:empty::before {
   display: block;
+  margin: 10px 12px;
+  content: 'Ho, hum... Nothing’s happened yet!';
 }
 .kifi-notice {
   position: relative;

--- a/packrat/styles/keeper/pane.css
+++ b/packrat/styles/keeper/pane.css
@@ -101,13 +101,10 @@
   color: #fff;
   -webkit-font-smoothing: antialiased;
 }
-.kifi-pane[data-locator='/notices'] .kifi-pane-head-title::before {
+.kifi-pane[data-locator='/box'] .kifi-pane-head-title::before {
   content: 'Message Box';
 }
-.kifi-pane[data-locator='/messages'] .kifi-pane-head-title::before {
-  content: 'Messages';
-}
-.kifi-pane[data-locator^='/messages/'] .kifi-pane-head-title::before {
+.kifi-pane .kifi-pane-head-title::before {
   content: 'Kifi Chat';
 }
 a.kifi-pane-settings {
@@ -224,36 +221,6 @@ a.kifi-pane-settings.kifi-active {
   width: 18px;
 }
 
-.kifi-pane input[type=text].kifi-pane-search {
-  margin: 0;
-  width: 100%;
-  height: auto;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
-  border: 0 solid transparent !important;
-  border-width: 0 6px !important;
-  border-radius: 0;
-  outline: none !important;
-  box-shadow: none !important;
-  background: #ecf0f1 padding-box !important;
-  padding: 9px 12px;
-  font-family: inherit;
-  font-size: 16px;
-  line-height: 20px;
-  font-weight: normal;
-  color: #333;
-  transition: background-color linear .1s;
-}
-.kifi-pane input[type=text].kifi-pane-search:focus {
-  background-color: #fff !important;
-}
-.kifi-pane input[type=text].kifi-pane-search::-moz-placeholder {
-  color: #a9a9a9 !important;
-}
-.kifi-pane input[type=text].kifi-pane-search::-webkit-input-placeholder {
-  color: #a9a9a9 !important;
-}
-
 /* shared */
 .kifi-pane-cubby {
   position: absolute;
@@ -296,6 +263,7 @@ a.kifi-pane-settings.kifi-active {
 .kifi-pane-box-cart.kifi-forward .kifi-pane-box:nth-child(2) {
   left: 316px;
 }
+
 /*
 a.kifi-pane-back[href] {
   position: absolute;
@@ -337,6 +305,7 @@ a.kifi-pane-back::after {
   content: "Back";
 }
 */
+
 .kifi-pane-tall {
   position: absolute;
   top: 0;

--- a/packrat/styles/keeper/pane.css
+++ b/packrat/styles/keeper/pane.css
@@ -101,10 +101,10 @@
   color: #fff;
   -webkit-font-smoothing: antialiased;
 }
-.kifi-pane[data-locator='/box'] .kifi-pane-head-title::before {
+.kifi-pane .kifi-pane-head-title::before {
   content: 'Message Box';
 }
-.kifi-pane .kifi-pane-head-title::before {
+.kifi-pane[data-locator^='/messages/'] .kifi-pane-head-title::before {
   content: 'Kifi Chat';
 }
 a.kifi-pane-settings {

--- a/packrat/threadlist.js
+++ b/packrat/threadlist.js
@@ -57,16 +57,14 @@
         }
       }
     },
-    getUnreadLocator: function () {
-      if (this.numUnreadUnmuted === 1) {
-        for (var i = 0; i < this.ids.length; i++) {
-          var id = this.ids[i];
-          if (this.allById[id].unread) {
-            return '/messages/' + id;
-          }
+    firstUnreadUnmuted: function () {
+      for (var i = 0; i < this.ids.length; i++) {
+        var id = this.ids[i];
+        var th = this.allById[id];
+        if (th.unread && !th.muted) {
+          return id;
         }
       }
-      return '/messages';
     },
     decNumUnreadUnmuted: function() {
       if (this.numUnreadUnmuted <= 0) {


### PR DESCRIPTION
`/messages:all` - the All tab (corresponds to old `/notices`)
`/messages:sent`
`/messages:unread`
`/messages:page` or `/messages` - the This Page tab (same as old `/messages`)

`/messages/<thread_id>` - a thread (unchanged)

It seems that the only locators we persist are of the `/messages/...` variety, which aren’t changing. The website uses `/messages`, which is unchanged.

It appears that `/notices` has only ever been used within the extension.

I’d appreciate any opinions @andrewconner @stkem @joonho1101
