### PR TITLE
Minor fixes

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoPics.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoPics.tpl.html
@@ -1,3 +1,3 @@
-<div class="kf-keep-who-pics">
-  <a class="kf-keep-who-pic" title="You! You look great!" ng-attr-style="background-image: url({{getPicUrl(me)}})"></a><a kf-keep-who-pic keeper="keeper" ng-repeat="keeper in keepers | limitTo: 9"></a>
-</div>
+<span class="kf-keep-who-pics">
+  <a class="kf-keep-who-pic me" title="You! You look great!" ng-attr-style="background-image: url({{getPicUrl(me)}})"></a><a kf-keep-who-pic keeper="keeper" ng-repeat="keeper in keepers | limitTo: 9"></a>
+</span>

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepWho.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepWho.styl
@@ -1,5 +1,5 @@
 //keep-who styling specific to my-keeps pane
-#kf-my-keeps
+.kf-my-keeps
 
   .kf-keep-who-pic
   .kf-keep-who-others

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
@@ -1,7 +1,6 @@
 <div class="kf-main-keeps" antiscroll="{ autoHide: false }">
   <div smart-scroll scroll-distance="scrollDistance" scroll-disabled="isScrollDisabled()" scroll-next="scrollNext()">
-    <ol id="kf-search-results"></ol>
-    <ol id="kf-my-keeps">
+    <ol class="kf-my-keeps">
       <div kf-keep ng-repeat="keep in keeps" ng-click="onClickKeep(keep, $event)" post-repeat-directive></div>
     </ol>
     <div class="kf-keep-group-title-fixed"></div>


### PR DESCRIPTION
@martinraison Some minor fixes.

`div`s are block elements, which means they are on their own line. `span` works better here, because it won't wrap.

Adding `.me` to the user's icon.

Switching `kf-my-keeps` from an id to a class. Classes are a very tiny bit slower, but reusable.
