### PR TITLE
2.9.25: properly identifying domain of more kinds of http(s) URLs

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.9.24
+version=2.9.25

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -7,9 +7,9 @@ var log = log || api.log;
 
 var THREAD_BATCH_SIZE = 8;
 
-//                          | sub |    |------- country domain -------|-- generic domain --|           |-- port? --|
-var domainRe = /^https?:\/\/[^\/]*?((?:[^.\/]+\.[^.\/]{2,3}\.[^.\/]{2}|[^.\/]+\.[^.\/]{2,6}|localhost))(?::\d{2,5})?(?:$|\/)/;
-var hostRe = /^https?:\/\/([^\/]+)/;
+//                          | sub -| |-------- country domain --------|--- generic domain ---|---- IP v4 address ----| name -| |.||-- port? --|
+var domainRe = /^https?:\/\/[^\/:]*?([^.:\/]+\.[^.:\/]{2,3}\.[^.\/]{2}|[^.:\/]+\.[^.:\/]{2,6}|\d{1,3}(?:\.\d{1,3}){3}|[^.:\/]+)\.?(?::\d{2,5})?(?:$|\/|#)/;
+var hostRe = /^https?:\/\/([^\/?#]+)/;
 
 var tabsByUrl = {}; // normUrl => [tab]
 var tabsByLocator = {}; // locator => [tab]


### PR DESCRIPTION
The trailing dot after the hostname and before the optional port part is pretty funny, but consistent across Chrome and Firefox. Try it: [https://www.kifi.com.](https://www.kifi.com.)
