### PR TITLE
tmp disable nlp phrase detection

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/MainQueryParser.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/MainQueryParser.scala
@@ -141,13 +141,7 @@ class MainQueryParser(
         val tPhraseDetection = System.currentTimeMillis
         val p = phraseDetector.detectAll(phStemmedTerms)
         phraseDetectionTime = System.currentTimeMillis - tPhraseDetection
-
-        if (p.size > 0) p else {
-          val tNlpPhraseDetection = System.currentTimeMillis
-          val nlpPhrases = NlpPhraseDetector.detectAll(queryText.toString, stemmingAnalyzer, lang)
-          nlpPhraseDetectionTime = System.currentTimeMillis - tNlpPhraseDetection
-          nlpPhrases
-        }
+        p
       }
     }
   }


### PR DESCRIPTION
We are considering filtering documents in proximityScorer. The NLP phrase detector may give aggressive phrase suggestion, which may dramatically reduce proximity score of a potentially relevant document. The proximity score difference could be a factor of 10. If we want to filter based on threshold, we need more consistent behavior of phrase detectors. We turn off NLP phrase detector for now. 
