### PR TITLE
sending message to client without waiting on the db and logging userThread.notificationUpdatedAt and userThread.notificationLastSeen

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/ElizaEmailNotifier.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/ElizaEmailNotifier.scala
@@ -70,6 +70,8 @@ class ElizaEmailNotifierActor @Inject() (
       ThreadItem(message.from.get, MessageLookHereRemover(message.messageText))
     } reverse
 
+    log.info(s"preparing to send email for thread ${thread.id}, user thread ${thread.id} of user ${userThread.user} with notificationUpdatedAt=${userThread.notificationUpdatedAt} and notificationLastSeen=${userThread.notificationLastSeen} with ${threadItems.size} items")
+
     if (threadItems.nonEmpty) {
       val title  = thread.pageTitle.getOrElse(thread.nUrl.get).abbreviate(50)
       shoebox.sendUnreadMessages(threadItems, otherParticipants, userThread.user, title, thread.deepLocator)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/ElizaEmailNotifier.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/ElizaEmailNotifier.scala
@@ -70,7 +70,7 @@ class ElizaEmailNotifierActor @Inject() (
       ThreadItem(message.from.get, MessageLookHereRemover(message.messageText))
     } reverse
 
-    log.info(s"preparing to send email for thread ${thread.id}, user thread ${thread.id} of user ${userThread.user} with notificationUpdatedAt=${userThread.notificationUpdatedAt} and notificationLastSeen=${userThread.notificationLastSeen} with ${threadItems.size} items")
+    log.info(s"preparing to send email for thread ${thread.id}, user thread ${thread.id} of user ${userThread.user} with notificationUpdatedAt=${userThread.notificationUpdatedAt} and notificationLastSeen=${userThread.notificationLastSeen} with ${threadItems.size} items and unread=${userThread.unread}")
 
     if (threadItems.nonEmpty) {
       val title  = thread.pageTitle.getOrElse(thread.nUrl.get).abbreviate(50)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/ElizaEmailNotifier.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/ElizaEmailNotifier.scala
@@ -70,7 +70,7 @@ class ElizaEmailNotifierActor @Inject() (
       ThreadItem(message.from.get, MessageLookHereRemover(message.messageText))
     } reverse
 
-    log.info(s"preparing to send email for thread ${thread.id}, user thread ${thread.id} of user ${userThread.user} with notificationUpdatedAt=${userThread.notificationUpdatedAt} and notificationLastSeen=${userThread.notificationLastSeen} with ${threadItems.size} items and unread=${userThread.unread}")
+    log.info(s"preparing to send email for thread ${thread.id}, user thread ${thread.id} of user ${userThread.user} with notificationUpdatedAt=${userThread.notificationUpdatedAt} and notificationLastSeen=${userThread.notificationLastSeen} with ${threadItems.size} items and unread=${userThread.unread} and notificationEmailed ${userThread.notificationEmailed}")
 
     if (threadItems.nonEmpty) {
       val title  = thread.pageTitle.getOrElse(thread.nUrl.get).abbreviate(50)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -215,7 +215,7 @@ class MessagingCommander @Inject() (
       (message.threadExtId, userThreadRepo.getByThread(threadId))
     }
     if (userThreads.length != 1) {
-      airbrake.notify(s"Trying to delete notification for thread ${threadExtId} with not exactly one participant. Not permitted.")
+      airbrake.notify(s"Trying to delete notification for thread $threadExtId with not exactly one participant. Not permitted.")
     } else {
       userThreads.foreach{ userThread =>
         db.readWrite { implicit session =>

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessageThread.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessageThread.scala
@@ -121,7 +121,7 @@ case class MessageThread(
   def clean(): MessageThread = copy(pageTitle = pageTitle.map(_.trimAndRemoveLineBreaks()))
 
   def withId(id: Id[MessageThread]): MessageThread = this.copy(id = Some(id))
-  def withUpdateTime(updateTime: DateTime) = this.copy(updateAt=updateTime)
+  def withUpdateTime(updateTime: DateTime) = this.copy(updateAt = updateTime)
 
   def withParticipants(when: DateTime, userIds: Seq[Id[User]], nonUsers: Seq[NonUserParticipant] = Seq.empty) = {
     val newUsers = userIds.map(_ -> when).toMap

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThread.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThread.scala
@@ -36,5 +36,5 @@ case class UserThread(
   extends Model[UserThread] {
 
   def withId(id: Id[UserThread]): UserThread = this.copy(id = Some(id))
-  def withUpdateTime(updateTime: DateTime) = this.copy(updateAt=updateTime)
+  def withUpdateTime(updateTime: DateTime) = this.copy(updateAt = updateTime)
 }


### PR DESCRIPTION
to understand a high latency emails bug

@andrewconner & @stkem what is the rule that we should send emails on? Is it exactly 15 minutes after notificationUpdatedAt provided that notificationEmailed is false and unread is true?

I would like to document it and create a check before sending verifying that the email sent it within the boundaries of time we expect it to be sent (e.g. not more then three minutes after the time it should have been sent).
