### PR TITLE
randomized cache expiration

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/cache/ObjectCache.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/ObjectCache.scala
@@ -6,8 +6,10 @@ import play.api.libs.concurrent.Execution.Implicits._
 
 trait ObjectCache[K <: Key[T], T] {
   val outerCache: Option[ObjectCache[K, T]] = None
-  val ttl: Duration
-  outerCache map {outer => require(ttl <= outer.ttl)}
+  val minTTL: Duration
+  val maxTTL: Duration
+
+  outerCache map {outer => require(maxTTL <= outer.minTTL)}
 
   protected[cache] def getFromInnerCache(key: K): ObjectState[T]
   protected[cache] def setInnerCache(key: K, value: Option[T]): Unit

--- a/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionLocalCache.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionLocalCache.scala
@@ -8,14 +8,15 @@ import play.api.libs.json._
 
 
 class TransactionLocalCache[K <: Key[T], T] private(
-  val ttl: Duration,
+  override val minTTL: Duration,
+  override val maxTTL: Duration,
   override val outerCache: Option[ObjectCache[K, T]],
   underlying: ObjectCache[K, T],
   serializer: Serializer[T]
 ) extends ObjectCache[K, T] {
 
   // outerCache is wrapped in ReadOnlyCacheWrapper to block updates silently
-  def this(underlying: ObjectCache[K, T], serializer: Serializer[T]) = this(Duration.Inf, Some(new ReadOnlyCacheWrapper(underlying)), underlying, serializer)
+  def this(underlying: ObjectCache[K, T], serializer: Serializer[T]) = this(Duration.Inf, Duration.Inf, Some(new ReadOnlyCacheWrapper(underlying)), underlying, serializer)
 
   sealed trait LocalObjectState
   case class LFound(value: Any) extends LocalObjectState
@@ -71,7 +72,8 @@ class TransactionLocalCache[K <: Key[T], T] private(
 }
 
 class ReadOnlyCacheWrapper[K <: Key[T], T](underlying: ObjectCache[K, T]) extends ObjectCache[K, T] {
-  val ttl: Duration = Duration.Inf
+  val minTTL: Duration = Duration.Inf
+  val maxTTL: Duration = Duration.Inf
 
   protected[cache] def getFromInnerCache(key: K): ObjectState[T] = underlying.getFromInnerCache(key)
 

--- a/kifi-backend/modules/common/test/com/keepit/common/cache/TransactionalCachingTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/cache/TransactionalCachingTest.scala
@@ -10,7 +10,8 @@ class TransactionalCachingTest extends Specification {
 
   class TestCache[K <: Key[T], T] extends ObjectCache[K, T] {
     private[this] val store = TrieMap.empty[K, Option[T]]
-    val ttl = Duration.Inf
+    val minTTL = Duration.Inf
+    val maxTTL = Duration.Inf
 
     protected[cache] def getFromInnerCache(key: K): ObjectState[T] = {
       store.get(key) match {


### PR DESCRIPTION
Optionally, you can set a range of TTL (minTTL, maxTTL) to a cache. Cache will choose TTL for an item randomly between minTTL and maxTTL.
I plan to use this for BookmarkCountForCollectionCache to reduce the impact of cache miss.
