### PR TITLE
2.8.87: serializing HTTP requests to shoebox upon socket connect, adding up to 9 retries

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.8.86
+version=2.8.87


### PR DESCRIPTION
Note: All `GET` requests are now retried up to 9 times with linearly increasing backoff (2s, 4s, 6s, ...).
