### PR TITLE
Fixing setting bookmarks as private/public if they already exist.

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/BookmarkInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/BookmarkInterner.scala
@@ -93,7 +93,7 @@ class BookmarkInterner @Inject() (
       installationId: Option[ExternalId[KifiInstallation]], source: BookmarkSource, title: Option[String], url: String)(implicit session: RWSession) = {
     val startTime = System.currentTimeMillis
     bookmarkRepo.getByUriAndUser(uri.id.get, user.id.get, excludeState = None) match {
-      case Some(bookmark) if bookmark.isActive => (false, bookmark.withPrivate(isPrivate = isPrivate))
+      case Some(bookmark) if bookmark.isActive => (false, bookmarkRepo.save(bookmark.withPrivate(isPrivate = isPrivate)))
       case Some(bookmark) => (false, bookmarkRepo.save(bookmark.withActive(true).withPrivate(isPrivate).withTitle(title orElse(uri.title)).withUrl(url)))
       case None =>
         val urlObj = urlRepo.get(url).getOrElse(urlRepo.save(URLFactory(url = url, normalizedUriId = uri.id.get)))


### PR DESCRIPTION
I was the last to touch this — no clue why the `save` was dropped. 
