### PR TITLE
[angular] fixing modals

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/modal/basicModalContent.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/modal/basicModalContent.tpl.html
@@ -1,8 +1,8 @@
 <div class="dialog-content">
-  <div class="dialog-title" ng-if="!title.length">kifi</div>
-  <div class="dialog-header" ng-if="title.length" ng-bind-html="title"></div>
+  <div class="dialog-title">kifi</div>
   <a class="dialog-x" ng-click="hideAndCancel()">✕</a>
   <div class="dialog-body-wrap">
+    <div class="dialog-header" ng-if="title.length" ng-bind-html="title"></div>
     <div class="dialog-body" ng-transclude ng-class="{'dialog-centered': centered}"></div>
   </div>
   <div class="dialog-buttons" ng-if="singleAction">

--- a/kifi-backend/modules/shoebox/angular/src/common/modal/modal.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/modal/modal.styl
@@ -5,13 +5,7 @@
   transform: translate(-50%, -50%)
   width: auto
   margin: 0
-
-  .modal.in &
-    transform: translate(-50%, -50%)
-
-  .modal.fade &
-    transform: translate(-50%, -50%)
-
+  z-index: 1050
 
 .modal-content.modal-content
   width: 100%
@@ -19,6 +13,8 @@
   border: 1px solid #f2eeed
   box-shadow: 12px 12px 0 rgba(0, 40, 90, 0.2)
   background: #faf8f7
+  border-radius: 5px
+  overflow: hidden
 
 
 .kifi-onboarding-iframe
@@ -92,13 +88,12 @@
 .dialog-header
   font-size: 18px
   font-weight: 300
-  padding: 19px 6px 8px
-  border-bottom: 2px solid #ecf0f1
-  margin: 0 11px
+  padding: 9px 6px 8px
   color: #3a495b
   overflow: hidden
   text-overflow: ellipsis
   white-space: nowrap
+  text-align: center
       
 .dialog-x
   position: absolute
@@ -123,7 +118,6 @@
   background-color: #eff2f7
   line-height: 50px
   margin-bottom: 15px
-  border-radius: 6px 6px 0 0
 
   .dialog-x
     font-size: 13px
@@ -145,7 +139,16 @@
   .dialog-body
     margin: 0 auto
 
-
 .dialog-centered
   text-align: center
+
+.modal-backdrop
+  position: fixed
+  top: 0
+  right: 0
+  bottom: 0
+  left: 0
+  z-index: 1030
+  background-color: #000000
+  opacity: 0.5
 

--- a/kifi-backend/modules/shoebox/angular/src/common/modal/modal.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/modal/modal.tpl.html
@@ -1,5 +1,5 @@
 <div ng-show="show">
-  <div class="modal-backdrop fade in" style="z-index: 1040;" ng-click="hideModal()" ng-style="backdropStyle"></div>
+  <div class="modal-backdrop fade in" ng-click="hideModal()" ng-style="backdropStyle"></div>
   <div tabindex="-1" index="0" class="modal-dialog" ng-style="dialogStyle">
     <div class="modal-content" ng-transclude></div>
   </div>


### PR DESCRIPTION
@andrewconner 
- modal backdrop should be working again (I don't know why the style from bootstrap.css was not picked up anymore - anyway since we want to get rid of bootstrap and it's only a few lines of css I just copied what we need about modal-backdrop style to modal.styl
- the kifi title bar is always shown, if a title is provided it is shown below the title bar (cf modal for deleting an email address)
- modals have round corners (like in the reference you sent to me)
