### PR TITLE
Scraper admin page: linkable urls and ids linked to pages in admin

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration._
 import com.google.inject.Inject
 
 import com.keepit.search.{IndexInfo, SearchServiceClient}
-import com.keepit.common.controller.{AdminController, ActionAuthenticator}
+import com.keepit.common.controller.{AuthenticatedRequest, AdminController, ActionAuthenticator}
 import com.keepit.common.db._
 import com.keepit.common.db.slick.DBSession._
 import com.keepit.common.db.slick._
@@ -21,6 +21,7 @@ import views.html
 import com.keepit.common.store.S3ScreenshotStore
 import com.keepit.common.db.Id
 import com.keepit.common.time._
+import play.api.mvc.{AnyContent, Action}
 
 class AdminBookmarksController @Inject() (
   actionAuthenticator: ActionAuthenticator,
@@ -38,19 +39,36 @@ class AdminBookmarksController @Inject() (
 
   implicit val dbMasterSlave = Database.Slave
 
-  def edit(id: Id[Bookmark]) = AdminHtmlAction { request =>
+  private def editBookmark(bookmark: Bookmark)(implicit request: AuthenticatedRequest[AnyContent]) = {
+    db.readOnly { implicit session =>
+      val uri = uriRepo.get(bookmark.uriId)
+      val user = userRepo.get(bookmark.userId)
+      val scrapeInfo = scrapeRepo.getByUriId(bookmark.uriId)
+      val screenshotUrl = s3ScreenshotStore.getScreenshotUrl(uri).getOrElse("")
+      Ok(html.admin.bookmark(user, bookmark, uri, scrapeInfo, screenshotUrl))
+    }
+  }
+
+  def edit(id: Id[Bookmark]) = AdminHtmlAction { implicit request =>
     Async {
       db.readOnlyAsync { implicit session =>
         val bookmark = bookmarkRepo.get(id)
-        val uri = uriRepo.get(bookmark.uriId)
-        val user = userRepo.get(bookmark.userId)
-        val scrapeInfo = scrapeRepo.getByUriId(bookmark.uriId)
-        val screenshotUrl = s3ScreenshotStore.getScreenshotUrl(uri).getOrElse("")
-        Ok(html.admin.bookmark(user, bookmark, uri, scrapeInfo, screenshotUrl))
+        editBookmark(bookmark)
       }
     }
   }
 
+  def editFirstBookmarkForUri(id: Id[NormalizedURI]) = AdminHtmlAction { implicit request =>
+    Async {
+      db.readOnlyAsync { implicit session =>
+        val bookmarkOpt = bookmarkRepo.getByUri(id).headOption
+        bookmarkOpt match {
+          case Some(bookmark) => editBookmark(bookmark)
+          case None => NotFound(s"No bookmark for id $id")
+        }
+      }
+    }
+  }
 
   def rescrape = AdminJsonAction { request =>
     val id = Id[Bookmark]((request.body.asJson.get \ "id").as[Int])

--- a/kifi-backend/modules/shoebox/app/views/admin/pendingScraperRequests.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/pendingScraperRequests.scala.html
@@ -17,14 +17,14 @@
     @for(info <- pending) {
     <tr>
         <td>@info.id</td>
-        <td>@info.uriId</td>
+        <td><a href="@com.keepit.controllers.admin.routes.AdminBookmarksController.editFirstBookmarkForUri(info.uriId)">@info.uriId</a></td>
         <td>@info.lastScrape</td>
         <td>@info.nextScrape</td>
         <td>@info.interval</td>
         <td>@info.failures</td>
         <td>@info.state</td>
         <td>@info.signature.take(20)</td>
-        <td>@info.destinationUrl</td>
+        <td><a href="@info.destinationUrl">@info.destinationUrl</a></td>
     </tr>
     }
 </table>

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -271,6 +271,7 @@ GET     /admin/analytics/:repo/events @com.keepit.controllers.admin.AdminAnalyti
 
 GET     /admin/bookmarks/page/:page @com.keepit.controllers.admin.AdminBookmarksController.bookmarksView(page: Int)
 GET     /admin/bookmarks/edit       @com.keepit.controllers.admin.AdminBookmarksController.edit(id: Id[Bookmark])
+GET     /admin/bookmarks/editWithUri       @com.keepit.controllers.admin.AdminBookmarksController.editFirstBookmarkForUri(id: Id[NormalizedURI])
 POST    /admin/bookmarks/rescrape   @com.keepit.controllers.admin.AdminBookmarksController.rescrape
 POST    /admin/bookmarks/update     @com.keepit.controllers.admin.AdminBookmarksController.updateBookmarks
 POST    /admin/bookmarks/delete     @com.keepit.controllers.admin.AdminBookmarksController.delete(id: Id[Bookmark])


### PR DESCRIPTION
@raymondng This adds links to the scraper admin page. When clicking on a URI id, shoebox attempts to retrieve the set of bookmarks associated to this URI, and shows one of them as in https://admin.kifi.com/admin/bookmarks/edit?id=212081 (some information such as the screenshot may not be available). Also there is a direct link to the URL.

I'm not sure whether or not a scraping request is tied to a particular user ID - if it was the case we could retrieve the corresponding bookmark by both URI and userID, which would give us exactly one bookmark (the right one) instead of a set of bookmarks.
