### PR TITLE
added UserGraphsCommander.clear() and undid refactoring

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/controllers/mobile/MobileSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/mobile/MobileSearchController.scala
@@ -14,12 +14,10 @@ import com.keepit.search.IdFilterCompressor
 import com.keepit.search.result.KifiSearchResult
 import com.keepit.search.result.ResultUtil
 import com.keepit.search.SearchCommander
-import com.keepit.search.graph.user.UserGraphsCommander
 
 class MobileSearchController @Inject() (
   actionAuthenticator: ActionAuthenticator,
-  searchCommander: SearchCommander,
-  userGraphsCommander: UserGraphsCommander
+  searchCommander: SearchCommander
 ) extends BrowserExtensionController(actionAuthenticator) with SearchServiceController with Logging {
 
   def searchV1(
@@ -36,11 +34,10 @@ class MobileSearchController @Inject() (
   ) = JsonAction.authenticated { request =>
 
     val userId = request.userId
-    val (friendsFuture, unfriendsFuture) = (userGraphsCommander.getConnectedUsersFuture(userId), userGraphsCommander.getUnfriendedFuture(userId))
     val acceptLangs : Seq[String] = request.request.acceptLanguages.map(_.code)
     val noSearchExperiments : Boolean = request.experiments.contains(NO_SEARCH_EXPERIMENTS)
 
-    val decoratedResult = searchCommander.search(userId, friendsFuture, unfriendsFuture, acceptLangs, noSearchExperiments, query, filter, maxHits, lastUUIDStr, context, predefinedConfig = None, start, end, tz, coll, None)
+    val decoratedResult = searchCommander.search(userId, acceptLangs, noSearchExperiments, query, filter, maxHits, lastUUIDStr, context, predefinedConfig = None, start, end, tz, coll, None)
 
     Ok(toKifiSearchResultV1(decoratedResult)).withHeaders("Cache-Control" -> "private, max-age=10")
   }

--- a/kifi-backend/modules/search/app/com/keepit/controllers/search/URIGraphController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/search/URIGraphController.scala
@@ -20,7 +20,6 @@ import com.keepit.search.graph.collection.CollectionGraphPlugin
 import com.keepit.search.graph.bookmark.URIGraphIndexer
 import com.keepit.search.graph.collection.CollectionIndexer
 import com.keepit.search.sharding._
-import com.keepit.search.graph.user.UserGraphsCommander
 
 class URIGraphController @Inject()(
     activeShards: ActiveShards,
@@ -29,8 +28,7 @@ class URIGraphController @Inject()(
     shoeboxClient: ShoeboxServiceClient,
     mainSearcherFactory: MainSearcherFactory,
     shardedUriGraphIndexer: ShardedURIGraphIndexer,
-    shardedCollectionIndexer: ShardedCollectionIndexer,
-    userGraphsCommander: UserGraphsCommander) extends SearchServiceController {
+    shardedCollectionIndexer: ShardedCollectionIndexer) extends SearchServiceController {
 
   def reindex() = Action { implicit request =>
     uriGraphPlugin.reindex()
@@ -50,8 +48,7 @@ class URIGraphController @Inject()(
       ids.map{ id =>
         activeShards.find(id) match {
           case Some(shard) =>
-            val (friendsFuture, unfriendsFuture) = (userGraphsCommander.getConnectedUsersFuture(userId), userGraphsCommander.getUnfriendedFuture(userId))
-            val searcher = mainSearcherFactory.getURIGraphSearcher(shard, userId, friendsFuture, unfriendsFuture)
+            val searcher = mainSearcherFactory.getURIGraphSearcher(shard, userId)
             searcher.getSharingUserInfo(id)
           case None =>
             throw new Exception("shard not found")

--- a/kifi-backend/modules/search/app/com/keepit/search/SearchCommander.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/SearchCommander.scala
@@ -31,8 +31,6 @@ import com.keepit.search.result.ResultUtil
 trait SearchCommander {
   def search(
     userId: Id[User],
-    friendsFuture: Future[Set[Long]],
-    unfriendsFuture: Future[Set[Long]],
     acceptLangs: Seq[String],
     noSearchExperiments: Boolean,
     query: String,
@@ -63,8 +61,6 @@ class SearchCommanderImpl @Inject() (
 
   def search(
     userId: Id[User],
-    friendsFuture: Future[Set[Long]],
-    unfriendsFuture: Future[Set[Long]],
     acceptLangs: Seq[String],
     noSearchExperiments: Boolean,
     query: String,
@@ -104,7 +100,7 @@ class SearchCommanderImpl @Inject() (
     val mergedResult = {
       timing.factory
       val future = Future.traverse(shards.shards){ shard =>
-        val searcher = mainSearcherFactory(shard, userId, friendsFuture, unfriendsFuture, query, lang, maxHits, searchFilter, config)
+        val searcher = mainSearcherFactory(shard, userId, query, lang, maxHits, searchFilter, config)
         debug.foreach{ searcher.debug(_) }
         SafeFuture{ searcher.search() }
       }

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/bookmark/URIGraphSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/bookmark/URIGraphSearcher.scala
@@ -37,9 +37,9 @@ object URIGraphSearcher {
     new URIGraphSearcher(indexSearcher, storeSearcher)
   }
 
-  def apply(userId: Id[User], uriGraphIndexer: URIGraphIndexer, friendsFuture: Future[Set[Long]], unfriendsFuture: Future[Set[Long]]): URIGraphSearcherWithUser = {
+  def apply(userId: Id[User], uriGraphIndexer: URIGraphIndexer, userGraphsCommander: UserGraphsCommander): URIGraphSearcherWithUser = {
     val (indexSearcher, storeSearcher) = uriGraphIndexer.getSearchers
-    new URIGraphSearcherWithUser(indexSearcher, storeSearcher, userId, friendsFuture, unfriendsFuture)
+    new URIGraphSearcherWithUser(indexSearcher, storeSearcher, userId, userGraphsCommander)
   }
 }
 
@@ -77,8 +77,11 @@ class URIGraphSearcher(searcher: Searcher, storeSearcher: Searcher) extends Base
   }
 }
 
-class URIGraphSearcherWithUser(searcher: Searcher, storeSearcher: Searcher, myUserId: Id[User], friendIdsFuture: Future[Set[Long]], unfriendedFuture: Future[Set[Long]])
+class URIGraphSearcherWithUser(searcher: Searcher, storeSearcher: Searcher, myUserId: Id[User], userGraphsCommander: UserGraphsCommander)
   extends URIGraphSearcher(searcher, storeSearcher) {
+
+  private[this] val friendIdsFuture: Future[Set[Long]] = userGraphsCommander.getConnectedUsersFuture(myUserId)
+  private[this] val unfriendedFuture: Future[Set[Long]] = userGraphsCommander.getUnfriendedFuture(myUserId)
 
   private[this] lazy val myInfo: UserInfo = {
     val docid = reader.getIdMapper.getDocId(myUserId.id)

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/user/UserGraphsCommander.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/user/UserGraphsCommander.scala
@@ -11,7 +11,7 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 class UserGraphsCommander @Inject()(
   userGraph: UserGraphIndexer,
   searchFriendGraph: SearchFriendIndexer
-){
+) {
   private[this] val consolidatedConnectedUsersReq = new RequestConsolidator[Id[User], Set[Long]](3 seconds)
   private[this] val consolidatedUnfriendedReq = new RequestConsolidator[Id[User], Set[Long]](3 seconds)
 
@@ -26,5 +26,10 @@ class UserGraphsCommander @Inject()(
   def getUnfriended(id: Id[User]): Set[Long] = {
     val searcher = new SearchFriendSearcher(searchFriendGraph.getSearcher)
     searcher.getUnfriended(id)
+  }
+
+  def clear(): Unit = {
+    consolidatedConnectedUsersReq.clear()
+    consolidatedUnfriendedReq.clear()
   }
 }

--- a/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtSearchControllerTest.scala
@@ -21,7 +21,6 @@ import com.keepit.search.sharding.Shard
 import com.keepit.search.index.IndexModule
 import com.keepit.search.result._
 import com.keepit.search.result.DecoratedResult
-import scala.concurrent.Future
 
 class ExtSearchControllerTest extends Specification with SearchApplicationInjector {
 
@@ -165,8 +164,6 @@ class FixedResultSearchCommander extends SearchCommander {
 
   def search(
     userId: Id[User],
-    friendsFuture: Future[Set[Long]],
-    unfriendsFuture: Future[Set[Long]],
     acceptLangs: Seq[String],
     noSearchExperiments: Boolean,
     query: String,

--- a/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
@@ -22,7 +22,6 @@ import com.keepit.search.sharding.Shard
 import com.keepit.search.index.IndexModule
 import com.keepit.search.result._
 import com.keepit.search.result.DecoratedResult
-import scala.concurrent.Future
 
 class MobileSearchControllerTest extends Specification with SearchApplicationInjector {
 
@@ -166,8 +165,6 @@ class FixedResultSearchCommander extends SearchCommander {
 
   def search(
     userId: Id[User],
-    friendsFuture: Future[Set[Long]],
-    unfriendsFuture: Future[Set[Long]],
     acceptLangs: Seq[String],
     noSearchExperiments: Boolean,
     query: String,

--- a/kifi-backend/modules/search/test/com/keepit/search/MainSearcherTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/MainSearcherTest.scala
@@ -62,10 +62,9 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
           users.sliding(3).foreach{ friends =>
             val userId = user.id.get
             setConnections(Map(userId -> (friends.map(_.id.get).toSet - userId)))
-            mainSearcherFactory.clear
             userGraphIndexer.update()
-            val (friendsFuture, unfriendsFuture) = (Future.successful(userGraphsCommander.getConnectedUsers(userId)), Future.successful(userGraphsCommander.getUnfriended(userId)))   // avoid using request consolidater
-            val mainSearcher = mainSearcherFactory(singleShard, userId, friendsFuture, unfriendsFuture, "alldocs", english, numHitsPerCategory, SearchFilter.default(), allHitsConfig)
+            mainSearcherFactory.clear
+            val mainSearcher = mainSearcherFactory(singleShard, userId, "alldocs", english, numHitsPerCategory, SearchFilter.default(), allHitsConfig)
             val graphSearcher = mainSearcher.uriGraphSearcher
             val (myHits, friendsHits, othersHits, _) = mainSearcher.searchText(numHitsPerCategory)
 
@@ -120,8 +119,7 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
             setConnections(Map(userId -> (friends.map(_.id.get).toSet - userId)))
             userGraphIndexer.update()
             mainSearcherFactory.clear
-            val (friendsFuture, unfriendsFuture) = (Future.successful(userGraphsCommander.getConnectedUsers(userId)), Future.successful(userGraphsCommander.getUnfriended(userId)))
-            val mainSearcher = mainSearcherFactory(singleShard, userId, friendsFuture, unfriendsFuture, "alldocs", english, numHitsToReturn, SearchFilter.default(), allHitsConfig)
+            val mainSearcher = mainSearcherFactory(singleShard, userId, "alldocs", english, numHitsToReturn, SearchFilter.default(), allHitsConfig)
             val graphSearcher = mainSearcher.uriGraphSearcher
             val res = mainSearcher.search()
 
@@ -170,10 +168,9 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
             val userId = user.id.get
             //println("user:" + userId)
             setConnections(Map(userId -> (users.map(_.id.get).toSet - userId)))
-            mainSearcherFactory.clear
             userGraphIndexer.update()
-            val (friendsFuture, unfriendsFuture) = (Future.successful(userGraphsCommander.getConnectedUsers(userId)), Future.successful(userGraphsCommander.getUnfriended(userId)))
-            val mainSearcher = mainSearcherFactory(singleShard, userId, friendsFuture, unfriendsFuture, "personal", english, numHitsToReturn, SearchFilter.default(), allHitsConfig)
+            mainSearcherFactory.clear
+            val mainSearcher = mainSearcherFactory(singleShard, userId, "personal", english, numHitsToReturn, SearchFilter.default(), allHitsConfig)
             val graphSearcher = mainSearcher.uriGraphSearcher
             val res = mainSearcher.search()
 
@@ -233,8 +230,8 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
         //println("user:" + userId)
         setConnections(Map(userId -> (users.map(_.id.get).toSet - userId)))
         userGraphIndexer.update()
-        val (friendsFuture, unfriendsFuture) = (Future.successful(userGraphsCommander.getConnectedUsers(userId)), Future.successful(userGraphsCommander.getUnfriended(userId)))
-        val mainSearcher = mainSearcherFactory(singleShard, userId, friendsFuture, unfriendsFuture, "personal title3 content3 xyz", english, numHitsToReturn, SearchFilter.default(), noBoostConfig("myBookMarkBoost" -> "1.5"))
+        mainSearcherFactory.clear()
+        val mainSearcher = mainSearcherFactory(singleShard, userId, "personal title3 content3 xyz", english, numHitsToReturn, SearchFilter.default(), noBoostConfig("myBookMarkBoost" -> "1.5"))
         val graphSearcher = mainSearcher.uriGraphSearcher
 
         val expected = (uris(3) :: ((uris.toList diff List(uris(3))).reverse)).map(_.id.get).toList
@@ -260,11 +257,14 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
 
         val numHitsToReturn = 3
         val userId = Id[User](8)
+
         setConnections(Map(userId -> Set(Id[User](6))))
+        userGraphIndexer.update()
+
         var uriSeen = Set.empty[Long]
         var context = Some(IdFilterCompressor.fromSetToBase64(uriSeen))
-        val (friendsFuture, unfriendsFuture) = (Future.successful(userGraphsCommander.getConnectedUsers(userId)), Future.successful(userGraphsCommander.getUnfriended(userId)))
-        val mainSearcher = mainSearcherFactory(singleShard, userId, friendsFuture, unfriendsFuture, "alldocs", english, numHitsToReturn, SearchFilter.default(context), allHitsConfig)
+        mainSearcherFactory.clear()
+        val mainSearcher = mainSearcherFactory(singleShard, userId, "alldocs", english, numHitsToReturn, SearchFilter.default(context), allHitsConfig)
         val graphSearcher = mainSearcher.uriGraphSearcher
         val reachableUris = users.foldLeft(Set.empty[Long])((s, u) => s ++ graphSearcher.getUserToUriEdgeSet(u.id.get, publicOnly = true).destIdLongSet)
 
@@ -272,8 +272,7 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
         while (cnt < reachableUris.size && uriSeen.size < reachableUris.size) {
           cnt += 1
           context = Some(IdFilterCompressor.fromSetToBase64(uriSeen))
-           val (friendsFuture, unfriendsFuture) = (Future.successful(userGraphsCommander.getConnectedUsers(userId)), Future.successful(userGraphsCommander.getUnfriended(userId)))
-          val mainSearcher = mainSearcherFactory(singleShard, userId, friendsFuture, unfriendsFuture, "alldocs", english, numHitsToReturn, SearchFilter.default(context), allHitsConfig)
+          val mainSearcher = mainSearcherFactory(singleShard, userId, "alldocs", english, numHitsToReturn, SearchFilter.default(context), allHitsConfig)
           //println("---" + uriSeen + ":" + reachableUris)
           val res = mainSearcher.search()
           res.hits.foreach{ h =>
@@ -302,8 +301,10 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
         indexer.update() === uris.size
 
         setConnections(Map(userId -> Set.empty[Id[User]]))
+        userGraphIndexer.update()
 
-        val mainSearcher = mainSearcherFactory(singleShard, userId, Future.successful(Set[Long]()), Future.successful(Set[Long]()), "alldocs", english, uris.size, SearchFilter.default(), noBoostConfig("recencyBoost" -> "1.0"))
+        mainSearcherFactory.clear()
+        val mainSearcher = mainSearcherFactory(singleShard, userId, "alldocs", english, uris.size, SearchFilter.default(), noBoostConfig("recencyBoost" -> "1.0"))
         val res = mainSearcher.search()
 
         var lastTime = Long.MaxValue
@@ -335,8 +336,10 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
         uriGraph.update()
         indexer.update() === uris.size
         setConnections(Map(userId -> Set.empty[Id[User]]))
+        userGraphIndexer.update()
 
-        var mainSearcher = mainSearcherFactory(singleShard, userId, Future.successful(Set[Long]()), Future.successful(Set[Long]()), "alldocs", english, uris.size, SearchFilter.default(), noBoostConfig)
+        mainSearcherFactory.clear()
+        var mainSearcher = mainSearcherFactory(singleShard, userId, "alldocs", english, uris.size, SearchFilter.default(), noBoostConfig)
         var res = mainSearcher.search()
         //println("Scores: " + res.hits.map(_.score))
         val sz = res.hits.size
@@ -346,7 +349,7 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
         (minScore < medianScore && medianScore < maxScore) === true // this is a sanity check of test data
 
         val tailCuttingConfig = noBoostConfig("tailCutting" -> medianScore.toString)
-        mainSearcher = mainSearcherFactory(singleShard, userId, Future.successful(Set[Long]()), Future.successful(Set[Long]()), "alldocs", english, uris.size, SearchFilter.default(), tailCuttingConfig)
+        mainSearcher = mainSearcherFactory(singleShard, userId, "alldocs", english, uris.size, SearchFilter.default(), tailCuttingConfig)
         res = mainSearcher.search()
         //println("Scores: " + res.hits.map(_.score))
         (res.hits.map(h => h.score).reduce((s1, s2) => min(s1, s2)) >= medianScore) === true
@@ -370,9 +373,9 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
 
         setConnections(Map(user1.id.get -> Set(user2.id.get)))
         userGraphIndexer.update()
-        val (friendsFuture, unfriendsFuture) = (Future.successful(userGraphsCommander.getConnectedUsers(user1.id.get)), Future.successful(userGraphsCommander.getUnfriended(user1.id.get)))
 
-        val mainSearcher = mainSearcherFactory(singleShard, user1.id.get, friendsFuture, unfriendsFuture, "alldocs", english, uris.size, SearchFilter.default(), noBoostConfig)
+        mainSearcherFactory.clear()
+        val mainSearcher = mainSearcherFactory(singleShard, user1.id.get, "alldocs", english, uris.size, SearchFilter.default(), noBoostConfig)
         val res = mainSearcher.search()
 
         res.hits.size === uris.size
@@ -396,9 +399,9 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
 
         setConnections(Map(user1.id.get -> Set(user2.id.get)))
         userGraphIndexer.update()
-        val (friendsFuture, unfriendsFuture) = (Future.successful(userGraphsCommander.getConnectedUsers(user1.id.get)), Future.successful(userGraphsCommander.getUnfriended(user1.id.get)))
 
-        val mainSearcher = mainSearcherFactory(singleShard, user1.id.get, friendsFuture, unfriendsFuture, "alldocs", english, uris.size, SearchFilter.friends(), noBoostConfig)
+        mainSearcherFactory.clear()
+        val mainSearcher = mainSearcherFactory(singleShard, user1.id.get, "alldocs", english, uris.size, SearchFilter.friends(), noBoostConfig)
         val res = mainSearcher.search()
 
         val publicSet = publicUris.map(u => u.id.get).toSet
@@ -427,12 +430,13 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
         val userId = users(0).id.get
         setConnections(Map(userId -> (users.map(_.id.get).toSet - userId)))
         userGraphIndexer.update()
-        val (friendsFuture, unfriendsFuture) = (Future.successful(userGraphsCommander.getConnectedUsers(userId)), Future.successful(userGraphsCommander.getUnfriended(userId)))
-        val mainSearcher1 = mainSearcherFactory(singleShard, userId, friendsFuture, unfriendsFuture, "document", english, numHitsToReturn, SearchFilter.default(), noBoostConfig)
+
+        mainSearcherFactory.clear()
+        val mainSearcher1 = mainSearcherFactory(singleShard, userId, "document", english, numHitsToReturn, SearchFilter.default(), noBoostConfig)
         val res1 = mainSearcher1.search()
         (res1.hits.size > 0) === true
 
-        val mainSearcher2 = mainSearcherFactory(singleShard, userId, friendsFuture, unfriendsFuture, "book", english, numHitsToReturn, SearchFilter.default(), noBoostConfig)
+        val mainSearcher2 = mainSearcherFactory(singleShard, userId, "book", english, numHitsToReturn, SearchFilter.default(), noBoostConfig)
         val res2 = mainSearcher2.search()
         (res2.hits.size > 0) === true
       }
@@ -463,11 +467,12 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
 
         setConnections(Map(user1.id.get -> Set(user2.id.get)))
         userGraphIndexer.update()
-        val (friendsFuture, unfriendsFuture) = (Future.successful(userGraphsCommander.getConnectedUsers(user1.id.get)), Future.successful(userGraphsCommander.getUnfriended(user1.id.get)))
+
+        mainSearcherFactory.clear()
 
         val coll1Future = Promise.successful(Seq(coll1.id.get)).future
         val searchFilter1 = SearchFilter.mine(collectionsFuture = Some(coll1Future), monitoredAwait = inject[MonitoredAwait])
-        val mainSearcher1 = mainSearcherFactory(singleShard, user1.id.get, friendsFuture, unfriendsFuture, "alldocs", english, uris.size, searchFilter1, noBoostConfig)
+        val mainSearcher1 = mainSearcherFactory(singleShard, user1.id.get, "alldocs", english, uris.size, searchFilter1, noBoostConfig)
         val res1 = mainSearcher1.search()
 
         res1.hits.size == coll1set.size
@@ -475,7 +480,7 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
 
         val coll2Future = Promise.successful(Seq(coll2.id.get)).future
         val searchFilter2 = SearchFilter.mine(collectionsFuture = Some(coll2Future), monitoredAwait = inject[MonitoredAwait])
-        val mainSearcher2 = mainSearcherFactory(singleShard, user1.id.get, friendsFuture, unfriendsFuture, "alldocs", english, uris.size, searchFilter2, noBoostConfig)
+        val mainSearcher2 = mainSearcherFactory(singleShard, user1.id.get, "alldocs", english, uris.size, searchFilter2, noBoostConfig)
         val res2 = mainSearcher2.search()
 
         res2.hits.size == coll2set.size
@@ -483,7 +488,7 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
 
         val coll3Future = Promise.successful(Seq(coll1.id.get, coll2.id.get)).future
         val searchFilter3 = SearchFilter.mine(collectionsFuture = Some(coll3Future), monitoredAwait = inject[MonitoredAwait])
-        val mainSearcher3 = mainSearcherFactory(singleShard, user1.id.get, friendsFuture, unfriendsFuture, "alldocs", english, uris.size, searchFilter3, noBoostConfig)
+        val mainSearcher3 = mainSearcherFactory(singleShard, user1.id.get, "alldocs", english, uris.size, searchFilter3, noBoostConfig)
         val res3 = mainSearcher3.search()
 
         res3.hits.size == (coll1set.size + coll2set.size)
@@ -511,25 +516,24 @@ class MainSearcherTest extends Specification with SearchApplicationInjector with
         uriGraph.update()
         collectionGraph.update() == 2
         indexer.update() === uris.size
-
+        mainSearcherFactory.clear()
 
         val searchFilter = SearchFilter.mine(monitoredAwait = inject[MonitoredAwait])
-        val emptyFuture = Future.successful(Set[Long]())
-        val mainSearcher1 = mainSearcherFactory(singleShard, user1.id.get, emptyFuture, emptyFuture,  "mycoll", english, uris.size, searchFilter, noBoostConfig)
+        val mainSearcher1 = mainSearcherFactory(singleShard, user1.id.get,  "mycoll", english, uris.size, searchFilter, noBoostConfig)
         val res1 = mainSearcher1.search()
         val expected1 = coll1set.toSet
 
         res1.hits.size == expected1.size
         res1.hits.map(_.uriId.id).toSet === expected1.map(_.uriId.id).toSet
 
-        val mainSearcher2 = mainSearcherFactory(singleShard, user1.id.get, emptyFuture, emptyFuture, "different mycoll", english, uris.size, searchFilter, noBoostConfig)
+        val mainSearcher2 = mainSearcherFactory(singleShard, user1.id.get, "different mycoll", english, uris.size, searchFilter, noBoostConfig)
         val res2 = mainSearcher2.search()
         val expected2 = (coll1set ++ coll2set).toSet
 
         res2.hits.size == expected2.size
         res2.hits.map(_.uriId.id).toSet === expected2.map(_.uriId.id).toSet
 
-        val mainSearcher3 = mainSearcherFactory(singleShard, user1.id.get, emptyFuture, emptyFuture, "different", english, uris.size, searchFilter, noBoostConfig)
+        val mainSearcher3 = mainSearcherFactory(singleShard, user1.id.get, "different", english, uris.size, searchFilter, noBoostConfig)
         val res3 = mainSearcher3.search()
 
         res3.hits.size == 0

--- a/kifi-backend/modules/search/test/com/keepit/search/SearchCommanderTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/SearchCommanderTest.scala
@@ -73,8 +73,6 @@ class SearchCommanderTest extends Specification with SearchApplicationInjector w
 
         val res = searchCommander.search(
             userId = users(0).id.get,
-            friendsFuture = friendsFuture,
-            unfriendsFuture = unfriendsFuture,
             acceptLangs = Seq("en"),
             noSearchExperiments = false,
             query = "keepit",

--- a/kifi-backend/modules/search/test/com/keepit/search/graph/bookmark/URIGraphSearcherTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/graph/bookmark/URIGraphSearcherTest.scala
@@ -217,10 +217,9 @@ class URIGraphSearcherTest extends Specification with GraphTestHelper {
 
         val (userGraph, _, userGraphsCommander) = mkUserGraphsCommander()
         userGraph.update()
-        val (friendsFuture, unfriendsFuture) = (userGraphsCommander.getConnectedUsersFuture(users(0).id.get), userGraphsCommander.getUnfriendedFuture(users(0).id.get))
-        val (friendsFuture1, unfriendsFuture1) = (userGraphsCommander.getConnectedUsersFuture(users(1).id.get), userGraphsCommander.getUnfriendedFuture(users(1).id.get))
-        val searcher0 = URIGraphSearcher(users(0).id.get, indexer, friendsFuture, unfriendsFuture)
-        val searcher1 = URIGraphSearcher(users(1).id.get, indexer, friendsFuture1, unfriendsFuture1)
+        userGraphsCommander.clear()
+        val searcher0 = URIGraphSearcher(users(0).id.get, indexer, userGraphsCommander)
+        val searcher1 = URIGraphSearcher(users(1).id.get, indexer, userGraphsCommander)
 
         searcher0.search(personaltitle).keySet === Set(2L, 4L, 6L)
         searcher1.search(personaltitle).keySet === Set(1L, 3L, 5L)
@@ -246,9 +245,9 @@ class URIGraphSearcherTest extends Specification with GraphTestHelper {
         addConnections(Map(users(0).id.get -> Set()))
         val (userGraph, _, userGraphsCommander) = mkUserGraphsCommander()
         userGraph.update()
-        val (friendsFuture, unfriendsFuture) = (userGraphsCommander.getConnectedUsersFuture(users(0).id.get), userGraphsCommander.getUnfriendedFuture(users(0).id.get))
+        userGraphsCommander.clear()
 
-        val searcher = URIGraphSearcher(users(0).id.get, indexer, friendsFuture, unfriendsFuture)
+        val searcher = URIGraphSearcher(users(0).id.get, indexer, userGraphsCommander)
 
         def mkSiteQuery(site: String) = {
           new ConditionalQuery(new TermQuery(new Term("title", "personaltitle")), SiteQuery(site))
@@ -288,9 +287,9 @@ class URIGraphSearcherTest extends Specification with GraphTestHelper {
         addConnections(Map(users(0).id.get -> Set()))
         val (userGraph, _, userGraphsCommander) = mkUserGraphsCommander()
         userGraph.update()
+        userGraphsCommander.clear()
 
-        val (friendsFuture, unfriendsFuture) = (userGraphsCommander.getConnectedUsersFuture(users(0).id.get), userGraphsCommander.getUnfriendedFuture(users(0).id.get))
-        val searcher = URIGraphSearcher(users(0).id.get, indexer, friendsFuture, unfriendsFuture)
+        val searcher = URIGraphSearcher(users(0).id.get, indexer, userGraphsCommander)
 
         def mkQuery(word: String) = new TermQuery(new Term("title", word))
 
@@ -328,9 +327,9 @@ class URIGraphSearcherTest extends Specification with GraphTestHelper {
         addConnections(Map(users(0).id.get -> Set()))
         val (userGraph, _, userGraphsCommander) = mkUserGraphsCommander()
         userGraph.update()
+        userGraphsCommander.clear()
 
-        val (friendsFuture, unfriendsFuture) = (userGraphsCommander.getConnectedUsersFuture(users(0).id.get), userGraphsCommander.getUnfriendedFuture(users(0).id.get))
-        val searcher = URIGraphSearcher(users(0).id.get, indexer, friendsFuture, unfriendsFuture)
+        val searcher = URIGraphSearcher(users(0).id.get, indexer, userGraphsCommander)
 
         uris.take(3).foreach{ uri =>
           val uriId =  uri.id.get

--- a/kifi-backend/modules/search/test/com/keepit/search/sharding/IndexShardingTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/sharding/IndexShardingTest.scala
@@ -58,7 +58,7 @@ class IndexShardingTest extends Specification with SearchApplicationInjector wit
         users.foreach{ user =>
           val userId = user.id.get
           activeShards.shards.foreach{ shard =>
-            val mainSearcher = mainSearcherFactory(shard, userId, emptyFuture, emptyFuture, "alldocs", english, 1000, SearchFilter.default(), allHitsConfig)
+            val mainSearcher = mainSearcherFactory(shard, userId, "alldocs", english, 1000, SearchFilter.default(), allHitsConfig)
             val uriGraphSearcher = mainSearcher.uriGraphSearcher
             val collectionSearcher = mainSearcher.collectionSearcher
 
@@ -87,7 +87,7 @@ class IndexShardingTest extends Specification with SearchApplicationInjector wit
 
           val keeps = bookmarks.filter( _.userId == userId).map(_.uriId).toSet
           val shardedKeeps = activeShards.shards.map{ shard =>
-            val uriGraphSearcher = mainSearcherFactory.getURIGraphSearcher(shard, userId, emptyFuture, emptyFuture)
+            val uriGraphSearcher = mainSearcherFactory.getURIGraphSearcher(shard, userId)
 
             uriGraphSearcher.getUserToUriEdgeSet(userId).destIdSet
           }
@@ -139,7 +139,7 @@ class IndexShardingTest extends Specification with SearchApplicationInjector wit
         collectionGraph.update()
         mainSearcherFactory.clear()
 
-        def getKeepSize(shard: Shard[NormalizedURI]) = mainSearcherFactory.getURIGraphSearcher(shard, userId, emptyFuture, emptyFuture).getUserToUriEdgeSet(userId).size
+        def getKeepSize(shard: Shard[NormalizedURI]) = mainSearcherFactory.getURIGraphSearcher(shard, userId).getUserToUriEdgeSet(userId).size
         def getCollectionSize(shard: Shard[NormalizedURI]) = mainSearcherFactory.getCollectionSearcher(shard, userId).getCollectionToUriEdgeSet(collection.id.get).size
 
         val oldKeepSizes = activeShards.shards.map{ shard => (shard -> getKeepSize(shard)) }.toMap
@@ -157,7 +157,7 @@ class IndexShardingTest extends Specification with SearchApplicationInjector wit
         val newCollSizes = activeShards.shards.map{ shard => (shard -> getCollectionSize(shard)) }.toMap
 
         activeShards.shards.foreach{ shard =>
-          val mainSearcher = mainSearcherFactory(shard, userId, emptyFuture, emptyFuture, "alldocs", english, 1000, SearchFilter.default(), allHitsConfig)
+          val mainSearcher = mainSearcherFactory(shard, userId, "alldocs", english, 1000, SearchFilter.default(), allHitsConfig)
           val uriGraphSearcher = mainSearcher.uriGraphSearcher
           val collectionSearcher = mainSearcher.collectionSearcher
 


### PR DESCRIPTION
@yingjieMiao 
I added UserGraphsCommander.clear() method which clears the request consolidators in UserGraphsCommander. A call to it is added to MainSearcherFactory.clear() method. In a test, we call MainSearcherFactory.clear() in many places already to disable caching effect of consolidator. We no longer need to pass two futures around all over the places, so I undid most refactoring you did earlier. Please review.
