### PR TITLE
[angular] Fix bug where tags in list become inactive after reordering tags

### DIFF
--- a/kifi-backend/modules/shoebox/angular/gruntfile.js
+++ b/kifi-backend/modules/shoebox/angular/gruntfile.js
@@ -63,7 +63,7 @@ module.exports = function (grunt) {
           'lib/angular-moment/angular-moment.js',
           'managed-lib/bootstrap/ui-bootstrap-custom-tpls-0.10.0.js',
           'lib/angular-facebook-api/dist/angular-facebook-api.js',
-          'lib/angular-dragdrop/draganddrop.js'
+          'managed-lib/angular-dragdrop/draganddrop.js'
         ],
         libMinJs: [
           'lib/lodash/dist/lodash.min.js',
@@ -85,7 +85,7 @@ module.exports = function (grunt) {
           'lib/angular-moment/angular-moment.min.js',
           'managed-lib/bootstrap/ui-bootstrap-custom-tpls-0.10.0.min.js',
           'lib/angular-facebook-api/dist/angular-facebook-api.min.js',
-          'lib/angular-dragdrop/draganddrop.js'
+          'managed-lib/angular-dragdrop/draganddrop.js'
         ],
         src: 'src',
         common: 'src/common/build-css',

--- a/kifi-backend/modules/shoebox/angular/managed-lib/angular-dragdrop/draganddrop.js
+++ b/kifi-backend/modules/shoebox/angular/managed-lib/angular-dragdrop/draganddrop.js
@@ -1,0 +1,130 @@
+/**
+ * Created with IntelliJ IDEA.
+ * User: Ganaraj.Pr
+ * Date: 11/10/13
+ * Time: 11:27
+ * To change this template use File | Settings | File Templates.
+ */
+angular.module("ngDragDrop",[])
+  .directive("uiDraggable", [
+    '$parse',
+    '$rootScope',
+    function ($parse, $rootScope) {
+      return function (scope, element, attrs) {
+        if (window.jQuery && !window.jQuery.event.props.dataTransfer) {
+          window.jQuery.event.props.push('dataTransfer');
+        }
+        element.attr("draggable", false);
+        attrs.$observe("uiDraggable", function (newValue) {
+          element.attr("draggable", newValue);
+        });
+        var dragData = "";
+        scope.$watch(attrs.drag, function (newValue) {
+          dragData = newValue;
+        });
+        element.bind("dragstart", function (e) {
+          var sendData = angular.toJson(dragData);
+          var sendChannel = attrs.dragChannel || "defaultchannel";
+          e.dataTransfer.setData("Text", sendData);
+          $rootScope.$broadcast("ANGULAR_DRAG_START", sendChannel);
+
+        });
+
+        //For IE
+        element.bind("selectstart",function() {
+          this.dragDrop();
+          return false;
+        }, false);
+
+        element.bind("dragend", function (e) {
+          console.log("triggered");
+          var sendChannel = attrs.dragChannel || "defaultchannel";
+          $rootScope.$broadcast("ANGULAR_DRAG_END", sendChannel);
+          if (e.dataTransfer && e.dataTransfer.dropEffect !== "none") {
+            if (attrs.onDropSuccess) {
+              var fn = $parse(attrs.onDropSuccess);
+              scope.$apply(function () {
+                fn(scope, {$event: e});
+              });
+            }
+          }
+        });
+
+
+      };
+    }
+  ])
+  .directive("uiOnDrop", [
+    '$parse',
+    '$rootScope',
+    function ($parse, $rootScope) {
+      return function (scope, element, attr) {
+        var dropChannel = "defaultchannel";
+        var dragChannel = "";
+        var dragEnterClass = attr.dragEnterClass || "on-drag-enter";
+
+        function onDragOver(e) {
+
+          if (e.preventDefault) {
+            e.preventDefault(); // Necessary. Allows us to drop.
+          }
+
+          if (e.stopPropagation) {
+            e.stopPropagation();
+          }
+          e.dataTransfer.dropEffect = 'move';
+          return false;
+        }
+
+        function onDrop(e) {
+          if (e.preventDefault) {
+            e.preventDefault(); // Necessary. Allows us to drop.
+          }
+          if (e.stopPropagation) {
+            e.stopPropagation(); // Necessary. Allows us to drop.
+          }
+          var data = e.dataTransfer.getData("Text");
+          data = angular.fromJson(data);
+          var fn = $parse(attr.uiOnDrop);
+          scope.$apply(function () {
+            fn(scope, {$data: data, $event: e});
+          });
+          element.removeClass(dragEnterClass);
+        }
+
+
+        $rootScope.$on("ANGULAR_DRAG_START", function (event, channel) {
+          dragChannel = channel;
+          if (dropChannel === channel) {
+
+            element.bind("dragover", onDragOver);
+
+            element.bind("drop", onDrop);
+            element.addClass(dragEnterClass);
+          }
+
+        });
+
+
+
+        $rootScope.$on("ANGULAR_DRAG_END", function (e, channel) {
+          dragChannel = "";
+          if (dropChannel === channel) {
+
+            element.unbind("dragover", onDragOver);
+
+            element.unbind("drop", onDrop);
+            element.removeClass(dragEnterClass);
+          }
+        });
+
+
+        attr.$observe('dropChannel', function (value) {
+          if (value) {
+            dropChannel = value;
+          }
+        });
+
+      };
+    }
+  ]);

--- a/kifi-backend/modules/shoebox/angular/src/tags/tagItem.js
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tagItem.js
@@ -144,6 +144,8 @@ angular.module('kifi.tagItem', ['kifi.tagService'])
         scope.onTagDrop = function (tag) {
           stopTagDrag();
           if (isTop !== null && scope.watchTagReorder()) {
+            // The "dragend" handler must be called before removing the element from the DOM.
+            element.find('.kf-nav-link').triggerHandler('dragend');
             scope.reorderTag({isTop: isTop, srcTag: tag, dstTag: scope.tag});
           }
         };

--- a/kifi-backend/modules/shoebox/angular/src/tags/tagService.js
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tagService.js
@@ -45,6 +45,7 @@ angular.module('kifi.tagService', ['kifi.keepService', 'kifi.routeService'])
     }
 
     function reorderTag(isTop, srcTag, dstTag) {
+      // isTop indicates whether dstTag should be placed before or after srcTag
       var index = _.findIndex(list, function (tag) { return tag.id === dstTag.id; });
       var newSrcTag = _.clone(srcTag);
       var srcTagId = srcTag.id;


### PR DESCRIPTION
@andrewconner 
I'm also temporarily (or not) moving angular-draganddrop to managed-libs, since there is a small thing I needed to fix (submitted a pull request just in case).

Remaining tag-list related bugs that I'm aware of:
- some tags can be in hover state even when the mouse is not on top of it
- bug when adding a tag twice to a keep (the tag count gets incremented twice)
