### PR TITLE
Use created_at instead of updated_at to determine latest keep. 

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
@@ -62,7 +62,7 @@ object Keep {
   def applyWithPrimary(id:Option[Id[Keep]], createdAt:DateTime, updatedAt:DateTime, externalId:ExternalId[Keep], title:Option[String], uriId:Id[NormalizedURI], isPrimary:Option[Boolean], urlId:Id[URL], url:String, bookmarkPath:Option[String], isPrivate:Boolean, userId:Id[User], state:State[Keep], source:KeepSource, kifiInstallation:Option[ExternalId[KifiInstallation]], seq:SequenceNumber[Keep]) =
     Keep(id, createdAt, updatedAt, externalId, title, uriId, isPrimary.exists(b => b), urlId, url, bookmarkPath, isPrivate, userId, state, source, kifiInstallation, seq)
   def unapplyWithPrimary(k:Keep) = {
-    Some(k.id, k.createdAt, k.updatedAt, k.externalId, k.title, k.uriId, if (k.isPrimary) Some(true) else None, k.urlId, k.url, k.bookmarkPath, k.isPrivate, k.userId, k.state, k.source, k.kifiInstallation, k.seq)  
+    Some(k.id, k.createdAt, k.updatedAt, k.externalId, k.title, k.uriId, if (k.isPrimary) Some(true) else None, k.urlId, k.url, k.bookmarkPath, k.isPrivate, k.userId, k.state, k.source, k.kifiInstallation, k.seq)
   }
 
   implicit def bookmarkFormat = (
@@ -115,8 +115,8 @@ class KeepUriUserCache(stats: CacheStatistics, accessLog: AccessLog, innermostPl
   extends JsonCacheImpl[KeepUriUserKey, Keep](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)
 
 case class LatestKeepUriKey(uriId: Id[NormalizedURI]) extends Key[Keep] {
-  override val version = 2
-  val namespace = "latest_bookmark_uri"
+  override val version = 1
+  val namespace = "latest_keep_uri"
   def toKey(): String = uriId.toString
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -318,7 +318,7 @@ class KeepsCommander @Inject() (
 
   def setFirstKeeps(userId: Id[User], keeps: Seq[Keep]): Unit = {
     db.readWrite { implicit session =>
-      val origin = keepRepo.oldestBookmark(userId).map(_.createdAt) getOrElse currentDateTime
+      val origin = keepRepo.oldestKeep(userId).map(_.createdAt) getOrElse currentDateTime
       keeps.zipWithIndex.foreach { case (keep, i) =>
         keepRepo.save(keep.copy(createdAt = origin.minusSeconds(i + 1)))
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -451,7 +451,7 @@ class ShoeboxController @Inject() (
 
   def getLatestBookmark(uriId: Id[NormalizedURI]) = Action { request =>
     val bookmarkOpt = db.readOnly(2) { implicit session => //using cache
-      keepRepo.latestBookmark(uriId)
+      keepRepo.latestKeep(uriId)
     }
     log.info(s"[getLatestBookmark($uriId)] $bookmarkOpt")
     Ok(Json.toJson(bookmarkOpt))

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepTest.scala
@@ -179,25 +179,25 @@ class KeepTest extends Specification with ShoeboxTestInjector {
           (uri, uriId, url, firstUserId, secondUserId, urlId)
         }
         db.readOnly{ implicit s =>
-          keepRepo.latestBookmark(uriId) === None
+          keepRepo.latestKeep(uriId) === None
         }
         val firstUserBookmark = db.readWrite{ implicit s =>
           keepRepo.save(Keep(userId = firstUserId, uriId = uriId, urlId = urlId, url = url, source = hover))
         }
         db.readOnly{ implicit s =>
-          keepRepo.latestBookmark(uriId).flatMap(_.id) === firstUserBookmark.id
+          keepRepo.latestKeep(uriId).flatMap(_.id) === firstUserBookmark.id
         }
         val secondUserBookmark = db.readWrite{ implicit s =>
           keepRepo.save(Keep(userId = secondUserId, uriId = uriId, urlId = urlId, url = url, source = hover))
         }
         db.readOnly{ implicit s =>
-          keepRepo.latestBookmark(uriId).flatMap(_.id) === secondUserBookmark.id
+          keepRepo.latestKeep(uriId).flatMap(_.id) === secondUserBookmark.id
         }
         val latestBookmark = db.readWrite{ implicit s =>
           keepRepo.save(firstUserBookmark)
         }
         db.readOnly{ implicit s =>
-          keepRepo.latestBookmark(uriId).flatMap(_.id) === latestBookmark.id
+          keepRepo.latestKeep(uriId).flatMap(_.id) === latestBookmark.id
         }
       }
     }


### PR DESCRIPTION
@ymatsuda @yingjieMiao 
This fixes a bug preventing us from correctly processing a chain of 301 redirects. 
