### PR TITLE
encode non-ascii for mobile

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/net/URIParserUtil.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/URIParserUtil.scala
@@ -2,6 +2,7 @@ package com.keepit.common.net
 
 import com.keepit.common.strings.UTF8
 import java.net.{URLEncoder, URLDecoder}
+import scala.collection.mutable.ArrayBuffer
 
 object URIParserUtil {
   private[this] val controls = "\001\002\003\005\006\007\010\011\012\013\015\016\017\020\021\022\023\025\026\027\030\031\032\033\035\036\037\177"
@@ -33,6 +34,16 @@ object URIParserUtil {
     symbols.foldLeft(tmp){ (s, c) =>
       if (c == '%') s else replaceChar(s, c)
     }
+  }
+
+  def encodeNonASCII(string: String, symbols: Set[Char]): String = {
+    val builder = new StringBuilder()
+    string.foreach{ c =>
+      if (symbols.contains(c)) builder ++= encodingMap(c)
+      else if (c <= 255) builder += c // ASCII
+      else builder ++= encodeChar(c)  // non-ASCII
+    }
+    builder.toString
   }
 
   def decodePercentEncode(string: String) = {

--- a/kifi-backend/modules/common/app/com/keepit/common/net/URISanitizer.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/URISanitizer.scala
@@ -5,7 +5,13 @@ import com.keepit.common.logging.Logging
 object URISanitizer extends Logging {
 
   private[this] val parser = new URIParserGrammar {
+    import URIParserUtil.{encodeNonASCII, decodePercentEncode, pathReservedChars, paramNameReservedChars, paramValueReservedChars, fragmentReservedChars}
+
+    override def normalizePathComponent(component: String) = encodeNonASCII(decodePercentEncode(component), pathReservedChars)
     override def normalizeParams(params: Seq[Param]): Seq[Param] = params
+    override def normalizeParamName(name: String) = encodeNonASCII(decodePercentEncode(name.replace('+', ' ')), paramNameReservedChars).replace(' ', '+')
+    override def normalizeParamValue(value: String) = encodeNonASCII(decodePercentEncode(value.replace('+', ' ')), paramValueReservedChars).replace(' ', '+')
+    override def normalizeFragment(fragment: String) = encodeNonASCII(decodePercentEncode(fragment), fragmentReservedChars)
   }
 
   def sanitize(uriString: String): String = {

--- a/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
@@ -56,7 +56,7 @@ class MobileSearchControllerTest extends Specification with SearchApplicationInj
                   "bookmark":
                     {
                       "title":"this is a test",
-                      "url":"http://kifi.com/%5B%5D",
+                      "url":"http://kifi.com/%5B%E3%83%86%E3%82%B9%E3%83%88%5D",
                       "id":"604754fb-182d-4c39-a314-2d1994b24159",
                       "matches":
                         {
@@ -125,7 +125,7 @@ class FixedResultSearchCommander extends SearchCommander {
           2, // bookmarkCount
           BasicSearchHit(
             Some("this is a test"),  // title
-            "http://kifi.com/[]",  // url, '[' and ']' should be percent-encoded and the result json
+            "http://kifi.com/[テスト]",  // url, '[' and ']' should be percent-encoded and the result json
             Some(Seq(  // collections
               ExternalId[Collection]("c17da7ce-64bb-4c91-8832-1f1a6a88b7be"),
               ExternalId[Collection]("19ccb3db-4e18-4ade-91bd-1a98ef33aa63")


### PR DESCRIPTION
@leogrim @eishay @ebfaed 
Please review.

This should encode any non-ASCII (code point <= 255) in path, parameter name, parameter value and fragment. 
