### PR TITLE
abook service client boilerplate for propagating

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/abook/ABookController.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/ABookController.scala
@@ -21,6 +21,7 @@ import com.keepit.abook.typeahead.EContactABookTypeahead
 import com.keepit.typeahead.TypeaheadHit
 import scala.concurrent.Future
 import com.keepit.common.akka.SafeFuture
+import com.keepit.common.queue.RichConnectionUpdateMessage
 import java.text.Normalizer
 
 // provider-specific
@@ -340,6 +341,12 @@ class ABookController @Inject() (
   def prefixSearch(userId:Id[User], query:String) = Action { request =>
     val res = prefixSearchDirect(userId, query)
     Ok(Json.toJson(res))
+  }
+
+  def richConnectionUpdate() = Action(parse.json) { request =>
+    val updateMessage = request.body.as[RichConnectionUpdateMessage]
+    //ZZZ needs to actully do something with the data
+    Ok("")
   }
 
 }

--- a/kifi-backend/modules/abook/conf/abook.routes
+++ b/kifi-backend/modules/abook/conf/abook.routes
@@ -27,6 +27,8 @@ GET      /internal/abook/:userId/queryEContacts                 @com.keepit.aboo
 GET      /internal/abook/:userId/prefixSearch                   @com.keepit.abook.ABookController.prefixSearch(userId:Id[User], query:String)
 GET      /internal/abook/:userId/prefixQuery                    @com.keepit.abook.ABookController.prefixQuery(userId:Id[User], limit:Int, search:Option[String], after:Option[String])
 
+POST     /internal/abook/richConnectionUpdate                   @com.keepit.abook.ABookController.richConnectionUpdate()
+
 
 ->  / common.Routes
 

--- a/kifi-backend/modules/common/app/com/keepit/abook/ABookServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/abook/ABookServiceClient.scala
@@ -9,6 +9,7 @@ import com.keepit.common.logging.Logging
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.net.{CallTimeouts, HttpClientImpl, HttpClient}
 import com.keepit.common.zookeeper.ServiceCluster
+import com.keepit.common.queue.RichConnectionUpdateMessage
 import scala.concurrent._
 
 import akka.actor.Scheduler
@@ -52,6 +53,7 @@ trait ABookServiceClient extends ServiceClient {
   def queryEContacts(userId:Id[User], limit:Int, search:Option[String], after:Option[String]):Future[Seq[EContact]]
   def prefixSearch(userId:Id[User], query:String):Future[Seq[EContact]]
   def prefixQuery(userId:Id[User], limit:Int, search:Option[String], after:Option[String]):Future[Seq[EContact]]
+  def richConnectionUpdate(message: RichConnectionUpdateMessage): Unit
 }
 
 
@@ -195,6 +197,10 @@ class ABookServiceClientImpl @Inject() (
       Json.fromJson[Seq[EContact]](r.json).get
     }
   }
+
+  def richConnectionUpdate(message: RichConnectionUpdateMessage) = {
+    call(ABook.internal.richConnectionUpdate, Json.toJson(message))
+  }
 }
 
 class FakeABookServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, scheduler: Scheduler) extends ABookServiceClient {
@@ -242,4 +248,6 @@ class FakeABookServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, schedul
   def prefixSearch(userId: Id[User], query: String): Future[Seq[EContact]] = ???
 
   def prefixQuery(userId: Id[User], limit: Int, search: Option[String], after: Option[String]): Future[Seq[EContact]] = ???
+
+  def richConnectionUpdate(message: RichConnectionUpdateMessage) =  ???
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -229,6 +229,7 @@ object ABook extends Service {
     def queryEContacts(userId:Id[User], limit:Int, search:Option[String], after:Option[String]) = ServiceRoute(GET, s"/internal/abook/${userId.id}/queryEContacts", Param("limit", limit), Param("search", search), Param("after", after))
     def prefixSearch(userId:Id[User], query:String) = ServiceRoute(GET, s"/internal/abook/${userId.id}/prefixSearch", Param("query", query))
     def prefixQuery(userId:Id[User], limit:Int, search:Option[String], after:Option[String]) = ServiceRoute(GET, s"/internal/abook/${userId.id}/prefixQuery", Param("limit", limit), Param("search", search), Param("after", after))
+    def richConnectionUpdate() = ServiceRoute(POST, s"/internal/abook/richConnectionUpdate")
   }
 }
 


### PR DESCRIPTION
package naming needs work, since we are using the messages both in the queue and in in direct calls (sort of as two processing priority layers)
@leogrim another piece of the puzzle. Queuing coming shortly.
