### PR TITLE
Search refactor

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/controllers/search/SearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/search/SearchController.scala
@@ -9,7 +9,7 @@ import com.keepit.model._
 import com.keepit.model.ExperimentType.NO_SEARCH_EXPERIMENTS
 import com.keepit.search.tracker.ResultClickBoosts
 import com.keepit.search._
-import com.keepit.search.index.{MutableHit, HitQueue}
+import com.keepit.search.index.{MutableHit, SearcherHitQueue}
 import org.apache.commons.math3.linear.{EigenDecomposition, Array2DRowRealMatrix}
 import play.api.mvc.Action
 import scala.collection.mutable.ArrayBuffer

--- a/kifi-backend/modules/search/app/com/keepit/controllers/search/SearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/search/SearchController.scala
@@ -9,7 +9,7 @@ import com.keepit.model._
 import com.keepit.model.ExperimentType.NO_SEARCH_EXPERIMENTS
 import com.keepit.search.tracker.ResultClickBoosts
 import com.keepit.search._
-import com.keepit.search.index.{MutableHit, SearcherHitQueue}
+import com.keepit.search.{MutableHit, SearcherHitQueue}
 import org.apache.commons.math3.linear.{EigenDecomposition, Array2DRowRealMatrix}
 import play.api.mvc.Action
 import scala.collection.mutable.ArrayBuffer

--- a/kifi-backend/modules/search/app/com/keepit/search/BookmarkSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/BookmarkSearcher.scala
@@ -5,7 +5,6 @@ import com.keepit.common.logging.Logging
 import com.keepit.common.time._
 import com.keepit.search.graph.URIGraphSearcherWithUser
 import com.keepit.search.index.DefaultAnalyzer
-import com.keepit.search.index.Searcher
 import com.keepit.search.query.SiteQuery
 import com.keepit.search.query.parser.DefaultSyntax
 import com.keepit.search.query.parser.QueryParser

--- a/kifi-backend/modules/search/app/com/keepit/search/MainSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/MainSearcher.scala
@@ -16,7 +16,6 @@ import com.keepit.search.graph.UserToUriEdgeSet
 import com.keepit.search.graph.UserToUserEdgeSet
 import com.keepit.search.article.ArticleRecord
 import com.keepit.search.article.ArticleVisibility
-import com.keepit.search.index.Searcher
 import com.keepit.search.spellcheck.SpellCorrector
 import com.keepit.search.query.HotDocSetFilter
 import com.keepit.search.query.QueryUtil

--- a/kifi-backend/modules/search/app/com/keepit/search/PersonalizedSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/PersonalizedSearcher.scala
@@ -13,8 +13,6 @@ import scala.concurrent.Future
 import com.keepit.common.akka.MonitoredAwait
 import scala.concurrent.Await
 import com.keepit.search.tracker.ClickedURI
-import com.keepit.search.index.SearchSemanticContext
-import com.keepit.search.index.Searcher
 import com.keepit.search.index.WrappedIndexReader
 
 

--- a/kifi-backend/modules/search/app/com/keepit/search/Searcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/Searcher.scala
@@ -1,8 +1,7 @@
-package com.keepit.search.index
+package com.keepit.search
 
-import com.keepit.search.SemanticVector
+
 import com.keepit.search.SemanticVector.Sketch
-import com.keepit.search.SemanticVectorComposer
 import com.keepit.search.semantic.SemanticVectorEnum
 import com.keepit.search.query.IdSetFilter
 import com.keepit.search.query.QueryUtil._
@@ -22,6 +21,7 @@ import org.apache.lucene.search.similarities.TFIDFSimilarity
 import org.apache.lucene.util.Bits
 import org.apache.lucene.util.BytesRef
 import org.apache.lucene.util.PriorityQueue
+import com.keepit.search.index._
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConversions._
 import scala.math._

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/BaseGraphSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/BaseGraphSearcher.scala
@@ -1,7 +1,7 @@
 package com.keepit.search.graph
 
 import com.keepit.common.logging.Logging
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import com.keepit.search.index.WrappedSubReader
 import org.apache.lucene.search.DocIdSetIterator
 import org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/CollectionIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/CollectionIndexer.scala
@@ -12,7 +12,7 @@ import com.keepit.model.CollectionStates._
 import com.keepit.search.index._
 import com.keepit.search.index.DocUtil
 import com.keepit.search.index.{Indexable, Indexer}
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import com.keepit.shoebox.ShoeboxServiceClient
 import scala.concurrent.duration._
 import scala.concurrent.{Future, Await}

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/CollectionSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/CollectionSearcher.scala
@@ -6,7 +6,7 @@ import com.keepit.common.logging.Logging
 import com.keepit.common.strings._
 import com.keepit.model.{NormalizedURI, User, Collection}
 import com.keepit.search.graph.CollectionFields._
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import com.keepit.search.line.LineIndexReader
 import com.keepit.search.util.LongArraySet
 import org.apache.lucene.index.AtomicReader

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/EdgeSet.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/EdgeSet.scala
@@ -3,7 +3,7 @@ package com.keepit.search.graph
 import com.keepit.common.db.Id
 import com.keepit.common.logging.Logging
 import com.keepit.search.index.IdMapper
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import com.keepit.search.query.QueryUtil._
 import org.apache.lucene.search.DocIdSet
 import org.apache.lucene.search.DocIdSetIterator

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphIndexer.scala
@@ -9,6 +9,7 @@ import com.keepit.common.net._
 import com.keepit.model._
 import com.keepit.search.Lang
 import com.keepit.search.LangDetector
+import com.keepit.search.Searcher
 import com.keepit.search.index._
 import com.keepit.search.index.Indexable.IteratorTokenStream
 import com.keepit.search.line.LineField

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphSearcher.scala
@@ -9,7 +9,7 @@ import com.keepit.search.index.ArrayIdMapper
 import com.keepit.search.index.CachedIndex
 import com.keepit.search.index.CachingIndexReader
 import com.keepit.search.index.IdMapper
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import com.keepit.search.index.WrappedSubReader
 import com.keepit.search.line.LineIndexReader
 import com.keepit.search.query.QueryUtil

--- a/kifi-backend/modules/search/app/com/keepit/search/index/Indexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/Indexer.scala
@@ -12,6 +12,7 @@ import org.apache.lucene.index.Term
 import com.keepit.common.db.{SequenceNumber, Id}
 import com.keepit.common.logging.Logging
 import com.keepit.common.time._
+import com.keepit.search.Searcher
 import play.modules.statsd.api.Statsd
 import org.apache.commons.io.FileUtils
 import org.apache.lucene.store.IOContext

--- a/kifi-backend/modules/search/app/com/keepit/search/message/MessageSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/message/MessageSearcher.scala
@@ -2,7 +2,7 @@ package com.keepit.search.message
 
 import com.keepit.common.db.Id
 import com.keepit.model.User
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import com.keepit.search.query.ConditionalQuery
 import com.keepit.common.strings.UTF8
 

--- a/kifi-backend/modules/search/app/com/keepit/search/query/BooleanQueryWithSemanticMatch.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/BooleanQueryWithSemanticMatch.scala
@@ -22,7 +22,7 @@ import org.apache.lucene.search.similarities.Similarity
 import org.apache.lucene.util.Bits
 import org.apache.lucene.util.Bits.MatchNoBits
 import org.apache.lucene.util.PriorityQueue
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import com.keepit.common.logging.Logging
 import com.keepit.search.semantic.SemanticContextAnalyzer

--- a/kifi-backend/modules/search/app/com/keepit/search/query/ConditionalQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/ConditionalQuery.scala
@@ -1,7 +1,7 @@
 package com.keepit.search.query
 
 import com.keepit.common.logging.Logging
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import org.apache.lucene.index.AtomicReaderContext
 import org.apache.lucene.index.IndexReader
 import org.apache.lucene.index.Term

--- a/kifi-backend/modules/search/app/com/keepit/search/query/ProximityQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/ProximityQuery.scala
@@ -1,6 +1,6 @@
 package com.keepit.search.query
 
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import com.keepit.search.query.QueryUtil._
 import com.keepit.search.util.AhoCorasick
 import com.keepit.search.util.LocalAlignment

--- a/kifi-backend/modules/search/app/com/keepit/search/query/QueryUtil.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/QueryUtil.scala
@@ -4,7 +4,7 @@ import com.keepit.common.logging.Logging
 import org.apache.lucene.index.AtomicReaderContext
 import org.apache.lucene.index.DocsEnum
 import org.apache.lucene.index.DocsAndPositionsEnum
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import org.apache.lucene.index.IndexReader
 import org.apache.lucene.index.Term
 import org.apache.lucene.index.ReaderUtil

--- a/kifi-backend/modules/search/app/com/keepit/search/query/SemanticVectorExtractorQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/SemanticVectorExtractorQuery.scala
@@ -3,7 +3,7 @@ package com.keepit.search.query
 import com.keepit.common.logging.Logging
 import com.keepit.search.SemanticVector
 import com.keepit.search.PersonalizedSearcher
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import org.apache.lucene.index.AtomicReaderContext
 import org.apache.lucene.index.IndexReader
 import org.apache.lucene.index.Term

--- a/kifi-backend/modules/search/app/com/keepit/search/query/SemanticVectorQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/SemanticVectorQuery.scala
@@ -2,7 +2,7 @@ package com.keepit.search.query
 
 import com.keepit.common.logging.Logging
 import com.keepit.search.SemanticVector
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import com.keepit.search.semantic.SemanticVectorEnum
 import com.keepit.search.query.QueryUtil._
 import org.apache.lucene.index.AtomicReader

--- a/kifi-backend/modules/search/app/com/keepit/search/semantic/SemanticContextAnalyzer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/semantic/SemanticContextAnalyzer.scala
@@ -1,6 +1,6 @@
 package com.keepit.search.semantic
 
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import com.keepit.search.index.Analyzer
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute
 import java.io.StringReader

--- a/kifi-backend/modules/search/app/com/keepit/search/semantic/SemanticVectorSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/semantic/SemanticVectorSearcher.scala
@@ -3,7 +3,7 @@ package com.keepit.search.semantic
 import com.keepit.common.db.Id
 import com.keepit.model._
 import com.keepit.search.index.DefaultAnalyzer
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import com.keepit.search.graph.URIGraphSearcher
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute
 import org.apache.lucene.index.Term

--- a/kifi-backend/modules/search/app/com/keepit/search/user/UserSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/user/UserSearcher.scala
@@ -8,7 +8,7 @@ import org.apache.lucene.util.PriorityQueue
 import com.keepit.common.db.Id
 import com.keepit.model.User
 import com.keepit.search.IdFilterCompressor
-import com.keepit.search.index.Searcher
+import com.keepit.search.Searcher
 import com.keepit.social.BasicUser
 
 

--- a/kifi-backend/modules/search/test/com/keepit/search/article/ArticleIndexerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/article/ArticleIndexerTest.scala
@@ -23,7 +23,7 @@ import com.keepit.shoebox.{FakeShoeboxServiceClientImpl, ShoeboxServiceClient}
 import com.keepit.search.SearchConfig
 import com.google.inject.Singleton
 import com.keepit.search.index.DefaultAnalyzer
-import com.keepit.search.index.Hit
+import com.keepit.search.index.SearcherHit
 import com.keepit.search.index.VolatileIndexDirectoryImpl
 import com.keepit.search.phrasedetector.FakePhraseIndexer
 
@@ -73,13 +73,13 @@ class ArticleIndexerTest extends Specification with ApplicationInjector {
     val searchConfig = SearchConfig.defaultConfig.apply("siteBoost" -> "1.0")
 
     class Searchable(indexer: ArticleIndexer) {
-      def search(queryString: String, percentMatch: Float = 0.0f): Seq[Hit] = {
+      def search(queryString: String, percentMatch: Float = 0.0f): Seq[SearcherHit] = {
         val parser = parserFactory(Lang("en"), searchConfig)
         parser.setPercentMatch(percentMatch)
         val searcher = indexer.getSearcher.withSemanticContext
         parser.parse(queryString, None) match {
           case Some(query) => searcher.search(query)
-          case None => Seq.empty[Hit]
+          case None => Seq.empty[SearcherHit]
         }
       }
     }

--- a/kifi-backend/modules/search/test/com/keepit/search/article/ArticleIndexerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/article/ArticleIndexerTest.scala
@@ -23,7 +23,7 @@ import com.keepit.shoebox.{FakeShoeboxServiceClientImpl, ShoeboxServiceClient}
 import com.keepit.search.SearchConfig
 import com.google.inject.Singleton
 import com.keepit.search.index.DefaultAnalyzer
-import com.keepit.search.index.SearcherHit
+import com.keepit.search.SearcherHit
 import com.keepit.search.index.VolatileIndexDirectoryImpl
 import com.keepit.search.phrasedetector.FakePhraseIndexer
 

--- a/kifi-backend/modules/search/test/com/keepit/search/graph/URIGraphTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/graph/URIGraphTest.scala
@@ -1,6 +1,7 @@
 package com.keepit.search.graph
 
-import com.keepit.search.index.{Searcher, WrappedIndexReader, WrappedSubReader}
+import com.keepit.search.index.{WrappedIndexReader, WrappedSubReader}
+import com.keepit.search.Searcher
 import com.keepit.search.query.SiteQuery
 import com.keepit.search.query.ConditionalQuery
 import com.keepit.model._


### PR DESCRIPTION
@ymatsuda 

Renamed Hit and HitQueue as SearcherHit, SearcherHitQueue. Only affects Searcher file locally. Otherwise we will have naming conflicts in MainSearcher. 
