### PR TITLE
Don't mark pending invites as accepted too early

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
@@ -174,8 +174,6 @@ class AuthCommander @Inject()(
       val (emailPassIdentity, userId) = saveUserPasswordIdentity(None, Some(socialIdentity),
         email = sfi.email, passwordInfo = pInfo, firstName = sfi.firstName, lastName = sfi.lastName, isComplete = true)
 
-      SafeFuture { inviteCommander.markPendingInvitesAsAccepted(userId, inviteExtIdOpt) }
-
       val user = db.readOnly { implicit session =>
         userRepo.get(userId)
       }
@@ -186,6 +184,8 @@ class AuthCommander @Inject()(
       sfi.picToken.map { token =>
         s3ImageStore.copyTempFileToUserPic(user.id.get, user.externalId, token, cropAttributes)
       }
+
+      SafeFuture { inviteCommander.markPendingInvitesAsAccepted(userId, inviteExtIdOpt) }
 
       (user, emailPassIdentity)
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -75,7 +75,6 @@ class AuthController @Inject() (
 
   def afterLogin() = HtmlAction(allowPending = true)(authenticatedAction = { implicit request =>
     if (request.user.state == UserStates.PENDING) {
-      inviteCommander.markPendingInvitesAsAccepted(request.user.id.get, request.cookies.get("inv").flatMap(v => ExternalId.asOpt[Invitation](v.value)))
       Redirect("/")
     } else if (request.user.state == UserStates.INCOMPLETE_SIGNUP) {
       Redirect(com.keepit.controllers.core.routes.AuthController.signupPage())

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
@@ -172,8 +172,6 @@ class HomeController @Inject() (
   def pendingHome()(implicit request: AuthenticatedRequest[_]) = {
     val user = request.user
 
-    inviteCommander.markPendingInvitesAsAccepted(user.id.get, request.cookies.get("inv").flatMap(v => ExternalId.asOpt[Invitation](v.value)))
-
     val (email, friendsOnKifi) = db.readOnly { implicit session =>
       val email = emailRepo.getAllByUser(user.id.get).sortBy(a => a.id.get.id).lastOption.map(_.address)
       val friendsOnKifi = userConnectionRepo.getConnectedUsers(user.id.get).map { u =>


### PR DESCRIPTION
cc @andrewconner 
Turns out it was already in the right place (at the end of `finalize*Account`), we just had a few extras in other places.
Still not 100% clear on the control flow during signup, but I think I'm starting to get the hang of it :-)
