### PR TITLE
move personalized searcher to search package

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/MainSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/MainSearcher.scala
@@ -17,7 +17,6 @@ import com.keepit.search.graph.UserToUserEdgeSet
 import com.keepit.search.article.ArticleRecord
 import com.keepit.search.article.ArticleVisibility
 import com.keepit.search.index.Searcher
-import com.keepit.search.index.PersonalizedSearcher
 import com.keepit.search.spellcheck.SpellCorrector
 import com.keepit.search.query.HotDocSetFilter
 import com.keepit.search.query.QueryUtil

--- a/kifi-backend/modules/search/app/com/keepit/search/PersonalizedSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/PersonalizedSearcher.scala
@@ -1,4 +1,4 @@
-package com.keepit.search.index
+package com.keepit.search
 
 import com.keepit.common.db.Id
 import com.keepit.common.logging.Logging
@@ -12,8 +12,10 @@ import com.keepit.shoebox.ShoeboxServiceClient
 import scala.concurrent.Future
 import com.keepit.common.akka.MonitoredAwait
 import scala.concurrent.Await
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import com.keepit.search.tracker.ClickedURI
+import com.keepit.search.index.SearchSemanticContext
+import com.keepit.search.index.Searcher
+import com.keepit.search.index.WrappedIndexReader
 
 
 object PersonalizedSearcher {

--- a/kifi-backend/modules/search/app/com/keepit/search/query/CollectionQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/CollectionQuery.scala
@@ -4,7 +4,7 @@ import com.keepit.common.db.Id
 import com.keepit.common.logging.Logging
 import com.keepit.model.Collection
 import com.keepit.search.graph.CollectionToUriEdgeSet
-import com.keepit.search.index.PersonalizedSearcher
+import com.keepit.search.PersonalizedSearcher
 import org.apache.lucene.index.AtomicReaderContext
 import org.apache.lucene.index.IndexReader
 import org.apache.lucene.index.Term

--- a/kifi-backend/modules/search/app/com/keepit/search/query/SemanticVectorExtractorQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/SemanticVectorExtractorQuery.scala
@@ -2,7 +2,7 @@ package com.keepit.search.query
 
 import com.keepit.common.logging.Logging
 import com.keepit.search.SemanticVector
-import com.keepit.search.index.PersonalizedSearcher
+import com.keepit.search.PersonalizedSearcher
 import com.keepit.search.index.Searcher
 import org.apache.lucene.index.AtomicReaderContext
 import org.apache.lucene.index.IndexReader

--- a/kifi-backend/modules/search/app/com/keepit/search/query/TextQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/TextQuery.scala
@@ -1,7 +1,7 @@
 package com.keepit.search.query
 
 import com.keepit.common.logging.Logging
-import com.keepit.search.index.PersonalizedSearcher
+import com.keepit.search.PersonalizedSearcher
 import org.apache.lucene.index.AtomicReaderContext
 import org.apache.lucene.index.IndexReader
 import org.apache.lucene.index.Term

--- a/kifi-backend/modules/search/app/com/keepit/search/semantic/SemanticVariance.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/semantic/SemanticVariance.scala
@@ -1,6 +1,6 @@
 package com.keepit.search.semantic
 
-import com.keepit.search.index.PersonalizedSearcher
+import com.keepit.search.PersonalizedSearcher
 import com.keepit.search.query.IdSetFilter
 import com.keepit.search.query.SemanticVectorExtractorScorer
 import com.keepit.search.query.TextQuery

--- a/kifi-backend/modules/search/test/com/keepit/search/query/SemanticVectorQueryTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/query/SemanticVectorQueryTest.scala
@@ -7,6 +7,7 @@ import org.apache.lucene.util.Version
 import com.keepit.common.db.Id
 import com.keepit.common.db.SequenceNumber
 import com.keepit.search.index._
+import com.keepit.search.PersonalizedSearcher
 import com.keepit.search.SemanticVectorBuilder
 import java.io.StringReader
 import scala.Some

--- a/kifi-backend/modules/search/test/com/keepit/search/query/TextQueryTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/query/TextQueryTest.scala
@@ -1,16 +1,23 @@
 package com.keepit.search.query
 
-import org.specs2.mutable.Specification
-import com.keepit.common.db.Id
-import org.apache.lucene.index.IndexWriterConfig
-import com.keepit.search.index._
 import java.io.StringReader
-import com.keepit.common.db.SequenceNumber
-import org.apache.lucene.util.Version
-import org.apache.lucene.search.TermQuery
+
+import org.apache.lucene.index.IndexWriterConfig
 import org.apache.lucene.index.Term
+import org.apache.lucene.search.TermQuery
+import org.apache.lucene.util.Version
+import org.specs2.mutable.Specification
+
+import com.keepit.common.db.Id
+import com.keepit.common.db.SequenceNumber
+import com.keepit.search.PersonalizedSearcher
 import com.keepit.search.SemanticVectorBuilder
-import scala.Some
+import com.keepit.search.index.DefaultAnalyzer
+import com.keepit.search.index.IndexDirectory
+import com.keepit.search.index.Indexable
+import com.keepit.search.index.Indexer
+import com.keepit.search.index.VolatileIndexDirectoryImpl
+
 
 class TextQueryTest extends Specification {
 

--- a/kifi-backend/modules/search/test/com/keepit/search/semantic/SemanticVarianceTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/semantic/SemanticVarianceTest.scala
@@ -11,6 +11,8 @@ import com.keepit.search.query.TextQuery
 import org.apache.lucene.search.TermQuery
 import org.apache.lucene.index.Term
 import com.keepit.search.SemanticVectorBuilder
+import com.keepit.search.PersonalizedSearcher
+
 
 class SemanticVarianceTest extends Specification {
 


### PR DESCRIPTION
@ymatsuda 

Move searchers to search package. This is more consistent with Lucene's package organization. 

Only move personalizedSearcher this time. 

The "base" Searcher has more problems in migration. It contains Hit and HitQueue. Seems to cause lots of conflicts with the ones in util package. Will take care of that later. 
