### PR TITLE
:/internal/eliza/getThreadContentForIndexing is calling getThreadContent...

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/net/ClientResponse.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/ClientResponse.scala
@@ -84,6 +84,7 @@ class ClientResponseImpl(val request: Request, val res: Response, airbrake: Prov
         url.contains("/getEContacts") ||
         url.contains("/getContacts") ||
         url.contains("/internal/shoebox/database/getIndexable") ||
+        url.contains("/internal/eliza/getThreadContentForIndexing") ||
         url.contains("/internal/shoebox/database/getUriIdsInCollection") ||
         url.contains("graph.facebook.com/") ||
         url.contains("api.linkedin.com/")) {


### PR DESCRIPTION
...sForMessagesFromIdToId on eliza which may take a very long time to execute (5119ms tonight). until we’ll check the server side, its fine to reduce the wait time errors
