### PR TITLE
stop reporting socket disconnect reasons to heimdal via shoebox

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -286,9 +286,6 @@ function onSocketConnect() {
 
 function onSocketDisconnect(why) {
   log('[onSocketDisconnect]', why)();
-  if (api.mode.isDev() !== api.isPackaged()) {
-    ajax('POST', '/error/report', {message: 'socket disconnect (' + why + ')'});
-  }
 }
 
 function getLatestThreads() {


### PR DESCRIPTION
cc @eishay @stkem 

By the way, where can I see these errors (user events)?
I don’t see them in mixpanel and I don’t remember how to read from mongodb. Can’t find anything about it on our wiki. Does heimdal have a database? I can’t find it. Thanks.
