### PR TITLE
New routes for site profile settings

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -447,7 +447,7 @@ class AuthController @Inject() (
           postOffice.sendMail(ElectronicMail(
             from = EmailAddresses.NOTIFICATIONS,
             to = Seq(GenericEmailAddress(emailAddrStr)),
-            subject = "Kifi.com |  Please confirm your email address",
+            subject = "Kifi.com | Please confirm your email address",
             htmlBody = views.html.email.verifyEmail(newIdentity.firstName, verifyUrl).body,
             category = ElectronicMailCategory("email_confirmation")
           ))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -16,7 +16,6 @@ import play.api.libs.json.Json.toJson
 import com.keepit.abook.ABookServiceClient
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
-import play.api.libs.json._
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.concurrent.{Promise => PlayPromise}
 import play.api.libs.Comet
@@ -34,14 +33,9 @@ import com.keepit.common.store.{ImageCropAttributes, S3ImageStore}
 import play.api.data.Form
 import play.api.data.Forms._
 import com.keepit.model.SocialConnection
-import scala.util.Failure
 import com.keepit.model.EmailAddress
-import play.api.libs.json.JsString
-import play.api.libs.json.JsBoolean
-import scala.Some
-import play.api.libs.json.JsArray
-import play.api.libs.json.JsNumber
-import scala.util.Success
+import play.api.libs.json._
+import scala.util.{Success, Failure}
 import com.keepit.common.controller.AuthenticatedRequest
 import play.api.libs.json.JsObject
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -7,7 +7,7 @@ import com.keepit.common.controller.{AuthenticatedRequest, ActionAuthenticator, 
 import com.keepit.common.db.{Id, ExternalId}
 import com.keepit.common.db.slick.DBSession.RSession
 import com.keepit.common.db.slick._
-import com.keepit.common.mail.{PostOffice, EmailAddresses, ElectronicMail, LocalPostOffice}
+import com.keepit.common.mail._
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.controllers.core.NetworkInfoLoader
 import com.keepit.commanders._
@@ -31,6 +31,34 @@ import com.keepit.common.akka.SafeFuture
 import play.api.Play
 import com.keepit.social.SocialNetworks
 import com.keepit.eliza.ElizaServiceClient
+import play.api.mvc.{Result, Request}
+import scala.util.{Failure, Success}
+import com.keepit.common.healthcheck.{AirbrakeNotifier, AirbrakeError}
+import com.keepit.common.store.{ImageCropAttributes, S3ImageStore}
+import play.api.data.Form
+import play.api.data.Forms._
+import com.keepit.model.SocialConnection
+import scala.util.Failure
+import com.keepit.model.EmailAddress
+import play.api.libs.json.JsString
+import play.api.libs.json.JsBoolean
+import scala.Some
+import play.api.libs.json.JsArray
+import play.api.libs.json.JsNumber
+import scala.util.Success
+import com.keepit.common.controller.AuthenticatedRequest
+import play.api.libs.json.JsObject
+import com.keepit.model.SocialConnection
+import scala.util.Failure
+import com.keepit.model.EmailAddress
+import play.api.libs.json.JsString
+import play.api.libs.json.JsBoolean
+import scala.Some
+import play.api.libs.json.JsArray
+import play.api.libs.json.JsNumber
+import scala.util.Success
+import com.keepit.common.controller.AuthenticatedRequest
+import play.api.libs.json.JsObject
 
 class UserController @Inject() (
   db: Database,
@@ -50,7 +78,10 @@ class UserController @Inject() (
   userCommander: UserCommander,
   elizaServiceClient: ElizaServiceClient,
   clock: Clock,
-  abookServiceClient: ABookServiceClient
+  s3ImageStore: S3ImageStore,
+  abookServiceClient: ABookServiceClient,
+  airbrakeNotifier: AirbrakeNotifier,
+  emailAddressRepo: EmailAddressRepo
 ) extends WebsiteController(actionAuthenticator) {
 
   def friends() = AuthenticatedJsonAction { request =>
@@ -354,6 +385,74 @@ class UserController @Inject() (
       log.info(s"[queryContacts(id=$userId)] res(len=${objs.length}):${objs.mkString.take(200)}")
       objs
     }
+  }
+
+  def uploadBinaryUserPicture() = AuthenticatedJsonAction(allowPending = false, bodyParser = parse.temporaryFile) { implicit request =>
+    s3ImageStore.uploadTemporaryPicture(request.body.file) match {
+      case Success((token, pictureUrl)) =>
+        Ok(Json.obj("token" -> token, "url" -> pictureUrl))
+      case Failure(ex) =>
+        airbrakeNotifier.notify(AirbrakeError(ex, Some("Couldn't upload temporary picture (xhr direct)")))
+        BadRequest(JsNumber(0))
+    }
+  }
+
+  private case class UserPicInfo(
+    picToken: Option[String],
+    picHeight: Option[Int], picWidth: Option[Int],
+    cropX: Option[Int], cropY: Option[Int],
+    cropSize: Option[Int])
+  private val userPicForm = Form[UserPicInfo](
+    mapping(
+      "picToken" -> optional(text),
+      "picHeight" -> optional(number),
+      "picWidth" -> optional(number),
+      "cropX" -> optional(number),
+      "cropY" -> optional(number),
+      "cropSize" -> optional(number)
+    )(UserPicInfo.apply)(UserPicInfo.unapply)
+  )
+  def setUserPicture() = AuthenticatedJsonAction(allowPending = false) { implicit request =>
+    userPicForm.bindFromRequest.fold(
+    formWithErrors => BadRequest(Json.obj("error" -> formWithErrors.errors.head.message)),
+    { case UserPicInfo(picToken, picHeight, picWidth, cropX, cropY, cropSize) =>
+        val cropAttributes = parseCropForm(picHeight, picWidth, cropX, cropY, cropSize)
+        picToken.map { token =>
+          s3ImageStore.copyTempFileToUserPic(request.user.id.get, request.user.externalId, token, cropAttributes)
+        }
+        Ok("0")
+    })
+  }
+  private def parseCropForm(picHeight: Option[Int], picWidth: Option[Int], cropX: Option[Int], cropY: Option[Int], cropSize: Option[Int]) = {
+    for {
+      h <- picHeight
+      w <- picWidth
+      x <- cropX
+      y <- cropY
+      s <- cropSize
+    } yield ImageCropAttributes(w = w, h = h, x = x, y = y, s = s)
+  }
+
+  private val url = current.configuration.getString("application.baseUrl").get
+  def resendVerificationEmail(email: String) = AuthenticatedJsonAction { implicit request =>
+    db.readWrite { implicit s =>
+      emailAddressRepo.getByAddressOpt(email) match {
+        case Some(emailAddr) if emailAddr.userId == request.userId =>
+          val emailAddr = emailAddressRepo.save(emailAddressRepo.getByAddressOpt(email).get.withVerificationCode(clock.now))
+          val verifyUrl = s"$url${com.keepit.controllers.core.routes.AuthController.verifyEmail(emailAddr.verificationCode.get)}"
+          postOffice.sendMail(ElectronicMail(
+            from = EmailAddresses.NOTIFICATIONS,
+            to = Seq(GenericEmailAddress(email)),
+            subject = "Kifi.com | Please confirm your email address",
+            htmlBody = views.html.email.verifyEmail(request.user.firstName, verifyUrl).body,
+            category = ElectronicMailCategory("email_confirmation")
+          ))
+          Ok("0")
+        case _ =>
+          Forbidden("0")
+      }
+    }
+    Ok
   }
 
   def getAllConnections(search: Option[String], network: Option[String], after: Option[String], limit: Int) = AuthenticatedJsonAction {  request =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -3,7 +3,7 @@ package com.keepit.controllers.website
 import java.text.Normalizer
 
 import com.google.inject.Inject
-import com.keepit.common.controller.{AuthenticatedRequest, ActionAuthenticator, WebsiteController}
+import com.keepit.common.controller.{ActionAuthenticator, WebsiteController}
 import com.keepit.common.db.{Id, ExternalId}
 import com.keepit.common.db.slick.DBSession.RSession
 import com.keepit.common.db.slick._
@@ -25,29 +25,14 @@ import play.api.templates.Html
 import play.api.libs.iteratee.Enumerator
 import play.api.Play.current
 
-import java.util.concurrent.atomic.{AtomicInteger, AtomicBoolean}
-import com.keepit.heimdal.HeimdalServiceClient
-import com.keepit.common.akka.SafeFuture
+import java.util.concurrent.atomic.AtomicBoolean
 import play.api.Play
 import com.keepit.social.SocialNetworks
 import com.keepit.eliza.ElizaServiceClient
-import play.api.mvc.{Result, Request}
-import scala.util.{Failure, Success}
 import com.keepit.common.healthcheck.{AirbrakeNotifier, AirbrakeError}
 import com.keepit.common.store.{ImageCropAttributes, S3ImageStore}
 import play.api.data.Form
 import play.api.data.Forms._
-import com.keepit.model.SocialConnection
-import scala.util.Failure
-import com.keepit.model.EmailAddress
-import play.api.libs.json.JsString
-import play.api.libs.json.JsBoolean
-import scala.Some
-import play.api.libs.json.JsArray
-import play.api.libs.json.JsNumber
-import scala.util.Success
-import com.keepit.common.controller.AuthenticatedRequest
-import play.api.libs.json.JsObject
 import com.keepit.model.SocialConnection
 import scala.util.Failure
 import com.keepit.model.EmailAddress

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -187,6 +187,9 @@ GET     /site/user/socialConnections  @com.keepit.controllers.website.UserContro
 GET     /site/user/abookUploadStatus @com.keepit.controllers.website.UserController.getABookUploadStatus(id:Id[ABookInfo], callbackOpt:Option[String])
 GET     /site/user/prefs            @com.keepit.controllers.website.UserController.getPrefs()
 POST    /site/user/prefs            @com.keepit.controllers.website.UserController.savePrefs()
+POST    /site/user/upload-pic       @com.keepit.controllers.website.UserController.uploadBinaryUserPicture()
+POST    /site/user/pic              @com.keepit.controllers.website.UserController.setUserPicture()
+POST    /site/user/resend-verification @com.keepit.controllers.website.UserController.resendVerificationEmail(email: String)
 
 GET     /site/*path                 @com.keepit.controllers.website.HomeController.kifiSiteRedirect(path: String)
 GET     /site/                      @com.keepit.controllers.website.HomeController.kifiSiteRedirect(path: String = "")

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -187,7 +187,7 @@ GET     /site/user/socialConnections  @com.keepit.controllers.website.UserContro
 GET     /site/user/abookUploadStatus @com.keepit.controllers.website.UserController.getABookUploadStatus(id:Id[ABookInfo], callbackOpt:Option[String])
 GET     /site/user/prefs            @com.keepit.controllers.website.UserController.getPrefs()
 POST    /site/user/prefs            @com.keepit.controllers.website.UserController.savePrefs()
-POST    /site/user/upload-pic       @com.keepit.controllers.website.UserController.uploadBinaryUserPicture()
+POST    /site/user/pic/upload       @com.keepit.controllers.website.UserController.uploadBinaryUserPicture()
 POST    /site/user/pic              @com.keepit.controllers.website.UserController.setUserPicture()
 POST    /site/user/resend-verification @com.keepit.controllers.website.UserController.resendVerificationEmail(email: String)
 


### PR DESCRIPTION
@joonho1101, the two requested APIs are complete.

To upload a user’s image, two requests will be made. The API is extremely similar to the signup flow if you want to look at that. The first request is to POST /site/user/upload-pic which accepts binary image uploads. It will return a token and url of the image. While it’s uploading, show the resize dialog and let the user crop/resize it.

Then, once the upload is complete and the image is cropped/resized, make a call to POST /site/user/pic, which accepts a JSON body of the following form:

```
{“picToken”: <the token the previous endpoint gave>, “picHeight”: <height of original image>, “picWidth”: <width of original image>, “cropX”: <x coordinate of the start of the user cropped image>, “cropY”: <y coordinate of the start of the user cropped image>, “cropSize”: <number of pixels past x and y to include>}
```

It will return a 200 if everything is good.

To resend a verification link, call POST /site/user/resend-verification?email=(email address). It will return a 200 is everything is good.
