### PR TITLE
trying to fix a deadlock

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
@@ -109,14 +109,14 @@ class UriIntegrityActor @Inject()(
         case _ =>
       }
 
-      urlRepo.getByNormUri(oldUriId).foreach{ url =>
-        handleURLMigration(url, newUriId)
-      }
-
       uriRepo.getByRedirection(oldUri.id.get).foreach{ uri =>
         uriRepo.save(uri.withRedirect(newUriId, currentDateTime))
       }
       uriRepo.save(oldUri.withRedirect(newUriId, currentDateTime))
+
+      urlRepo.getByNormUri(oldUriId).foreach{ url =>
+        handleURLMigration(url, newUriId)
+      }
 
       changedUriRepo.saveWithoutIncreSeqnum((change.withState(ChangedURIStates.APPLIED)))
     }


### PR DESCRIPTION
@eishay @leogrim @yingjieMiao @andrewconner 

I found a possible cause of a deadlock.

BookmarkInterner may update NormalizedURIRepo first then BookmarkRepo while UriInterigyPlugin may update BookmarkRepo first then NormalizedURIRepo. To avoid a deadlock, we need to update the repos in the same order.

The code change moved BookmarkRepo update after NormalizedURIRepo update in UriInterigyPlugin.
