### PR TITLE
transactional caching

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/cache/FortyTwoCache.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/FortyTwoCache.scala
@@ -15,7 +15,7 @@ import com.keepit.common.healthcheck.{AirbrakeNotifier, AirbrakeError}
 import com.keepit.common.logging.Access.CACHE
 import com.keepit.common.logging._
 import com.keepit.common.time._
-import com.keepit.serializer.{Serializer, BinaryFormat}
+import com.keepit.serializer.Serializer
 import com.keepit.common.logging.{AccessLogTimer, AccessLog}
 import com.keepit.common.logging.Access._
 
@@ -201,34 +201,3 @@ class FortyTwoCacheImpl[K <: Key[T], T](
       (innermostPluginSettings._1, innermostPluginSettings._2, serializer), innerToOuterPluginSettings.map {case (plugin, ttl) => (plugin, ttl, serializer)}:_*)
 }
 
-abstract class JsonCacheImpl[K <: Key[T], T] private(cache: ObjectCache[K, T]) extends TransactionalCache(cache) {
-  def this(
-    stats: CacheStatistics, accessLog: AccessLog,
-    innermostPluginSettings: (FortyTwoCachePlugin, Duration),
-    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)(implicit formatter: Format[T]) =
-      this(new FortyTwoCacheImpl(stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer(formatter)))
-}
-
-abstract class BinaryCacheImpl[K <: Key[T], T] private(cache: ObjectCache[K, T]) extends TransactionalCache(cache) {
-  def this(
-    stats: CacheStatistics, accessLog: AccessLog,
-    innermostPluginSettings: (FortyTwoCachePlugin, Duration),
-    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)(implicit formatter: BinaryFormat[T]) =
-      this(new FortyTwoCacheImpl[K, T](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer(formatter)))
-}
-
-abstract class PrimitiveCacheImpl[K <: Key[P], P <: AnyVal] private(cache: ObjectCache[K, P]) extends TransactionalCache(cache) {
-  def this(
-    stats: CacheStatistics, accessLog: AccessLog,
-    innermostPluginSettings: (FortyTwoCachePlugin, Duration),
-    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*) =
-      this(new FortyTwoCacheImpl[K, P](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer[P]))
-}
-
-abstract class StringCacheImpl[K <: Key[String]] private(cache: ObjectCache[K, String]) extends TransactionalCache(cache) {
-  def this(
-    stats: CacheStatistics, accessLog: AccessLog,
-    innermostPluginSettings: (FortyTwoCachePlugin, Duration),
-    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*) =
-      this(new FortyTwoCacheImpl[K, String](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer.string))
-}

--- a/kifi-backend/modules/common/app/com/keepit/common/cache/FortyTwoCache.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/FortyTwoCache.scala
@@ -34,7 +34,7 @@ trait FortyTwoCache[K <: Key[T], T] extends ObjectCache[K, T] {
   val repo: FortyTwoCachePlugin
   val serializer: Serializer[T]
 
-  protected[cache] def getFromInnerCache(key: K): Option[Option[T]] = {
+  protected[cache] def getFromInnerCache(key: K): ObjectState[T] = {
     val timer = accessLog.timer(CACHE)
     val valueOpt = try repo.get(key.toString) catch {
       case e: Throwable =>
@@ -44,12 +44,12 @@ trait FortyTwoCache[K <: Key[T], T] extends ObjectCache[K, T] {
     decodeValue(key, valueOpt, timer)
   }
 
-  private[this] def decodeValue(key: K, valueOpt: Option[Any], timer: AccessLogTimer): Option[Option[T]] = {
+  private[this] def decodeValue(key: K, valueOpt: Option[Any], timer: AccessLogTimer): ObjectState[T] = {
     try {
       val objOpt = valueOpt.map(serializer.reads)
       val namespace = key.namespace
       objOpt match {
-        case Some(_) => {
+        case Some(obj) => {
           val duration = if (repo.logAccess) {
             accessLog.add(timer.done(space = s"${repo.toString}.${namespace}", key = key.toString, result = "HIT")).duration
           } else {
@@ -57,6 +57,7 @@ trait FortyTwoCache[K <: Key[T], T] extends ObjectCache[K, T] {
           }
           stats.recordHit(repo.toString, repo.logAccess, namespace, key.toString, duration)
           stats.recordHit("Cache", false, namespace, key.toString, duration)
+          Found(obj)
         }
         case None => {
           val duration = if (repo.logAccess) {
@@ -67,13 +68,13 @@ trait FortyTwoCache[K <: Key[T], T] extends ObjectCache[K, T] {
           stats.recordMiss(repo.toString, repo.logAccess, namespace, key.toString, duration)
           if (outerCache isEmpty) stats.recordMiss("Cache", false, namespace, key.toString, duration)
         }
+        NotFound()
       }
-      objOpt
     } catch {
       case e: Throwable =>
         repo.onError(AirbrakeError(e, Some(s"Failed deserializing key $key from $repo, got raw value $valueOpt")))
         repo.remove(key.toString)
-        None
+        NotFound()
     }
   }
 
@@ -90,10 +91,10 @@ trait FortyTwoCache[K <: Key[T], T] extends ObjectCache[K, T] {
       }
     }
     keys.foldLeft(Map.empty[K, Option[T]]){ (m, key) =>
-      val objOpt = decodeValue(key, valueMap.get(key.toString), timer)
-      objOpt match {
-        case Some(obj) => m + (key -> obj)
-        case None => m
+      val state = decodeValue(key, valueMap.get(key.toString), timer)
+      state match {
+        case Found(obj) => m + (key -> obj)
+        case _ => m
       }
     }
   }
@@ -200,30 +201,34 @@ class FortyTwoCacheImpl[K <: Key[T], T](
       (innermostPluginSettings._1, innermostPluginSettings._2, serializer), innerToOuterPluginSettings.map {case (plugin, ttl) => (plugin, ttl, serializer)}:_*)
 }
 
-abstract class JsonCacheImpl[K <: Key[T], T](
+abstract class JsonCacheImpl[K <: Key[T], T] private(cache: ObjectCache[K, T]) extends TransactionalCache(cache) {
+  def this(
     stats: CacheStatistics, accessLog: AccessLog,
     innermostPluginSettings: (FortyTwoCachePlugin, Duration),
-    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)(implicit formatter: Format[T])
-  extends FortyTwoCacheImpl[K, T](stats, accessLog,
-    innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer(formatter))
+    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)(implicit formatter: Format[T]) =
+      this(new FortyTwoCacheImpl(stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer(formatter)))
+}
 
-abstract class BinaryCacheImpl[K <: Key[T], T](
+abstract class BinaryCacheImpl[K <: Key[T], T] private(cache: ObjectCache[K, T]) extends TransactionalCache(cache) {
+  def this(
     stats: CacheStatistics, accessLog: AccessLog,
     innermostPluginSettings: (FortyTwoCachePlugin, Duration),
-    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)(implicit formatter: BinaryFormat[T])
-  extends FortyTwoCacheImpl[K, T](stats, accessLog,
-    innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer(formatter))
+    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)(implicit formatter: BinaryFormat[T]) =
+      this(new FortyTwoCacheImpl[K, T](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer(formatter)))
+}
 
-abstract class PrimitiveCacheImpl[K <: Key[P], P <: AnyVal](
+abstract class PrimitiveCacheImpl[K <: Key[P], P <: AnyVal] private(cache: ObjectCache[K, P]) extends TransactionalCache(cache) {
+  def this(
     stats: CacheStatistics, accessLog: AccessLog,
     innermostPluginSettings: (FortyTwoCachePlugin, Duration),
-    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
-  extends FortyTwoCacheImpl[K, P](stats, accessLog,
-    innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer[P])
+    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*) =
+      this(new FortyTwoCacheImpl[K, P](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer[P]))
+}
 
-abstract class StringCacheImpl[K <: Key[String]](
+abstract class StringCacheImpl[K <: Key[String]] private(cache: ObjectCache[K, String]) extends TransactionalCache(cache) {
+  def this(
     stats: CacheStatistics, accessLog: AccessLog,
     innermostPluginSettings: (FortyTwoCachePlugin, Duration),
-    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
-  extends FortyTwoCacheImpl[K, String](stats, accessLog,
-    innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer.string)
+    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*) =
+      this(new FortyTwoCacheImpl[K, String](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer.string))
+}

--- a/kifi-backend/modules/common/app/com/keepit/common/cache/FortyTwoCache.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/FortyTwoCache.scala
@@ -48,7 +48,7 @@ trait FortyTwoCache[K <: Key[T], T] extends ObjectCache[K, T] {
     try {
       val objOpt = valueOpt.map(serializer.reads)
       val namespace = key.namespace
-      objOpt match {
+      valueOpt.map(serializer.reads) match {
         case Some(obj) => {
           val duration = if (repo.logAccess) {
             accessLog.add(timer.done(space = s"${repo.toString}.${namespace}", key = key.toString, result = "HIT")).duration
@@ -67,8 +67,8 @@ trait FortyTwoCache[K <: Key[T], T] extends ObjectCache[K, T] {
           }
           stats.recordMiss(repo.toString, repo.logAccess, namespace, key.toString, duration)
           if (outerCache isEmpty) stats.recordMiss("Cache", false, namespace, key.toString, duration)
+          NotFound()
         }
-        NotFound()
       }
     } catch {
       case e: Throwable =>

--- a/kifi-backend/modules/common/app/com/keepit/common/cache/PlayCachePlugin.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/PlayCachePlugin.scala
@@ -26,6 +26,8 @@ class PlayCachePlugin(app: Application) extends CachePlugin {
 class PlayCacheApi(stats: CacheStatistics, accessLog: AccessLog, inner: (FortyTwoCachePlugin, Duration), outer: (FortyTwoCachePlugin, Duration)*)
   extends BinaryCacheImpl[PlayCacheKey, Any](stats, accessLog, inner, outer: _*)(PlayBinaryFormat) with CacheAPI with Logging {
 
+  import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
+
   def set(key: String, value: Any, expiration: Int): Unit = {
     log.info(s"Setting cache key: $key, value: $value")
     set(PlayCacheKey(key), value)

--- a/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionLocalCache.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionLocalCache.scala
@@ -1,0 +1,65 @@
+package com.keepit.common.cache
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration.Duration
+import scala.concurrent.Future
+
+
+class TransactionLocalCache[K <: Key[T], T] private(val ttl: Duration, override val outerCache: Option[ObjectCache[K, T]], underlying: ObjectCache[K, T]) extends ObjectCache[K, T] {
+  // outerCache is wrapped in ReadOnlyCacheWrapper to block updates silently
+  def this(underlying: ObjectCache[K, T]) = this(Duration.Inf, Some(new ReadOnlyCacheWrapper(underlying)), underlying)
+
+  private[this] val txnLocalStore = TrieMap.empty[K, ObjectState[T]]
+
+  protected[cache] def getFromInnerCache(key: K): ObjectState[T] = {
+    txnLocalStore.get(key) match {
+      case Some(state) => state
+      case None => NotFound() // failed to find the key, go to outerCache
+    }
+  }
+
+  protected[cache] def setInnerCache(key: K, valueOpt: Option[T]) = {
+    txnLocalStore += (key -> Found(valueOpt))
+  }
+
+  protected[cache] def bulkGetFromInnerCache(keys: Set[K]): Map[K, Option[T]] = {
+    keys.foldLeft(Map.empty[K, Option[T]]){ (result, key) =>
+      txnLocalStore.get(key) match {
+        case Some(state) =>
+          state match {
+            case Found(valueOpt) => result + (key -> valueOpt)
+            case Removed() => result + (key -> None)
+            case state => throw new Exception(s"this state ($state) shouldn't be in the cache")
+          }
+        case None => result
+      }
+    }
+  }
+
+  def remove(key: K): Unit = {
+    txnLocalStore += (key -> Removed())
+  }
+
+  def flush(): Unit = {
+    // all changes made in the transaction are going to be flushed directly to the underlying cache
+    txnLocalStore.foreach{ case (key, valueOptOpt) =>
+      valueOptOpt match {
+        case Found(valueOpt) => underlying.set(key, valueOpt)
+        case Removed() => underlying.remove(key)
+        case state => throw new Exception(s"this state ($state) shouldn't be in the cache")
+      }
+    }
+  }
+}
+
+class ReadOnlyCacheWrapper[K <: Key[T], T](underlying: ObjectCache[K, T]) extends ObjectCache[K, T] {
+  val ttl: Duration = Duration.Inf
+
+  protected[cache] def getFromInnerCache(key: K): ObjectState[T] = underlying.getFromInnerCache(key)
+
+  protected[cache] def setInnerCache(key: K, valueOpt: Option[T]) = { } // ignore silently
+
+  protected[cache] def bulkGetFromInnerCache(keys: Set[K]): Map[K, Option[T]] = underlying.bulkGetFromInnerCache(keys)
+
+  def remove(key: K): Unit = { } // ignore silently
+}

--- a/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionalCache.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionalCache.scala
@@ -9,12 +9,12 @@ object TransactionalCache {
   implicit def getObjectCache[K <: Key[T], T](cache: TransactionalCache[K, T])(implicit txn: TransactionalCaching): ObjectCache[K, T] = cache(txn)
 }
 
-abstract class TransactionalCache[K <: Key[T], T](cache: ObjectCache[K, T], name: Option[String] = None) {
+abstract class TransactionalCache[K <: Key[T], T](cache: ObjectCache[K, T], serializer: Serializer[T], name: Option[String] = None) {
   val cacheName = name.getOrElse(this.getClass.getName)
 
   def apply(txn: TransactionalCaching): ObjectCache[K, T] = {
     if (txn.inCacheTransaction) {
-      txn.getOrCreate(cacheName){ new TransactionLocalCache(cache) }
+      txn.getOrCreate(cacheName){ new TransactionLocalCache(cache, serializer) }
     } else {
       cache
     }
@@ -24,35 +24,35 @@ abstract class TransactionalCache[K <: Key[T], T](cache: ObjectCache[K, T], name
 }
 
 
-abstract class JsonCacheImpl[K <: Key[T], T] private(cache: ObjectCache[K, T]) extends TransactionalCache(cache) {
+abstract class JsonCacheImpl[K <: Key[T], T] private(cache: ObjectCache[K, T], serializer: Serializer[T]) extends TransactionalCache(cache, serializer) {
   def this(
     stats: CacheStatistics, accessLog: AccessLog,
     innermostPluginSettings: (FortyTwoCachePlugin, Duration),
     innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)(implicit formatter: Format[T]) =
-      this(new FortyTwoCacheImpl(stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer(formatter)))
+      this(new FortyTwoCacheImpl(stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer(formatter)), Serializer(formatter))
 }
 
-abstract class BinaryCacheImpl[K <: Key[T], T] private(cache: ObjectCache[K, T]) extends TransactionalCache(cache) {
+abstract class BinaryCacheImpl[K <: Key[T], T] private(cache: ObjectCache[K, T], serializer: Serializer[T]) extends TransactionalCache(cache, serializer) {
   def this(
     stats: CacheStatistics, accessLog: AccessLog,
     innermostPluginSettings: (FortyTwoCachePlugin, Duration),
     innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)(implicit formatter: BinaryFormat[T]) =
-      this(new FortyTwoCacheImpl[K, T](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer(formatter)))
+      this(new FortyTwoCacheImpl[K, T](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer(formatter)), Serializer(formatter))
 }
 
-abstract class PrimitiveCacheImpl[K <: Key[P], P <: AnyVal] private(cache: ObjectCache[K, P]) extends TransactionalCache(cache) {
+abstract class PrimitiveCacheImpl[K <: Key[P], P <: AnyVal] private(cache: ObjectCache[K, P], serializer: Serializer[P]) extends TransactionalCache(cache, serializer) {
   def this(
     stats: CacheStatistics, accessLog: AccessLog,
     innermostPluginSettings: (FortyTwoCachePlugin, Duration),
     innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*) =
-      this(new FortyTwoCacheImpl[K, P](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer[P]))
+      this(new FortyTwoCacheImpl[K, P](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer[P]), Serializer[P])
 }
 
-abstract class StringCacheImpl[K <: Key[String]] private(cache: ObjectCache[K, String]) extends TransactionalCache(cache) {
+abstract class StringCacheImpl[K <: Key[String]] private(cache: ObjectCache[K, String], serializer: Serializer[String]) extends TransactionalCache(cache, serializer) {
   def this(
     stats: CacheStatistics, accessLog: AccessLog,
     innermostPluginSettings: (FortyTwoCachePlugin, Duration),
     innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*) =
-      this(new FortyTwoCacheImpl[K, String](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer.string))
+      this(new FortyTwoCacheImpl[K, String](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer.string), Serializer.string)
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionalCache.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionalCache.scala
@@ -1,0 +1,20 @@
+package com.keepit.common.cache
+
+object TransactionalCache {
+  implicit def getObjectCache[K <: Key[T], T](cache: TransactionalCache[K, T])(implicit txn: TransactionalCaching): ObjectCache[K, T] = cache(txn)
+}
+
+abstract class TransactionalCache[K <: Key[T], T](cache: ObjectCache[K, T], name: Option[String] = None) {
+  val cacheName = name.getOrElse(this.getClass.getName)
+
+  def apply(txn: TransactionalCaching): ObjectCache[K, T] = {
+    if (txn.inCacheTransaction) {
+      txn.getOrCreate(cacheName){ new TransactionLocalCache(cache) }
+    } else {
+      cache
+    }
+  }
+
+  def direct: ObjectCache[K, T] = cache
+}
+

--- a/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionalCache.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionalCache.scala
@@ -1,5 +1,10 @@
 package com.keepit.common.cache
 
+import com.keepit.common.logging.{AccessLogTimer, AccessLog}
+import com.keepit.serializer.{Serializer, BinaryFormat}
+import play.api.libs.json._
+import scala.concurrent.duration._
+
 object TransactionalCache {
   implicit def getObjectCache[K <: Key[T], T](cache: TransactionalCache[K, T])(implicit txn: TransactionalCaching): ObjectCache[K, T] = cache(txn)
 }
@@ -16,5 +21,38 @@ abstract class TransactionalCache[K <: Key[T], T](cache: ObjectCache[K, T], name
   }
 
   def direct: ObjectCache[K, T] = cache
+}
+
+
+abstract class JsonCacheImpl[K <: Key[T], T] private(cache: ObjectCache[K, T]) extends TransactionalCache(cache) {
+  def this(
+    stats: CacheStatistics, accessLog: AccessLog,
+    innermostPluginSettings: (FortyTwoCachePlugin, Duration),
+    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)(implicit formatter: Format[T]) =
+      this(new FortyTwoCacheImpl(stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer(formatter)))
+}
+
+abstract class BinaryCacheImpl[K <: Key[T], T] private(cache: ObjectCache[K, T]) extends TransactionalCache(cache) {
+  def this(
+    stats: CacheStatistics, accessLog: AccessLog,
+    innermostPluginSettings: (FortyTwoCachePlugin, Duration),
+    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)(implicit formatter: BinaryFormat[T]) =
+      this(new FortyTwoCacheImpl[K, T](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer(formatter)))
+}
+
+abstract class PrimitiveCacheImpl[K <: Key[P], P <: AnyVal] private(cache: ObjectCache[K, P]) extends TransactionalCache(cache) {
+  def this(
+    stats: CacheStatistics, accessLog: AccessLog,
+    innermostPluginSettings: (FortyTwoCachePlugin, Duration),
+    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*) =
+      this(new FortyTwoCacheImpl[K, P](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer[P]))
+}
+
+abstract class StringCacheImpl[K <: Key[String]] private(cache: ObjectCache[K, String]) extends TransactionalCache(cache) {
+  def this(
+    stats: CacheStatistics, accessLog: AccessLog,
+    innermostPluginSettings: (FortyTwoCachePlugin, Duration),
+    innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*) =
+      this(new FortyTwoCacheImpl[K, String](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)(Serializer.string))
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionalCaching.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionalCaching.scala
@@ -1,0 +1,56 @@
+package com.keepit.common.cache
+
+import scala.collection.concurrent.TrieMap
+import com.keepit.common.logging.Logging
+
+object TransactionalCaching {
+  object Implicits {
+    implicit val directCacheAccess = new TransactionalCaching with Logging {
+      override def inCacheTransaction: Boolean = false
+    }
+  }
+}
+
+trait TransactionalCaching { self: Logging =>
+  private[this] val caches = TrieMap.empty[String, TransactionLocalCache[_, _]]
+
+  private[this] var inTxn: Boolean = false
+
+  def inCacheTransaction: Boolean = inTxn
+
+  def getOrCreate[K <: Key[T], T](cacheName: String)(createNewCache: => TransactionLocalCache[K, T]) : ObjectCache[K, T] = {
+    caches.get(cacheName) match {
+      case Some(cache) => cache.asInstanceOf[ObjectCache[K, T]]
+      case _ =>
+        val newCache = createNewCache
+        caches.putIfAbsent(cacheName, newCache) match {
+          case Some(existing) => existing.asInstanceOf[ObjectCache[K, T]]
+          case _ => newCache
+        }
+    }
+  }
+
+  def beginCacheTransaction() = {
+    inTxn = true
+  }
+
+  def commitCacheTransaction(): Unit = {
+    try {
+      caches.foreach{ case (name, cache) =>
+        try {
+          cache.flush()
+        } catch {
+          case ex: Throwable => log.error("error during flush", ex)
+        }
+      }
+    } finally {
+      caches.clear()
+      inTxn = false
+    }
+  }
+
+  def rollbackCacheTransaction() = {
+    caches.clear
+    inTxn = false
+  }
+}

--- a/kifi-backend/modules/common/app/com/keepit/search/S3ArticleSearchResultStore.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/S3ArticleSearchResultStore.scala
@@ -4,6 +4,7 @@ import com.amazonaws.services.s3._
 import com.keepit.common.store._
 import com.keepit.common.db.ExternalId
 import com.keepit.common.cache._
+import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 import com.keepit.common.logging.AccessLog
 import scala.concurrent.duration.Duration
 import com.keepit.common.store.S3Bucket

--- a/kifi-backend/modules/common/app/com/keepit/search/SearchConfigExperiment.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchConfigExperiment.scala
@@ -10,6 +10,7 @@ import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import scala.concurrent.duration._
+import com.keepit.common.cache.TransactionalCaching
 
 case class SearchConfigExperiment(
     id: Option[Id[SearchConfigExperiment]] = None,
@@ -66,8 +67,8 @@ object ActiveExperimentsKey extends ActiveExperimentsKey
 
 class ActiveExperimentsCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
   extends JsonCacheImpl[ActiveExperimentsKey, Seq[SearchConfigExperiment]](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*) {
-    def getOrElseUpdate(value: => Seq[SearchConfigExperiment]): Seq[SearchConfigExperiment] = getOrElse(ActiveExperimentsKey)(value)
-    def remove(): Unit = remove(ActiveExperimentsKey)
+    def getOrElseUpdate(value: => Seq[SearchConfigExperiment])(implicit txn: TransactionalCaching): Seq[SearchConfigExperiment] = this.getOrElse(ActiveExperimentsKey)(value)
+    def remove()(implicit txn: TransactionalCaching): Unit = this.remove(ActiveExperimentsKey)
 }
 
 object SearchConfigExperimentStates extends States[SearchConfigExperiment] {

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -39,6 +39,7 @@ import com.keepit.common.usersegment.UserSegment
 import com.keepit.common.usersegment.UserSegmentFactory
 import com.keepit.common.usersegment.UserSegmentCache
 import com.keepit.common.usersegment.UserSegmentKey
+import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 
 trait ShoeboxServiceClient extends ServiceClient {
   final val serviceType = ServiceType.SHOEBOX

--- a/kifi-backend/modules/common/test/com/keepit/common/cache/FortyTwoCacheTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/cache/FortyTwoCacheTest.scala
@@ -64,6 +64,8 @@ class TestStringCache(stats: CacheStatistics, accessLog: AccessLog, innermostPlu
 
 class FortyTwoCacheTest extends Specification with DeprecatedTestInjector {
 
+  import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
+
   "JsonCacheImpl Instance" should {
     withInjector(EhCacheCacheModule(), FakeAirbrakeModule()){ implicit injector =>
       val cachePlugin = inject[FortyTwoCachePlugin]

--- a/kifi-backend/modules/common/test/com/keepit/common/cache/TransactionalCachingTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/cache/TransactionalCachingTest.scala
@@ -1,0 +1,224 @@
+package com.keepit.common.cache
+
+import org.specs2.mutable.Specification
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration.Duration
+import com.keepit.common.logging.Logging
+
+class TransactionalCachingTest extends Specification {
+
+  class TestCache[K <: Key[T], T] extends ObjectCache[K, T] {
+    private[this] val store = TrieMap.empty[K, Option[T]]
+    val ttl = Duration.Inf
+
+    protected[cache] def getFromInnerCache(key: K): ObjectState[T] = {
+      store.get(key) match {
+        case Some(valueOpt) => Found(valueOpt)
+        case None => NotFound()
+      }
+    }
+
+    protected[cache] def setInnerCache(key: K, valueOpt: Option[T]) = { store += (key -> valueOpt) }
+
+    protected[cache] def bulkGetFromInnerCache(keys: Set[K]): Map[K, Option[T]] = {
+      keys.foldLeft(Map.empty[K, Option[T]]){ (result, key) =>
+        store.get(key) match {
+          case Some(value) => result + (key -> value)
+          case _ => result + (key -> None)
+        }
+      }
+    }
+    def remove(key: K): Unit = { store -= key }
+
+    def exists(key: K): Boolean = store.contains(key)
+    def clear(): Unit = store.clear()
+  }
+
+
+  case class TestKey1(id: Int) extends Key[String] {
+    override val version = 1
+    val namespace = "test1"
+    def toKey(): String = id.toString
+  }
+
+  case class TestKey2(id: Int) extends Key[String] {
+    override val version = 1
+    val namespace = "test2"
+    def toKey(): String = id.toString
+  }
+
+  class Cache1 extends TestCache[TestKey1, String]
+  class Cache2 extends TestCache[TestKey2, String]
+
+  private val cache1 = new Cache1
+  private val cache2 = new Cache2
+
+  class TxnCache1(c: Cache1) extends TransactionalCache(c)
+  class TxnCache2(c: Cache2) extends TransactionalCache(c)
+
+  val txnCache1 = new TxnCache1(cache1)
+  val txnCache2 = new TxnCache2(cache2)
+
+  implicit private val txn = new TransactionalCaching with Logging
+
+  "TransactionalCaching" should {
+    "rollback cache data" in {
+      txn.beginCacheTransaction()
+
+      txnCache1.set(TestKey1(1), "foo")
+      txnCache2.set(TestKey2(1), "bar")
+
+      txnCache1.get(TestKey1(1)) === Some("foo")
+      txnCache2.get(TestKey2(1)) === Some("bar")
+      cache1.get(TestKey1(1)) === None
+      cache2.get(TestKey2(1)) === None
+
+      txn.rollbackCacheTransaction()
+
+      txnCache1.get(TestKey1(1)) === None
+      txnCache2.get(TestKey2(1)) === None
+      cache1.get(TestKey1(1)) === None
+      cache2.get(TestKey2(1)) === None
+    }
+
+    "commit cache data" in {
+      txn.beginCacheTransaction()
+
+      txnCache1.set(TestKey1(1), "foo")
+      txnCache2.set(TestKey2(1), "bar")
+
+      txnCache1.get(TestKey1(1)) === Some("foo")
+      txnCache2.get(TestKey2(1)) === Some("bar")
+      cache1.get(TestKey1(1)) === None
+      cache2.get(TestKey2(1)) === None
+
+      txn.commitCacheTransaction()
+
+      txnCache1.get(TestKey1(1)) === Some("foo")
+      txnCache2.get(TestKey2(1)) === Some("bar")
+      cache1.get(TestKey1(1)) === Some("foo")
+      cache2.get(TestKey2(1)) === Some("bar")
+
+      txn.beginCacheTransaction()
+
+      txnCache1.set(TestKey1(1), "foo2")
+      txnCache2.set(TestKey2(1), "bar2")
+
+      txnCache1.get(TestKey1(1)) === Some("foo2")
+      txnCache2.get(TestKey2(1)) === Some("bar2")
+      cache1.get(TestKey1(1)) === Some("foo")
+      cache2.get(TestKey2(1)) === Some("bar")
+
+      txn.commitCacheTransaction()
+
+      txnCache1.get(TestKey1(1)) === Some("foo2")
+      txnCache2.get(TestKey2(1)) === Some("bar2")
+      cache1.get(TestKey1(1)) === Some("foo2")
+      cache2.get(TestKey2(1)) === Some("bar2")
+    }
+
+    "remove cache data" in {
+      cache1.clear()
+      cache2.clear()
+      cache1.set(TestKey1(1), "foo")
+      cache2.set(TestKey2(1), "bar")
+
+      txnCache1.get(TestKey1(1)) === Some("foo")
+      txnCache2.get(TestKey2(1)) === Some("bar")
+
+      txn.beginCacheTransaction()
+
+      txnCache1.remove(TestKey1(1))
+
+      cache1.get(TestKey1(1)) === Some("foo")
+      cache2.get(TestKey2(1)) === Some("bar")
+      txnCache1.get(TestKey1(1)) === None
+      txnCache2.get(TestKey2(1)) === Some("bar")
+
+      txn.rollbackCacheTransaction()
+
+      txnCache1.get(TestKey1(1)) === Some("foo")
+      txnCache2.get(TestKey2(1)) === Some("bar")
+
+
+      txn.beginCacheTransaction()
+
+      txnCache1.remove(TestKey1(1))
+
+      txnCache1.get(TestKey1(1)) === None
+      txnCache2.get(TestKey2(1)) === Some("bar")
+      cache1.get(TestKey1(1)) === Some("foo")
+      cache2.get(TestKey2(1)) === Some("bar")
+
+      txn.commitCacheTransaction()
+
+      txnCache1.get(TestKey1(1)) === None
+      txnCache2.get(TestKey2(1)) === Some("bar")
+      cache1.get(TestKey1(1)) === None
+      cache2.get(TestKey2(1)) === Some("bar")
+      cache1.exists(TestKey1(1)) === false
+    }
+
+    "bulkGet cache data" in {
+      cache1.clear()
+      cache2.clear()
+
+      txn.beginCacheTransaction()
+
+      txnCache1.set(TestKey1(1), "foo")
+      txnCache1.set(TestKey1(2), "bar")
+
+      txnCache1.bulkGet(Set(TestKey1(1), TestKey1(2))) === Map(TestKey1(1) -> Some("foo"), TestKey1(2) -> Some("bar"))
+      txnCache1.bulkGet(Set(TestKey1(1), TestKey1(3))) === Map(TestKey1(1) -> Some("foo"), TestKey1(3) -> None)
+
+      txn.rollbackCacheTransaction()
+
+      txnCache1.bulkGet(Set(TestKey1(1), TestKey1(2))) === Map(TestKey1(1) -> None, TestKey1(2) -> None)
+
+      cache1.set(TestKey1(1), "foo")
+
+      txn.beginCacheTransaction()
+
+      txnCache1.set(TestKey1(2), "bar")
+      txnCache1.bulkGet(Set(TestKey1(1), TestKey1(2))) === Map(TestKey1(1) -> Some("foo"), TestKey1(2) -> Some("bar"))
+
+      txn.commitCacheTransaction()
+
+      txnCache1.bulkGet(Set(TestKey1(1), TestKey1(2))) === Map(TestKey1(1) -> Some("foo"), TestKey1(2) -> Some("bar"))
+
+      txn.beginCacheTransaction()
+
+      txnCache1.remove(TestKey1(1))
+
+      txnCache1.bulkGet(Set(TestKey1(1), TestKey1(2))) === Map(TestKey1(1) -> None, TestKey1(2) -> Some("bar"))
+
+      txn.commitCacheTransaction()
+
+      txnCache1.bulkGet(Set(TestKey1(1), TestKey1(2))) === Map(TestKey1(1) -> None, TestKey1(2) -> Some("bar"))
+      cache1.exists(TestKey1(1)) === false
+    }
+
+    "perform getOrElse" in {
+      cache1.clear()
+      txn.beginCacheTransaction()
+
+      txnCache1.get(TestKey1(1)) === None
+      txnCache1.getOrElse(TestKey1(1)){ "orElse invoked" } === "orElse invoked"
+      txnCache1.get(TestKey1(1)) === Some("orElse invoked")
+
+      txn.rollbackCacheTransaction()
+
+      cache1.get(TestKey1(1)) === None
+
+      txn.beginCacheTransaction()
+
+      txnCache1.get(TestKey1(1)) === None
+      txnCache1.getOrElse(TestKey1(1)){ "orElse invoked again" } === "orElse invoked again"
+      txnCache1.get(TestKey1(1)) === Some("orElse invoked again")
+
+      txn.commitCacheTransaction()
+
+      cache1.get(TestKey1(1)) === Some("orElse invoked again")
+    }
+  }
+}

--- a/kifi-backend/modules/common/test/com/keepit/common/cache/TransactionalCachingTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/cache/TransactionalCachingTest.scala
@@ -1,9 +1,10 @@
 package com.keepit.common.cache
 
+import com.keepit.common.logging.Logging
+import com.keepit.serializer.Serializer
 import org.specs2.mutable.Specification
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.Duration
-import com.keepit.common.logging.Logging
 
 class TransactionalCachingTest extends Specification {
 
@@ -53,8 +54,8 @@ class TransactionalCachingTest extends Specification {
   private val cache1 = new Cache1
   private val cache2 = new Cache2
 
-  class TxnCache1(c: Cache1) extends TransactionalCache(c)
-  class TxnCache2(c: Cache2) extends TransactionalCache(c)
+  class TxnCache1(c: Cache1) extends TransactionalCache(c, Serializer.string)
+  class TxnCache2(c: Cache2) extends TransactionalCache(c, Serializer.string)
 
   val txnCache1 = new TxnCache1(cache1)
   val txnCache2 = new TxnCache2(cache2)

--- a/kifi-backend/modules/heimdal/app/com/keepit/heimdal/AnomymousEventRepos.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/heimdal/AnomymousEventRepos.scala
@@ -5,6 +5,7 @@ import reactivemongo.api.collections.default.BSONCollection
 
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.cache.{Key, JsonCacheImpl, FortyTwoCachePlugin, CacheStatistics}
+import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 import com.keepit.common.logging.AccessLog
 import scala.concurrent.duration.Duration
 import com.keepit.common.KestrelCombinator

--- a/kifi-backend/modules/heimdal/app/com/keepit/heimdal/SystemEventRepos.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/heimdal/SystemEventRepos.scala
@@ -5,6 +5,7 @@ import reactivemongo.api.collections.default.BSONCollection
 
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.cache.{Key, JsonCacheImpl, FortyTwoCachePlugin, CacheStatistics}
+import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 import com.keepit.common.logging.AccessLog
 import scala.concurrent.duration.Duration
 import com.keepit.common.KestrelCombinator

--- a/kifi-backend/modules/heimdal/app/com/keepit/heimdal/UserEventRepos.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/heimdal/UserEventRepos.scala
@@ -4,6 +4,7 @@ import com.keepit.common.healthcheck.AirbrakeNotifier
 import reactivemongo.bson.{BSONDocument, BSONLong}
 import reactivemongo.api.collections.default.BSONCollection
 import com.keepit.common.cache.{JsonCacheImpl, FortyTwoCachePlugin, CacheStatistics, Key}
+import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 import com.keepit.common.logging.AccessLog
 import com.keepit.common.KestrelCombinator
 import play.api.libs.concurrent.Execution.Implicits.defaultContext

--- a/kifi-backend/modules/search/app/com/keepit/search/tracker/BrowsingHistoryTracker.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/tracker/BrowsingHistoryTracker.scala
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.google.inject.{ImplementedBy, Inject, Singleton}
 import com.keepit.common.store.S3Bucket
 import com.keepit.common.cache.{BinaryCacheImpl, FortyTwoCachePlugin, CacheStatistics, Key}
+import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 import com.keepit.common.logging.AccessLog
 import scala.concurrent.duration.Duration
 import com.keepit.search.MultiHashFilter

--- a/kifi-backend/modules/search/app/com/keepit/search/tracker/ClickHistoryTracker.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/tracker/ClickHistoryTracker.scala
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.google.inject.{ImplementedBy, Inject, Singleton}
 import com.keepit.common.store.S3Bucket
 import com.keepit.common.cache.{BinaryCacheImpl, FortyTwoCachePlugin, CacheStatistics, Key}
+import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 import com.keepit.common.logging.AccessLog
 import scala.concurrent.duration.Duration
 import com.keepit.search.MultiHashFilter

--- a/kifi-backend/modules/search/app/com/keepit/search/tracker/ProbablisticLRU.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/tracker/ProbablisticLRU.scala
@@ -1,6 +1,7 @@
 package com.keepit.search.tracker
 
 import com.keepit.common.logging.Logging
+import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 import scala.math._
 import scala.concurrent.future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
@@ -559,9 +559,9 @@ class UserCommander @Inject() (
   }
 
   def disconnect(userId:Id[User], networkString: String):(Option[SocialUserInfo], String) = {
-    userCache.remove(SocialUserInfoUserKey(userId))
     val network = SocialNetworkType(networkString)
     val (thisNetwork, otherNetworks) = db.readOnly { implicit s =>
+      userCache.remove(SocialUserInfoUserKey(userId))
       socialUserInfoRepo.getByUser(userId).partition(_.networkType == network)
     }
     if (otherNetworks.isEmpty) {
@@ -576,8 +576,8 @@ class UserCommander @Inject() (
         socialUserInfoRepo.invalidateCache(sui)
         socialUserInfoRepo.save(sui.copy(credentials = None, userId = None))
         socialUserInfoRepo.getByUser(userId).map(socialUserInfoRepo.invalidateCache)
+        userCache.remove(SocialUserInfoUserKey(userId))
       }
-      userCache.remove(SocialUserInfoUserKey(userId))
       val newLoginUser = otherNetworks.find(_.networkType == SocialNetworks.FORTYTWO).getOrElse(otherNetworks.head)
       (Some(newLoginUser), "disconnected")
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserConnectionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserConnectionRepo.scala
@@ -46,7 +46,7 @@ class UserConnectionRepoImpl @Inject() (
   import FortyTwoTypeMappers._
   import db.Driver.Implicit._
 
-  def invalidateCache(userId: Id[User]): Unit = {
+  def invalidateCache(userId: Id[User])(implicit session: RSession): Unit = {
     userConnCache.remove(UserConnectionIdKey(userId))
     connCountCache.remove(UserConnectionCountKey(userId))
     searchFriendsCache.remove(SearchFriendsKey(userId))

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/HttpProxyTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/HttpProxyTest.scala
@@ -2,6 +2,7 @@ package com.keepit.model
 
 import com.keepit.test.ShoeboxTestInjector
 import org.specs2.mutable._
+import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 import com.keepit.common.db.slick._
 
 class HttpProxyTest extends Specification with ShoeboxTestInjector {

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/SocialUserInfoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/SocialUserInfoTest.scala
@@ -107,10 +107,12 @@ class SocialUserInfoTest extends Specification with ShoeboxTestInjector with Tes
 
         val networkCache = inject[SocialUserInfoRepoImpl].networkCache
         val cacheKey = SocialUserInfoNetworkKey(SocialNetworks.FACEBOOK, SocialId("eishay"))
-        networkCache.get(cacheKey) === None
-        val sui = db.readOnly { implicit s => socialUserInfoRepo.get(SocialId("eishay"), SocialNetworks.FACEBOOK) }
-        sui.fullName === "John Smith"
-        networkCache.get(cacheKey).isDefined === true
+        db.readOnly { implicit s =>
+          networkCache.get(cacheKey) === None
+          val sui = socialUserInfoRepo.get(SocialId("eishay"), SocialNetworks.FACEBOOK)
+          sui.fullName === "John Smith"
+          networkCache.get(cacheKey).isDefined === true
+        }
         val socialUserOpt = inject[TestSlickSessionProvider].doWithoutCreatingSessions {
           db.readOnly { implicit s => socialUserInfoRepo.getOpt(SocialId("eishay"), SocialNetworks.FACEBOOK) }
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UrlPatternRuleTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UrlPatternRuleTest.scala
@@ -14,29 +14,27 @@ class UrlPatternRuleTest extends Specification with ShoeboxTestInjector {
 
         val urlPatternRuleCache = inject[UrlPatternRuleRepoImpl].urlPatternRuleAllCache
 
-        urlPatternRuleCache.get(UrlPatternRuleAllKey()).isDefined === false
-
         val db = inject[Database]
 
         db.readWrite { implicit session =>
+          urlPatternRuleCache.get(UrlPatternRuleAllKey()).isDefined === false
           urlPatternRuleRepo.save(UrlPatternRule(pattern = "^https*://www\\.facebook\\.com/login.*$", isUnscrapable = true))
           urlPatternRuleRepo.save(UrlPatternRule(pattern = "^https*://.*.google.com.*/ServiceLogin.*$", isUnscrapable = true))
         }
-        urlPatternRuleCache.get(UrlPatternRuleAllKey()).isDefined === false
 
         db.readOnly { implicit session =>
+          urlPatternRuleCache.get(UrlPatternRuleAllKey()).isDefined === false
           urlPatternRuleRepo.allActive().length === 2
+          urlPatternRuleCache.get(UrlPatternRuleAllKey()).isDefined === true
+          urlPatternRuleCache.get(UrlPatternRuleAllKey()).get.length === 2
         }
-        urlPatternRuleCache.get(UrlPatternRuleAllKey()).isDefined === true
-        urlPatternRuleCache.get(UrlPatternRuleAllKey()).get.length === 2
 
         db.readWrite { implicit session =>
           urlPatternRuleRepo.save(UrlPatternRule(pattern = "^https*://app.asana.com.*$", isUnscrapable = true))
         }
 
-        urlPatternRuleCache.get(UrlPatternRuleAllKey()).isDefined === false
-
         db.readOnly { implicit session =>
+          urlPatternRuleCache.get(UrlPatternRuleAllKey()).isDefined === false
           urlPatternRuleRepo.isUnscrapable("http://www.google.com/") === false
           urlPatternRuleRepo.isUnscrapable("https://www.facebook.com/login.php?bb") === true
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UserValueTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UserValueTest.scala
@@ -11,9 +11,9 @@ class UserValueTest extends Specification with ShoeboxTestInjector {
     "create, update, delete using the cache (and invalidate properly)" in {
       withDb() { implicit injector =>
         val userValueRepo = inject[UserValueRepoImpl]
-        userValueRepo.valueCache.get(UserValueKey(Id[User](1), "test")).isDefined === false
 
         val (user1, uv) = db.readWrite { implicit session =>
+          userValueRepo.valueCache.get(UserValueKey(Id[User](1), "test")).isDefined === false
           val user1 = userRepo.save(User(firstName = "Andrew", lastName = "Conner"))
           userValueRepo.getValue(user1.id.get, "test").isDefined === false
 

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
@@ -74,12 +74,10 @@ trait DbRepo[M <: Model[M]] extends Repo[M] with DelayedInit {
       case Some(id) => update(toUpdate)
       case None => toUpdate.withId(insert(toUpdate))
     }
-    session.onTransactionSuccess({
-      model match {
-        case m: ModelWithState[M] if m.state == State[M]("inactive") => deleteCache(result)
-        case _ => invalidateCache(result)
-      }
-    })(ExecutionContext.immediate) // invalidate the cache immediately after commit
+    model match {
+      case m: ModelWithState[M] if m.state == State[M]("inactive") => deleteCache(result)
+      case _ => invalidateCache(result)
+    }
     result
   } catch {
     case m: MySQLIntegrityConstraintViolationException =>


### PR DESCRIPTION
Please review carefully. @eishay @andrewconner @leogrim @stkem @raymondng @yingjieMiao 

This change makes cache behavior transactional. From a read write session, updates are applied to a transaction local cache immediately (thru a repo's invalidateCache methods), so the session won't read stale data. But actual shared caches (ehcache, memcahed) are unchanged, so the thread not in the same readWrite session won't see uncommitted data. Updates are applied to shared caches on transaction commit.

TransactionLocalCache
- intercept write accesses to the underlying shared cache (ehcache, memcached)
  - save the changes in local hash map
  - does not update the underlying cache
- intercept read accesses
  - look up its local hash map first
  - if not found, call underlying shared cache
- flush changed data on transaction commit
- discard changed data on transaction rollback

TransactionalCaching trait
- bad name :(
- a method inCacheTransaction returns true is in transaction, otherwise false
- a place to hold TransactionLocalCache instances
- RSession and RWSession is subclasses of this  
  - the name looks good in "... extends Session with TransactionalCaching" :)

TransactionalCaching.Implicits.directCacheAccess
- this is an instance of TransactionalCaching whose inCacheTransaction always returns false
- import this when no db session is available (ex. shoebox client)
- mixing this with db session is confusing and hard to debug (use TransactionalCache.direct instead)

TransactionalCache[K,T]
- not a subclass of ObjectCache[K,T]
- this wraps an FortytwoCache instance
- has apply(txn: TransactionalCaching) which returns ObjectCache[K,T]
  - if the execution is in a transaction, the returned ObjectCache is TransactionLocalCache which wraps FortytwoCache
- otherwise, it is theunderlying FortytwoCache
- also has direct which returns underlying FortytwoCache

TransactionalCache object
- defines implicit funciton for conversion from TransactionalCache to ObjectCache when an implicit TransactionCaching (=RSession) is in scope

JsonCacheImpl, BinaruCacheImpl, PrimitiveCacheImpl, StringCacheImpl
- used to be subclasses of FortytwoCache, but now subclasses of TransactionalCache
- cache access in db.readWrite becomes transactional
