### PR TITLE
actual logic for removing a user from a thread the hard way

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/MessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/MessagingController.scala
@@ -90,8 +90,12 @@ class MessagingController @Inject() (
 
   }
 
+  //The whole code path starting here isn't the best.
+  //What we really need is some sort of notion that a notification has a call to action
+  //and a marker when that was completed.
   def unsendNotification(messageId: Long) = Action { request =>
-    Ok("This doesn't do anything yet")
+    messagingCommander.deleteUserThreadsForMessageId(Id[Message](messageId))
+    Ok("It's a goner.")
   }
 
   def verifyAllNotifications() = Action { request => //Use with caution, very expensive!


### PR DESCRIPTION
Only allowed use right now is for triggered notifications. It’s not the
cleanest, but it will unblock mobile. Better data cleanup coming
shortly.
