### PR TITLE
Much faster tag queries

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/BookmarkRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/BookmarkRepo.scala
@@ -38,13 +38,13 @@ trait BookmarkRepo extends Repo[Bookmark] with ExternalIdColumnFunction[Bookmark
 
 @Singleton
 class BookmarkRepoImpl @Inject() (
-  val db: DataBaseComponent,
-  val clock: Clock,
-  val countCache: BookmarkCountCache,
-  val keepToCollectionRepo: KeepToCollectionRepoImpl,
-  collectionRepo: CollectionRepo,
-  bookmarkUriUserCache: BookmarkUriUserCache,
-  latestBookmarkUriCache: LatestBookmarkUriCache)
+                                   val db: DataBaseComponent,
+                                   val clock: Clock,
+                                   val countCache: BookmarkCountCache,
+                                   val keepToCollectionRepo: KeepToCollectionRepoImpl,
+                                   collectionRepo: CollectionRepo,
+                                   bookmarkUriUserCache: BookmarkUriUserCache,
+                                   latestBookmarkUriCache: LatestBookmarkUriCache)
   extends DbRepo[Bookmark] with BookmarkRepo with ExternalIdColumnDbFunction[Bookmark] with Logging {
 
   import DBSession._
@@ -66,7 +66,7 @@ class BookmarkRepoImpl @Inject() (
     def kifiInstallation = column[ExternalId[KifiInstallation]]("kifi_installation", O.Nullable)
     def seq = column[SequenceNumber]("seq", O.Nullable)//indexd
     def * = id.? ~ createdAt ~ updatedAt ~ externalId ~ title.? ~ uriId ~ urlId.? ~ url ~ bookmarkPath.? ~ isPrivate ~
-      userId ~ state ~ source ~ kifiInstallation.? ~ seq <> (Bookmark.apply _, Bookmark.unapply _)
+        userId ~ state ~ source ~ kifiInstallation.? ~ seq <> (Bookmark.apply _, Bookmark.unapply _)
   }
 
   private implicit val getBookmarkResult = GetResult(r => table.*.getResult(db.Driver.profile, r))
@@ -126,7 +126,7 @@ class BookmarkRepoImpl @Inject() (
   def getByUser(userId: Id[User], excludeState: Option[State[Bookmark]] = Some(BookmarkStates.INACTIVE))(implicit session: RSession): Seq[Bookmark] =
     (for(b <- table if b.userId === userId && b.state =!= excludeState.orNull) yield b).sortBy(_.createdAt).list
 
-  def getByUser(userId: Id[User], beforeId: Option[ExternalId[Bookmark]], afterId: Option[ExternalId[Bookmark]], count: Int)(implicit session: RSession): Seq[Bookmark] = com.keepit.common.performance.timing(s"QUERYING:1: $beforeId, $afterId, $count, $userId") {
+  def getByUser(userId: Id[User], beforeId: Option[ExternalId[Bookmark]], afterId: Option[ExternalId[Bookmark]], count: Int)(implicit session: RSession): Seq[Bookmark] = {
     import keepToCollectionRepo.{stateTypeMapper => ktcStateMapper}
     import StaticQuery.interpolation
     import scala.collection.JavaConversions._
@@ -146,7 +146,7 @@ class BookmarkRepoImpl @Inject() (
     interpolated.as[Bookmark].list
   }
 
-  def getByUserAndCollection(userId: Id[User], collectionId: Id[Collection], beforeId: Option[ExternalId[Bookmark]], afterId: Option[ExternalId[Bookmark]], count: Int)(implicit session: RSession): Seq[Bookmark] = com.keepit.common.performance.timing(s"QUERYING:1: $beforeId, $afterId, $collectionId, $count, $userId") {
+  def getByUserAndCollection(userId: Id[User], collectionId: Id[Collection], beforeId: Option[ExternalId[Bookmark]], afterId: Option[ExternalId[Bookmark]], count: Int)(implicit session: RSession): Seq[Bookmark] = {
     import keepToCollectionRepo.{stateTypeMapper => ktcStateMapper}
     import StaticQuery.interpolation
 
@@ -185,10 +185,10 @@ class BookmarkRepoImpl @Inject() (
     }
 
   def getPrivatePublicCountByUser(userId: Id[User])(implicit session: RSession): (Int, Int) = {
-      val privateCount = StaticQuery.queryNA[Int](s"select count(*) from bookmark where user_id=${userId.id} and state = '${BookmarkStates.ACTIVE.value}' and is_private = true").first()
-      val publicCount = StaticQuery.queryNA[Int](s"select count(*) from bookmark where user_id=${userId.id} and state = '${BookmarkStates.ACTIVE.value}' and is_private = false").first()
-      (privateCount, publicCount)
-    }
+    val privateCount = StaticQuery.queryNA[Int](s"select count(*) from bookmark where user_id=${userId.id} and state = '${BookmarkStates.ACTIVE.value}' and is_private = true").first()
+    val publicCount = StaticQuery.queryNA[Int](s"select count(*) from bookmark where user_id=${userId.id} and state = '${BookmarkStates.ACTIVE.value}' and is_private = false").first()
+    (privateCount, publicCount)
+  }
 
   def getCountByTime(from: DateTime, to: DateTime)(implicit session: RSession): Int = {
     val sql = s"select count(*) from bookmark where updated_at between '${SQL_DATETIME_FORMAT.print(from)}' and '${SQL_DATETIME_FORMAT.print(to)}' and state='${BookmarkStates.ACTIVE.value}'"

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/BookmarkRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/BookmarkRepo.scala
@@ -6,8 +6,8 @@ import com.keepit.common.db.slick.DBSession.{RWSession, RSession}
 import com.keepit.common.db.{SequenceNumber, ExternalId, State, Id}
 import com.keepit.common.time._
 import org.joda.time.DateTime
-import scala.Some
-import scala.slick.jdbc.StaticQuery
+import scala.slick.jdbc.{GetResult, StaticQuery}
+import com.keepit.common.logging.Logging
 
 @ImplementedBy(classOf[BookmarkRepoImpl])
 trait BookmarkRepo extends Repo[Bookmark] with ExternalIdColumnFunction[Bookmark] {
@@ -17,8 +17,8 @@ trait BookmarkRepo extends Repo[Bookmark] with ExternalIdColumnFunction[Bookmark
   def getByUri(uriId: Id[NormalizedURI], excludeState: Option[State[Bookmark]] = Some(BookmarkStates.INACTIVE))(implicit session: RSession): Seq[Bookmark]
   def getByUriWithoutTitle(uriId: Id[NormalizedURI])(implicit session: RSession): Seq[Bookmark]
   def getByUser(userId: Id[User], excludeState: Option[State[Bookmark]] = Some(BookmarkStates.INACTIVE))(implicit session: RSession): Seq[Bookmark]
-  def getByUser(userId: Id[User], beforeId: Option[ExternalId[Bookmark]], afterId: Option[ExternalId[Bookmark]],
-                collectionId: Option[Id[Collection]], count: Int)(implicit session: RSession): Seq[Bookmark]
+  def getByUser(userId: Id[User], beforeId: Option[ExternalId[Bookmark]], afterId: Option[ExternalId[Bookmark]], count: Int)(implicit session: RSession): Seq[Bookmark]
+  def getByUserAndCollection(userId: Id[User], collectionId: Id[Collection], beforeId: Option[ExternalId[Bookmark]], afterId: Option[ExternalId[Bookmark]], count: Int)(implicit session: RSession): Seq[Bookmark]
   def getCountByUser(userId: Id[User], includePrivate: Boolean = true)(implicit session: RSession): Int
   def getPrivatePublicCountByUser(userId: Id[User])(implicit session: RSession): (Int, Int)
   def getCountByTime(from: DateTime, to: DateTime)(implicit session: RSession): Int
@@ -45,7 +45,7 @@ class BookmarkRepoImpl @Inject() (
   collectionRepo: CollectionRepo,
   bookmarkUriUserCache: BookmarkUriUserCache,
   latestBookmarkUriCache: LatestBookmarkUriCache)
-  extends DbRepo[Bookmark] with BookmarkRepo with ExternalIdColumnDbFunction[Bookmark] {
+  extends DbRepo[Bookmark] with BookmarkRepo with ExternalIdColumnDbFunction[Bookmark] with Logging {
 
   import DBSession._
   import FortyTwoTypeMappers._
@@ -54,8 +54,8 @@ class BookmarkRepoImpl @Inject() (
 
   private val sequence = db.getSequence("bookmark_sequence")
 
-  override val table = new RepoTable[Bookmark](db, "bookmark") with ExternalIdColumn[Bookmark] {
-    def title = column[Option[String]]("title", O.Nullable)//indexd
+  override val table = new RepoTable[Bookmark](db, "bookmark") with ExternalIdColumn[Bookmark] with NamedColumns {
+    def title = column[String]("title", O.Nullable)//indexd
     def uriId = column[Id[NormalizedURI]]("uri_id", O.NotNull)//indexd
     def urlId = column[Id[URL]]("url_id", O.NotNull)
     def url =   column[String]("url", O.NotNull)//indexd
@@ -65,9 +65,13 @@ class BookmarkRepoImpl @Inject() (
     def source = column[BookmarkSource]("source", O.NotNull)
     def kifiInstallation = column[ExternalId[KifiInstallation]]("kifi_installation", O.Nullable)
     def seq = column[SequenceNumber]("seq", O.Nullable)//indexd
-    def * = id.? ~ createdAt ~ updatedAt ~ externalId ~ title ~ uriId ~ urlId.? ~ url ~ bookmarkPath.? ~ isPrivate ~
+    def * = id.? ~ createdAt ~ updatedAt ~ externalId ~ title.? ~ uriId ~ urlId.? ~ url ~ bookmarkPath.? ~ isPrivate ~
       userId ~ state ~ source ~ kifiInstallation.? ~ seq <> (Bookmark.apply _, Bookmark.unapply _)
   }
+
+  private implicit val getBookmarkResult = GetResult(r => table.*.getResult(db.Driver.profile, r))
+  private val bookmarkColumnOrder = table.columnStrings("bm")
+
 
   override def save(model: Bookmark)(implicit session: RWSession) = {
     val newModel = model.copy(seq = sequence.incrementAndGet())
@@ -122,25 +126,51 @@ class BookmarkRepoImpl @Inject() (
   def getByUser(userId: Id[User], excludeState: Option[State[Bookmark]] = Some(BookmarkStates.INACTIVE))(implicit session: RSession): Seq[Bookmark] =
     (for(b <- table if b.userId === userId && b.state =!= excludeState.orNull) yield b).sortBy(_.createdAt).list
 
-  def getByUser(userId: Id[User], beforeId: Option[ExternalId[Bookmark]], afterId: Option[ExternalId[Bookmark]],
-                collectionId: Option[Id[Collection]], count: Int)(implicit session: RSession): Seq[Bookmark] = {
+  def getByUser(userId: Id[User], beforeId: Option[ExternalId[Bookmark]], afterId: Option[ExternalId[Bookmark]], count: Int)(implicit session: RSession): Seq[Bookmark] = com.keepit.common.performance.timing(s"QUERYING:1: $beforeId, $afterId, $count, $userId") {
     import keepToCollectionRepo.{stateTypeMapper => ktcStateMapper}
-    val (maybeBefore, maybeAfter) = (beforeId map get, afterId map get)
-    val q = (for {
-      b <- table if b.userId === userId && b.state === BookmarkStates.ACTIVE &&
-      (maybeBefore.map { before =>
-        b.createdAt < before.createdAt || b.id < before.id.get && b.createdAt === before.createdAt
-      } getOrElse (b.id === b.id)) &&
-      (maybeAfter.map { after =>
-        b.createdAt > after.createdAt || b.id > after.id.get && b.createdAt === after.createdAt
-      } getOrElse (b.id === b.id))
-    } yield b).sortBy(_.createdAt)
-    (collectionId.map { cid =>
-      for {
-        (b, ktc) <- q join keepToCollectionRepo.table on (_.id === _.bookmarkId)
-        if ktc.collectionId === cid && ktc.state === KeepToCollectionStates.ACTIVE
-      } yield b
-    } getOrElse q).sortBy(_.id desc).sortBy(_.createdAt desc).take(count).list
+    import StaticQuery.interpolation
+    import scala.collection.JavaConversions._
+
+    // Performance sensitive call.
+    // Separate queries for each case because the db will cache the query plans when we only use parametrized queries instead of raw strings.
+    val interpolated = (beforeId map get, afterId map get) match {
+      case (None, None) =>
+        sql"""select #$bookmarkColumnOrder from bookmark bm where bm.user_id = ${userId.id} and bm.state = 'active' order by bm.id desc limit $count;"""
+      case (None, Some(after)) =>
+        sql"""select #$bookmarkColumnOrder from bookmark bm where bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}' and bm.id > ${after.id.get.id} order by bm.id desc limit $count;"""
+      case (Some(before), None) =>
+        sql"""select #$bookmarkColumnOrder from bookmark bm where bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}' and bm.id < ${before.id.get.id} order by bm.id desc limit $count;"""
+      case (Some(before), Some(after)) =>
+        sql"""select #$bookmarkColumnOrder from bookmark bm where bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}' and bm.id < ${before.id.get.id} and bm.id > ${after.id.get.id} order by bm.id desc limit $count;"""
+    }
+    interpolated.as[Bookmark].list
+  }
+
+  def getByUserAndCollection(userId: Id[User], collectionId: Id[Collection], beforeId: Option[ExternalId[Bookmark]], afterId: Option[ExternalId[Bookmark]], count: Int)(implicit session: RSession): Seq[Bookmark] = com.keepit.common.performance.timing(s"QUERYING:1: $beforeId, $afterId, $collectionId, $count, $userId") {
+    import keepToCollectionRepo.{stateTypeMapper => ktcStateMapper}
+    import StaticQuery.interpolation
+
+    // Performance sensitive call.
+    // Separate queries for each case because the db will cache the query plans when we only use parametrized queries.
+    val interpolated = (beforeId map get, afterId map get) match {
+      case (None, None) =>
+        sql"""select #$bookmarkColumnOrder from bookmark bm left join keep_to_collection kc on (bm.id = kc.bookmark_id)
+                where kc.collection_id = ${collectionId.id} and bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}'
+                and kc.state='#${KeepToCollectionStates.ACTIVE.value}' order by bm.id desc limit $count;"""
+      case (None, Some(after)) =>
+        sql"""select #$bookmarkColumnOrder from bookmark bm left join keep_to_collection kc on (bm.id = kc.bookmark_id)
+                where kc.collection_id = ${collectionId.id} and bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}'
+                and kc.state='#${KeepToCollectionStates.ACTIVE.value}' and bm.id > ${after.id.get.id} order by bm.id desc limit $count;"""
+      case (Some(before), None) =>
+        sql"""select #$bookmarkColumnOrder from bookmark bm left join keep_to_collection kc on (bm.id = kc.bookmark_id)
+                where kc.collection_id = ${collectionId.id} and bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}'
+                and kc.state='#${KeepToCollectionStates.ACTIVE.value}' and bm.id < ${before.id.get.id} order by bm.id desc limit $count;"""
+      case (Some(before), Some(after)) =>
+        sql"""select #$bookmarkColumnOrder from bookmark bm left join keep_to_collection kc on (bm.id = kc.bookmark_id)
+                where kc.collection_id = ${collectionId.id} and bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}'
+                and kc.state='#${KeepToCollectionStates.ACTIVE.value}' and bm.id < ${before.id.get.id} and bm.id > ${after.id.get.id} order by bm.id desc limit $count;"""
+    }
+    interpolated.as[Bookmark].list
   }
 
   def getCountByUser(userId: Id[User], includePrivate: Boolean)(implicit session: RSession): Int =

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
@@ -54,14 +54,14 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
         db.readOnly { implicit s =>
           val tagId = collections(0).id.get
           collectionRepo.get(tagId).state.value === "active"
-          val bookmarksWithTags = bookmarkRepo.getByUser(user.id.get, None, None, Some(collections(0).id.get), 1000)
+          val bookmarksWithTags = bookmarkRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
           bookmarksWithTags.size === 2
           (bookmarksWithTags map {b => b.id.get}).toSet === Set(bookmark1.id.get, bookmark2.id.get)
         }
 
         db.readOnly { implicit s =>
           collectionRepo.get(collections(1).id.get).state.value === "active"
-          val bookmarksWithTags = bookmarkRepo.getByUser(user.id.get, None, None, Some(collections(1).id.get), 1000)
+          val bookmarksWithTags = bookmarkRepo.getByUserAndCollection(user.id.get, collections(1).id.get, None, None, 1000)
           bookmarksWithTags.size === 1
           bookmarksWithTags.head.id.get === bookmark1.id.get
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtBookmarksControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtBookmarksControllerTest.scala
@@ -97,12 +97,12 @@ class ExtBookmarksControllerTest extends Specification with ApplicationInjector 
         }
 
         val bookmarksWithTags = db.readOnly { implicit s =>
-          bookmarkRepo.getByUser(user.id.get, None, None, Some(collections(0).id.get), 1000)
+          bookmarkRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
         }
         bookmarksWithTags.size === 1
 
         db.readOnly { implicit s =>
-          bookmarkRepo.getByUser(user.id.get, None, None, None, 100).size === 2
+          bookmarkRepo.getByUser(user.id.get, None, None, 100).size === 2
           val uris = uriRepo.all
           println(uris mkString "\n")
           uris.size === 2
@@ -120,7 +120,7 @@ class ExtBookmarksControllerTest extends Specification with ApplicationInjector 
         Json.parse(contentAsString(result)) must equalTo(Json.obj())
 
         val bookmarks = db.readOnly { implicit s =>
-          bookmarkRepo.getByUser(user.id.get, None, None, Some(collections(0).id.get), 1000)
+          bookmarkRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
         }
         bookmarks.size === 0
       }
@@ -164,7 +164,7 @@ class ExtBookmarksControllerTest extends Specification with ApplicationInjector 
         }
 
         db.readOnly {implicit s =>
-          bookmarkRepo.getByUser(user.id.get, None, None, None, 100).size === 2
+          bookmarkRepo.getByUser(user.id.get, None, None, 100).size === 2
           val uris = uriRepo.all
           println(uris mkString "\n")
           uris.size === 2
@@ -185,13 +185,13 @@ class ExtBookmarksControllerTest extends Specification with ApplicationInjector 
         Json.parse(contentAsString(result)) must equalTo(expected)
 
         db.readWrite {implicit s =>
-          val keeps = bookmarkRepo.getByUser(user.id.get, None, None, None, 100)
+          val keeps = bookmarkRepo.getByUser(user.id.get, None, None, 100)
           println(keeps mkString "\n")
           keeps.size === 2
         }
 
         val bookmarks = db.readOnly { implicit s =>
-          bookmarkRepo.getByUser(user.id.get, None, None, Some(collections(0).id.get), 1000)
+          bookmarkRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
         }
         bookmarks.size === 1
         bookmarks(0).id.get === bookmark1.id.get
@@ -227,7 +227,7 @@ class ExtBookmarksControllerTest extends Specification with ApplicationInjector 
         }
 
         db.readOnly {implicit s =>
-          bookmarkRepo.getByUser(user.id.get, None, None, None, 100).size === 0
+          bookmarkRepo.getByUser(user.id.get, None, None, 100).size === 0
           val uris = uriRepo.all
           uris.size === 0
         }
@@ -247,13 +247,13 @@ class ExtBookmarksControllerTest extends Specification with ApplicationInjector 
         Json.parse(contentAsString(result)) must equalTo(expected)
 
         db.readWrite {implicit s =>
-          val keeps = bookmarkRepo.getByUser(user.id.get, None, None, None, 100)
+          val keeps = bookmarkRepo.getByUser(user.id.get, None, None, 100)
           println(keeps mkString "\n")
           keeps.size === 1
         }
 
         val bookmarks = db.readOnly { implicit s =>
-          bookmarkRepo.getByUser(user.id.get, None, None, Some(collections(0).id.get), 1000)
+          bookmarkRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
         }
         bookmarks.size === 1
         bookmarks(0).url === "http://www.google.com/"

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileBookmarksControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileBookmarksControllerTest.scala
@@ -119,12 +119,12 @@ class MobileBookmarksControllerTest extends Specification with ApplicationInject
       }
 
       val bookmarksWithTags = db.readOnly { implicit s =>
-        bookmarkRepo.getByUser(user.id.get, None, None, Some(collections(0).id.get), 1000)
+        bookmarkRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
       }
       bookmarksWithTags.size === 1
 
       db.readOnly {implicit s =>
-        bookmarkRepo.getByUser(user.id.get, None, None, None, 100).size === 2
+        bookmarkRepo.getByUser(user.id.get, None, None, 100).size === 2
         val uris = uriRepo.all
         println(uris mkString "\n")
         uris.size === 2
@@ -136,13 +136,13 @@ class MobileBookmarksControllerTest extends Specification with ApplicationInject
       inject[FakeActionAuthenticator].setUser(user)
       val request = FakeRequest("POST", path).withJsonBody(JsObject(Seq("url" -> JsString("http://www.google.com/"))))
       val result = route(request).get
-      status(result) must equalTo(OK);
-      contentType(result) must beSome("application/json");
+      status(result) must equalTo(OK)
+      contentType(result) must beSome("application/json")
 
       Json.parse(contentAsString(result)) must equalTo(Json.obj())
 
       val bookmarks = db.readOnly { implicit s =>
-        bookmarkRepo.getByUser(user.id.get, None, None, Some(collections(0).id.get), 1000)
+        bookmarkRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
       }
       bookmarks.size === 0
     }
@@ -186,7 +186,7 @@ class MobileBookmarksControllerTest extends Specification with ApplicationInject
       }
 
       db.readOnly {implicit s =>
-        bookmarkRepo.getByUser(user.id.get, None, None, None, 100).size === 2
+        bookmarkRepo.getByUser(user.id.get, None, None, 100).size === 2
         val uris = uriRepo.all
         println(uris mkString "\n")
         uris.size === 2
@@ -207,13 +207,13 @@ class MobileBookmarksControllerTest extends Specification with ApplicationInject
       Json.parse(contentAsString(result)) must equalTo(expected)
 
       db.readWrite {implicit s =>
-        val keeps = bookmarkRepo.getByUser(user.id.get, None, None, None, 100)
+        val keeps = bookmarkRepo.getByUser(user.id.get, None, None, 100)
         println(keeps mkString "\n")
         keeps.size === 2
       }
 
       val bookmarks = db.readOnly { implicit s =>
-        bookmarkRepo.getByUser(user.id.get, None, None, Some(collections(0).id.get), 1000)
+        bookmarkRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
       }
 
       bookmarks.size === 1
@@ -248,7 +248,7 @@ class MobileBookmarksControllerTest extends Specification with ApplicationInject
       }
 
       db.readOnly {implicit s =>
-        bookmarkRepo.getByUser(user.id.get, None, None, None, 100).size === 0
+        bookmarkRepo.getByUser(user.id.get, None, None, 100).size === 0
         val uris = uriRepo.all
         uris.size === 0
       }
@@ -259,8 +259,8 @@ class MobileBookmarksControllerTest extends Specification with ApplicationInject
       inject[FakeActionAuthenticator].setUser(user)
       val request = FakeRequest("POST", path).withJsonBody(JsObject(Seq("url" -> JsString("http://www.google.com/"))))
       val result = route(request).get
-      status(result) must equalTo(OK);
-      contentType(result) must beSome("application/json");
+      status(result) must equalTo(OK)
+      contentType(result) must beSome("application/json")
 
       val expected = Json.parse(s"""
         {"id":"${collections(0).externalId}","name":"myCollaction1"}
@@ -268,13 +268,13 @@ class MobileBookmarksControllerTest extends Specification with ApplicationInject
       Json.parse(contentAsString(result)) must equalTo(expected)
 
       db.readWrite {implicit s =>
-        val keeps = bookmarkRepo.getByUser(user.id.get, None, None, None, 100)
+        val keeps = bookmarkRepo.getByUser(user.id.get, None, None, 100)
         println(keeps mkString "\n")
         keeps.size === 1
       }
 
       val bookmarks = db.readOnly { implicit s =>
-        bookmarkRepo.getByUser(user.id.get, None, None, Some(collections(0).id.get), 1000)
+        bookmarkRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
       }
       bookmarks.size === 1
       bookmarks(0).url === "http://www.google.com/"
@@ -316,7 +316,7 @@ class MobileBookmarksControllerTest extends Specification with ApplicationInject
       }
 
       val keeps = db.readWrite {implicit s =>
-        bookmarkRepo.getByUser(user1.id.get, None, None, None, 100)
+        bookmarkRepo.getByUser(user1.id.get, None, None, 100)
       }
       keeps.size === 2
 
@@ -398,7 +398,7 @@ class MobileBookmarksControllerTest extends Specification with ApplicationInject
       }
 
       val keeps = db.readWrite {implicit s =>
-        bookmarkRepo.getByUser(user.id.get, None, None, None, 100)
+        bookmarkRepo.getByUser(user.id.get, None, None, 100)
       }
       keeps.size === 2
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/BookmarksControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/BookmarksControllerTest.scala
@@ -115,7 +115,7 @@ class BookmarksControllerTest extends Specification with ApplicationInjector {
         }
 
         val keeps = db.readWrite {implicit s =>
-          bookmarkRepo.getByUser(user1.id.get, None, None, None, 100)
+          bookmarkRepo.getByUser(user1.id.get, None, None, 100)
         }
         keeps.size === 2
 
@@ -201,7 +201,7 @@ class BookmarksControllerTest extends Specification with ApplicationInjector {
         }
 
         val keeps = db.readWrite {implicit s =>
-          bookmarkRepo.getByUser(user.id.get, None, None, None, 100)
+          bookmarkRepo.getByUser(user.id.get, None, None, 100)
         }
         keeps.size === 2
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/BookmarkTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/BookmarkTest.scala
@@ -48,14 +48,14 @@ class BookmarkTest extends Specification with ShoeboxTestInjector {
       withDb() { implicit injector =>
         val (user1, user2, uri1, uri2, uri3, _, _) = setup()
         db.readOnly { implicit s =>
-          val marks = bookmarkRepo.getByUser(user1.id.get, None, None, None, 3)
+          val marks = bookmarkRepo.getByUser(user1.id.get, None, None, 3)
           marks.map(_.uriId) === Seq(uri3.id.get, uri2.id.get, uri1.id.get)
-          bookmarkRepo.getByUser(user1.id.get, Some(marks(0).externalId), None, None, 5).map(_.uriId) === Seq(uri2.id.get, uri1.id.get)
-          bookmarkRepo.getByUser(user1.id.get, Some(marks(2).externalId), None, None, 5) must beEmpty
-          bookmarkRepo.getByUser(user1.id.get, Some(marks(2).externalId), None, None, 5) must beEmpty
-          bookmarkRepo.getByUser(user1.id.get, None, Some(marks(1).externalId), None, 5).map(_.uriId) === Seq(uri3.id.get)
-          bookmarkRepo.getByUser(user1.id.get, None, Some(marks(0).externalId), None, 5) must beEmpty
-          bookmarkRepo.getByUser(user1.id.get, None, None, None, 0) must beEmpty
+          bookmarkRepo.getByUser(user1.id.get, Some(marks(0).externalId), None, 5).map(_.uriId) === Seq(uri2.id.get, uri1.id.get)
+          bookmarkRepo.getByUser(user1.id.get, Some(marks(2).externalId), None, 5) must beEmpty
+          bookmarkRepo.getByUser(user1.id.get, Some(marks(2).externalId), None, 5) must beEmpty
+          bookmarkRepo.getByUser(user1.id.get, None, Some(marks(1).externalId), 5).map(_.uriId) === Seq(uri3.id.get)
+          bookmarkRepo.getByUser(user1.id.get, None, Some(marks(0).externalId), 5) must beEmpty
+          bookmarkRepo.getByUser(user1.id.get, None, None, 0) must beEmpty
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/CollectionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/CollectionTest.scala
@@ -57,10 +57,10 @@ class CollectionTest extends Specification with ShoeboxTestInjector {
         }
         db.readOnly { implicit s =>
           collectionRepo.getByUser(user1.id.get).map(_.name).toSet === Set("Apparel", "Cooking", "Scala")
-          bookmarkRepo.getByUser(user1.id.get, None, None, coll1.id, 5) must haveLength(2)
-          bookmarkRepo.getByUser(user1.id.get, None, None, None, 5) must haveLength(2)
-          bookmarkRepo.getByUser(user1.id.get, None, None, coll2.id, 5) must haveLength(1)
-          bookmarkRepo.getByUser(user1.id.get, None, None, coll3.id, 5) must beEmpty
+          bookmarkRepo.getByUserAndCollection(user1.id.get, coll1.id.get, None, None, 5) must haveLength(2)
+          bookmarkRepo.getByUser(user1.id.get, None, None, 5) must haveLength(2)
+          bookmarkRepo.getByUserAndCollection(user1.id.get, coll2.id.get, None, None, 5) must haveLength(1)
+          bookmarkRepo.getByUserAndCollection(user1.id.get, coll3.id.get, None, None, 5) must beEmpty
         }
       }
     }

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
@@ -152,6 +152,13 @@ trait DbRepo[M <: Model[M]] extends Repo[M] with DelayedInit {
 
     def externalId = column[ExternalId[M]]("external_id", O.NotNull)
   }
+
+  trait NamedColumns { self: RepoTable[_] =>
+    lazy val _columnStrings = {
+      create_*.map(_.name).take(30).map(db.entityName)
+    }
+    def columnStrings(tableName: String = tableName) = _columnStrings.map(c => tableName + "." + c).mkString(", ")
+  }
 }
 
 trait DbRepoWithDelete[M <: Model[M]] extends RepoWithDelete[M] { self:DbRepo[M] =>


### PR DESCRIPTION
The previous query to get bookmarks given date restrictions and an optional collection was quite inefficient (the generated query was making 4 temporary tables, one of which was the size of all of `bookmark` and one was all of `keep_to_collection`.

The solution was to hand write the queries. Since this is a very sensitive call, I used separate prepared statements so the db caches the query plan. A little bit of code repetition makes it faster. The result of every case is well-tested. @eishay

---
###### An aside for some Slick implementation details (for those interested):

`StaticQuery`s cannot directly use `MappedProjections`, which is quite a shame since it _would_ be possible since all of the information needed (column names, type mappers) is supplied in the `def *` projection. Instead, you must supply a `PositionedResult => T` (aliased `GetResult`), where order (not type) matters. Since our schema and/or variable order in our case classes may change, I wanted to make it safer than hard-coding the column order.

I spent some time trying to make an automatic converter from `table.*[T]` to an appropriate `GetResult` so that we can more-easily hand write queries and have them deserialize correctly. Unfortunately, it's quite difficult to get the correct mapper for an arbitrary column, and Scala's type system does not let you construct objects of dynamic size easily (see `Tuple`, `Function`, and `Projection`).

`table.*.getResult` exists, but does not let you specify or use an arbitrary column order. This is unfortunate because many of our table definitions are not in the same order as the database schema. So, if the select statement requests the columns in the correct order (as defined in the `table.*`), we can easily deserialize into our case class. I settled on providing a convenience method that gives the column names in the correct order.
