### PR TITLE
Safer nuri updates from screenshot

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/store/S3ScreenshotStore.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/S3ScreenshotStore.scala
@@ -150,7 +150,7 @@ class S3ScreenshotStoreImpl(
             } catch {
               case ex: Throwable =>
                 airbrake.notify(AirbrakeError(
-                  exception = trace.withCause(e),
+                  exception = trace.withCause(ex),
                   message = Some(s"Failed to update normalized uri ($url) to S3")
                 ))
             }

--- a/kifi-backend/modules/common/app/com/keepit/common/store/S3ScreenshotStore.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/S3ScreenshotStore.scala
@@ -144,8 +144,16 @@ class S3ScreenshotStoreImpl(
       }
       future onComplete {
         case Success(result) =>
-          if (result) {
-            shoeboxServiceClient.updateNormalizedURI(uriId = normalizedUri.id.get, screenshotUpdatedAt = Some(clock.now))
+          if (result && normalizedUri.id.nonEmpty) {
+            try {
+              shoeboxServiceClient.updateNormalizedURI(uriId = normalizedUri.id.get, screenshotUpdatedAt = Some(clock.now))
+            } catch {
+              case ex: Throwable =>
+                airbrake.notify(AirbrakeError(
+                  exception = trace.withCause(e),
+                  message = Some(s"Failed to update normalized uri ($url) to S3")
+                ))
+            }
           }
         case Failure(e) =>
           airbrake.notify(AirbrakeError(

--- a/kifi-backend/modules/common/app/com/keepit/common/strings/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/strings/package.scala
@@ -2,7 +2,7 @@ package com.keepit.common
 
 import org.apache.commons.lang3.StringUtils
 import play.api.libs.json.Json.JsValueWrapper
-import play.api.libs.json.{JsValue, JsNull, Json, JsObject}
+import play.api.libs.json.{Json, JsObject, JsNull, JsString, JsUndefined}
 
 package object strings {
   val UTF8 = "UTF-8"
@@ -38,7 +38,14 @@ package object strings {
   implicit class OptionWrappedJsObject(obj: JsObject) {
     def stripJsNulls(): JsObject = {
       JsObject(obj.value.map { v =>
-        if (v._2 == JsNull) Some(v._1 -> v._2) else None
+        v._2 match {
+          case null => None
+          case s: JsUndefined => None
+          case JsNull => None
+          case JsString(null) => None
+          case JsString("null") => None
+          case other => Some(v._1 -> v._2)
+        }
       }.flatten.toSeq)
     }
   }

--- a/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
@@ -51,7 +51,10 @@ object NormalizedURI {
   implicit val nIdFormat = Id.format[NormalizedURI]
   implicit val extIdFormat = ExternalId.format[NormalizedURI]
   implicit val stateFormat = State.format[NormalizedURI]
-  implicit val urlHashFormat = __.format[String].inmap(UrlHash.apply, unlift(UrlHash.unapply))
+  implicit val urlHashFormat = Format(
+    __.read[String].map(UrlHash(_)),
+    new Writes[UrlHash]{ def writes(o: UrlHash) = JsString(o.hash)}
+  )
 
   val TitleMaxLen = 2040
 

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -452,10 +452,20 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
 
   def saveNormalizedURI(uri: NormalizedURI)(implicit timeout:Int): Future[NormalizedURI] = ???
 
-  def updateNormalizedURI(uriId: Id[NormalizedURI], createdAt: DateTime, updatedAt: DateTime, externalId: ExternalId[NormalizedURI],
-                          title: Option[String], url: String, urlHash: UrlHash, state: State[NormalizedURI], seq: SequenceNumber,
-                          screenshotUpdatedAt: Option[DateTime], restriction: Option[Restriction], normalization: Option[Normalization],
-                          redirect: Option[Id[NormalizedURI]], redirectTime: Option[DateTime])(implicit timeout:Int): Future[Boolean] = Future.successful(true)
+  def updateNormalizedURI(uriId: => Id[NormalizedURI],
+                          createdAt: => DateTime,
+                          updatedAt: => DateTime,
+                          externalId: => ExternalId[NormalizedURI],
+                          title: => Option[String],
+                          url: => String,
+                          urlHash: => UrlHash,
+                          state: => State[NormalizedURI],
+                          seq: => SequenceNumber,
+                          screenshotUpdatedAt: => Option[DateTime],
+                          restriction: => Option[Restriction],
+                          normalization: => Option[Normalization],
+                          redirect: => Option[Id[NormalizedURI]],
+                          redirectTime: => Option[DateTime])(implicit timeout:Int): Future[Boolean] = Future.successful(true)
 
   def scraped(uri: NormalizedURI, info: ScrapeInfo): Future[Option[NormalizedURI]] = ???
 


### PR DESCRIPTION
I noticed we didn't have airbrake around a future callback, so adding that, making the `?` default parameters by name (safer against NPEs)
