### PR TITLE
Fixing router in kifi-backend

### DIFF
--- a/kifi-backend/conf/application.conf
+++ b/kifi-backend/conf/application.conf
@@ -1,7 +1,10 @@
 # Configuration for all of Kifi backend
 
-include "../modules/common/conf/application-dev.conf"
-
 include "../modules/graph/conf/graph-dev.conf"
 
+
+################################################
+# Do not add anything after this:
+
+include "../modules/common/conf/application-dev.conf"
 application.global="com.keepit.dev.DevGlobal"

--- a/kifi-backend/conf/routes
+++ b/kifi-backend/conf/routes
@@ -14,3 +14,4 @@
 -> /  scraper.Routes
 
 -> /  cortex.Routes
+

--- a/kifi-backend/modules/graph/conf/graph-dev.conf
+++ b/kifi-backend/modules/graph/conf/graph-dev.conf
@@ -1,7 +1,9 @@
 # Dev mod configurations for this module.
 
-application.global="com.keepit.dev.GraphDevGlobal"
-application.router=graph.Routes
+# Leo: This can't be here. This file is included in kifi-backend/application.conf.
+# Perhaps place this in graph's application.conf?
+#application.global="com.keepit.dev.GraphDevGlobal"
+#application.router=graph.Routes
 
 # Graph Resources
 # ~~~~~


### PR DESCRIPTION
@leogrim @yingjieMiao 

Léo, we should include anything specific to graph running independently into something other than `graph-dev.conf`, because that will override globals and the routers in kifi-backend. I'll continue to play with it, commented out for now so dev mode isn't broken.
