### PR TITLE
typeahead: +TTL based on S3 metadata

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/abook/typeahead/EContactABookTypeahead.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/typeahead/EContactABookTypeahead.scala
@@ -2,7 +2,7 @@ package com.keepit.abook.typeahead
 
 import com.google.inject.Inject
 import com.keepit.common.healthcheck.AirbrakeNotifier
-import com.keepit.typeahead.abook.{EContactTypeaheadKey, EContactTypeahead, EContactTypeaheadCache, EContactTypeaheadStore}
+import com.keepit.typeahead.abook._
 import com.keepit.model.{User, EContact}
 import com.keepit.common.logging.Logging
 import com.keepit.typeahead.{PrefixFilter, Typeahead}
@@ -16,58 +16,18 @@ import scala.concurrent.duration.Duration
 import scala.collection.mutable.ArrayBuffer
 import com.keepit.common.akka.SafeFuture
 import com.keepit.common.concurrent.ExecutionContext
+import com.keepit.typeahead.abook.EContactTypeaheadKey
+import scala.Some
 
+// ABook-local; direct db access
 class EContactABookTypeahead @Inject() (
   db:Database,
   override val airbrake:AirbrakeNotifier,
-  store:EContactTypeaheadStore,
+  cache: EContactTypeaheadCache,
+  store: EContactTypeaheadStore,
   abookInfoRepo: ABookInfoRepo,
-  econtactRepo: EContactRepo,
-  cache: EContactTypeaheadCache
-) extends Typeahead[EContact, EContact] with Logging {
-
-  override protected def extractName(info: EContact): String = {
-    val name = info.name.getOrElse("").trim
-    val pres = EmailParser.parse(EmailParser.email, info.email)
-    if (pres.successful) {
-      s"$name ${pres.get.local.toStrictString}"
-    } else {
-      airbrake.notify(s"[EContactTypeahead.extractName($info)] Failed to parse email ${info.email}")
-      val local = info.email.takeWhile(c => c != '@').trim // best effort
-      s"$name $local"
-    }
-  }
-
-  override protected def extractId(info: EContact): Id[EContact] = info.id.get
-
-  protected def asyncGetOrCreatePrefixFilter(userId: Id[User]): Future[PrefixFilter[EContact]] = {
-    cache.getOrElseFuture(EContactTypeaheadKey(userId)) {
-      store.get(userId) match {
-        case Some(filter) => Future.successful(filter)
-        case None =>
-          build(userId).map{ filter =>
-            store += (userId -> filter.data)
-            filter.data
-          }(ExecutionContext.fj)
-      }
-    }.map{ new PrefixFilter[EContact](_) }(ExecutionContext.fj)
-  }
-
-  def refresh(userId:Id[User]):Future[Unit] = {
-    build(userId) map { filter =>
-      store += (userId -> filter.data)
-      cache.set(EContactTypeaheadKey(userId), filter.data)
-      log.info(s"[refresh($userId)] cache updated; filter=$filter")
-    }
-  }
-
-  def refreshByIds(userIds:Seq[Id[User]]):Future[Unit] = {
-    val futures = new ArrayBuffer[Future[Unit]]
-    for (userId <- userIds) {
-      futures += refresh(userId)
-    }
-    Future.sequence(futures.toSeq) map { s => Unit }
-  }
+  econtactRepo: EContactRepo
+) extends EContactTypeaheadBase(airbrake, cache, store) {
 
   def refreshAll():Future[Unit] = {
     val infos = db.readOnly { implicit ro =>

--- a/kifi-backend/modules/common/app/com/keepit/typeahead/PrefixFilterStore.scala
+++ b/kifi-backend/modules/common/app/com/keepit/typeahead/PrefixFilterStore.scala
@@ -1,15 +1,14 @@
 package com.keepit.typeahead
 
 import com.keepit.common.db.Id
-import com.keepit.common.store.ObjectStore
-import com.keepit.common.store.S3Bucket
+import com.keepit.common.store._
 import com.keepit.common.logging.AccessLog
-import com.keepit.common.store.S3BlobStore
-import com.keepit.common.store.InMemoryObjectStore
 import com.amazonaws.services.s3.AmazonS3
 import java.nio.ByteBuffer
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.keepit.common.store.S3Bucket
 
-trait PrefixFilterStore[T] extends ObjectStore[Id[T], Array[Long]]
+trait PrefixFilterStore[T] extends ObjectStore[Id[T], Array[Long]] with MetadataAccess[Id[T], Array[Long]]
 
 class S3PrefixFilterStoreImpl[T](val bucketName: S3Bucket, val amazonS3Client: AmazonS3, val accessLog: AccessLog) extends S3BlobStore[Id[T], Array[Long]] with PrefixFilterStore[T] {
 

--- a/kifi-backend/modules/common/app/com/keepit/typeahead/abook/EContactTypeahead.scala
+++ b/kifi-backend/modules/common/app/com/keepit/typeahead/abook/EContactTypeahead.scala
@@ -16,19 +16,20 @@ import com.keepit.common.akka.SafeFuture
 import com.keepit.common.concurrent.ExecutionContext
 import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 import com.keepit.common.healthcheck.AirbrakeNotifier
+import play.api.Play
+import org.joda.time.{Minutes, Seconds}
+import scala.collection.mutable.ArrayBuffer
 
-class EContactTypeahead @Inject() (
+abstract class EContactTypeaheadBase(
   override val airbrake:AirbrakeNotifier,
-  store: EContactTypeaheadStore,
   cache: EContactTypeaheadCache,
-  econtactCache: EContactCache,
-  abookClient:ABookServiceClient
+  store: EContactTypeaheadStore
 )extends Typeahead[EContact, EContact] with Logging {
 
   val MYSQL_MAX_ROWS = 50000000
 
-  override protected def extractName(info: EContact):String = { // todo(ray): revisit
-    val name = info.name.getOrElse("").trim
+  override protected def extractName(info: EContact):String = {
+  val name = info.name.getOrElse("").trim
     val pres = EmailParser.parse(EmailParser.email, info.email)
     if (pres.successful) {
       s"$name ${pres.get.local.toStrictString}"
@@ -41,17 +42,68 @@ class EContactTypeahead @Inject() (
 
   override protected def extractId(info: EContact):Id[EContact] = info.id.get
 
-  override protected def asyncGetAllInfosForUser(id: Id[User]):Future[Seq[EContact]] = abookClient.getEContacts(id, MYSQL_MAX_ROWS) // MySQL limit
-
   override protected def getAllInfosForUser(id: Id[User]):Seq[EContact] = {
-    Await.result(asyncGetAllInfosForUser(id), Duration.Inf) // todo(ray):revisit
+    Await.result(asyncGetAllInfosForUser(id), Duration.Inf)
   }
+
+  override protected def getInfos(ids: Seq[Id[EContact]]):Seq[EContact] = {
+    Await.result(asyncGetInfos(ids), Duration.Inf)
+  }
+
+  protected def rebuild(userId:Id[User]):Future[Array[Long]] = {
+    build(userId).map { filter =>
+      cache.set(EContactTypeaheadKey(userId), filter.data)
+      store += (userId -> filter.data)
+      log.info(s"[rebuild($userId)] cache/store updated; filter=$filter")
+      filter.data
+    }(ExecutionContext.fj)
+  }
+
+  def refresh(userId:Id[User]):Future[Unit] = rebuild(userId).map{ _ => }(ExecutionContext.fj) // todo(ray):merge with rebuild
+
+  def refreshByIds(userIds:Seq[Id[User]]):Future[Unit] = {
+    implicit val fj = ExecutionContext.fj
+    val futures = new ArrayBuffer[Future[Unit]]
+    for (userId <- userIds) {
+      futures += refresh(userId)
+    }
+    Future.sequence(futures.toSeq).map{ _ => }
+  }
+
+  import com.keepit.common.time._
+  protected def asyncGetOrCreatePrefixFilter(userId: Id[User]): Future[PrefixFilter[EContact]] = {
+    cache.getOrElseFuture(EContactTypeaheadKey(userId)) {
+      val res = store.getWithMetadata(userId)
+      res match {
+        case Some((filter, meta)) =>
+          if (meta.exists(m => m.lastModified.plusMinutes(15).isBefore(currentDateTime))) {
+            log.info(s"[asyncGetOrCreatePrefixFilter($userId)] filter EXPIRED (lastModified=${meta.get.lastModified}); (curr=${currentDateTime}); (delta=${Minutes.minutesBetween(meta.get.lastModified, currentDateTime)} minutes) - rebuild")
+            rebuild(userId) // async
+          }
+          Future.successful(filter) // return curr one
+        case None => rebuild(userId)
+      }
+    }.map{ new PrefixFilter[EContact](_) }(ExecutionContext.fj)
+  }
+
+}
+
+// "Remote"; uses abookServiceClient
+class EContactTypeahead @Inject() (
+  override val airbrake:AirbrakeNotifier,
+  cache: EContactTypeaheadCache,
+  store: EContactTypeaheadStore,
+  econtactCache: EContactCache,
+  abookClient:ABookServiceClient
+)extends EContactTypeaheadBase(airbrake, cache, store) {
+
+  override protected def asyncGetAllInfosForUser(id: Id[User]):Future[Seq[EContact]] = abookClient.getEContacts(id, MYSQL_MAX_ROWS) // MySQL limit
 
   override protected def asyncGetInfos(ids:Seq[Id[EContact]]):Future[Seq[EContact]] = {
     implicit val fj = ExecutionContext.fj
     if (ids.isEmpty) Future.successful(Seq.empty[EContact])
     else {
-      val s3F = econtactCache.bulkGetOrElseFuture(ids.map(EContactKey(_)).toSet) { keys =>
+      val cacheF = econtactCache.bulkGetOrElseFuture(ids.map(EContactKey(_)).toSet) { keys =>
         val missing = keys.map(_.id)
         log.info(s"[asyncGetInfos(${ids.length};${ids.take(10).mkString(",")})-S3] missing(len=${missing.size}):${missing.take(10).mkString(",")}")
         val res = abookClient.getEContactsByIds(missing.toSeq).map { res =>
@@ -59,7 +111,7 @@ class EContactTypeahead @Inject() (
         }
         res
        }
-      val localF = s3F map { res =>
+      val localF = cacheF map { res =>
         val v = res.valuesIterator.toVector
         log.info(s"[asyncGetInfos(${ids.length};${ids.take(10).mkString(",")})-S3] res=$v")
         v
@@ -72,25 +124,6 @@ class EContactTypeahead @Inject() (
     }
   }
 
-  override protected def getInfos(ids: Seq[Id[EContact]]):Seq[EContact] = {
-    Await.result(asyncGetInfos(ids), Duration.Inf) // todo(ray):revisit
-  }
-
-  protected def asyncGetOrCreatePrefixFilter(userId: Id[User]): Future[PrefixFilter[EContact]] = {
-    cache.getOrElseFuture(EContactTypeaheadKey(userId)) {
-      store.get(userId) match {
-        case Some(filter) => Future.successful(filter)
-        case None =>
-          build(userId).map{ filter =>
-            store += (userId -> filter.data)
-            filter.data
-          }(ExecutionContext.fj)
-      }
-    }.map{ new PrefixFilter[EContact](_) }(ExecutionContext.fj)
-  }
-
-  def refresh(userId: Id[User]): Future[Unit] = abookClient.refreshPrefixFilter(userId)
-  def refreshByIds(ids: Seq[Id[User]]): Future[Unit] = abookClient.refreshPrefixFiltersByIds(ids)
   def refreshAll(): Future[Unit] = abookClient.refreshAllFilters()
 }
 


### PR DESCRIPTION
- wired-in S3 MetadataAccess
- when TTL (based on lastModified) is up; return the current filter and rebuild filter concurrently, which then updates cache & store
- factor out EContactTypeaheadBase to reduce dup code

cc: @ymatsuda @eishay 
