### PR TITLE
Using ModelWithState

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/classify/Domain.scala
+++ b/kifi-backend/modules/common/app/com/keepit/classify/Domain.scala
@@ -1,7 +1,7 @@
 package com.keepit.classify
 
 import org.joda.time.DateTime
-import com.keepit.common.db.{State, States, Model, Id}
+import com.keepit.common.db.{State, States, ModelWithState, Id}
 import com.keepit.common.time._
 import com.keepit.common.logging.AccessLog
 import com.keepit.model.Normalization
@@ -18,7 +18,7 @@ case class Domain(
   state: State[Domain] = DomainStates.ACTIVE,
   createdAt: DateTime = currentDateTime,
   updatedAt: DateTime = currentDateTime
-) extends Model[Domain] {
+) extends ModelWithState[Domain] {
   def withId(id: Id[Domain]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withAutoSensitive(sensitive: Option[Boolean]) = this.copy(autoSensitive = sensitive)

--- a/kifi-backend/modules/common/app/com/keepit/classify/DomainTag.scala
+++ b/kifi-backend/modules/common/app/com/keepit/classify/DomainTag.scala
@@ -1,7 +1,7 @@
 package com.keepit.classify
 
 import org.joda.time.DateTime
-import com.keepit.common.db.{State, States, Model, Id}
+import com.keepit.common.db.{State, States, ModelWithState, Id}
 import com.keepit.common.time._
 
 
@@ -12,7 +12,7 @@ case class DomainTag(
   state: State[DomainTag] = DomainTagStates.ACTIVE,
   createdAt: DateTime = currentDateTime,
   updatedAt: DateTime = currentDateTime
-) extends Model[DomainTag] {
+) extends ModelWithState[DomainTag] {
   def withId(id: Id[DomainTag]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withSensitive(sensitive: Option[Boolean]) = this.copy(sensitive = sensitive)

--- a/kifi-backend/modules/common/app/com/keepit/classify/DomainToTag.scala
+++ b/kifi-backend/modules/common/app/com/keepit/classify/DomainToTag.scala
@@ -1,7 +1,7 @@
 package com.keepit.classify
 
 import org.joda.time.DateTime
-import com.keepit.common.db.{Id, Model, State, States}
+import com.keepit.common.db.{Id, ModelWithState, State, States}
 import com.keepit.common.time._
 
 
@@ -12,7 +12,7 @@ case class DomainToTag(
   state: State[DomainToTag] = DomainToTagStates.ACTIVE,
   createdAt: DateTime = currentDateTime,
   updatedAt: DateTime = currentDateTime
-) extends Model[DomainToTag] {
+) extends ModelWithState[DomainToTag] {
   def withId(id: Id[DomainToTag]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[DomainToTag]) = this.copy(state = state)

--- a/kifi-backend/modules/common/app/com/keepit/model/ABookInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/ABookInfo.scala
@@ -76,7 +76,7 @@ case class ABookInfo(
     oauth2TokenId: Option[Id[OAuth2Token]] = None,
     numContacts: Option[Int] = None,
     numProcessed: Option[Int] = None
-  ) extends Model[ABookInfo] {
+  ) extends ModelWithState[ABookInfo] {
   def withId(id: Id[ABookInfo]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withOwnerInfo(ownerId: Option[String], ownerEmail: Option[String]) = this.copy(ownerId = ownerId, ownerEmail = ownerEmail)
@@ -149,7 +149,7 @@ case class OAuth2Token(
   lastRefreshedAt: Option[DateTime] = None,
   idToken: Option[String] = None,
   rawToken: Option[String] = None
-) extends Model[OAuth2Token] {
+) extends ModelWithState[OAuth2Token] {
   def withId(id: Id[OAuth2Token]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[OAuth2Token]) = this.copy(state = state)

--- a/kifi-backend/modules/common/app/com/keepit/model/ChangedURI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/ChangedURI.scala
@@ -11,7 +11,7 @@ case class ChangedURI(
   newUriId: Id[NormalizedURI],
   state: State[ChangedURI] = ChangedURIStates.ACTIVE,
   seq: SequenceNumber = SequenceNumber.ZERO
-) extends Model[ChangedURI] {
+) extends ModelWithState[ChangedURI] {
   def withId(id: Id[ChangedURI]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[ChangedURI]) = copy(state = state)

--- a/kifi-backend/modules/common/app/com/keepit/model/DeepLink.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/DeepLink.scala
@@ -23,7 +23,7 @@ case class DeepLink(
   deepLocator: DeepLocator,
   token: DeepLinkToken = DeepLinkToken(),
   state: State[DeepLink] = DeepLinkStates.ACTIVE
-) extends Model[DeepLink] {
+) extends ModelWithState[DeepLink] {
   def withId(id: Id[DeepLink]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
 

--- a/kifi-backend/modules/common/app/com/keepit/model/DuplicateDocument.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/DuplicateDocument.scala
@@ -12,7 +12,7 @@ case class DuplicateDocument (
   uri2Id: Id[NormalizedURI],
   percentMatch: Double,
   state: State[DuplicateDocument] = DuplicateDocumentStates.NEW
-) extends Model[DuplicateDocument] {
+) extends ModelWithState[DuplicateDocument] {
 
   assert(uri1Id.id < uri2Id.id, "uri1Id ≥ uri2Id")
 

--- a/kifi-backend/modules/common/app/com/keepit/model/EContact.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/EContact.scala
@@ -20,7 +20,7 @@ case class EContact(
   firstName: Option[String] = None,
   lastName:  Option[String] = None,
   state:     State[EContact] = EContactStates.ACTIVE
-) extends Model[EContact] {
+) extends ModelWithState[EContact] {
   def withId(id: Id[EContact]) = this.copy(id = Some(id))
   def withName(name: Option[String]) = this.copy(name = name)
   def withEmail(email: String) = this.copy(email = email)

--- a/kifi-backend/modules/common/app/com/keepit/model/EmailAddress.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/EmailAddress.scala
@@ -19,7 +19,7 @@ case class EmailAddress (
   verifiedAt: Option[DateTime] = None,
   lastVerificationSent: Option[DateTime] = None,
   verificationCode: Option[String] = None
-) extends Model[EmailAddress] with EmailAddressHolder {
+) extends ModelWithState[EmailAddress] with EmailAddressHolder {
   def withId(id: Id[EmailAddress]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def sameAddress(otherAddress: String) = otherAddress == address

--- a/kifi-backend/modules/common/app/com/keepit/model/EmailOptOut.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/EmailOptOut.scala
@@ -12,7 +12,7 @@ case class EmailOptOut(
   address: EmailAddressHolder,
   category: ElectronicMailCategory,
   state: State[EmailOptOut] = EmailOptOutStates.ACTIVE
-) extends Model[EmailOptOut] {
+) extends ModelWithState[EmailOptOut] {
   def withId(id: Id[EmailOptOut]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[EmailOptOut]) = copy(state = state)

--- a/kifi-backend/modules/common/app/com/keepit/model/FailedContentCheck.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/FailedContentCheck.scala
@@ -15,7 +15,7 @@ case class FailedContentCheck(
   state: State[FailedContentCheck] = FailedContentCheckStates.ACTIVE,
   counts: Int,
   lastContentCheck: DateTime
-) extends Model[FailedContentCheck] {
+) extends ModelWithState[FailedContentCheck] {
   def withId(id: Id[FailedContentCheck]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[FailedContentCheck]) = copy(state = state)

--- a/kifi-backend/modules/common/app/com/keepit/model/FriendRequest.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/FriendRequest.scala
@@ -2,7 +2,7 @@ package com.keepit.model
 
 import scala.Some
 import org.joda.time.DateTime
-import com.keepit.common.db.{Model, State, Id}
+import com.keepit.common.db.{ModelWithState, State, Id}
 import com.keepit.common.time._
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
@@ -15,7 +15,7 @@ case class FriendRequest(
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime,
     state: State[FriendRequest] = FriendRequestStates.ACTIVE
-    ) extends Model[FriendRequest] {
+    ) extends ModelWithState[FriendRequest] {
   def withId(id: Id[FriendRequest]) = copy(id = Some(id))
   def withUpdateTime(now: DateTime) = copy(updatedAt = now)
 }

--- a/kifi-backend/modules/common/app/com/keepit/model/HttpProxy.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/HttpProxy.scala
@@ -1,7 +1,7 @@
 package com.keepit.model
 
 import com.keepit.common.db.Id
-import com.keepit.common.db.Model
+import com.keepit.common.db.ModelWithState
 import com.keepit.common.db.State
 import com.keepit.common.db.States
 import com.keepit.common.time._
@@ -24,7 +24,7 @@ case class HttpProxy(
   scheme: String,
   username: Option[String],
   password: Option[String]
-  ) extends Model[HttpProxy] {
+  ) extends ModelWithState[HttpProxy] {
 
   def withId(id: Id[HttpProxy]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)

--- a/kifi-backend/modules/common/app/com/keepit/model/KeepToCollection.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepToCollection.scala
@@ -15,7 +15,7 @@ case class KeepToCollection(
   state: State[KeepToCollection] = KeepToCollectionStates.ACTIVE,
   createdAt: DateTime = currentDateTime,
   updatedAt: DateTime = currentDateTime
-  ) extends Model[KeepToCollection] {
+  ) extends ModelWithState[KeepToCollection] {
   def isActive: Boolean = state == KeepToCollectionStates.ACTIVE
   def withId(id: Id[KeepToCollection]): KeepToCollection = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime): KeepToCollection = this.copy(updatedAt = now)

--- a/kifi-backend/modules/common/app/com/keepit/model/PasswordReset.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/PasswordReset.scala
@@ -15,7 +15,7 @@ case class PasswordReset (
   usedAt: Option[DateTime] = None,
   usedByIP: Option[String] = None,
   sentTo: Option[String] = None
-) extends Model[PasswordReset] {
+) extends ModelWithState[PasswordReset] {
   def withId(id: Id[PasswordReset]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[PasswordReset]) = copy(state = state)

--- a/kifi-backend/modules/common/app/com/keepit/model/Phrase.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Phrase.scala
@@ -17,7 +17,7 @@ case class Phrase (
   source: String,
   state: State[Phrase] = PhraseStates.ACTIVE,
   seq: SequenceNumber = SequenceNumber.ZERO
-  ) extends Model[Phrase] {
+  ) extends ModelWithState[Phrase] {
   def withId(id: Id[Phrase]): Phrase = copy(id = Some(id))
   def withUpdateTime(now: DateTime): Phrase = this.copy(updatedAt = now)
   def isActive: Boolean = state == PhraseStates.ACTIVE

--- a/kifi-backend/modules/common/app/com/keepit/model/RenormalizedURL.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/RenormalizedURL.scala
@@ -12,7 +12,7 @@ case class RenormalizedURL(
   newUriId: Id[NormalizedURI],
   state: State[RenormalizedURL] = RenormalizedURLStates.ACTIVE,
   seq: SequenceNumber = SequenceNumber.ZERO
-) extends Model[RenormalizedURL] {
+) extends ModelWithState[RenormalizedURL] {
   def withId(id: Id[RenormalizedURL]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[RenormalizedURL]) = copy(state = state)

--- a/kifi-backend/modules/common/app/com/keepit/model/ScrapeInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/ScrapeInfo.scala
@@ -21,7 +21,7 @@ case class ScrapeInfo(
   state: State[ScrapeInfo] = ScrapeInfoStates.ACTIVE,
   signature: String = "",
   destinationUrl: Option[String] = None
-) extends Model[ScrapeInfo] with Logging {
+) extends ModelWithState[ScrapeInfo] with Logging {
   def withId(id: Id[ScrapeInfo]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this
   def withState(state: State[ScrapeInfo]) = {

--- a/kifi-backend/modules/common/app/com/keepit/model/SliderHistory.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/SliderHistory.scala
@@ -18,7 +18,7 @@ case class SliderHistory (
   numHashFuncs: Int,
   minHits: Int,
   updatesCount: Int = 0
-) extends Model[SliderHistory] {
+) extends ModelWithState[SliderHistory] {
   def withFilter(filter: Array[Byte]) = this.copy(filter = filter)
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withId(id: Id[SliderHistory]) = this.copy(id = Some(id))

--- a/kifi-backend/modules/common/app/com/keepit/model/SliderRule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/SliderRule.scala
@@ -13,7 +13,7 @@ case class SliderRule (
   state: State[SliderRule] = SliderRuleStates.ACTIVE,
   createdAt: DateTime = currentDateTime,
   updatedAt: DateTime = currentDateTime
-) extends Model[SliderRule] {
+) extends ModelWithState[SliderRule] {
   def withId(id: Id[SliderRule]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[SliderRule]) = this.copy(state = state)

--- a/kifi-backend/modules/common/app/com/keepit/model/SocialConnection.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/SocialConnection.scala
@@ -11,7 +11,7 @@ case class SocialConnection(
   socialUser1: Id[SocialUserInfo],
   socialUser2: Id[SocialUserInfo],
   state: State[SocialConnection] = SocialConnectionStates.ACTIVE
-) extends Model[SocialConnection] {
+) extends ModelWithState[SocialConnection] {
   def withId(id: Id[SocialConnection]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[SocialConnection]) = copy(state = state)

--- a/kifi-backend/modules/common/app/com/keepit/model/SocialUserInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/SocialUserInfo.scala
@@ -28,7 +28,7 @@ case class SocialUserInfo(
   networkType: SocialNetworkType,
   credentials: Option[SocialUser] = None,
   lastGraphRefresh: Option[DateTime] = Some(currentDateTime)
-) extends Model[SocialUserInfo] {
+) extends ModelWithState[SocialUserInfo] {
   def withId(id: Id[SocialUserInfo]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def reset() = copy(state = SocialUserInfoStates.CREATED, credentials = None)

--- a/kifi-backend/modules/common/app/com/keepit/model/URL.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/URL.scala
@@ -22,7 +22,7 @@ object URLHistory {
     (__ \ 'id).format(Id.format[NormalizedURI]) and
     (__ \ 'cause).format[String].inmap(URLHistoryCause.apply, unlift(URLHistoryCause.unapply))
   )(URLHistory.apply _, unlift(URLHistory.unapply))
-  
+
   val LENGTH_LIMIT = 3    // only last 3 history records to prevent DB column overflow
 }
 
@@ -35,12 +35,12 @@ case class URL (
   normalizedUriId: Id[NormalizedURI],
   history: Seq[URLHistory] = Seq(),
   state: State[URL] = URLStates.ACTIVE
-) extends Model[URL] {
+) extends ModelWithState[URL] {
   def withId(id: Id[URL]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withNormUriId(normUriId: Id[NormalizedURI]) = copy(normalizedUriId = normUriId)
   def withHistory(historyItem: URLHistory): URL = copy(history = (historyItem +: history).take(URLHistory.LENGTH_LIMIT))
-  
+
   def withState(state: State[URL]) = copy(state = state)
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/model/URLPattern.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/URLPattern.scala
@@ -11,7 +11,7 @@ case class URLPattern (
   createdAt: DateTime = currentDateTime,
   updatedAt: DateTime = currentDateTime,
   state: State[URLPattern] = URLPatternStates.ACTIVE
-) extends Model[URLPattern] {
+) extends ModelWithState[URLPattern] {
   def withId(id: Id[URLPattern]): URLPattern = copy(id = Some(id))
   def withPattern(pattern: String): URLPattern = copy(pattern = pattern)
   def withExample(example: Option[String]): URLPattern = copy(example = example)

--- a/kifi-backend/modules/common/app/com/keepit/model/UserExperiment.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserExperiment.scala
@@ -16,7 +16,7 @@ case class UserExperiment (
   userId: Id[User],
   experimentType: ExperimentType,
   state: State[UserExperiment] = UserExperimentStates.ACTIVE
-) extends Model[UserExperiment] {
+) extends ModelWithState[UserExperiment] {
   def withId(id: Id[UserExperiment]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[UserExperiment]) = this.copy(state = state)

--- a/kifi-backend/modules/common/app/com/keepit/model/UserNotifyPreference.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserNotifyPreference.scala
@@ -12,7 +12,7 @@ case class UserNotifyPreference(
   name: String,
   canSend: Boolean,
   state: State[UserNotifyPreference] = UserNotifyPreferenceStates.ACTIVE
-  ) extends Model[UserNotifyPreference] {
+  ) extends ModelWithState[UserNotifyPreference] {
   def withId(id: Id[UserNotifyPreference]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[UserNotifyPreference]) = copy(state = state)

--- a/kifi-backend/modules/common/app/com/keepit/model/UserPicture.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserPicture.scala
@@ -1,6 +1,6 @@
 package com.keepit.model
 
-import com.keepit.common.db.{States, Model, State, Id}
+import com.keepit.common.db.{States, ModelWithState, State, Id}
 import org.joda.time.DateTime
 import com.keepit.common.time._
 import org.apache.commons.lang3.RandomStringUtils
@@ -22,7 +22,7 @@ case class UserPicture(
   origin: UserPictureSource,
   state: State[UserPicture] = UserPictureStates.ACTIVE,
   attributes: Option[JsObject]
-  ) extends Model[UserPicture] {
+  ) extends ModelWithState[UserPicture] {
   def withId(id: Id[UserPicture]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[UserPicture]) = copy(state = state)

--- a/kifi-backend/modules/common/app/com/keepit/model/UserToDomain.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserToDomain.scala
@@ -2,7 +2,7 @@ package com.keepit.model
 
 import org.joda.time.DateTime
 
-import com.keepit.common.db.{Id, Model, State, States}
+import com.keepit.common.db.{Id, ModelWithState, State, States}
 import com.keepit.common.time._
 import com.keepit.classify.Domain
 
@@ -17,7 +17,7 @@ case class UserToDomain(
   state: State[UserToDomain] = UserToDomainStates.ACTIVE,
   createdAt: DateTime = currentDateTime,
   updatedAt: DateTime = currentDateTime
-) extends Model[UserToDomain] {
+) extends ModelWithState[UserToDomain] {
   def withId(id: Id[UserToDomain]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[UserToDomain]) = this.copy(state = state)

--- a/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
@@ -16,7 +16,7 @@ case class UserValue(
   name: String,
   value: String,
   state: State[UserValue] = UserValueStates.ACTIVE
-) extends Model[UserValue] {
+) extends ModelWithState[UserValue] {
 
   def withId(id: Id[UserValue]) = this.copy(id = Some(id))
   def withState(newState: State[UserValue]) = this.copy(state = newState)

--- a/kifi-backend/modules/common/app/com/keepit/search/SearchConfigExperiment.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchConfigExperiment.scala
@@ -4,7 +4,7 @@ import com.keepit.common.cache.{JsonCacheImpl, Key, FortyTwoCachePlugin}
 import com.keepit.common.cache.CacheStatistics
 import com.keepit.common.logging.AccessLog
 import com.keepit.common.db.Id
-import com.keepit.common.db.{Model, State, States}
+import com.keepit.common.db.{ModelWithState, State, States}
 import com.keepit.common.time._
 import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
@@ -20,7 +20,7 @@ case class SearchConfigExperiment(
     state: State[SearchConfigExperiment] = SearchConfigExperimentStates.CREATED,
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime
-    ) extends Model[SearchConfigExperiment] {
+    ) extends ModelWithState[SearchConfigExperiment] {
   def withId(id: Id[SearchConfigExperiment]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[SearchConfigExperiment]) = {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NonUserThread.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NonUserThread.scala
@@ -1,24 +1,16 @@
 package com.keepit.eliza.model
 
-import com.google.inject.{Inject, Singleton, ImplementedBy}
-import com.keepit.common.db.slick.{StringMapperDelegate, Repo, DbRepo, DataBaseComponent}
-import com.keepit.common.db.slick.FortyTwoTypeMappers._
-import com.keepit.common.db.slick.DBSession.{RWSession, RSession}
 import org.joda.time.DateTime
-import com.keepit.common.logging.Logging
 import com.keepit.common.time._
-import com.keepit.common.db.{States, State, Model, Id}
-import com.keepit.model.{EContact, User, NormalizedURI}
+import com.keepit.common.db._
+import com.keepit.model.{EContact, NormalizedURI}
 import play.api.libs.json._
-import scala.slick.lifted.{BaseTypeMapper, Query}
-import com.keepit.eliza._
-import play.api.libs.functional.syntax._
+import com.keepit.common.mail.EmailAddressHolder
+import com.keepit.social.{BasicNonUser, NonUserKinds, NonUserKind}
+import play.api.libs.json.JsSuccess
 import play.api.libs.json.JsObject
-import com.keepit.common.mail.{GenericEmailAddress, EmailAddressHolder}
-import scala.slick.driver.BasicProfile
-import MessagingTypeMappers._
-import com.keepit.common.crypto.SimpleDESCrypt
-import com.keepit.social.{BasicNonUser, NonUserKinds, NonUserKind, BasicUserLikeEntity}
+import play.api.libs.json.JsString
+import com.keepit.common.mail.GenericEmailAddress
 
 sealed trait NonUserParticipant {
   val identifier: String
@@ -71,7 +63,7 @@ case class NonUserThread(
   threadUpdatedAt: Option[DateTime],
   muted: Boolean,
   state: State[NonUserThread] = NonUserThreadStates.ACTIVE
-) extends Model[NonUserThread] {
+) extends ModelWithState[NonUserThread] {
   def withId(id: Id[NonUserThread]): NonUserThread = this.copy(id = Some(id))
   def withUpdateTime(updateTime: DateTime) = this.copy(updatedAt = updateTime)
   def withState(state: State[NonUserThread]) = copy(state = state)

--- a/kifi-backend/modules/eliza/app/com/keepit/realtime/UrbanAirship.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/realtime/UrbanAirship.scala
@@ -33,7 +33,7 @@ case class Device(
    state: State[Device] = DeviceStates.ACTIVE,
    createdAt: DateTime = currentDateTime,
    updatedAt: DateTime = currentDateTime
-   ) extends Model[Device] {
+   ) extends ModelWithState[Device] {
 
   def withId(id: Id[Device]): Device = copy(id = Some(id))
   def withUpdateTime(updateTime: DateTime): Device = copy(updatedAt = updateTime)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/SearchFriend.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/SearchFriend.scala
@@ -2,7 +2,7 @@ package com.keepit.model
 
 import org.joda.time.DateTime
 
-import com.keepit.common.db.{States, Model, State, Id}
+import com.keepit.common.db._
 import com.keepit.common.time._
 
 case class SearchFriend(
@@ -12,7 +12,7 @@ case class SearchFriend(
     state: State[SearchFriend] = SearchFriendStates.EXCLUDED,
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime
-    ) extends Model[SearchFriend] {
+    ) extends ModelWithState[SearchFriend] {
   def withId(id: Id[SearchFriend]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[SearchFriend]) = copy(state = state)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/TopicSeqNumInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/TopicSeqNumInfo.scala
@@ -1,13 +1,11 @@
 package com.keepit.model
 
 import com.google.inject.{Inject, ImplementedBy, Singleton}
-import com.keepit.common.db.Id
-import com.keepit.common.db.Model
+import com.keepit.common.db.{Id, Model, SequenceNumber}
 import com.keepit.common.time._
 import org.joda.time.DateTime
 import com.keepit.common.db.slick._
 import com.keepit.common.db.slick.DBSession._
-import com.keepit.common.db.SequenceNumber
 import com.keepit.common.db.slick.FortyTwoTypeMappers.SequenceNumberTypeMapper
 
 /**

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserConnection.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserConnection.scala
@@ -2,10 +2,7 @@ package com.keepit.model
 
 import org.joda.time.DateTime
 
-import com.keepit.common.db.Id
-import com.keepit.common.db.Model
-import com.keepit.common.db.State
-import com.keepit.common.db.States
+import com.keepit.common.db._
 import com.keepit.common.time._
 import com.keepit.common.time.currentDateTime
 
@@ -16,7 +13,7 @@ case class UserConnection(
     state: State[UserConnection] = UserConnectionStates.ACTIVE,
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime
-  ) extends Model[UserConnection] {
+  ) extends ModelWithState[UserConnection] {
   def withId(id: Id[UserConnection]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def withState(state: State[UserConnection]) = copy(state = state)

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
@@ -76,7 +76,7 @@ trait DbRepo[M <: Model[M]] extends Repo[M] with DelayedInit {
     }
     session.onTransactionSuccess({
       model match {
-        case _: ModelWithState[M] => deleteCache(result)
+        case m: ModelWithState[M] if m.state == State[M]("inactive") => deleteCache(result)
         case _ => invalidateCache(result)
       }
     })(ExecutionContext.immediate) // invalidate the cache immediately after commit

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
@@ -74,7 +74,12 @@ trait DbRepo[M <: Model[M]] extends Repo[M] with DelayedInit {
       case Some(id) => update(toUpdate)
       case None => toUpdate.withId(insert(toUpdate))
     }
-    session.onTransactionSuccess(invalidateCache(result))(ExecutionContext.immediate) // invalidate the cache immediately after commit
+    session.onTransactionSuccess({
+      model match {
+        case _: ModelWithState[M] => deleteCache(result)
+        case _ => invalidateCache(result)
+      }
+    })(ExecutionContext.immediate) // invalidate the cache immediately after commit
     result
   } catch {
     case m: MySQLIntegrityConstraintViolationException =>


### PR DESCRIPTION
@yingjieMiao made an awesome catch: we're caching inactive objects. He added a `ModelWithState` trait, and proposed that we do the following.

This adds it to all models that use a `state: State[T]`. On transaction complete, if it's a `ModelWithState` and the state is inactive, call `deleteCache` instead of `invalidateCache`.

@ymatsuda @eishay @leogrim @stkem @martinraison @raymondng 
