### PR TITLE
2.9.20: avoiding kifi friend hover glitches on google.com

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.9.19
+version=2.9.20


### PR DESCRIPTION
There were invisible orphaned hovers being left on the page, covering links (making them unclickable).

Also, moving the mouse pointer over a picture from the top would trigger the friend card to appear directly under the mouse pointer, triggering a mouseout from the picture, which would immediately hide the friend card. Now we never hide the hover element as long as the mouse pointer is anywhere in the trigger element or the hover element, regardless of the configuration options.
