### PR TITLE
thread retrieval fixes for mobile

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -532,7 +532,7 @@ class MessagingCommander @Inject() (
   }
 
   private def getThreadMessagesWithBasicUser(thread: MessageThread, pageOpt: Option[Int]): Future[(MessageThread, Seq[MessageWithBasicUser])] = {
-    val userParticipantSet = thread.participants.map(_.allUsers).getOrElse(Set())
+    val userParticipantSet = if (thread.replyable) thread.participants.map(_.allUsers).getOrElse(Set()) else Set()
     log.info(s"[get_thread] got participants for extId ${thread.externalId}: $userParticipantSet")
     new SafeFuture(shoebox.getBasicUsers(userParticipantSet.toSeq) map { id2BasicUser =>
       val messages = getThreadMessages(thread, pageOpt)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
@@ -95,18 +95,28 @@ class MobileMessagingController @Inject() (
       Future.sequence(msgsWithModifiedAuxData).map { completeMsgs =>
         val participants: Set[BasicUserLikeEntity] = completeMsgs.map(_.participants).flatten.toSet
         Ok(Json.obj(
-        "id" -> threadId,
-        "uri" -> url,
-        "nUrl" -> nUrl,
-        "participants" -> participants,
-        "messages" -> (completeMsgs.reverse map { m =>
-          Json.obj(
-            "id" -> m.id.toString,
-            "time" -> m.createdAt.getMillis,
-            "text" -> m.text,
-            "userId" -> m.user.map(_.externalId.toString)
-          )
-        })))
+          "id" -> threadId,
+          "uri" -> url,
+          "nUrl" -> nUrl,
+          "participants" -> participants,
+          "messages" -> (completeMsgs.reverse map { m =>
+            val added: Option[Seq[String]] = m.auxData match {
+              case Some(JsArray(Seq(JsString("add_participants"), _, addedBasicUsers))) => Some(addedBasicUsers.as[Seq[BasicUser]].map(_.externalId.id))
+              case _ => None
+            }
+            val msgJson = Json.obj(
+              "id" -> m.id.toString,
+              "time" -> m.createdAt.getMillis,
+              "text" -> m.text,
+              "userId" -> m.user.map(_.externalId.toString)
+            )
+            added.map { seq =>
+              msgJson.deepMerge(Json.obj("added" -> seq))
+            } getOrElse{
+              msgJson
+            }
+          })
+        ))
       }
     }
   }


### PR DESCRIPTION
-Include "added" field (when appropriate) in the compact thread view
-Safeguard when accidentally requesting a thread with a global notification id (so we don't send you all users, which was also a bit of a security issue)
@ebfaed 
