### PR TITLE
images/schema + pageInfo

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/store/S3ScreenshotStore.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/S3ScreenshotStore.scala
@@ -55,7 +55,7 @@ case class EmbedlyExtractResponse(
   content:Option[String],
   safe:Option[Boolean],
   faviconUrl:Option[String],
-  images:Seq[ImageInfo]) extends PageGenericInfo with PageSafetyInfo {
+  images:Seq[ImageInfo]) extends PageGenericInfo with PageSafetyInfo with PageMediaInfo {
   def toPageInfo(nuriId:Id[NormalizedURI]):PageInfo =
     PageInfo(
       id = None,

--- a/kifi-backend/modules/common/app/com/keepit/model/PageInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/PageInfo.scala
@@ -1,0 +1,74 @@
+package com.keepit.model
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import com.keepit.common.db._
+import org.joda.time.DateTime
+import com.keepit.common.time._
+
+trait PageSafetyInfo {
+  def safe:Option[Boolean]
+}
+
+trait PageMediaInfo {
+  def images:Seq[ImageInfo]
+}
+
+trait PageGenericInfo {
+  def description:Option[String]
+  // def content:Option[String]
+  def faviconUrl:Option[String]
+}
+
+object PageInfoStates extends States[PageInfo]
+
+case class PageInfo(
+  id:Option[Id[PageInfo]],
+  createdAt: DateTime = currentDateTime,
+  updatedAt: DateTime = currentDateTime,
+  state:     State[PageInfo] = PageInfoStates.ACTIVE,
+  seq:       SequenceNumber[PageInfo] = SequenceNumber.ZERO,
+  uriId:Id[NormalizedURI],
+  description:Option[String],
+  safe:Option[Boolean],
+  faviconUrl:Option[String],
+  imageAvail:Option[Boolean],
+  screenshotAvail:Option[Boolean]
+) extends ModelWithState[PageInfo] with ModelWithSeqNumber[PageInfo] with PageGenericInfo with PageSafetyInfo {
+  def withId(pageInfoId: Id[PageInfo]) = copy(id = Some(pageInfoId))
+  def withUpdateTime(now: DateTime) = copy(updatedAt = now)
+}
+
+object PageInfo {
+  implicit val format = (
+    (__ \ 'id).formatNullable(Id.format[PageInfo]) and
+    (__ \ 'createdAt).format[DateTime] and
+    (__ \ 'updatedAt).format[DateTime] and
+    (__ \ 'state).format(State.format[PageInfo]) and
+    (__ \ 'seq).format(SequenceNumber.format[PageInfo]) and
+    (__ \ 'uri_id).format(Id.format[NormalizedURI]) and
+    (__ \ 'description).formatNullable[String] and
+    (__ \ 'safe).formatNullable[Boolean] and
+    (__ \ 'favicon_url).formatNullable[String] and
+    (__ \ 'image_avail).formatNullable[Boolean] and
+    (__ \ 'screenshot_avail).formatNullable[Boolean]
+  )(PageInfo.apply _, unlift(PageInfo.unapply))
+}
+
+case class ImageInfo(
+  url:String,
+  caption:Option[String],
+  height:Option[Int],
+  width:Option[Int],
+  size:Option[Int])
+
+object ImageInfo {
+  implicit val format = (
+    (__ \ 'url).format[String] and
+    (__ \ 'caption).formatNullable[String] and
+    (__ \ 'height).formatNullable[Int] and
+    (__ \ 'weight).formatNullable[Int] and
+    (__ \ 'size).formatNullable[Int]
+    )(ImageInfo.apply _, unlift(ImageInfo.unapply))
+}
+

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/145.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/145.sql
@@ -1,0 +1,32 @@
+# SHOEBOX
+
+# --- !Ups
+
+CREATE TABLE page_info (
+  id bigint(20) NOT NULL AUTO_INCREMENT,
+  created_at datetime NOT NULL,
+  updated_at datetime NOT NULL,
+  state varchar(20) NOT NULL,
+  seq bigint(20) NOT NULL,
+  uri_id bigint(20) NOT NULL,
+  description varchar(1024),
+  safe boolean,
+  favicon_url varchar(1024),
+  image_avail boolean,
+  screenshot_avail boolean,
+
+  PRIMARY KEY (id),
+  UNIQUE INDEX page_info_uri_id (uri_id)
+);
+
+-- MySQL:
+-- CREATE TABLE page_info_sequence (id INT NOT NULL);
+-- INSERT INTO page_info_sequence VALUES (0);
+
+
+CREATE SEQUENCE page_info_sequence;
+CREATE INDEX page_info_seq_index on page_info(seq);
+
+insert into evolutions (name, description) values('146.sql', 'adding page_info');
+
+# --- !Downs

--- a/kifi-backend/modules/common/test/com/keepit/common/store/FakeS3ScreenshotStore.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/store/FakeS3ScreenshotStore.scala
@@ -1,6 +1,6 @@
 package com.keepit.common.store
 
-import com.keepit.model.{NormalizedURI}
+import com.keepit.model.{PageInfo, ImageInfo, NormalizedURI}
 import scala.concurrent._
 
 case class FakeS3ScreenshotStore() extends S3ScreenshotStore {
@@ -8,7 +8,7 @@ case class FakeS3ScreenshotStore() extends S3ScreenshotStore {
   def getScreenshotUrl(normalizedUri: NormalizedURI): Option[String] = None
   def getScreenshotUrl(normalizedUriOpt: Option[NormalizedURI]): Option[String] = None
   def updatePicture(normalizedUri: NormalizedURI): Future[Boolean] = Future.successful(true)
-  def asyncGetImageUrl(uri:NormalizedURI):Future[Option[String]] = Future.successful(None)
+  def asyncGetImageUrl(uri:NormalizedURI, pageInfo:Option[PageInfo], cb:Option[PageInfo => Unit]):Future[Option[String]] = Future.successful(None)
   def getImageUrl(normalizedUri: NormalizedURI): Option[String] = None
   def processImage(uri: NormalizedURI, imageInfo: ImageInfo): Future[Boolean] = Future.successful(true)
   def getImageInfos(normalizedUri: NormalizedURI): Future[Seq[ImageInfo]] = Future.successful(Seq.empty[ImageInfo])

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/PageInfoRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/PageInfoRepo.scala
@@ -1,0 +1,55 @@
+package com.keepit.model
+
+
+import com.google.inject.{Provider, Inject, Singleton, ImplementedBy}
+import com.google.inject.Inject
+import com.keepit.common.time.Clock
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.logging.Logging
+import com.keepit.common.db.Id
+import com.keepit.common.db._
+import com.keepit.common.db.slick._
+import com.keepit.common.db.slick.DBSession.{RWSession, RSession}
+
+@ImplementedBy(classOf[PageInfoRepoImpl])
+trait PageInfoRepo extends Repo[PageInfo] with SeqNumberFunction[PageInfo] {
+  def getByUri(uriId:Id[NormalizedURI])(implicit ro:RSession):Option[PageInfo]
+}
+
+@Singleton
+class PageInfoRepoImpl @Inject() (
+  val db: DataBaseComponent,
+  val clock: Clock,
+  airbrake: AirbrakeNotifier)
+extends DbRepo[PageInfo] with PageInfoRepo with SeqNumberDbFunction[PageInfo] with Logging {
+
+  import db.Driver.simple._
+
+  private val sequence = db.getSequence[PageInfo]("page_info_sequence")
+
+  type RepoImpl = PageInfoTable
+  class PageInfoTable(tag: Tag) extends RepoTable[PageInfo](db, tag, "page_info") with SeqNumberColumn[PageInfo] {
+    def uriId           = column[Id[NormalizedURI]]("uri_id", O.NotNull)
+    def description     = column[String]("description")
+    def safe            = column[Boolean]("safe")
+    def faviconUrl      = column[String]("favicon_url")
+    def imageAvail      = column[Boolean]("image_avail")
+    def screenshotAvail = column[Boolean]("screenshot_avail")
+    def * = (id.?,createdAt,updatedAt,state,seq,uriId,description.?,safe.?,faviconUrl.?,imageAvail.?,screenshotAvail.?) <> ((PageInfo.apply _).tupled, PageInfo.unapply _)
+  }
+
+  def table(tag:Tag) = new PageInfoTable(tag)
+  initTable()
+
+  override def deleteCache(model: PageInfo)(implicit session: RSession):Unit = {}
+  override def invalidateCache(model: PageInfo)(implicit session: RSession):Unit = {}
+
+  override def save(model: PageInfo)(implicit session: RWSession): PageInfo = {
+    val toSave = model.copy(seq = sequence.incrementAndGet())
+    super.save(toSave)
+  }
+
+  override def getByUri(uriId: Id[NormalizedURI])(implicit ro: RSession): Option[PageInfo] = {
+    (for(f <- rows if f.uriId === uriId && f.state === PageInfoStates.ACTIVE) yield f).firstOption
+  }
+}

--- a/kifi-backend/modules/shoebox/app/views/admin/imageInfos.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/imageInfos.scala.html
@@ -1,6 +1,6 @@
 @(uri:NormalizedURI,
   screenshotUrl:Option[String],
-  imageInfos:Seq[com.keepit.common.store.ImageInfo]
+  imageInfos:Seq[com.keepit.model.ImageInfo]
 )
 
 @admin("ImageInfos") {


### PR DESCRIPTION
- PageInfo table to hold some metadata about uri
  -- currently holds a strict (simple) subset of information returned (primarily) by embedly API
  -- we _could_ put the extra info in normalized_uri but the nuri table is already heavily used, so I created a new table/repo
  -- this should/will allow us to remove screenshotUpdatedAt from normalized_uri (see separate pull request)

cc: @eishay @andrewconner @ymatsuda @leogrim 
