### PR TITLE
2.9.29: avoid URIError when decoding Google Search queries using decodeURIComponent

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -111,8 +111,15 @@ var api = (function createApi() {
   chrome.webNavigation.onBeforeNavigate.addListener(errors.wrap(function (details) {
     var match = details.url.match(googleSearchRe);
     if (match && details.frameId === 0) {
-      var query = decodeURIComponent(match[1].replace(plusRe, ' ')).trim();
-      if (query) dispatch.call(api.on.search, query, ~details.url.indexOf('sourceid=chrome') ? 'o' : 'n');
+      var query;
+      try {
+        query = decodeURIComponent(match[1].replace(plusRe, ' ')).trim();
+      } catch (e) {
+        log('[onBeforeNavigate] non-UTF-8 search query:', match[1], e)();  // e.g. www.google.co.il/search?hl=iw&q=%EE%E9%E4
+      }
+      if (query) {
+        dispatch.call(api.on.search, query, ~details.url.indexOf('sourceid=chrome') ? 'o' : 'n');
+      }
     }
   }));
 

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -546,7 +546,12 @@ require('./location').onChange(errors.wrap(function onLocationChange(tabId, newP
     let page = getPageOrHideOldAndCreatePage(tab);
     let match = googleSearchRe.exec(tab.url);
     if (match) {
-      let query = decodeURIComponent(match[1].replace(plusRe, ' ')).trim();
+      let query;
+      try {
+        query = decodeURIComponent(match[1].replace(plusRe, ' ')).trim();
+      } catch (e) {
+        log('[onLocationChange] non-UTF-8 search query:', match[1], e)();  // e.g. www.google.co.il/search?hl=iw&q=%EE%E9%E4
+      }
       if (query) {
         let channel = match[2];
         dispatch.call(exports.on.search, query, channel === 'fflb' ? 'a' : channel === 'sb' ? 's' : 'n');

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.9.25
+version=2.9.26


### PR DESCRIPTION
Google does some smart character set guessing when the search query is not encoded using UTF-8. We should probably do that someday.

Also retrying parsing the search query from the DOM, if necessary, once it’s ready.
