### PR TITLE
2.9.6: fixing friend name match highlighting

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.9.5
+version=2.9.6

--- a/packrat/scorefilter.js
+++ b/packrat/scorefilter.js
@@ -105,7 +105,7 @@
   }
 
   function intComparator(a, b) {
-    return b - a;
+    return a - b;
   }
 
   function getCandidate(o) {


### PR DESCRIPTION
for search queries consisting of more than one word
