### PR TITLE
Scrape scheduler refactoring

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
@@ -110,19 +110,17 @@ object NormalizedURIStates extends States[NormalizedURI] {
   val UNSCRAPABLE = State[NormalizedURI]("unscrapable")
   val SCRAPE_WANTED = State[NormalizedURI]("scrape_wanted")
   val REDIRECTED = State[NormalizedURI]("redirected")
-  val SCRAPE_LATER = State[NormalizedURI]("scrape_later")
 
   type Transitions = Map[State[NormalizedURI], Set[State[NormalizedURI]]]
 
   val ALL_TRANSITIONS: Transitions = Map(
-      (ACTIVE -> Set(SCRAPE_WANTED, REDIRECTED, SCRAPE_LATER)),
+      (ACTIVE -> Set(SCRAPE_WANTED, REDIRECTED)),
       (SCRAPE_WANTED -> Set(SCRAPED, SCRAPE_FAILED, UNSCRAPABLE, INACTIVE, REDIRECTED)),
       (SCRAPED -> Set(SCRAPE_WANTED, INACTIVE, REDIRECTED)),
       (SCRAPE_FAILED -> Set(SCRAPE_WANTED, INACTIVE, REDIRECTED)),
       (UNSCRAPABLE -> Set(SCRAPE_WANTED, INACTIVE, REDIRECTED)),
-      (INACTIVE -> Set(SCRAPE_WANTED, ACTIVE, INACTIVE, REDIRECTED, SCRAPE_LATER)),
-      (REDIRECTED -> Set(SCRAPE_WANTED, ACTIVE, INACTIVE, REDIRECTED)),
-      (SCRAPE_LATER -> Set(SCRAPE_WANTED)))
+      (INACTIVE -> Set(SCRAPE_WANTED, ACTIVE, INACTIVE, REDIRECTED)),
+      (REDIRECTED -> Set(SCRAPE_WANTED, ACTIVE, INACTIVE, REDIRECTED)))
 
   val ADMIN_TRANSITIONS: Transitions = Map(
       (ACTIVE -> Set.empty),

--- a/kifi-backend/modules/common/app/com/keepit/model/ScrapeInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/ScrapeInfo.scala
@@ -34,16 +34,13 @@ case class ScrapeInfo(
     this.copy(state = state)
   }
 
-  def withStateAndNextScrape(state: State[ScrapeInfo], nextScrape: Option[DateTime] = None) = {
+  def withStateAndNextScrape(state: State[ScrapeInfo]) = {
     val (curState, curNS) = (this.state, this.nextScrape)
-    val res = nextScrape match {
-      case Some(dateTime) => copy(state = state, nextScrape = dateTime)
-      case None => state match { // TODO: revisit
-        case ScrapeInfoStates.ACTIVE => copy(state = state, nextScrape = START_OF_TIME) // scrape ASAP when switched to ACTIVE
-        case ScrapeInfoStates.INACTIVE => copy(state = state, nextScrape = END_OF_TIME) // never scrape when switched to INACTIVE
-        case ScrapeInfoStates.PENDING => copy(state = state, nextScrape = currentDateTime) // TODO: add & use updatedAt
-        case ScrapeInfoStates.ASSIGNED => copy(state = state, nextScrape = currentDateTime)
-      }
+    val res = state match { // TODO: revisit
+      case ScrapeInfoStates.ACTIVE => copy(state = state, nextScrape = START_OF_TIME) // scrape ASAP when switched to ACTIVE
+      case ScrapeInfoStates.INACTIVE => copy(state = state, nextScrape = END_OF_TIME) // never scrape when switched to INACTIVE
+      case ScrapeInfoStates.PENDING => copy(state = state, nextScrape = currentDateTime) // TODO: add & use updatedAt
+      case ScrapeInfoStates.ASSIGNED => copy(state = state, nextScrape = currentDateTime)
     }
     log.debug(s"[withStateAndNextScrape($id, $uriId, $destinationUrl)] ${curState} => ${res.state.toString.toUpperCase}; ${curNS} => ${res.nextScrape}")
     res

--- a/kifi-backend/modules/search/app/com/keepit/search/article/ArticleIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/article/ArticleIndexer.scala
@@ -69,7 +69,7 @@ class ArticleIndexer(
 }
 
 object ArticleIndexer extends Logging {
-  private[this] val toBeDeletedStates = Set[State[NormalizedURI]](ACTIVE, INACTIVE, SCRAPE_WANTED, UNSCRAPABLE, REDIRECTED, SCRAPE_LATER)
+  private[this] val toBeDeletedStates = Set[State[NormalizedURI]](ACTIVE, INACTIVE, SCRAPE_WANTED, UNSCRAPABLE, REDIRECTED)
   def shouldDelete(uri: IndexableUri): Boolean = toBeDeletedStates.contains(uri.state)
 
   class ArticleIndexable(

--- a/kifi-backend/modules/search/test/com/keepit/search/article/ArticleIndexerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/article/ArticleIndexerTest.scala
@@ -301,16 +301,6 @@ class ArticleIndexerTest extends Specification with ApplicationInjector {
       indexer.search("content1").size === 0
       indexer.search("content2").size === 1
       indexer.search("content3").size === 1
-
-      uri1 = fakeShoeboxServiceClient.saveURIs(uri1.withState(SCRAPE_LATER)).head
-      uri2 = fakeShoeboxServiceClient.saveURIs(uri2.withState(SCRAPED)).head
-      uri3 = fakeShoeboxServiceClient.saveURIs(uri3.withState(SCRAPED)).head
-
-      indexer.update()
-      indexer.numDocs === 2
-      indexer.search("content1").size === 0
-      indexer.search("content2").size === 1
-      indexer.search("content3").size === 1
     })
 
     "retrieve article records from index" in running(new DeprecatedEmptyApplication().withShoeboxServiceModule)(new IndexerScope {

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/DataIntegrity.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/DataIntegrity.scala
@@ -15,6 +15,7 @@ import com.keepit.common.akka.{FortyTwoActor, UnsupportedActorMessage}
 import com.keepit.common.plugin.{SchedulerPlugin, SchedulingProperties}
 import com.keepit.common.zookeeper.CentralConfig
 import com.keepit.common.zookeeper.LongCentralConfigKey
+import com.keepit.commanders.BookmarkInterner
 
 
 trait DataIntegrityPlugin extends SchedulerPlugin
@@ -54,6 +55,7 @@ class OrphanCleaner @Inject() (
     renormalizedURLRepo: RenormalizedURLRepo,
     nuriRepo: NormalizedURIRepo,
     bookmarkRepo: BookmarkRepo,
+    bookmarkInterner: BookmarkInterner,
     centralConfig: CentralConfig,
     airbrake: AirbrakeNotifier
 ) extends Logging {
@@ -183,7 +185,7 @@ class OrphanCleaner @Inject() (
                 if (u.state == NormalizedURIStates.ACTIVE || u.state == NormalizedURIStates.INACTIVE) {
                   numUrisChangedToScrapeWanted += 1
                   if (!readOnly) {
-                    nuriRepo.save(u.withState(NormalizedURIStates.SCRAPE_WANTED)) // this will fix ScrapeInfo as well
+                    bookmarkInterner.internUri(u.withState(NormalizedURIStates.SCRAPE_WANTED))
                   }
                 }
               case BookmarkStates.INACTIVE =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/NormalizedURIRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/NormalizedURIRepo.scala
@@ -120,22 +120,7 @@ extends DbRepo[NormalizedURI] with NormalizedURIRepo with ExternalIdColumnDbFunc
             scrapeRepo.save(scrapeInfo.withState(ScrapeInfoStates.ACTIVE))
           case _ => // do nothing
         }
-      case SCRAPE_WANTED => // ensure that ScrapeInfo has an ACTIVE record for it.
-        scrapeRepo.getByUriId(saved.id.get) match {
-          case Some(scrapeInfo) if scrapeInfo.state == ScrapeInfoStates.INACTIVE =>
-            scrapeRepo.save(scrapeInfo.withStateAndNextScrape(ScrapeInfoStates.ACTIVE))
-          case Some(scrapeInfo) => // do nothing
-          case None =>
-            scrapeRepo.save(ScrapeInfo(uriId = saved.id.get))
-        }
-      case SCRAPE_LATER => // ensure that ScrapeInfo has an ACTIVE record for it.
-        scrapeRepo.getByUriId(saved.id.get) match {
-          case Some(scrapeInfo) if scrapeInfo.state == ScrapeInfoStates.INACTIVE =>
-            scrapeRepo.save(scrapeInfo.withStateAndNextScrape(ScrapeInfoStates.ACTIVE, Some(END_OF_TIME))) // no scheduling at this point
-          case Some(scrapeInfo) => // do nothing
-          case None =>
-            scrapeRepo.save(ScrapeInfo(uriId = saved.id.get, nextScrape = END_OF_TIME))
-        }
+      case SCRAPE_WANTED => // do nothing
       case _ =>
         throw new IllegalStateException(s"Unhandled state=${uri.state}; uri=$uri")
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPlugin.scala
@@ -5,9 +5,11 @@ import scala.concurrent.Future
 import com.keepit.model.NormalizedURI
 import com.keepit.scraper.extractor.{ExtractorProviderType}
 import com.keepit.common.db.slick.DBSession.RWSession
+import org.joda.time.DateTime
+import com.keepit.common.time._
 
 trait ScrapeSchedulerPlugin extends Plugin {
-  def scheduleScrape(uri: NormalizedURI, delayMillis: Int = 0)(implicit session: RWSession): Unit
+  def scheduleScrape(uri: NormalizedURI, date: DateTime = currentDateTime)(implicit session: RWSession): Unit
   def scrapeBasicArticle(url: String, extractorProviderType:Option[ExtractorProviderType]): Future[Option[BasicArticle]] // todo: move out
   def getSignature(url: String, extractorProviderType: Option[ExtractorProviderType]): Future[Option[Signature]]
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/normalizer/NormalizationServiceTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/normalizer/NormalizationServiceTest.scala
@@ -16,6 +16,7 @@ import com.google.inject.Injector
 import com.keepit.scraper.extractor.{ExtractorProviderType, Extractor}
 import com.keepit.common.healthcheck.FakeAirbrakeModule
 import com.keepit.eliza.FakeElizaServiceClientModule
+import com.keepit.shoebox.FakeKeepImportsModule
 
 class NormalizationServiceTest extends TestKitScope with SpecificationLike with ShoeboxTestInjector {
 
@@ -41,6 +42,7 @@ class NormalizationServiceTest extends TestKitScope with SpecificationLike with 
     FakeAirbrakeModule(),
     StandaloneTestActorSystemModule(),
     FakeElizaServiceClientModule(),
+    FakeKeepImportsModule(),
     new ScalaModule { def configure() { bind[NormalizationService].to[NormalizationServiceImpl] }})
 
   "NormalizationService" should {

--- a/kifi-backend/modules/shoebox/test/com/keepit/scraper/FakeScrapeSchedulerModule.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/scraper/FakeScrapeSchedulerModule.scala
@@ -6,6 +6,7 @@ import com.google.inject.{Provides, Singleton}
 import com.keepit.scraper.extractor.{ExtractorProviderType, Extractor}
 import com.keepit.common.db.slick.DBSession.RWSession
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import org.joda.time.DateTime
 
 case class FakeScrapeSchedulerModule(fakeArticles: Option[PartialFunction[(String, Option[ExtractorProviderType]), BasicArticle]] = None) extends ScrapeSchedulerModule {
   override def configure() {}
@@ -19,7 +20,7 @@ case class FakeScrapeSchedulerModule(fakeArticles: Option[PartialFunction[(Strin
 
 class FakeScrapeSchedulerPlugin(fakeArticles: Option[PartialFunction[(String, Option[ExtractorProviderType]), BasicArticle]]) extends ScrapeSchedulerPlugin {
   def scrapePending() = Future.successful(Seq())
-  def scheduleScrape(uri: NormalizedURI, delayMillis: Int)(implicit session: RWSession): Unit = {}
+  def scheduleScrape(uri: NormalizedURI, date: DateTime)(implicit session: RWSession): Unit = {}
   def scrapeBasicArticle(url: String, extractorProviderType:Option[ExtractorProviderType] = None): Future[Option[BasicArticle]] = Future.successful(fakeArticles.map(_.apply((url, extractorProviderType))))
   def getSignature(url: String, extractorProviderType: Option[ExtractorProviderType] = None): Future[Option[Signature]] = scrapeBasicArticle(url, extractorProviderType).map(_.map(_.signature))
 }


### PR DESCRIPTION
Scraper prioritization: SCRAPE_LATER not necessary anymore + hover keeps are now scheduled for START_OF_TIME
Moved some scrape_info logic out of NormalizedURIRepo (to be continued). Adding a normalized URI with state SCRAPE_WANTED to the normalized URI repo does not automatically update scrape_info anymore. The function to use is now internUri() in BookmarkInterner. I updated the affected tests accordingly. The ultimate goal is to completely remove ScrapeInfoRepo from NormalizedURIRepo. 
@raymondng @yingjieMiao 
