### PR TITLE
Allowing extra headers on a per email basis

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/mail/ElectronicMail.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/ElectronicMail.scala
@@ -38,7 +38,8 @@ case class ElectronicMail (
   timeSubmitted: Option[DateTime] = None,
   messageId: Option[ElectronicMailMessageId] = None, //of the format 475082848.3.1353745094337.JavaMail.eishay@eishay-mbp.local
   inReplyTo: Option[ElectronicMailMessageId] = None,
-  category: ElectronicMailCategory //type of mail in free form, will be use for tracking
+  category: ElectronicMailCategory, //type of mail in free form, will be use for tracking
+  extraHeaders: Option[Map[String, String]] = None
 ) extends ModelWithExternalId[ElectronicMail] {
 
   def clean(): ElectronicMail = copy(subject = subject.trimAndRemoveLineBreaks())
@@ -106,7 +107,8 @@ object ElectronicMail {
       (__ \ 'timeSubmitted).formatNullable[DateTime] and
       (__ \ 'messageId).formatNullable[ElectronicMailMessageId] and
       (__ \ 'inReplyTo).formatNullable[ElectronicMailMessageId] and
-      (__ \ 'category).format[ElectronicMailCategory]
+      (__ \ 'category).format[ElectronicMailCategory] and
+      (__ \ 'extraHeaders).formatNullable[Map[String,String]]
   )(ElectronicMail.apply, unlift(ElectronicMail.unapply))
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/mail/PostOffice.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/PostOffice.scala
@@ -41,6 +41,13 @@ object PostOffice {
     }
   }
 
+  object Headers {
+    val ALL = Seq[String]("Reply-To", "List-Unsubscribe", "Precedence")
+    val REPLY_TO = "Reply-To"
+    val LIST_UNSUBSCRIBE = "List-Unsubscribe"
+    val PRECEDENCE = "Precedence"
+  }
+
   val BODY_MAX_SIZE = 1048576
 }
 

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/131.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/131.sql
@@ -1,0 +1,10 @@
+# SHOEBOX
+
+# --- !Ups
+
+alter TABLE electronic_mail
+    add column extra_headers longtext NULL;
+
+insert into evolutions (name, description) values('131.sql', 'adding extra headers column to electronic mail');
+
+# --- !Downs

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/ElectronicMailRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/ElectronicMailRepo.scala
@@ -35,8 +35,9 @@ class ElectronicMailRepoImpl @Inject() (val db: DataBaseComponent, val clock: Cl
     def messageId = column[ElectronicMailMessageId]("message_id", O.Nullable)
     def inReplyTo = column[ElectronicMailMessageId]("in_reply_to", O.Nullable)
     def category = column[ElectronicMailCategory]("category", O.NotNull)
+    def extraHeaders = column[Map[String,String]]("extra_headers", O.Nullable)
     def * = id.? ~ createdAt ~ updatedAt ~ externalId ~ senderUserId.? ~ from ~ fromName.? ~ to ~ cc ~ subject ~ state ~
-      htmlBody ~ textBody.? ~ responseMessage.? ~ timeSubmitted.? ~ messageId.? ~ inReplyTo.? ~ category <>
+      htmlBody ~ textBody.? ~ responseMessage.? ~ timeSubmitted.? ~ messageId.? ~ inReplyTo.? ~ category ~ extraHeaders.? <>
       (ElectronicMail.apply _, ElectronicMail.unapply _)
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/SendgridMailProvider.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/SendgridMailProvider.scala
@@ -31,8 +31,6 @@ class SendgridMailProvider @Inject() (
     heimdal: HeimdalServiceClient)
   extends MailProvider with Logging {
 
-  private val validHeaders = Seq[String]("Reply-To", "List-Unsubscribe", "Precedence")
-
   private class SMTPAuthenticator extends Authenticator {
     override def getPasswordAuthentication(): PasswordAuthentication = {
       val username = "fortytwo"//load from conf
@@ -143,7 +141,7 @@ class SendgridMailProvider @Inject() (
     }
 
     mail.extraHeaders.foreach{ headers =>
-      validHeaders.foreach{ header =>
+      PostOffice.Headers.ALL.foreach{ header =>
         headers.get(header).foreach{ value =>
           message.setHeader(header, value)
         }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/SendgridMailProvider.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/SendgridMailProvider.scala
@@ -31,6 +31,8 @@ class SendgridMailProvider @Inject() (
     heimdal: HeimdalServiceClient)
   extends MailProvider with Logging {
 
+  private val validHeaders = Seq[String]("Reply-To", "List-Unsubscribe", "Precedence")
+
   private class SMTPAuthenticator extends Authenticator {
     override def getPasswordAuthentication(): PasswordAuthentication = {
       val username = "fortytwo"//load from conf
@@ -139,6 +141,15 @@ class SendgridMailProvider @Inject() (
       message.setHeader("In-Reply-To", id.toEmailHeader)
       message.setHeader("References", id.toEmailHeader)
     }
+
+    mail.extraHeaders.foreach{ headers =>
+      validHeaders.foreach{ header =>
+        headers.get(header).foreach{ value =>
+          message.setHeader(header, value)
+        }
+      }
+    }
+
     val multipart = new MimeMultipart("alternative")
 
     val part1 = new MimeBodyPart()

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoTypeMappers.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoTypeMappers.scala
@@ -301,6 +301,10 @@ object FortyTwoTypeMappers {
     def apply(profile:BasicProfile) = new UserPictureSourceMapperDelegate(profile)
   }
 
+  implicit object SimpleKeyValueTypeMapper extends BaseTypeMapper[Map[String,String]] {
+    def apply(profile : BasicProfile) = new SimpleKeyValueMapperDelegate(profile)
+  }
+
 }
 
 //************************************
@@ -673,3 +677,13 @@ class RestrictionMapperDelegate(profile: BasicProfile) extends StringMapperDeleg
   def sourceToDest(value: Restriction): String = value.context
   def safeDestToSource(str: String): Restriction = Restriction(str)
 }
+
+//******************************************
+//       Map[String,String] -> String (json)
+//******************************************
+class SimpleKeyValueMapperDelegate(profile: BasicProfile) extends StringMapperDelegate[Map[String,String]](profile) {
+  def zero = Map[String,String]()
+  def sourceToDest(value: Map[String,String]): String = Json.stringify(JsObject(value.mapValues(JsString(_)).toSeq))
+  def safeDestToSource(str: String): Map[String,String] = Json.parse(str).as[JsObject].fields.toMap.mapValues(_.as[JsString].value)
+}
+


### PR DESCRIPTION
For reply-to and various headers related to spam filter traversal.
@andrewconner @eishay @leogrim could one of you give this a quick review? (Being the three people with the most commits on the email related code)
