### PR TITLE
use latest thread object from server even if no new messages on it

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1309,7 +1309,7 @@ function gotPageThreads(uri, nUri, threads, numTotal) {
   threads.forEach(function (th) {
     standardizeNotification(th);
     var oldTh = threadsById[th.thread];
-    if (!oldTh || oldTh.id !== th.id && new Date(oldTh.time) <= new Date(th.time)) {
+    if (!oldTh || new Date(oldTh.time) <= new Date(th.time)) {
       threadsById[th.thread] = th;
       if (th.unread && threadReadAt[th.thread] >= new Date(th.time)) {
         th.unread = false;


### PR DESCRIPTION
This is debatable, but why not?
