### PR TITLE
healthcheck_startup_sleep_config

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/Healthcheck.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/Healthcheck.scala
@@ -210,10 +210,12 @@ class HealthcheckPluginImpl @Inject() (
     email
   }
 
+  val sleep = sys.props.getOrElse("healthcheck.startup.sleep", "30").toInt // seconds
+
   override def warmUp(benchmarkRunner: BenchmarkRunner) : Unit = {
-    log.info("going to sleep for one minute to make sure all plugins are ready to go")
+    log.info(s"going to sleep for $sleep seconds to make sure all plugins are ready to go")
     log.info(s"benchmark 1: ${benchmarkRunner.runBenchmark()}")
-    Thread.sleep(30 * 1000)//30 sec
+    Thread.sleep(sleep * 1000)
     log.info(s"benchmark 2: ${benchmarkRunner.runBenchmark()}")
     log.info("ok, i'm warmed up and ready to roll!")
     super.warmUp(benchmarkRunner)


### PR DESCRIPTION
1) Fix "bug" in log ... which says 1 minute when in fact it's 30 seconds :)

2) Make this configurable -- for abook/scraper and perhaps other non-shoebox services, we may not need such a long sleep duration during startup ... in fact we may not need it at all. This is a quick way to test -- I'll first tweak/test this in abook/scraper.

Implicit goal: faster deployment (esp when the # of machines increases as we scale out)

cc: @stkem 
cc: @andrewconner 
cc: @eishay 
cc: @ymatsuda 
