### PR TITLE
Some style tweaks for dragging

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/classes.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/classes.styl
@@ -44,3 +44,4 @@
 .kf-dragged
   .kf-drag-mask
     border-style: solid
+

--- a/kifi-backend/modules/shoebox/angular/src/common/classes.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/classes.styl
@@ -32,18 +32,14 @@
   height: 100%
   z-index: 1
   box-sizing: border-box
-  border-width: 2px
-  border-color: #c3dba8
+  border-width: 1px
+  border-color: #c4d4e9
   border-style: none
 
 .kf-candidate-drag-target
 .kf-dragged
   .kf-drag-mask
     display: block
-
-.kf-drag-target
-  .kf-drag-mask
-    border-style: dashed
 
 .kf-dragged
   .kf-drag-mask

--- a/kifi-backend/modules/shoebox/angular/src/friends/friends.js
+++ b/kifi-backend/modules/shoebox/angular/src/friends/friends.js
@@ -17,9 +17,9 @@ angular.module('kifi.friends', [
 ])
 
 .controller('FriendsCtrl', [
-  '$scope', 'profileService', '$window',
+  '$scope', '$window',
   function ($scope, $window) {
-    //$window.document.title = 'Kifi • Your Friends on Kifi';
+    $window.document.title = 'Kifi • Your Friends on Kifi';
 
     // plenty to do!
   }

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
@@ -280,3 +280,6 @@
 
 .kf-keep.detailed .kf-keep-button-preview
   display: none
+
+.kf-drag-target
+  background-color: #E2E6EC

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
@@ -76,7 +76,7 @@ angular.module('kifi.keeps', ['kifi.profileService', 'kifi.keepService'])
 
         function keepKeyBindings(e) {
           var meta = e && (e.shiftKey || e.altKey || e.ctrlKey || e.metaKey);
-          if (meta && e.currentTarget && e.currentTarget.activeElement && e.currentTarget.activeElement.tagName === 'BODY') {
+          if (e && !meta && e.currentTarget && e.currentTarget.activeElement && e.currentTarget.activeElement.tagName === 'BODY') {
             var captured = false;
             /* jshint maxcomplexity: false */
             switch (e.which) {

--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.styl
@@ -26,6 +26,7 @@
 
   .kf-nav-item.active &
     color: #556179
+    background-color: #e3e6ee
 
 .kf-nav-count
   float: right

--- a/kifi-backend/modules/shoebox/angular/src/tags/tagItem.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tagItem.tpl.html
@@ -22,7 +22,7 @@
         </ul>
       </div>
       <input class="kf-tag-rename" type="text" placeholder="Type new tag name" ng-model="renameTag.value" ng-keydown="onRenameKeydown($event)" ng-show="isRenaming">
-      <div class="kf-drag-mask" ng-class="{ 'kf-drag-target': isDragTarget }"></div>
+      <div class="kf-drag-mask"></div>
       <div class="kf-tag-drag-mask"></div>
       <div class="kf-tag-new-location-mask hidden"></div>
     </div>

--- a/kifi-backend/modules/shoebox/angular/src/tags/tags.styl
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tags.styl
@@ -86,10 +86,10 @@ nav-item()
     &.hover
       background-color: #e9ecf2
 
-  &.highlight
-  &.drop-hover
-    .kf-nav-link
-      background-color: #6fa6ef
+  .highlight,
+  .kf-drag-target.kf-drag-target.kf-drag-target // specificity
+    background-color: #6fa6ef
+    color: white
 
     .kf-tag-caption
     .kf-tag-name
@@ -195,10 +195,6 @@ nav-item()
       border-top-color: white
 
 
-  .kf-drag-mask
-  .kf-tag-drag-mask
-    border-color: #b8c5d3
-
 .kf-tag-new-location-mask
   pointer-events: none
   border-style: solid
@@ -209,9 +205,6 @@ nav-item()
     border-color: rgba(184,197,211,0)
     transition: all 1.5s
 
-.kf-candidate-tag-drag-target
-  .kf-tag-drag-mask
-    display: block
 
 .kf-tag-rename.kf-tag-rename
   padding: 0


### PR DESCRIPTION
@martinraison This makes it a bit more like the current site. Specifically, changing the background color of drag targets.

It's not perfect, noticed a few bugs, but it makes it easier to see what the target is (previously when dragging a keep to a tag, the dashed border was hard to see).

Also, I can't figure out where opacity for the dragged item is set. Any clue?
