### PR TITLE
Fixing tag privacy bug

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/BookmarkInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/BookmarkInterner.scala
@@ -37,7 +37,7 @@ class BookmarkInterner @Inject() (
   implicit private val fortyTwoServices: FortyTwoServices)
     extends Logging {
 
-  def internBookmarks(value: JsValue, user: User, experiments: Set[ExperimentType], source: BookmarkSource, installationId: Option[ExternalId[KifiInstallation]] = None)(implicit context: HeimdalContext): Seq[Bookmark] = {
+  def internBookmarks(value: JsValue, user: User, experiments: Set[ExperimentType], source: BookmarkSource, mutatePrivacy: Boolean, installationId: Option[ExternalId[KifiInstallation]] = None)(implicit context: HeimdalContext): Seq[Bookmark] = {
     val referenceId = UUID.randomUUID
     log.info(s"[internBookmarks] user=(${user.id} ${user.firstName} ${user.lastName}) source=$source installId=$installationId value=$value $referenceId ")
     val parseStart = System.currentTimeMillis()
@@ -53,7 +53,7 @@ class BookmarkInterner @Inject() (
     }
     log.info(s"[internBookmarks-$referenceId] Parsing took: ${System.currentTimeMillis - parseStart}ms")
 
-    var count = new AtomicInteger(0)
+    val count = new AtomicInteger(0)
     val total = bookmarks.size
     val batchConcurrency = 1
     val batchSize = 100
@@ -62,7 +62,7 @@ class BookmarkInterner @Inject() (
         val startTime = System.currentTimeMillis
         log.info(s"[internBookmarks-$referenceId] Persisting $batchSize bookmarks: ${count.get}/$total")
         val persisted = db.readWrite(attempts = 2) { implicit session =>
-          bms.map { bm => internUriAndBookmark(bm, user, experiments, source) }.flatten
+          bms.map { bm => internUriAndBookmark(bm, user, experiments, source, mutatePrivacy) }.flatten
         }
         log.info(s"[internBookmarks-$referenceId] Done with ${count.addAndGet(bms.size)}/$total. Took ${System.currentTimeMillis - startTime}ms")
         persisted
@@ -89,20 +89,20 @@ class BookmarkInterner @Inject() (
     }
   }
 
-  private def internBookmark(uri: NormalizedURI, user: User, isPrivate: Boolean, experiments: Set[ExperimentType],
+  private def internBookmark(uri: NormalizedURI, user: User, isPrivate: Boolean, mutatePrivacy: Boolean, experiments: Set[ExperimentType],
       installationId: Option[ExternalId[KifiInstallation]], source: BookmarkSource, title: Option[String], url: String)(implicit session: RWSession) = {
     bookmarkRepo.getByUriAndUser(uri.id.get, user.id.get, excludeState = None) match {
-      case Some(bookmark) if bookmark.isActive =>
-        (false, bookmarkRepo.save(bookmark.withPrivate(isPrivate).withTitle(title orElse bookmark.title orElse uri.title)))
       case Some(bookmark) =>
-        (false, bookmarkRepo.save(bookmark.withPrivate(isPrivate).withTitle(title orElse bookmark.title orElse uri.title).withUrl(url).withActive(true)))
+        val keepWithPrivate = if (mutatePrivacy) bookmark.copy(isPrivate = isPrivate) else bookmark
+        val keep = if (!bookmark.isActive) { keepWithPrivate.withUrl(url).withActive(true) } else keepWithPrivate
+        (false, bookmarkRepo.save(keep.withTitle(title orElse bookmark.title orElse uri.title)))
       case None =>
         val urlObj = urlRepo.get(url).getOrElse(urlRepo.save(URLFactory(url = url, normalizedUriId = uri.id.get)))
         (true, bookmarkRepo.save(BookmarkFactory(uri, user.id.get, title orElse uri.title, urlObj, source, isPrivate, installationId)))
     }
   }
 
-  private def internUriAndBookmark(json: JsObject, user: User, experiments: Set[ExperimentType], source: BookmarkSource, installationId: Option[ExternalId[KifiInstallation]] = None)(implicit session: RWSession): Option[(Bookmark, NormalizedURI, Boolean)] = try {
+  private def internUriAndBookmark(json: JsObject, user: User, experiments: Set[ExperimentType], source: BookmarkSource, mutatePrivacy: Boolean, installationId: Option[ExternalId[KifiInstallation]] = None)(implicit session: RWSession): Option[(Bookmark, NormalizedURI, Boolean)] = try {
     val startTime = System.currentTimeMillis
     val title = (json \ "title").asOpt[String]
     val url = (json \ "url").as[String]
@@ -116,7 +116,7 @@ class BookmarkInterner @Inject() (
           uriRepo.save(initialURI.withState(NormalizedURIStates.SCRAPE_WANTED))
         else initialURI
       }
-      val (isNewKeep, bookmark) = internBookmark(uri, user, isPrivate, experiments, installationId, source, title, url)
+      val (isNewKeep, bookmark) = internBookmark(uri, user, isPrivate, mutatePrivacy, experiments, installationId, source, title, url)
 
       if (uri.state == NormalizedURIStates.SCRAPE_WANTED) {
         Try(scraper.scheduleScrape(uri))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/BookmarksCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/BookmarksCommander.scala
@@ -101,7 +101,7 @@ class BookmarksCommander @Inject() (
   def keepMultiple(keepInfosWithCollection: KeepInfosWithCollection, user: User, experiments: Set[ExperimentType], source: BookmarkSource)(implicit context: HeimdalContext):
                   (Seq[KeepInfo], Option[Int]) = {
     val KeepInfosWithCollection(collection, keepInfos) = keepInfosWithCollection
-    val keeps = bookmarkInterner.internBookmarks(Json.toJson(keepInfos), user, experiments, source)
+    val keeps = bookmarkInterner.internBookmarks(Json.toJson(keepInfos), user, experiments, source, true)
 
     val addedToCollection = collection flatMap {
       case Left(collectionId) => db.readOnly { implicit s => collectionRepo.getOpt(collectionId) }
@@ -183,7 +183,7 @@ class BookmarksCommander @Inject() (
   }
 
   def tagUrl(tag: Collection, json: JsValue, user: User, experiments: Set[ExperimentType], source: BookmarkSource, kifiInstallationId: Option[ExternalId[KifiInstallation]])(implicit context: HeimdalContext) = {
-    val bookmark = bookmarkInterner.internBookmarks(json, user, experiments, source, kifiInstallationId)
+    val bookmark = bookmarkInterner.internBookmarks(json, user, experiments, source, mutatePrivacy = false, installationId = kifiInstallationId)
     addToCollection(tag, bookmark)
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailToKeepPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailToKeepPlugin.scala
@@ -105,7 +105,7 @@ class MailToKeepActor @Inject() (
                   val bookmark = bookmarkInterner.internBookmarks(Json.obj(
                     "url" -> uri.toString,
                     "isPrivate" -> (keepType == KeepType.Private)
-                  ), user, Set(), BookmarkSource.email).head
+                  ), user, Set(), BookmarkSource.email, mutatePrivacy = true).head
                   log.info(s"created bookmark from email with id ${bookmark.id.get}")
                   sendReply(
                     message = message,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
@@ -187,7 +187,7 @@ class ExtBookmarksController @Inject() (
 
           val experiments = request.experiments
           implicit val context = heimdalContextBuilder.withRequestInfo(request).build
-          val bookmarks = bookmarkInterner.internBookmarks(json \ "bookmarks", request.user, experiments, bookmarkSource, installationId)
+          val bookmarks = bookmarkInterner.internBookmarks(json \ "bookmarks", request.user, experiments, bookmarkSource, mutatePrivacy = true, installationId = installationId)
 
           if (request.kifiInstallationId.isDefined && bookmarkSource == BookmarkSource.initLoad) {
             // User selected to import Léo

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/BookmarkInternerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/BookmarkInternerTest.scala
@@ -23,7 +23,7 @@ class BookmarkInternerTest extends Specification with ShoeboxApplicationInjector
         val bookmarks = bookmarkInterner.internBookmarks(Json.obj(
             "url" -> "http://42go.com",
             "isPrivate" -> true
-          ), user, Set(), BookmarkSource.email)
+          ), user, Set(), BookmarkSource.email, true)
         db.readWrite { implicit db =>
           userRepo.get(user.id.get) === user
           bookmarks.size === 1
@@ -45,7 +45,7 @@ class BookmarkInternerTest extends Specification with ShoeboxApplicationInjector
           ), Json.obj(
             "url" -> "http://kifi.com",
             "isPrivate" -> false
-          )), user, Set(), BookmarkSource.email)
+          )), user, Set(), BookmarkSource.email, true)
         db.readWrite { implicit db =>
           userRepo.get(user.id.get) === user
           bookmarks.size === 2
@@ -70,7 +70,7 @@ class BookmarkInternerTest extends Specification with ShoeboxApplicationInjector
           ), Json.obj(
             "url" -> "http://kifi.com",
             "isPrivate" -> true
-          )), user, Set(), BookmarkSource.email)
+          )), user, Set(), BookmarkSource.email, true)
         db.readWrite { implicit db =>
           bookmarks.size === 2
           bookmarkRepo.all.size === 2
@@ -87,7 +87,7 @@ class BookmarkInternerTest extends Specification with ShoeboxApplicationInjector
         val initialBookmarks = bookmarkInterner.internBookmarks(Json.arr(Json.obj(
           "url" -> "http://42go.com/",
           "isPrivate" -> true
-        )), user, Set(), BookmarkSource.keeper)
+        )), user, Set(), BookmarkSource.keeper, true)
         initialBookmarks.size === 1
         db.readWrite { implicit s =>
           bookmarkRepo.save(bookmarkRepo.getByUser(user.id.get).head.withActive(false))
@@ -95,7 +95,7 @@ class BookmarkInternerTest extends Specification with ShoeboxApplicationInjector
         val bookmarks = bookmarkInterner.internBookmarks(Json.arr(Json.obj(
           "url" -> "http://42go.com/",
           "isPrivate" -> true
-        )), user, Set(), BookmarkSource.keeper)
+        )), user, Set(), BookmarkSource.keeper, true)
         db.readOnly { implicit s =>
           bookmarks.size === 1
           bookmarkRepo.all.size === 1


### PR DESCRIPTION
Last week, I noticed that we were not saving bookmarks when they were rekept (but were mutating the objects), so I added a `save()` around it.

This caused a bug that we have had: We are sometimes assuming that `isPrivate` missing means `true` (example: in bookmark imports). Other times, we assume it means "don't change the privacy of an active keep" (example: when you keep to tag).

So I added a field "mutatePrivacy" to make this clear and fix the bug. This complicates the internBookmark API, but keeps the cases separate. I think we should decide which of these we prefer, and settle on one. Unfortunately, that means client changes.

Open to suggestions to improve this. When I get some time, I plan on rewriting `BookmarkInterner` to not use JsObject inputs, so that we can a) deal with typed / safe objects and leave serialization to the controllers, b) handle defaults at the controller source.

@stkem @leogrim @2is10 
