### PR TITLE
fixing invitation source in mixpanel

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/InviteCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/InviteCommander.scala
@@ -448,7 +448,7 @@ class InviteCommander @Inject() (
     contextBuilder += ("socialNetwork", socialNetwork.toString)
     contextBuilder += ("inviteId", invite.externalId.id)
     contextBuilder += ("invitationNumber", inviteInfo.invitationNumber)
-    inviteInfo.source.foreach { source => contextBuilder += ("source", source) }
+    contextBuilder += ("source", inviteInfo.source)
     invite.recipientEContactId.foreach { eContactId => contextBuilder += ("recipientEContactId", eContactId.toString) }
     invite.recipientSocialUserId.foreach { socialUserId => contextBuilder += ("recipientSocialUserId", socialUserId.toString) }
     heimdal.trackEvent(UserEvent(senderId, contextBuilder.build, UserEventTypes.INVITED, invite.lastSentAt getOrElse invite.createdAt))


### PR DESCRIPTION
in which we see how type-safe languages with sufficiently rich APIs and implicit type conversions facilitate the same kinds of programming errors as scripting languages

cc @leogrim 
