### PR TITLE
Fix email verification

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/EmailAddressRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/EmailAddressRepo.scala
@@ -17,7 +17,7 @@ trait EmailAddressRepo extends Repo[EmailAddress] with RepoWithDelete[EmailAddre
   def getAllByUser(userId: Id[User])(implicit session: RSession): Seq[EmailAddress]
   def getByUser(userId: Id[User])(implicit session: RSession): EmailAddress
   def getByUserAndCode(userId: Id[User], verificationCode: String)(implicit session: RSession): Option[EmailAddress]
-  def verify(userId: Id[User], verificationCode: String)(implicit session: RWSession): (Boolean, Boolean) // returns (isValidVerificationCode, isFirstTimeUsed)
+  def verify(userId: Id[User], verificationCode: String)(implicit session: RWSession): (Option[EmailAddress], Boolean) // returns (verifiedEmailOption, isFirstTimeUsed)
   def getByCode(verificationCode: String)(implicit session: RSession): Option[EmailAddress]
 }
 
@@ -75,13 +75,12 @@ class EmailAddressRepoImpl @Inject() (val db: DataBaseComponent, val clock: Cloc
     (for (e <- rows if e.userId === userId && e.verificationCode === verificationCode && e.state =!= EmailAddressStates.INACTIVE) yield e).firstOption
 
   def verify(userId: Id[User], verificationCode: String)(implicit session: RWSession): (Boolean, Boolean) = {
-    // returns (isValidVerificationCode, isFirstTimeUsed)
-    val now = clock.now()
-    val updateCount = rows.filter(e => e.userId === userId && e.verificationCode === verificationCode && e.state === EmailAddressStates.UNVERIFIED)
-      .map(e => (e.verifiedAt, e.updatedAt, e.state)).update((now, now, EmailAddressStates.VERIFIED))
-
-    if (updateCount > 0) (true, true)
-    else (getByUserAndCode(userId, verificationCode).exists(_.state == EmailAddressStates.VERIFIED), false)
+    // returns (verifiedEmailOption, isFirstTimeUsed)
+    getByUserAndCode(userId, verificationCode) match {
+      case Some(verifiedAddress) if verifiedAddress.state == EmailAddressStates.VERIFIED => (Some(verifiedAddress), false)
+      case Some(unverifiedAddress) if unverifiedAddress.state == EmailAddressStates.UNVERIFIED => (Some(save(unverifiedAddress.withState(EmailAddressStates.VERIFIED))), true)
+      case None => (None, false)
+    }
   }
 
   def getByCode(verificationCode: String)(implicit session: RSession): Option[EmailAddress] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/EmailAddressRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/EmailAddressRepo.scala
@@ -81,7 +81,7 @@ class EmailAddressRepoImpl @Inject() (val db: DataBaseComponent, val clock: Cloc
       .map(e => (e.verifiedAt, e.updatedAt, e.state)).update((now, now, EmailAddressStates.VERIFIED))
 
     if (updateCount > 0) (true, true)
-    else (getByUserAndCode(userId, verificationCode).isDefined, false)
+    else (getByUserAndCode(userId, verificationCode).exists(_.state == EmailAddressStates.VERIFIED), false)
   }
 
   def getByCode(verificationCode: String)(implicit session: RSession): Option[EmailAddress] = {


### PR DESCRIPTION
@andrewconner 
I rewrote EmailAddressRepo.verify to use "save" instead of "update" and return the actual verified email instead of a Boolean. (do you know if there is any reason why we were using update? Performance?)
