### PR TITLE
not subtracting 1 from the known keep count before appending "+"

### DIFF
--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -172,7 +172,7 @@ if (searchUrlRe.test(document.URL)) !function() {
             .attr('href', 'javascript:');
           if (!numTop) {
             $status.attr('data-of', resp.mayHaveMore ?
-              insertCommas(Math.max(resp.hits.length, resp.myTotal + resp.friendsTotal) - 1) + '+' :
+              insertCommas(Math.max(resp.hits.length, resp.myTotal + resp.friendsTotal)) + '+' :
               (resp.hits.length || 'No'));
           }
         }


### PR DESCRIPTION
...because it can lead to “0+” and “1+” sometimes, which are awkward, and it’s not actually that bad if we say, for example, 3+, and there end up being only 3. Cognitively, I think “2+” does a worse job of representing 3 than “3+”.
