### PR TITLE
scraper_config_tweaks

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/scraper/ScraperConfig.scala
+++ b/kifi-backend/modules/common/app/com/keepit/scraper/ScraperConfig.scala
@@ -16,7 +16,7 @@ case class ScraperConfig(
   actorTimeout: Int = sys.props.getOrElse("scraper.actor.timeout", "20000").toInt,
   syncAwaitTimeout: Int = sys.props.getOrElse("scraper.plugin.sync.await.timeout", "20000").toInt,
   serviceCallTimeout: Int = sys.props.getOrElse("scraper.service.call.timeout", "20000").toInt,
-  numInstances: Int = sys.props.getOrElse("scraper.service.instances", (Runtime.getRuntime.availableProcessors * 8).toString).toInt,
+  numInstances: Int = sys.props.getOrElse("scraper.service.instances", (Runtime.getRuntime.availableProcessors * 32).toString).toInt,
   batchSize: Int = sys.props.getOrElse("scraper.service.batch.size", "10").toInt,
   batchMax: Int = sys.props.getOrElse("scraper.service.batch.max", "50").toInt,
   pendingOverdueThreshold: Int = sys.props.getOrElse("scraper.service.pending.overdue.threshold", "3600").toInt,

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeProcessorModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeProcessorModule.scala
@@ -25,8 +25,8 @@ case class ScrapeProcessorImplModule() extends ScrapeProcessorModule {
   def httpFetcher: HttpFetcher = {
     new HttpFetcherImpl(
       userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17",
-      connectionTimeout = 30000,
-      soTimeOut = 30000,
+      connectionTimeout = scraperConfig.scrapePendingFrequency * 1000, // todo: revisit
+      soTimeOut = scraperConfig.scrapePendingFrequency * 1000,
       trustBlindly = true
     )
   }


### PR DESCRIPTION
Made some tweaks based on observations over weekend

fetcher timeout (connection/socket) -> reduced from 30s to 15s (based on polling frequency)
(actually I didn't notice this until today, so it might be long overdue)

scraper scaling factor 8 -> 32 (for 1 core m1.medium, 8 does appear to be too conservative esp. considering our long timeouts)

will continue to monitor & tweak

cc: @ymatsuda 
cc: @leogrim 
cc: @andrewconner 
cc: @eishay 
