### PR TITLE
Automatically connect email inviters on sign up

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/InvitationRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/InvitationRepo.scala
@@ -21,6 +21,7 @@ trait InvitationRepo extends Repo[Invitation] with RepoWithDelete[Invitation] wi
   def getByUser(urlId: Id[User])(implicit session: RSession): Seq[Invitation]
   def countByUser(urlId: Id[User])(implicit session: RSession): Int
   def getByRecipientSocialUserId(socialUserInfoId: Id[SocialUserInfo])(implicit session: RSession): Seq[Invitation]
+  def getByRecipientEmailAddress(emailAddress: String)(implicit session: RSession): Seq[Invitation]
   def getBySenderIdAndRecipientEContactId(senderId:Id[User], econtactId: Id[EContact])(implicit session: RSession):Option[Invitation]
   def getBySenderIdAndRecipientSocialUserId(senderId:Id[User], socialUserInfoId: Id[SocialUserInfo])(implicit session: RSession):Option[Invitation]
   def getBySenderIdAndRecipientEmailAddress(senderId:Id[User], emailAddress: String)(implicit session: RSession): Option[Invitation]
@@ -115,6 +116,10 @@ class InvitationRepoImpl @Inject() (
 
   def getByRecipientSocialUserId(socialUserInfoId: Id[SocialUserInfo])(implicit session: RSession): Seq[Invitation] = {
     (for(b <- rows if b.recipientSocialUserId === socialUserInfoId) yield b).list
+  }
+
+  def getByRecipientEmailAddress(emailAddress: String)(implicit session: RSession): Seq[Invitation] = {
+    (for { row <- rows if row.recipientEmailAddress === emailAddress } yield row).list
   }
 
   def getBySenderIdAndRecipientEContactId(senderId: Id[User], econtactId: Id[EContact])(implicit session: RSession): Option[Invitation] = {

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoTypeMappers.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoTypeMappers.scala
@@ -22,6 +22,7 @@ import play.api.libs.json.JsObject
 import com.keepit.common.mail.GenericEmailAddress
 import com.keepit.social.SocialId
 import com.keepit.model.DeepLocator
+import com.keepit.abook.model.RichSocialConnection
 
 case class InvalidDatabaseEncodingException(msg: String) extends java.lang.Throwable
 
@@ -135,6 +136,7 @@ trait FortyTwoGenericTypeMappers { self: {val db: DataBaseComponent} =>
   def getResultOptionFromMapper[T](implicit mapper: BaseColumnType[T]): GetResult[Option[T]] = GetResult[Option[T]](mapper.nextOption)
 
   implicit val getDateTimeResult = getResultFromMapper[DateTime]
+  implicit val getSocialNetworkTypeResult = getResultFromMapper[SocialNetworkType]
   implicit def getSequenceNumberResult[T] = getResultFromMapper[SequenceNumber[T]]
   implicit def getIdResult[M <: Model[M]] = getResultFromMapper[Id[M]]
   implicit def getOptIdResult[M <: Model[M]] = getResultOptionFromMapper[Id[M]]


### PR DESCRIPTION
@andrewconner 
It could make sense to have an optional "acceptedBy" field in invitation to store the accepting user's id instead of replacing the social user (that keeps track of the original invite channel)
