### PR TITLE
Changing reset password emails to support@kifi.com 

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -232,7 +232,8 @@ class AuthHelper @Inject() (
               val reset = passwordResetRepo.createNewResetToken(userId, resetEmailAddress)
               val resetUrl = s"$url${routes.AuthController.setPasswordPage(reset.token)}"
               postOffice.sendMail(ElectronicMail(
-                from = EmailAddresses.NOTIFICATIONS,
+                fromName = Some("Kifi Support"),
+                from = EmailAddresses.SUPPORT,
                 to = Seq(resetEmailAddress),
                 subject = "Kifi.com | Password reset requested",
                 htmlBody = views.html.email.resetPassword(resetUrl).body,


### PR DESCRIPTION
More accurate than notifications@kifi.com, and some users may have that address filtered.

@2is10 You requested this a while back.
