### PR TITLE
always use context vector

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
@@ -17,7 +17,6 @@ import com.keepit.common.logging.Logging
 object SearchConfig {
   private[search] val defaultParams =
     Map[String, String](
-      "useContextVector" -> "false",
       "enableWarp" -> "true",
       "phraseBoost" -> "0.33",
       "siteBoost" -> "1.0",
@@ -50,7 +49,6 @@ object SearchConfig {
     )
   private[this] val descriptions =
     Map[String, String](
-      "useContextVector" -> "use the context vector as the query semantic vector",
       "enableWarp" -> "warp",
       "phraseBoost" -> "boost value for the detected phrase [0f,1f]",
       "siteBoost" -> "boost value for matching website names and domains",

--- a/kifi-backend/modules/search/app/com/keepit/search/MainQueryParser.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/MainQueryParser.scala
@@ -43,7 +43,6 @@ class MainQueryParser(
   override val siteBoost: Float,
   override val concatBoost: Float,
   homePageBoost: Float,
-  useContextVector: Boolean,
   phraseDetector: PhraseDetector,
   phraseDetectionConsolidator: RequestConsolidator[(CharSequence, Lang), Set[(Int, Int)]],
   monitoredAwait: MonitoredAwait
@@ -83,7 +82,7 @@ class MainQueryParser(
         if (semanticBoost > 0.0f) {
           textQueries.foreach{ textQuery =>
             textQuery.setSemanticBoost(semanticBoost)
-            textQuery.stems.map{ stemTerm => textQuery.addSemanticVectorQuery("sv", stemTerm.text, useContextVector) }
+            textQuery.stems.map{ stemTerm => textQuery.addSemanticVectorQuery("sv", stemTerm.text) }
           }
         }
 

--- a/kifi-backend/modules/search/app/com/keepit/search/MainQueryParserFactory.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/MainQueryParserFactory.scala
@@ -20,7 +20,6 @@ class MainQueryParserFactory @Inject() (phraseDetector: PhraseDetector, monitore
     val siteBoost = config.asFloat("siteBoost")
     val concatBoost = config.asFloat("concatBoost")
     val homePageBoost = config.asFloat("homePageBoost")
-    val useContextVector = config.asBoolean("useContextVector")
 
     new MainQueryParser(
       lang,
@@ -32,7 +31,6 @@ class MainQueryParserFactory @Inject() (phraseDetector: PhraseDetector, monitore
       siteBoost,
       concatBoost,
       homePageBoost,
-      useContextVector,
       phraseDetector,
       phraseDetectionConsolidator,
       monitoredAwait

--- a/kifi-backend/modules/search/app/com/keepit/search/index/PersonalizedSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/PersonalizedSearcher.scala
@@ -46,7 +46,7 @@ class PersonalizedSearcher(
   scaledWeightMyBookMarks: Int,
   scaledWeightClickHistory: Int
 )
-extends Searcher(indexReader) with Logging {
+extends Searcher(indexReader) with SearchSemanticContext with Logging {
   import PersonalizedSearcher._
 
   lazy val clickFilter: MultiHashFilter[ClickedURI] = clickFilterFunc

--- a/kifi-backend/modules/search/app/com/keepit/search/query/SemanticVectorQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/SemanticVectorQuery.scala
@@ -44,8 +44,6 @@ class SemanticVectorQuery(val term: Term) extends Query {
 
   override def extractTerms(out: JSet[Term]): Unit = out.add(term)
 
-  var useContextVector: Boolean = false
-
   override def toString(s: String) = {
     "semanticvector(%s)%s".format(term.toString(), ToStringUtils.boost(getBoost()))
   }
@@ -64,6 +62,8 @@ class SemanticVectorWeight(query: SemanticVectorQuery, searcher: Searcher) exten
 
   val term = query.term
 
+  searcher.addContextTerm(query.term)
+
   override def getQuery() = query
   override def scoresDocsOutOfOrder() = false
 
@@ -73,7 +73,6 @@ class SemanticVectorWeight(query: SemanticVectorQuery, searcher: Searcher) exten
   }
 
   override def normalize(norm: Float, topLevelBoost: Float) {
-    searcher.addContextTerm(query.term)
     value = query.getBoost * norm * topLevelBoost
   }
 
@@ -96,14 +95,9 @@ class SemanticVectorWeight(query: SemanticVectorQuery, searcher: Searcher) exten
   }
 
   override def scorer(context: AtomicReaderContext, scoreDocsInOrder: Boolean, topScorer: Boolean, acceptDocs: Bits): Scorer = {
-    val contextSketch = searcher.getContextSketch
-    val vector = if (query.useContextVector) SemanticVector.vectorize(contextSketch) else {
-      val weight = (searcher.numOfContextTerms - 1).toFloat / searcher.numOfContextTerms
-      searcher.getSemanticVector(query.term, contextSketch, weight)
-    }
-
+    val contextVector = searcher.getContextVector
     val tp = searcher.getSemanticVectorEnum(context, query.term, context.reader.getLiveDocs)
-    if (tp != null) new SemanticVectorScorerImpl(this, tp, vector, value) else new EmptySemanticVectorScorerImpl(this, vector)
+    if (tp != null) new SemanticVectorScorerImpl(this, tp, contextVector, value) else new EmptySemanticVectorScorerImpl(this, contextVector)
   }
 }
 

--- a/kifi-backend/modules/search/app/com/keepit/search/query/TextQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/TextQuery.scala
@@ -91,9 +91,8 @@ class TextQuery extends Query with Logging {
 
   def getSemanticBoost(): Float = semanticBoost
 
-  def addSemanticVectorQuery(field: String, text: String, useContextVector: Boolean = false): Unit = {
+  def addSemanticVectorQuery(field: String, text: String): Unit = {
     val query = SemanticVectorQuery(new Term(field, text))
-    query.useContextVector = useContextVector
     semanticVectorQuery = semanticVectorQuery match {
       case disjunct: DisjunctionMaxQuery =>
         totalSubQueryCnt += 1

--- a/kifi-backend/modules/search/test/com/keepit/search/index/ArticleIndexerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/index/ArticleIndexerTest.scala
@@ -73,7 +73,7 @@ class ArticleIndexerTest extends Specification with ApplicationInjector {
       def search(queryString: String, percentMatch: Float = 0.0f): Seq[Hit] = {
         val parser = parserFactory(Lang("en"), searchConfig)
         parser.setPercentMatch(percentMatch)
-        val searcher = indexer.getSearcher
+        val searcher = indexer.getSearcher.withSemanticContext
         parser.parse(queryString, None) match {
           case Some(query) => searcher.search(query)
           case None => Seq.empty[Hit]


### PR DESCRIPTION
@yingjieMiao 
- SemanticVectorQuery always uses the context vector as the query vector
- added getContextVector to Searcher for convenience and sharing
- Searcher instance from Indexer won't support addContextTerm/getContextSketch/getContextVector. It will throw UnsupportedOperationException
- the real implementation of above methods are in SearchSemanticContext trait 
- to use a context vector (or a sketch), create a new Searcher instance using withSemanticContext method. This will create a new instance of Searcher with SearchSemanticContext
