### PR TITLE
2.9.23: fixing rare JS error due to fetching thread info in wrong format

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.9.22
+version=2.9.23

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -802,7 +802,7 @@ api.port.on({
       emitThreadInfoToTab(th, tab);
     } else {
       // TODO: remember that this tab needs this thread info until it gets it or its pane changes?
-      socket.send(['get_thread_info', id], function (th) {
+      socket.send(['get_one_thread', id], function (th) {
         standardizeNotification(th);
         updateIfJustRead(th);
         threadsById[th.thread] = th;


### PR DESCRIPTION
This code path is only used to display the message header (participants) when a thread is viewed before its thread info has been retrieved as part of a thread list.
