### PR TITLE
avoid deadlock in AppScope

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/inject/AppScope.scala
+++ b/kifi-backend/modules/common/app/com/keepit/inject/AppScope.scala
@@ -6,10 +6,15 @@ import com.google.inject.Scope
 import com.keepit.common.db.ExternalId
 import com.keepit.common.logging.Logging
 import com.keepit.common.plugin.SchedulingPlugin
-
 import play.api.Application
 import play.api.Plugin
 import play.utils.Threads
+import scala.collection.concurrent
+import scala.concurrent.Future
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.concurrent.Promise
+import scala.util.Try
 
 class AppScope extends Scope with Logging {
 
@@ -21,7 +26,7 @@ class AppScope extends Scope with Logging {
 
   private var plugins: List[Plugin] = Nil
   private[inject] var pluginsToStart: List[Plugin] = Nil
-  private var instances: Map[Key[_], Any] = Map.empty
+  private[this] val instances: concurrent.TrieMap[Key[_], Future[_]] = new concurrent.TrieMap[Key[_], Future[_]]
 
   private var app: Application = _
 
@@ -80,7 +85,6 @@ class AppScope extends Scope with Logging {
 
     // if this instance is a plugin, start it and add to the list of plugins
     startIfPlugin(inst)
-    instances += key -> inst
     log.debug(s"returning initiated instance of ${inst.getClass().getName()}")
     inst
   }
@@ -102,20 +106,14 @@ class AppScope extends Scope with Logging {
       def get: T = {
         log.debug(s"requesting for $key")
         val instance = {
-          instances.get(key) match {
-            case Some(inst) =>
-              inst.asInstanceOf[T]
+          val promise = Promise[T]
+          val instFuture = instances.putIfAbsent(key, promise.future) match {
+            case Some(instFuture) => instFuture
             case None =>
-              appScope synchronized {
-                //double check, it may have been initialized already
-                instances.get(key) match {
-                  case Some(inst) =>
-                    inst.asInstanceOf[T]
-                  case None =>
-                    createInstance(key, unscoped)
-                }
-              }
+              promise.complete(Try(createInstance(key, unscoped)))
+              promise.future
           }
+          Await.result(instFuture, Duration.Inf).asInstanceOf[T]
         }
         log.debug(s"instance of key $key is $instance")
         instance


### PR DESCRIPTION
@raymondng @andrewconner @eishay 
This change replaces the synchronization in AppScope with a concurrent map. This should reduce a chance of deadlocks.
