### PR TITLE
Putting back /bookarks/private endpoint until mobile can fully

### DIFF
--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -64,6 +64,8 @@ POST    /bookmarks/add              @com.keepit.controllers.ext.ExtBookmarksCont
 # Note: /bookmarks/remove is deprecated. Use /ext/keeps/:id/unkeep instead.
 POST    /bookmarks/remove           @com.keepit.controllers.ext.ExtBookmarksController.remove()
 POST    /ext/keeps/:id/unkeep       @com.keepit.controllers.ext.ExtBookmarksController.unkeep(id: ExternalId[Keep])
+# Note: /bookmarks/private should be deprecated as soon as we move mobile onto it's own endpoitns for bookmarks entirely
+POST    /bookmarks/private          @com.keepit.controllers.ext.ExtBookmarksController.updateKeepInfo()
 POST    /bookmarks/update           @com.keepit.controllers.ext.ExtBookmarksController.updateKeepInfo()
 
 GET     /tags                       @com.keepit.controllers.ext.ExtBookmarksController.tags()


### PR DESCRIPTION
update to using newer supported endpoints
