### PR TITLE
Eliza API support for "unsending" notifications

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -190,6 +190,7 @@ object Eliza extends Service {
     def sendToAllUsers() = ServiceRoute(POST, "/internal/eliza/sendToAllUsers")
     def connectedClientCount() = ServiceRoute(GET, "/internal/eliza/connectedClientCount")
     def sendGlobalNotification() = ServiceRoute(POST, "/internal/eliza/sendGlobalNotification")
+    def unsendNotification(id: Long) = ServiceRoute(GET, "/internal/eliza/unsendNotification", Param("id", id))
     def importThread() = ServiceRoute(POST, "/internal/eliza/importThread")
     def getUserThreadStats(userId: Id[User]) = ServiceRoute(GET, "/internal/eliza/getUserThreadStats", Param("userId", userId))
     def getThreadContentForIndexing(sequenceNumber: SequenceNumber[ThreadContent], maxBatchSize: Long) = ServiceRoute(GET, "/internal/eliza/getThreadContentForIndexing", Param("sequenceNumber", sequenceNumber), Param("maxBatchSize", maxBatchSize))

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -160,54 +160,56 @@ class MessagingCommander @Inject() (
 
       (message, thread)
     }
+    SafeFuture {
+      val notificationAttempts = userIds.map { userId =>
+        Try {
+          val (notifJson, userThread) = db.readWrite{ implicit session =>
+            val categoryString = NotificationCategory.User.kifiMessageFormattingCategory.get(category) getOrElse "global"
+            val notifJson = Json.obj(
+              "id"       -> message.externalId.id,
+              "time"     -> message.createdAt,
+              "thread"   -> message.threadExtId.id,
+              "unread"   -> true,
+              "category" -> categoryString,
+              "title"    -> title,
+              "bodyHtml" -> body,
+              "linkText" -> linkText,
+              "url"      -> linkUrl,
+              "isSticky" -> sticky,
+              "image"    -> imageUrl
+            )
 
-    val notificationAttempts = userIds.map { userId =>
-      Try {
-        val (notifJson, userThread) = db.readWrite{ implicit session =>
-          val categoryString = NotificationCategory.User.kifiMessageFormattingCategory.get(category) getOrElse "global"
-          val notifJson = Json.obj(
-            "id"       -> message.externalId.id,
-            "time"     -> message.createdAt,
-            "thread"   -> message.threadExtId.id,
-            "unread"   -> true,
-            "category" -> categoryString,
-            "title"    -> title,
-            "bodyHtml" -> body,
-            "linkText" -> linkText,
-            "url"      -> linkUrl,
-            "isSticky" -> sticky,
-            "image"    -> imageUrl
+            val userThread = userThreadRepo.save(UserThread(
+              id = None,
+              user = userId,
+              thread = thread.id.get,
+              uriId = None,
+              lastSeen = None,
+              unread = true,
+              lastMsgFromOther = Some(message.id.get),
+              lastNotification = notifJson,
+              notificationUpdatedAt = message.createdAt,
+              replyable = false
+            ))
+
+            (notifJson, userThread)
+          }
+
+          notificationRouter.sendToUser(
+            userId,
+            Json.arr("notification", notifJson)
           )
-
-          val userThread = userThreadRepo.save(UserThread(
-            id = None,
-            user = userId,
-            thread = thread.id.get,
-            uriId = None,
-            lastSeen = None,
-            unread = true,
-            lastMsgFromOther = Some(message.id.get),
-            lastNotification = notifJson,
-            notificationUpdatedAt = message.createdAt,
-            replyable = false
-          ))
-
-          (notifJson, userThread)
+          userId
         }
-
-        notificationRouter.sendToUser(
-          userId,
-          Json.arr("notification", notifJson)
-        )
-        userId
       }
+
+      val notified = notificationAttempts collect { case Success(userId) => userId }
+      messagingAnalytics.sentGlobalNotification(notified, message, thread, category)
+
+      val errors = notificationAttempts collect { case Failure(ex) => ex }
+      if (errors.size>0) throw scala.collection.parallel.CompositeThrowable(errors)
     }
-
-    val notified = notificationAttempts collect { case Success(userId) => userId }
-    messagingAnalytics.sentGlobalNotification(notified, message, thread, category)
-
-    val errors = notificationAttempts collect { case Failure(ex) => ex }
-    if (errors.size>0) throw scala.collection.parallel.CompositeThrowable(errors)
+    message.id.get
   }
 
   private def buildMessageNotificationJson(

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/MessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/MessagingController.scala
@@ -75,22 +75,23 @@ class MessagingController @Inject() (
   }
 
   def sendGlobalNotification() = Action(parse.json) { request =>
-    SafeFuture {
-      val data : JsObject = request.body.asInstanceOf[JsObject]
+    val data : JsObject = request.body.asInstanceOf[JsObject]
 
-      val userIds  : Set[Id[User]]  =  (data \ "userIds").as[JsArray].value.map(v => v.asOpt[Long].map(Id[User](_))).flatten.toSet
-      val title    : String         =  (data \ "title").as[String]
-      val body     : String         =  (data \ "body").as[String]
-      val linkText : String         =  (data \ "linkText").as[String]
-      val linkUrl  : String         =  (data \ "linkUrl").as[String]
-      val imageUrl : String         =  (data \ "imageUrl").as[String]
-      val sticky   : Boolean        =  (data \ "sticky").as[Boolean]
-      val category : NotificationCategory =  (data \ "category").as[NotificationCategory]
+    val userIds  : Set[Id[User]]  =  (data \ "userIds").as[JsArray].value.map(v => v.asOpt[Long].map(Id[User](_))).flatten.toSet
+    val title    : String         =  (data \ "title").as[String]
+    val body     : String         =  (data \ "body").as[String]
+    val linkText : String         =  (data \ "linkText").as[String]
+    val linkUrl  : String         =  (data \ "linkUrl").as[String]
+    val imageUrl : String         =  (data \ "imageUrl").as[String]
+    val sticky   : Boolean        =  (data \ "sticky").as[Boolean]
+    val category : NotificationCategory =  (data \ "category").as[NotificationCategory]
 
-      messagingCommander.createGlobalNotification(userIds, title, body, linkText, linkUrl, imageUrl, sticky, category)
+    Ok(messagingCommander.createGlobalNotification(userIds, title, body, linkText, linkUrl, imageUrl, sticky, category).id.toString)
 
-    }
-    Status(ACCEPTED)
+  }
+
+  def unsendNotification(messageId: Long) = Action { request =>
+    Ok("This doesn't do anything yet")
   }
 
   def verifyAllNotifications() = Action { request => //Use with caution, very expensive!

--- a/kifi-backend/modules/eliza/conf/eliza.routes
+++ b/kifi-backend/modules/eliza/conf/eliza.routes
@@ -40,6 +40,7 @@ GET   /internal/eliza/getUserThreadStats        @com.keepit.eliza.controllers.in
 GET   /internal/eliza/sequenceNumber/renormalization @com.keepit.eliza.controllers.internal.ElizaController.getRenormalizationSequenceNumber()
 
 POST  /internal/eliza/sendGlobalNotification    @com.keepit.eliza.controllers.internal.MessagingController.sendGlobalNotification
+GET   /internal/eliza/unsendNotification        @com.keepit.eliza.controllers.internal.MessagingController.unsendNotification(id: Long)
 GET   /internal/eliza/getThreadContentForIndexing  @com.keepit.eliza.controllers.internal.MessagingController.getThreadContentForIndexing(sequenceNumber: Long, maxBatchSize: Long)
 
 GET   /internal/eliza/verifyAllNotifications    @com.keepit.eliza.controllers.internal.MessagingController.verifyAllNotifications


### PR DESCRIPTION
actual unsending endpoint is still a noOp.
@eishay fell free to merge. This should decouple us. You'll have to change all the `long`s to `Id[MessageHandle]`
