### PR TITLE
2.9.5: moving friend score filtering to the background page

### DIFF
--- a/packrat/adapters/chrome/main.html
+++ b/packrat/adapters/chrome/main.html
@@ -9,3 +9,4 @@
 <script src="threadlist.js"></script>
 <script src="main.js"></script>
 <script src="lzstring.min.js"></script>
+<script src="scorefilter.js"></script>

--- a/packrat/bin/build.sh
+++ b/packrat/bin/build.sh
@@ -58,8 +58,8 @@ for f in $(find out/chrome/scripts -name '*.js' -not -path '*/iframes/*'); do
   echo "api.injected['${f:11}']=1;"$'\n'"//@ sourceURL=http://kifi/${f:19}" >> $f
 done
 
-cp main.js threadlist.js lzstring.min.js out/chrome/
-cp main.js threadlist.js lzstring.min.js out/firefox/lib/
+cp main.js threadlist.js lzstring.min.js scorefilter.js out/chrome/
+cp main.js threadlist.js lzstring.min.js scorefilter.js out/firefox/lib/
 
 matches=()
 cssDeps=()

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.9.4
+version=2.9.5

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -377,14 +377,13 @@ var socketHandlers = {
     log('[socket:new_friends]', fr)();
     if (friends) {
       for (var i = 0; i < fr.length; i++) {
-        var f = fr[i];
+        var f = standardizeUser(fr[i]);
         if (friendsById[f.id]) {
           friends = friends.filter(idIsNot(f.id))
         }
         friends.push(f)
         friendsById[f.id] = f;
       }
-      // TODO: push friends to interested tabs
     }
   },
   lost_friends: function (fr) {
@@ -397,7 +396,6 @@ var socketHandlers = {
         }
         delete friendsById[f.id];
       }
-      // TODO: push friends to interested tabs
     }
   },
   create_tag: onTagChangeFromServer.bind(null, 'create'),
@@ -940,8 +938,24 @@ api.port.on({
   web_base_uri: function(_, respond) {
     respond(webBaseUri());
   },
-  get_friends: function(_, respond) {
-    respond(friends || [SUPPORT]);
+  search_friends: function(data, respond) {
+    var sf = global.scoreFilter || require('./scorefilter').scoreFilter;
+    var candidates = friends || [SUPPORT];
+    var allResults = sf.filter(data.q, candidates, getName);
+
+    // TODO: cache raw matches for 30s
+
+    var results = allResults.length > 4 ? allResults.slice(0, 4) : allResults;
+    for (var i = 0; i < results.length; i++) {
+      var result = results[i];
+      results[i] = {
+        id: result.id,
+        name: result.name,
+        pictureName: result.pictureName,
+        parts: sf.splitOnMatches(data.q, result.name)
+      };
+    }
+    respond(results);
   },
   open_deep_link: function(link, _, tab) {
     if (link.inThisTab || tab.nUri === link.nUri) {
@@ -1104,6 +1118,11 @@ function onTagChangeFromServer(op, tag) {
   tabsTagging.forEach(function (tab) {
     api.tabs.emit(tab, 'tag_change', this);
   }, {op: op, tag: tag});
+}
+
+function standardizeUser(u) {
+  u.name = (u.firstName + ' ' + u.lastName).trim();
+  return u;
 }
 
 function removeNotificationPopups(threadId) {
@@ -2001,6 +2020,9 @@ function idIsNot(id) {
 function getId(o) {
   return o.id;
 }
+function getName(o) {
+  return o.name;
+}
 function getThreadId(n) {
   return n.thread;
 }
@@ -2038,10 +2060,9 @@ function getFriends(next) {
     friends = fr;
     friendsById = {};
     for (var i = 0; i < fr.length; i++) {
-      var f = fr[i];
+      var f = standardizeUser(fr[i]);
       friendsById[f.id] = f;
     }
-    // TODO: push friends to potentially interested tabs
     if (next) next();
   });
 }
@@ -2133,7 +2154,7 @@ function startSession(callback, retryMs) {
     unstore('logout');
 
     api.toggleLogging(data.experiments.indexOf('extension_logging') >= 0);
-    me = data.user;
+    me = standardizeUser(data.user);
     experiments = data.experiments;
     eip = data.eip;
     socket = socket || api.socket.open(

--- a/packrat/scorefilter.js
+++ b/packrat/scorefilter.js
@@ -1,0 +1,166 @@
+/**
+ * scoreFilter is for searching a list using a query string.
+ * Results are ordered by descending match score.
+ */
+
+(this.exports || this).scoreFilter = (function () {
+  'use strict';
+
+  var WORD_DELIMITER = /[\s,.]+/;
+  var WORD_DELIMITER_CAPTURING = /([\s,.]+)/;
+  var LOCALE_COMPARE_OPTIONS = {
+    usage: 'search',
+    sensitivity: 'base'
+  };
+
+  function localeEquals(str1, str2) {
+    return str1.localeCompare(str2, void 0, LOCALE_COMPARE_OPTIONS) === 0;
+  }
+
+  /**
+   * Tests whether the first string starts with the second string in locale comparison.
+   */
+  function localeStartsWith(str1, str2) {
+    return localeEquals(str1.substr(0, str2.length), str2);
+  }
+
+  /**
+   * Scores how well a candidate string matches a filter query.
+   *
+   * @param {string[]} queryTerms - An array of search/filter query parts (lowercased words/terms)
+   * @param {string} candidate - The match candidate
+   * @param {number[]} matches - An optional array to which the start index (in candidate) of the
+   *   best match for each query term will be inserted
+   *
+   * @return {Number} A match score (zero if the candidate does not match the query)
+   */
+  function scoreCandidate(queryTerms, candidate, matches) {
+    var score = 0;
+    var candidateParts = candidate.toLowerCase().split(WORD_DELIMITER_CAPTURING);
+
+    for (var qi = 0, ql = queryTerms.length; qi < ql; qi++) {
+      var qTerm = queryTerms[qi];
+      var qTermLen = qTerm.length;
+      var qTermScore = 0;
+      var qTermMatchPartIdx;
+      var qTermMatchCharIdx;
+
+      for (var ci = 0, cl = candidateParts.length; ci < cl; ci += 2) {
+        var cPart = candidateParts[ci];
+        if (cPart.length < qTermLen) {
+          continue;
+        }
+
+        var cPartScore = 0;
+        var cPartMatchIdx = 0;
+        var addIndexScore = true;
+
+        if (cPart === qTerm) {
+          cPartScore += 4;
+        } else if (cPart.lastIndexOf(qTerm, 0) === 0) {  // startsWith
+          cPartScore += 2;
+        } else if (localeStartsWith(cPart, qTerm)) {
+          if (cPart.length === qTermLen) {
+            cPartScore += 3;
+          }
+        } else {
+          cPartMatchIdx = cPart.indexOf(qTerm, 1);
+          if (cPartMatchIdx === -1) {
+            continue;
+          }
+
+          cPartScore += 1;
+          addIndexScore = false;
+        }
+
+        if (addIndexScore) {
+          cPartScore += qi === ci ? 5 : qi < ci ? 3 : 2;
+        }
+
+        if (qTermScore < cPartScore) {
+          qTermScore = cPartScore;
+          qTermMatchPartIdx = ci;
+          qTermMatchCharIdx = cPartMatchIdx;
+        }
+      }
+
+      if (qTermScore) {
+        score += qTermScore;
+        if (matches) {
+          for (var cj = 0; cj < qTermMatchPartIdx; cj++) {
+            qTermMatchCharIdx += candidateParts[cj].length;
+          }
+          matches[qi] = qTermMatchCharIdx;
+        }
+      } else {
+        return 0;
+      }
+    }
+
+    return score;
+  }
+
+  function scoreComparator(a, b) {
+    return b.score - a.score;
+  }
+
+  function intComparator(a, b) {
+    return b - a;
+  }
+
+  function getCandidate(o) {
+    return o.candidate;
+  }
+
+  return {
+    filter: function (query, candidates, extract) {
+      var queryTerms = query.trim().toLowerCase().split(WORD_DELIMITER);
+      var vals = extract ? candidates.map(extract) : candidates;
+      var results = [];
+      for (var i = 0, n = vals.length; i < n; i++) {
+        var score = scoreCandidate(queryTerms, vals[i]);
+        if (score) {
+          results.push({candidate: candidates[i], score: score});
+        }
+      }
+      results.sort(scoreComparator);
+      return results.map(getCandidate);
+    },
+
+    /**
+     * Returns the candidate string split into adjacent substrings on match boundaries. The substrings
+     * alternate between matching and non-matching regions, beginning with a non-matching region
+     * (which may be empty). This can be used to highlight matches.
+     */
+    splitOnMatches: function (query, candidate, extract) {
+      var queryTerms = query.trim().toLowerCase().split(WORD_DELIMITER);
+      var val = extract ? extract(candidate) : candidate;
+      var starts = [];
+      scoreCandidate(queryTerms, val, starts);
+      var ends = starts.map(function (start, i) {
+        return start + queryTerms[i].length;
+      });
+      // sorting starts and ends to deal with overlapping matches correctly
+      starts.sort(intComparator);
+      ends.sort(intComparator);
+      var parts = [];
+      var partsTotalLen = 0;
+      for (var i = 0; i < starts.length; i++) {
+        var start = starts[i];
+        var end = ends[i];
+        if (start > partsTotalLen) {
+          parts.push(val.substring(partsTotalLen, start), val.substring(start, end));
+        } else if (start === partsTotalLen) {
+          parts.push('', val.substring(start, end));
+        } else {
+          parts[parts.length - 1] += val.substring(partsTotalLen, end);
+        }
+        partsTotalLen = end;
+      }
+      if (partsTotalLen < val.length) {
+        parts.push(val.substr(partsTotalLen));
+      }
+      return parts;
+    }
+  };
+}());

--- a/packrat/scripts/compose.js
+++ b/packrat/scripts/compose.js
@@ -101,9 +101,9 @@ var initCompose = (function() {
   .handleLookClicks();
 
   if ($t.length) {
-    $t.tokenInput({}, {
-      searchDelay: 0,
-      minChars: 1,
+    $t.tokenInput(function search(query, withResults) {
+      api.port.emit('search_friends', {q: query}, withResults);
+    }, {
       placeholder: 'To',
       hintText: '',
       searchingText: '',
@@ -131,8 +131,12 @@ var initCompose = (function() {
       },
       zindex: 999999999992,
       resultsFormatter: function (f) {
-        return '<li style="background-image:url(//' + cdnBase + '/users/' + f.id + '/pics/100/' + f.pictureName + ')">' +
-          Mustache.escape(f.name) + '</li>';
+        var html = Mustache.escape(f.parts[0]);
+        for (var i = 1; i < f.parts.length; i++) {
+          html += i % 2 ? '<b>' : '</b>';
+          html += Mustache.escape(f.parts[i]);
+        }
+        return '<li style="background-image:url(//' + cdnBase + '/users/' + f.id + '/pics/100/' + f.pictureName + ')">' + html + '</li>';
       },
       onAdd: function () {
         if (defaultText && !$d.text()) {
@@ -152,13 +156,6 @@ var initCompose = (function() {
       onTip: function () {
         api.port.emit('invite_friends', 'composePane');
       }
-    });
-    api.port.emit('get_friends', function (friends) {
-      friends.forEach(function (f) {
-        f.name = f.firstName + ' ' + f.lastName;
-      });
-      $t.data('settings').local_data = friends;
-      $t.data('friends', friends);
     });
   }
 

--- a/packrat/scripts/message_participants.js
+++ b/packrat/scripts/message_participants.js
@@ -141,13 +141,9 @@ var messageParticipants = this.messageParticipants = (function ($, win) {
 		initAndAsyncFocusInput: function () {
 			var $input = this.$input;
 			if (!$input) {
-				$input = this.$input = this.get$('.kifi-message-participant-dialog-input').tokenInput({}, {
-					// The delay, in milliseconds, between the user finishing typing and the search being performed. default: 300
-					searchDelay: 0,
-
-					// The minimum number of characters the user must enter before a search is performed.
-					minChars: 1,
-
+				$input = this.$input = this.get$('.kifi-message-participant-dialog-input').tokenInput(function search(query, withResults) {
+					api.port.emit('search_friends', {q: query}, withResults);
+				}, {
 					placeholder: 'Type a name...',
 					hintText: '',
 					searchingText: '',
@@ -175,8 +171,12 @@ var messageParticipants = this.messageParticipants = (function ($, win) {
 					},
 					zindex: 999999999992,
 					resultsFormatter: function (f) {
-						return '<li style="background-image:url(//' + cdnBase + '/users/' + f.id + '/pics/100/' + f.pictureName + ')">' +
-							Mustache.escape(f.name) + '</li>';
+						var html = Mustache.escape(f.parts[0]);
+						for (var i = 1; i < f.parts.length; i++) {
+							html += i % 2 ? '<b>' : '</b>';
+							html += Mustache.escape(f.parts[i]);
+						}
+						return '<li style="background-image:url(//' + cdnBase + '/users/' + f.id + '/pics/100/' + f.pictureName + ')">' + html + '</li>';
 					},
 					onAdd: function () {
 						this.getAddDialog().addClass('kifi-non-empty');
@@ -189,14 +189,6 @@ var messageParticipants = this.messageParticipants = (function ($, win) {
 					onTip: function () {
 						api.port.emit('invite_friends', 'threadPane');
 					}
-				});
-
-				api.port.emit('get_friends', function (friends) {
-					friends.forEach(function (f) {
-						f.name = f.firstName + ' ' + f.lastName;
-					});
-					$input.data('settings').local_data = friends;
-					$input.data('friends', friends);
 				});
 			}
 

--- a/packrat/scripts/tagbox.js
+++ b/packrat/scripts/tagbox.js
@@ -490,18 +490,6 @@ this.tagbox = (function ($, win) {
 		},
 
 		/**
-		 * Returns an index of a tag with the given id.
-		 * Returns -1 if not found.
-		 *
-		 * @param {string} tagId - An tag id to search for
-		 *
-		 * @return {number} An index of a tag. -1 if not found.
-		 */
-		indexOfTagById: function (tagId) {
-			return indexOfTag(this.tags, tagId);
-		},
-
-		/**
 		 * Returns an index of a tag with the given tag name.
 		 * Returns -1 if not found.
 		 *
@@ -608,7 +596,7 @@ this.tagbox = (function ($, win) {
 				if (!(tags || (tags = this.tags))) {
 					return [];
 				}
-				if (text) {
+				if (text) {  // TODO: delegate filtering to background page
 					return win.scorefilter.filter(text, tags, options).map(extractData);
 				}
 				return tags;


### PR DESCRIPTION
This removes the original match scoring code Andrew added to jquery-tokeninput.js, which was later factored out (and duplicated) in scorefilter.js.

Also removes the code in jquery-tokeninput.js used for AJAX calls and for searching a concrete array. I intend to always keep data that’s big enough to be searched in the background page, so that it doesn’t need to be passed around to pages, which creates copies that then need to be kept in sync.

Introduces a copy of scorefilter.js for the background page with slight modifications, primarily to avoid generating HTML, which is a concern better handled at the point where matches are inserted into a page.

I intend to update tagbox.js in a similar manner (to delegate filtering to the background page) soon, after which we can eliminate the other copy of scorefilter.js.
