### PR TITLE
Adding instance name and service to AmazonInstanceInfo

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/amazon/AmazonInstanceInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/amazon/AmazonInstanceInfo.scala
@@ -18,6 +18,8 @@ object AmazonInstanceInfo {
 
   implicit val format: Format[AmazonInstanceInfo] = (
     (__ \ 'instanceId).format[AmazonInstanceId] and
+    (__ \ 'name).formatNullable[String] and
+    (__ \ 'service).formatNullable[String] and
     (__ \ 'localHostname).format[String] and
     (__ \ 'publicHostname).format[String] and
     (__ \ 'localIp).format[IpAddress] and
@@ -32,6 +34,8 @@ object AmazonInstanceInfo {
 
 case class AmazonInstanceInfo (
   instanceId: AmazonInstanceId,
+  name: Option[String],
+  service: Option[String],
   localHostname: String,
   publicHostname: String,
   localIp: IpAddress,

--- a/kifi-backend/modules/common/app/com/keepit/common/store/ProdStoreModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/ProdStoreModule.scala
@@ -25,7 +25,7 @@ trait ProdStoreModule extends StoreModule {
   @Singleton
   @Provides
   def amazonS3Client(): AmazonS3 = {
-    val conf = current.configuration.getConfig("amazon.s3").get
+    val conf = current.configuration.getConfig("amazon").get
     val awsCredentials = new BasicAWSCredentials(
       conf.getString("accessKey").get,
       conf.getString("secretKey").get)
@@ -87,7 +87,7 @@ abstract class DevStoreModule[T <: ProdStoreModule](val prodStoreModule: T) exte
   @Singleton
   @Provides
   def amazonS3Client(): AmazonS3 = {
-    val conf = current.configuration.getConfig("amazon.s3").get
+    val conf = current.configuration.getConfig("amazon").get
     val awsCredentials = new BasicAWSCredentials(
       conf.getString("accessKey").get,
       conf.getString("secretKey").get)

--- a/kifi-backend/modules/common/conf/application-dev.conf
+++ b/kifi-backend/modules/common/conf/application-dev.conf
@@ -91,6 +91,13 @@ amazon.s3 = {
   #browsingHistory.bucket = "browsing-history-b-dev"
   # If the index.bucket or browsingHistory.bucket is missing then a LocalFileStore will be used. Uncomment to use the s3 storage.
   #index.bucket = "index-b-dev"
+}
+
+amazon.ec2 = {
+  endpoint = "ec2.us-west-1.amazonaws.com"
+}
+
+amazon = {
   accessKey = "AKIAJB5MKHQZU4GKCXSQ"
   secretKey = "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"
 }

--- a/kifi-backend/modules/common/conf/prod/prod.conf
+++ b/kifi-backend/modules/common/conf/prod/prod.conf
@@ -55,6 +55,13 @@ amazon.s3 = {
   clickHistory.bucket = "click-history-b-prod"
   browsingHistory.bucket = "browsing-history-b-prod"
   index.bucket = "index-b-prod"
+}
+
+amazon.ec2 = {
+  endpoint = "ec2.us-west-1.amazonaws.com"
+}
+
+amazon = {
   accessKey = "AKIAJA24QAUWFTZN5JTQ"
   secretKey = "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"
 }

--- a/kifi-backend/modules/common/test/com/keepit/common/zookeeper/RemoteServiceTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/zookeeper/RemoteServiceTest.scala
@@ -9,6 +9,8 @@ class RemoteServiceTest extends Specification {
 
   val instance = new AmazonInstanceInfo(
     instanceId = AmazonInstanceId("i-f168c1a8"),
+    name = Some("some-name"),
+    service = Some("some-service"),
     localHostname = "ip-10-160-95-26.us-west-1.compute.internal",
     publicHostname = "ec2-50-18-183-73.us-west-1.compute.amazonaws.com",
     localIp = IpAddress("10.160.95.26"),
@@ -24,7 +26,7 @@ class RemoteServiceTest extends Specification {
     "be serialized and deserialized" in {
       val remoteService = RemoteService(instance, ServiceStatus.UP, ServiceType.TEST_MODE)
       val json = Json.toJson(remoteService)
-      json === Json.parse("""{"amazonInstanceInfo":{"instanceId":{"id":"i-f168c1a8"},"localHostname":"ip-10-160-95-26.us-west-1.compute.internal","publicHostname":"ec2-50-18-183-73.us-west-1.compute.amazonaws.com","localIp":{"ip":"10.160.95.26"},"publicIp":{"ip":"50.18.183.73"},"instanceType":"c1.medium","availabilityZone":"us-west-1b","securityGroups":"default","amiId":"ami-1bf9de5e","amiLaunchIndex":"0"},"status":"up","serviceType":"TEST_MODE"}""")
+      json === Json.parse("""{"amazonInstanceInfo":{"instanceId":{"id":"i-f168c1a8"},"name":"some-name","service":"some-service","localHostname":"ip-10-160-95-26.us-west-1.compute.internal","publicHostname":"ec2-50-18-183-73.us-west-1.compute.amazonaws.com","localIp":{"ip":"10.160.95.26"},"publicIp":{"ip":"50.18.183.73"},"instanceType":"c1.medium","availabilityZone":"us-west-1b","securityGroups":"default","amiId":"ami-1bf9de5e","amiLaunchIndex":"0"},"status":"up","serviceType":"TEST_MODE"}""")
       val fromJson = Json.fromJson[RemoteService](json).get
       fromJson === remoteService
     }

--- a/kifi-backend/modules/common/test/com/keepit/common/zookeeper/ServiceClusterTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/zookeeper/ServiceClusterTest.scala
@@ -12,6 +12,8 @@ class ServiceClusterTest extends Specification {
 
   val instance1 = new AmazonInstanceInfo(
     instanceId = AmazonInstanceId("i-f168c1a8"),
+    name = Some("some-name"),
+    service = Some("some-service"),
     localHostname = "ip-10-160-95-26.us-west-1.compute.internal",
     publicHostname = "ec2-50-18-183-73.us-west-1.compute.amazonaws.com",
     localIp = IpAddress("10.160.95.26"),
@@ -27,6 +29,8 @@ class ServiceClusterTest extends Specification {
 
   val instance2 = new AmazonInstanceInfo(
     instanceId = AmazonInstanceId("i-f168c1a9"),
+    name = Some("some-name"),
+    service = Some("some-service"),
     localHostname = "ip-10-160-95-25.us-west-1.compute.internal",
     publicHostname = "ec2-50-18-183-74.us-west-1.compute.amazonaws.com",
     localIp = IpAddress("10.160.95.23"),
@@ -42,6 +46,8 @@ class ServiceClusterTest extends Specification {
 
   val instance3 = new AmazonInstanceInfo(
     instanceId = AmazonInstanceId("i-f168c1a8"),
+    name = Some("some-name"),
+    service = Some("some-service"),
     localHostname = "ip-10-160-95-2.us-west-1.compute.internal",
     publicHostname = "ec2-50-18-183-7.us-west-1.compute.amazonaws.com",
     localIp = IpAddress("10.160.95.2"),

--- a/kifi-backend/modules/common/test/com/keepit/common/zookeeper/ServiceDiscoveryLiveTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/zookeeper/ServiceDiscoveryLiveTest.scala
@@ -25,6 +25,8 @@ class ServiceDiscoveryLiveTest extends Specification with ApplicationInjector {
 
   def amazonInstanceInfo(id: Int) = new AmazonInstanceInfo(
       instanceId = AmazonInstanceId("i-f168c1a8"),
+      name = Some("some-name"),
+      service = Some("some-service"),
       localHostname = s"host$id",
       publicHostname = s"host$id",
       localIp = IpAddress(s"127.0.0.$id"),

--- a/kifi-backend/modules/shoebox/app/views/admin/adminHelper/instanceInfoModal.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/adminHelper/instanceInfoModal.scala.html
@@ -6,6 +6,12 @@
         <th>Instance</th><td><a href="https://console.aws.amazon.com/ec2/home?region=@{amazonInstanceInfo.availabilityZone}#s=Instances">@{amazonInstanceInfo.instanceId}</a></td>
     </tr>
     <tr>
+        <th>Name</th><td>@{amazonInstanceInfo.name.getOrElse("-")}</td>
+    </tr>
+    <tr>
+        <th>Service</th><td>@{amazonInstanceInfo.service.getOrElse("-")}</td>
+    </tr>
+    <tr>
         <th>Local Hostname</th><td>@{amazonInstanceInfo.localHostname}</td>
     </tr>
     <tr>

--- a/kifi-backend/modules/shoebox/app/views/admin/pendingScraperRequests.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/pendingScraperRequests.scala.html
@@ -1,6 +1,14 @@
 @(pending:Seq[ScrapeInfo], count:Int, threadInstanceInfoSeq:Seq[com.keepit.scraper.ScraperThreadInstanceInfo])(implicit flash: Flash)
 
 @import com.keepit.controllers.admin.routes
+@import com.keepit.common.amazon.AmazonInstanceInfo
+
+@instanceTitle(instanceInfo: AmazonInstanceInfo) = {
+    @instanceInfo.name match {
+        case Some(name) => {@name}
+        case None => {@instanceInfo.instanceId.toString (anonymous instance)}
+    }
+}
 
 <div>
     <span class="title-hint">
@@ -50,7 +58,7 @@
                 @adminHelper.instanceInfoModal(threadInstanceInfo.info.instanceId.toString, threadInstanceInfo.info)
                 <div class="well" style="background-color:#efefef;margin-bottom:10px;">
                     <div style="margin-bottom:10px;overflow:hidden;">
-                        <div style="float:left"><h4 style="padding:0;margin:0">Instance @threadInstanceInfo.info.instanceId.toString</h4></div>
+                        <div style="float:left"><h4 style="padding:0;margin:0">@instanceTitle(threadInstanceInfo.info)</h4></div>
                         <div style="float:right"><button type="button" data-toggle="modal" data-target="#@threadInstanceInfo.info.instanceId.toString">Show Info</button></div>
                     </div>
                     <table class="table table-condensed table-bordered" style="padding:0;margin:0;table-layout:fixed;word-wrap:break-word;">


### PR DESCRIPTION
Updated scraper admin page and cluster overview accordingly
Note: I created dev_ec2 & prod_ec2 IAM groups and added shoebox_dev and shoebox_prod to them. Permissions are minimal - only describing instances is allowed for now (we can be more permissive in the future)
@raymondng @andrewconner 
