### PR TITLE
play does not like timeout being overridden (WS uses it as both object a...

### DIFF
--- a/kifi-backend/modules/common/conf/prod/prod.conf
+++ b/kifi-backend/modules/common/conf/prod/prod.conf
@@ -156,7 +156,7 @@ include "prod-akka-sync.conf"
 # ~~~~~~~~~~~~~~~~~~
 ws {
   #play's default is 2 minutes (120000ms), which seems too high
-  timeout = 30000
+  #timeout = 30000
   #do we really need it that high as default?
   followRedirects = true
   #default is true


### PR DESCRIPTION
...nd number)
