### PR TITLE
2.8.48: caching less user session data globally in every page

### DIFF
--- a/packrat/.jshintrc
+++ b/packrat/.jshintrc
@@ -87,7 +87,7 @@
 	"globals": {
     // Kifi Globals
     "api": true,
-    "session": true,
+    "me": true,
     "pageData": true,
     "log": true,
     "util": true,

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.8.45
+version=2.8.48

--- a/packrat/html/keeper/compose.html
+++ b/packrat/html/keeper/compose.html
@@ -5,7 +5,7 @@
   <div class="kifi-compose-draft" contenteditable="" data-placeholder="{{draftPlaceholder}}" data-default="{{draftDefault}}"></div>
   <div class="kifi-compose-bar">
     <a class="kifi-compose-snapshot" href="javascript:" style="background-image:url({{snapshotUri}})" tabindex="-1"></a>
-    <span class="kifi-compose-tip">{{submitTip}}<span class="kifi-compose-tip-tri">&#x25be;</span></span>{{!
-  }}<a href="javascript:" class="kifi-compose-submit" tabindex="0">{{submitButtonLabel}}</a>
+    <span class="kifi-compose-tip">{{sendKeyTip}}<span class="kifi-compose-tip-tri">&#x25be;</span></span>{{!
+  }}<a href="javascript:" class="kifi-compose-submit" tabindex="0">Send</a>
   </div>
 </div>

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -144,7 +144,7 @@ var mixpanel = {
   },
   augmentAndBatch: function (data) {
     data.properties.token = 'cff752ff16ee39eda30ae01bb6fa3bd6';
-    data.properties.distinct_id = session.user.id;
+    data.properties.distinct_id = me.id;
     data.properties.browser = api.browser.name;
     data.properties.browserDetails = api.browser.userAgent;
     this.batch.push(data);
@@ -163,7 +163,7 @@ var mixpanel = {
         'event': eventName,
         'properties': properties
       };
-      if (session) {
+      if (me) {
         this.augmentAndBatch(data);
       } else {
         this.queue.push(data);
@@ -301,7 +301,7 @@ var socketHandlers = {
   },
   experiments: function(exp) {
     log("[socket:experiments]", exp)();
-    session.experiments = exp;
+    experiments = exp;
     api.toggleLogging(exp.indexOf('extension_logging') >= 0);
   },
   new_friends: function(fr) {
@@ -369,7 +369,7 @@ var socketHandlers = {
   message: function(threadId, message) {
     log('[socket:message]', threadId, message, message.nUrl)();
     forEachTabAtLocator('/messages/' + threadId, function(tab) {
-      api.tabs.emit(tab, 'message', {threadId: threadId, message: message, userId: session.user.id});
+      api.tabs.emit(tab, 'message', {threadId: threadId, message: message, userId: me.id});
     });
     var messages = messageData[threadId];
     if (messages) {
@@ -557,23 +557,23 @@ api.port.on({
     ajax("POST", "/ext/pref/keeperPosition", {host: o.host, pos: o.pos});
   },
   set_enter_to_send: function(data) {
-    session.prefs.enterToSend = data;
+    prefs.enterToSend = data;
     ajax('POST', '/ext/pref/enterToSend?enterToSend=' + data);
   },
   set_max_results: function(n) {
-    session.prefs.maxResults = n;
+    prefs.maxResults = n;
     ajax('POST', '/ext/pref/maxResults?n=' + n);
   },
   set_show_find_friends: function(show) {
-    session.prefs.showFindFriends = show;
+    prefs.showFindFriends = show;
     ajax('POST', '/ext/pref/showFindFriends?show=' + show);
   },
   set_show_keeper_intro: function(show) {
-    session.prefs.showKeeperIntro = show;
+    prefs.showKeeperIntro = show;
     ajax('POST', '/ext/pref/showKeeperIntro?show=' + show);
   },
   set_show_search_intro: function(show) {
-    session.prefs.showSearchIntro = show;
+    prefs.showSearchIntro = show;
     ajax('POST', '/ext/pref/showSearchIntro?show=' + show);
   },
   useful_page: function(o, _, tab) {
@@ -646,14 +646,17 @@ api.port.on({
   thread: function(id, respond, tab) {
     var msgs = messageData[id];
     if (msgs) {
-      respond({id: id, messages: msgs});
+      reply({id: id, messages: msgs});
     } else {
       var tc = threadCallbacks[id];
       if (!tc) {
         tc = threadCallbacks[id] = [];
         socket.send(['get_thread', id]);
       }
-      tc.push(respond);
+      tc.push(reply);
+    }
+    function reply(o) {
+      respond({id: o.id, messages: o.messages, enterToSend: prefs ? prefs.enterToSend : true});
     }
   },
   get_unread_thread_count: function(_, __, tab) {
@@ -759,8 +762,11 @@ api.port.on({
       socket.send(['set_all_notifications_visited', msgId]);
     }
   },
-  session: function(_, respond) {
-    respond(session);
+  me: function(_, respond) {
+    respond(me);
+  },
+  prefs: function(_, respond) {
+    respond(prefs);
   },
   web_base_uri: function(_, respond) {
     respond(webBaseUri());
@@ -1247,7 +1253,7 @@ function tellVisibleTabsNoticeCountIfChanged() {
 function searchOnServer(request, respond) {
   if (request.first && getPrefetched(request, respond)) return;
 
-  if (!session) {
+  if (!me) {
     log("[searchOnServer] no session")();
     respond({});
     return;
@@ -1271,7 +1277,9 @@ function searchOnServer(request, respond) {
   var respHandler = function(resp) {
     log('[searchOnServer] response:', resp)();
     resp.filter = request.filter;
-    resp.session = session;
+    resp.me = me;
+    resp.prefs = prefs || {maxResults: 1};
+    resp.experiments = experiments;
     resp.admBaseUri = admBaseUri();
     resp.myTotal = resp.myTotal || 0;
     resp.friendsTotal = resp.friendsTotal || 0;
@@ -1301,14 +1309,14 @@ function processSearchHit(hit) {
 }
 
 function kifify(tab) {
-  log("[kifify]", tab.id, tab.url, tab.icon || '', tab.nUri || '', session ? '' : 'no session')();
+  log("[kifify]", tab.id, tab.url, tab.icon || '', tab.nUri || '', me ? '' : 'no session')();
   if (!tab.icon) {
     api.icon.set(tab, 'icons/k_gray' + (silence ? '.paused' : '') + '.png');
   } else {
     updateIconSilence(tab);
   }
 
-  if (!session) {
+  if (!me) {
     if (!stored('logout') || tab.url.indexOf(webBaseUri()) === 0) {
       ajax("GET", "/ext/authed", function(loggedIn) {
         if (loggedIn !== false) {
@@ -1385,7 +1393,8 @@ function kififyWithPageData(tab, d) {
     kept: d.kept,
     position: d.position,
     hide: d.neverOnSite || ruleSet.rules.sensitive && d.sensitive,
-    tags: d.tags
+    tags: d.tags,
+    showKeeperIntro: prefs && prefs.showKeeperIntro
   }, {queue: 1});
 
   // consider triggering automatic keeper behavior on page to engage user (only once)
@@ -1543,7 +1552,7 @@ function updateThreadInTabs(oldMessageCount, o) {
 }
 
 function isSent(th) {
-  return th.firstAuthor != null && th.participants[th.firstAuthor].id === session.user.id;
+  return th.firstAuthor != null && th.participants[th.firstAuthor].id === me.id;
 }
 
 function isUnread(th) {
@@ -1672,12 +1681,12 @@ api.on.beforeSearch.add(throttle(function () {
 var searchPrefetchCache = {};  // for searching before the results page is ready
 var searchFilterCache = {};    // for restoring filter if user navigates back to results
 api.on.search.add(function prefetchResults(query) {
-  if (!session) return;
+  if (!me) return;
   log('[prefetchResults] prefetching for query:', query)();
   var entry = searchPrefetchCache[query];
   if (!entry) {
     entry = searchPrefetchCache[query] = {callbacks: [], response: null};
-    searchOnServer({query: query, filter: (searchFilterCache[query] || {}).filter}, function(response) {
+    searchOnServer({query: query, filter: (searchFilterCache[query] || {}).filter}, function (response) {
       entry.response = response;
       while (entry.callbacks.length) entry.callbacks.shift()(response);
       api.timers.clearTimeout(entry.expireTimeout);
@@ -1841,12 +1850,14 @@ function getTags() {
   });
 }
 
-function getPrefs() {
-  ajax("GET", "/ext/prefs", function(o) {
-    log("[getPrefs]", o)();
-    session.prefs = o[1];
-    session.eip = o[2];
-    socket && socket.send(["eip", session.eip]);
+function getPrefs () {
+  ajax('GET', '/ext/prefs', function (arr) {
+    log('[getPrefs]', arr)();
+    if (me) {
+      prefs = arr[1];
+      eip = arr[2];
+      socket.send(['eip', eip]);
+    }
   });
 }
 
@@ -1892,7 +1903,7 @@ function throttle(func, wait, opts) {  // underscore.js
 
 // ===== Session management
 
-var session, socket, silence, onLoadingTemp;
+var me, prefs, experiments, eip, socket, silence, onLoadingTemp;
 
 function authenticate(callback, retryMs) {
   if (api.mode.isDev()) {
@@ -1905,16 +1916,18 @@ function authenticate(callback, retryMs) {
 function startSession(callback, retryMs) {
   ajax("POST", "/kifi/start", {
     installation: stored('installation_id'),
-    version: api.version},
+    version: api.version
+  },
   function done(data) {
     log("[authenticate:done] reason: %s session: %o", api.loadReason, data)();
     unstore('logout');
 
     api.toggleLogging(data.experiments.indexOf('extension_logging') >= 0);
-    session = data;
-    session.prefs = {}; // to come via socket
+    me = data.user;
+    experiments = data.experiments;
+    eip = data.eip;
     socket = socket || api.socket.open(
-      elizaBaseUri().replace(/^http/, 'ws') + '/eliza/ext/ws?version=' + api.version + (session.eip ? '&eip=' + session.eip : ''),
+      elizaBaseUri().replace(/^http/, 'ws') + '/eliza/ext/ws?version=' + api.version + (eip ? '&eip=' + eip : ''),
       socketHandlers, onSocketConnect, onSocketDisconnect);
     logEvent.catchUp();
     mixpanel.catchUp();
@@ -1922,12 +1935,9 @@ function startSession(callback, retryMs) {
     ruleSet = data.rules;
     urlPatterns = compilePatterns(data.patterns);
     store('installation_id', data.installationId);
-    delete session.rules;
-    delete session.patterns;
-    delete session.installationId;
 
     api.tabs.on.loading.remove(onLoadingTemp), onLoadingTemp = null;
-    emitAllTabs("session_change", session);
+    emitAllTabs('me_change', me);
     callback();
   },
   function fail(xhr) {
@@ -1974,13 +1984,13 @@ function openLogin(callback, retryMs) {
 }
 
 function clearSession() {
-  if (session) {
-    api.tabs.each(function(tab) {
+  if (me) {
+    api.tabs.each(function (tab) {
       api.icon.set(tab, 'icons/k_gray.png');
-      api.tabs.emit(tab, 'session_change', null);
+      api.tabs.emit(tab, 'me_change', null);
     });
   }
-  session = null;
+  me = prefs = experiments = eip = null;
   if (socket) {
     socket.close();
     socket = null;

--- a/packrat/scripts/formatting.js
+++ b/packrat/scripts/formatting.js
@@ -165,12 +165,12 @@ function addParticipantsFormatter(actor, addedUsers) {
 }
 
 function isSessionUser(user) {
-  return Boolean(user && user.id === session.user.id);
+  return user.id === me.id;
 }
 
 function bringSessionUserToFront(users) {
-  for (var i = 1, len = users.length, user; i < len; i++) {
-    user = users[i];
+  for (var i = 1, len = users.length; i < len; i++) {
+    var user = users[i];
     if (isSessionUser(user)) {
       users.splice(i, 1);
       users.unshift(user);

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -81,7 +81,7 @@ if (searchUrlRe.test(document.URL)) !function() {
         "experimentId": response.experimentId,
         "query": response.query,
         "filter": filter,
-        "maxResults": response.session.prefs.maxResults,
+        "maxResults": response.prefs.maxResults,
         "kifiResults": response.hits.length,
         "kifiExpanded": response.expanded || false,
         "kifiTime": tKifiResultsReceived - tQuery,
@@ -140,7 +140,7 @@ if (searchUrlRe.test(document.URL)) !function() {
       if (q !== query || !areSameFilter(newFilter, filter)) {
         log("[results] ignoring for query:", q, "filter:", newFilter)();
         return;
-      } else if (!resp.session) {
+      } else if (!resp.me) {
         log("[results] no user info")();
         return;
       }
@@ -180,8 +180,8 @@ if (searchUrlRe.test(document.URL)) !function() {
         $res.find('.kifi-filter-yours').attr('data-n', insertCommas(resp.myTotal));
         $res.find('.kifi-filter-friends').attr('data-n', insertCommas(resp.friendsTotal));
       }
-      if (showPreview && resp.hits.length > resp.session.prefs.maxResults) {
-        resp.nextHits = resp.hits.splice(resp.session.prefs.maxResults);
+      if (showPreview && resp.hits.length > resp.prefs.maxResults) {
+        resp.nextHits = resp.hits.splice(resp.prefs.maxResults);
         resp.nextUUID = resp.uuid;
         resp.nextContext = resp.context;
         resp.mayHaveMore = true;
@@ -207,7 +207,7 @@ if (searchUrlRe.test(document.URL)) !function() {
         }
       }
 
-      if (showPreview && isFirst && resp.session.prefs.showSearchIntro && document.hasFocus()) {
+      if (showPreview && isFirst && resp.prefs.showSearchIntro && document.hasFocus()) {
         setTimeout(api.require.bind(api, 'scripts/search_intro.js', function () {
           if (tQuery === t1) {
             searchIntro.show($res);
@@ -309,7 +309,7 @@ if (searchUrlRe.test(document.URL)) !function() {
           "origin": window.location.origin,
           "uuid": isKifi ? hit.uuid : response.uuid,
           "filter": filter,
-          "maxResults": response.session.prefs.maxResults,
+          "maxResults": response.prefs.maxResults,
           "experimentId": response.experimentId,
           "kifiResults": response.hits.length,
           "kifiExpanded": response.expanded || false,
@@ -468,8 +468,8 @@ if (searchUrlRe.test(document.URL)) !function() {
       document.addEventListener('mousewheel', hide, true);
       document.addEventListener('wheel', hide, true);
       document.addEventListener('keypress', hide, true);
-      if (response.session && !$leaves.filter('.kifi-res-max-results-n.kifi-checked').length) {
-        $leaves.filter('.kifi-res-max-results-' + response.session.prefs.maxResults).addClass('kifi-checked').removeAttr('href');
+      if (!$leaves.filter('.kifi-res-max-results-n.kifi-checked').length) {
+        $leaves.filter('.kifi-res-max-results-' + response.prefs.maxResults).addClass('kifi-checked').removeAttr('href');
       }
       // .kifi-hover class needed because :hover does not work during drag
       function enterItem() {
@@ -511,7 +511,7 @@ if (searchUrlRe.test(document.URL)) !function() {
       var n = +$this.text();
       api.port.emit('set_max_results', n);
     }).on('click', '.kifi-res-bar', function (e) {
-      if (e.shiftKey && response.session && ~response.session.experiments.indexOf("admin")) {
+      if (e.shiftKey && ~(response.experiments || []).indexOf('admin')) {
         location.href = response.admBaseUri + '/admin/search/results/' + response.uuid;
       }
     }).on('click', '.kifi-filter[href]', function (e, alreadySearched) {
@@ -575,7 +575,7 @@ if (searchUrlRe.test(document.URL)) !function() {
       .finish().removeAttr('style')
       .append(render('html/search/google_hits', {
           results: response.hits,
-          self: response.session.user,
+          self: response.me,
           images: api.url('images'),
           filter: response.filter,
           mayHaveMore: response.mayHaveMore
@@ -638,7 +638,7 @@ if (searchUrlRe.test(document.URL)) !function() {
     delete response.nextContext;
 
     for (var i = 0; i < hits.length; i++) {
-      hitHtml.push(render("html/search/google_hit", $.extend({self: response.session.user, images: api.url("images")}, hits[i])));
+      hitHtml.push(render('html/search/google_hit', $.extend({self: response.me, images: api.url('images')}, hits[i])));
     }
     $(hitHtml.join(''))
     .css({visibility: 'hidden', height: 0, margin: 0})
@@ -668,7 +668,7 @@ if (searchUrlRe.test(document.URL)) !function() {
       boldSearchTerms(hit.bookmark.title, matches.title) :
       formatTitleFromUrl(hit.bookmark.url, matches.url, bolded);
     hit.descHtml = formatDesc(hit.bookmark.url, matches.url);
-    hit.scoreText = ~response.session.experiments.indexOf('show_hit_scores') ? String(Math.round(hit.score * 100) / 100) : '';
+    hit.scoreText = ~response.experiments.indexOf('show_hit_scores') ? String(Math.round(hit.score * 100) / 100) : '';
     hit.tagsText = (hit.bookmark.tagNames || []).join(', ');
 
     var who = response.filter && response.filter.who || "", ids = who.length > 1 ? who.split(".") : null;

--- a/packrat/scripts/keeper_intro.js
+++ b/packrat/scripts/keeper_intro.js
@@ -5,8 +5,8 @@
 // @require scripts/render.js
 // @require scripts/html/keeper/keeper_intro.js
 
-api.port.emit('session', function (sess) {
-  if (sess.prefs.showKeeperIntro && document.hasFocus() && !window.keeper) {
+api.port.emit('prefs', function (prefs) {
+  if (prefs.showKeeperIntro && document.hasFocus() && !window.keeper) {
     var $intro = $(render('html/keeper/keeper_intro'))
       .insertAfter(tile)
       .on('click', '.kifi-keeper-intro-x', hide)

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -2,7 +2,7 @@
 // @require scripts/api.js
 // loaded on every page, so no more dependencies
 
-var session, tags = [];
+var me, tags = [];
 var tile = tile || function() {  // idempotent for Chrome
   'use strict';
   log("[keeper_scout]", location.hostname)();
@@ -13,7 +13,7 @@ var tile = tile || function() {  // idempotent for Chrome
     }
   };
 
-  var whenSessionKnown = [], tileCard, tileCount, onScroll;
+  var whenMeKnown = [], tileCard, tileCount, onScroll;
   while ((tile = document.getElementById('kifi-tile'))) {
     tile.remove();
   }
@@ -42,9 +42,9 @@ var tile = tile || function() {  // idempotent for Chrome
 
   document.addEventListener("keydown", onKeyDown, true);
 
-  api.port.emit("session", onSessionChange);
+  api.port.emit('me', onMeChange);
   api.port.on({
-    session_change: onSessionChange,
+    me_change: onMeChange,
     open_to: loadAndDo.bind(null, 'pane', 'show'),
     button_click: loadAndDo.bind(null, 'pane', 'toggle', 'button'),
     auto_show: loadAndDo.bind(null, 'keeper', 'show', 'auto'),
@@ -67,7 +67,7 @@ var tile = tile || function() {  // idempotent for Chrome
       api.require(["styles/insulate.css", "styles/keeper/tile.css"], function() {
         if (!o.hide) {
           tile.style.display = "";
-          if (session && session.prefs.showKeeperIntro && !/\.(?:kifi|google)\./.test(location.hostname) && document.hasFocus()) {
+          if (o.showKeeperIntro && !/\.(?:kifi|google)\./.test(location.hostname) && document.hasFocus()) {
             setTimeout(api.require.bind(api, 'scripts/keeper_intro.js', api.noop), 5000);
           }
         }
@@ -117,9 +117,9 @@ var tile = tile || function() {  // idempotent for Chrome
     if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.isTrusted !== false) {  // ⌘-shift-[key], ctrl-shift-[key]; tolerating alt
       switch (e.keyCode) {
       case 75: // k
-        if (session === undefined) {  // not yet initialized
-          whenSessionKnown.push(onKeyDown.bind(this, e));
-        } else if (!session) {
+        if (me === undefined) {  // not yet initialized
+          whenMeKnown.push(onKeyDown.bind(this, e));
+        } else if (!me) {
           toggleLoginDialog();
         } else if (tile && tile.dataset.kept) {
           api.port.emit("unkeep", withUrls({}));
@@ -172,11 +172,11 @@ var tile = tile || function() {  // idempotent for Chrome
   }
 
   function loadAndDo(name, methodName) {  // gateway to keeper.js or pane.js
-    if (session === undefined) {  // not yet initialized
+    if (me === undefined) {  // not yet initialized
       var args = Array.prototype.slice.call(arguments);
       args.unshift(null);
-      whenSessionKnown.push(Function.bind.apply(loadAndDo, args));
-    } else if (!session) {
+      whenMeKnown.push(Function.bind.apply(loadAndDo, args));
+    } else if (!me) {
       toggleLoginDialog();
     } else {
       var args = Array.prototype.slice.call(arguments, 2);
@@ -194,13 +194,13 @@ var tile = tile || function() {  // idempotent for Chrome
     }
   }
 
-  function onSessionChange(s) {
-    if ((session = s)) {
+  function onMeChange(newMe) {
+    if ((me = newMe)) {
       attachTile();
     } else {
       cleanUpDom();
     }
-    while (whenSessionKnown.length) whenSessionKnown.shift()();
+    while (whenMeKnown.length) whenMeKnown.shift()();
   }
 
   function attachTile() {
@@ -263,7 +263,7 @@ var tile = tile || function() {  // idempotent for Chrome
   api.onEnd.push(function() {
     document.removeEventListener("keydown", onKeyDown, true);
     cleanUpDom();
-    session = tile = tileCard = tileCount = null;
+    me = tile = tileCard = tileCount = null;
   });
 
   return tile;

--- a/packrat/scripts/message_participants.js
+++ b/packrat/scripts/message_participants.js
@@ -274,7 +274,7 @@ var messageParticipants = this.messageParticipants = (function ($, win) {
 		 */
 		getOtherParticipant: function () {
 			return this.getParticipants().filter(function (user) {
-				return user.id !== win.session.user.id;
+				return user.id !== win.me.id;
 			})[0];
 		},
 

--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -180,7 +180,7 @@ panes.notices = function () {
       var nParticipants = participants.length;
       notice.author = notice.author || notice.participants[0];
       if (notice.authors === 1) {
-        notice[notice.author.id === session.user.id ? 'isSent' : 'isReceived'] = true;
+        notice[notice.author.id === me.id ? 'isSent' : 'isReceived'] = true;
       } else if (notice.firstAuthor > 1) {
         participants.splice(1, 0, participants.splice(notice.firstAuthor, 1)[0]);
       }
@@ -204,11 +204,11 @@ panes.notices = function () {
         }
       } else {
         if (nParticipants === 2) {
-          notice.namedParticipant = participants.filter(idIsNot(session.user.id))[0];
+          notice.namedParticipant = participants.filter(idIsNot(me.id))[0];
         } else if (nParticipants <= nNamesMax) {
-          notice.namedParticipants = participants.map(makeFirstNameYou(session.user.id));
+          notice.namedParticipants = participants.map(makeFirstNameYou(me.id));
         } else {
-          notice.namedParticipants = participants.slice(0, nNamesMax - 1).map(makeFirstNameYou(session.user.id));
+          notice.namedParticipants = participants.slice(0, nNamesMax - 1).map(makeFirstNameYou(me.id));
           notice.otherParticipants = participants.slice(nNamesMax - 1);
           notice.otherParticipantsJson = toNamesJson(notice.otherParticipants);
         }
@@ -220,7 +220,7 @@ panes.notices = function () {
         notice.nameIndex = counter();
         notice.nameSeriesLength = notice.namedParticipants.length + (notice.otherParticipants ? 1 : 0);
       }
-      notice.authorShortName = notice.author.id === session.user.id ? 'Me' : notice.author.firstName;
+      notice.authorShortName = notice.author.id === me.id ? 'Me' : notice.author.firstName;
       return render('html/keeper/notice_message', notice);
     case 'triggered':
       return render('html/keeper/notice_triggered', notice);
@@ -442,7 +442,7 @@ panes.notices = function () {
   }
 
   function isSent(th) {
-    return th.firstAuthor != null && th.participants[th.firstAuthor].id === session.user.id;
+    return th.firstAuthor != null && th.participants[th.firstAuthor].id === me.id;
   }
 
   function toNamesJson(users) {

--- a/packrat/scripts/notifier_scout.js
+++ b/packrat/scripts/notifier_scout.js
@@ -5,22 +5,22 @@ var notifierScout = notifierScout || function() {  // idempotent for Chrome
   'use strict';
   if (document.documentElement.style) { // not XML viewer
     api.port.on({
-      session_change: function(s) {
-        if (!s) {
-          var notifications = document.getElementsByClassName('kifi-notify-item-wrapper');
-          while (notifications.length) {
-            notifications[0].remove();
+      me_change: function (me) {
+        if (!me) {
+          var els = document.getElementsByClassName('kifi-notify-item-wrapper');
+          while (els.length) {
+            els[0].remove();
           }
         }
       },
-      remove_notification: function(threadId) {
-        if (document.querySelector(".kifi-notify-item-wrapper[data-thread-id='" + threadId + "']")) {
+      remove_notification: function (threadId) {
+        if (document.querySelector('.kifi-notify-item-wrapper[data-thread-id="' + threadId + '"]')) {
           api.require('scripts/notifier.js', function() {
             notifier.hide(threadId);
           });
         }
       },
-      show_notification: function(n) {
+      show_notification: function (n) {
         var p = document.querySelector('.kifi-pane'), loc = p && p.dataset.locator;
         if (loc !== n.locator) {
           api.require('scripts/notifier.js', function() {

--- a/packrat/scripts/pane.js
+++ b/packrat/scripts/pane.js
@@ -122,7 +122,7 @@ var pane = pane || function () {  // idempotent for Chrome
       $pane = $(render('html/keeper/pane',
         $.extend(params, {
           site: location.hostname,
-          user: session.user
+          user: me
         }), {
           pane_top_menu: 'pane_top_menu',
           pane: 'pane_' + name

--- a/packrat/scripts/search_intro.js
+++ b/packrat/scripts/search_intro.js
@@ -6,8 +6,8 @@
 
 var searchIntro = searchIntro || {
   show: function show($parent) {
-    api.port.emit('session', function (sess) {
-      if (sess.prefs.showSearchIntro && searchIntro.show === show && document.hasFocus()) {
+    api.port.emit('prefs', function (prefs) {
+      if (prefs.showSearchIntro && searchIntro.show === show && document.hasFocus()) {
         searchIntro.$el = $(render('html/search/search_intro'))
           .appendTo($parent)
           .on('click', '.kifi-search-intro-x', searchIntro.hide)

--- a/packrat/scripts/thread.js
+++ b/packrat/scripts/thread.js
@@ -33,7 +33,7 @@ panes.thread = function () {
       var $tall = $paneBox.find('.kifi-pane-tall'); //.css('margin-top', $who.outerHeight());
       api.port.on(handlers);  // important to subscribe to 'message' before requesting thread
       api.port.emit('thread', threadId, function (th) {
-        renderThread($paneBox, $tall, $who, th.id, th.messages, session);
+        renderThread($paneBox, $tall, $who, th.id, th.messages, th.enterToSend);
         var lastMsg = th.messages[th.messages.length - 1];
         messageHeader.init($who.find('.kifi-message-header'), th.id, lastMsg.participants);
         emitRendered(threadId, lastMsg);
@@ -51,9 +51,9 @@ panes.thread = function () {
       }
     }};
 
-  function renderThread($paneBox, $tall, $who, threadId, messages, session) {
+  function renderThread($paneBox, $tall, $who, threadId, messages, enterToSend) {
     messages.forEach(function (m) {
-      m.isLoggedInUser = m.user.id === session.user.id;
+      m.isLoggedInUser = m.user.id === me.id;
     });
     $(render('html/keeper/messages', {
       formatMessage: getTextFormatter,
@@ -61,8 +61,7 @@ panes.thread = function () {
       formatLocalDate: getLocalDateFormatter,
       messages: messages,
       draftPlaceholder: 'Type a message…',
-      submitButtonLabel: 'Send',
-      submitTip: (session.prefs.enterToSend ? '' : CO_KEY + '-') + 'Enter to send',
+      sendKeyTip: (enterToSend ? '' : CO_KEY + '-') + 'Enter to send',
       snapshotUri: api.url('images/snapshot.png')
     }, {
       message: 'message',
@@ -77,7 +76,7 @@ panes.thread = function () {
 
     $holder = $tall.find('.kifi-scroll-inner').preventAncestorScroll().data('threadId', threadId);
     var $scroll = $tall.find('.kifi-scroll-wrap');
-    var compose = initCompose($tall, session.prefs.enterToSend, {onSubmit: sendReply.bind(null, threadId), resetOnSubmit: true});
+    var compose = initCompose($tall, enterToSend, {onSubmit: sendReply.bind(null, threadId), resetOnSubmit: true});
     var heighter = maintainHeight($scroll[0], $holder[0], $tall[0], [$who[0], compose.form()]);
 
     $scroll.antiscroll({x: false});
@@ -135,8 +134,8 @@ panes.thread = function () {
       id: '',
       createdAt: new Date().toISOString(),
       text: text,
-      user: session.user
-    }, session.user.id)
+      user: me
+    }, me.id)
     .data('text', text);
     $holder.append($m).scrollToBottom();
 

--- a/packrat/threadlist.js
+++ b/packrat/threadlist.js
@@ -93,7 +93,7 @@
           this.numUnreadUnmuted--;
         } else {
           log('#a00', '[decNumUnreadUnmuted] already at:', this.numUnreadUnmuted)();
-          if (~session.experiments.indexOf('admin')) {
+          if (~experiments.indexOf('admin')) {
             this.numUnreadUnmuted--;
           }
         }


### PR DESCRIPTION
By never caching the user’s preferences and experiments in each page, we avoid issues where they are out-of-date or not yet initialized.
