### PR TITLE
sending emails (only to eishay) when there’s a bad sendgrid event.

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/api/SendgridController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/api/SendgridController.scala
@@ -6,7 +6,6 @@ import com.keepit.common.logging.Logging
 import com.keepit.common.controller.{WebsiteController, ActionAuthenticator}
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import com.keepit.commanders.{SendgridCommander, SendgridEvent}
-import java.lang.Exception
 import scala.Exception
 
 /**


### PR DESCRIPTION
will make it more robust the tested then use the sendgrid@42go.com list for these.
too many dropped emails should be an error
