### PR TITLE
starting search instance faster

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/sharding/ShardedIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/sharding/ShardedIndexer.scala
@@ -66,6 +66,10 @@ trait ShardedIndexer[K, T <: Indexer[_]] extends IndexManager[T] with Logging{
     indexShards.valuesIterator.foreach(_.refreshSearcher())
   }
 
+  def warmUpIndexDirectory(): Unit = {
+    indexShards.valuesIterator.foreach(_.warmUpIndexDirectory())
+  }
+
   def backup(): Unit = updateLock.synchronized {
     indexShards.valuesIterator.foreach(_.backup())
   }


### PR DESCRIPTION
- doing index directory warm up asynchronously on regular search instances
- skipping index directory warm up on the search backup
