### PR TITLE
service_register_disable

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
@@ -43,11 +43,14 @@ class ServiceDiscoveryImpl(
     amazonInstanceInfoProvider: Provider[AmazonInstanceInfo],
     scheduler: Scheduler,
     airbrake: Provider[AirbrakeNotifier],
+    disableRegistration: Boolean = sys.props.getOrElse("service.register.disable", "false").toBoolean, // todo: inject config
     servicesToListenOn: Seq[ServiceType] =
         ServiceType.SEARCH :: ServiceType.SHOEBOX :: ServiceType.ELIZA :: ServiceType.HEIMDAL :: ServiceType.ABOOK :: ServiceType.SCRAPER :: Nil,
     doKeepAlive: Boolean = true)
   extends ServiceDiscovery with Logging {
 
+
+  if (disableRegistration) log.warn("[ServiceDiscovery] registration DISABLED")
 
   private[this] val registrationLock = new AnyRef
   @volatile private[this] var registered = false
@@ -74,7 +77,8 @@ class ServiceDiscoveryImpl(
 
   def serviceCluster(serviceType: ServiceType): ServiceCluster = clusters(serviceType)
 
-  def isLeader: Boolean = {
+  def isLeader: Boolean = if (disableRegistration) false
+  else {
     if (!stillRegistered()) {
       log.warn(s"service did not register itself yet!")
       return false
@@ -103,7 +107,7 @@ class ServiceDiscoveryImpl(
     myCluster.instanceForNode(instance.node).isDefined
   }
 
-  private def keepAlive() : Unit = {
+  private def keepAlive() : Unit = if (!disableRegistration) {
     scheduler.scheduleOnce(2 minutes){
       if (registered) {
         forceUpdate()
@@ -138,7 +142,8 @@ class ServiceDiscoveryImpl(
     }
   }
 
-  def register(): ServiceInstance = registrationLock.synchronized {
+  def register(): ServiceInstance = if (disableRegistration) ServiceInstance.EMPTY
+  else registrationLock.synchronized {
     if (unregistered) throw new IllegalStateException("unable to register once unregistered")
 
     registered = true
@@ -147,7 +152,8 @@ class ServiceDiscoveryImpl(
     myInstance.get
   }
 
-  private def doRegister(): Unit = {
+
+  private def doRegister(): Unit = if (!disableRegistration) {
     if (registered) {
       log.info(s"registered clusters: $clusters, my service is ${thisRemoteService.serviceType}, my instance is $myInstance")
 
@@ -173,14 +179,14 @@ class ServiceDiscoveryImpl(
     }
   }
 
-  override def unRegister(): Unit = registrationLock.synchronized {
+  override def unRegister(): Unit = if (!disableRegistration) registrationLock.synchronized {
     registered = false
     unregistered = true
     myInstance foreach {instance => zk.deleteNode(instance.node)}
     myInstance = None
   }
 
-  def changeStatus(newStatus: ServiceStatus): Unit = if(stillRegistered()) {
+  def changeStatus(newStatus: ServiceStatus): Unit = if (!disableRegistration) if(stillRegistered()) {
     myInstance foreach { instance =>
       log.info(s"Changing instance status to $newStatus")
       thisRemoteService.status = newStatus

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceInstance.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceInstance.scala
@@ -31,3 +31,8 @@ case class ServiceInstance(node: Node, var remoteService: RemoteService, thisIns
 
   private def isAlmostUp: Boolean = remoteService.healthyStatus == ServiceStatus.UP && (remoteService.status == ServiceStatus.SICK || remoteService.status == ServiceStatus.SELFCHECK_FAIL)
 }
+
+
+object ServiceInstance {
+  def EMPTY = ServiceInstance(null, null, true)
+}

--- a/kifi-backend/modules/common/test/com/keepit/common/zookeeper/ServiceDiscoveryTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/zookeeper/ServiceDiscoveryTest.scala
@@ -40,7 +40,7 @@ class ServiceDiscoveryTest extends Specification with DeprecatedTestInjector {
     "register" in {
       withInjector() { implicit injector =>
         val zk = inject[ZooKeeperClient]
-        val discovery = new ServiceDiscoveryImpl(inject[ZooKeeperClient], inject[FortyTwoServices], inject[Provider[AmazonInstanceInfo]], inject[Scheduler], null, ServiceType.TEST_MODE::Nil, doKeepAlive = false)
+        val discovery = new ServiceDiscoveryImpl(inject[ZooKeeperClient], inject[FortyTwoServices], inject[Provider[AmazonInstanceInfo]], inject[Scheduler], null, false, ServiceType.TEST_MODE::Nil, doKeepAlive = false)
         val registeredInstance = discovery.register()
         fromByteArray(zk.get(registeredInstance.node)) === RemoteService.toJson(RemoteService(inject[AmazonInstanceInfo], ServiceStatus.STARTING, ServiceType.TEST_MODE))
       }


### PR DESCRIPTION
A simple mechanism to disable self-registration. Tested locally -- appears to work ok. 

This is not expected to change any default behavior.

Directly use system properties for now; will use injected config later.

cc: @stkem 
cc: @ymatsuda 
