### PR TITLE
more concurrent processing in socialgraphinfo computation

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/MainSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/MainSearcher.scala
@@ -127,16 +127,16 @@ class MainSearcher(
     val personalizedSearcher = parsedQuery.map{ articleQuery =>
       log.debug("articleQuery: %s".format(articleQuery.toString))
 
-      val myUriEdgeAccessor = socialGraphInfo.myUriEdgeAccessor
-      val mySearchUris = socialGraphInfo.mySearchUris
-      val friendSearchUris = socialGraphInfo.friendSearchUris
-
       val tPersonalSearcher = currentDateTime.getMillis()
       val personalizedSearcher = getPersonalizedSearcher(articleQuery, nonPersonalizedContextVector)
       personalizedSearcher.setSimilarity(similarity)
       timeLogs.personalizedSearcher = currentDateTime.getMillis() - tPersonalSearcher
 
       val weight = personalizedSearcher.createWeight(articleQuery)
+
+      val myUriEdgeAccessor = socialGraphInfo.myUriEdgeAccessor
+      val mySearchUris = socialGraphInfo.mySearchUris
+      val friendSearchUris = socialGraphInfo.friendSearchUris
 
       val tClickBoosts = currentDateTime.getMillis()
       val clickBoosts = monitoredAwait.result(clickBoostsFuture, 5 seconds, s"getting clickBoosts for user Id $userId")

--- a/kifi-backend/modules/search/app/com/keepit/search/SocialGraphInfo.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/SocialGraphInfo.scala
@@ -2,26 +2,34 @@ package com.keepit.search
 
 import com.keepit.common.akka.SafeFuture
 import com.keepit.common.akka.MonitoredAwait
+import com.keepit.common.concurrent.ExecutionContext
 import com.keepit.common.db.Id
+import com.keepit.model.Collection
+import com.keepit.model.NormalizedURI
 import com.keepit.model.User
 import com.keepit.search.graph._
 import com.keepit.search.graph.collection.CollectionSearcherWithUser
 import com.keepit.search.graph.bookmark.URIGraphSearcherWithUser
-import scala.concurrent.duration._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import com.keepit.model.NormalizedURI
-import com.keepit.model.Collection
+import scala.concurrent.duration._
+import scala.math.max
 
 class SocialGraphInfo(userId: Id[User], val uriGraphSearcher: URIGraphSearcherWithUser, val collectionSearcher: CollectionSearcherWithUser, filter: SearchFilter, monitoredAwait: MonitoredAwait) {
 
-  lazy val (myUriEdgeAccessor, friendsUriEdgeAccessors, mySearchUris, friendSearchUris, relevantFriendEdgeSet, socialGraphInfoTime) = {
-    monitoredAwait.result(socialGraphInfoFuture, 5 seconds, s"getting SocialGraphInfo for user Id $userId")
+  private[this] val startTime: Long = System.currentTimeMillis
+
+  lazy val (myUriEdgeAccessor, mySearchUris, part1End) = {
+    monitoredAwait.result(part1, 5 seconds, s"getting SocialGraphInfo.my* for user Id $userId")
+  }
+  lazy val (friendsUriEdgeAccessors, friendSearchUris, relevantFriendEdgeSet, part2End) = {
+    monitoredAwait.result(part2, 5 seconds, s"getting SocialGraphInfo.friends* for user Id $userId")
   }
 
-  private[this] val socialGraphInfoFuture = SafeFuture {
-    val startTime: Long = System.currentTimeMillis
+  lazy val socialGraphInfoTime = max(part1End, part2End) - startTime
 
-    // initialize user's social graph info
+  // initialize user's social graph info in two parts
+
+  private[this] val part1 = SafeFuture {
     val myUriEdges = uriGraphSearcher.myUriEdgeSet
     val mySearchUris =
       filter.timeRange match {
@@ -43,7 +51,10 @@ class SocialGraphInfo(userId: Id[User], val uriGraphSearcher: URIGraphSearcherWi
             case _ => myUriEdges.destIdLongSet
           }
       }
+    (myUriEdges.accessor.asInstanceOf[BookmarkInfoAccessor[User, NormalizedURI]], mySearchUris, System.currentTimeMillis)
+  }
 
+  private[this] val part2 = SafeFuture {
     val friendEdgeSet = uriGraphSearcher.searchFriendEdgeSet
     val friendsUriEdgeSets = uriGraphSearcher.friendsUriEdgeSets
     val (filteredFriendEdgeSet, relevantFriendEdgeSet) = {
@@ -72,8 +83,6 @@ class SocialGraphInfo(userId: Id[User], val uriGraphSearcher: URIGraphSearcherWi
         }
     }
 
-    val time: Long = System.currentTimeMillis - startTime
-
-    (myUriEdges.accessor.asInstanceOf[BookmarkInfoAccessor[User, NormalizedURI]], friendsUriEdgeSets.mapValues{ _.accessor.asInstanceOf[BookmarkInfoAccessor[User, NormalizedURI]] }, mySearchUris, friendSearchUris, relevantFriendEdgeSet, time)
+    (friendsUriEdgeSets.mapValues{ _.accessor.asInstanceOf[BookmarkInfoAccessor[User, NormalizedURI]] }, friendSearchUris, relevantFriendEdgeSet, System.currentTimeMillis)
   }
 }


### PR DESCRIPTION
@eishay 

Splitting SocialGraphInfo computation in two parts. The 1st part is cheaper and is needed by search earlier than the 2nd part. By splitting the processing in two, search doesn't need to wait for the expensive 2nd part.
(The 2nd part is expensive set union operation.)

This works better with more CPUs (better CPU utilization). But even with a small number of CPUs, this should improve the performance because both parts involve index accesses (= logical or physical I/Os).
