### PR TITLE
Skip empty terms when building SemanticVector

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/search/SemanticVector.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SemanticVector.scala
@@ -155,7 +155,7 @@ class SemanticVectorBuilder(windowSize: Int) {
     val termAttr = tokenStream.getAttribute(classOf[CharTermAttribute])
 
     tokenStream.reset()
-    while (tokenStream.incrementToken()) add(new String(termAttr.buffer, 0, termAttr.length))
+    while (tokenStream.incrementToken()) if (termAttr.length > 0) add(new String(termAttr.buffer, 0, termAttr.length))
     flush
   }
 


### PR DESCRIPTION
@ymatsuda @eishay 
Not sure about this fix, I don't know this code at all and there's a lot of var so I hope I'm not introducing any off-by-one error, but it looks like that might do it.
