### PR TITLE
passing the .kifi-pane-box to each pane for its initialization

### DIFF
--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -55,22 +55,22 @@ panes.notices = function () {
 
   var $notices, $markAll;
   return {
-    render: function ($container) {
+    render: function ($paneBox) {
       api.port.emit('notifications', function (o) {
-        renderNotices($container, o.notifications, o.timeLastSeen, o.numNotVisited);
+        renderNotices($paneBox, $paneBox.find('.kifi-pane-tall'), o.notifications, o.timeLastSeen, o.numNotVisited);
         api.port.on(handlers);
       });
     }};
 
-  function renderNotices($container, notices, timeLastSeen, numNotVisited) {
+  function renderNotices($paneBox, $tall, notices, timeLastSeen, numNotVisited) {
     $notices = $(render('html/keeper/notices', {}))
       .append(notices.map(renderNotice).join(''))
-      .appendTo($container)
+      .appendTo($tall)
       .preventAncestorScroll();
     $notices.find('time').timeago();
-    $container.antiscroll({x: false});
+    $tall.antiscroll({x: false});
 
-    var scroller = $container.data('antiscroll');
+    var scroller = $tall.data('antiscroll');
     $(window).on('resize.notices', scroller.refresh.bind(scroller));
 
     $notices.on('click', '.kifi-notice', function (e) {
@@ -107,13 +107,13 @@ panes.notices = function () {
       });
     });
 
-    var $box = $container.closest('.kifi-pane-box').on('kifi:remove', function () {
+    $paneBox.on('kifi:remove', function () {
       $notices = $markAll = null;
       $(window).off('resize.notices');
       api.port.off(handlers);
     });
 
-    $markAll = $box.find('.kifi-pane-mark-notices-read').click(function () {
+    $markAll = $paneBox.find('.kifi-pane-mark-notices-read').click(function () {
       var o = $notices.find('.kifi-notice').toArray().reduce(function (o, el) {
         var t = new Date(el.dataset.createdAt);
         return t > o.time ? {time: t, id: el.dataset.id} : o;

--- a/packrat/scripts/pane.js
+++ b/packrat/scripts/pane.js
@@ -296,12 +296,8 @@ var pane = pane || function () {  // idempotent for Chrome
   }
 
   function populatePane($box, name, locator) {
-    var $tall = $box.find(".kifi-pane-tall");
-    if (name == "thread") {
-      $tall.css("margin-top", $box.find(".kifi-thread-who").outerHeight());
-    }
-    api.require("scripts/" + name + ".js", function () {
-      panes[name].render($tall, locator);
+    api.require('scripts/' + name + '.js', function () {
+      panes[name].render($box, locator);
     });
   };
 

--- a/packrat/scripts/threads.js
+++ b/packrat/scripts/threads.js
@@ -23,9 +23,9 @@ panes.threads = function () {
 
   var $list = $();
   return {
-    render: function ($container) {
+    render: function ($paneBox) {
       api.port.emit('threads', function (threads) {
-        renderThreads($container, threads, session.prefs);
+        renderThreads($paneBox, $paneBox.find('.kifi-pane-tall'), threads, session.prefs);
         api.port.on(handlers);
         threads.forEach(function (th) {
           api.port.emit('thread', {id: th.id});  // preloading
@@ -33,7 +33,7 @@ panes.threads = function () {
       });
     }};
 
-  function renderThreads($container, threads, prefs) {
+  function renderThreads($paneBox, $tall, threads, prefs) {
     threads.forEach(function (t) {
       var n = messageCount(t);
       t.messageCount = n < -9 ? '9+' : Math.abs(n);
@@ -55,7 +55,7 @@ panes.threads = function () {
       thread: 'thread',
       compose: 'compose'
     }))
-    .prependTo($container)
+    .prependTo($tall)
     .on('mousedown', 'a[href^="x-kifi-sel:"]', lookMouseDown)
     .on('click', 'a[href^="x-kifi-sel:"]', function (e) {
       e.preventDefault();
@@ -68,26 +68,26 @@ panes.threads = function () {
     })
     .find('time').timeago();
 
-    $list = $container.find('.kifi-threads-list').preventAncestorScroll();
+    $list = $tall.find('.kifi-threads-list').preventAncestorScroll();
     var $scroll = $list.parent();
-    var compose = initCompose($container, prefs.enterToSend, {onSubmit: sendMessage});
-    var heighter = maintainHeight($scroll[0], $list[0], $container[0], [compose.form()]);
+    var compose = initCompose($tall, prefs.enterToSend, {onSubmit: sendMessage});
+    var heighter = maintainHeight($scroll[0], $list[0], $tall[0], [compose.form()]);
 
     $scroll.antiscroll({x: false});
     var scroller = $scroll.data('antiscroll');
     $(window).on('resize.threads', scroller.refresh.bind(scroller));
 
-    var $box = $container.closest('.kifi-pane-box').on('kifi:remove', function () {
+    $paneBox.on('kifi:remove', function () {
       $list.length = 0;
       $(window).off('resize.threads');
       compose.destroy();
       heighter.destroy();
       api.port.off(handlers);
     });
-    if ($box.data('shown')) {
+    if ($paneBox.data('shown')) {
       compose.focus();
     } else {
-      $box.on('kifi:shown', compose.focus);
+      $paneBox.on('kifi:shown', compose.focus);
     }
   }
 


### PR DESCRIPTION
cc @joonho1101 This makes it a little more convenient for each pane to initialize anything/everything in its containing box. No longer any need to use `.closest` to look up the DOM tree.
