### PR TITLE
need a fast get current seqNum method

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/NormalizedURIRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/NormalizedURIRepo.scala
@@ -72,9 +72,7 @@ extends DbRepo[NormalizedURI] with NormalizedURIRepo with ExternalIdColumnDbFunc
   }
 
   override def getCurrentSeqNum()(implicit session: RSession): SequenceNumber = {
-    val q = (for( r <- table ) yield r.seq)
-    val m = q.list.map{_.value}.max
-    SequenceNumber(m)
+    sequence.getLastGeneratedSeq()
   }
 
   override def invalidateCache(uri: NormalizedURI)(implicit session: RSession): Unit = {

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/DbSequence.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/DbSequence.scala
@@ -1,6 +1,6 @@
 package com.keepit.common.db
 
-import com.keepit.common.db.slick.DBSession.RWSession
+import com.keepit.common.db.slick.DBSession.{RSession, RWSession}
 import scalax.io.JavaConverters._
 import scala.util.matching.Regex
 import play.api.libs.json._
@@ -22,6 +22,7 @@ abstract class DbSequence(val name: String) {
   if (DbSequence.validSequenceName.findFirstIn(name).isEmpty)
     throw new IllegalArgumentException(s"Sequence name $name is invalid")
   def incrementAndGet()(implicit session: RWSession): SequenceNumber
+  def getLastGeneratedSeq()(implicit session: RSession): SequenceNumber
 }
 
 object DbSequence {

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/H2.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/H2.scala
@@ -1,6 +1,6 @@
 package com.keepit.common.db.slick
 
-import com.keepit.common.db.slick.DBSession.RWSession
+import com.keepit.common.db.slick.DBSession.{RSession, RWSession}
 import com.keepit.common.db.{DbSequence, SequenceNumber, H2DatabaseDialect}
 import scala.slick.driver.H2Driver
 import scala.collection.concurrent.TrieMap
@@ -29,6 +29,13 @@ class H2(val masterDb: SlickDatabase, val slaveDb: Option[SlickDatabase])
     initSequence(name)
     def incrementAndGet()(implicit sess: RWSession): SequenceNumber = {
       val stmt = sess.conn.prepareStatement(s"""SELECT NEXTVAL('$name')""")
+      val rs = stmt.executeQuery()
+      rs.next()
+      SequenceNumber(rs.getLong(1))
+    }
+
+    def getLastGeneratedSeq()(implicit session: RSession): SequenceNumber = {
+      val stmt = session.conn.prepareStatement(s"""SELECT CURRVAL('$name')""")
       val rs = stmt.executeQuery()
       rs.next()
       SequenceNumber(rs.getLong(1))

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/MySQL.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/MySQL.scala
@@ -1,6 +1,6 @@
 package com.keepit.common.db.slick
 
-import com.keepit.common.db.slick.DBSession.RWSession
+import com.keepit.common.db.slick.DBSession.{RSession, RWSession}
 import com.keepit.common.db.{DbSequence, SequenceNumber, MySqlDatabaseDialect}
 import scala.slick.driver.MySQLDriver
 import scala.slick.session.{Database => SlickDatabase}
@@ -16,6 +16,12 @@ class MySQL(val masterDb: SlickDatabase, val slaveDb: Option[SlickDatabase])
     def incrementAndGet()(implicit sess: RWSession): SequenceNumber = {
       sess.getPreparedStatement(s"UPDATE $name SET id=LAST_INSERT_ID(id+1);").execute()
       val rs = sess.getPreparedStatement(s"SELECT LAST_INSERT_ID();").executeQuery()
+      rs.next()
+      SequenceNumber(rs.getLong(1))
+    }
+
+    def getLastGeneratedSeq()(implicit session: RSession): SequenceNumber = {
+      val rs = session.getPreparedStatement(s"SELECT LAST_INSERT_ID();").executeQuery()
       rs.next()
       SequenceNumber(rs.getLong(1))
     }


### PR DESCRIPTION
@eishay @ymatsuda @andrewconner 

We have incrementAndGet() method for sequenceNumber. 
For fast reindex, search need to query the current sequence number, i.e. the last generated one. 
