### PR TITLE
keep: remove user_id_2 constraint

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/94.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/94.sql
@@ -1,7 +1,7 @@
 #Shoebox
 
 # --- !Ups
-alter table bookmark add CONSTRAINT user_id_2 UNIQUE (user_id, uri_id);
+-- alter table bookmark add CONSTRAINT user_id_2 UNIQUE (user_id, uri_id);
 
 insert into evolutions (name, description) values('94.sql', 'adding unique key constrain to bookmark');
 


### PR DESCRIPTION
Already removed in prod

Dropping this constraint via evolution 154.sql somehow didn't work; as this is effectively documentation at this point, commenting this out to get dev mode working

cc: @ymatsuda 
