### PR TITLE
gracefully shutting down websockets when the server is announcing shutdown

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/shutdown/ShutdownCommander.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/shutdown/ShutdownCommander.scala
@@ -1,0 +1,22 @@
+package com.keepit.common.shutdown
+
+import com.google.inject.{Inject, Singleton}
+
+@Singleton
+class ShutdownCommander @Inject() () {
+  private var listeners: Vector[ShutdownListener] = Vector()
+  @volatile private var isShutdown = false
+  def shuttingDown: Boolean = isShutdown
+
+  def addListener(listener: ShutdownListener): Unit = synchronized {
+    if (isShutdown) throw new Exception("is already shutdown")
+    listeners = listeners :+ listener
+  }
+
+  def shutdown(): Unit = synchronized {
+    if (isShutdown) throw new Exception("is already shutdown")
+    listeners foreach { listener => listener.shutdown() }
+    isShutdown = true
+  }
+
+}

--- a/kifi-backend/modules/common/app/com/keepit/common/shutdown/ShutdownListener.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/shutdown/ShutdownListener.scala
@@ -1,0 +1,5 @@
+package com.keepit.common.shutdown
+
+trait ShutdownListener {
+  def shutdown(): Unit
+}

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -1,6 +1,6 @@
 package com.keepit.eliza.commanders
 
-import com.keepit.eliza.controllers.NotificationRouter
+import com.keepit.eliza.controllers.WebSocketRouter
 import com.keepit.eliza._
 import com.keepit.eliza.model._
 import com.keepit.model._
@@ -59,7 +59,7 @@ class MessagingCommander @Inject() (
   clock: Clock,
   abookServiceClient: ABookServiceClient,
   messagingAnalytics: MessagingAnalytics,
-  notificationRouter: NotificationRouter,
+  notificationRouter: WebSocketRouter,
   urbanAirship: UrbanAirship,
   shoebox: ShoeboxServiceClient) extends Logging {
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/WebSocketRouter.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/WebSocketRouter.scala
@@ -31,7 +31,7 @@ trait WebSocketRouter {
 
   def unregisterUserSocket(socket: SocketInfo) : Unit
 
-  def getRandomSocketInfo: Option[SocketInfo]
+  def getArbitrarySocketInfo: Option[SocketInfo]
 
   def sendToUser(userId: Id[User], data: JsArray) : Unit
 
@@ -53,7 +53,7 @@ class WebSocketRouterImpl @Inject() (
   private var notificationCallbacks = Vector[(Option[Id[User]], Notification) => Unit]()
   private val userSockets = TrieMap[Id[User], TrieMap[Long, SocketInfo]]()
 
-  def getRandomSocketInfo: Option[SocketInfo] = userSockets.values.map(_.values).flatten.headOption
+  def getArbitrarySocketInfo: Option[SocketInfo] = userSockets.values.map(_.values).flatten.headOption
 
   private def logTiming(tag: String, msg: JsArray) = {
     try {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/WebsocketsShutdownListener.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/WebsocketsShutdownListener.scala
@@ -1,0 +1,33 @@
+package com.keepit.eliza.controllers
+
+import com.keepit.common.shutdown.ShutdownListener
+import java.util.{TimerTask, Timer}
+import com.keepit.common.logging.Access.WS_IN
+import play.api.libs.json.Json
+import com.keepit.common.logging.AccessLog
+import com.keepit.common.logging.Logging
+
+/**
+ * At this point, akka may start shutting down so we can't trust it or any other plugins we have :-(
+ */
+class WebsocketsShutdownListener(websocketRouter: WebSocketRouter, accessLog: AccessLog) extends ShutdownListener with Logging {
+
+  val ShutdownWindowInMilli = 18000
+
+  def shutdown(): Unit = {
+    new Timer(getClass.getCanonicalName, true).scheduleAtFixedRate(task, 0, ShutdownWindowInMilli / websocketRouter.connectedSockets)
+  }
+
+  private def task = new TimerTask {
+    def run(): Unit = {
+      websocketRouter.getRandomSocketInfo map {socketInfo =>
+        log.info(s"Closing socket $socketInfo because of server shutdown")
+        val timer = accessLog.timer(WS_IN)
+        socketInfo.channel.push(Json.arr("goodbye", "server shutdown"))
+        socketInfo.channel.eofAndEnd()
+        websocketRouter.unregisterUserSocket(socketInfo)
+        accessLog.add(timer.done(trackingId = socketInfo.trackingId, method = "DISCONNECT", body = "disconnect on server shutdown"))
+      }
+    }
+  }
+}

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/WebsocketsShutdownListener.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/WebsocketsShutdownListener.scala
@@ -20,7 +20,7 @@ class WebsocketsShutdownListener(websocketRouter: WebSocketRouter, accessLog: Ac
 
   private def task = new TimerTask {
     def run(): Unit = {
-      websocketRouter.getRandomSocketInfo map {socketInfo =>
+      websocketRouter.getArbitrarySocketInfo map {socketInfo =>
         log.info(s"Closing socket $socketInfo because of server shutdown")
         val timer = accessLog.timer(WS_IN)
         socketInfo.channel.push(Json.arr("goodbye", "server shutdown"))

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/ext/ExtMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/ext/ExtMessagingController.scala
@@ -12,7 +12,6 @@ import com.keepit.common.amazon.AmazonInstanceInfo
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.heimdal._
 import com.keepit.search.SearchServiceClient
-import com.keepit.common.crypto.SimpleDESCrypt
 import com.keepit.common.mail.RemotePostOffice
 
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -29,7 +28,7 @@ class ExtMessagingController @Inject() (
     postOffice: RemotePostOffice,
     messagingCommander: MessagingCommander,
     actionAuthenticator: ActionAuthenticator,
-    notificationRouter: NotificationRouter,
+    notificationRouter: WebSocketRouter,
     amazonInstanceInfo: AmazonInstanceInfo,
     threadRepo: MessageThreadRepo,
     protected val shoebox: ShoeboxServiceClient,

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaController.scala
@@ -1,6 +1,6 @@
 package com.keepit.eliza.controllers.internal
 
-import com.keepit.eliza.controllers.NotificationRouter
+import com.keepit.eliza.controllers.WebSocketRouter
 import com.keepit.eliza._
 import com.keepit.common.controller.ElizaServiceController
 import com.keepit.common.logging.Logging
@@ -18,7 +18,7 @@ import com.keepit.eliza.commanders.ElizaStatsCommander
 import com.keepit.eliza.model.UserThreadStats
 
 class ElizaController @Inject() (
-  notificationRouter: NotificationRouter,
+  notificationRouter: WebSocketRouter,
   elizaStatsCommander: ElizaStatsCommander)
     extends ElizaServiceController with Logging {
 

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
@@ -19,7 +19,7 @@ import com.keepit.heimdal.{HeimdalContext, TestHeimdalServiceClientModule}
 import com.keepit.common.healthcheck.FakeAirbrakeNotifier
 import com.keepit.abook.{FakeABookServiceClientImpl, ABookServiceClient, TestABookServiceClientModule}
 
-import com.keepit.eliza.controllers.NotificationRouter
+import com.keepit.eliza.controllers.WebSocketRouter
 import com.keepit.eliza.commanders.{MessagingCommander, MessagingIndexCommander}
 import com.keepit.eliza.controllers.internal.MessagingController
 import com.keepit.eliza.model._
@@ -110,7 +110,7 @@ class MessagingTest extends Specification with DbTestInjector {
         val messagingCommander = inject[MessagingCommander]
         var notified = scala.collection.concurrent.TrieMap[Id[User], Int]()
 
-        inject[NotificationRouter].onNotification{ (userId, notification) =>
+        inject[WebSocketRouter].onNotification{ (userId, notification) =>
           // println(s"Got Notification $notification for $userId")
           if (notified.isDefinedAt(userId.get)) {
             notified(userId.get) = notified(userId.get) + 1

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/ext/ExtMessagingControllerTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/ext/ExtMessagingControllerTest.scala
@@ -22,7 +22,7 @@ import com.keepit.common.healthcheck.FakeAirbrakeNotifier
 import com.keepit.abook.{FakeABookServiceClientImpl, ABookServiceClient, TestABookServiceClientModule}
 
 import com.keepit.eliza.FakeElizaServiceClientModule
-import com.keepit.eliza.controllers.NotificationRouter
+import com.keepit.eliza.controllers.WebSocketRouter
 import com.keepit.eliza.commanders.{MessagingCommander, MessagingIndexCommander}
 import com.keepit.eliza.controllers.internal.MessagingController
 import com.keepit.eliza.model._

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/mobile/MobileMessagingControllerTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/mobile/MobileMessagingControllerTest.scala
@@ -24,7 +24,7 @@ import com.keepit.abook.{FakeABookServiceClientImpl, ABookServiceClient, TestABo
 import com.keepit.common.db.{Id, ExternalId}
 
 import com.keepit.eliza.FakeElizaServiceClientModule
-import com.keepit.eliza.controllers.NotificationRouter
+import com.keepit.eliza.controllers.WebSocketRouter
 import com.keepit.eliza.commanders.{MessagingCommander, MessagingIndexCommander}
 import com.keepit.eliza.controllers.internal.MessagingController
 import com.keepit.eliza.model._


### PR DESCRIPTION
When server is announcing shutdown we’ll:
- Refuse new connections coming in
- Start disconnecting websockets over a spread of 18 seconds
