### PR TITLE
2.9.11: a cache for friend prefix search results

### DIFF
--- a/packrat/adapters/chrome/main.html
+++ b/packrat/adapters/chrome/main.html
@@ -10,3 +10,4 @@
 <script src="main.js"></script>
 <script src="lzstring.min.js"></script>
 <script src="scorefilter.js"></script>
+<script src="friend_search_cache.js"></script>

--- a/packrat/bin/build.sh
+++ b/packrat/bin/build.sh
@@ -58,8 +58,8 @@ for f in $(find out/chrome/scripts -name '*.js' -not -path '*/iframes/*'); do
   echo "api.injected['${f:11}']=1;"$'\n'"//@ sourceURL=http://kifi/${f:19}" >> $f
 done
 
-cp main.js threadlist.js lzstring.min.js scorefilter.js out/chrome/
-cp main.js threadlist.js lzstring.min.js scorefilter.js out/firefox/lib/
+cp main.js threadlist.js lzstring.min.js scorefilter.js friend_search_cache.js out/chrome/
+cp main.js threadlist.js lzstring.min.js scorefilter.js friend_search_cache.js out/firefox/lib/
 
 matches=()
 cssDeps=()

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.9.10
+version=2.9.11

--- a/packrat/friend_search_cache.js
+++ b/packrat/friend_search_cache.js
@@ -1,0 +1,35 @@
+'use strict';
+
+function FriendSearchCache(lifeSec) {
+  this.cache = {};
+  this.putAt = {};
+  this.lifeSec = lifeSec;
+}
+FriendSearchCache.prototype = {
+  key: function (o) {
+    return (o.includeSelf ? '+' : '-') + o.q;
+  },
+  put: function (o, friends) {
+    this.prune();
+    var key = this.key(o);
+    this.cache[key] = friends;
+    this.putAt[key] = Date.now();
+  },
+  get: function (o) {
+    var key = this.key(o);
+    return this.cache[key];
+  },
+  prune: function () {
+    var minPutAt = Date.now() - this.lifeSec;
+    for (var key in this.cache) {
+      if (this.putAt[key] < minPutAt) {
+        delete this.cache[key];
+        delete this.putAt[key];
+      }
+    }
+  }
+};
+
+if (this.exports) {
+  this.exports.FriendSearchCache = FriendSearchCache;
+}

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -25,6 +25,7 @@ var threadsById = {}; // threadId => thread (notification JSON)
 var messageData = {}; // threadId => [message, ...]; TODO: evict old threads from memory
 var friends;
 var friendsById;
+var friendSearchCache;
 var ruleSet = {rules: {}};
 var urlPatterns;
 var tags;
@@ -47,6 +48,7 @@ function clearDataCache() {
   messageData = {};
   friends = null;
   friendsById = null;
+  friendSearchCache = null;
   ruleSet = {rules: {}};
   urlPatterns = null;
   tags = null;
@@ -378,11 +380,12 @@ var socketHandlers = {
     if (friends) {
       for (var i = 0; i < fr.length; i++) {
         var f = standardizeUser(fr[i]);
-        if (friendsById[f.id]) {
+        if (f.id in friendsById) {
           friends = friends.filter(idIsNot(f.id))
         }
-        friends.push(f)
+        friends.push(f);
         friendsById[f.id] = f;
+        friendSearchCache = null;
       }
     }
   },
@@ -391,10 +394,11 @@ var socketHandlers = {
     if (friends) {
       for (var i = 0; i < fr.length; i++) {
         var f = fr[i];
-        if (friendsById[f.id]) {
+        if (f.id in friendsById) {
           friends = friends.filter(idIsNot(f.id));
+          delete friendsById[f.id];
+          friendSearchCache = null;
         }
-        delete friendsById[f.id];
       }
     }
   },
@@ -937,21 +941,21 @@ api.port.on({
   },
   search_friends: function(data, respond) {
     var sf = global.scoreFilter || require('./scorefilter').scoreFilter;
-    var candidates = data.includeSelf ?
-     friends ? [me].concat(friends) : [me, SUPPORT] :
-     friends || [SUPPORT];
-    var allResults = sf.filter(data.q, candidates, getName);  // cache q -> allResults?
-    var results = allResults.length > 4 ? allResults.slice(0, 4) : allResults;
-    for (var i = 0; i < results.length; i++) {
-      var result = results[i];
-      results[i] = {
-        id: result.id,
-        name: result.name,
-        pictureName: result.pictureName,
-        parts: sf.splitOnMatches(data.q, result.name)
-      };
+    var results;
+    if (friendSearchCache) {
+      results = friendSearchCache.get(data);
+    } else {
+      friendSearchCache = new (global.FriendSearchCache || require('./friend_search_cache').FriendSearchCache)(3600000);
     }
-    respond(results);
+    if (!results) {
+      var candidates = friendSearchCache.get({includeSelf: data.includeSelf, q: data.q.substr(0, data.q.length - 1)}) ||
+        (data.includeSelf ?
+           friends ? [me].concat(friends) : [me, SUPPORT] :
+           friends || [SUPPORT]);
+      results = sf.filter(data.q, candidates, getName);
+      friendSearchCache.put(data, results);
+    }
+    respond((results.length > 4 ? results.slice(0, 4) : results).map(toFriendSearchResult, {sf: sf, q: data.q}));
   },
   open_deep_link: function(link, _, tab) {
     if (link.inThisTab || tab.nUri === link.nUri) {
@@ -2007,6 +2011,15 @@ function compilePatterns(arr) {
   return arr;
 }
 
+function toFriendSearchResult(f) {
+  return {
+    id: f.id,
+    name: f.name,
+    pictureName: f.pictureName,
+    parts: this.sf.splitOnMatches(this.q, f.name)
+  };
+}
+
 function reTest(s) {
   return function (re) {return re.test(s)};
 }
@@ -2062,6 +2075,7 @@ function getFriends(next) {
       var f = standardizeUser(fr[i]);
       friendsById[f.id] = f;
     }
+    friendSearchCache = null;
     if (next) next();
   });
 }


### PR DESCRIPTION
This makes the search for “alic” only look through results for “ali” if it was searched recently (quite likely), and not search at all if “alic” was searched recently. Should make friend autocomplete suggestions appear noticeably faster for users with the “can message all users” experiment.
