### PR TITLE
integration_exp_and_reaper

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/abook/EmailParser.scala
+++ b/kifi-backend/modules/common/app/com/keepit/abook/EmailParser.scala
@@ -21,9 +21,17 @@ case class Email(local:LocalPart, host:Host) {
       case _ => false
     }
   }
+
+  def isKifi = (domain == Email.KIFI_DOMAIN)
+  def isTest = isKifi && (local.tag exists (tag => tag.t.startsWith(ETag.TEST) || tag.t.startsWith(ETag.AUTOGEN)))
+  def isFake = isKifi && (local.tag exists (tag => tag.t.startsWith(ETag.TEST)))
+  def isAutoGen = isKifi && (local.tag exists (tag => tag.t.startsWith(ETag.AUTOGEN)))
 }
 
 object Email {
+
+  val KIFI_DOMAIN = "42go.com" // todo: kifi.com
+
   def apply(s:String) = {
     EmailParser.parse[Email](EmailParser.email, s).getOrElse(throw new IllegalArgumentException(s"Cannot parse $s"))
   }
@@ -35,6 +43,11 @@ case class EComment(c:String) {
 case class ETag(t:String) {
   override val toString = s"+$t"
 }
+object ETag {
+  val TEST    = "test"
+  val AUTOGEN = "autogen"
+}
+
 case class LocalPart(p:Option[EComment], s:String, tag:Option[ETag], t:Option[EComment]) {
   val localName = s.trim.toLowerCase  // mysql is case-insensitive
   override val toString = tag match { // todo: revisit default for tag handling
@@ -64,4 +77,19 @@ object EmailParser extends RegexParsers { // rudimentary; also see @URIParser
   }
   def domainPart:Parser[String] = """[^~/?#@:\.]+""".r ^^ (_.toLowerCase)
   // todo: quotes, dots, nameprep
+
+  implicit class Wrapper(val res:ParseResult[Email]) extends AnyVal {
+    def asOpt:Option[Email] = if (res.successful) Some(res.get) else None
+  }
+}
+
+object EmailParserUtils {
+
+  def parseOpt(s:String):Option[Email] = EmailParser.parseAll(EmailParser.email, s).asOpt
+
+  def isKifiEmail(s:String) = parseOpt(s) exists { _.isKifi }
+  def isTestEmail(s:String) = parseOpt(s) exists { _.isTest }
+  def isFakeEmail(s:String) = parseOpt(s) exists { _.isFake }
+  def isAutoGenEmail(s:String) = parseOpt(s) exists { _.isAutoGen }
+
 }

--- a/kifi-backend/modules/common/app/com/keepit/model/EmailAddress.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/EmailAddress.scala
@@ -7,7 +7,7 @@ import com.keepit.common.db._
 import com.keepit.common.time._
 import org.joda.time.DateTime
 import com.keepit.common.mail.EmailAddressHolder
-import com.keepit.abook.EmailParser
+import com.keepit.abook.{EmailParserUtils, EmailParser}
 
 case class EmailAddress (
   id: Option[Id[EmailAddress]] = None,
@@ -28,20 +28,9 @@ case class EmailAddress (
     lastVerificationSent = Some(now),
     verificationCode = Some(new BigInteger(128, EmailAddressObject.random).toString(36)))
   def verified: Boolean = state == EmailAddressStates.VERIFIED
-  def parse = EmailParser.parseAll(EmailParser.email, address)
-  def parseOpt = if (parse.successful) Some(parse.get) else None
-  def isTestEmail(): Boolean = {
-    (for {
-      email <- parseOpt
-      tag <- email.local.tag
-    } yield email.domain == "42go.com" && (tag.t.startsWith("test") || tag.t.startsWith("autogen"))) getOrElse false
-  }
-  def isAutoGenEmail(): Boolean = {
-    (for {
-      email <- parseOpt
-      tag <- email.local.tag
-    } yield email.domain == "42go.com" && tag.t.startsWith("autogen")) getOrElse false
-  }
+  def isTestEmail() = EmailParserUtils.isTestEmail(address)
+  def isFakeEmail() = EmailParserUtils.isFakeEmail(address) // +test
+  def isAutoGenEmail() = EmailParserUtils.isAutoGenEmail(address)  // +autogen
 }
 
 object EmailAddressObject {

--- a/kifi-backend/modules/common/app/com/keepit/model/UserExperiment.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserExperiment.scala
@@ -35,6 +35,7 @@ object ExperimentType {
   )
 
   val ADMIN = ExperimentType("admin")
+  val AUTO_GEN = ExperimentType("autogen")
   val FAKE = ExperimentType("fake")
   val NO_SEARCH_EXPERIMENTS = ExperimentType("no search experiments")
   val NOT_SENSITIVE = ExperimentType("not sensitive")
@@ -51,6 +52,7 @@ object ExperimentType {
 
   def get(str: String): ExperimentType = str.toLowerCase.trim match {
     case ADMIN.value => ADMIN
+    case AUTO_GEN.value => AUTO_GEN
     case FAKE.value => FAKE
     case NOT_SENSITIVE.value => NOT_SENSITIVE
     case NO_SEARCH_EXPERIMENTS.value => NO_SEARCH_EXPERIMENTS
@@ -64,7 +66,8 @@ object ExperimentType {
   }
 
   def getUserStatus(experiments: Set[ExperimentType]): String =
-    if (experiments.contains(FAKE)) FAKE.value
+    if (experiments.contains(AUTO_GEN)) AUTO_GEN.value
+    else if (experiments.contains(FAKE)) FAKE.value
     else if (experiments.contains(ADMIN)) ADMIN.value
     else "standard"
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/integration/AutogenReaper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/integration/AutogenReaper.scala
@@ -64,7 +64,9 @@ private[integration] class AutogenAcctReaperActor @Inject() (
           socialUserInfoRepo.getByUser(exp.userId) map { sui =>
             socialUserInfoRepo.save(sui.withState(SocialUserInfoStates.INACTIVE))
           }
-          emailAddressRepo.save(emailAddressRepo.getByUser(exp.userId).withState(EmailAddressStates.INACTIVE))
+          emailAddressRepo.getAllByUser(exp.userId) foreach { emailAddr =>
+            emailAddressRepo.save(emailAddr.withState(EmailAddressStates.INACTIVE))
+          }
           // skip UserCred/UserExp for now; delete later
         }
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/integration/AutogenReaper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/integration/AutogenReaper.scala
@@ -1,0 +1,74 @@
+package com.keepit.common.integration
+
+import com.keepit.model._
+import scala.concurrent.duration._
+
+import com.google.inject.Inject
+import com.keepit.common.actor.ActorInstance
+import com.keepit.common.akka.{FortyTwoActor, UnsupportedActorMessage}
+import com.keepit.common.db.slick._
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.logging.Logging
+import com.keepit.common.plugin.{SchedulingPlugin, SchedulingProperties}
+import play.api.{Play, Plugin}
+import play.api.Play.current
+
+trait AutogenReaperPlugin extends Plugin {
+  def reap()
+}
+
+class AutogenReaperPluginImpl @Inject() (
+  actor: ActorInstance[AutogenAcctReaperActor],
+  val schedulingProperties: SchedulingProperties //only on leader
+) extends Logging with AutogenReaperPlugin with SchedulingPlugin {
+
+  log.info(s"<ctr> ReaperPlugin created")
+
+  // plugin lifecycle methods
+  override def enabled: Boolean = true
+  override def onStart() {
+    for (app <- Play.maybeApplication) {
+      val (initDelay, freq) = if (Play.isDev) (1 minute, 1 minute) else (5 minutes, 1 hour)
+      log.info(s"[onStart] ReaperPlugin started with initDelay=$initDelay freq=$freq")
+      scheduleTask(actor.system, initDelay, freq, actor.ref, Reap)
+    }
+  }
+
+  override def reap() { actor.ref ! Reap }
+}
+
+private[integration] case class Reap()
+
+private[integration] class AutogenAcctReaperActor @Inject() (
+  db: Database,
+  userExperimentRepo: UserExperimentRepo,
+  userRepo: UserRepo,
+  userCredRepo: UserCredRepo,
+  userSessionRepo: UserSessionRepo,
+  socialUserInfoRepo: SocialUserInfoRepo,
+  emailAddressRepo: EmailAddressRepo,
+  airbrake: AirbrakeNotifier
+) extends FortyTwoActor(airbrake) with Logging {
+
+  def receive() = {
+    case Reap =>
+      db.readWrite { implicit rw =>
+        // a variant of this could live in UserCommander
+        val generated = userExperimentRepo.getByType(ExperimentType.AUTO_GEN)
+        log.info(s"[reap] got (${generated.length}) to be reaped: ${generated.mkString(",")}")
+        generated foreach { exp =>
+          val user = userRepo.get(exp.userId)
+          log.info(s"[reap] processing $user")
+          userSessionRepo.invalidateByUser(exp.userId)
+          userRepo.save(user.withState(UserStates.INACTIVE)) // mark as inactive for now; delete later
+          socialUserInfoRepo.getByUser(exp.userId) map { sui =>
+            socialUserInfoRepo.save(sui.withState(SocialUserInfoStates.INACTIVE))
+          }
+          emailAddressRepo.save(emailAddressRepo.getByUser(exp.userId).withState(EmailAddressStates.INACTIVE))
+          // skip UserCred/UserExp for now; delete later
+        }
+      }
+    case m => throw new UnsupportedActorMessage(m)
+  }
+
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/integration/ReaperModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/integration/ReaperModule.scala
@@ -1,0 +1,18 @@
+package com.keepit.common.integration
+
+import net.codingwell.scalaguice.ScalaModule
+import com.keepit.inject.AppScoped
+
+trait ReaperModule extends ScalaModule
+
+case class ProdReaperModule() extends ReaperModule {
+  def configure() {
+    bind[AutogenReaperPlugin].to[AutogenReaperPluginImpl].in[AppScoped]
+  }
+}
+
+case class DevReaperModule() extends ReaperModule {
+  def configure() {
+    bind[AutogenReaperPlugin].to[AutogenReaperPluginImpl].in[AppScoped]
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/dev/ShoeboxDevModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/dev/ShoeboxDevModule.scala
@@ -10,10 +10,12 @@ import com.keepit.social.ProdShoeboxSecureSocialModule
 import com.keepit.common.analytics.DevAnalyticsModule
 import com.keepit.common.store.ShoeboxDevStoreModule
 import com.keepit.inject.CommonDevModule
+import com.keepit.common.integration.DevReaperModule
 
 case class ShoeboxDevModule() extends ShoeboxModule(
   secureSocialModule = ProdShoeboxSecureSocialModule(),
   mailModule = DevMailModule(),
+  reaperModule = DevReaperModule(),
   storeModule = ShoeboxDevStoreModule(),
 
   // Shoebox Functional Modules

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxGlobal.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxGlobal.scala
@@ -15,6 +15,7 @@ import com.keepit.social.SocialGraphPlugin
 import com.keepit.controllers.internal.ExpertRecommenderController
 import com.keepit.learning.topicmodel.TopicModelSwitcherPlugin
 import com.keepit.integrity.{UriIntegrityPlugin, DataIntegrityPlugin}
+import com.keepit.common.integration.AutogenReaperPlugin
 
 object ShoeboxGlobal extends FortyTwoGlobal(Prod) with ShoeboxServices {
 
@@ -34,6 +35,7 @@ trait ShoeboxServices { self: FortyTwoGlobal =>
     require(injector.instance[SocialGraphPlugin].enabled)
     require(injector.instance[SocialGraphRefresher].enabled)
     require(injector.instance[MailSenderPlugin].enabled)
+    require(injector.instance[AutogenReaperPlugin].enabled)
     injector.instance[MailSenderPlugin].processOutbox()
     require(injector.instance[MailToKeepPlugin].enabled)
     require(injector.instance[HealthcheckPlugin].enabled)

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxModule.scala
@@ -17,10 +17,12 @@ import com.keepit.eliza.ProdElizaServiceClientModule
 import com.keepit.common.social.ProdSocialGraphModule
 import com.keepit.heimdal.ProdHeimdalServiceClientModule
 import com.keepit.abook.ProdABookServiceClientModule
+import com.keepit.common.integration.ReaperModule
 
 abstract class ShoeboxModule(
   val secureSocialModule: SecureSocialModule,
   val mailModule: MailModule,
+  val reaperModule: ReaperModule,
   val storeModule: ShoeboxDevStoreModule,
 
   // Shoebox Functional Modules

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxProdModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxProdModule.scala
@@ -8,10 +8,12 @@ import com.keepit.common.mail.ProdMailModule
 import com.keepit.common.store.ShoeboxDevStoreModule
 import com.keepit.classify.ProdDomainTagImporterModule
 import com.keepit.inject.CommonProdModule
+import com.keepit.common.integration.ProdReaperModule
 
 case class ShoeboxProdModule() extends ShoeboxModule (
   secureSocialModule = ProdShoeboxSecureSocialModule(),
   mailModule = ProdMailModule(),
+  reaperModule = ProdReaperModule(),
   storeModule = ShoeboxDevStoreModule(),
 
   // Shoebox Functional Modules

--- a/kifi-backend/modules/shoebox/app/com/keepit/social/SecureSocialUserServiceImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/social/SecureSocialUserServiceImpl.scala
@@ -26,6 +26,7 @@ import com.keepit.model.UserExperiment
 import com.keepit.model.UserCred
 import com.keepit.commanders.UserCommander
 import com.keepit.heimdal.{HeimdalContext, HeimdalContextBuilder}
+import com.keepit.abook.EmailParserUtils
 
 @Singleton
 class SecureSocialUserPluginImpl @Inject() (
@@ -93,16 +94,22 @@ class SecureSocialUserPluginImpl @Inject() (
     socialUser
   }
 
-  private def updateExperimentIfTestUser(userId: Id[User]): Unit = db.readWrite { implicit session =>
-    val isTestUser = emailRepo.getAllByUser(userId).exists(_.isTestEmail())
-    if (isTestUser) {
-      val markedAsFake = userExperimentRepo.hasExperiment(userId, ExperimentType.FAKE)
-      if (markedAsFake)
-        log.info(s"test user $userId is already marked as FAKE")
+  private def updateExperimentIfTestUser(userId: Id[User]): Unit = db.readWrite { implicit rw =>
+    @inline def setExp(exp: ExperimentType) {
+      val marked = userExperimentRepo.hasExperiment(userId, exp)
+      if (marked)
+        log.info(s"test user $userId is already marked as $exp")
       else {
-        log.info(s"setting test user $userId as FAKE")
-        db.readWrite { implicit session => userExperimentRepo.save(UserExperiment(userId = userId, experimentType = ExperimentType.FAKE)) }
+        log.info(s"setting test user $userId as $exp")
+        userExperimentRepo.save(UserExperiment(userId = userId, experimentType = exp))        
       }
+    }
+
+    val emailAddresses = emailRepo.getAllByUser(userId)
+    for (e <- emailAddresses filter (_.isTestEmail()) headOption) {
+      setExp(ExperimentType.FAKE)
+      if (e.isAutoGenEmail())
+        setExp(ExperimentType.AUTO_GEN)
     }
   }
 
@@ -124,7 +131,7 @@ class SecureSocialUserPluginImpl @Inject() (
     log.info(s"[createUser] new user: name=${u.firstName + " " + u.lastName} state=${u.state}")
 
     // TODO(Léo) MOVE BACK TO USERCOMMANDER AFTER TESTING PERIOD
-    val isTestUser = identity.email.map(email => EmailAddress(userId = u.id.get, address = email).isTestEmail()) getOrElse false
+    val isTestUser = identity.email.map(e => EmailParserUtils.isFakeEmail(e)) getOrElse false
     if (Play.isDev || isTestUser) userCommander.createDefaultKeeps(u.id.get)(HeimdalContext.empty)
     u
   }


### PR DESCRIPTION
Added user experiment and reaper for auto-generated test user accounts

Right now the reaper/cleaner only (mostly) marks rows as inactive; will change to real delete later

@andrewconner @eishay please take a quick look and let me know if I have missed anything. Thanks!
