### PR TITLE
revert back to personal sv

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/query/BooleanQueryWithSemanticMatch.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/BooleanQueryWithSemanticMatch.scala
@@ -23,7 +23,6 @@ import org.apache.lucene.util.Bits
 import org.apache.lucene.util.Bits.MatchNoBits
 import org.apache.lucene.util.PriorityQueue
 import com.keepit.search.index.Searcher
-import com.keepit.search.index.PersonalizedSearcher
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import com.keepit.common.logging.Logging
 
@@ -96,10 +95,7 @@ class BooleanQueryWithSemanticMatch(val disableCoord: Boolean = false) extends B
       }
 
       val semanticMatch: Map[String, Float] = {
-        val ps = searcher.asInstanceOf[PersonalizedSearcher]
-        val nonPs = Searcher(ps.indexReader.inner)
-        val analyzer = new SemanticContextAnalyzer(nonPs, null, null)     // this uses global semantic vector instead of personal ones.
-        //val analyzer = new SemanticContextAnalyzer(searcher.asInstanceOf[Searcher], null, null)
+        val analyzer = new SemanticContextAnalyzer(searcher.asInstanceOf[Searcher], null, null)
         analyzer.semanticLoss(optionalTerms.flatten.toSet)
       }
 


### PR DESCRIPTION
@ymatsuda 

Two reasons: 
1. global one is too slow. Usually increase search time by 20 millis or more.  This could be solved by creating a dedicated indexer just for global sv payload.
2. Semantic loss penalty from personalized sv seems to be greater than that from global sv. If a user's personal corpus doesn't contain some words, we create random seeds as sv. Missing those terms may receive big penalty, because of the randomness. A (potentially nice) side effect is that, if a user searches for something outside his corpus, it's likely he doesn't expect kifi to return anything. The randomly generated seeds forces kifi to provide article that matches (almost) all terms. Thus, only very good match are provided. 
