### PR TITLE
running @asap (document start) scripts on existing tabs (on focus) after extension install

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -347,7 +347,7 @@ var api = (function createApi() {
     }
     page.injecting = true;
 
-    var scripts = meta.contentScripts.filter(function(cs) { return !cs[2] && cs[1].test(page.url) });
+    var scripts = meta.contentScripts.filter(function(cs) { return cs[1].test(page.url) });
 
     var injected;
     chrome.tabs.executeScript(page.id, {

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -279,9 +279,9 @@ if (searchUrlRe.test(document.URL)) !function () {
       if ($res[0].nextElementSibling !== ires) {
         $res.insertBefore(ires);
         $res.find('.kifi-res-sub:not(.kifi-fitted)').each(makeDescAndTagsFit);
-        if (bindResHandlers) {
+        if (!boundResHandlers) {
           setTimeout(bindResHandlers);
-          bindResHandlers = null;
+          boundResHandlers = true;
         }
       }
       return true;
@@ -434,7 +434,9 @@ if (searchUrlRe.test(document.URL)) !function () {
     this.style.tableLayout = 'fixed';
   }
 
-  var bindResHandlers = function() {
+  var boundResHandlers;
+  function bindResHandlers() {
+    log('[bindResHandlers]')();
     $status.click(function (e) {
       if (e.which > 1 || !this.href) return;
       e.preventDefault();


### PR DESCRIPTION
This fixes the “Install kifi extension” link still showing on old kifi.com tabs after extension installation.
