### PR TITLE
[angular] fixed tag reordering + directive for disabling drag on input

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -11,6 +11,7 @@ angular.module('kifi', [
   'util',
   'dom',
   'antiscroll',
+  'nodraginput',
   'jun.smartScroll',
   'angularMoment',
   'kifi.home',

--- a/kifi-backend/modules/shoebox/angular/src/common/classes.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/classes.styl
@@ -48,6 +48,10 @@
   .kf-drag-mask
     display: block
 
+.kf-candidate-tag-drag-target
+  .kf-tag-drag-mask
+    display: block
+
 .kf-dragged
   .kf-drag-mask
     border-style: solid

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoPics.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoPics.js
@@ -82,7 +82,6 @@ angular.module('kifi.keepWhoPics', ['kifi.keepWhoService'])
       link: function (scope) {
         scope.getPicUrl = keepWhoService.getPicUrl;
         scope.getName = keepWhoService.getName;
-        console.log('xxxx', scope.keep)
         scope.isMyBookmark = scope.keep && scope.keep.isMyBookmark;
       }
     };

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/nodraginput.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/nodraginput.js
@@ -1,0 +1,27 @@
+'use strict';
+
+angular.module('nodraginput', [])
+
+.directive('kfNoDragInput', [
+  function () {
+    return {
+      restrict: 'A',
+      link: function (scope, element /*, attrs */ ) {
+
+        function disableDragEffect(event) {
+          if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = 'none';
+          }
+          event.stopPropagation();
+          event.preventDefault();
+        }
+
+        element.attr('draggable', 'false');
+        element.on('dragstart', function () { return false; });
+        element.on('dragenter', disableDragEffect);
+        element.on('dragover', disableDragEffect);
+        element.on('drop', disableDragEffect);
+      }
+    };
+  }
+]);

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keepService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keepService.js
@@ -368,7 +368,7 @@ angular.module('kifi.keepService', [
           var keeps = result.keeps;
           var _before = result.before;
 
-          if (!keeps.length || keeps.length < params.count-1) {
+          if (!keeps.length || keeps.length < params.count - 1) {
             end = true;
           }
 

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/main.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/main.tpl.html
@@ -1,6 +1,6 @@
 <div class="kf-col-inner" ng-controller="MainCtrl">
   <div class="kf-query-wrap" ng-class="{ empty: isEmpty(), focus: focus }">
-    <input class="kf-query" type="text" placeholder="Find anything..." ng-model="search.text" ng-keydown="onKeydown($event)" ng-focus="onFocus()" ng-blur="onBlur()" ng-change="onChange()">
+    <input kf-no-drag-input class="kf-query" type="text" placeholder="Find anything..." ng-model="search.text" ng-keydown="onKeydown($event)" ng-focus="onFocus()" ng-blur="onBlur()" ng-change="onChange()">
     <span class="kf-query-icon">
       <b class="kf-query-mag"></b>
       <a class="kf-query-x" href="javascript:" ng-click="clear()"></a>

--- a/kifi-backend/modules/shoebox/angular/src/tags/tagItem.js
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tagItem.js
@@ -115,7 +115,7 @@ angular.module('kifi.tagItem', ['kifi.tagService'])
         var tagDragMask = element.find('.kf-tag-drag-mask');
         var tagDraggedUpon = false;
         var yBoundary = parseInt(element.css('height'), 10) / 2;
-        var isTop;
+        var isTop = null;
 
         function startTagDrag() {
           tagDraggedUpon = true;
@@ -133,10 +133,10 @@ angular.module('kifi.tagItem', ['kifi.tagService'])
             var posY = e.originalEvent.clientY - util.offset(element).top;
             if (posY > yBoundary) {
               isTop = false;
-              tagDragMask.css({borderTopStyle: 'none', borderBottomStyle: 'dotted', marginTop: 0});
+              tagDragMask.css({borderTopStyle: 'none', borderBottomStyle: 'dotted', marginTop: '1px'});
             } else {
               isTop = true;
-              tagDragMask.css({borderTopStyle: 'dotted', borderBottomStyle: 'none', marginTop: '-2px'});
+              tagDragMask.css({borderTopStyle: 'dotted', borderBottomStyle: 'none', marginTop: 0});
             }
           }
         });

--- a/kifi-backend/modules/shoebox/angular/src/tags/tags.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tags.tpl.html
@@ -1,7 +1,7 @@
 <div class="kf-tags">
   <div class="kf-nav-group-name">Tags</div>
   <label class="kf-nav-item kf-tag-input-box">
-    <input name="filterName" placeholder="Find or add a tag..." ng-model="filter.name" focus-when="focusFilter" ng-keydown="onKeydown($event)" ng-blur="dehighlight()">
+    <input kf-no-drag-input name="filterName" placeholder="Find or add a tag..." ng-model="filter.name" focus-when="focusFilter" ng-keydown="onKeydown($event)" ng-blur="dehighlight()">
     <a class="kf-tag-input-clear" href="javascript:" ng-click="clearFilter(true)" ng-show="filter.name">&times;</a>
   </label>
   <div class="kf-tag-list-hidden"></div>


### PR DESCRIPTION
@stkem @andrewconner Dragging an element on an input field causes pretty bad behavior (basically the json of the data being dragged is pasted into the input field, which is very confusing for the user). Adding the kf-no-drag-input directive to the field  disables that behavior. I think it should be used in many cases, but if you think it is too costly to spend a directive on this, we can also manually add a (pretty long) list of attributes to every input field where drag&drop should be disabled (I'm also interested in any better solution).
