### PR TITLE
modifided scoring when boostScorer does not hit

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/query/MultiplicativeBoostQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/MultiplicativeBoostQuery.scala
@@ -114,7 +114,8 @@ extends Scorer(weight) with Logging {
           if (boosterScorer.docID() == doc) {
             score *= (boosterScorer.score() * boosterStrength + (1.0f - boosterStrength))
           } else {
-            score *= (1.0f - boosterStrength)
+            log.info("boostscorer doesn't have this doc id")
+            score *= 0f // (1.0f - boosterStrength)
           }
         } else {
           score *= (1.0f - boosterStrength)


### PR DESCRIPTION
@ymatsuda 

When boostScorer doesn't consider a doc a hit and textScorer consider that doc a hit, do we still return it? If we return this doc, this may cause problem when Lucene explain the doc.  Previously, proximity scorer doesn't filter out documents. If we want the proximity scorer to filter out bad documents, those documents should be filtered out in multiplicativeScorer too. A quick solution is to return zero score. An alternative is to change the next() function. A third option is to let proximity scorer never filter out documents, but return close to zero score. 

Comments? 
