### PR TITLE
2.9.21: update extension immediately with new user picture

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.9.20
+version=2.9.21

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -378,6 +378,33 @@ var socketHandlers = {
     experiments = exp;
     api.toggleLogging(exp.indexOf('extension_logging') >= 0);
   },
+  new_pic: function (name) {
+    log('[socket:new_pic]', name)();
+    if (me) {
+      me.pictureName = name;
+      emitAllTabs('me_change', me);
+      for (var thId in messageData) {
+        var arr = messageData[thId];
+        for (var i = 0; i < arr.length; i++) {
+          var m = arr[i];
+          updatePic(m.user);
+          m.participants.forEach(updatePic);
+        }
+      }
+      for (var thId in threadsById) {
+        var th = threadsById[thId];
+        if (th.category === 'message') {
+          updatePic(th.author);
+          th.participants.forEach(updatePic);
+        }
+      }
+    }
+    function updatePic(u) {
+      if (u.id === me.id) {
+        u.pictureName = name;
+      }
+    }
+  },
   new_friends: function (fr) {
     log('[socket:new_friends]', fr)();
     if (friends) {


### PR DESCRIPTION
Note: The user’s old picture may still show up in his/her extension after it knows about the picture change because eliza continues to send responses containing the old picture name for at least a few minutes, and the extension doesn’t (yet) overwrite the user’s picture name in all the different responses eliza can send.

cc @eishay @stkem 
