### PR TITLE
remove references to TopicModelController from routes, tried to make it ...

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/TopicModelController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/TopicModelController.scala
@@ -71,7 +71,8 @@ class TopicModelController  @Inject() (
       case (None, Some(b)) => makeString(b, topic(b))
       case (Some(a), Some(b)) => makeString(a, topic(a)) + ", " + makeString(b, topic(b))
     }
-    Redirect(com.keepit.controllers.admin.routes.TopicModelController.documentTopic(Some(content), Some(topics)))
+//    Redirect(com.keepit.controllers.admin.routes.TopicModelController.documentTopic(Some(content), Some(topics)))
+    throw new IllegalStateException("should be disabled")
   }
 
   def wordTopic(word: Option[String] = None, topic: Option[String] = None) = AdminHtmlAction { implicit request =>
@@ -96,7 +97,8 @@ class TopicModelController  @Inject() (
       case None => ""
     }
 
-   Redirect(com.keepit.controllers.admin.routes.TopicModelController.wordTopic(Some(word), Some(topic)))
+//   Redirect(com.keepit.controllers.admin.routes.TopicModelController.wordTopic(Some(word), Some(topic)))
+    throw new IllegalStateException("should be disabled")
   }
 
   def userTopic(userId: Option[String] = None, topic: Option[String] = None) = AdminHtmlAction { implicit request =>
@@ -121,7 +123,8 @@ class TopicModelController  @Inject() (
     }
 
     val rv = buildString(topic)
-    Redirect(com.keepit.controllers.admin.routes.TopicModelController.userTopic(Some(userId.id.toString), Some(rv)))
+//    Redirect(com.keepit.controllers.admin.routes.TopicModelController.userTopic(Some(userId.id.toString), Some(rv)))
+    throw new IllegalStateException("should be disabled")
   }
 
   def updateTopicName(id: Id[TopicName]) = AdminHtmlAction{ implicit request =>
@@ -164,7 +167,8 @@ class TopicModelController  @Inject() (
       topics.foreach{accessor.topicNameRepo.save(_)}
     }
 
-    Redirect(com.keepit.controllers.admin.routes.TopicModelController.topicsView(flag, 0))
+//    Redirect(com.keepit.controllers.admin.routes.TopicModelController.topicsView(flag, 0))
+    throw new IllegalStateException("should be disabled")
   }
 
   def genModelFiles(flag: String) = AdminHtmlAction{ implicit request =>

--- a/kifi-backend/modules/shoebox/app/views/admin/addTopicNames.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/addTopicNames.scala.html
@@ -1,10 +1,10 @@
 @(flag: String)
 
 @admin("Set Topic Names"){
-  <form action = "@com.keepit.controllers.admin.routes.TopicModelController.saveAddedTopics(flag)" method = "POST">
+  <form action = "com.keepit.controllers.admin.routes.TopicModelController.saveAddedTopics(flag)" method = "POST">
   <h4>
-    Set topic names for model @flag. 
-    For model @{if (flag == "a") "b" else "a"}, click <a href = "@com.keepit.controllers.admin.routes.TopicModelController.addTopics({if (flag == "a") "b" else "a"})"> here </a> 
+    Set topic names for model @flag.
+    For model @{if (flag == "a") "b" else "a"}, click <a href = "com.keepit.controllers.admin.routes.TopicModelController.addTopics({if (flag == "a") "b" else "a"})"> here </a>
   </h4>
   
   <div>
@@ -12,7 +12,7 @@
     <br>
     <b>NOTE: Existing topic names will all be removed.</b>
     <br>
-    To edit topic names, click <a href = "@com.keepit.controllers.admin.routes.TopicModelController.topicsView(flag, 0)">here</a>
+    To edit topic names, click <a href = "com.keepit.controllers.admin.routes.TopicModelController.topicsView(flag, 0)">here</a>
     </label>
     <textarea id="topics" name="topics" rows="20"></textarea>
   </div>    

--- a/kifi-backend/modules/shoebox/app/views/admin/documentTopic.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/documentTopic.scala.html
@@ -1,7 +1,7 @@
 @(content: Option[String], topicId: Option[String])
 
 @admin("Document Topic") {
-  <form action = "@com.keepit.controllers.admin.routes.TopicModelController.inferTopic" method = "POST">
+  <form action = "com.keepit.controllers.admin.routes.TopicModelController.inferTopic" method = "POST">
     <div>
       <label for = "doc">Type or paste document here </label>
       <textarea id="doc" name="doc" rows="10" cols="100" maxlength = 20000>@{content.getOrElse("")}</textarea>

--- a/kifi-backend/modules/shoebox/app/views/admin/topicDetails.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/topicDetails.scala.html
@@ -25,7 +25,7 @@
     
     @for((uriId, content) <- randArticles){
      <tr>
-      <td><a href="@com.keepit.controllers.admin.routes.ScraperAdminController.getScraped(uriId)"> @uriId.id </td>
+      <td><a href="com.keepit.controllers.admin.routes.ScraperAdminController.getScraped(uriId)"> @uriId.id </td>
       <td><pre> @content </pre></td>
      </tr> 
     }
@@ -52,7 +52,7 @@
             var $td = $div.closest("td");
             var $sp = $("<img src='/assets/images/spinner.15.gif'>").appendTo($td);
             var topicId = $div.data("id");
-            $.post('@com.keepit.controllers.admin.routes.TopicModelController.updateTopicName(Id(-1))'
+            $.post('com.keepit.controllers.admin.routes.TopicModelController.updateTopicName(Id(-1))'
                 .replace('-1', topicId), { topicName: $(this).val() }).done(done).fail(fail);
             function done(data) {
               $div.text(data.topicName).show();

--- a/kifi-backend/modules/shoebox/app/views/admin/topicNames.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/topicNames.scala.html
@@ -5,7 +5,7 @@
     <ul>
       <li>
         @if(page > 0) {
-          <a href="@com.keepit.controllers.admin.routes.TopicModelController.topicsView(flag, page - 1)">
+          <a href="com.keepit.controllers.admin.routes.TopicModelController.topicsView(flag, page - 1)">
         } else {
          <a href="#">
         }
@@ -15,17 +15,17 @@
       @for(i <- 0 to (pageCount - 1)) {
         @if(i == page) {
           <li class="disabled">
-            <a href="@com.keepit.controllers.admin.routes.TopicModelController.topicsView(flag, i)">@{i + 1}</a>
+            <a href="com.keepit.controllers.admin.routes.TopicModelController.topicsView(flag, i)">@{i + 1}</a>
           </li>
         } else {
           <li class="active">
-            <a href="@com.keepit.controllers.admin.routes.TopicModelController.topicsView(flag, i)">@{i + 1}</a>
+            <a href="com.keepit.controllers.admin.routes.TopicModelController.topicsView(flag, i)">@{i + 1}</a>
           </li>
         }
       }
       <li>
         @if(topics.size > 0) {
-          <a href="@com.keepit.controllers.admin.routes.TopicModelController.topicsView(flag, page + 1)">
+          <a href="com.keepit.controllers.admin.routes.TopicModelController.topicsView(flag, page + 1)">
         } else {
          <a href="#">
         }
@@ -37,7 +37,7 @@
 }
 
 @admin(count + " topics") {
-  <h2> Showing topics for model @flag. For model @{if (flag == "a") "b" else "a"}, click <a href = "@com.keepit.controllers.admin.routes.TopicModelController.topicsView({if (flag == "a") "b" else "a"}, 0)"> here </a> </h2>
+  <h2> Showing topics for model @flag. For model @{if (flag == "a") "b" else "a"}, click <a href = "com.keepit.controllers.admin.routes.TopicModelController.topicsView({if (flag == "a") "b" else "a"}, 0)"> here </a> </h2>
 
   <h2>showing @topics.size (page @{page + 1})</h2>
   @pagination(page, pageCount)
@@ -48,8 +48,8 @@
     </tr>
   @for((topic, i) <- topics.zipWithIndex) {
     <tr>
-      <td><a href = "@com.keepit.controllers.admin.routes.TopicModelController.viewTopicDetails(flag, i + 1 + page*maxPageSize)"> @{i + 1 + page*maxPageSize} </a></td>
-      <td><a href = "@com.keepit.controllers.admin.routes.TopicModelController.viewTopicDetails(flag, i + 1 + page*maxPageSize)"> @topic.topicName </a></td>
+      <td><a href = "com.keepit.controllers.admin.routes.TopicModelController.viewTopicDetails(flag, i + 1 + page*maxPageSize)"> @{i + 1 + page*maxPageSize} </a></td>
+      <td><a href = "com.keepit.controllers.admin.routes.TopicModelController.viewTopicDetails(flag, i + 1 + page*maxPageSize)"> @topic.topicName </a></td>
     </tr>
   }
   </table>

--- a/kifi-backend/modules/shoebox/app/views/admin/userTopic.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/userTopic.scala.html
@@ -1,7 +1,7 @@
 @(userId: Option[String], topic: Option[String])
 
 @admin("User Topic"){
-  <form action = "@com.keepit.controllers.admin.routes.TopicModelController.getUserTopic" method = "POST">
+  <form action = "com.keepit.controllers.admin.routes.TopicModelController.getUserTopic" method = "POST">
     <div>
       <label for = "user">Type userId </label>
       <input type="text" id="user" name="user" 

--- a/kifi-backend/modules/shoebox/app/views/admin/wordTopic.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/wordTopic.scala.html
@@ -1,7 +1,7 @@
 @(word: Option[String], topic: Option[String])
 
 @admin("Word Topic"){
-  <form action = "@com.keepit.controllers.admin.routes.TopicModelController.getWordTopic" method = "POST">
+  <form action = "com.keepit.controllers.admin.routes.TopicModelController.getWordTopic" method = "POST">
     <div>
       <label for = "word">Type your word </label>
       <input type="text" id="word" name="word" value = "@word.getOrElse("")" ></input>

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -414,23 +414,6 @@ POST    /admin/invites/reject       @com.keepit.controllers.admin.AdminInvitatio
 GET     /admin/labs/friendMap       @com.keepit.controllers.admin.AdminSearchLabsController.friendMap(q: Option[String] ?= None, minKeeps: Option[Int] ?= None)
 GET     /admin/labs/friendMap.json  @com.keepit.controllers.admin.AdminSearchLabsController.friendMapJson(q: Option[String] ?= None, minKeeps: Option[Int] ?= None)
 
-GET     /admin/learning/docTopic        @com.keepit.controllers.admin.TopicModelController.documentTopic(content: Option[String] ?= None, topicId: Option[String] ?= None)
-POST    /admin/learning/inferDocTopic   @com.keepit.controllers.admin.TopicModelController.inferTopic
-GET     /admin/learning/wordTopic       @com.keepit.controllers.admin.TopicModelController.wordTopic(word: Option[String] ?= None, topic: Option[String] ?= None)
-POST    /admin/learning/getWordTopic    @com.keepit.controllers.admin.TopicModelController.getWordTopic
-GET     /admin/learning/userTopic       @com.keepit.controllers.admin.TopicModelController.userTopic(userId: Option[String] ?= None, topic: Option[String] ?= None)
-POST    /admin/learning/getUserTopic    @com.keepit.controllers.admin.TopicModelController.getUserTopic
-GET     /admin/learning/topic/remodel   @com.keepit.controllers.admin.TopicModelController.remodel()
-GET     /admin/learning/topics          @com.keepit.controllers.admin.TopicModelController.topicsViewDefault
-GET     /admin/learning/topics/:flag/:page            @com.keepit.controllers.admin.TopicModelController.topicsView(flag: String, page: Int)
-POST    /admin/learning/topics/updateTopicName/:id    @com.keepit.controllers.admin.TopicModelController.updateTopicName(id: Id[TopicName])
-GET     /admin/learning/addTopics/:flag               @com.keepit.controllers.admin.TopicModelController.addTopics(flag: String)
-POST    /admin/learning/saveAddedTopics/:flag         @com.keepit.controllers.admin.TopicModelController.saveAddedTopics(flag: String)
-GET     /admin/learning/genTopicModelS3Files/:flag    @com.keepit.controllers.admin.TopicModelController.genModelFiles(flag: String)
-GET     /admin/learning/viewTopicWords/:flag          @com.keepit.controllers.admin.TopicModelController.viewTopicWords(flag: String)
-GET     /admin/learning/topicDetails/:flag/:index     @com.keepit.controllers.admin.TopicModelController.viewTopicDetails(flag: String, index: Int)
-GET     /admin/learning/topic/summary                 @com.keepit.controllers.admin.TopicModelController.summary
-
 GET     /admin/clusters/overview        @com.keepit.controllers.admin.AdminClusterController.clustersView
 
 ##########################################


### PR DESCRIPTION
...in a way that’s easy to re-add since we would like to have it soon (probably in a service of its own)
