### PR TITLE
fix_dev_mode_startup_hang

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperPluginImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperPluginImpl.scala
@@ -25,7 +25,6 @@ private[scraper] class ScrapeScheduler @Inject() (
     airbrake: AirbrakeNotifier,
     db: Database,
     articleStore: ArticleStore,
-    extractorFactory: ExtractorFactory,
     scrapeInfoRepo: ScrapeInfoRepo,
     normalizedURIRepo: NormalizedURIRepo,
     urlPatternRuleRepo: UrlPatternRuleRepo,


### PR DESCRIPTION
Interestingly the presence of this dependency in ScrapeScheduler caused the startup deadlock
The presence was transplanted here from Scraper (now removed).
Thanks much @ymatsuda and @andrewconner for their help in resolving this.
