### PR TITLE
[angular] better UI for dragging group of keeps

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/classes.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/classes.styl
@@ -44,7 +44,6 @@
   border-style: none
 
 .kf-candidate-drag-target
-.kf-dragged
   .kf-drag-mask
     display: block
 

--- a/kifi-backend/modules/shoebox/angular/src/detail/detail.js
+++ b/kifi-backend/modules/shoebox/angular/src/detail/detail.js
@@ -68,7 +68,7 @@ angular.module('kifi.detail',
         };
 
         scope.isPublic = function () {
-          return scope.howKept === 'public' && scope.keep.isMyBookmark;
+          return scope.howKept === 'public';
         };
 
         scope.toggleKeep = function () {

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -42,8 +42,18 @@ angular.module('kifi.keep', ['kifi.keepWhoPics', 'kifi.keepWhoText', 'kifi.tagSe
   function ($document, $rootElement, tagService, util) {
     return {
       restrict: 'A',
-      scope: true,
+      scope: {
+        keep: '=',
+        me: '=',
+        toggleSelect: '&',
+        isPreviewed: '&',
+        isSelected: '&',
+        clickAction: '&',
+        dragKeeps: '&',
+        stopDraggingKeeps: '&'
+      },
       controller: 'KeepCtrl',
+      replace: true,
       templateUrl: 'keep/keep.tpl.html',
       link: function (scope, element /*, attrs*/ ) {
         scope.getTags = function () {
@@ -133,8 +143,6 @@ angular.module('kifi.keep', ['kifi.keepWhoPics', 'kifi.keepWhoText', 'kifi.tagSe
         updateTitleHtml();
         updateDescHtml();
 
-        var $k = element.find('li.kf-keep');
-
         // Really weird hack to fix a ng-class bug
         // In certain cases, ng-class is not setting DOM classes correctly.
         // Reproduction: select several keeps, preview one of the keeps,
@@ -145,15 +153,16 @@ angular.module('kifi.keep', ['kifi.keepWhoPics', 'kifi.keepWhoText', 'kifi.tagSe
             'mine': scope.isMyBookmark(scope.keep),
             'example': scope.isExample(scope.keep),
             'private': scope.isPrivate(scope.keep),
-            'detailed': scope.isPreviewed(scope.keep),
-            'selected': !!scope.isSelected(scope.keep)
+            'detailed': scope.isPreviewed({keep: scope.keep}),
+            'selected': !!scope.isSelected({keep: scope.keep})
           };
         }, function (cur) {
           _.forOwn(cur, function (value, key) {
-            if (value && !$k.hasClass(key)) {
-              $k.addClass(key);
-            } else if (!value && $k.hasClass(key)) {
-              $k.removeClass(key);
+            if (value && !element.hasClass(key)) {
+              console.log(key);
+              element.addClass(key);
+            } else if (!value && element.hasClass(key)) {
+              element.removeClass(key);
             }
           });
         });
@@ -190,7 +199,7 @@ angular.module('kifi.keep', ['kifi.keepWhoPics', 'kifi.keepWhoText', 'kifi.tagSe
         scope.onCheck = function (e) {
           // needed to prevent previewing
           e.stopPropagation();
-          return scope.toggleSelect(scope.keep);
+          return scope.toggleSelect();
         };
 
         var dragMask = element.find('.kf-drag-mask');
@@ -216,12 +225,11 @@ angular.module('kifi.keep', ['kifi.keepWhoPics', 'kifi.keepWhoText', 'kifi.tagSe
           mouseY = e.pageY - util.offset(element).top;
         });
         element.on('dragstart', function (e) {
-          element.addClass('kf-dragged');
-          var draggedKeepsElement = scope.dragKeeps(scope.keep);
-          var sendData = angular.toJson(scope.draggedKeeps);
-          e.dataTransfer.setData('Text', sendData);
-          e.dataTransfer.setDragImage(draggedKeepsElement[0], mouseX, mouseY);
-          scope.$apply(function () { scope.isDragging = true; });
+          scope.$apply(function () {
+            element.addClass('kf-dragged');
+            scope.dragKeeps({keep: scope.keep, event: e, mouseX: mouseX, mouseY: mouseY});
+            scope.isDragging = true;
+          });
         });
         element.on('dragend', function () {
           scope.$apply(function () {
@@ -230,18 +238,6 @@ angular.module('kifi.keep', ['kifi.keepWhoPics', 'kifi.keepWhoText', 'kifi.tagSe
             scope.isDragging = false;
           });
         });
-      }
-    };
-  }
-])
-
-.directive('kfDraggedKeep', [
-  function () {
-    return {
-      restrict: 'A',
-      scope: true,
-      link: function (scope, element /*, attrs*/) {
-        element.css({top: scope.$index * 37 + 'px', width: element.parent().parent()[0].offsetWidth + 'px'});
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
@@ -8,10 +8,6 @@
   &.detailed
     background-color: #eff2f7
 
-  &.selected
-    background-color: #fffcf1
-    border-color: #f0f0f0
-
   &.selected.detailed
     background-color: #F7F7F5
 
@@ -44,6 +40,11 @@
   &.ng-hide-add
   &.ng-hide-remove.ng-hide-remove-active
     max-height: 200px
+
+.kf-keep.selected
+.kf-shadow-keep-ellipsis
+  background-color: #fffcf1
+  border-color: #f0f0f0
 
 .kf-keep-time
   float: right
@@ -284,9 +285,51 @@
 .kf-drag-target
   background-color: #E2E6EC
 
-.kf-dragged-keep
-  position: absolute
+.kf-keep.kf-dragged-keep
   box-sizing: border-box
   border-width: 1px
-  border-color: #c4d4e9
+  border-color: #d2d2d2
   border-style: solid
+
+.kf-shadow-keep-first
+.kf-shadow-keep-second
+.kf-shadow-keep-ellipsis
+.kf-shadow-keep-last
+  position: absolute
+  top: 0
+  left: 0
+  width: 100%
+
+.kf-shadow-keep-ellipsis
+  display: none
+  box-sizing: border-box
+  border-width: 1px
+  border-style: solid
+  border-bottom: none
+  border-color: #d2d2d2
+
+  &.active
+    display: inline
+
+.kf-shadow-keep-ellipsis-line
+  position: relative
+  top: 50%
+  height: 50%
+  width: 100%
+  border: inherit
+  border-left: none
+  border-right: none
+  margin-top: -1px
+
+.kf-shadow-keep-ellipsis-counter
+.kf-shadow-keep-ellipsis-counter-hidden
+  position: absolute
+  font-size: 13px
+  color: #818692
+  background-color: inherit
+  height: 80%
+  top: 20%
+  padding: 0 3px
+
+.kf-shadow-keep-ellipsis-counter-hidden
+  visibility: hidden

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.tpl.html
@@ -1,4 +1,4 @@
-<li class="kf-keep"
+<li class="kf-keep" ng-click="clickAction({keep: keep, event: $event})"
   ng-hide="keep.unkept"
   ui-draggable="true" drag-channel="keepDragChannel" ui-on-drop="onTagDrop($data)" drop-channel="tagDragChannel" drag-enter-class="kf-candidate-drag-target"
   ng-class="{ 'kf-dragged': isDragging, 'kf-drag-target': isDragTarget }">

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
@@ -6,7 +6,7 @@ angular.module('kifi.keeps', ['kifi.profileService', 'kifi.keepService'])
   '$scope', 'profileService', 'keepService', 'tagService',
   function ($scope, profileService, keepService, tagService) {
     $scope.me = profileService.me;
-    $scope.draggedKeeps = null;
+    $scope.data = {draggedKeeps: null};
 
     $scope.$watch(function () {
       return ($scope.keeps && $scope.keeps.length || 0) + ',' + tagService.list.length;
@@ -19,17 +19,20 @@ angular.module('kifi.keeps', ['kifi.profileService', 'kifi.keepService'])
       }
     });
 
-    $scope.dragKeeps = function (keep) {
+    $scope.dragKeeps = function (keep, event, mouseX, mouseY) {
       var draggedKeeps = keepService.getSelected();
       if (draggedKeeps.length === 0) {
         draggedKeeps = [keep];
       }
-      $scope.draggedKeeps = draggedKeeps;
-      return $scope.getDraggedKeepsElement();
+      $scope.data.draggedKeeps = draggedKeeps;
+      var draggedKeepsElement = $scope.getDraggedKeepsElement();
+      var sendData = angular.toJson($scope.data.draggedKeeps);
+      event.dataTransfer.setData('Text', sendData);
+      event.dataTransfer.setDragImage(draggedKeepsElement[0], mouseX, mouseY);
     };
 
     $scope.stopDraggingKeeps = function () {
-      $scope.draggedKeeps = null;
+      $scope.data.draggedKeeps = null;
     };
   }
 ])
@@ -169,8 +172,28 @@ angular.module('kifi.keeps', ['kifi.profileService', 'kifi.keepService'])
         }
 
         scope.getDraggedKeepsElement = function () {
+          var ellipsis = element.find('.kf-shadow-keep-ellipsis');
+          var ellipsisCounter = element.find('.kf-shadow-keep-ellipsis-counter');
+          var ellipsisCounterHidden = element.find('.kf-shadow-keep-ellipsis-counter-hidden');
+          var second = element.find('.kf-shadow-keep-second');
+          var last = element.find('.kf-shadow-keep-last');
+          var keepHeaderHeight = 35;
+          var ellipsisHeight = 28;
+          if (scope.data.draggedKeeps.length === 2) {
+            last.css({top: keepHeaderHeight + 'px'});
+          } else if (scope.data.draggedKeeps.length === 3) {
+            second.css({top: keepHeaderHeight + 'px'});
+            last.css({top: 2 * keepHeaderHeight + 'px'});
+          } else if (scope.data.draggedKeeps.length >= 4) {
+            ellipsis.css({top: keepHeaderHeight + 'px', height: ellipsisHeight + 'px'});
+            ellipsisCounter.css({left: (parseInt(ellipsis.width(), 10) - parseInt(ellipsisCounterHidden.width(), 10)) / 2});
+            last.css({top: keepHeaderHeight + ellipsisHeight + 'px'});
+          }
           return element.find('.kf-shadow-dragged-keeps');
         };
+
+        var shadowDraggedKeeps = element.find('.kf-shadow-dragged-keeps');
+        shadowDraggedKeeps.css({top: 0, width: element.find('.kf-my-keeps')[0].offsetWidth + 'px'});
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
@@ -2,10 +2,26 @@
 	antiscroll="{ autoHide: false }">
   <div smart-scroll scroll-distance="scrollDistance" scroll-disabled="isScrollDisabled()" scroll-next="scrollNext()" class="keeps-list">
     <ol class="kf-my-keeps">
-      <div kf-keep ng-repeat="keep in keeps" ng-click="onClickKeep(keep, $event)"></div>
+      <div ng-repeat="keep in keeps">
+        <div kf-keep is-previewed="isPreviewed(keep)" is-selected="!!isSelected(keep)"
+          keep="keep" me="me" toggle-select="toggleSelect(keep)" click-action="onClickKeep(keep, event)" drag-keeps="dragKeeps(keep, event, mouseX, mouseY)" stop-dragging-keeps="stopDraggingKeeps()"></div>
+      </div>
     </ol>
     <ol class="kf-shadow-dragged-keeps">
-      <div kf-keep kf-dragged-keep class="kf-dragged-keep" ng-repeat="keep in draggedKeeps"></div>
+      <span class="kf-shadow-keep-first">
+        <li ng-if="data.draggedKeeps.length >= 1" class="kf-dragged-keep" kf-keep kf-shadow-keep-first keep="data.draggedKeeps[0]" is-previewed="isPreviewed(keep)" is-selected="!!isSelected(keep)"><li>
+      </span>
+      <span class="kf-shadow-keep-second">
+        <li ng-if="data.draggedKeeps.length === 3" class="kf-dragged-keep" kf-keep kf-shadow-keep-first keep="data.draggedKeeps[1]" is-previewed="isPreviewed(keep)" is-selected="!!isSelected(keep)"><li>
+      </span>
+      <span class="kf-shadow-keep-ellipsis" ng-class="{'active': data.draggedKeeps.length >= 4}">
+        <div class="kf-shadow-keep-ellipsis-line"></div>
+        <div class="kf-shadow-keep-ellipsis-counter">{{data.draggedKeeps.length - 2}} other keeps selected</div>
+      </span>
+      <div class="kf-shadow-keep-ellipsis-counter-hidden">{{data.draggedKeeps.length - 2}} other keeps selected</div>
+      <span class="kf-shadow-keep-last">
+        <li ng-if="data.draggedKeeps.length >= 2" class="kf-dragged-keep" kf-keep kf-shadow-keep-last keep="data.draggedKeeps[data.draggedKeeps.length-1]" is-previewed="isPreviewed(keep)" is-selected="!!isSelected(keep)"></li>
+      </span>
     </ol>
     <div class="kf-keep-group-title-fixed"></div>
     <img class="kf-keeps-loading" ng-show="keepsLoading" src="/img/wait.gif">


### PR DESCRIPTION
@andrewconner @stkem 
- Feedback welcome for the UI.
- Now the animation is smooth even when selecting lots of keeps at once - however the tag count can take a while to be updated, which is not a great user experience. I'll see if this can be improved.
- I had to do some refactoring so that kf-keep has its own isolate scope, instead of "scope:true" which I believe was originally dictated by the use of ng-repeat ("scope:true" actually made the directive more difficult to reuse)
