### PR TITLE
avoiding JS errors caused by kosher israeli firewalls

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -409,8 +409,8 @@ var api = (function createApi() {
   }
 
   var onXhrLoadEnd = errors.wrap(function onXhrLoadEnd(done, fail) {
-    if (this.status >= 200 && this.status < 300) {
-      if (done) done(/^application\/json/.test(this.getResponseHeader('Content-Type')) ? JSON.parse(this.responseText) : this);
+    if (this.status >= 200 && this.status < 300 && /^application\/json/.test(this.getResponseHeader('Content-Type'))) {
+      if (done) done(JSON.parse(this.responseText));
     } else {
       if (fail) fail(this);
     }

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -197,8 +197,8 @@ exports.request = function(method, url, data, done, fail) {
   require('sdk/request').Request(options)[method.toLowerCase()]();
 };
 var onRequestEnd = errors.wrap(function onRequestEnd(done, fail, resp) {
-  if (resp.status >= 200 && resp.status < 300) {
-    if (done) done(resp.json || resp);
+  if (resp.status >= 200 && resp.status < 300 && /^application\/json/.test(resp.headers['Content-Type'])) {
+    if (done) done(resp.json);
   } else {
     if (fail) fail(resp);
   }


### PR DESCRIPTION
We no longer trust a 2xx response status of ajax calls. We now require the application/json Content-Type as well.

safepage.neto.net.il was intercepting some of our search ajax calls and responding with a 200 HTML page, presumably saying the request is not kosher.
