### PR TITLE
Scraper admin page - improved reloading behavior

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/ScraperAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/ScraperAdminController.scala
@@ -20,12 +20,20 @@ class ScraperAdminController @Inject() (
   httpProxyRepo: HttpProxyRepo)
     extends AdminController(actionAuthenticator) {
 
-  def searchScraper = AdminHtmlAction { implicit request =>
-    val pending = db.readOnly(dbMasterSlave = Slave) { implicit ro =>
+  def getPendingScraperRequests: Seq[ScrapeInfo] = {
+    db.readOnly(dbMasterSlave = Slave) { implicit ro =>
       scrapeInfoRepo.getPendingList()
     }
-    Ok(html.admin.searchScraper(pending))
   }
+
+  def searchScraper = AdminHtmlAction { implicit request =>
+    Ok(html.admin.searchScraper(getPendingScraperRequests))
+  }
+
+  def pendingScraperRequests = AdminHtmlAction { implicit request =>
+    Ok(html.admin.pendingScraperRequests(getPendingScraperRequests))
+  }
+
 
   def rescrapeByRegex(urlRegex: String, withinMinutes: Int) = AdminHtmlAction { implicit request =>
     val updateCount = db.readWrite { implicit session =>

--- a/kifi-backend/modules/shoebox/app/views/admin/pendingScraperRequests.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/pendingScraperRequests.scala.html
@@ -1,0 +1,30 @@
+@(pending:Seq[ScrapeInfo])(implicit flash: Flash)
+
+@import com.keepit.controllers.admin.routes
+
+<table class="table table-condensed table-striped">
+    <tr>
+        <th class="span1">Id</th>
+        <th class="span1">uriId</th>
+        <th class="span2">lastScrape</th>
+        <th class="span2">nextScrape</th>
+        <th class="span1">interval</th>
+        <th class="span1">failures</th>
+        <th class="span1">state</th>
+        <th class="span1">signature</th>
+        <th class="span2">destUrl</th>
+    </tr>
+    @for(info <- pending) {
+    <tr>
+        <td>@info.id</td>
+        <td>@info.uriId</td>
+        <td>@info.lastScrape</td>
+        <td>@info.nextScrape</td>
+        <td>@info.interval</td>
+        <td>@info.failures</td>
+        <td>@info.state</td>
+        <td>@info.signature.take(20)</td>
+        <td>@info.destinationUrl</td>
+    </tr>
+    }
+</table>

--- a/kifi-backend/modules/shoebox/app/views/admin/searchScraper.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/searchScraper.scala.html
@@ -30,7 +30,7 @@
         var refresh = function(){
             if ($("#autoreload").is(":checked")) {
                 $.ajax({
-                    url : "/admin/data/scraper_pending",
+                    url : "@com.keepit.controllers.admin.routes.ScraperAdminController.pendingScraperRequests",
                     dataType: "html",
                     success : function(data){
                         document.getElementById("pending-requests").innerHTML = data;

--- a/kifi-backend/modules/shoebox/app/views/admin/searchScraper.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/searchScraper.scala.html
@@ -5,32 +5,15 @@
 @admin("Scraper") {
     <h2>Pending Queue</h2>
 
-    <table class="table table-condensed table-striped">
-        <tr>
-            <th class="span1">Id</th>
-            <th class="span1">uriId</th>
-            <th class="span2">lastScrape</th>
-            <th class="span2">nextScrape</th>
-            <th class="span1">interval</th>
-            <th class="span1">failures</th>
-            <th class="span1">state</th>
-            <th class="span1">signature</th>
-            <th class="span2">destUrl</th>
-        </tr>
-        @for(info <- pending) {
-        <tr>
-            <td>@info.id</td>
-            <td>@info.uriId</td>
-            <td>@info.lastScrape</td>
-            <td>@info.nextScrape</td>
-            <td>@info.interval</td>
-            <td>@info.failures</td>
-            <td>@info.state</td>
-            <td>@info.signature.take(20)</td>
-            <td>@info.destinationUrl</td>
-        </tr>
-        }
-    </table>
+    <div class="checkbox">
+        <label>
+            <input type="checkbox" id="autoreload" checked/> Enable autoreload
+        </label>
+    </div>
+
+    <div id="pending-requests">
+        @pendingScraperRequests(pending)
+    </div>
 
     <h2>Rescrape Documents</h2>
 
@@ -44,6 +27,23 @@
     </form>
 
     <script>
-            setInterval(function(){location.reload();}, 5000);
+        var refresh = function(){
+            if ($("#autoreload").is(":checked")) {
+                $.ajax({
+                    url : "/admin/data/scraper_pending",
+                    dataType: "html",
+                    success : function(data){
+                        document.getElementById("pending-requests").innerHTML = data;
+                    },
+                    complete: function(){
+                        setTimeout(refresh, 5000);
+                    }
+                });
+            }
+        };
+        $("#autoreload").change(function() {
+            if (this.checked) { refresh(); }
+        });
+        refresh();
     </script>
 }

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -294,6 +294,7 @@ POST    /admin/data/patterns      @com.keepit.controllers.admin.UrlController.sa
 GET     /admin/data/proxies      @com.keepit.controllers.admin.ScraperAdminController.getProxies
 POST    /admin/data/proxies      @com.keepit.controllers.admin.ScraperAdminController.saveProxies
 GET     /admin/data/scrape        @com.keepit.controllers.admin.ScraperAdminController.searchScraper
+GET     /admin/data/scraper_pending        @com.keepit.controllers.admin.ScraperAdminController.pendingScraperRequests
 GET     /admin/data/scrape/regex  @com.keepit.controllers.admin.ScraperAdminController.rescrapeByRegex(urlRegex: String ?= "", withinMinutes: Int ?= 8)
 
 GET     /admin/article/index        @com.keepit.controllers.admin.AdminArticleIndexerController.index


### PR DESCRIPTION
@raymondng @eishay 
Refreshing the list of scraping requests does not reload the whole page, and the auto-refresh can be enabled/disabled.
