### PR TITLE
Introducing typed SequenceNumber[T]

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/db/Model.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/db/Model.scala
@@ -18,5 +18,5 @@ trait ModelWithExternalId[M] extends Model[M] { self: Model[M] =>
 }
 
 trait ModelWithSeqNumber[M] extends Model[M] { self: Model[M]=>
-  val seq: SequenceNumber
+  val seq: SequenceNumber[M]
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/db/SequenceNumber.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/db/SequenceNumber.scala
@@ -3,7 +3,7 @@ package com.keepit.common.db
 import play.api.libs.json._
 import play.api.mvc.{PathBindable, QueryStringBindable}
 
-case class SequenceNumber[T](value: Long) extends AnyVal with Ordered[SequenceNumber[T]] {
+case class SequenceNumber[T](value: Long) extends Ordered[SequenceNumber[T]] {
   def compare(that: SequenceNumber[T]) = value compare that.value
   def +(offset: Long): SequenceNumber[T] = SequenceNumber[T](this.value + offset)
   def -[T](other: SequenceNumber[T]): Long = this.value - other.value

--- a/kifi-backend/modules/common/app/com/keepit/common/db/SequenceNumber.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/db/SequenceNumber.scala
@@ -6,7 +6,8 @@ import play.api.mvc.{PathBindable, QueryStringBindable}
 case class SequenceNumber[T](value: Long) extends Ordered[SequenceNumber[T]] {
   def compare(that: SequenceNumber[T]) = value compare that.value
   def +(offset: Long): SequenceNumber[T] = SequenceNumber[T](this.value + offset)
-  def -[T](other: SequenceNumber[T]): Long = this.value - other.value
+  def -(other: SequenceNumber[T]): Long = this.value - other.value
+  def max(other: SequenceNumber[T]): SequenceNumber[T] = SequenceNumber[T](this.value max other.value)
   override def toString = value.toString
 }
 
@@ -15,7 +16,7 @@ case class SequenceNumber[T](value: Long) extends Ordered[SequenceNumber[T]] {
 object SequenceNumber {
   def ZERO[T] = SequenceNumber[T](0)
   def MinValue[T] = SequenceNumber[T](Long.MinValue)
-  implicit def sequenceNumberFormat[T] = new Format[SequenceNumber[T]] {
+  implicit def format[T] = new Format[SequenceNumber[T]] {
     def reads(json: JsValue): JsResult[SequenceNumber[T]] = __.read[Long].reads(json).map(SequenceNumber[T](_))
     def writes(o: SequenceNumber[T]): JsValue = JsNumber(o.value)
   }

--- a/kifi-backend/modules/common/app/com/keepit/common/db/SequenceNumber.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/db/SequenceNumber.scala
@@ -3,42 +3,42 @@ package com.keepit.common.db
 import play.api.libs.json._
 import play.api.mvc.{PathBindable, QueryStringBindable}
 
-case class SequenceNumber(value: Long) extends AnyVal with Ordered[SequenceNumber] {
-  def compare(that: SequenceNumber) = value compare that.value
-  def +(offset: Long): SequenceNumber = SequenceNumber(this.value + offset)
-  def -(other: SequenceNumber): Long = this.value - other.value
+case class SequenceNumber[T](value: Long) extends AnyVal with Ordered[SequenceNumber[T]] {
+  def compare(that: SequenceNumber[T]) = value compare that.value
+  def +(offset: Long): SequenceNumber[T] = SequenceNumber[T](this.value + offset)
+  def -[T](other: SequenceNumber[T]): Long = this.value - other.value
   override def toString = value.toString
 }
 
 
 
 object SequenceNumber {
-  val ZERO = SequenceNumber(0)
-  val MinValue = SequenceNumber(Long.MinValue)
-  implicit val sequenceNumberFormat = new Format[SequenceNumber] {
-    def reads(json: JsValue): JsResult[SequenceNumber] = __.read[Long].reads(json).map(SequenceNumber(_))
-    def writes(o: SequenceNumber): JsValue = JsNumber(o.value)
+  def ZERO[T] = SequenceNumber[T](0)
+  def MinValue[T] = SequenceNumber[T](Long.MinValue)
+  implicit def sequenceNumberFormat[T] = new Format[SequenceNumber[T]] {
+    def reads(json: JsValue): JsResult[SequenceNumber[T]] = __.read[Long].reads(json).map(SequenceNumber[T](_))
+    def writes(o: SequenceNumber[T]): JsValue = JsNumber(o.value)
   }
 
-  implicit def queryStringBinder(implicit longBinder: QueryStringBindable[Long]) = new QueryStringBindable[SequenceNumber] {
-    override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, SequenceNumber]] = {
+  implicit def queryStringBinder[T](implicit longBinder: QueryStringBindable[Long]) = new QueryStringBindable[SequenceNumber[T]] {
+    override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, SequenceNumber[T]]] = {
       longBinder.bind(key, params) map {
-        case Right(value) => Right(SequenceNumber(value))
+        case Right(value) => Right(SequenceNumber[T](value))
         case _ => Left("Unable to bind a SequenceNumber")
       }
     }
-    override def unbind(key: String, seqNum: SequenceNumber): String = {
+    override def unbind(key: String, seqNum: SequenceNumber[T]): String = {
       longBinder.unbind(key, seqNum.value)
     }
   }
 
-  implicit def pathBinder(implicit longBinder: PathBindable[Long]) = new PathBindable[SequenceNumber] {
-    override def bind(key: String, value: String): Either[String, SequenceNumber] =
+  implicit def pathBinder[T](implicit longBinder: PathBindable[Long]) = new PathBindable[SequenceNumber[T]] {
+    override def bind(key: String, value: String): Either[String, SequenceNumber[T]] =
       longBinder.bind(key, value) match {
-        case Right(seqNumValue) => Right(SequenceNumber(seqNumValue))
+        case Right(seqNumValue) => Right(SequenceNumber[T](seqNumValue))
         case _ => Left("Unable to bind a SequenceNumber")
       }
-    override def unbind(key: String, seqNum: SequenceNumber): String = seqNum.value.toString
+    override def unbind(key: String, seqNum: SequenceNumber[T]): String = seqNum.value.toString
   }
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -29,7 +29,7 @@ object ParamValue {
   implicit def externalIdToParam[T](i: ExternalId[T]) = ParamValue(i.id)
   implicit def idToParam[T](i: Id[T]) = ParamValue(i.id.toString)
   implicit def optionToParam[T](i: Option[T])(implicit e: T => ParamValue) = if(i.nonEmpty) e(i.get) else ParamValue("")
-  implicit def seqNumToParam(seqNum: SequenceNumber) = ParamValue(seqNum.value.toString)
+  implicit def seqNumToParam[T](seqNum: SequenceNumber[T]) = ParamValue(seqNum.value.toString)
 }
 
 abstract class Method(name: String)

--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -5,6 +5,7 @@ import com.keepit.model._
 import com.keepit.search.SearchConfigExperiment
 import java.net.URLEncoder
 import com.keepit.common.strings.UTF8
+import com.keepit.search.message.ThreadContent
 
 trait Service
 
@@ -49,7 +50,7 @@ case object PUT extends Method("PUT")
 
 object Shoebox extends Service {
   object internal {
-    def getNormalizedURI(id: Long) = ServiceRoute(GET, "/internal/shoebox/database/getNormalizedURI", Param("id", id))
+    def getNormalizedURI(id: Id[NormalizedURI]) = ServiceRoute(GET, "/internal/shoebox/database/getNormalizedURI", Param("id", id))
     def getNormalizedURIs(ids: String) = ServiceRoute(GET, "/internal/shoebox/database/getNormalizedURIs", Param("ids", ids))
     def getNormalizedURIByURL() = ServiceRoute(POST, "/internal/shoebox/database/getNormalizedURIByURL")
     def getNormalizedUriByUrlOrPrenormalize() = ServiceRoute(POST, "/internal/shoebox/database/getNormalizedUriByUrlOrPrenormalize")
@@ -68,7 +69,7 @@ object Shoebox extends Service {
     def getBrowsingHistoryFilter(userId: Id[User]) = ServiceRoute(GET, "/internal/shoebox/tracker/browsingHistory", Param("userId", userId))
     def getClickHistoryFilter(userId: Id[User]) = ServiceRoute(GET, "/internal/shoebox/tracker/clickHistory", Param("userId", userId))
     def getBookmarks(userId: Id[User]) = ServiceRoute(GET, "/internal/shoebox/database/bookmark", Param("userId", userId))
-    def getBookmarksChanged(seqNum: Long, fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/changedBookmark", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
+    def getBookmarksChanged(seqNum: SequenceNumber[Bookmark], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/changedBookmark", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def getBookmarkByUriAndUser(uriId: Id[NormalizedURI], userId: Id[User]) = ServiceRoute(GET, "/internal/shoebox/database/bookmarkByUriUser", Param("uriId", uriId), Param("userId", userId))
     def getBookmarksByUriWithoutTitle(uriId: Id[NormalizedURI]) = ServiceRoute(GET, "/internal/shoebox/database/getBookmarksByUriWithoutTitle", Param("uriId", uriId))
     def getLatestBookmark(uriId: Id[NormalizedURI]) = ServiceRoute(GET, "/internal/shoebox/database/getLatestBookmark", Param("uriId", uriId))
@@ -76,16 +77,16 @@ object Shoebox extends Service {
     def persistServerSearchEvent() = ServiceRoute(POST, "/internal/shoebox/persistServerSearchEvent")
     def sendMail() = ServiceRoute(POST, "/internal/shoebox/database/sendMail")
     def sendMailToUser() = ServiceRoute(POST, "/internal/shoebox/database/sendMailToUser")
-    def getPhrasesChanged(seqNum: Long, fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getPhrasesChanged", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
-    def getCollectionsChanged(seqNum: Long, fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/changedCollections", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
+    def getPhrasesChanged(seqNum: SequenceNumber[Phrase], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getPhrasesChanged", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
+    def getCollectionsChanged(seqNum: SequenceNumber[Collection], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/changedCollections", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def getBookmarksInCollection(collectionId: Id[Collection]) = ServiceRoute(GET, "/internal/shoebox/database/getBookmarksInCollection", Param("collectionId", collectionId))
     def getUriIdsInCollection(collectionId: Id[Collection]) = ServiceRoute(GET, "/internal/shoebox/database/getUriIdsInCollection", Param("collectionId", collectionId))
     def getCollectionsByUser(userId: Id[User]) = ServiceRoute(GET, "/internal/shoebox/database/getCollectionsByUser", Param("userId", userId))
-    def getIndexable(seqNum: Long, fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getIndexable", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
-    def getIndexableUris(seqNum: Long, fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getIndexableUris", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
-    def getScrapedUris(seqNum: Long, fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getScrapedUris", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
+    def getIndexable(seqNum: SequenceNumber[NormalizedURI], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getIndexable", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
+    def getIndexableUris(seqNum: SequenceNumber[NormalizedURI], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getIndexableUris", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
+    def getScrapedUris(seqNum: SequenceNumber[NormalizedURI], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getScrapedUris", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def getHighestUriSeq() = ServiceRoute(GET, "/internal/shoebox/database/getHighestUriSeq")
-    def getUserIndexable(seqNum: Long, fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getUserIndexable", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
+    def getUserIndexable(seqNum: SequenceNumber[User], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getUserIndexable", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def getActiveExperiments() = ServiceRoute(GET, "/internal/shoebox/database/getActiveExperiments")
     def getExperiments() = ServiceRoute(GET, "/internal/shoebox/database/getExperiments")
     def getExperiment(id: Id[SearchConfigExperiment]) = ServiceRoute(GET, "/internal/shoebox/database/getExperiment", Param("id", id))
@@ -103,7 +104,7 @@ object Shoebox extends Service {
     def getUnfriends(userId: Id[User]) = ServiceRoute(GET, "/internal/shoebox/database/unfriends", Param("userId", userId))
     def logEvent() = ServiceRoute(POST, "/internal/shoebox/logEvent")
     def createDeepLink() = ServiceRoute(POST, "/internal/shoebox/database/createDeepLink")
-    def getNormalizedUriUpdates(lowSeq: SequenceNumber, highSeq: SequenceNumber) =  ServiceRoute(GET, "/internal/shoebox/database/getNormalizedUriUpdates", Param("lowSeq", lowSeq.value), Param("highSeq", highSeq.value))
+    def getNormalizedUriUpdates(lowSeq: SequenceNumber[ChangedURI], highSeq: SequenceNumber[ChangedURI]) =  ServiceRoute(GET, "/internal/shoebox/database/getNormalizedUriUpdates", Param("lowSeq", lowSeq.value), Param("highSeq", highSeq.value))
     def clickAttribution() = ServiceRoute(POST, "/internal/shoebox/database/clickAttribution")
     def assignScrapeTasks(zkId:Long, max:Int) = ServiceRoute(GET, "/internal/shoebox/database/assignScrapeTasks", Param("zkId", zkId), Param("max", max))
     def getScrapeInfo() = ServiceRoute(POST, "/internal/shoebox/database/getScrapeInfo")
@@ -125,8 +126,8 @@ object Shoebox extends Service {
     def getExtensionVersion(installationId: ExternalId[KifiInstallation]) = ServiceRoute(GET, "/internal/shoebox/database/extensionVersion", Param("installationId", installationId))
     def triggerRawKeepImport() = ServiceRoute(POST, "/internal/shoebox/database/triggerRawKeepImport")
     def triggerSocialGraphFetch(socialUserInfoId: Id[SocialUserInfo]) = ServiceRoute(POST, "/internal/shoebox/database/triggerSocialGraphFetch", Param("id", socialUserInfoId))
-    def getUserConnectionsChanged(seqNum: Long, fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getUserConnectionsChanged", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
-    def getSearchFriendsChanged(seqNum: Long, fetchSize: Int)  = ServiceRoute(GET, "/internal/shoebox/database/getSearchFriendsChanged", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
+    def getUserConnectionsChanged(seqNum: SequenceNumber[UserConnection], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getUserConnectionsChanged", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
+    def getSearchFriendsChanged(seqNum: SequenceNumber[SearchFriend], fetchSize: Int)  = ServiceRoute(GET, "/internal/shoebox/database/getSearchFriendsChanged", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def isSensitiveURI() = ServiceRoute(POST, "/internal/shoebox/database/isSensitiveURI")
   }
 }
@@ -184,7 +185,7 @@ object Eliza extends Service {
     def sendGlobalNotification() = ServiceRoute(POST, "/internal/eliza/sendGlobalNotification")
     def importThread() = ServiceRoute(POST, "/internal/eliza/importThread")
     def getUserThreadStats(userId: Id[User]) = ServiceRoute(GET, "/internal/eliza/getUserThreadStats", Param("userId", userId))
-    def getThreadContentForIndexing(sequenceNumber: Long, maxBatchSize: Long) = ServiceRoute(GET, "/internal/eliza/getThreadContentForIndexing", Param("sequenceNumber", sequenceNumber), Param("maxBatchSize", maxBatchSize))
+    def getThreadContentForIndexing(sequenceNumber: SequenceNumber[ThreadContent], maxBatchSize: Long) = ServiceRoute(GET, "/internal/eliza/getThreadContentForIndexing", Param("sequenceNumber", sequenceNumber), Param("maxBatchSize", maxBatchSize))
     def getRenormalizationSequenceNumber() = ServiceRoute(GET, "/internal/eliza/sequenceNumber/renormalization")
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/integrity/UriUrlMigrationSeqNumKey.scala
+++ b/kifi-backend/modules/common/app/com/keepit/integrity/UriUrlMigrationSeqNumKey.scala
@@ -1,18 +1,23 @@
 package com.keepit.integrity
 
-import com.keepit.common.zookeeper.LongCentralConfigKey
+import com.keepit.common.zookeeper.{SequenceNumberCentralConfigKey, LongCentralConfigKey}
+import com.keepit.model.{RenormalizedURL, ChangedURI}
 
-case object URIMigrationSeqNumKey extends LongCentralConfigKey {
-  val name: String = "changed_uri_seq"
-  val namespace = "changed_uri"
-  def key: String = name
+case object URIMigrationSeqNumKey extends SequenceNumberCentralConfigKey[ChangedURI] {
+  val longKey = new LongCentralConfigKey {
+    val name: String = "changed_uri_seq"
+    val namespace = "changed_uri"
+    def key: String = name
+   }
 }
 
 // keep track of processed url migration
-case object URLMigrationSeqNumKey extends LongCentralConfigKey {
-  val name: String = "migrated_url_seq"
-  val namespace = "changed_uri"
-  def key: String = name
+case object URLMigrationSeqNumKey extends SequenceNumberCentralConfigKey[RenormalizedURL] {
+  val longKey = new LongCentralConfigKey {
+    val name: String = "migrated_url_seq"
+    val namespace = "changed_uri"
+    def key: String = name
+  }
 }
 
 // keep track of checked renormalization

--- a/kifi-backend/modules/common/app/com/keepit/model/Bookmark.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Bookmark.scala
@@ -25,7 +25,7 @@ case class Bookmark(
   state: State[Bookmark] = BookmarkStates.ACTIVE,
   source: BookmarkSource,
   kifiInstallation: Option[ExternalId[KifiInstallation]] = None,
-  seq: SequenceNumber = SequenceNumber.ZERO
+  seq: SequenceNumber[Bookmark] = SequenceNumber.ZERO
 ) extends ModelWithExternalId[Bookmark] with ModelWithState[Bookmark] with ModelWithSeqNumber[Bookmark]{
 
   override def toString: String = s"Bookmark[id:$id,externalId:$externalId,title:$title,uriId:$uriId,urlId:$urlId,url:$url,isPrivate:$isPrivate,userId:$userId,state:$state,source:$source,seq:$seq],path:$bookmarkPath"
@@ -68,7 +68,7 @@ object Bookmark {
     (__ \ 'state).format(State.format[Bookmark]) and
     (__ \ 'source).format[String].inmap(BookmarkSource.apply, unlift(BookmarkSource.unapply)) and
     (__ \ 'kifiInstallation).formatNullable(ExternalId.format[KifiInstallation]) and
-    (__ \ 'seq).format(SequenceNumber.sequenceNumberFormat)
+    (__ \ 'seq).format(SequenceNumber.format[Bookmark])
   )(Bookmark.apply, unlift(Bookmark.unapply))
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/model/ChangedURI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/ChangedURI.scala
@@ -10,7 +10,7 @@ case class ChangedURI(
   oldUriId: Id[NormalizedURI],
   newUriId: Id[NormalizedURI],
   state: State[ChangedURI] = ChangedURIStates.ACTIVE,
-  seq: SequenceNumber = SequenceNumber.ZERO
+  seq: SequenceNumber[ChangedURI] = SequenceNumber.ZERO
 ) extends ModelWithState[ChangedURI] with ModelWithSeqNumber[ChangedURI] {
   def withId(id: Id[ChangedURI]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)

--- a/kifi-backend/modules/common/app/com/keepit/model/Collection.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Collection.scala
@@ -21,7 +21,7 @@ case class Collection(
   createdAt: DateTime = currentDateTime,
   updatedAt: DateTime = currentDateTime,
   lastKeptTo: Option[DateTime] = None,
-  seq: SequenceNumber = SequenceNumber.ZERO
+  seq: SequenceNumber[Collection] = SequenceNumber.ZERO
   ) extends ModelWithExternalId[Collection] with ModelWithState[Collection] with ModelWithSeqNumber[Collection]{
   def withLastKeptTo(now: DateTime) = this.copy(lastKeptTo = Some(now))
   def withId(id: Id[Collection]) = this.copy(id = Some(id))
@@ -39,7 +39,7 @@ object Collection {
     (__ \ 'createdAt).format(DateTimeJsonFormat) and
     (__ \ 'updatedAt).format(DateTimeJsonFormat) and
     (__ \ 'lastKeptTo).formatNullable[DateTime] and
-    (__ \ 'seq).format(SequenceNumber.sequenceNumberFormat)
+    (__ \ 'seq).format(SequenceNumber.format[Collection])
   )(Collection.apply, unlift(Collection.unapply))
 
   val MaxNameLength = 64

--- a/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
@@ -26,7 +26,7 @@ case class NormalizedURI (
   url: String,
   urlHash: UrlHash,
   state: State[NormalizedURI] = NormalizedURIStates.ACTIVE,
-  seq: SequenceNumber = SequenceNumber.ZERO,
+  seq: SequenceNumber[NormalizedURI] = SequenceNumber.ZERO,
   screenshotUpdatedAt: Option[DateTime] = None,
   restriction: Option[Restriction] = None,
   normalization: Option[Normalization] = None,
@@ -67,7 +67,7 @@ object NormalizedURI {
     (__ \ 'url).format[String] and
     (__ \ 'urlHash).format[String].inmap(UrlHash.apply, unlift(UrlHash.unapply)) and
     (__ \ 'state).format(State.format[NormalizedURI]) and
-    (__ \ 'seq).format(SequenceNumber.sequenceNumberFormat) and
+    (__ \ 'seq).format(SequenceNumber.format[NormalizedURI]) and
     (__ \ 'screenshotUpdatedAt).formatNullable[DateTime] and
     (__ \ 'restriction).formatNullable[Restriction] and
     (__ \ 'normalization).formatNullable[Normalization] and
@@ -162,7 +162,7 @@ case class IndexableUri(
    url: String,
    restriction: Option[Restriction] = None,
    state: State[NormalizedURI] = NormalizedURIStates.ACTIVE,
-   seq: SequenceNumber)
+   seq: SequenceNumber[NormalizedURI])
 
 object IndexableUri {
 
@@ -174,6 +174,6 @@ object IndexableUri {
     (__ \ 'url).format[String] and
     (__ \ 'restriction).formatNullable[Restriction] and
     (__ \ 'state).format(State.format[NormalizedURI]) and
-    (__ \ 'seq).format(SequenceNumber.sequenceNumberFormat)
+    (__ \ 'seq).format(SequenceNumber.format[NormalizedURI])
   )(IndexableUri.apply, unlift(IndexableUri.unapply))
 }

--- a/kifi-backend/modules/common/app/com/keepit/model/Phrase.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Phrase.scala
@@ -16,7 +16,7 @@ case class Phrase (
   lang: Lang,
   source: String,
   state: State[Phrase] = PhraseStates.ACTIVE,
-  seq: SequenceNumber = SequenceNumber.ZERO
+  seq: SequenceNumber[Phrase] = SequenceNumber.ZERO
   ) extends ModelWithState[Phrase] with ModelWithSeqNumber[Phrase] {
   def withId(id: Id[Phrase]): Phrase = copy(id = Some(id))
   def withUpdateTime(now: DateTime): Phrase = this.copy(updatedAt = now)
@@ -33,7 +33,7 @@ object Phrase {
     (__ \ 'lang).format[String].inmap(Lang.apply, unlift(Lang.unapply)) and
     (__ \ 'source).format[String] and
     (__ \ 'state).format(State.format[Phrase]) and
-    (__ \ 'seq).format(SequenceNumber.sequenceNumberFormat)
+    (__ \ 'seq).format(SequenceNumber.format[Phrase])
     )(Phrase.apply, unlift(Phrase.unapply))
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/model/RenormalizedURL.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/RenormalizedURL.scala
@@ -11,7 +11,7 @@ case class RenormalizedURL(
   oldUriId: Id[NormalizedURI],
   newUriId: Id[NormalizedURI],
   state: State[RenormalizedURL] = RenormalizedURLStates.ACTIVE,
-  seq: SequenceNumber = SequenceNumber.ZERO
+  seq: SequenceNumber[RenormalizedURL] = SequenceNumber.ZERO
 ) extends ModelWithState[RenormalizedURL] with ModelWithSeqNumber[RenormalizedURL]{
   def withId(id: Id[RenormalizedURL]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)

--- a/kifi-backend/modules/common/app/com/keepit/model/SearchFriend.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/SearchFriend.scala
@@ -15,7 +15,7 @@ case class SearchFriend(
     state: State[SearchFriend] = SearchFriendStates.EXCLUDED,
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime,
-    seq: SequenceNumber = SequenceNumber.ZERO
+    seq: SequenceNumber[SearchFriend] = SequenceNumber.ZERO
     ) extends ModelWithState[SearchFriend] with ModelWithSeqNumber[SearchFriend] {
   def withId(id: Id[SearchFriend]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
@@ -30,7 +30,7 @@ object SearchFriend {
     (__ \ 'state).format(State.format[SearchFriend]) and
     (__ \ 'createdAt).format(DateTimeJsonFormat) and
     (__ \ 'updatedAt).format(DateTimeJsonFormat) and
-    (__ \ 'seq).format(SequenceNumber.sequenceNumberFormat)
+    (__ \ 'seq).format(SequenceNumber.format[SearchFriend])
   )(SearchFriend.apply, unlift(SearchFriend.unapply))
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/model/User.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/User.scala
@@ -22,7 +22,7 @@ case class User(
   state: State[User] = UserStates.ACTIVE,
   pictureName: Option[String] = None, // denormalized UserPicture.name
   userPictureId: Option[Id[UserPicture]] = None,
-  seq: SequenceNumber = SequenceNumber.ZERO,
+  seq: SequenceNumber[User] = SequenceNumber.ZERO,
   primaryEmailId: Option[Id[EmailAddress]] = None
 ) extends ModelWithExternalId[User] with ModelWithState[User] with ModelWithSeqNumber[User]{
   def withId(id: Id[User]) = this.copy(id = Some(id))
@@ -47,7 +47,7 @@ object User {
     (__ \ 'state).format(State.format[User]) and
     (__ \ 'pictureName).formatNullable[String] and
     (__ \ 'userPictureId).formatNullable[Id[UserPicture]] and
-    (__ \ 'seq).format(SequenceNumber.sequenceNumberFormat) and
+    (__ \ 'seq).format(SequenceNumber.format[User]) and
     (__ \ 'primaryEmailId).formatNullable[Id[EmailAddress]]
   )(User.apply, unlift(User.unapply))
 

--- a/kifi-backend/modules/common/app/com/keepit/model/UserConnection.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserConnection.scala
@@ -16,7 +16,7 @@ case class UserConnection(
     state: State[UserConnection] = UserConnectionStates.ACTIVE,
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime,
-    seq: SequenceNumber = SequenceNumber.ZERO
+    seq: SequenceNumber[UserConnection] = SequenceNumber.ZERO
   ) extends ModelWithState[UserConnection] with ModelWithSeqNumber[UserConnection]{
   def withId(id: Id[UserConnection]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
@@ -31,7 +31,7 @@ object UserConnection {
     (__ \'state).format(State.format[UserConnection]) and
     (__ \ 'createdAt).format(DateTimeJsonFormat) and
     (__ \ 'updatedAt).format(DateTimeJsonFormat) and
-    (__ \ 'seq).format(SequenceNumber.sequenceNumberFormat)
+    (__ \ 'seq).format(SequenceNumber.format[UserConnection])
   )(UserConnection.apply, unlift(UserConnection.unapply))
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/search/IndexInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/IndexInfo.scala
@@ -5,7 +5,7 @@ import com.keepit.model.User
 import play.api.libs.json._
 case class IndexInfo(
   name: String,
-  sequenceNumber: SequenceNumber,
+  sequenceNumber: Long,
   numDocs: Int,
   committedAt: Option[String],
   indexSize: Option[Long]
@@ -13,14 +13,14 @@ case class IndexInfo(
 
 case class ReadableIndexInfo(
   name: String,
-  sequenceNumber: SequenceNumber,
+  sequenceNumber: Long,
   numDocs: Int,
   committedAt: Option[String],
   indexSize: Option[String]
 )
 
 object IndexInfo {
-  implicit val indexInfoFormat = Json.format[IndexInfo]
+  implicit def indexInfoFormat = Json.format[IndexInfo]
 
   def toReadableSize(n: Long): String = {
     (n/1e3, n/1e6, n/1e9) match {

--- a/kifi-backend/modules/common/app/com/keepit/search/message/ThreadContent.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/message/ThreadContent.scala
@@ -37,7 +37,7 @@ object ThreadContentUpdateMode {
 case class ThreadContent(
   mode: ThreadContentUpdateMode,
   id: Id[ThreadContent],
-  seq: SequenceNumber,
+  seq: SequenceNumber[ThreadContent],
   participants: Seq[BasicUser],
   updatedAt: DateTime,
   url: String,
@@ -55,7 +55,7 @@ object ThreadContent {
   implicit def format = (
     (__ \ 'mode).format[ThreadContentUpdateMode] and
     (__ \ 'id).format(Id.format[ThreadContent]) and
-    (__ \ 'seq).format[SequenceNumber] and
+    (__ \ 'seq).format(SequenceNumber.format[ThreadContent]) and
     (__ \ 'participants).format[Seq[BasicUser]] and
     (__ \ 'updatedAt).format[DateTime] and
     (__ \ 'url).format[String] and

--- a/kifi-backend/modules/common/app/com/keepit/serializer/CollectionTupleSerializer.scala
+++ b/kifi-backend/modules/common/app/com/keepit/serializer/CollectionTupleSerializer.scala
@@ -10,6 +10,6 @@ object CollectionTupleSerializer {
   implicit val collectionTupleFormat = (
     (__ \ 'collId).format(Id.format[Collection]) and
     (__ \ 'userId).format(Id.format[User]) and
-    (__ \ 'seq).format(SequenceNumber.sequenceNumberFormat)
+    (__ \ 'seq).format(SequenceNumber.format)
   ).tupled
 }

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -71,25 +71,22 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
   // Fake sequence counters
 
   private val userSeqCounter = new AtomicInteger(0)
-  private def nextUserSeqNum() = SequenceNumber(userSeqCounter.incrementAndGet())
+  private def nextUserSeqNum() = SequenceNumber[User](userSeqCounter.incrementAndGet())
 
   private val uriSeqCounter = new AtomicInteger(0)
-  private def nextUriSeqNum() = { SequenceNumber(uriSeqCounter.incrementAndGet()) }
+  private def nextUriSeqNum() = { SequenceNumber[NormalizedURI](uriSeqCounter.incrementAndGet()) }
 
   private val bookmarkSeqCounter = new AtomicInteger(0)
-  private def nextBookmarkSeqNum() = { SequenceNumber(bookmarkSeqCounter.incrementAndGet()) }
+  private def nextBookmarkSeqNum() = { SequenceNumber[Bookmark](bookmarkSeqCounter.incrementAndGet()) }
 
   private val collectionSeqCounter = new AtomicInteger(0)
-  private def nextCollectionSeqNum() = { SequenceNumber(collectionSeqCounter.incrementAndGet()) }
-
-  private val commentSeqCounter = new AtomicInteger(0)
-  private def nextCommentSeqNum() = { SequenceNumber(commentSeqCounter.incrementAndGet()) }
+  private def nextCollectionSeqNum() = { SequenceNumber[Collection](collectionSeqCounter.incrementAndGet()) }
 
   private val userConnSeqCounter = new AtomicInteger(0)
-  private def nextUserConnSeqNum() = SequenceNumber(userConnSeqCounter.incrementAndGet())
+  private def nextUserConnSeqNum() = SequenceNumber[UserConnection](userConnSeqCounter.incrementAndGet())
 
   private val searchFriendSeqCounter = new AtomicInteger(0)
-  private def nextSearchFriendSeqNum() = SequenceNumber(searchFriendSeqCounter.incrementAndGet())
+  private def nextSearchFriendSeqNum() = SequenceNumber[SearchFriend](searchFriendSeqCounter.incrementAndGet())
 
   // Fake repos
 
@@ -318,7 +315,7 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
     Future.successful(bookmarks)
   }
 
-  def getBookmarksChanged(seqNum: SequenceNumber, fetchSize: Int): Future[Seq[Bookmark]] = {
+  def getBookmarksChanged(seqNum: SequenceNumber[Bookmark], fetchSize: Int): Future[Seq[Bookmark]] = {
     val bookmarks = allBookmarks.values.filter(_.seq > seqNum).toSeq.sortBy(_.seq).take(fetchSize)
     Future.successful(bookmarks)
   }
@@ -380,7 +377,7 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
 
   def sendMail(email: com.keepit.common.mail.ElectronicMail): Future[Boolean] = ???
   def sendMailToUser(userId: Id[User], email: ElectronicMail): Future[Boolean] = ???
-  def getPhrasesChanged(seqNum: SequenceNumber, fetchSize: Int): Future[Seq[Phrase]] = Future.successful(Seq())
+  def getPhrasesChanged(seqNum: SequenceNumber[Phrase], fetchSize: Int): Future[Seq[Phrase]] = Future.successful(Seq())
   def getSocialUserInfoByNetworkAndSocialId(id: SocialId, networkType: SocialNetworkType): Future[Option[SocialUserInfo]] = ???
   def getSessionByExternalId(sessionId: com.keepit.common.db.ExternalId[com.keepit.model.UserSession]): scala.concurrent.Future[Option[com.keepit.model.UserSession]] = ???
   def getSocialUserInfosByUserId(userId: com.keepit.common.db.Id[com.keepit.model.User]): scala.concurrent.Future[List[com.keepit.model.SocialUserInfo]] = ???
@@ -392,9 +389,9 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
   def userChannelCountFanout(): Seq[scala.concurrent.Future[Int]] = Seq()
 
   def suggestExperts(urisAndKeepers: Seq[(Id[NormalizedURI], Seq[Id[User]])]): Future[Seq[Id[User]]] = ???
-  def getNormalizedUriUpdates(lowSeq: SequenceNumber, highSeq: SequenceNumber): Future[Seq[(Id[NormalizedURI], NormalizedURI)]] = ???
+  def getNormalizedUriUpdates(lowSeq: SequenceNumber[ChangedURI], highSeq: SequenceNumber[ChangedURI]): Future[Seq[(Id[NormalizedURI], NormalizedURI)]] = ???
 
-  def getCollectionsChanged(seqNum: SequenceNumber, fetchSize: Int): Future[Seq[Collection]] = {
+  def getCollectionsChanged(seqNum: SequenceNumber[Collection], fetchSize: Int): Future[Seq[Collection]] = {
     val collections = allCollections.values.filter(_.seq > seqNum).toSeq.sortBy(_.seq).take(fetchSize)
     Future.successful(collections)
   }
@@ -416,32 +413,32 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
 
   def getCollectionIdsByExternalIds(collIds: Seq[ExternalId[Collection]]): Future[Seq[Id[Collection]]] = ???
 
-  def getIndexable(seqNum: Long, fetchSize: Int = -1) : Future[Seq[NormalizedURI]] = {
-    val uris = allNormalizedURIs.values.filter(_.seq > SequenceNumber(seqNum)).toSeq.sortBy(_.seq)
+  def getIndexable(seqNum: SequenceNumber[NormalizedURI], fetchSize: Int = -1) : Future[Seq[NormalizedURI]] = {
+    val uris = allNormalizedURIs.values.filter(_.seq > seqNum).toSeq.sortBy(_.seq)
     val fewerUris = (if (fetchSize >= 0) uris.take(fetchSize) else uris)
     Future.successful(fewerUris)
   }
 
-  def getIndexableUris(seqNum: Long, fetchSize: Int = -1) : Future[Seq[IndexableUri]] = {
-    val uris = allNormalizedURIs.values.filter(_.seq > SequenceNumber(seqNum)).toSeq.sortBy(_.seq)
+  def getIndexableUris(seqNum: SequenceNumber[NormalizedURI], fetchSize: Int = -1) : Future[Seq[IndexableUri]] = {
+    val uris = allNormalizedURIs.values.filter(_.seq > seqNum).toSeq.sortBy(_.seq)
     val fewerUris = (if (fetchSize >= 0) uris.take(fetchSize) else uris)
     Future.successful(fewerUris map { u => IndexableUri(u) })
   }
 
-  def getScrapedUris(seqNum: Long, fetchSize: Int = -1) : Future[Seq[IndexableUri]] = {
+  def getScrapedUris(seqNum: SequenceNumber[NormalizedURI], fetchSize: Int = -1) : Future[Seq[IndexableUri]] = {
     val scrapedStates = Set(NormalizedURIStates.SCRAPED, NormalizedURIStates.SCRAPE_WANTED, NormalizedURIStates.SCRAPE_FAILED, NormalizedURIStates.UNSCRAPABLE)
-    val uris = allNormalizedURIs.values.filter(x => x.seq > SequenceNumber(seqNum) && scrapedStates.contains(x.state)).toSeq.sortBy(_.seq)
+    val uris = allNormalizedURIs.values.filter(x => x.seq > seqNum && scrapedStates.contains(x.state)).toSeq.sortBy(_.seq)
     val fewerUris = (if (fetchSize >= 0) uris.take(fetchSize) else uris)
     Future.successful(fewerUris map { u => IndexableUri(u) })
   }
 
-  def getHighestUriSeq(): Future[Long] = {
-    val seq = allNormalizedURIs.values.map{_.seq.value}
-    Future.successful(if (seq.isEmpty) 0L else seq.max)
+  def getHighestUriSeq(): Future[SequenceNumber[NormalizedURI]] = {
+    val seq = allNormalizedURIs.values.map{_.seq}
+    Future.successful(if (seq.isEmpty) SequenceNumber.ZERO else seq.max)
   }
 
-  def getUserIndexable(seqNum: Long, fetchSize: Int): Future[Seq[User]] = {
-    val users = allUsers.values.filter(_.seq.value > seqNum).toSeq.sortBy(_.seq.value).take(fetchSize)
+  def getUserIndexable(seqNum: SequenceNumber[User], fetchSize: Int): Future[Seq[User]] = {
+    val users = allUsers.values.filter(_.seq > seqNum).toSeq.sortBy(_.seq).take(fetchSize)
     Future.successful(users)
   }
 
@@ -535,7 +532,7 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
                           url: => String,
                           urlHash: => UrlHash,
                           state: => State[NormalizedURI],
-                          seq: => SequenceNumber,
+                          seq: => SequenceNumber[NormalizedURI],
                           screenshotUpdatedAt: => Option[DateTime],
                           restriction: => Option[Restriction],
                           normalization: => Option[Normalization],
@@ -576,13 +573,13 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
     Future.successful()
   }
 
-  def getUserConnectionsChanged(seq: Long, fetchSize: Int): Future[Seq[UserConnection]] = {
-    val changed = allConnections.values.filter(_.seq.value > seq).toSeq.sortBy(_.seq)
+  def getUserConnectionsChanged(seq: SequenceNumber[UserConnection], fetchSize: Int): Future[Seq[UserConnection]] = {
+    val changed = allConnections.values.filter(_.seq > seq).toSeq.sortBy(_.seq)
     Future.successful(if (fetchSize < 0) changed else changed.take(fetchSize))
   }
 
-  def getSearchFriendsChanged(seq: Long, fetchSize: Int): Future[Seq[SearchFriend]] = {
-    val changed = allSearchFriends.values.filter(_.seq.value > seq).toSeq.sortBy(_.seq)
+  def getSearchFriendsChanged(seq: SequenceNumber[SearchFriend], fetchSize: Int): Future[Seq[SearchFriend]] = {
+    val changed = allSearchFriends.values.filter(_.seq > seq).toSeq.sortBy(_.seq)
     Future.successful(if (fetchSize < 0) changed else changed.take(fetchSize))
   }
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/UriNormalizationUpdater.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/UriNormalizationUpdater.scala
@@ -4,7 +4,7 @@ package com.keepit.eliza
 import com.keepit.common.db.slick.Database
 import com.keepit.shoebox.ShoeboxServiceClient
 import com.keepit.common.db.{SequenceNumber, Id}
-import com.keepit.model.NormalizedURI
+import com.keepit.model.{ChangedURI, NormalizedURI}
 import com.keepit.common.zookeeper.CentralConfig
 import com.keepit.common.logging.Logging
 import com.keepit.integrity.URIMigrationSeqNumKey
@@ -35,11 +35,11 @@ class UriNormalizationUpdater @Inject() (
     system: ActorSystem
   ) extends Logging {
 
-  centralConfig.onChange(URIMigrationSeqNumKey)(seqNumValueOpt => checkAndUpdate(seqNumValueOpt.map(SequenceNumber.apply)))
+  centralConfig.onChange(URIMigrationSeqNumKey)(checkAndUpdate)
 
-  def localSequenceNumber(): SequenceNumber = db.readOnly{ implicit session => renormRepo.getCurrentSequenceNumber() }
+  def localSequenceNumber(): SequenceNumber[ChangedURI] = db.readOnly{ implicit session => renormRepo.getCurrentSequenceNumber() }
 
-  def checkAndUpdate(remoteSequenceNumberOpt: Option[SequenceNumber]) : Unit = synchronized {
+  def checkAndUpdate(remoteSequenceNumberOpt: Option[SequenceNumber[ChangedURI]]) : Unit = synchronized {
     var localSeqNum = localSequenceNumber()
     log.info(s"Renormalization: Checking if I need to update. Leader: ${serviceDiscovery.isLeader}. seqNum: ${remoteSequenceNumberOpt}. locSeqNum: ${localSeqNum}")
     remoteSequenceNumberOpt match {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaStatsCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaStatsCommander.scala
@@ -5,7 +5,7 @@ import com.keepit.eliza.model.{UriRenormalizationTrackingRepo, UserThreadStats, 
 import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
 import com.keepit.common.db.{SequenceNumber, Id}
-import com.keepit.model.User
+import com.keepit.model.{ChangedURI, User}
 
 class ElizaStatsCommander @Inject() (
   userThreadRepo: UserThreadRepo,
@@ -18,6 +18,6 @@ class ElizaStatsCommander @Inject() (
     }
   }
 
-  def getCurrentRenormalizationSequenceNumber(): SequenceNumber = db.readOnly { implicit session => renormalizationRepo.getCurrentSequenceNumber() }
+  def getCurrentRenormalizationSequenceNumber(): SequenceNumber[ChangedURI] = db.readOnly { implicit session => renormalizationRepo.getCurrentSequenceNumber() }
 
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingIndexCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingIndexCommander.scala
@@ -30,7 +30,7 @@ class MessagingIndexCommander @Inject() (
     else getMessages(fromId, Id[Message](toId.id+100), maxId)
   }
 
-  private def getThreadContentsForThreadWithSequenceNumber(threadId: Id[MessageThread], seq: SequenceNumber): Future[ThreadContent] = {
+  private def getThreadContentsForThreadWithSequenceNumber(threadId: Id[MessageThread], seq: SequenceNumber[ThreadContent]): Future[ThreadContent] = {
     val thread = db.readOnly{ implicit session => threadRepo.get(threadId) }
     val participants : Seq[Id[User]] = thread.participants.map(_.allUsers).getOrElse(Set[Id[User]]()).toSeq
     val participantBasicUsersFuture = shoebox.getBasicUsers(participants)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UriRenormalizationTracking.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UriRenormalizationTracking.scala
@@ -2,7 +2,7 @@ package com.keepit.eliza.model
 
 import com.keepit.common.db.{SequenceNumber, Model, Id}
 import com.keepit.common.db.slick.DBSession.{RWSession, RSession}
-import com.keepit.model.NormalizedURI
+import com.keepit.model.{ChangedURI, NormalizedURI}
 import com.keepit.common.db.slick.{Repo, DbRepo, DataBaseComponent}
 import com.keepit.common.time._
 import MessagingTypeMappers._
@@ -17,7 +17,7 @@ case class UriRenormalizationEvent(
     id: Option[Id[UriRenormalizationEvent]] = None,
     createdAt: DateTime = currentDateTime,
     updateAt: DateTime = currentDateTime,
-    sequenceNumber: SequenceNumber,
+    sequenceNumber: SequenceNumber[ChangedURI],
     numIdsChanged: Long,
     idsRetired: Seq[Id[NormalizedURI]]
   )

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UriRenormalizationTrackingRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UriRenormalizationTrackingRepo.scala
@@ -2,7 +2,7 @@ package com.keepit.eliza.model
 
 import com.keepit.common.db.{SequenceNumber, Model, Id}
 import com.keepit.common.db.slick.DBSession.{RWSession, RSession}
-import com.keepit.model.NormalizedURI
+import com.keepit.model.{ChangedURI, NormalizedURI}
 import com.keepit.common.db.slick.{Repo, DbRepo, DataBaseComponent}
 import com.keepit.common.time._
 import play.api.libs.json.{Json, JsArray, JsNumber}
@@ -13,9 +13,9 @@ import org.joda.time.DateTime
 @ImplementedBy(classOf[UriRenormalizationTrackingRepoImpl])
 trait UriRenormalizationTrackingRepo extends Repo[UriRenormalizationEvent] {
 
-  def getCurrentSequenceNumber()(implicit session: RSession): SequenceNumber
+  def getCurrentSequenceNumber()(implicit session: RSession): SequenceNumber[ChangedURI]
 
-  def addNew(sequenceNumber: SequenceNumber, numIdsChanged: Long, idsRetired: Seq[Id[NormalizedURI]])(implicit session: RWSession) : Unit
+  def addNew(sequenceNumber: SequenceNumber[ChangedURI], numIdsChanged: Long, idsRetired: Seq[Id[NormalizedURI]])(implicit session: RWSession) : Unit
 }
 
 @Singleton
@@ -39,7 +39,7 @@ class UriRenormalizationTrackingRepoImpl @Inject() (
 
   type RepoImpl = UriRenormalizationEventTable
   class UriRenormalizationEventTable(tag: Tag) extends RepoTable[UriRenormalizationEvent](db, tag, "uri_renormalization_event") {
-    def sequenceNumber = column[SequenceNumber]("sequence_number", O.NotNull)
+    def sequenceNumber = column[SequenceNumber[ChangedURI]]("sequence_number", O.NotNull)
     def numIdsChanged = column[Long]("num_ids_changed", O.NotNull)
     def idsRetired = column[Seq[Id[NormalizedURI]]]("ids_retired", O.NotNull)
     def * = (id.?, createdAt, updatedAt, sequenceNumber, numIdsChanged, idsRetired) <> ((UriRenormalizationEvent.apply _).tupled, UriRenormalizationEvent.unapply _)
@@ -50,13 +50,13 @@ class UriRenormalizationTrackingRepoImpl @Inject() (
   override def deleteCache(model: UriRenormalizationEvent)(implicit session: RSession): Unit = {}
   override def invalidateCache(model: UriRenormalizationEvent)(implicit session: RSession): Unit = {}
 
-  def getCurrentSequenceNumber()(implicit session: RSession): SequenceNumber = {
+  def getCurrentSequenceNumber()(implicit session: RSession): SequenceNumber[ChangedURI] = {
     import scala.slick.jdbc.StaticQuery.interpolation
     val sql = sql"select max(sequence_number) as max from uri_renormalization_event"
-    sql.as[SequenceNumber].firstOption().getOrElse(SequenceNumber.ZERO)
+    sql.as[SequenceNumber[ChangedURI]].firstOption().getOrElse(SequenceNumber.ZERO)
   }
 
-  def addNew(sequenceNumber: SequenceNumber, numIdsChanged: Long, idsRetired: Seq[Id[NormalizedURI]])(implicit session: RWSession) : Unit = {
+  def addNew(sequenceNumber: SequenceNumber[ChangedURI], numIdsChanged: Long, idsRetired: Seq[Id[NormalizedURI]])(implicit session: RWSession) : Unit = {
     super.save(UriRenormalizationEvent(sequenceNumber=sequenceNumber, numIdsChanged=numIdsChanged, idsRetired=idsRetired))
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/controllers/search/URIGraphController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/search/URIGraphController.scala
@@ -75,11 +75,11 @@ class URIGraphController @Inject()(
     )
   }
 
-  private def mkIndexInfo(name: String, indexer: Indexer[_]): IndexInfo = {
+  private def mkIndexInfo(name: String, indexer: Indexer[_, _, _]): IndexInfo = {
     IndexInfo(
       name = name,
       numDocs = indexer.numDocs,
-      sequenceNumber = indexer.commitSequenceNumber,
+      sequenceNumber = indexer.commitSequenceNumber.value,
       committedAt = indexer.committedAt,
       indexSize = None
     )

--- a/kifi-backend/modules/search/app/com/keepit/search/article/ArticleIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/article/ArticleIndexer.scala
@@ -30,7 +30,7 @@ class ArticleIndexer(
     indexWriterConfig: IndexWriterConfig,
     articleStore: ArticleStore,
     airbrake: AirbrakeNotifier)
-  extends Indexer[NormalizedURI](indexDirectory, indexWriterConfig) {
+  extends Indexer[NormalizedURI, NormalizedURI, ArticleIndexer](indexDirectory, indexWriterConfig) {
 
   import ArticleIndexer.ArticleIndexable
 
@@ -38,7 +38,7 @@ class ArticleIndexer(
 
   override val commitBatchSize = 1000
 
-  override def onFailure(indexable: Indexable[NormalizedURI], e: Throwable) {
+  override def onFailure(indexable: Indexable[NormalizedURI, NormalizedURI], e: Throwable) {
     airbrake.notify(s"Error indexing article from normalized uri ${indexable.id}", e)
     super.onFailure(indexable, e)
   }
@@ -74,11 +74,11 @@ object ArticleIndexer extends Logging {
 
   class ArticleIndexable(
     override val id: Id[NormalizedURI],
-    override val sequenceNumber: SequenceNumber,
+    override val sequenceNumber: SequenceNumber[NormalizedURI],
     override val isDeleted: Boolean,
     val uri: IndexableUri,
     articleStore: ArticleStore
-  ) extends Indexable[NormalizedURI] {
+  ) extends Indexable[NormalizedURI, NormalizedURI] {
     implicit def toReader(text: String) = new StringReader(text)
 
     private def enrichedContent(article: Article): String = {

--- a/kifi-backend/modules/search/app/com/keepit/search/article/ArticleIndexerPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/article/ArticleIndexerPlugin.scala
@@ -14,16 +14,16 @@ import com.keepit.search.sharding.ShardedArticleIndexer
 import com.keepit.search.sharding.ShardedIndexerPlugin
 import com.keepit.search.sharding.ShardedIndexerPluginImpl
 
-trait ArticleIndexerPlugin extends ShardedIndexerPlugin[NormalizedURI, ArticleIndexer]
+trait ArticleIndexerPlugin extends ShardedIndexerPlugin[NormalizedURI, NormalizedURI, ArticleIndexer]
 
 class ArticleIndexerPluginImpl @Inject() (
   actor: ActorInstance[ArticleIndexerActor],
   indexer: ShardedArticleIndexer,
   serviceDiscovery: ServiceDiscovery,
   val scheduling: SchedulingProperties
-) extends ShardedIndexerPluginImpl[NormalizedURI, ArticleIndexer, ArticleIndexerActor](indexer, actor, serviceDiscovery) with ArticleIndexerPlugin
+) extends ShardedIndexerPluginImpl[NormalizedURI, NormalizedURI, ArticleIndexer, ArticleIndexerActor](indexer, actor, serviceDiscovery) with ArticleIndexerPlugin
 
 class ArticleIndexerActor @Inject() (
   airbrake: AirbrakeNotifier,
   indexer: ShardedArticleIndexer
-) extends IndexerActor[ArticleIndexer](airbrake, indexer)
+) extends IndexerActor[NormalizedURI, ArticleIndexer](airbrake, indexer)

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/URIGraphPlugin.scala
@@ -6,7 +6,7 @@ import com.keepit.common.db.Id
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.plugin.SchedulingProperties
 import com.keepit.common.zookeeper.ServiceDiscovery
-import com.keepit.model.NormalizedURI
+import com.keepit.model.{Bookmark, NormalizedURI}
 import com.keepit.search.index.IndexerActor
 import com.keepit.search.index.IndexerPlugin
 import com.keepit.search.index.IndexManager
@@ -16,16 +16,16 @@ import com.keepit.search.sharding.ShardedIndexerPlugin
 import com.keepit.search.sharding.ShardedIndexerPluginImpl
 import scala.concurrent.duration._
 
-trait URIGraphPlugin extends ShardedIndexerPlugin[NormalizedURI, URIGraphIndexer]
+trait URIGraphPlugin extends ShardedIndexerPlugin[NormalizedURI, Bookmark, URIGraphIndexer]
 
 class URIGraphPluginImpl @Inject() (
   actor: ActorInstance[URIGraphActor],
   indexer: ShardedURIGraphIndexer,
   serviceDiscovery: ServiceDiscovery,
   val scheduling: SchedulingProperties
-) extends ShardedIndexerPluginImpl[NormalizedURI, URIGraphIndexer, URIGraphActor](indexer, actor, serviceDiscovery) with URIGraphPlugin
+) extends ShardedIndexerPluginImpl[NormalizedURI, Bookmark, URIGraphIndexer, URIGraphActor](indexer, actor, serviceDiscovery) with URIGraphPlugin
 
 class URIGraphActor @Inject()(
   airbrake: AirbrakeNotifier,
   indexer: ShardedURIGraphIndexer
-) extends IndexerActor[URIGraphIndexer](airbrake, indexer)
+) extends IndexerActor[Bookmark, URIGraphIndexer](airbrake, indexer)

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/bookmark/BookmarkStore.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/bookmark/BookmarkStore.scala
@@ -32,11 +32,11 @@ class BookmarkStore(
     indexDirectory: IndexDirectory,
     indexWriterConfig: IndexWriterConfig,
     airbrake: AirbrakeNotifier)
-  extends Indexer[Bookmark](indexDirectory, indexWriterConfig) {
+  extends Indexer[Bookmark, Bookmark, BookmarkStore](indexDirectory, indexWriterConfig) {
 
   import BookmarkStoreFields._
 
-  override def onFailure(indexable: Indexable[Bookmark], e: Throwable): Unit = {
+  override def onFailure(indexable: Indexable[Bookmark, Bookmark], e: Throwable): Unit = {
     val msg = s"failed to build document for id=${indexable.id}: ${e.toString}"
     airbrake.notify(msg)
     super.onFailure(indexable, e)
@@ -104,10 +104,10 @@ class BookmarkStore(
 
   class BookmarkIndexable(
     override val id: Id[Bookmark],
-    override val sequenceNumber: SequenceNumber,
+    override val sequenceNumber: SequenceNumber[Bookmark],
     override val isDeleted: Boolean,
     val bookmark: Bookmark
-  ) extends Indexable[Bookmark] {
+  ) extends Indexable[Bookmark, Bookmark] {
 
     implicit def toReader(text: String) = new StringReader(text)
 

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/collection/CollectionGraphPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/collection/CollectionGraphPlugin.scala
@@ -6,7 +6,7 @@ import com.keepit.common.db.Id
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.plugin.SchedulingProperties
 import com.keepit.common.zookeeper.ServiceDiscovery
-import com.keepit.model.NormalizedURI
+import com.keepit.model.{Collection, NormalizedURI}
 import com.keepit.search.index.IndexerActor
 import com.keepit.search.index.IndexerPlugin
 import com.keepit.search.index.IndexManager
@@ -14,16 +14,16 @@ import com.keepit.search.sharding.ShardedCollectionIndexer
 import com.keepit.search.sharding.ShardedIndexerPlugin
 import com.keepit.search.sharding.ShardedIndexerPluginImpl
 
-trait CollectionGraphPlugin extends ShardedIndexerPlugin[NormalizedURI, CollectionIndexer]
+trait CollectionGraphPlugin extends ShardedIndexerPlugin[NormalizedURI, Collection, CollectionIndexer]
 
 class CollectionGraphPluginImpl @Inject()(
   actor: ActorInstance[CollectionGraphActor],
   indexer: ShardedCollectionIndexer,
   serviceDiscovery: ServiceDiscovery,
   val scheduling: SchedulingProperties
-) extends ShardedIndexerPluginImpl[NormalizedURI, CollectionIndexer, CollectionGraphActor](indexer, actor, serviceDiscovery) with CollectionGraphPlugin
+) extends ShardedIndexerPluginImpl[NormalizedURI, Collection, CollectionIndexer, CollectionGraphActor](indexer, actor, serviceDiscovery) with CollectionGraphPlugin
 
 class CollectionGraphActor @Inject()(
   airbrake: AirbrakeNotifier,
   indexer: ShardedCollectionIndexer
-) extends IndexerActor[CollectionIndexer](airbrake, indexer)
+) extends IndexerActor[Collection, CollectionIndexer](airbrake, indexer)

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/user/SearchFriendPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/user/SearchFriendPlugin.scala
@@ -9,17 +9,18 @@ import com.keepit.search.index.IndexerActor
 import com.keepit.search.index.IndexerPlugin
 import com.keepit.search.index.IndexerPluginImpl
 import com.keepit.search.index.IndexManager
+import com.keepit.model.SearchFriend
 
-trait SearchFriendGraphPlugin extends IndexerPlugin[SearchFriendIndexer]
+trait SearchFriendGraphPlugin extends IndexerPlugin[SearchFriend, SearchFriendIndexer]
 
 class SearchFriendGraphPluginImpl @Inject()(
   actor: ActorInstance[SearchFriendIndexerActor],
   indexer: SearchFriendIndexer,
   serviceDiscovery: ServiceDiscovery,
   val scheduling: SchedulingProperties
-) extends IndexerPluginImpl[SearchFriendIndexer, SearchFriendIndexerActor](indexer.asInstanceOf[IndexManager[SearchFriendIndexer]], actor, serviceDiscovery) with SearchFriendGraphPlugin
+) extends IndexerPluginImpl[SearchFriend, SearchFriendIndexer, SearchFriendIndexerActor](indexer, actor, serviceDiscovery) with SearchFriendGraphPlugin
 
 class SearchFriendIndexerActor @Inject()(
   airbrake: AirbrakeNotifier,
   indexer: SearchFriendIndexer
-) extends IndexerActor[SearchFriendIndexer](airbrake, indexer.asInstanceOf[IndexManager[SearchFriendIndexer]])
+) extends IndexerActor[SearchFriend, SearchFriendIndexer](airbrake, indexer)

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/user/UserGraphPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/user/UserGraphPlugin.scala
@@ -9,17 +9,18 @@ import com.keepit.search.index.IndexerActor
 import com.keepit.search.index.IndexerPlugin
 import com.keepit.search.index.IndexerPluginImpl
 import com.keepit.search.index.IndexManager
+import com.keepit.model.{UserConnection, NormalizedURI}
 
-trait UserGraphPlugin extends IndexerPlugin[UserGraphIndexer]
+trait UserGraphPlugin extends IndexerPlugin[UserConnection, UserGraphIndexer]
 
 class UserGraphPluginImpl @Inject()(
   actor: ActorInstance[UserGraphActor],
   indexer: UserGraphIndexer,
   serviceDiscovery: ServiceDiscovery,
   val scheduling: SchedulingProperties
-) extends IndexerPluginImpl[UserGraphIndexer, UserGraphActor](indexer.asInstanceOf[IndexManager[UserGraphIndexer]], actor, serviceDiscovery) with UserGraphPlugin
+) extends IndexerPluginImpl[UserConnection, UserGraphIndexer, UserGraphActor](indexer, actor, serviceDiscovery) with UserGraphPlugin
 
 class UserGraphActor @Inject()(
   airbrake: AirbrakeNotifier,
   indexer: UserGraphIndexer
-) extends IndexerActor[UserGraphIndexer](airbrake, indexer.asInstanceOf[IndexManager[UserGraphIndexer]])
+) extends IndexerActor[UserConnection, UserGraphIndexer](airbrake, indexer)

--- a/kifi-backend/modules/search/app/com/keepit/search/index/Indexable.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/Indexable.scala
@@ -77,10 +77,10 @@ object Indexable {
 }
 
 
-trait Indexable[T] extends Logging{
+trait Indexable[T, S] extends Logging{
   import Indexable._
 
-  val sequenceNumber: SequenceNumber
+  val sequenceNumber: SequenceNumber[S]
   val id: Id[T]
   val isDeleted: Boolean
 

--- a/kifi-backend/modules/search/app/com/keepit/search/message/MessageIndexerPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/message/MessageIndexerPlugin.scala
@@ -10,16 +10,16 @@ import com.keepit.search.index.IndexerPlugin
 import com.keepit.search.index.IndexerPluginImpl
 import com.keepit.search.index.IndexManager
 
-trait MessageIndexerPlugin extends IndexerPlugin[MessageIndexer]
+trait MessageIndexerPlugin extends IndexerPlugin[ThreadContent, MessageIndexer]
 
 class MessageIndexerPluginImpl @Inject() (
   actor: ActorInstance[MessageIndexerActor],
   indexer: MessageIndexer,
   serviceDiscovery: ServiceDiscovery,
   val scheduling: SchedulingProperties
-) extends IndexerPluginImpl[MessageIndexer, MessageIndexerActor](indexer.asInstanceOf[IndexManager[MessageIndexer]], actor, serviceDiscovery) with MessageIndexerPlugin
+) extends IndexerPluginImpl[ThreadContent, MessageIndexer, MessageIndexerActor](indexer, actor, serviceDiscovery) with MessageIndexerPlugin
 
 class MessageIndexerActor @Inject() (
   airbrake: AirbrakeNotifier,
   indexer: MessageIndexer
-) extends IndexerActor[MessageIndexer](airbrake, indexer.asInstanceOf[IndexManager[MessageIndexer]])
+) extends IndexerActor[ThreadContent, MessageIndexer](airbrake, indexer)

--- a/kifi-backend/modules/search/app/com/keepit/search/phrasedetector/PhraseIndexerPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/phrasedetector/PhraseIndexerPlugin.scala
@@ -9,18 +9,19 @@ import com.keepit.search.index.IndexerActor
 import com.keepit.search.index.IndexerPlugin
 import com.keepit.search.index.IndexerPluginImpl
 import com.keepit.search.index.IndexManager
+import com.keepit.model.Phrase
 
-trait PhraseIndexerPlugin extends IndexerPlugin[PhraseIndexer]
+trait PhraseIndexerPlugin extends IndexerPlugin[Phrase, PhraseIndexer]
 
 class PhraseIndexerPluginImpl @Inject() (
   actor: ActorInstance[PhraseIndexerActor],
   indexer: PhraseIndexer,
   serviceDiscovery: ServiceDiscovery,
   val scheduling: SchedulingProperties
-) extends IndexerPluginImpl[PhraseIndexer, PhraseIndexerActor](indexer.asInstanceOf[IndexManager[PhraseIndexer]], actor, serviceDiscovery) with PhraseIndexerPlugin
+) extends IndexerPluginImpl[Phrase, PhraseIndexer, PhraseIndexerActor](indexer, actor, serviceDiscovery) with PhraseIndexerPlugin
 
 class PhraseIndexerActor @Inject() (
   airbrake: AirbrakeNotifier,
   indexer: PhraseIndexer
-) extends IndexerActor[PhraseIndexer](airbrake, indexer.asInstanceOf[IndexManager[PhraseIndexer]])
+) extends IndexerActor[Phrase, PhraseIndexer](airbrake, indexer)
 

--- a/kifi-backend/modules/search/app/com/keepit/search/sharding/ShardedCollectionIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/sharding/ShardedCollectionIndexer.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
 class ShardedCollectionIndexer(
   override val indexShards: Map[Shard[NormalizedURI], CollectionIndexer],
   shoeboxClient : ShoeboxServiceClient
-) extends ShardedIndexer[NormalizedURI, CollectionIndexer] {
+) extends ShardedIndexer[NormalizedURI, Collection, CollectionIndexer] {
 
   private val fetchSize = 2000
 

--- a/kifi-backend/modules/search/app/com/keepit/search/sharding/ShardedIndexerPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/sharding/ShardedIndexerPlugin.scala
@@ -8,15 +8,15 @@ import com.keepit.search.index.IndexerActor
 import com.keepit.search.index.IndexerPlugin
 import com.keepit.search.index.IndexerPluginImpl
 
-trait ShardedIndexerPlugin[K, T <: Indexer[_]] extends IndexerPlugin[T] {
-  def getIndexerFor(id: Id[K]): T
+trait ShardedIndexerPlugin[K, S, I <: Indexer[_, S, I]] extends IndexerPlugin[S, I] {
+  def getIndexerFor(id: Id[K]): I
 }
 
-abstract class ShardedIndexerPluginImpl[K, T <: Indexer[_], A <: IndexerActor[T]](
-  indexer: ShardedIndexer[K, T],
+abstract class ShardedIndexerPluginImpl[K, S, I <: Indexer[_, S, I], A <: IndexerActor[S, I]](
+  indexer: ShardedIndexer[K, S, I],
   actor: ActorInstance[A],
   serviceDiscovery: ServiceDiscovery
-) extends IndexerPluginImpl[T, A](indexer, actor, serviceDiscovery) {
+) extends IndexerPluginImpl[S, I, A](indexer, actor, serviceDiscovery) {
 
-  def getIndexerFor(id: Id[K]): T = indexer.getIndexerFor(id)
+  def getIndexerFor(id: Id[K]): I = indexer.getIndexerFor(id)
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/sharding/ShardedURIGraphIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/sharding/ShardedURIGraphIndexer.scala
@@ -1,7 +1,7 @@
 package com.keepit.search.sharding
 
 import com.keepit.common.db.SequenceNumber
-import com.keepit.model.NormalizedURI
+import com.keepit.model.{Bookmark, NormalizedURI}
 import com.keepit.search.graph.bookmark.URIGraphIndexer
 import com.keepit.search.index.Indexer
 import com.keepit.shoebox.ShoeboxServiceClient
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 class ShardedURIGraphIndexer(
   override val indexShards: Map[Shard[NormalizedURI], URIGraphIndexer],
   shoeboxClient : ShoeboxServiceClient
-) extends ShardedIndexer[NormalizedURI, URIGraphIndexer] {
+) extends ShardedIndexer[NormalizedURI, Bookmark, URIGraphIndexer] {
 
   private val fetchSize = 2000
 

--- a/kifi-backend/modules/search/app/com/keepit/search/user/UserIndexerPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/user/UserIndexerPlugin.scala
@@ -9,18 +9,19 @@ import com.keepit.search.index.IndexerActor
 import com.keepit.search.index.IndexerPlugin
 import com.keepit.search.index.IndexerPluginImpl
 import com.keepit.search.index.IndexManager
+import com.keepit.model.User
 
-trait UserIndexerPlugin extends IndexerPlugin[UserIndexer]
+trait UserIndexerPlugin extends IndexerPlugin[User, UserIndexer]
 
 class UserIndexerPluginImpl @Inject() (
   actor: ActorInstance[UserIndexerActor],
   indexer: UserIndexer,
   serviceDiscovery: ServiceDiscovery,
   val scheduling: SchedulingProperties
-) extends IndexerPluginImpl[UserIndexer, UserIndexerActor](indexer.asInstanceOf[IndexManager[UserIndexer]], actor, serviceDiscovery) with UserIndexerPlugin
+) extends IndexerPluginImpl[User, UserIndexer, UserIndexerActor](indexer, actor, serviceDiscovery) with UserIndexerPlugin
 
 class UserIndexerActor @Inject() (
   airbrake: AirbrakeNotifier,
   indexer: UserIndexer
-) extends IndexerActor[UserIndexer](airbrake, indexer.asInstanceOf[IndexManager[UserIndexer]])
+) extends IndexerActor[User, UserIndexer](airbrake, indexer)
 

--- a/kifi-backend/modules/search/app/views/admin/luceneDocDump.scala.html
+++ b/kifi-backend/modules/search/app/views/admin/luceneDocDump.scala.html
@@ -1,4 +1,4 @@
-@(title: String, doc: org.apache.lucene.document.Document, indexer: com.keepit.search.index.Indexer[_])
+@(title: String, doc: org.apache.lucene.document.Document, indexer: com.keepit.search.index.Indexer[_, _, _])
 
 @printField(f: org.apache.lucene.index.IndexableField) = {
   <tr> <td>@f.name</td> <td>@indexer.getFieldDecoder(f.name).apply(f)</td> </tr>

--- a/kifi-backend/modules/search/test/com/keepit/search/TstIndexer.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/TstIndexer.scala
@@ -12,9 +12,9 @@ import java.io.StringReader
 
 class Tst(val id: Id[Tst], val text: String, val personalText: String)
 
-class TstIndexer(indexDirectory: IndexDirectory, indexWriterConfig: IndexWriterConfig) extends Indexer[Tst](indexDirectory, indexWriterConfig) {
-  def buildIndexable(id: Id[Tst]): Indexable[Tst] = throw new UnsupportedOperationException()
-  def buildIndexable(data: Tst): Indexable[Tst] = new TstIndexable(data.id, data.text, data.personalText, indexWriterConfig.getAnalyzer)
+class TstIndexer(indexDirectory: IndexDirectory, indexWriterConfig: IndexWriterConfig) extends Indexer[Tst, Tst, TstIndexer](indexDirectory, indexWriterConfig) {
+  def buildIndexable(id: Id[Tst]): Indexable[Tst, Tst] = throw new UnsupportedOperationException()
+  def buildIndexable(data: Tst): Indexable[Tst, Tst] = new TstIndexable(data.id, data.text, data.personalText, indexWriterConfig.getAnalyzer)
 
   def index(id: Id[Tst], text: String, personalText: String) = {
     indexDocuments(Some(buildIndexable(new Tst(id, text, personalText))).iterator, 100)
@@ -25,11 +25,11 @@ class TstIndexer(indexDirectory: IndexDirectory, indexWriterConfig: IndexWriterC
   def update(): Int = ???
 }
 
-class TstIndexable[Tst](override val id: Id[Tst], val text: String, val personalText: String, analyzer: Analyzer) extends Indexable[Tst] {
+class TstIndexable(override val id: Id[Tst], val text: String, val personalText: String, analyzer: Analyzer) extends Indexable[Tst, Tst] {
 
   implicit def toReader(text: String) = new StringReader(text)
 
-  override val sequenceNumber = SequenceNumber.ZERO
+  override val sequenceNumber = SequenceNumber.ZERO[Tst]
   override val isDeleted = false
 
   override def buildDocument = {

--- a/kifi-backend/modules/search/test/com/keepit/search/article/StandaloneArticleIndexer.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/article/StandaloneArticleIndexer.scala
@@ -23,7 +23,7 @@ class StandaloneArticleIndexer(
     var total = 0
     var done = false
     while (!done) {
-      val uris = Await.result(shoeboxClient.getIndexableUris(sequenceNumber.value, 1000), 180 seconds)
+      val uris = Await.result(shoeboxClient.getIndexableUris(sequenceNumber, 1000), 180 seconds)
       done = uris.isEmpty
       total += update("", uris, Shard(0,1))
     }
@@ -34,7 +34,7 @@ class StandaloneArticleIndexer(
     resetSequenceNumberIfReindex()
 
     doUpdate("ArticleIndex") {
-      val uris = Await.result(shoeboxClient.getIndexableUris(sequenceNumber.value, fsize), 180 seconds)
+      val uris = Await.result(shoeboxClient.getIndexableUris(sequenceNumber, fsize), 180 seconds)
       uris.iterator.map(buildIndexable)
     }
   }

--- a/kifi-backend/modules/search/test/com/keepit/search/message/MessageSearcherTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/message/MessageSearcherTest.scala
@@ -34,7 +34,7 @@ class MessageSearcherTest extends Specification with TestInjector{
     val thread1 = ThreadContent(
       mode =  FULL,
       id = Id[ThreadContent](44),
-      seq = SequenceNumber(1), 
+      seq = SequenceNumber(1),
       participants = Seq(user1, user2),
       updatedAt = currentDateTime,
       url = "http://theenterprise.com",
@@ -46,13 +46,13 @@ class MessageSearcherTest extends Specification with TestInjector{
         "Pretty good. Can't complain.",
         "Good to hear."
       ),
-      participantIds = Seq(Id[User](1), Id[User](2)) 
+      participantIds = Seq(Id[User](1), Id[User](2))
     )
 
     val thread2 = ThreadContent(
       mode =  FULL,
       id = Id[ThreadContent](9),
-      seq = SequenceNumber(2),  
+      seq = SequenceNumber(2),
       participants = Seq(user1, user2),
       updatedAt = currentDateTime,
       url = "http://thereliant.com",
@@ -63,13 +63,13 @@ class MessageSearcherTest extends Specification with TestInjector{
         "How's the vulcan doing? Good?",
         "No complaints. Living long and prosper."
       ),
-      participantIds = Seq(Id[User](1), Id[User](2)) 
+      participantIds = Seq(Id[User](1), Id[User](2))
     )
 
     val thread3 = ThreadContent(
       mode =  FULL,
       id = Id[ThreadContent](388),
-      seq = SequenceNumber(3),  
+      seq = SequenceNumber(3),
       participants = Seq(user1, user3),
       updatedAt = currentDateTime,
       url = "http://amazon.com",
@@ -80,7 +80,7 @@ class MessageSearcherTest extends Specification with TestInjector{
         "Good evening Ambassador. How are you feeling?",
         "You are so illogical."
       ),
-      participantIds = Seq(Id[User](1), Id[User](3)) 
+      participantIds = Seq(Id[User](1), Id[User](3))
     )
 
     val threadIndexable1 = new MessageContentIndexable(
@@ -102,7 +102,7 @@ class MessageSearcherTest extends Specification with TestInjector{
       airbrake = inject[AirbrakeNotifier]
     )
 
-    val threadIndexableIterable = Seq[Indexable[ThreadContent]](threadIndexable1,threadIndexable2,threadIndexable3)
+    val threadIndexableIterable = Seq[Indexable[ThreadContent, ThreadContent]](threadIndexable1,threadIndexable2,threadIndexable3)
 
     val indexer = new MessageIndexer(
       indexDirectory =  new VolatileIndexDirectoryImpl(),
@@ -120,7 +120,7 @@ class MessageSearcherTest extends Specification with TestInjector{
 
     "find and rank correctly" in {
       withInjector(){ implicit injector =>
-        val indexer = setupIndexer() 
+        val indexer = setupIndexer()
 
         val searcher = new MessageSearcher(indexer.getSearcher)
 
@@ -137,7 +137,7 @@ class MessageSearcherTest extends Specification with TestInjector{
             (result \ "digest").as[String]
           }
           digests(0)==="This is thread 1."
-          digests(1)==="This is thread 2."  
+          digests(1)==="This is thread 2."
         }
 
         parser.parse("spock").map{ parsedQuery =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -122,9 +122,9 @@ class ShoeboxController @Inject() (
     Ok("true")
   }
 
-  def getNormalizedURI(id: Long) = SafeAsyncAction {
+  def getNormalizedURI(id: Id[NormalizedURI]) = SafeAsyncAction {
     val uri = db.readOnly { implicit s =>
-      normUriRepo.get(Id[NormalizedURI](id))//using cache
+      normUriRepo.get(id)//using cache
     }
     Ok(Json.toJson(uri))
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
@@ -190,14 +190,14 @@ class UriIntegrityActor @Inject()(
       }
     }
 
-    toMerge.sortBy(_.seq).lastOption.map{ x => centralConfig.update(URIMigrationSeqNumKey, x.seq.value) }
+    toMerge.sortBy(_.seq).lastOption.map{ x => centralConfig.update(URIMigrationSeqNumKey, x.seq) }
     log.info(s"batch merge uris completed in database: ${toMerge.size} pairs of uris merged. zookeeper seqNum updated.")
     toMerge.size
   }
 
   private def getOverDueList(fetchSize: Int = -1) = {
-    val lowSeq = centralConfig(URIMigrationSeqNumKey) getOrElse 0L
-    db.readOnly{ implicit s => changedUriRepo.getChangesSince(SequenceNumber(lowSeq), fetchSize, state = ChangedURIStates.ACTIVE)}
+    val lowSeq = centralConfig(URIMigrationSeqNumKey) getOrElse SequenceNumber.ZERO
+    db.readOnly{ implicit s => changedUriRepo.getChangesSince(lowSeq, fetchSize, state = ChangedURIStates.ACTIVE)}
   }
 
   private def batchURLMigration(batchSize: Int) = {
@@ -218,13 +218,13 @@ class UriIntegrityActor @Inject()(
       }
     }
 
-    toMigrate.sortBy(_.seq).lastOption.map{ x => centralConfig.update(URLMigrationSeqNumKey, x.seq.value)}
+    toMigrate.sortBy(_.seq).lastOption.map{ x => centralConfig.update(URLMigrationSeqNumKey, x.seq)}
     log.info(s"${toMigrate.size} urls renormalized.")
   }
 
   private def getOverDueURLMigrations(fetchSize: Int = -1) = {
-    val lowSeq = centralConfig(URLMigrationSeqNumKey) getOrElse 0L
-    db.readOnly{ implicit s => renormRepo.getChangesSince(SequenceNumber(lowSeq), fetchSize, state = RenormalizedURLStates.ACTIVE)}
+    val lowSeq = centralConfig(URLMigrationSeqNumKey) getOrElse SequenceNumber.ZERO
+    db.readOnly{ implicit s => renormRepo.getChangesSince(lowSeq, fetchSize, state = RenormalizedURLStates.ACTIVE)}
   }
 
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/learning/topicmodel/TopicUpdater.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/learning/topicmodel/TopicUpdater.scala
@@ -80,7 +80,7 @@ class TopicUpdater @Inject() (
     val (uriSeq, bookmarkSeq) = db.readOnly { implicit s =>
       getAccessor(useActive).topicSeqInfoRepo.getSeqNums match {
         case Some((uriSeq, bookmarkSeq)) => (uriSeq, bookmarkSeq)
-        case None => (SequenceNumber.ZERO, SequenceNumber.ZERO)
+        case None => (SequenceNumber.ZERO[NormalizedURI], SequenceNumber.ZERO[Bookmark])
       }
     }
     val m = updateUriTopic(uriSeq, useActive)
@@ -108,8 +108,8 @@ class TopicUpdater @Inject() (
     log.info(s"successfully switched to model ${modelAccessor.getCurrentFlag}")
   }
 
-  private def updateUriTopic(seqNum: SequenceNumber, useActive: Boolean): Int = {
-    def getOverdueUris(seqNum: SequenceNumber): Seq[NormalizedURI] = {
+  private def updateUriTopic(seqNum: SequenceNumber[NormalizedURI], useActive: Boolean): Int = {
+    def getOverdueUris(seqNum: SequenceNumber[NormalizedURI]): Seq[NormalizedURI] = {
       db.readOnly { implicit s =>
         uriRepo.getChanged(seqNum, Set(NormalizedURIStates.SCRAPED), fetchSize)
       }
@@ -129,8 +129,8 @@ class TopicUpdater @Inject() (
     uris.size
   }
 
-  private def updateUserTopic(seqNum: SequenceNumber, useActive: Boolean): Int = {
-    def getOverdueUserUris(seqNum: SequenceNumber): Seq[Bookmark] = {
+  private def updateUserTopic(seqNum: SequenceNumber[Bookmark], useActive: Boolean): Int = {
+    def getOverdueUserUris(seqNum: SequenceNumber[Bookmark]): Seq[Bookmark] = {
       db.readOnly { implicit s =>
         bookmarkRepo.getBookmarksChanged(seqNum, fetchSize)
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/ChangedURIRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/ChangedURIRepo.scala
@@ -10,9 +10,9 @@ import com.keepit.common.db.State
 
 @ImplementedBy(classOf[ChangedURIRepoImpl])
 trait ChangedURIRepo extends Repo[ChangedURI] with SeqNumberFunction[ChangedURI]{
-  def getChangesSince(num: SequenceNumber, limit: Int, state: State[ChangedURI] = ChangedURIStates.APPLIED)(implicit session: RSession): Seq[ChangedURI]
-  def getChangesBetween(lowSeq: SequenceNumber, highSeq: SequenceNumber, state: State[ChangedURI] = ChangedURIStates.APPLIED)(implicit session: RSession): Seq[ChangedURI]   // (low, high]
-  def getHighestSeqNum()(implicit session: RSession): Option[SequenceNumber]
+  def getChangesSince(num: SequenceNumber[ChangedURI], limit: Int, state: State[ChangedURI] = ChangedURIStates.APPLIED)(implicit session: RSession): Seq[ChangedURI]
+  def getChangesBetween(lowSeq: SequenceNumber[ChangedURI], highSeq: SequenceNumber[ChangedURI], state: State[ChangedURI] = ChangedURIStates.APPLIED)(implicit session: RSession): Seq[ChangedURI]   // (low, high]
+  def getHighestSeqNum()(implicit session: RSession): Option[SequenceNumber[ChangedURI]]
   def page(pageNum: Int, pageSize: Int)(implicit session: RSession): Seq[ChangedURI]
   def countState(state: State[ChangedURI])(implicit session: RSession): Int
   def saveWithoutIncreSeqnum(model: ChangedURI)(implicit session: RWSession): ChangedURI     // useful when we track processed merge requests
@@ -26,7 +26,7 @@ class ChangedURIRepoImpl @Inject() (
 
   import db.Driver.simple._
 
-  private val sequence = db.getSequence("changed_uri_sequence")
+  private val sequence = db.getSequence[ChangedURI]("changed_uri_sequence")
 
   type RepoImpl = ChangedURITable
 
@@ -47,15 +47,15 @@ class ChangedURIRepoImpl @Inject() (
     super.save(newModel)
   }
 
-  def getChangesSince(num: SequenceNumber, limit: Int = -1, state: State[ChangedURI] = ChangedURIStates.APPLIED)(implicit session: RSession): Seq[ChangedURI] = {
+  def getChangesSince(num: SequenceNumber[ChangedURI], limit: Int = -1, state: State[ChangedURI] = ChangedURIStates.APPLIED)(implicit session: RSession): Seq[ChangedURI] = {
     super.getBySequenceNumber(num, limit).filter(_.state == state)
   }
 
-  def getChangesBetween(lowSeq: SequenceNumber, highSeq: SequenceNumber, state: State[ChangedURI] = ChangedURIStates.APPLIED)(implicit session: RSession): Seq[ChangedURI] = {
+  def getChangesBetween(lowSeq: SequenceNumber[ChangedURI], highSeq: SequenceNumber[ChangedURI], state: State[ChangedURI] = ChangedURIStates.APPLIED)(implicit session: RSession): Seq[ChangedURI] = {
     super.getBySequenceNumber(lowSeq, highSeq).filter(_.state == state)
   }
 
-  def getHighestSeqNum()(implicit session: RSession): Option[SequenceNumber] = {
+  def getHighestSeqNum()(implicit session: RSession): Option[SequenceNumber[ChangedURI]] = {
     Some(sequence.getLastGeneratedSeq())
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/CollectionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/CollectionRepo.scala
@@ -21,7 +21,7 @@ trait CollectionRepo extends Repo[Collection] with ExternalIdColumnFunction[Coll
   def getByUserAndName(userId: Id[User], name: String,
     excludeState: Option[State[Collection]] = Some(CollectionStates.INACTIVE))
     (implicit session: RSession): Option[Collection]
-  def getCollectionsChanged(num: SequenceNumber, limit: Int)(implicit session: RSession): Seq[Collection]
+  def getCollectionsChanged(num: SequenceNumber[Collection], limit: Int)(implicit session: RSession): Seq[Collection]
   def collectionChanged(modelId: Id[Collection], isActive: Boolean = false)(implicit session: RWSession)
 }
 
@@ -36,7 +36,7 @@ class CollectionRepoImpl @Inject() (
 
   import db.Driver.simple._
 
-  private val sequence = db.getSequence("collection_sequence")
+  private val sequence = db.getSequence[Collection]("collection_sequence")
 
   type RepoImpl = CollectionTable
 
@@ -99,7 +99,7 @@ class CollectionRepoImpl @Inject() (
     }
   }
 
-  def getCollectionsChanged(num: SequenceNumber, limit: Int)(implicit session: RSession): Seq[Collection] = super.getBySequenceNumber(num, limit)
+  def getCollectionsChanged(num: SequenceNumber[Collection], limit: Int)(implicit session: RSession): Seq[Collection] = super.getBySequenceNumber(num, limit)
 
 
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/PhraseRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/PhraseRepo.scala
@@ -14,7 +14,7 @@ trait PhraseRepo extends Repo[Phrase] with SeqNumberFunction[Phrase]{
   def get(phrase: String, lang: Lang, excludeState: Option[State[Phrase]] = Some(PhraseStates.INACTIVE))(implicit session: RSession): Option[Phrase]
   def insertAll(phrases: Seq[Phrase])(implicit session: RWSession): Option[Int]
   def allIterator(implicit session: RSession): CloseableIterator[Phrase]
-  def getPhrasesChanged(seq: SequenceNumber, fetchSize: Int)(implicit session: RSession): Seq[Phrase]
+  def getPhrasesChanged(seq: SequenceNumber[Phrase], fetchSize: Int)(implicit session: RSession): Seq[Phrase]
 }
 
 @Singleton
@@ -22,7 +22,7 @@ class PhraseRepoImpl @Inject() (val db: DataBaseComponent, val clock: Clock) ext
 
   import db.Driver.simple._
 
-  private val sequence = db.getSequence("phrase_sequence")
+  private val sequence = db.getSequence[Phrase]("phrase_sequence")
 
   type RepoImpl = PhraseTable
   class PhraseTable(tag: Tag) extends RepoTable[Phrase](db, tag, "phrase") with SeqNumberColumn[Phrase]{
@@ -50,5 +50,5 @@ class PhraseRepoImpl @Inject() (val db: DataBaseComponent, val clock: Clock) ext
     rows.map(t => t).iterator
   }
 
-  def getPhrasesChanged(seq: SequenceNumber, fetchSize: Int)(implicit session: RSession): Seq[Phrase] = super.getBySequenceNumber(seq, fetchSize)
+  def getPhrasesChanged(seq: SequenceNumber[Phrase], fetchSize: Int)(implicit session: RSession): Seq[Phrase] = super.getBySequenceNumber(seq, fetchSize)
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/RenormalizedURLRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/RenormalizedURLRepo.scala
@@ -9,8 +9,8 @@ import com.keepit.common.db.State
 
 @ImplementedBy(classOf[RenormalizedURLRepoImpl])
 trait RenormalizedURLRepo extends Repo[RenormalizedURL] with SeqNumberFunction[RenormalizedURL]{
-  def getChangesSince(num: SequenceNumber, limit: Int, state: State[RenormalizedURL] = RenormalizedURLStates.APPLIED)(implicit session: RSession): Seq[RenormalizedURL]
-  def getChangesBetween(lowSeq: SequenceNumber, highSeq: SequenceNumber, state: State[RenormalizedURL] = RenormalizedURLStates.APPLIED)(implicit session: RSession): Seq[RenormalizedURL]   // (low, high]
+  def getChangesSince(num: SequenceNumber[RenormalizedURL], limit: Int, state: State[RenormalizedURL] = RenormalizedURLStates.APPLIED)(implicit session: RSession): Seq[RenormalizedURL]
+  def getChangesBetween(lowSeq: SequenceNumber[RenormalizedURL], highSeq: SequenceNumber[RenormalizedURL], state: State[RenormalizedURL] = RenormalizedURLStates.APPLIED)(implicit session: RSession): Seq[RenormalizedURL]   // (low, high]
   def saveWithoutIncreSeqnum(model: RenormalizedURL)(implicit session: RWSession): RenormalizedURL     // useful when we track processed merge requests
   def pageView(pageNum: Int, pageSize: Int)(implicit session: RSession): Seq[RenormalizedURL]
   def activeCount()(implicit session: RSession): Int
@@ -24,7 +24,7 @@ class RenormalizedURLRepoImpl @Inject()(
 ) extends DbRepo[RenormalizedURL] with RenormalizedURLRepo with SeqNumberDbFunction[RenormalizedURL]{
   import db.Driver.simple._
 
-  private val sequence = db.getSequence("renormalized_url_sequence")
+  private val sequence = db.getSequence[RenormalizedURL]("renormalized_url_sequence")
 
   type RepoImpl = RenormalizedURLTable
 
@@ -46,11 +46,11 @@ class RenormalizedURLRepoImpl @Inject()(
   override def deleteCache(model: RenormalizedURL)(implicit session: RSession): Unit = {}
   override def invalidateCache(model: RenormalizedURL)(implicit session: RSession): Unit = {}
 
-  def getChangesSince(num: SequenceNumber, limit: Int = -1, state: State[RenormalizedURL])(implicit session: RSession): Seq[RenormalizedURL] = {
+  def getChangesSince(num: SequenceNumber[RenormalizedURL], limit: Int = -1, state: State[RenormalizedURL])(implicit session: RSession): Seq[RenormalizedURL] = {
     super.getBySequenceNumber(num, limit).filter(_.state == state)
   }
 
-  def getChangesBetween(lowSeq: SequenceNumber, highSeq: SequenceNumber, state: State[RenormalizedURL])(implicit session: RSession): Seq[RenormalizedURL] = {
+  def getChangesBetween(lowSeq: SequenceNumber[RenormalizedURL], highSeq: SequenceNumber[RenormalizedURL], state: State[RenormalizedURL])(implicit session: RSession): Seq[RenormalizedURL] = {
     super.getBySequenceNumber(lowSeq, highSeq).filter(_.state == state)
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/SearchFriendRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/SearchFriendRepo.scala
@@ -20,7 +20,7 @@ trait SearchFriendRepo extends Repo[SearchFriend] with SeqNumberFunction[SearchF
   def includeFriend(userId: Id[User], friendId: Id[User])(implicit session: RWSession): Boolean = {
     includeFriends(userId, Set(friendId)) > 0
   }
-  def getSearchFriendsChanged(seq: SequenceNumber, fetchSize: Int)(implicit session: RSession): Seq[SearchFriend]
+  def getSearchFriendsChanged(seq: SequenceNumber[SearchFriend], fetchSize: Int)(implicit session: RSession): Seq[SearchFriend]
 }
 
 @Singleton
@@ -34,7 +34,7 @@ class SearchFriendRepoImpl @Inject() (
   import DBSession._
   import db.Driver.simple._
 
-  private val sequence = db.getSequence("search_friend_sequence")
+  private val sequence = db.getSequence[SearchFriend]("search_friend_sequence")
 
   type RepoImpl = SearchFriendTable
   class SearchFriendTable(tag: Tag) extends RepoTable[SearchFriend](db, tag, "search_friend") with SeqNumberColumn[SearchFriend] {
@@ -114,5 +114,5 @@ class SearchFriendRepoImpl @Inject() (
     allConnections -- excludedConnections
   }
 
-  def getSearchFriendsChanged(seq: SequenceNumber, fetchSize: Int)(implicit session: RSession): Seq[SearchFriend] = super.getBySequenceNumber(seq, fetchSize)
+  def getSearchFriendsChanged(seq: SequenceNumber[SearchFriend], fetchSize: Int)(implicit session: RSession): Seq[SearchFriend] = super.getBySequenceNumber(seq, fetchSize)
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserConnectionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserConnectionRepo.scala
@@ -20,7 +20,7 @@ trait UserConnectionRepo extends Repo[UserConnection] with SeqNumberFunction[Use
   def unfriendConnections(userId: Id[User], users: Set[Id[User]])(implicit session: RWSession): Int
   def getConnectionCount(userId: Id[User])(implicit session: RSession): Int
   def deactivateAllConnections(userId: Id[User])(implicit session: RWSession): Unit
-  def getUserConnectionChanged(seq: SequenceNumber, fetchSize: Int)(implicit session: RSession): Seq[UserConnection]
+  def getUserConnectionChanged(seq: SequenceNumber[UserConnection], fetchSize: Int)(implicit session: RSession): Seq[UserConnection]
 }
 
 case class UnfriendedConnectionsKey(userId: Id[User]) extends Key[Set[Id[User]]] {
@@ -45,7 +45,7 @@ class UserConnectionRepoImpl @Inject() (
 
   import db.Driver.simple._
 
-  private val sequence = db.getSequence("user_connection_sequence")
+  private val sequence = db.getSequence[UserConnection]("user_connection_sequence")
 
   override def save(model: UserConnection)(implicit session: RWSession): UserConnection = {
     val seqNum = sequence.incrementAndGet()
@@ -170,5 +170,5 @@ class UserConnectionRepoImpl @Inject() (
     rows.insertAll(toInsert.map{connId => UserConnection(user1 = userId, user2 = connId, seq = sequence.incrementAndGet())}.toSeq: _*)
   }
 
-  def getUserConnectionChanged(seq: SequenceNumber, fetchSize: Int)(implicit session: RSession): Seq[UserConnection] = super.getBySequenceNumber(seq, fetchSize)
+  def getUserConnectionChanged(seq: SequenceNumber[UserConnection], fetchSize: Int)(implicit session: RSession): Seq[UserConnection] = super.getBySequenceNumber(seq, fetchSize)
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserRepo.scala
@@ -33,7 +33,7 @@ trait UserRepo extends Repo[User] with RepoWithDelete[User] with ExternalIdColum
   def getOpt(id: Id[User])(implicit session: RSession): Option[User]
   def getAllIds()(implicit session: RSession): Set[Id[User]] //Note: Need to revisit when we have >50k users.
   def getAllActiveIds()(implicit session: RSession):Seq[Id[User]]
-  def getUsersSince(seq: SequenceNumber, fetchSize: Int)(implicit session: RSession): Seq[User]
+  def getUsersSince(seq: SequenceNumber[User], fetchSize: Int)(implicit session: RSession): Seq[User]
 }
 
 @Singleton
@@ -51,7 +51,7 @@ class UserRepoImpl @Inject() (
   import DBSession._
   import db.Driver.simple._
 
-  private val sequence = db.getSequence("user_sequence")
+  private val sequence = db.getSequence[User]("user_sequence")
 
   private lazy val expRepo = expRepoProvider.get
 
@@ -197,5 +197,5 @@ class UserRepoImpl @Inject() (
     (for (f <- rows if f.state === UserStates.ACTIVE) yield f.id).list
   }
 
-  def getUsersSince(seq: SequenceNumber, fetchSize: Int)(implicit session: RSession): Seq[User] = super.getBySequenceNumber(seq, fetchSize)
+  def getUsersSince(seq: SequenceNumber[User], fetchSize: Int)(implicit session: RSession): Seq[User] = super.getBySequenceNumber(seq, fetchSize)
 }

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -464,7 +464,7 @@ GET     /admin/healthcheck/resetErrorCount     @com.keepit.controllers.admin.Adm
 GET     /internal/version                             @com.keepit.controllers.website.HomeController.version
 
 
-GET     /internal/shoebox/database/getNormalizedURI   @com.keepit.controllers.internal.ShoeboxController.getNormalizedURI(id: Long)
+GET     /internal/shoebox/database/getNormalizedURI   @com.keepit.controllers.internal.ShoeboxController.getNormalizedURI(id: Id[NormalizedURI])
 GET     /internal/shoebox/database/getNormalizedURIs  @com.keepit.controllers.internal.ShoeboxController.getNormalizedURIs(ids: String)
 POST    /internal/shoebox/database/getNormalizedURIByURL               @com.keepit.controllers.internal.ShoeboxController.getNormalizedURIByURL()
 POST    /internal/shoebox/database/getNormalizedUriByUrlOrPrenormalize @com.keepit.controllers.internal.ShoeboxController.getNormalizedUriByUrlOrPrenormalize()
@@ -479,29 +479,29 @@ GET     /internal/shoebox/database/getUserOpt                          @com.keep
 GET     /internal/shoebox/database/getUserExperiments                  @com.keepit.controllers.internal.ShoeboxController.getUserExperiments(id: Id[User])
 POST    /internal/shoebox/database/getExperimentsByUserIds            @com.keepit.controllers.internal.ShoeboxController.getExperimentsByUserIds()
 GET     /internal/shoebox/database/getExperimentGenerators             @com.keepit.controllers.internal.ShoeboxController.getExperimentGenerators()
-GET     /internal/shoebox/database/getNormalizedUriUpdates             @com.keepit.controllers.internal.ShoeboxDataPipeController.getNormalizedUriUpdates(lowSeq: SequenceNumber, highSeq: SequenceNumber)
+GET     /internal/shoebox/database/getNormalizedUriUpdates             @com.keepit.controllers.internal.ShoeboxDataPipeController.getNormalizedUriUpdates(lowSeq: SequenceNumber[ChangedURI], highSeq: SequenceNumber[ChangedURI])
 
 GET     /internal/shoebox/database/getConnectedUsers  @com.keepit.controllers.internal.ShoeboxController.getConnectedUsers(userId: Id[User])
 GET     /internal/shoebox/database/bookmark           @com.keepit.controllers.internal.ShoeboxController.getBookmarks(userId: Id[User])
-GET     /internal/shoebox/database/changedBookmark    @com.keepit.controllers.internal.ShoeboxDataPipeController.getBookmarksChanged(seqNum: Long, fetchSize: Int)
+GET     /internal/shoebox/database/changedBookmark    @com.keepit.controllers.internal.ShoeboxDataPipeController.getBookmarksChanged(seqNum: SequenceNumber[Bookmark], fetchSize: Int)
 GET     /internal/shoebox/database/bookmarkByUriUser  @com.keepit.controllers.internal.ShoeboxController.getBookmarkByUriAndUser(uriId: Id[NormalizedURI], userId: Id[User])
 GET     /internal/shoebox/database/getBookmarksByUriWithoutTitle @com.keepit.controllers.internal.ShoeboxController.getBookmarksByUriWithoutTitle(uriId: Id[NormalizedURI])
 GET     /internal/shoebox/database/getLatestBookmark  @com.keepit.controllers.internal.ShoeboxController.getLatestBookmark(uriId: Id[NormalizedURI])
 POST    /internal/shoebox/database/saveBookmark       @com.keepit.controllers.internal.ShoeboxController.saveBookmark
 POST    /internal/shoebox/database/sendMail           @com.keepit.controllers.internal.ShoeboxController.sendMail
 POST    /internal/shoebox/database/sendMailToUser     @com.keepit.controllers.internal.ShoeboxController.sendMailToUser
-GET     /internal/shoebox/database/getPhrasesChanged   @com.keepit.controllers.internal.ShoeboxDataPipeController.getPhrasesChanged(seqNum: Long, fetchSize: Int)
-GET     /internal/shoebox/database/changedCollections @com.keepit.controllers.internal.ShoeboxDataPipeController.getCollectionsChanged(seqNum: Long, fetchSize: Int)
+GET     /internal/shoebox/database/getPhrasesChanged   @com.keepit.controllers.internal.ShoeboxDataPipeController.getPhrasesChanged(seqNum: SequenceNumber[Phrase], fetchSize: Int)
+GET     /internal/shoebox/database/changedCollections @com.keepit.controllers.internal.ShoeboxDataPipeController.getCollectionsChanged(seqNum: SequenceNumber[Collection], fetchSize: Int)
 GET     /internal/shoebox/database/getBookmarksInCollection @com.keepit.controllers.internal.ShoeboxController.getBookmarksInCollection(collectionId: Id[Collection])
 GET     /internal/shoebox/database/getUriIdsInCollection @com.keepit.controllers.internal.ShoeboxController.getUriIdsInCollection(collectionId: Id[Collection])
 GET     /internal/shoebox/database/getCollectionsByUser @com.keepit.controllers.internal.ShoeboxController.getCollectionsByUser(userId: Id[User])
-GET     /internal/shoebox/database/getIndexable       @com.keepit.controllers.internal.ShoeboxDataPipeController.getIndexable(seqNum: Long, fetchSize: Int)
-GET     /internal/shoebox/database/getIndexableUris   @com.keepit.controllers.internal.ShoeboxDataPipeController.getIndexableUris(seqNum: Long, fetchSize: Int)
-GET     /internal/shoebox/database/getScrapedUris     @com.keepit.controllers.internal.ShoeboxDataPipeController.getScrapedUris(seqNum: Long, fetchSize: Int)
+GET     /internal/shoebox/database/getIndexable       @com.keepit.controllers.internal.ShoeboxDataPipeController.getIndexable(seqNum: SequenceNumber[NormalizedURI], fetchSize: Int)
+GET     /internal/shoebox/database/getIndexableUris   @com.keepit.controllers.internal.ShoeboxDataPipeController.getIndexableUris(seqNum: SequenceNumber[NormalizedURI], fetchSize: Int)
+GET     /internal/shoebox/database/getScrapedUris     @com.keepit.controllers.internal.ShoeboxDataPipeController.getScrapedUris(seqNum: SequenceNumber[NormalizedURI], fetchSize: Int)
 GET     /internal/shoebox/database/getHighestUriSeq   @com.keepit.controllers.internal.ShoeboxDataPipeController.getHighestUriSeq()
-GET     /internal/shoebox/database/getUserIndexable   @com.keepit.controllers.internal.ShoeboxDataPipeController.getUserIndexable(seqNum: Long, fetchSize: Int)
-GET     /internal/shoebox/database/getUserConnectionsChanged   @com.keepit.controllers.internal.ShoeboxDataPipeController.getUserConnectionsChanged(seqNum: Long, fetchSize: Int)
-GET     /internal/shoebox/database/getSearchFriendsChanged     @com.keepit.controllers.internal.ShoeboxDataPipeController.getSearchFriendsChanged(seqNum: Long, fetchSize: Int)
+GET     /internal/shoebox/database/getUserIndexable   @com.keepit.controllers.internal.ShoeboxDataPipeController.getUserIndexable(seqNum: SequenceNumber[User], fetchSize: Int)
+GET     /internal/shoebox/database/getUserConnectionsChanged   @com.keepit.controllers.internal.ShoeboxDataPipeController.getUserConnectionsChanged(seqNum: SequenceNumber[UserConnection], fetchSize: Int)
+GET     /internal/shoebox/database/getSearchFriendsChanged     @com.keepit.controllers.internal.ShoeboxDataPipeController.getSearchFriendsChanged(seqNum: SequenceNumber[SearchFriend], fetchSize: Int)
 
 POST    /internal/shoebox/database/createDeepLink      @com.keepit.controllers.ext.ExtDeepLinkController.createDeepLink()
 POST    /internal/shoebox/database/clickAttribution   @com.keepit.controllers.internal.ShoeboxController.clickAttribution()

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/shoebox/ShoeboxControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/shoebox/ShoeboxControllerTest.scala
@@ -24,6 +24,7 @@ import com.keepit.common.healthcheck.FakeAirbrakeModule
 import scala.concurrent.ExecutionContext.Implicits.global
 import com.keepit.abook.TestABookServiceClientModule
 import com.keepit.scraper.{TestScraperConfigModule, FakeScrapeSchedulerModule}
+import com.keepit.common.db.SequenceNumber
 
 class ShoeboxControllerTest extends Specification with ShoeboxApplicationInjector {
 
@@ -121,10 +122,10 @@ class ShoeboxControllerTest extends Specification with ShoeboxApplicationInjecto
     "return phrases changed from the database" in {
       running(new ShoeboxApplication(shoeboxControllerTestModules:_*)) {
         setupSomePhrases()
-        val route = com.keepit.controllers.internal.routes.ShoeboxDataPipeController.getPhrasesChanged(4, 2).toString
+        val route = com.keepit.controllers.internal.routes.ShoeboxDataPipeController.getPhrasesChanged(SequenceNumber(4) , 2).toString
         route === "/internal/shoebox/database/getPhrasesChanged?seqNum=4&fetchSize=2"
         val shoeboxController = inject[ShoeboxDataPipeController]
-        val result = shoeboxController.getPhrasesChanged(4 ,2)(FakeRequest())
+        val result = shoeboxController.getPhrasesChanged(SequenceNumber(4), 2)(FakeRequest())
         status(result) must equalTo(OK);
         contentType(result) must beSome("application/json");
         contentAsString(result) must contain("gaz parfait");

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
@@ -9,7 +9,7 @@ import com.keepit.test.ShoeboxTestInjector
 import com.google.inject.Injector
 import com.keepit.model._
 import com.keepit.common.db.slick.Database
-import com.keepit.common.db.Id
+import com.keepit.common.db.{SequenceNumber, Id}
 import com.keepit.scraper.FakeScrapeSchedulerModule
 import com.keepit.common.zookeeper.CentralConfig
 import com.keepit.common.healthcheck.FakeAirbrakeModule
@@ -85,7 +85,7 @@ class UriIntegrityPluginTest extends Specification with ShoeboxApplicationInject
         }
 
         val centralConfig = inject[CentralConfig]
-        centralConfig(URIMigrationSeqNumKey) === Some(1)
+        centralConfig(URIMigrationSeqNumKey) === Some(SequenceNumber[ChangedURI](1))
 
         // split
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/RenormalizedURLTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/RenormalizedURLTest.scala
@@ -24,14 +24,14 @@ class RenormalizedURLTest extends Specification with ShoeboxTestInjector{
         implicit def intToSeq(x : Int) = SequenceNumber(x)
 
         val records = db.readOnly{ implicit s =>
-          val records = repo.getChangesBetween(0, 5, state = RenormalizedURLStates.ACTIVE)
+          val records = repo.getChangesBetween(SequenceNumber(0), SequenceNumber(5), state = RenormalizedURLStates.ACTIVE)
           records.size === 5
           records
         }
 
         db.readWrite{ implicit s =>
           records.foreach{ r => repo.saveWithoutIncreSeqnum(r.withState(RenormalizedURLStates.APPLIED))}
-          repo.getChangesBetween(0, 5, state = RenormalizedURLStates.APPLIED).size === 5
+          repo.getChangesBetween(SequenceNumber(0), SequenceNumber(5), state = RenormalizedURLStates.APPLIED).size === 5
         }
 
       }

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/DbSequence.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/DbSequence.scala
@@ -18,11 +18,11 @@ CREATE SEQUENCE $sequenceName;
 
 */
 
-abstract class DbSequence(val name: String) {
+abstract class DbSequence[T](val name: String) {
   if (DbSequence.validSequenceName.findFirstIn(name).isEmpty)
     throw new IllegalArgumentException(s"Sequence name $name is invalid")
-  def incrementAndGet()(implicit session: RWSession): SequenceNumber
-  def getLastGeneratedSeq()(implicit session: RSession): SequenceNumber
+  def incrementAndGet()(implicit session: RWSession): SequenceNumber[T]
+  def getLastGeneratedSeq()(implicit session: RSession): SequenceNumber[T]
 }
 
 object DbSequence {

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DataBaseComponent.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DataBaseComponent.scala
@@ -17,7 +17,7 @@ trait DataBaseComponent {
   val masterDb: SlickDatabase
   val slaveDb: Option[SlickDatabase]
 
-  def getSequence(name: String): DbSequence
+  def getSequence[T](name: String): DbSequence[T]
 
   // MySQL and H2 have different preferences on casing the table and column names.
   // H2 specifically rather have them in upper case

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
@@ -157,9 +157,9 @@ trait DbRepo[M <: Model[M]] extends Repo[M] with FortyTwoGenericTypeMappers with
   }
 
   trait SeqNumberColumn[M <: ModelWithSeqNumber[M]] extends RepoTable[M] {
-    implicit val seqMapper = MappedColumnType.base[SequenceNumber, Long](_.value, SequenceNumber.apply)
+    implicit val seqMapper = MappedColumnType.base[SequenceNumber[M], Long](_.value, SequenceNumber[M].apply)
 
-    def seq = column[SequenceNumber]("seq", O.NotNull)
+    def seq[M] = column[SequenceNumber[M]]("seq", O.NotNull)
   }
 }
 
@@ -195,8 +195,8 @@ trait DbRepoWithDelete[M <: Model[M]] extends RepoWithDelete[M] { self:DbRepo[M]
 
 
 trait SeqNumberFunction[M <: ModelWithSeqNumber[M]]{ self: Repo[M] =>
-  def getBySequenceNumber(lowerBound: SequenceNumber, fetchSize: Int = -1)(implicit session: RSession): Seq[M]
-  def getBySequenceNumber(lowerBound: SequenceNumber, upperBound: SequenceNumber)(implicit session: RSession): Seq[M]
+  def getBySequenceNumber(lowerBound: SequenceNumber[M], fetchSize: Int = -1)(implicit session: RSession): Seq[M]
+  def getBySequenceNumber(lowerBound: SequenceNumber[M], upperBound: SequenceNumber[M])(implicit session: RSession): Seq[M]
 }
 
 trait SeqNumberDbFunction[M <: ModelWithSeqNumber[M]] extends SeqNumberFunction[M] { self: DbRepo[M] =>
@@ -205,12 +205,12 @@ trait SeqNumberDbFunction[M <: ModelWithSeqNumber[M]] extends SeqNumberFunction[
   protected def tableWithSeq(tag: Tag) = table(tag).asInstanceOf[SeqNumberColumn[M]]
   protected def rowsWithSeq = TableQuery(tableWithSeq)
 
-  def getBySequenceNumber(lowerBound: SequenceNumber, fetchSize: Int = -1)(implicit session: RSession): Seq[M] = {
+  def getBySequenceNumber(lowerBound: SequenceNumber[M], fetchSize: Int = -1)(implicit session: RSession): Seq[M] = {
     val q = (for(t <- rowsWithSeq if t.seq > lowerBound) yield t).sortBy(_.seq)
     if (fetchSize > 0) q.take(fetchSize).list else q.list
   }
 
-  def getBySequenceNumber(lowerBound: SequenceNumber, upperBound: SequenceNumber)(implicit session: RSession): Seq[M] = {
+  def getBySequenceNumber(lowerBound: SequenceNumber[M], upperBound: SequenceNumber[M])(implicit session: RSession): Seq[M] = {
     if (lowerBound > upperBound) throw new IllegalArgumentException(s"expecting upperBound > lowerBound, received: lowerBound = ${lowerBound}, upperBound = ${upperBound}")
     else if (lowerBound == upperBound) Seq()
     else (for(t <- rowsWithSeq if t.seq > lowerBound && t.seq <= upperBound) yield t).sortBy(_.seq).list

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
@@ -61,7 +61,7 @@ trait DbRepo[M <: Model[M]] extends Repo[M] with FortyTwoGenericTypeMappers with
   }
 
   def initTable() = {
-    rows // force `rows` lazy evaluation
+    rows // force `rows` lazy evaluationRe
   }
 
   def save(model: M)(implicit session: RWSession): M = try {
@@ -156,9 +156,7 @@ trait DbRepo[M <: Model[M]] extends Repo[M] with FortyTwoGenericTypeMappers with
   }
 
   trait SeqNumberColumn[M <: ModelWithSeqNumber[M]] extends RepoTable[M] {
-    implicit val seqMapper = MappedColumnType.base[SequenceNumber[M], Long](_.value, SequenceNumber[M].apply)
-
-    def seq[M] = column[SequenceNumber[M]]("seq", O.NotNull)
+    def seq = column[SequenceNumber[M]]("seq", O.NotNull)
   }
 }
 

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoTypeMappers.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoTypeMappers.scala
@@ -34,7 +34,7 @@ trait FortyTwoGenericTypeMappers { self: {val db: DataBaseComponent} =>
   implicit def nameMapper[M <: Model[M]] = MappedColumnType.base[Name[M], String](_.name, Name[M])
   implicit val dateTimeMapper = MappedColumnType.base[DateTime, Timestamp](d => new Timestamp(d.getMillis), t => new DateTime(t.getTime, zones.UTC))
 
-  implicit val sequenceNumberTypeMapper = MappedColumnType.base[SequenceNumber, Long](_.value, SequenceNumber.apply)
+  implicit def sequenceNumberTypeMapper[T] = MappedColumnType.base[SequenceNumber[T], Long](_.value, SequenceNumber.apply[T])
   implicit val abookOriginMapper = MappedColumnType.base[ABookOriginType, String](_.name, ABookOriginType.apply)
   implicit val normalizationMapper = MappedColumnType.base[Normalization, String](_.scheme, Normalization.apply)
   implicit val userToDomainKindMapper = MappedColumnType.base[UserToDomainKind, String](_.value, UserToDomainKind.apply)
@@ -135,7 +135,7 @@ trait FortyTwoGenericTypeMappers { self: {val db: DataBaseComponent} =>
   def getResultOptionFromMapper[T](implicit mapper: BaseColumnType[T]): GetResult[Option[T]] = GetResult[Option[T]](mapper.nextOption)
 
   implicit val getDateTimeResult = getResultFromMapper[DateTime]
-  implicit val getSequenceNumberResult = getResultFromMapper[SequenceNumber]
+  implicit def getSequenceNumberResult[T] = getResultFromMapper[SequenceNumber[T]]
   implicit def getIdResult[M <: Model[M]] = getResultFromMapper[Id[M]]
   implicit def getOptIdResult[M <: Model[M]] = getResultOptionFromMapper[Id[M]]
   implicit def getStateResult[M <: Model[M]] = getResultFromMapper[State[M]]

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoTypeMappers.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoTypeMappers.scala
@@ -34,7 +34,7 @@ trait FortyTwoGenericTypeMappers { self: {val db: DataBaseComponent} =>
   implicit def nameMapper[M <: Model[M]] = MappedColumnType.base[Name[M], String](_.name, Name[M])
   implicit val dateTimeMapper = MappedColumnType.base[DateTime, Timestamp](d => new Timestamp(d.getMillis), t => new DateTime(t.getTime, zones.UTC))
 
-  implicit def sequenceNumberTypeMapper[T] = MappedColumnType.base[SequenceNumber[T], Long](_.value, SequenceNumber.apply[T])
+  implicit def sequenceNumberTypeMapper[T] = MappedColumnType.base[SequenceNumber[T], Long](_.value, SequenceNumber[T](_))
   implicit val abookOriginMapper = MappedColumnType.base[ABookOriginType, String](_.name, ABookOriginType.apply)
   implicit val normalizationMapper = MappedColumnType.base[Normalization, String](_.scheme, Normalization.apply)
   implicit val userToDomainKindMapper = MappedColumnType.base[UserToDomainKind, String](_.value, UserToDomainKind.apply)

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/H2.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/H2.scala
@@ -26,20 +26,20 @@ class H2(val masterDb: SlickDatabase, val slaveDb: Option[SlickDatabase])
   tablesToInit foreach { case (tableName, ddl) => initTableNow(tableName, ddl) }
   val dialect = H2DatabaseDialect
 
-  def getSequence(name: String): DbSequence = new DbSequence(name) {
+  def getSequence[T](name: String): DbSequence[T] = new DbSequence[T](name) {
     initSequence(name)
-    def incrementAndGet()(implicit sess: RWSession): SequenceNumber = {
+    def incrementAndGet()(implicit sess: RWSession): SequenceNumber[T] = {
       val stmt = sess.conn.prepareStatement(s"""SELECT NEXTVAL('$name')""")
       val rs = stmt.executeQuery()
       rs.next()
-      SequenceNumber(rs.getLong(1))
+      SequenceNumber[T](rs.getLong(1))
     }
 
-    def getLastGeneratedSeq()(implicit session: RSession): SequenceNumber = {
+    def getLastGeneratedSeq()(implicit session: RSession): SequenceNumber[T] = {
       val stmt = session.conn.prepareStatement(s"""SELECT CURRVAL('$name')""")
       val rs = stmt.executeQuery()
       rs.next()
-      SequenceNumber(rs.getLong(1))
+      SequenceNumber[T](rs.getLong(1))
     }
   }
 

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/MySQL.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/MySQL.scala
@@ -12,18 +12,18 @@ class MySQL(val masterDb: SlickDatabase, val slaveDb: Option[SlickDatabase])
   val Driver = MySQLDriver
   val dialect = MySqlDatabaseDialect
 
-  def getSequence(name: String): DbSequence = new DbSequence(name) {
-    def incrementAndGet()(implicit sess: RWSession): SequenceNumber = {
+  def getSequence[T](name: String): DbSequence[T] = new DbSequence[T](name) {
+    def incrementAndGet()(implicit sess: RWSession): SequenceNumber[T] = {
       sess.getPreparedStatement(s"UPDATE $name SET id=LAST_INSERT_ID(id+1);").execute()
       val rs = sess.getPreparedStatement(s"SELECT LAST_INSERT_ID();").executeQuery()
       rs.next()
-      SequenceNumber(rs.getLong(1))
+      SequenceNumber[T](rs.getLong(1))
     }
 
-    def getLastGeneratedSeq()(implicit session: RSession): SequenceNumber = {
+    def getLastGeneratedSeq()(implicit session: RSession): SequenceNumber[T] = {
       val rs = session.getPreparedStatement(s"SELECT id from $name;").executeQuery()
       rs.next()
-      SequenceNumber(rs.getLong(1))
+      SequenceNumber[T](rs.getLong(1))
     }
   }
 }

--- a/kifi-backend/modules/sqldb/test/com/keepit/common/db/SlickTest.scala
+++ b/kifi-backend/modules/sqldb/test/com/keepit/common/db/SlickTest.scala
@@ -36,7 +36,7 @@ class SlickTest extends Specification with DbTestInjector {
         trait BarRepo extends Repo[Bar] {
           //here you may have model specific queries...
           def getByName(name: String)(implicit session: ROSession): Seq[Bar]
-          def getCurrentSeqNum()(implicit session: RSession): SequenceNumber
+          def getCurrentSeqNum()(implicit session: RSession): SequenceNumber[Bar]
         }
 
         //we can abstract out much of the standard repo and have it injected/mocked out
@@ -44,7 +44,7 @@ class SlickTest extends Specification with DbTestInjector {
                     import DBSession._
           import scala.slick.driver.JdbcDriver.simple._
 
-          private val sequence = db.getSequence("normalized_uri_sequence")
+          private val sequence = db.getSequence[Bar]("bar")
 
           override def save(bar: Bar)(implicit session: RWSession): Bar = {sequence.incrementAndGet(); super.save(bar)}
           def getCurrentSeqNum()(implicit session: RSession) = {sequence.getLastGeneratedSeq()}


### PR DESCRIPTION
1. SequenceNumber now takes a type parameter. It's no longer a value class because of type erasure conflicts. 
2. @eishay All models, repos and internal routes have been refactored to further enforce this typing: we no longer use Long and since proper bindings are now available, there is no excuse to ever again use Long in service calls instead of SequenceNumber[T](same was already true for Id, please let's avoid using Long for these as well). 
3. As a nice side-effect, typing SequenceNumbers leads to stricter typing of search indices: an index is now typed not only according to the identifier of a document but also by the type of the entities the document contains.
4. @ymatsuda @yingjieMiao I have also refined the typing in IndexerPlugin in order to avoid unsafe casting asInstanceOf[Indexer[...]]. I was able to remove these casts but the extra type parameter I adds some clutter. I'm going to try and improve on this using a type member instead, but this works.
5. @andrewconner Working on this, I found out that sqldb tests have probably been broken for a while (this is true on our Master branch today). So it looks like running kifi-backend's tests does not run them. What do you think?
