### PR TITLE
images: temporarily enable update in mobile endpoint

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
@@ -118,7 +118,7 @@ class MobileBookmarksController @Inject() (
 
   private def toJsObject(url: String, uri: NormalizedURI, pageInfoOpt: Option[PageInfo]): Future[JsObject] = {
     val screenshotUrlOpt = s3ScreenshotStore.getScreenshotUrl(uri)
-    s3ScreenshotStore.asyncGetImageUrl(uri, pageInfoOpt) map { imgUrlOpt =>
+    s3ScreenshotStore.asyncGetImageUrl(uri, pageInfoOpt, true) map { imgUrlOpt => // todo: disable update
       (screenshotUrlOpt, imgUrlOpt) match {
         case (None, None) =>
           Json.obj("url" -> url, "uriId" -> uri.id.get)


### PR DESCRIPTION
until scraper is wired up with embedly ...
