### PR TITLE
including total number of unread threads too in "get_latest_threads" response

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -918,6 +918,12 @@ class MessagingCommander @Inject() (
     }
   }
 
+  def getUnreadThreadCounts(userId: Id[User]): (Int, Int) = {
+    db.readOnly { implicit session =>
+      userThreadRepo.getUnreadThreadCounts(userId)
+    }
+  }
+
   def getLatestSendableNotificationsForPage(userId: Id[User], url: String, howMany: Int): Future[(String, Seq[JsObject], Int, Int)] = {
     new SafeFuture(shoebox.getNormalizedUriByUrlOrPrenormalize(url) flatMap { nUriOrPrenorm =>
       nUriOrPrenorm match {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
@@ -144,8 +144,8 @@ class SharedWsMessagingController @Inject() (
 
     "get_latest_threads" -> { case JsNumber(requestId) +: JsNumber(howMany) +: _ =>
       messagingCommander.getLatestSendableNotifications(socket.userId, howMany.toInt).map { notices =>
-        val numUnreadUnmuted = messagingCommander.getUnreadUnmutedThreadCount(socket.userId)
-        socket.channel.push(Json.arr(requestId.toLong, notices, numUnreadUnmuted))
+        val (numUnread, numUnreadUnmuted) = messagingCommander.getUnreadThreadCounts(socket.userId)
+        socket.channel.push(Json.arr(requestId.toLong, notices, numUnreadUnmuted, numUnread))
       }
     },
     "get_threads_before" -> { case JsNumber(requestId) +: JsNumber(howMany) +: JsString(time) +: _ =>
@@ -153,12 +153,12 @@ class SharedWsMessagingController @Inject() (
         socket.channel.push(Json.arr(requestId.toLong, notices))
       }
     },
-    "get_threads_since" -> { case JsNumber(requestId) +: JsString(time) +: _ =>
+    "get_threads_since" -> { case JsNumber(requestId) +: JsString(time) +: _ => // deprecated (unused since 2.8.38)
       messagingCommander.getSendableNotificationsSince(socket.userId, parseStandardTime(time)).map { notices =>
         socket.channel.push(Json.arr(requestId.toLong, notices, currentDateTime))
       }
     },
-    "get_unread_threads" -> { case JsNumber(requestId) +: JsNumber(howMany) +: _ =>
+    "get_unread_threads" -> { case JsNumber(requestId) +: JsNumber(howMany) +: _ =>  // deprecated (unused since 2.8.38)
       messagingCommander.getLatestUnreadSendableNotifications(socket.userId, howMany.toInt).map { case (notices, numTotal) =>
         socket.channel.push(Json.arr(requestId.toLong, notices, numTotal))
       }
@@ -178,7 +178,7 @@ class SharedWsMessagingController @Inject() (
         socket.channel.push(Json.arr(requestId.toLong, notices))
       }
     },
-    "get_sent_threads" -> { case JsNumber(requestId) +: JsNumber(howMany) +: _ =>
+    "get_sent_threads" -> { case JsNumber(requestId) +: JsNumber(howMany) +: _ => // deprecated (unused since 2.8.38)
       messagingCommander.getLatestSentSendableNotifications(socket.userId, howMany.toInt).map { notices =>
         socket.channel.push(Json.arr(requestId.toLong, notices))
       }


### PR DESCRIPTION
The extension will soon stop calling `"get_unread_threads"` and `"get_sent_threads"` too when it calls `"get_latest_threads"`.

Also switching to raw SQL for count queries since I recently saw Eishay do it elsewhere for better performance. (These count queries are called frequently.)
