### PR TITLE
Scrape discussed pages and deprecate SCRAPE_WANTED

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
@@ -115,19 +115,17 @@ object NormalizedURIStates extends States[NormalizedURI] {
   val SCRAPED	= State[NormalizedURI]("scraped")
   val SCRAPE_FAILED = State[NormalizedURI]("scrape_failed")
   val UNSCRAPABLE = State[NormalizedURI]("unscrapable")
-  val SCRAPE_WANTED = State[NormalizedURI]("scrape_wanted")
   val REDIRECTED = State[NormalizedURI]("redirected")
 
   type Transitions = Map[State[NormalizedURI], Set[State[NormalizedURI]]]
 
   val ALL_TRANSITIONS: Transitions = Map(
-      (ACTIVE -> Set(SCRAPE_WANTED, REDIRECTED)),
-      (SCRAPE_WANTED -> Set(SCRAPED, SCRAPE_FAILED, UNSCRAPABLE, INACTIVE, REDIRECTED)),
-      (SCRAPED -> Set(SCRAPE_WANTED, INACTIVE, REDIRECTED)),
-      (SCRAPE_FAILED -> Set(SCRAPE_WANTED, INACTIVE, REDIRECTED)),
-      (UNSCRAPABLE -> Set(SCRAPE_WANTED, INACTIVE, REDIRECTED)),
-      (INACTIVE -> Set(SCRAPE_WANTED, ACTIVE, INACTIVE, REDIRECTED)),
-      (REDIRECTED -> Set(SCRAPE_WANTED, ACTIVE, INACTIVE, REDIRECTED)))
+      (ACTIVE -> Set(REDIRECTED)),
+      (SCRAPED -> Set(INACTIVE, REDIRECTED)),
+      (SCRAPE_FAILED -> Set(INACTIVE, REDIRECTED)),
+      (UNSCRAPABLE -> Set(INACTIVE, REDIRECTED)),
+      (INACTIVE -> Set(ACTIVE, INACTIVE, REDIRECTED)),
+      (REDIRECTED -> Set(ACTIVE, INACTIVE, REDIRECTED)))
 
   val ADMIN_TRANSITIONS: Transitions = Map(
       (ACTIVE -> Set.empty),
@@ -136,7 +134,7 @@ object NormalizedURIStates extends States[NormalizedURI] {
       (UNSCRAPABLE -> Set(ACTIVE)),
       (INACTIVE -> Set.empty))
 
-  val DO_NOT_SCRAPE = Set(ACTIVE, INACTIVE, UNSCRAPABLE, REDIRECTED)
+  val DO_NOT_SCRAPE = Set(INACTIVE, UNSCRAPABLE, REDIRECTED)
 
   def transitionByAdmin[T](transition: (State[NormalizedURI], Set[State[NormalizedURI]]))(f:State[NormalizedURI]=>T) = {
     f(validate(transition, ADMIN_TRANSITIONS))

--- a/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
@@ -58,6 +58,10 @@ object NormalizedURI {
 
   val TitleMaxLen = 2040
 
+  val handleDeprecatedScrapeWantedState: State[NormalizedURI] => State[NormalizedURI] = {
+    case State("scrape_wanted") => NormalizedURIStates.ACTIVE
+    case state => state
+  }
   implicit def format = (
     (__ \ 'id).formatNullable(Id.format[NormalizedURI]) and
     (__ \ 'createdAt).format(DateTimeJsonFormat) and
@@ -66,7 +70,7 @@ object NormalizedURI {
     (__ \ 'title).formatNullable[String] and
     (__ \ 'url).format[String] and
     (__ \ 'urlHash).format[String].inmap(UrlHash.apply, unlift(UrlHash.unapply)) and
-    (__ \ 'state).format(State.format[NormalizedURI]) and
+    (__ \ 'state).format(State.format[NormalizedURI]).inmap(handleDeprecatedScrapeWantedState, identity[State[NormalizedURI]]) and
     (__ \ 'seq).format(SequenceNumber.format[NormalizedURI]) and
     (__ \ 'screenshotUpdatedAt).formatNullable[DateTime] and
     (__ \ 'restriction).formatNullable[Restriction] and

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -53,7 +53,7 @@ trait ShoeboxServiceClient extends ServiceClient {
   def getNormalizedURIs(uriIds: Seq[Id[NormalizedURI]]): Future[Seq[NormalizedURI]]
   def getNormalizedURIByURL(url: String): Future[Option[NormalizedURI]]
   def getNormalizedUriByUrlOrPrenormalize(url: String): Future[Either[NormalizedURI, String]]
-  def internNormalizedURI(urls: JsObject): Future[NormalizedURI]
+  def internNormalizedURI(url: String, scrapeWanted: Boolean = false): Future[NormalizedURI]
   def sendMail(email: ElectronicMail): Future[Boolean]
   def sendMailToUser(userId: Id[User], email: ElectronicMail): Future[Boolean]
   def persistServerSearchEvent(metaData: JsObject): Unit
@@ -369,8 +369,9 @@ class ShoeboxServiceClientImpl @Inject() (
       }
     }
 
-  def internNormalizedURI(urls: JsObject): Future[NormalizedURI] = {
-    call(Shoebox.internal.internNormalizedURI, urls).map(r => Json.fromJson[NormalizedURI](r.json).get)
+  def internNormalizedURI(url: String, scrapeWanted: Boolean): Future[NormalizedURI] = {
+    val payload = Json.obj("url" -> url, "scrapeWanted" -> scrapeWanted)
+    call(Shoebox.internal.internNormalizedURI, payload).map(r => Json.fromJson[NormalizedURI](r.json).get)
   }
 
   def persistServerSearchEvent(metaData: JsObject): Unit ={

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -426,7 +426,7 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
   }
 
   def getScrapedUris(seqNum: SequenceNumber[NormalizedURI], fetchSize: Int = -1) : Future[Seq[IndexableUri]] = {
-    val scrapedStates = Set(NormalizedURIStates.SCRAPED, NormalizedURIStates.SCRAPE_WANTED, NormalizedURIStates.SCRAPE_FAILED, NormalizedURIStates.UNSCRAPABLE)
+    val scrapedStates = Set(NormalizedURIStates.SCRAPED, NormalizedURIStates.SCRAPE_FAILED, NormalizedURIStates.UNSCRAPABLE)
     val uris = allNormalizedURIs.values.filter(x => x.seq > seqNum && scrapedStates.contains(x.state)).toSeq.sortBy(_.seq)
     val fewerUris = (if (fetchSize >= 0) uris.take(fetchSize) else uris)
     Future.successful(fewerUris map { u => IndexableUri(u) })

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -296,8 +296,7 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
   def getNormalizedUriByUrlOrPrenormalize(url: String): Future[Either[NormalizedURI, String]] = ???
 
 
-  def internNormalizedURI(urls: JsObject): Future[NormalizedURI] = {
-    val url = (urls \ "url").as[String]
+  def internNormalizedURI(url: String, scrapeWanted: Boolean): Future[NormalizedURI] = {
     val uri = allNormalizedURIs.values.find(_.url == url).getOrElse {
       NormalizedURI(
         id = Some(Id[NormalizedURI](url.hashCode)),
@@ -306,7 +305,6 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
         screenshotUpdatedAt=None
       )
     }
-
     Future.successful(uri)
   }
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -366,7 +366,7 @@ class MessagingCommander @Inject() (
     val userParticipants = (from +: userRecipients).distinct
     val urlOpt = (urls \ "url").asOpt[String]
     val tStart = currentDateTime
-    val nUriOpt = urlOpt.map { url: String => Await.result(shoebox.internNormalizedURI(urls), 10 seconds)} // todo: Remove Await
+    val nUriOpt = urlOpt.map { url: String => Await.result(shoebox.internNormalizedURI(url, scrapeWanted = true), 10 seconds)} // todo: Remove Await
     Statsd.timing(s"messaging.internNormalizedURI", currentDateTime.getMillis - tStart.getMillis)
     val uriIdOpt = nUriOpt.flatMap(_.id)
     val (thread, isNew) = db.readWrite{ implicit session =>
@@ -502,7 +502,7 @@ class MessagingCommander @Inject() (
     urlOpt.foreach { url =>
       (nUriOpt match {
         case Some(n) => Promise.successful(n).future
-        case None => shoebox.internNormalizedURI(Json.obj("url" -> url)) //Note, this also needs to include canonical/og when we have detached threads
+        case None => shoebox.internNormalizedURI(url, scrapeWanted = true) //Note, this also needs to include canonical/og when we have detached threads
       }) foreach { nUri =>
         db.readWrite { implicit session =>
           messageRepo.updateUriId(message, nUri.id.get)

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/AsyncScraper.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/AsyncScraper.scala
@@ -237,7 +237,6 @@ class AsyncScraper @Inject() (
       // check if document is not changed or does not need to be reindexed
       if (latestUri.title == Option(article.title) && // title change should always invoke indexing
         latestUri.restriction == updatedUri.restriction && // restriction change always invoke indexing
-        latestUri.state != NormalizedURIStates.SCRAPE_WANTED &&
         latestUri.state != NormalizedURIStates.SCRAPE_FAILED &&
         signature.similarTo(Signature(info.signature)) >= (1.0d - config.changeThreshold * (config.intervalConfig.minInterval / info.interval))
       ) {

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/SyncScraper.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/SyncScraper.scala
@@ -62,7 +62,6 @@ class SyncScraper @Inject() (
         // check if document is not changed or does not need to be reindexed
         if (latestUri.title == Option(article.title) && // title change should always invoke indexing
           latestUri.restriction == updatedUri.restriction && // restriction change always invoke indexing
-          latestUri.state != NormalizedURIStates.SCRAPE_WANTED &&
           latestUri.state != NormalizedURIStates.SCRAPE_FAILED &&
           signature.similarTo(Signature(info.signature)) >= (1.0d - config.changeThreshold * (config.intervalConfig.minInterval / info.interval))
         ) {

--- a/kifi-backend/modules/search/app/com/keepit/search/article/ArticleIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/article/ArticleIndexer.scala
@@ -69,7 +69,7 @@ class ArticleIndexer(
 }
 
 object ArticleIndexer extends Logging {
-  private[this] val toBeDeletedStates = Set[State[NormalizedURI]](ACTIVE, INACTIVE, SCRAPE_WANTED, UNSCRAPABLE, REDIRECTED)
+  private[this] val toBeDeletedStates = Set[State[NormalizedURI]](ACTIVE, INACTIVE, UNSCRAPABLE, REDIRECTED)
   def shouldDelete(uri: IndexableUri): Boolean = toBeDeletedStates.contains(uri.state)
 
   class ArticleIndexable(

--- a/kifi-backend/modules/search/test/com/keepit/search/article/ArticleIndexerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/article/ArticleIndexerTest.scala
@@ -263,7 +263,7 @@ class ArticleIndexerTest extends Specification with ApplicationInjector {
       doc.getFields.forall{ f => indexer.getFieldDecoder(f.name).apply(f).length > 0 } === true
     })
 
-    "delete documents with inactive, active, unscrapable, scrape_wanted or scrape_later state" in running(new DeprecatedEmptyApplication().withShoeboxServiceModule)(new IndexerScope {
+    "delete documents with inactive, active, unscrapable, or scrape_later state" in running(new DeprecatedEmptyApplication().withShoeboxServiceModule)(new IndexerScope {
       indexer.update()
       indexer.numDocs === 3
 
@@ -292,16 +292,6 @@ class ArticleIndexerTest extends Specification with ApplicationInjector {
       indexer.search("content1").size === 1
       indexer.search("content2").size === 1
       indexer.search("content3").size === 0
-
-      uri1 = fakeShoeboxServiceClient.saveURIs(uri1.withState(SCRAPE_WANTED)).head
-      uri2 = fakeShoeboxServiceClient.saveURIs(uri2.withState(SCRAPED)).head
-      uri3 = fakeShoeboxServiceClient.saveURIs(uri3.withState(SCRAPED)).head
-
-      indexer.update()
-      indexer.numDocs === 2
-      indexer.search("content1").size === 0
-      indexer.search("content2").size === 1
-      indexer.search("content3").size === 1
     })
 
     "retrieve article records from index" in running(new DeprecatedEmptyApplication().withShoeboxServiceModule)(new IndexerScope {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -357,7 +357,7 @@ class ShoeboxController @Inject() (
     val uri = db.readWrite(attempts = 2) { implicit s =>  //using cache
       normUriRepo.internByUri(url, NormalizationCandidate(o): _*)
     }
-    val scrapeWanted = (o \ "scrapedWanted").asOpt[Boolean] getOrElse false
+    val scrapeWanted = (o \ "scrapeWanted").asOpt[Boolean] getOrElse false
     if (scrapeWanted) SafeFuture { db.readWrite { implicit session => scrapeScheduler.scheduleScrape(uri) }}
     Ok(Json.toJson(uri))
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
@@ -38,7 +38,7 @@ class ShoeboxDataPipeController @Inject() (
   }
 
   def getScrapedUris(seqNum: SequenceNumber[NormalizedURI], fetchSize: Int) = Action { request =>
-    val scrapedStates = Set(NormalizedURIStates.SCRAPED, NormalizedURIStates.SCRAPE_WANTED, NormalizedURIStates.SCRAPE_FAILED, NormalizedURIStates.UNSCRAPABLE)
+    val scrapedStates = Set(NormalizedURIStates.SCRAPED, NormalizedURIStates.SCRAPE_FAILED, NormalizedURIStates.UNSCRAPABLE)
     val uris = db.readOnly(2, Slave) { implicit s =>
       normUriRepo.getChanged(seqNum, includeStates = scrapedStates,  limit = fetchSize)
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/NormalizedURIRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/NormalizedURIRepo.scala
@@ -15,12 +15,8 @@ import java.util.concurrent.TimeUnit
 import NormalizedURIStates._
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.normalizer.NormalizationReference
-import scala.slick.lifted.Tag
-import com.keepit.common.db.{Model, Id}
+import com.keepit.common.db.Id
 import com.keepit.queue._
-import play.api.libs.json._
-import play.api.Play._
-import play.api.Play
 import com.keepit.common.aws.AwsConfig
 
 @ImplementedBy(classOf[NormalizedURIRepoImpl])
@@ -136,7 +132,7 @@ extends DbRepo[NormalizedURI] with NormalizedURIRepo with ExternalIdColumnDbFunc
             scrapeRepo.save(scrapeInfo.withState(ScrapeInfoStates.ACTIVE))
           case _ => // do nothing
         }
-      case SCRAPE_WANTED => // do nothing
+      case ACTIVE => // do nothing
       case _ =>
         throw new IllegalStateException(s"Unhandled state=${uri.state}; uri=$uri")
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/scraper/DuplicateDocumentDetectionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/scraper/DuplicateDocumentDetectionTest.scala
@@ -27,11 +27,11 @@ class DuplicateDocumentDetectionTest extends Specification with ShoeboxTestInjec
         val uriRepo = inject[NormalizedURIRepo]
         val scrapeRepo = inject[ScrapeInfoRepo]
         val documentSignatures2 = inject[Database].readWrite { implicit s =>
-          val nuri1 = uriRepo.save(NormalizedURI.withHash("http://google.com/1", state = NormalizedURIStates.SCRAPE_WANTED))
-          val nuri2 = uriRepo.save(NormalizedURI.withHash("http://google.com/2", state = NormalizedURIStates.SCRAPE_WANTED))
-          val nuri3 = uriRepo.save(NormalizedURI.withHash("http://google.com/3", state = NormalizedURIStates.SCRAPE_WANTED))
-          val nuri4 = uriRepo.save(NormalizedURI.withHash("http://google.com/4", state = NormalizedURIStates.SCRAPE_WANTED))
-          val nuri5 = uriRepo.save(NormalizedURI.withHash("http://google.com/5", state = NormalizedURIStates.SCRAPE_WANTED))
+          val nuri1 = uriRepo.save(NormalizedURI.withHash("http://google.com/1"))
+          val nuri2 = uriRepo.save(NormalizedURI.withHash("http://google.com/2"))
+          val nuri3 = uriRepo.save(NormalizedURI.withHash("http://google.com/3"))
+          val nuri4 = uriRepo.save(NormalizedURI.withHash("http://google.com/4"))
+          val nuri5 = uriRepo.save(NormalizedURI.withHash("http://google.com/5"))
 
           scrapeRepo.save(ScrapeInfo(uriId = nuri1.id.get))
           scrapeRepo.save(ScrapeInfo(uriId = nuri2.id.get))


### PR DESCRIPTION
@eishay this ensures that discussed pages are scheduled for scraping

@martinraison @ymatsuda @yingjieMiao I noticed that the State[NormalizedURI] SCRAPE_WANTED could be removed with some care: we mostly rely on the existence of a ScrapeInfo to decide whether a page should be scraped so I saw an opportunity to further decouple the scraper logic from the NormalizedURIRepo. Thus I have deprecated SCRAPE_WANTED and effectively removed it from our code. This removes unnecessary writes to the NormalizedURI table but also reduces complexity: in order to scrape a uri, simply create a ScrapeInfo for it. 

I think the remaining states SCRAPED, UNSCRAPABLE and SCRAPE_FAILED could rather easily be migrated to the ScrapeInfo model itself (but I must wake up early tomorrow morning ;)

Thoughts?
