### PR TITLE
+ fjPool-based ExecutionContext & wire into Typeahead (experimental)

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/concurrent/ExecutionContext.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/concurrent/ExecutionContext.scala
@@ -17,4 +17,8 @@ object ExecutionContext extends Logging {
   }
 
   val singleThread: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(1))
+
+  val fjPool = new scala.concurrent.forkjoin.ForkJoinPool()
+  val fj = scala.concurrent.ExecutionContext.fromExecutor(fjPool)
+
 }

--- a/kifi-backend/modules/common/app/com/keepit/typeahead/abook/EContactTypeahead.scala
+++ b/kifi-backend/modules/common/app/com/keepit/typeahead/abook/EContactTypeahead.scala
@@ -12,7 +12,7 @@ import com.keepit.abook.{EmailParser, ABookServiceClient}
 import com.keepit.common.store.S3Bucket
 import scala.concurrent.{Future, Await}
 import scala.concurrent.duration.{Duration, DurationInt}
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
+//import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 import com.keepit.common.healthcheck.AirbrakeNotifier
 
@@ -47,6 +47,7 @@ class EContactTypeahead @Inject() (
   }
 
   override protected def asyncGetInfos(ids:Seq[Id[EContact]]):Future[Seq[EContact]] = {
+    implicit val fjCtx = com.keepit.common.concurrent.ExecutionContext.fj
     if (ids.isEmpty) Future.successful(Seq.empty[EContact])
     else {
       val s3F = econtactCache.bulkGetOrElseFuture(ids.map(EContactKey(_)).toSet) { keys =>

--- a/kifi-backend/modules/common/conf/application-dev.conf
+++ b/kifi-backend/modules/common/conf/application-dev.conf
@@ -92,8 +92,8 @@ amazon.s3 = {
   # If the index.bucket or browsingHistory.bucket is missing then a LocalFileStore will be used. Uncomment to use the s3 storage.
   #index.bucket = "index-b-dev"
   #install.bucket = "install-b-dev"
-  typeahead.social.bucket = "typeahead-social-b-dev"
-  typeahead.contact.bucket = "typeahead-contact-b-dev"
+  #typeahead.social.bucket = "typeahead-social-b-dev"
+  #typeahead.contact.bucket = "typeahead-contact-b-dev"
 }
 
 amazon.ec2 = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPluginImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPluginImpl.scala
@@ -44,8 +44,20 @@ private[scraper] class ScrapeScheduler @Inject() (
 
   implicit val config = scraperConfig
 
+  def checkFJCtx(): Unit = {
+    val fj = com.keepit.common.concurrent.ExecutionContext.fjPool
+    log.info(s"[checkFJCtx] #queuedSubmission=${fj.getQueuedSubmissionCount} #queuedTasks=${fj.getQueuedTaskCount} fj=${fj}")
+    if (fj.getQueuedSubmissionCount > Runtime.getRuntime.availableProcessors * 5) { // todo: tweak; airbrake if this proves useful
+      systemAdminMailSender.sendMail(ElectronicMail(from = EmailAddresses.ENG,
+        to = Seq(EmailAddresses.RAY),
+        category = NotificationCategory.System.HEALTHCHECK, // may need a new category
+        subject = s"fjPool-queuedSubmission=${fj.getQueuedSubmissionCount}",
+        htmlBody = s"ForkJoinPool-backed context queued submission count exceeded threshold ${fj}"))
+    }
+  }
+
   def checkOverdues(): Unit = {
-    // todo(ray): check overdue count
+    checkFJCtx() // todo(ray): remove or rename
     val (assignedCount, assignedOverdues) = db.readOnly(attempts = 2, dbMasterSlave = Slave) { implicit s =>
       val assignedCount = scrapeInfoRepo.getAssignedCount()
       val assignedOverdues = scrapeInfoRepo.getOverdueAssignedList(currentDateTime.minusMinutes(config.pendingOverdueThreshold))


### PR DESCRIPTION
A simple (simplest?) ExecutionContext implementation based on ForkJoinPool -- as mentioned FJPool has built-in stats that are very handy for monitoring purposes, already used in Scraper.

Wired into new Typeahead code to do sanity check. Seems to work fine in dev mode -- we'll see.

Added quick hack to monitor fjPool statistics. (very obviously) WIP. Let me know if you'd like to be added to the email list (might be spammy)

cc: @ymatsuda @eishay @stkem @andrewconner 
