### PR TITLE
2.7.21: ending the unread_notifications_count dance because it can cause bugs

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/ext/ExtMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/ext/ExtMessagingController.scala
@@ -179,14 +179,14 @@ class ExtMessagingController @Inject() (
       implicit val context = authenticatedWebSocketsContextBuilder(socket).build
       messagingCommander.addParticipantsToThread(socket.userId, ExternalId[MessageThread](threadId), users)
     },
+
+    // pre-inbox notification/thread handlers (soon will be obsolete)
+
     "get_unread_notifications_count" -> { _ =>
       val numUnreadUnmuted = messagingCommander.getUnreadUnmutedThreadCount(socket.userId)
       socket.channel.push(Json.arr("unread_notifications_count", numUnreadUnmuted))
       // note: "unread_notifications_count" is broadcasted elsewhere too
     },
-
-    // pre-inbox notification/thread handlers (soon will be obsolete)
-
     "get_notifications" -> { case JsNumber(howMany) +: _ =>
       messagingCommander.getLatestSendableNotificationsNotJustFromMe(socket.userId, howMany.toInt).map{ notices =>
         val numUnreadUnmuted = messagingCommander.getUnreadUnmutedThreadCount(socket.userId)


### PR DESCRIPTION
A bug it causes: [Red notification counter will continue to appear indicating a "new message" even if you have conversation open](https://app.asana.com/0/9081601379695/9123912893173)

If a counter consistency problem crops up in the new Inbox branch, I’d like to try to tackle it by identifying what cached threads are missing or have the wrong state and rectifying them. (If we don’t keep the extension’s cached unread/unmuted thread count in sync with its other cached thread data, we’re introducing a new problem.)

cc @andrewconner 
