### PR TITLE
exposing an alternative endpoint to getIndexable() containing only field...

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -83,6 +83,7 @@ object Shoebox extends Service {
     def getUriIdsInCollection(collectionId: Id[Collection]) = ServiceRoute(GET, "/internal/shoebox/database/getUriIdsInCollection", Param("collectionId", collectionId))
     def getCollectionsByUser(userId: Id[User]) = ServiceRoute(GET, "/internal/shoebox/database/getCollectionsByUser", Param("userId", userId))
     def getIndexable(seqNum: Long, fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getIndexable", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
+    def getIndexableUris(seqNum: Long, fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getIndexableUris", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def getUserIndexable(seqNum: Long, fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getUserIndexable", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def getActiveExperiments() = ServiceRoute(GET, "/internal/shoebox/database/getActiveExperiments")
     def getExperiments() = ServiceRoute(GET, "/internal/shoebox/database/getExperiments")

--- a/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
@@ -142,4 +142,24 @@ object NormalizedURIStates extends States[NormalizedURI] {
   }
 }
 
+case class IndexableUri(
+   id: Option[Id[NormalizedURI]] = None,
+   title: Option[String] = None,
+   url: String,
+   restriction: Option[Restriction] = None,
+   state: State[NormalizedURI] = NormalizedURIStates.ACTIVE,
+   seq: SequenceNumber)
 
+object IndexableUri {
+
+  def apply(uri: NormalizedURI): IndexableUri = IndexableUri(uri.id, uri.title, uri.url, uri.restriction, uri.state, uri.seq)
+
+  implicit def format = (
+    (__ \ 'id).formatNullable(Id.format[NormalizedURI]) and
+    (__ \ 'title).formatNullable[String] and
+    (__ \ 'url).format[String] and
+    (__ \ 'restriction).formatNullable[Restriction] and
+    (__ \ 'state).format(State.format[NormalizedURI]) and
+    (__ \ 'seq).format(SequenceNumber.sequenceNumberFormat)
+  )(IndexableUri.apply, unlift(IndexableUri.unapply))
+}

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -64,6 +64,7 @@ trait ShoeboxServiceClient extends ServiceClient {
   def getCollectionsByUser(userId: Id[User]): Future[Seq[Collection]]
   def getCollectionIdsByExternalIds(collIds: Seq[ExternalId[Collection]]): Future[Seq[Id[Collection]]]
   def getIndexable(seqNum: Long, fetchSize: Int): Future[Seq[NormalizedURI]]
+  def getIndexableUris(seqNum: Long, fetchSize: Int): Future[Seq[IndexableUri]]
   def getUserIndexable(seqNum: Long, fetchSize: Int): Future[Seq[User]]
   def getBookmarks(userId: Id[User]): Future[Seq[Bookmark]]
   def getBookmarksChanged(seqNum: SequenceNumber, fertchSize: Int): Future[Seq[Bookmark]]
@@ -440,6 +441,12 @@ class ShoeboxServiceClientImpl @Inject() (
   def getIndexable(seqNum: Long, fetchSize: Int): Future[Seq[NormalizedURI]] = {
     call(Shoebox.internal.getIndexable(seqNum, fetchSize)).map { r =>
       Json.fromJson[Seq[NormalizedURI]](r.json).get
+    }
+  }
+
+  def getIndexableUris(seqNum: Long, fetchSize: Int): Future[Seq[IndexableUri]] = {
+    call(Shoebox.internal.getIndexableUris(seqNum, fetchSize)).map { r =>
+      Json.fromJson[Seq[IndexableUri]](r.json).get
     }
   }
 

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -3,13 +3,13 @@ package com.keepit.shoebox
 import com.keepit.common.healthcheck.{FakeAirbrakeNotifier, AirbrakeNotifier}
 import com.keepit.common.service.ServiceType
 import com.keepit.common.zookeeper.ServiceCluster
-import com.keepit.common.logging.Logging
 import com.keepit.model._
 import com.keepit.common.db._
 import scala.concurrent.Future
 import com.keepit.search._
 import com.keepit.model.Phrase
 import com.keepit.model.NormalizedURI
+import com.keepit.model.IndexableUri
 import com.keepit.model.User
 import java.util.concurrent.atomic.AtomicInteger
 import collection.mutable.{Map => MutableMap}
@@ -382,6 +382,12 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
     val uris = allNormalizedURIs.values.filter(_.seq > SequenceNumber(seqNum)).toSeq.sortBy(_.seq)
     val fewerUris = (if (fetchSize >= 0) uris.take(fetchSize) else uris)
     Future.successful(fewerUris)
+  }
+
+  def getIndexableUris(seqNum: Long, fetchSize: Int = -1) : Future[Seq[IndexableUri]] = {
+    val uris = allNormalizedURIs.values.filter(_.seq > SequenceNumber(seqNum)).toSeq.sortBy(_.seq)
+    val fewerUris = (if (fetchSize >= 0) uris.take(fetchSize) else uris)
+    Future.successful(fewerUris map { u => IndexableUri(u) })
   }
 
   def getUserIndexable(seqNum: Long, fetchSize: Int): Future[Seq[User]] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
@@ -24,8 +24,15 @@ class ShoeboxDataPipeController @Inject() (
     val uris = db.readOnly(2, Slave) { implicit s =>
       normUriRepo.getIndexable(SequenceNumber(seqNum), fetchSize)
     }
-    //todo(eishay): need to have a dedicated serializer for those
     Ok(Json.toJson(uris))
+  }
+
+  def getIndexableUris(seqNum: Long, fetchSize: Int) = Action { request =>
+    val uris = db.readOnly(2, Slave) { implicit s =>
+      normUriRepo.getIndexable(SequenceNumber(seqNum), fetchSize)
+    }
+    val indexables = uris map { u => IndexableUri(u) }
+    Ok(Json.toJson(indexables))
   }
 
   def getCollectionsChanged(seqNum: Long, fetchSize: Int) = Action { request =>

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -458,6 +458,7 @@ GET     /internal/shoebox/database/getBookmarksInCollection @com.keepit.controll
 GET     /internal/shoebox/database/getUriIdsInCollection @com.keepit.controllers.internal.ShoeboxController.getUriIdsInCollection(collectionId: Id[Collection])
 GET     /internal/shoebox/database/getCollectionsByUser @com.keepit.controllers.internal.ShoeboxController.getCollectionsByUser(userId: Id[User])
 GET     /internal/shoebox/database/getIndexable       @com.keepit.controllers.internal.ShoeboxDataPipeController.getIndexable(seqNum: Long, fetchSize: Int)
+GET     /internal/shoebox/database/getIndexableUris   @com.keepit.controllers.internal.ShoeboxDataPipeController.getIndexableUris(seqNum: Long, fetchSize: Int)
 GET     /internal/shoebox/database/getUserIndexable   @com.keepit.controllers.internal.ShoeboxDataPipeController.getUserIndexable(seqNum: Long, fetchSize: Int)
 
 POST    /internal/shoebox/database/createDeepLink      @com.keepit.controllers.ext.ExtDeepLinkController.createDeepLink()


### PR DESCRIPTION
...s relevant for the uri indexing, should by much smaller in size
