### PR TITLE
smart word breaking/wrapping in compose text area in Chrome

### DIFF
--- a/packrat/styles/keeper/compose.css
+++ b/packrat/styles/keeper/compose.css
@@ -18,6 +18,7 @@ form.kifi-compose {
   outline: none;
   box-shadow: none;
   cursor: text; /* ff */
+  word-break: break-word;
 }
 .kifi-compose.kifi-empty .kifi-compose-draft:focus {
   -webkit-animation: paddingLeft10 .16s ease-out;


### PR DESCRIPTION
Unfortunately, `break-word` is not part of the CSS 3 spec and is not supported in Firefox. `break-all` is too aggressive, and I think scrolling is preferable.
