### PR TITLE
Fixing message text (2.8.79)

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.8.78
+version=2.8.79

--- a/packrat/scripts/thread.js
+++ b/packrat/scripts/thread.js
@@ -144,8 +144,8 @@ panes.thread = function () {
     });
   }
 
-  function textMatches(el) {
-    var matches = $(el).data('text') === message.text;
+  function textMatches(messageText, el) {
+    var matches = $(el).data('text') === messageText;
     log('[textMatches]', matches)();
     return matches;
   }


### PR DESCRIPTION
@2is10 I _think_ this was the intent. It seems to work fine on my system, but I wasn't able to reproduce the original issue directly.

Previous issue: `message` is undefined (on the message.text line)
