### PR TITLE
Keep track of GraphStatistics at runtime

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/package.scala
@@ -97,7 +97,7 @@ package object common {
       gZip.finish()
     }
 
-    def compress(file: File, destDir: String = FileUtils.getTempDirectoryPath): File = {
+    def compress(file: File, destDir: String): File = {
       val tarGz = new File(destDir, file.getName + ".tar.gz")
       val out = FileUtils.openOutputStream(tarGz)
       try { compress(file, out) }
@@ -129,13 +129,14 @@ package object common {
     def getDirectory(): File
     protected def getArchive(): File
     protected def saveArchive(archive: File): Unit
+    protected def tempDir(): File
 
     private val shouldBackup = new AtomicBoolean(false)
     def scheduleBackup() = shouldBackup.set(true)
     def cancelBackup() = shouldBackup.set(false)
     def doBackup() = if (shouldBackup.getAndSet(false)) {
       val dir = getDirectory()
-      val tarGz = IO.compress(dir)
+      val tarGz = IO.compress(dir, tempDir.getCanonicalPath)
       saveArchive(tarGz)
       tarGz.delete()
       true

--- a/kifi-backend/modules/common/conf/application-dev.conf
+++ b/kifi-backend/modules/common/conf/application-dev.conf
@@ -145,6 +145,7 @@ cdn {
 # config = "../../index/config"
 # shards = "0,1,2,3/4"
 
+#search.temporary.directory = "../../search/temp"
 
 #proxy = {
 #  host =  us.proxymesh.com

--- a/kifi-backend/modules/common/conf/prod/graph.conf
+++ b/kifi-backend/modules/common/conf/prod/graph.conf
@@ -18,14 +18,10 @@ dbplugin=disabled
 # ~~~~~
 graph {
   simple.directory = "../../graph/simple"
+  temporary.directory = "../../graph/temp"
 }
 
-amazon.s3 = {
-  graph = {
-    bucket = "graph-b-prod"
-    inbox = "../../graph/s3"
-  }
-}
+amazon.s3.graph.bucket = "graph-b-prod"
 
 airbrake {
   key = "640761a2e98c83abb33d939b87479b24"

--- a/kifi-backend/modules/common/conf/prod/search.conf
+++ b/kifi-backend/modules/common/conf/prod/search.conf
@@ -32,6 +32,8 @@ index {
   shards = "0,1,2,3/4"
 }
 
+search.temporary.directory = "../../search/temp"
+
 airbrake {
   key = "2b96f538e70463004bdbb6077fd42fc1"
 }

--- a/kifi-backend/modules/graph/app/com/keepit/graph/common/store/GraphStoreModule.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/common/store/GraphStoreModule.scala
@@ -40,7 +40,7 @@ case class GraphProdStoreModule() extends ProdStoreModule with GraphStoreModule 
   @Provides @Singleton
   def graphStore(amazonS3Client: AmazonS3, accessLog: AccessLog): GraphStore = {
     val bucketName = S3Bucket(current.configuration.getString("amazon.s3.graph.bucket").get)
-    val inboxDir = new File(current.configuration.getString("amazon.s3.graph.inbox").get).getCanonicalFile
+    val inboxDir = new File(current.configuration.getString("graph.temporary.directory").get, "s3").getCanonicalFile
     FileUtils.deleteDirectory(inboxDir)
     FileUtils.forceMkdir(inboxDir)
     inboxDir.deleteOnExit()

--- a/kifi-backend/modules/graph/app/com/keepit/graph/manager/GraphManager.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/manager/GraphManager.scala
@@ -8,7 +8,9 @@ import com.keepit.inject.AppScoped
 trait GraphManager {
   def readOnly[T](f: GraphReader => T): T
   def backup(): Unit
-  def update(updates: GraphUpdate*): GraphUpdaterState
+  def update(updates: GraphUpdate*): Unit
+  def state: GraphUpdaterState
+  def statistics: GraphStatistics
 }
 
 trait GraphManagerModule extends ScalaModule with Logging {

--- a/kifi-backend/modules/graph/app/com/keepit/graph/manager/GraphManagerPlugin.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/manager/GraphManagerPlugin.scala
@@ -32,10 +32,10 @@ class GraphManagerActor @Inject() (
       updating = true
     }
     case ProcessGraphUpdates(updates, maxBatchSize, lockTimeout) => {
-      val state = graph.update(updates.map(_.body): _*)
+      graph.update(updates.map(_.body): _*)
       updates.foreach(_.consume())
       updating = false
-      if (updates.length < maxBatchSize) { graphUpdateFetcher.fetch(state) }
+      if (updates.length < maxBatchSize) { graphUpdateFetcher.fetch(graph.state) }
       else { self ! UpdateGraph(maxBatchSize, lockTimeout) }
     }
     case BackupGraph => graph.backup()

--- a/kifi-backend/modules/graph/app/com/keepit/graph/manager/GraphStatistics.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/manager/GraphStatistics.scala
@@ -1,0 +1,25 @@
+package com.keepit.graph.manager
+
+import com.keepit.graph.model.{EdgeDataReader, EdgeKind, VertexDataReader, VertexKind}
+import com.keepit.graph.manager.GraphStatistics.{EdgeType, VertexType}
+import java.util.concurrent.atomic.AtomicLong
+
+case class GraphStatistics(vertexStatistics: Map[VertexType, Long], edgeStatistics: Map[EdgeType, Long])
+
+object GraphStatistics {
+  type VertexType = VertexKind[_ <: VertexDataReader]
+  type EdgeType = (VertexKind[_ <: VertexDataReader], VertexKind[_ <: VertexDataReader], EdgeKind[_ <: EdgeDataReader])
+
+  private val allEdgeKinds: Set[EdgeType] = for {
+    sourceKind <- VertexKind.all
+    destinationKind <- VertexKind.all
+    edgeKind <- EdgeKind.all
+  } yield (sourceKind, destinationKind, edgeKind)
+
+  def newVertexCounter(): Map[VertexType, AtomicLong] = VertexKind.all.map(_ -> new AtomicLong(0)).toMap
+  def newEdgeCounter(): Map[EdgeType, AtomicLong] = allEdgeKinds.map(_ -> new AtomicLong(0)).toMap
+
+  def filter(vertexCounter: Map[VertexType, AtomicLong], edgeCounter: Map[EdgeType, AtomicLong]): GraphStatistics = {
+    GraphStatistics(vertexCounter.mapValues(_.get()).filter(_._2 > 0), edgeCounter.mapValues(_.get()).filter(_._2 > 0))
+  }
+}

--- a/kifi-backend/modules/graph/app/com/keepit/graph/manager/GraphUpdater.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/manager/GraphUpdater.scala
@@ -25,8 +25,8 @@ class GraphUpdaterImpl @Inject() () extends GraphUpdater {
 
   private def processUserConnectionGraphUpdate(update: UserConnectionGraphUpdate)(implicit writer: GraphWriter) = update.state match {
     case UserConnectionStates.UNFRIENDED | UserConnectionStates.INACTIVE =>
-      writer.removeEdgeIfExists(update.firstUserId, update.secondUserId)
-      writer.removeEdgeIfExists(update.secondUserId, update.firstUserId)
+      writer.removeEdgeIfExists(update.firstUserId, update.secondUserId, EmptyEdgeDataReader)
+      writer.removeEdgeIfExists(update.secondUserId, update.firstUserId, EmptyEdgeDataReader)
     case UserConnectionStates.ACTIVE =>
       writer.saveVertex(UserData(update.firstUserId))
       writer.saveVertex(UserData(update.secondUserId))
@@ -63,8 +63,8 @@ class GraphUpdaterImpl @Inject() () extends GraphUpdater {
       val secondFacebookUserVertexId: VertexDataId[FacebookAccountReader] = update.secondSocialUserId
       update.state match {
         case SocialConnectionStates.INACTIVE =>
-          writer.removeEdgeIfExists(firstFacebookUserVertexId, secondFacebookUserVertexId)
-          writer.removeEdgeIfExists(secondFacebookUserVertexId, firstFacebookUserVertexId)
+          writer.removeEdgeIfExists(firstFacebookUserVertexId, secondFacebookUserVertexId, EmptyEdgeDataReader)
+          writer.removeEdgeIfExists(secondFacebookUserVertexId, firstFacebookUserVertexId, EmptyEdgeDataReader)
         case SocialConnectionStates.ACTIVE =>
           writer.saveVertex(FacebookAccountData(firstFacebookUserVertexId))
           writer.saveVertex(FacebookAccountData(secondFacebookUserVertexId))
@@ -77,8 +77,8 @@ class GraphUpdaterImpl @Inject() () extends GraphUpdater {
       val secondLinkedInUserVertexId: VertexDataId[LinkedInAccountReader] = update.secondSocialUserId
       update.state match {
         case SocialConnectionStates.INACTIVE =>
-          writer.removeEdgeIfExists(firstLinkedInUserVertexId, secondLinkedInUserVertexId)
-          writer.removeEdgeIfExists(secondLinkedInUserVertexId, firstLinkedInUserVertexId)
+          writer.removeEdgeIfExists(firstLinkedInUserVertexId, secondLinkedInUserVertexId, EmptyEdgeDataReader)
+          writer.removeEdgeIfExists(secondLinkedInUserVertexId, firstLinkedInUserVertexId, EmptyEdgeDataReader)
         case SocialConnectionStates.ACTIVE =>
           writer.saveVertex(LinkedInAccountData(firstLinkedInUserVertexId))
           writer.saveVertex(LinkedInAccountData(secondLinkedInUserVertexId))

--- a/kifi-backend/modules/graph/app/com/keepit/graph/model/GraphReader.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/model/GraphReader.scala
@@ -7,10 +7,10 @@ trait GraphReader {
 
 trait GraphWriter extends GraphReader {
   def saveVertex[V <: VertexDataReader](data: V): Boolean
-  def saveEdge[S <: VertexDataReader: VertexKind, D <: VertexDataReader: VertexKind, E <: EdgeDataReader](source: VertexDataId[S], destination: VertexDataId[D], data: E): Boolean
-  def removeEdge[S <: VertexDataReader: VertexKind, D <: VertexDataReader: VertexKind](source: VertexDataId[S], destination: VertexDataId[D]): Unit
-  def removeEdgeIfExists[S <: VertexDataReader: VertexKind, D <: VertexDataReader: VertexKind](source: VertexDataId[S], destination: VertexDataId[D]): Boolean = {
-    try { removeEdge(source, destination); true }
+  def saveEdge[S <: VertexDataReader, D <: VertexDataReader, E <: EdgeDataReader](source: VertexDataId[S], destination: VertexDataId[D], data: E)(implicit sourceKind: VertexKind[S], destinationKind: VertexKind[D]): Boolean
+  def removeEdge[S <: VertexDataReader, D <: VertexDataReader, E <: EdgeDataReader](source: VertexDataId[S], destination: VertexDataId[D], edgeKind: EdgeKind[E])(implicit sourceKind: VertexKind[S], destinationKind: VertexKind[D]): Unit
+  def removeEdgeIfExists[S <: VertexDataReader, D <: VertexDataReader, E <: EdgeDataReader](source: VertexDataId[S], destination: VertexDataId[D], edgeKind: EdgeKind[E])(implicit sourceKind: VertexKind[S], destinationKind: VertexKind[D]): Boolean = {
+    try { removeEdge(source, destination, edgeKind); true }
     catch { case VertexNotFoundException(_) | EdgeNotFoundException(_, _) => false }
   }
   def commit(): Unit

--- a/kifi-backend/modules/graph/app/com/keepit/graph/model/VertexId.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/model/VertexId.scala
@@ -9,8 +9,8 @@ case class VertexId(id: Long) extends AnyVal {
     VertexDataId[V](dataId)
   }
   def asIdOpt[V <: VertexDataReader](implicit kind: VertexKind[V]): Option[VertexDataId[V]] = Try(asId[V]).toOption
+  def kind: VertexKind[_ <: VertexDataReader] = VertexKind(code)
   override def toString() =  kind + "|" + dataId
-  private def kind: VertexKind[_ <: VertexDataReader] = VertexKind(code)
   private def code: Byte = (id >> VertexId.dataIdSpace).toByte
   private def dataId: Long = id & VertexId.maxVertexDataId
 }

--- a/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraphManager.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraphManager.scala
@@ -22,10 +22,11 @@ class SimpleGraphManager(
     }
   }
 
-  def update(updates: GraphUpdate*): GraphUpdaterState = {
+  def update(updates: GraphUpdate*): Unit = {
     val relevantUpdates = updates.filter { graphUpdate => graphUpdate.seq > state.getCurrentSequenceNumber(graphUpdate.kind) }
     simpleGraph.readWrite { implicit writer => relevantUpdates.sortBy(_.seq.value).foreach(graphUpdater(_)) }
-    state = state.withUpdates(relevantUpdates) // todo(Léo): not threadsafe, should add transaction callback capabilities to GraphWriter (cf SessionWrapper)
-    state
+    state = state.withUpdates(relevantUpdates) // todo(Léo): not threadsafe
   }
+
+  def statistics: GraphStatistics = simpleGraph.statistics
 }

--- a/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraphModule.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraphModule.scala
@@ -9,6 +9,7 @@ import scala.util.Success
 import scala.util.Failure
 import com.keepit.common.zookeeper.ServiceDiscovery
 import java.io.File
+import org.apache.commons.io.FileUtils
 
 trait SimpleGraphModule extends GraphManagerModule {
 
@@ -28,7 +29,12 @@ trait SimpleGraphModule extends GraphManagerModule {
   }
 
   protected def getArchivedSimpleGraphDirectory(path: String, graphStore: GraphStore): ArchivedSimpleGraphDirectory = {
-    val archivedDirectory = new ArchivedSimpleGraphDirectory(new File(path), graphStore)
+    val dir = new File(path)
+    val tempDir = new File(current.configuration.getString("graph.temporary.directory").get, dir.getName())
+    FileUtils.deleteDirectory(tempDir)
+    FileUtils.forceMkdir(tempDir)
+    tempDir.deleteOnExit()
+    val archivedDirectory = new ArchivedSimpleGraphDirectory(dir, tempDir, graphStore)
     archivedDirectory.init()
     archivedDirectory
   }

--- a/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraphWriter.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraphWriter.scala
@@ -3,6 +3,9 @@ package com.keepit.graph.simple
 import com.keepit.graph.model._
 import scala.collection.mutable.{Map => MutableMap, Set => MutableSet}
 import play.api.libs.json._
+import java.util.concurrent.atomic.AtomicLong
+import com.keepit.graph.manager.GraphStatistics.{EdgeType, VertexType}
+import com.keepit.graph.manager.GraphStatistics
 
 class MutableVertex(var data: VertexDataReader, val edges: MutableMap[VertexId, EdgeDataReader]) extends Vertex
 
@@ -27,7 +30,10 @@ object MutableVertex {
   }
 }
 
-class GraphWriterImpl(bufferedVertices: BufferedMap[VertexId, MutableVertex]) extends GraphReaderImpl(bufferedVertices) with GraphWriter {
+class SimpleGraphWriter(bufferedVertices: BufferedMap[VertexId, MutableVertex], vertexStatistics: Map[VertexType, AtomicLong], edgeStatistics: Map[EdgeType, AtomicLong]) extends SimpleGraphReader(bufferedVertices) with GraphWriter {
+
+  private val vertexDeltas = GraphStatistics.newVertexCounter()
+  private val edgeDeltas: Map[EdgeType, AtomicLong] = GraphStatistics.newEdgeCounter()
 
   private def getBufferedVertex(vertexId: VertexId): Option[MutableVertex] = bufferedVertices.get(vertexId) map {
     case alreadyBufferedVertex if bufferedVertices.hasBuffered(vertexId) => alreadyBufferedVertex
@@ -41,31 +47,42 @@ class GraphWriterImpl(bufferedVertices: BufferedMap[VertexId, MutableVertex]) ex
   def saveVertex[V <: VertexDataReader](data: V): Boolean = {
     val vertexId = VertexId(data.id)(data.kind)
     getBufferedVertex(vertexId) match {
-      case Some(bufferedVertex) => bufferedVertex.data = data; true
-      case None => bufferedVertices += (vertexId -> new MutableVertex(data, MutableMap())); false
+      case Some(bufferedVertex) =>
+        bufferedVertex.data = data
+        false
+      case None =>
+        bufferedVertices += (vertexId -> new MutableVertex(data, MutableMap()))
+        vertexDeltas(data.kind).incrementAndGet()
+        true
     }
   }
 
-  def saveEdge[S <: VertexDataReader: VertexKind, D <: VertexDataReader: VertexKind, E <: EdgeDataReader](source: VertexDataId[S], destination: VertexDataId[D], data: E): Boolean = {
+  def saveEdge[S <: VertexDataReader, D <: VertexDataReader, E <: EdgeDataReader](source: VertexDataId[S], destination: VertexDataId[D], data: E)(implicit sourceKind: VertexKind[S], destinationKind: VertexKind[D]): Boolean = {
     val sourceVertexId = VertexId(source)
     val bufferedSourceVertex = getBufferedVertex(sourceVertexId) getOrElse { throw new VertexNotFoundException(sourceVertexId) }
     val destinationVertexId = VertexId(destination)
     if (!bufferedVertices.contains(destinationVertexId)) { throw new VertexNotFoundException(destinationVertexId) }
-    val isUpdate = bufferedSourceVertex.edges.contains(destinationVertexId)
+    val isNewEdge = !bufferedSourceVertex.edges.contains(destinationVertexId)
     bufferedSourceVertex.edges += (destinationVertexId -> data)
-    isUpdate
+    if (isNewEdge) { edgeDeltas((sourceKind, destinationKind, data.kind)).incrementAndGet() }
+    isNewEdge
   }
 
-  def removeEdge[S <: VertexDataReader: VertexKind, D <: VertexDataReader: VertexKind](source: VertexDataId[S], destination: VertexDataId[D]): Unit = {
+  def removeEdge[S <: VertexDataReader, D <: VertexDataReader, E <: EdgeDataReader](source: VertexDataId[S], destination: VertexDataId[D], edgeKind: EdgeKind[E])(implicit sourceKind: VertexKind[S], destinationKind: VertexKind[D]): Unit = {
     val sourceVertexId = VertexId(source)
     val bufferedSourceVertex = getBufferedVertex(sourceVertexId) getOrElse { throw new VertexNotFoundException(sourceVertexId) }
     val destinationVertexId = VertexId(destination)
     if (!bufferedVertices.contains(destinationVertexId)) { throw new VertexNotFoundException(destinationVertexId) }
     if (!bufferedSourceVertex.edges.contains(destinationVertexId)) { throw new EdgeNotFoundException(sourceVertexId, destinationVertexId) }
     bufferedSourceVertex.edges -= destinationVertexId
+    edgeDeltas((sourceKind, destinationKind, edgeKind)).decrementAndGet()
   }
 
-  def commit(): Unit = { bufferedVertices.flush() }
+  def commit(): Unit = {
+    bufferedVertices.flush()
+    vertexDeltas.foreach { case (vertexKind, counter) => vertexStatistics(vertexKind).addAndGet(counter.getAndSet(0)) }
+    edgeDeltas.foreach { case (edgeKinds, counter) => edgeStatistics(edgeKinds).addAndGet(counter.getAndSet(0)) }
+  }
 }
 
 class BufferedMap[A, B](current: MutableMap[A, B], updated: MutableMap[A, B] = MutableMap[A, B](), removed: MutableSet[A] = MutableSet[A]()) extends MutableMap[A, B] {

--- a/kifi-backend/modules/graph/conf/graph-dev.conf
+++ b/kifi-backend/modules/graph/conf/graph-dev.conf
@@ -9,11 +9,7 @@
 # ~~~~~
 #graph {
 #  simple.directory = "../../graph/simple"
+#  temporary.directory = "../../graph/temp"
 #}
 
-#amazon.s3 = {
-#  graph = {
-#    bucket = "graph-b-dev"
-#    inbox = "../../graph/s3"
-#  }
-#}
+#amazon.s3.graph.bucket = "graph-b-dev"

--- a/kifi-backend/modules/graph/test/com/keepit/graph/simple/SimpleGraphTest.scala
+++ b/kifi-backend/modules/graph/test/com/keepit/graph/simple/SimpleGraphTest.scala
@@ -54,7 +54,7 @@ class SimpleGraphTest() extends Specification {
       vertexReader.edgeReader.degree === 0
 
       graph.readWrite { writer =>
-        writer.removeEdge(alfred, vertigo)
+        writer.removeEdge(alfred, vertigo, EmptyEdgeDataReader)
       }
 
       vertexReader.moveTo(alfred)

--- a/kifi-backend/modules/search/app/com/keepit/common/store/SearchProdStoreModule.scala
+++ b/kifi-backend/modules/search/app/com/keepit/common/store/SearchProdStoreModule.scala
@@ -26,7 +26,7 @@ case class SearchProdStoreModule() extends ProdStoreModule {
   @Provides @Singleton
   def indexStore(amazonS3Client: AmazonS3, accessLog: AccessLog): IndexStore = {
     val bucketName = S3Bucket(current.configuration.getString("amazon.s3.index.bucket").get)
-    val inboxDir = new File(current.configuration.getString("amazon.s3.index.inbox").get).getCanonicalFile
+    val inboxDir = new File(current.configuration.getString("graph.temporary.directory").get, "s3").getCanonicalFile
     FileUtils.deleteDirectory(inboxDir)
     FileUtils.forceMkdir(inboxDir)
     inboxDir.deleteOnExit()

--- a/kifi-backend/modules/search/app/com/keepit/search/index/IndexDirectory.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/IndexDirectory.scala
@@ -15,7 +15,7 @@ trait IndexDirectory extends Directory with BackedUpDirectory {
 
 trait IndexStore extends ObjectStore[ArchivedIndexDirectory, File]
 
-class ArchivedIndexDirectory(dir: File, store: IndexStore) extends MMapDirectory(dir) with ArchivedDirectory with IndexDirectory {
+class ArchivedIndexDirectory(dir: File, protected val tempDir: File, store: IndexStore) extends MMapDirectory(dir) with ArchivedDirectory with IndexDirectory {
   def asFile() = Some(dir)
   protected def getArchive() = store.get(this).get
   protected def saveArchive(tarFile: File) = store += (this, tarFile)

--- a/kifi-backend/modules/search/app/com/keepit/search/index/IndexModule.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/IndexModule.scala
@@ -34,7 +34,11 @@ trait IndexModule extends ScalaModule with Logging {
   protected def getArchivedIndexDirectory(maybeDir: Option[String], indexStore: IndexStore): Option[ArchivedIndexDirectory] = {
     maybeDir.map { d =>
       val dir = new File(d).getCanonicalFile
-      val indexDirectory = new ArchivedIndexDirectory(dir, indexStore)
+      val tempDir = new File(current.configuration.getString("search.temporary.directory").get, dir.getName)
+      FileUtils.deleteDirectory(tempDir)
+      FileUtils.forceMkdir(tempDir)
+      tempDir.deleteOnExit()
+      val indexDirectory = new ArchivedIndexDirectory(dir, tempDir, indexStore)
       if (!dir.exists()) {
         try {
           val t1 = currentDateTime.getMillis


### PR DESCRIPTION
Going forward, these statistics may be persisted.
Also:
Use implicit parameters instead of context bounds in GraphWriter API (meh)
Require an EdgeKind for edge removals

@stkem though only required for bookkeeping at this stage, the last point indirectly paves the way towards a multi-edge graph.
