### PR TITLE
2.9.13: identifying from whence /search and /warmUp requests come

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -105,14 +105,14 @@ var api = (function createApi() {
   }));
 
   var stripHashRe = /^[^#]*/;
-  var googleSearchRe = /^https?:\/\/www\.google\.[a-z]{2,3}(?:\.[a-z]{2})?\/(?:|search|webhp)\?(?:.*&)?q=([^&#]*)/;
+  var googleSearchRe = /^https?:\/\/www\.google\.[a-z]{2,3}(?:\.[a-z]{2})?\/(?:|search|webhp)[\?#](?:.*&)?q=([^&#]*)/;
   var plusRe = /\+/g;
 
   chrome.webNavigation.onBeforeNavigate.addListener(errors.wrap(function (details) {
     var match = details.url.match(googleSearchRe);
     if (match && details.frameId === 0) {
       var query = decodeURIComponent(match[1].replace(plusRe, ' ')).trim();
-      if (query) dispatch.call(api.on.search, query);
+      if (query) dispatch.call(api.on.search, query, ~details.url.indexOf('sourceid=chrome') ? 'o' : 'n');
     }
   }));
 
@@ -234,7 +234,7 @@ var api = (function createApi() {
   }));
 
   chrome.webRequest.onBeforeRequest.addListener(errors.wrap(function () {
-    dispatch.call(api.on.beforeSearch);
+    dispatch.call(api.on.beforeSearch, 'o');
   }), {
     tabId: -1,
     types: ['main_frame', 'other'],

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -575,7 +575,7 @@ require('./location').onFocus(errors.wrap(dispatch.bind(exports.on.beforeSearch)
 // navigation handling
 
 const stripHashRe = /^[^#]*/;
-const googleSearchRe = /^https?:\/\/www\.google\.[a-z]{2,3}(?:\.[a-z]{2})?\/(?:|search|webhp)\?(?:.*&)?q=([^&#]*)/;
+const googleSearchRe = /^https?:\/\/www\.google\.[a-z]{2,3}(?:\.[a-z]{2})?\/(?:|search|webhp)[\?#](?:.*&)?q=([^&#]*)(?:.*&channel=(\w+))?/;
 const plusRe = /\+/g;
 
 require('./location').onChange(errors.wrap(function onLocationChange(tabId, newPage) { // called before onAttach for all pages except images
@@ -586,7 +586,10 @@ require('./location').onChange(errors.wrap(function onLocationChange(tabId, newP
     let match = googleSearchRe.exec(tab.url);
     if (match) {
       let query = decodeURIComponent(match[1].replace(plusRe, ' ')).trim();
-      if (query) dispatch.call(exports.on.search, query);
+      if (query) {
+        let channel = match[2];
+        dispatch.call(exports.on.search, query, channel === 'fflb' ? 'a' : channel === 'sb' ? 's' : 'n');
+      }
     }
     if (httpRe.test(page.url)) {
       dispatch.call(exports.tabs.on.loading, page);

--- a/packrat/adapters/firefox/lib/location.js
+++ b/packrat/adapters/firefox/lib/location.js
@@ -39,7 +39,7 @@ function change(callback, browser, progress, req, loc, flags) {
 
 function onFocus(win, callback) {
   for (let id of ['urlbar', 'searchbar']) {
-    win.document.getElementById(id).addEventListener('focus', callback);
+    win.document.getElementById(id).addEventListener('focus', callback.bind(null, id === 'urlbar' ? 'a' : 's'));
   }
 }
 

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.9.12
+version=2.9.13

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1504,7 +1504,8 @@ function searchOnServer(request, respond) {
     maxHits: maxHits,
     lastUUID: request.lastUUID,
     context: request.context,
-    kifiVersion: api.version};
+    kifiVersion: api.version,
+    w: request.whence};
 
   var respHandler = function(resp) {
     log('[searchOnServer] response:', resp)();
@@ -1852,21 +1853,21 @@ api.tabs.on.unload.add(function(tab, historyApi) {
   }
 });
 
-api.on.beforeSearch.add(throttle(function () {
+api.on.beforeSearch.add(throttle(function (whence) {
   if (enabled('search')) {
-    ajax('search', 'GET', '/search/warmUp');
+    ajax('search', 'GET', '/search/warmUp', {w: whence});
   }
 }, 50000));
 
 var searchPrefetchCache = {};  // for searching before the results page is ready
 var searchFilterCache = {};    // for restoring filter if user navigates back to results
-api.on.search.add(function prefetchResults(query) {
+api.on.search.add(function prefetchResults(query, whence) {
   if (!me || !enabled('search')) return;
   log('[prefetchResults] prefetching for query:', query)();
   var entry = searchPrefetchCache[query];
   if (!entry) {
     entry = searchPrefetchCache[query] = {callbacks: [], response: null};
-    searchOnServer({query: query, filter: (searchFilterCache[query] || {}).filter}, function (response) {
+    searchOnServer({query: query, filter: (searchFilterCache[query] || {}).filter, whence: whence}, function (response) {
       entry.response = response;
       while (entry.callbacks.length) entry.callbacks.shift()(response);
       api.timers.clearTimeout(entry.expireTimeout);

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -134,7 +134,7 @@ if (searchUrlRe.test(document.URL)) !function () {
     tKifiResultsShown = null;
     var t1 = tQuery = Date.now();
     refinements++;
-    api.port.emit("get_keeps", {query: q, filter: newFilter, first: isFirst}, function results(resp) {
+    api.port.emit("get_keeps", {query: q, filter: newFilter, first: isFirst, whence: 'i'}, function results(resp) {
       if (q !== query || !areSameFilter(newFilter, filter)) {
         log("[results] ignoring for query:", q, "filter:", newFilter)();
         return;


### PR DESCRIPTION
/warmUp?w=
- o: Chrome Omnibar
- a: Firefox Awesome bar
- s: Firefox search box

/search?w=
- o: Chrome Omnibar
- a: Firefox Awesome bar
- s: Firefox search box
- n: Chrome or Firefox navigation
- i: Chrome or Firefox in-page
