### PR TITLE
bump up seqNum when migration failed. retry later

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
@@ -184,7 +184,7 @@ class UriIntegrityActor @Inject()(
       } catch {
         case e: Exception => {
           airbrake.notify(s"Exception in migrating uri ${change.oldUriId} to ${change.newUriId}. Going to delete them from cache",e)
-          db.readWrite{ implicit s => changedUriRepo.saveWithoutIncreSeqnum((change.withState(ChangedURIStates.INACTIVE))) }
+          db.readWrite{ implicit s => changedUriRepo.save((change.withState(ChangedURIStates.ACTIVE)))}   // bump up seqNum. Will be retried.
 
           try{
             db.readOnly{ implicit s => List(uriRepo.get(change.oldUriId), uriRepo.get(change.newUriId)) foreach {uriRepo.deleteCache} }


### PR DESCRIPTION
@leogrim 

This is safe. If I remember, the old problem was, when I apply change and save, the seqNum jumped out of the correct range. So I introduced saveWithoutIncreaseSeq(). 
