### PR TITLE
Ordering bookmarks correctly.

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/BookmarkRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/BookmarkRepo.scala
@@ -39,14 +39,14 @@ trait BookmarkRepo extends Repo[Bookmark] with ExternalIdColumnFunction[Bookmark
 
 @Singleton
 class BookmarkRepoImpl @Inject() (
-                                   val db: DataBaseComponent,
-                                   val clock: Clock,
-                                   val countCache: BookmarkCountCache,
-                                   val keepToCollectionRepo: KeepToCollectionRepoImpl,
-                                   collectionRepo: CollectionRepo,
-                                   bookmarkUriUserCache: BookmarkUriUserCache,
-                                   latestBookmarkUriCache: LatestBookmarkUriCache
-                                   ) extends DbRepo[Bookmark] with BookmarkRepo with ExternalIdColumnDbFunction[Bookmark] with SeqNumberDbFunction[Bookmark] with Logging {
+  val db: DataBaseComponent,
+  val clock: Clock,
+  val countCache: BookmarkCountCache,
+  val keepToCollectionRepo: KeepToCollectionRepoImpl,
+  collectionRepo: CollectionRepo,
+  bookmarkUriUserCache: BookmarkUriUserCache,
+  latestBookmarkUriCache: LatestBookmarkUriCache
+) extends DbRepo[Bookmark] with BookmarkRepo with ExternalIdColumnDbFunction[Bookmark] with SeqNumberDbFunction[Bookmark] with Logging {
 
   import DBSession._
   import FortyTwoTypeMappers._

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/BookmarkRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/BookmarkRepo.scala
@@ -174,8 +174,7 @@ class BookmarkRepoImpl @Inject() (
         sql"""select #$bookmarkColumnOrder from bookmark bm left join keep_to_collection kc on (bm.id = kc.bookmark_id)
                 where kc.collection_id = ${collectionId.id} and bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}'
                 and kc.state='#${KeepToCollectionStates.ACTIVE.value}' and (bm.created_at < ${before.createdAt} or (bm.created_at = ${before.createdAt} and bm.id < ${before.id.get.id}))
-                order by bm.created_at desc, bm.id desc limit     import StaticQuery.interpolation
-$count;"""
+                order by bm.created_at desc, bm.id desc limit $count"""
       case (Some(before), Some(after)) =>
         sql"""select #$bookmarkColumnOrder from bookmark bm left join keep_to_collection kc on (bm.id = kc.bookmark_id)
                 where kc.collection_id = ${collectionId.id} and bm.user_id = ${userId.id} and bm.state = '#${BookmarkStates.ACTIVE.value}'

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/BookmarkTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/BookmarkTest.scala
@@ -65,7 +65,6 @@ class BookmarkTest extends Specification with ShoeboxTestInjector {
         val cxAll = db.readOnly {implicit s =>
           bookmarkRepo.all
         }
-        println(cxAll mkString "\n")
         val all = inject[Database].readOnly(implicit session => bookmarkRepo.all)
         all.map(_.title) === Seq(Some("G1"), Some("A1"), Some("A2"), None)
       }
@@ -102,9 +101,7 @@ class BookmarkTest extends Specification with ShoeboxTestInjector {
         setup()
         val clock = inject[FakeClock]
         db.readOnly {implicit s =>
-          println(bookmarkRepo.all.map(_.updatedAt).map(SQL_DATETIME_FORMAT.print).mkString("\n"))
           val now = clock.now
-          println("now = " + now + " = " + SQL_DATETIME_FORMAT.print(now))
           bookmarkRepo.getCountByTime(now.minusHours(3), now.plusMinutes(1)) === 3
           bookmarkRepo.getCountByTime(now.minusHours(6), now.minusHours(3)) === 0
         }
@@ -148,11 +145,7 @@ class BookmarkTest extends Specification with ShoeboxTestInjector {
         db.readWrite{ implicit s =>
           bookmarkRepo.count === 4
           val bm = bookmarkRepo.getByUriAndUser(uri1.id.get, user1.id.get)
-          println(bm)
-          println(bookmarkRepo.all.mkString("\n"))
           bookmarkRepo.delete(bm.get.id.get)
-          println("=============================")
-          println(bookmarkRepo.all.mkString("\n"))
         }
         db.readWrite{ implicit s =>
           bookmarkRepo.all.size === 3

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/DatabaseDialect.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/DatabaseDialect.scala
@@ -7,18 +7,13 @@ import org.joda.time._
 
 trait DatabaseDialect[T <: DataBaseComponent] {
   def day(date: DateTime): String
-  def dateTime(date: DateTime): String
 }
 
 object MySqlDatabaseDialect extends DatabaseDialect[MySQL] {
   def day(date: DateTime): String = s"""STR_TO_DATE('${date.toStandardDateString}', '%Y-%m-%d')"""
-  def dateTime(date: DateTime): String = s"""STR_TO_DATE('${date.toStandardTimeString}', '%Y-%m-%dT%H:%i:%s')""" // no milliseconds!
 }
 
 object H2DatabaseDialect extends DatabaseDialect[H2] {
   def day(date: DateTime): String = s"""PARSEDATETIME('${date.toStandardDateString}', 'y-M-d')"""
-
-  // H2 uses SimpleDateFormat which is *not* ISO-8601 compatible!
-  def dateTime(date: DateTime): String = s"""PARSEDATETIME('${date.toStandardTimeString.replace('T',' ').replace("Z", "")}', 'yyyy-MM-d hh:mm:ss.SSS')"""
 }
 

--- a/kifi-backend/modules/sqldb/test/com/keepit/common/db/DatabaseDialectTest.scala
+++ b/kifi-backend/modules/sqldb/test/com/keepit/common/db/DatabaseDialectTest.scala
@@ -9,7 +9,7 @@ import com.keepit.test._
 
 class DatabaseDialectTest extends Specification with DbTestInjector {
 
-  val dec_20_2013 = new DateTime(2013, 12, 20, 10, 1, 30, DEFAULT_DATE_TIME_ZONE)
+  val dec_20_2013 = new DateTime(2013, 12, 20, 0, 0, 0, DEFAULT_DATE_TIME_ZONE)
 
   "MySqlDatabaseDialect" should {
 
@@ -30,25 +30,6 @@ class DatabaseDialectTest extends Specification with DbTestInjector {
           val st = s.conn.createStatement()
           val sql = s"""select DATEADD('MONTH', 1, ${H2DatabaseDialect.day(dec_20_2013)}) as day from dual"""
           sql === """select DATEADD('MONTH', 1, PARSEDATETIME('2013-12-20', 'y-M-d')) as day from dual"""
-          val rs = st.executeQuery(sql)
-          rs.next
-          rs.getString("day").split(' ')(0) === "2014-01-20"
-        }
-      }
-    }
-
-
-    // H2 uses SimpleDateFormat which is *not* ISO-8601 compatible!
-    "stringToDate to string" in {
-      H2DatabaseDialect.dateTime(dec_20_2013) === """PARSEDATETIME('2013-12-20 10:01:30.000', 'yyyy-MM-d hh:mm:ss.SSS')"""
-    }
-
-    "stringToDay to db" in {
-      withDb() { implicit injector: Injector =>
-        inject[Database].readWrite { implicit s =>
-          val st = s.conn.createStatement()
-          val sql = s"""select DATEADD('MONTH', 1, ${H2DatabaseDialect.dateTime(dec_20_2013)}) as day from dual"""
-          sql === """select DATEADD('MONTH', 1, PARSEDATETIME('2013-12-20 10:01:30.000', 'yyyy-MM-d hh:mm:ss.SSS')) as day from dual"""
           val rs = st.executeQuery(sql)
           rs.next
           rs.getString("day").split(' ')(0) === "2014-01-20"


### PR DESCRIPTION
Slick provides the necessary implicits for native date time comparisons. Unfortunately, even with proper date comparisons, since we don’t have ms precision, we have a 1 second window when keeps before/after a given keep are considered equal. This is problematic for quick imports, which do several a second. This has a fallback often for keeps who have the same createdAt date time, at the cost of performance.
