### PR TITLE
keeps: unkeep with extIds

### DIFF
--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -215,6 +215,7 @@ POST    /waitlist                   @com.keepit.controllers.website.FeatureWaitl
 GET     /site/keeps/all             @com.keepit.controllers.website.KeepsController.allKeeps(before: Option[String], after: Option[String], collection: Option[String], count: Int ?= Integer.MAX_VALUE)
 POST    /site/keeps/add             @com.keepit.controllers.website.KeepsController.keepMultiple()
 POST    /site/keeps/remove          @com.keepit.controllers.website.KeepsController.unkeepMultiple()
+POST    /site/keeps/delete          @com.keepit.controllers.website.KeepsController.unkeepBatch()
 GET     /site/keeps/count           @com.keepit.controllers.website.KeepsController.numKeeps()
 GET     /site/keeps/import/status   @com.keepit.controllers.website.KeepsController.importStatus()
 GET     /site/keeps/:id             @com.keepit.controllers.website.KeepsController.getKeepInfo(id: ExternalId[Keep])


### PR DESCRIPTION
Initial pass. This version only deals with (requires) external id.

The single version is basically a stricter version of what we have today. It's based on external id instead of relying url lookup. It also improves on robustness by attempting to catch/report (via Try) on error conditions.

The batch version will return two sets of results: "removedKeeps" and "errors". 

The error reporting likely needs some work -- right now it's really just some human readable string -- would love to talk to you about how to properly report/handle various error types.

cc: @ymatsuda @andrewconner @2is10 @eishay  
