### PR TITLE
[Need Review] Checking for service state as it gets requests and returns responses

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/controller/CommonHeaders.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/CommonHeaders.scala
@@ -6,4 +6,5 @@ object CommonHeaders {
   val LocalServiceId = "si"
   val LocalServiceType = "st"
   val IsLeader = "ld"
+  val IsUP = "up"
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/controller/LoggingFilter.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/LoggingFilter.scala
@@ -12,39 +12,51 @@ import com.keepit.common.zookeeper.ServiceDiscovery
 
 import play.api.mvc._
 import play.api.Play
+import play.mvc.Http.Status
+import play.api.libs.iteratee.{Done, Iteratee, Enumerator}
 
 class LoggingFilter() extends EssentialFilter {
 
   lazy val global = Play.current.global.asInstanceOf[FortyTwoGlobal]
   lazy val accessLog = global.injector.instance[AccessLog]
   lazy val discovery = global.injector.instance[ServiceDiscovery]
+  lazy val midFlightRequests = global.injector.instance[MidFlightRequests]
 
   def apply(next: EssentialAction) = new EssentialAction {
-    def apply(rh: RequestHeader) = {
-      val timer = accessLog.timer(HTTP_IN)
-      def logTime(result: PlainResult): Result = {
-        val trackingId = rh.headers.get(CommonHeaders.TrackingId).getOrElse(null)
-        val remoteServiceId = rh.headers.get(CommonHeaders.LocalServiceId).getOrElse(null)
-        val remoteIsLeader = rh.headers.get(CommonHeaders.IsLeader).getOrElse(null)
-        val remoteServiceType = rh.headers.get(CommonHeaders.LocalServiceType).getOrElse(null)
-        val event = accessLog.add(timer.done(
-          trackingId = trackingId,
-          remoteLeader = remoteIsLeader,
-          remoteServiceId = remoteServiceId,
-          remoteServiceType = remoteServiceType,
-          method = rh.method,
-          url = rh.uri,
-          statusCode = result.header.status
-        ))
-        result.withHeaders(
-          CommonHeaders.ResponseTime -> event.duration.toString,
-          CommonHeaders.IsLeader -> (if(discovery.isLeader()) "Y" else "N"),
-          CommonHeaders.LocalServiceId -> discovery.thisInstance.map(_.id.id.toString).getOrElse("NA"))
-      }
+    def apply(rh: RequestHeader): Iteratee[Array[Byte],play.api.mvc.Result] = {
+      if (!discovery.amIUp) {
+        val message = s"Current status of service ${discovery.thisInstance.map(_.instanceInfo.localIp).getOrElse("UNREGISTERED")} ${discovery.myStatus.getOrElse("UNKNOWN")}"
+        Done(SimpleResult[String](header = ResponseHeader(Status.SERVICE_UNAVAILABLE), body = Enumerator(message)))
+      } else {
+        val countStart = midFlightRequests.comingIn()
+        val timer = accessLog.timer(HTTP_IN)
 
-      next(rh).map {
-        case plain: PlainResult => logTime(plain)
-        case async: AsyncResult => async.transform(logTime)
+        def logTime(result: PlainResult): Result = {
+          midFlightRequests.goingOut()
+          val trackingId = rh.headers.get(CommonHeaders.TrackingId).getOrElse(null)
+          val remoteServiceId = rh.headers.get(CommonHeaders.LocalServiceId).getOrElse(null)
+          val remoteIsLeader = rh.headers.get(CommonHeaders.IsLeader).getOrElse(null)
+          val remoteServiceType = rh.headers.get(CommonHeaders.LocalServiceType).getOrElse(null)
+          val event = accessLog.add(timer.done(
+            trackingId = trackingId,
+            remoteLeader = remoteIsLeader,
+            remoteServiceId = remoteServiceId,
+            remoteServiceType = remoteServiceType,
+            method = rh.method,
+            currentRequestCount = countStart,
+            url = rh.uri,
+            statusCode = result.header.status
+          ))
+          result.withHeaders(
+            CommonHeaders.ResponseTime -> event.duration.toString,
+            CommonHeaders.IsLeader -> (if(discovery.isLeader()) "Y" else "N"),
+            CommonHeaders.IsUP -> (if(discovery.amIUp) "Y" else "N"),
+            CommonHeaders.LocalServiceId -> discovery.thisInstance.map(_.id.id.toString).getOrElse("NA"))
+        }
+        next(rh).map {
+          case plain: PlainResult => logTime(plain)
+          case async: AsyncResult => async.transform(logTime)
+        }
       }
     }
   }

--- a/kifi-backend/modules/common/app/com/keepit/common/controller/MidFlightRequests.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/MidFlightRequests.scala
@@ -1,0 +1,18 @@
+package com.keepit.common.controller
+
+import java.util.concurrent.atomic.{AtomicLong, AtomicInteger}
+import com.google.inject.{Inject, Singleton}
+
+@Singleton
+class MidFlightRequests @Inject() () {
+  private val currentCount = new AtomicInteger(0)
+  private val totalRequests = new AtomicLong(0L)
+  def totalRequestsSoFar: Long = totalRequests.get()
+  def comingIn(): Int = {
+    totalRequests.incrementAndGet()
+    currentCount.incrementAndGet()
+  }
+  def goingOut(): Int = {
+    currentCount.decrementAndGet()
+  }
+}

--- a/kifi-backend/modules/common/app/com/keepit/common/controller/MidFlightRequests.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/MidFlightRequests.scala
@@ -2,15 +2,20 @@ package com.keepit.common.controller
 
 import java.util.concurrent.atomic.{AtomicLong, AtomicInteger}
 import com.google.inject.{Inject, Singleton}
+import com.keepit.common.healthcheck.AirbrakeNotifier
 
 @Singleton
-class MidFlightRequests @Inject() () {
+class MidFlightRequests @Inject() (airbrake: AirbrakeNotifier) {
   private val currentCount = new AtomicInteger(0)
   private val totalRequests = new AtomicLong(0L)
   def totalRequestsSoFar: Long = totalRequests.get()
   def comingIn(): Int = {
     totalRequests.incrementAndGet()
-    currentCount.incrementAndGet()
+    val count = currentCount.incrementAndGet()
+    if (count > 100) { //say that more then 100 concurrent request is an issue
+      airbrake.notify(s"There are $count concurrent requests on this service, $totalRequestsSoFar since start")
+    }
+    count
   }
   def goingOut(): Int = {
     currentCount.decrementAndGet()

--- a/kifi-backend/modules/common/app/com/keepit/common/logging/AccessLogEvent.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/logging/AccessLogEvent.scala
@@ -50,12 +50,14 @@ case class AccessLogTimer(eventType: AccessLogEventType, clock: Clock) {
           result: String = null,
           error: String = null,
           remoteServiceType: String = null,
+          remoteUp: String = null,
           remoteLeader: String = null,
           remoteServiceId: String = null,
           remoteIsLeader: String = null,
           query: String = null,
           trackingId: String = null,
           method: String = null,
+          currentRequestCount : Int = NoIntValue,
           body: String = null,
           key: String = null,
           space: String = null,
@@ -71,12 +73,14 @@ case class AccessLogTimer(eventType: AccessLogEventType, clock: Clock) {
       statusCode = intOption(statusCode),
       result = Option(result),
       error = Option(error),
+      remoteUp = Option(remoteUp),
       remoteLeader = Option(remoteLeader),
       remoteServiceType = Option(remoteServiceType),
       remoteServiceId = Option(remoteServiceId),
       query = Option(query),
       trackingId = Option(trackingId),
       method = Option(method),
+      currentRequestCount = intOption(currentRequestCount),
       body = Option(body),
       key = Option(key),
       space = Option(space),
@@ -95,11 +99,13 @@ case class AccessLogEvent(
   result: Option[String],
   error: Option[String],
   remoteServiceType: Option[String],
+  remoteUp: Option[String],
   remoteLeader: Option[String],
   remoteServiceId: Option[String],
   query: Option[String],
   trackingId: Option[String],
   method: Option[String],
+  currentRequestCount: Option[Int],
   body: Option[String],
   key: Option[String],
   space: Option[String],
@@ -130,6 +136,7 @@ class AccessLog @Inject() (clock: Clock) {
       Some(s"t:${formatter.print(e.time)}") ::
       Some(s"type:${e.eventType.name}") ::
       Some(s"duration:${e.duration}") ::
+      e.currentRequestCount.map("currentRequestCount:" + _) ::
       e.method.map("method:" + _) ::
       e.trackingId.map("trackingId:" + _) ::
       e.key.map("key:" + _) ::
@@ -141,6 +148,7 @@ class AccessLog @Inject() (clock: Clock) {
       e.result.map("result:" + _) ::
       e.remoteServiceType.map("remoteServiceType:" + _) ::
       e.remoteServiceId.map("remoteServiceId:" + _) ::
+      e.remoteUp.map("remoteUp:" + _) ::
       e.remoteLeader.map("remoteLeader:" + _) ::
       e.query.map("query:" + _) ::
       e.url.map("url:" + _) ::

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/RemoteService.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/RemoteService.scala
@@ -14,7 +14,7 @@ object RemoteService {
   	def toJson(remote: RemoteService): String = Json.toJson[RemoteService](remote).toString
 }
 
-case class RemoteService(amazonInstanceInfo: AmazonInstanceInfo, var status: ServiceStatus, serviceType: ServiceType) {
+case class RemoteService(amazonInstanceInfo: AmazonInstanceInfo, var status: ServiceStatus, serviceType: ServiceType, sentServiceUnavailable: Int = 0) {
   def healthyStatus: ServiceStatus = serviceType.healthyStatus(amazonInstanceInfo)
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
@@ -40,7 +40,9 @@ class ServiceCluster(val serviceType: ServiceType, airbrake: Provider[AirbrakeNo
   override def toString(): String = s"""Service Cluster of $serviceType:
     ${instances.toString}"""
 
-  //using round robin, also use sick etc. instances if less than half of the instances ar UP.
+  /**
+   * using round robin, also use sick etc. instances if less than half of the instances ar UP.
+   */
   def nextService(): Option[ServiceInstance] = {
     val upList = routingList.filter(_.isUp)
     val availableList = routingList.filter(_.isAvailable)

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
@@ -228,8 +228,8 @@ class ServiceDiscoveryImpl(
   }
 
   def amIUp: Boolean = {
-    myStatus.map{ status =>
-      myHealthyStatus.map(_==status).getOrElse(false)
+    myStatus.map { status =>
+      myHealthyStatus.map(_ == status).getOrElse(false)
     } getOrElse(false)
   }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtBookmarksControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtBookmarksControllerTest.scala
@@ -61,6 +61,7 @@ class ExtBookmarksControllerTest extends Specification with ApplicationInjector 
   "BookmarksController" should {
     "remove tag" in {
       running(new ShoeboxApplication(controllerTestModules:_*)) {
+        inject[MidFlightRequests].totalRequestsSoFar === 0L
         val t1 = new DateTime(2013, 2, 14, 21, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val t2 = new DateTime(2013, 3, 22, 14, 30, 0, 0, DEFAULT_DATE_TIME_ZONE)
 
@@ -100,7 +101,7 @@ class ExtBookmarksControllerTest extends Specification with ApplicationInjector 
         }
         bookmarksWithTags.size === 1
 
-        db.readOnly {implicit s =>
+        db.readOnly { implicit s =>
           bookmarkRepo.getByUser(user.id.get, None, None, None, 100).size === 2
           val uris = uriRepo.all
           println(uris mkString "\n")
@@ -122,6 +123,7 @@ class ExtBookmarksControllerTest extends Specification with ApplicationInjector 
           bookmarkRepo.getByUser(user.id.get, None, None, Some(collections(0).id.get), 1000)
         }
         bookmarks.size === 0
+        inject[MidFlightRequests].totalRequestsSoFar === 1L
       }
     }
 


### PR DESCRIPTION
- The service checks if its in an “up” state. If its not it immediately returns an error ServiceUnavailable and have the client mark it as unhealthy.
- The service also returns a header with its current state that could be used by the client if the service started to shut down while mid flight.
- The service logs to access log how many mid flight requests it handles at the moment. We may send this number to the client so to try and explain wait time.
- alerting if there are more then 100 concurrent requests processed at the same time
