### PR TITLE
admin method to remove duplicate keeps

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/UrlController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/UrlController.scala
@@ -259,6 +259,11 @@ class UrlController @Inject() (
     }
     Ok(Json.toJson(problematicUris))
   }
+
+  def fixDuplicateKeeps(readOnly: Boolean = true) = AdminHtmlAction.authenticated { implicit request =>
+    uriIntegrityPlugin.fixDuplicateKeeps(readOnly)
+    Ok(s"started readOnly=$readOnly")
+  }
 }
 
 case class DisplayedDuplicate(id: Id[DuplicateDocument], normUriId: Id[NormalizedURI], url: String, percentMatch: Double)

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/DataIntegrity.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/DataIntegrity.scala
@@ -19,7 +19,7 @@ class DataIntegrityPluginImpl @Inject() (
   // plugin lifecycle methods
   override def enabled: Boolean = true
   override def onStart() {
-    scheduleTaskOnLeader(actor.system, 5 minutes, 1 hour, actor.ref, Cron)
+    scheduleTaskOnLeader(actor.system, 5 minutes, 15 minutes, actor.ref, Cron)
   }
 }
 

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -334,6 +334,7 @@ GET     /admin/data/scrapeArticle       @com.keepit.controllers.admin.ScraperAdm
 GET     /admin/data/scraperRequests     @com.keepit.controllers.admin.ScraperAdminController.scraperRequests(stateFilter: Option[String] ?= None)
 GET     /admin/data/scrape/regex        @com.keepit.controllers.admin.ScraperAdminController.rescrapeByRegex(urlRegex: String ?= "", withinMinutes: Int ?= 8)
 GET     /admin/data/remigrate           @com.keepit.controllers.admin.UrlController.fixRedirectedUriStates(doIt: Boolean ?= false)
+GET     /admin/data/dedupKeeps          @com.keepit.controllers.admin.UrlController.fixDuplicateKeeps(readOnly: Boolean ?= true)
 
 GET     /admin/article/index        @com.keepit.controllers.admin.AdminArticleIndexerController.index
 GET     /admin/article/reindex      @com.keepit.controllers.admin.AdminArticleIndexerController.reindex

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
@@ -28,14 +28,14 @@ class UriIntegrityPluginTest extends Specification with ShoeboxApplicationInject
 
         def setup() = {
           db.readWrite { implicit session =>
-            val nuri0 = uriRepo.save(NormalizedURI.withHash("http://www.google.com/", Some("Google")).withState(NormalizedURIStates.SCRAPED))
-            val nuri1 = uriRepo.save(NormalizedURI.withHash("http://google.com/", Some("Google")))
-            val nuri2 = uriRepo.save(NormalizedURI.withHash("http://www.bing.com/", Some("Bing")).withState(NormalizedURIStates.SCRAPED))
-            val nuri3 = uriRepo.save(NormalizedURI.withHash("http://www.fakebing.com/", Some("Bing")))
+            val nuri0 = uriRepo.save(NormalizedURI.withHash("http://www.google.com", Some("Google")).withState(NormalizedURIStates.SCRAPED))
+            val nuri1 = uriRepo.save(NormalizedURI.withHash("http://google.com", Some("Google")))
+            val nuri2 = uriRepo.save(NormalizedURI.withHash("http://www.bing.com", Some("Bing")).withState(NormalizedURIStates.SCRAPED))
+            val nuri3 = uriRepo.save(NormalizedURI.withHash("http://www.fakebing.com", Some("Bing")))
 
-            val url0 = urlRepo.save(URLFactory("http://www.google.com/#1", nuri0.id.get))             // to be redirected to nuri1
-            val url1 = urlRepo.save(URLFactory("http://www.bing.com/index", nuri2.id.get))
-            val url2 = urlRepo.save(URLFactory("http://www.fakebing.com/index", nuri2.id.get))        // to be splitted, to be pointing to
+            val url0 = urlRepo.save(URLFactory("http://www.google.com/", nuri0.id.get))             // to be redirected to nuri1
+            val url1 = urlRepo.save(URLFactory("http://www.bing.com/", nuri2.id.get))
+            val url2 = urlRepo.save(URLFactory("http://www.fakebing.com/", nuri2.id.get))        // to be splitted, to be pointing to
 
             val user = userRepo.save(User(firstName = "foo", lastName = "bar"))
             val user2 = userRepo.save(User(firstName = "abc", lastName = "xyz"))
@@ -137,8 +137,8 @@ class UriIntegrityPluginTest extends Specification with ShoeboxApplicationInject
 
             val user = userRepo.save(User(firstName = "foo", lastName = "bar"))
 
-            val uri0 = uriRepo.save(NormalizedURI.withHash("http://www.google.com/", Some("Google")))
-            val uri0better = uriRepo.save(NormalizedURI.withHash("http://google.com/", Some("Google")))
+            val uri0 = uriRepo.save(NormalizedURI.withHash("http://www.google.com", Some("Google")))
+            val uri0better = uriRepo.save(NormalizedURI.withHash("http://google.com", Some("Google")))
 
             val uri1 = uriRepo.save(NormalizedURI.withHash("http://www.google.com/drive", Some("Google")))
             val uri1better = uriRepo.save(NormalizedURI.withHash("http://google.com/drive", Some("Google")))


### PR DESCRIPTION
@raymondng @yingjieMiao @leogrim 
Please review.

fixDuplicateKeeps will go thru all keeps and fix uri ids. It uses handleBookmarks to merge duplicate bookmarks and also update collections.

In addition, I modified handleBookmarks to handle the privacy flag properly.
