### PR TITLE
Fixing production bookmark ordering. More to do.

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/BookmarkRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/BookmarkRepo.scala
@@ -134,13 +134,13 @@ class BookmarkRepoImpl @Inject() (
     // Separate queries for each case because the db will cache the query plans when we only use parametrized queries instead of raw strings.
     val interpolated = (beforeId map get, afterId map get) match {
       case (None, None) =>
-        sql"""select #$bookmarkColumnOrder from bookmark bm where bm.user_id = ${userId.id} and bm.state = 'active' order by bm.updated_at desc limit $count;"""
+        sql"""select #$bookmarkColumnOrder from bookmark bm where bm.user_id = ${userId.id} and bm.state = 'active' order by bm.created_at desc limit $count;"""
       case (None, Some(after)) =>
-        sql"""select #$bookmarkColumnOrder from bookmark bm where bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}' and bm.id > ${after.id.get.id} order by bm.updated_at desc limit $count;"""
+        sql"""select #$bookmarkColumnOrder from bookmark bm where bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}' and bm.created_at > ${SQL_DATETIME_FORMAT.print(after.createdAt)} order by bm.created_at desc limit $count;"""
       case (Some(before), None) =>
-        sql"""select #$bookmarkColumnOrder from bookmark bm where bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}' and bm.id < ${before.id.get.id} order by bm.updated_at desc limit $count;"""
+        sql"""select #$bookmarkColumnOrder from bookmark bm where bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}' and bm.created_at < ${SQL_DATETIME_FORMAT.print(before.createdAt)} order by bm.created_at desc limit $count;"""
       case (Some(before), Some(after)) =>
-        sql"""select #$bookmarkColumnOrder from bookmark bm where bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}' and bm.id < ${before.id.get.id} and bm.id > ${after.id.get.id} order by bm.updated_at desc limit $count;"""
+        sql"""select #$bookmarkColumnOrder from bookmark bm where bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}' and bm.created_at < ${SQL_DATETIME_FORMAT.print(before.createdAt)} and bm.created_at > ${SQL_DATETIME_FORMAT.print(after.createdAt)} order by bm.created_at desc limit $count;"""
     }
     interpolated.as[Bookmark].list
   }
@@ -155,19 +155,19 @@ class BookmarkRepoImpl @Inject() (
       case (None, None) =>
         sql"""select #$bookmarkColumnOrder from bookmark bm left join keep_to_collection kc on (bm.id = kc.bookmark_id)
                 where kc.collection_id = ${collectionId.id} and bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}'
-                and kc.state='#${KeepToCollectionStates.ACTIVE.value}' order by bm.updated_at desc limit $count;"""
+                and kc.state='#${KeepToCollectionStates.ACTIVE.value}' order by bm.created_at desc limit $count;"""
       case (None, Some(after)) =>
         sql"""select #$bookmarkColumnOrder from bookmark bm left join keep_to_collection kc on (bm.id = kc.bookmark_id)
                 where kc.collection_id = ${collectionId.id} and bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}'
-                and kc.state='#${KeepToCollectionStates.ACTIVE.value}' and bm.id > ${after.id.get.id} order by bm.updated_at desc limit $count;"""
+                and kc.state='#${KeepToCollectionStates.ACTIVE.value}' and bm.created_at > ${SQL_DATETIME_FORMAT.print(after.createdAt)} order by bm.created_at desc limit $count;"""
       case (Some(before), None) =>
         sql"""select #$bookmarkColumnOrder from bookmark bm left join keep_to_collection kc on (bm.id = kc.bookmark_id)
                 where kc.collection_id = ${collectionId.id} and bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}'
-                and kc.state='#${KeepToCollectionStates.ACTIVE.value}' and bm.id < ${before.id.get.id} order by bm.updated_at desc limit $count;"""
+                and kc.state='#${KeepToCollectionStates.ACTIVE.value}' and bm.created_at < ${SQL_DATETIME_FORMAT.print(before.createdAt)} order by bm.created_at desc limit $count;"""
       case (Some(before), Some(after)) =>
         sql"""select #$bookmarkColumnOrder from bookmark bm left join keep_to_collection kc on (bm.id = kc.bookmark_id)
                 where kc.collection_id = ${collectionId.id} and bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}'
-                and kc.state='#${KeepToCollectionStates.ACTIVE.value}' and bm.id < ${before.id.get.id} and bm.id > ${after.id.get.id} order by bm.updated_at desc limit $count;"""
+                and kc.state='#${KeepToCollectionStates.ACTIVE.value}' and bm.created_at < ${SQL_DATETIME_FORMAT.print(before.createdAt)} and bm.id > ${SQL_DATETIME_FORMAT.print(after.createdAt)} order by bm.created_at desc limit $count;"""
     }
     interpolated.as[Bookmark].list
   }

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/DatabaseDialect.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/DatabaseDialect.scala
@@ -7,13 +7,18 @@ import org.joda.time._
 
 trait DatabaseDialect[T <: DataBaseComponent] {
   def day(date: DateTime): String
+  def dateTime(date: DateTime): String
 }
 
 object MySqlDatabaseDialect extends DatabaseDialect[MySQL] {
   def day(date: DateTime): String = s"""STR_TO_DATE('${date.toStandardDateString}', '%Y-%m-%d')"""
+  def dateTime(date: DateTime): String = s"""STR_TO_DATE('${date.toStandardTimeString}', '%Y-%m-%dT%H:%i:%s')""" // no milliseconds!
 }
 
 object H2DatabaseDialect extends DatabaseDialect[H2] {
   def day(date: DateTime): String = s"""PARSEDATETIME('${date.toStandardDateString}', 'y-M-d')"""
+
+  // H2 uses SimpleDateFormat which is *not* ISO-8601 compatible!
+  def dateTime(date: DateTime): String = s"""PARSEDATETIME('${date.toStandardTimeString.replace('T',' ').replace("Z", "")}', 'yyyy-MM-d hh:mm:ss.SSS')"""
 }
 

--- a/kifi-backend/modules/sqldb/test/com/keepit/common/db/DatabaseDialectTest.scala
+++ b/kifi-backend/modules/sqldb/test/com/keepit/common/db/DatabaseDialectTest.scala
@@ -9,7 +9,7 @@ import com.keepit.test._
 
 class DatabaseDialectTest extends Specification with DbTestInjector {
 
-  val dec_20_2013 = new DateTime(2013, 12, 20, 0, 0, 0, DEFAULT_DATE_TIME_ZONE)
+  val dec_20_2013 = new DateTime(2013, 12, 20, 10, 1, 30, DEFAULT_DATE_TIME_ZONE)
 
   "MySqlDatabaseDialect" should {
 
@@ -30,6 +30,25 @@ class DatabaseDialectTest extends Specification with DbTestInjector {
           val st = s.conn.createStatement()
           val sql = s"""select DATEADD('MONTH', 1, ${H2DatabaseDialect.day(dec_20_2013)}) as day from dual"""
           sql === """select DATEADD('MONTH', 1, PARSEDATETIME('2013-12-20', 'y-M-d')) as day from dual"""
+          val rs = st.executeQuery(sql)
+          rs.next
+          rs.getString("day").split(' ')(0) === "2014-01-20"
+        }
+      }
+    }
+
+
+    // H2 uses SimpleDateFormat which is *not* ISO-8601 compatible!
+    "stringToDate to string" in {
+      H2DatabaseDialect.dateTime(dec_20_2013) === """PARSEDATETIME('2013-12-20 10:01:30.000', 'yyyy-MM-d hh:mm:ss.SSS')"""
+    }
+
+    "stringToDay to db" in {
+      withDb() { implicit injector: Injector =>
+        inject[Database].readWrite { implicit s =>
+          val st = s.conn.createStatement()
+          val sql = s"""select DATEADD('MONTH', 1, ${H2DatabaseDialect.dateTime(dec_20_2013)}) as day from dual"""
+          sql === """select DATEADD('MONTH', 1, PARSEDATETIME('2013-12-20 10:01:30.000', 'yyyy-MM-d hh:mm:ss.SSS')) as day from dual"""
           val rs = st.executeQuery(sql)
           rs.next
           rs.getString("day").split(' ')(0) === "2014-01-20"


### PR DESCRIPTION
@eishay @ymatsuda This fixes the ordering issue. Unfortunately, it does not use the dialect's `dateTime` function yet. H2 does not allow functions (ex: `PARSEDATETIME`) to be inside of prepared statement values.

Either we use plain text for these queries or write functions that output database dependent strings that can be read without datetime parsing (non-ISO 8601). There are slight differences between mysql and h2's preferred formats. Thoughts? My solution here was just low risk to get it fixed in production, I'm happy to do a cleaner job.
