### PR TITLE
avoids race condition when adding thread participants

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
@@ -89,8 +89,7 @@ class SharedWsMessagingController @Inject() (
         (obj \ "email").as[String]
       }
       implicit val context = authenticatedWebSocketsContextBuilder(socket).build
-      messagingCommander.addUsersToThread(socket.userId, ExternalId[MessageThread](threadId), users)
-      messagingCommander.addEmailNonUsersToThread(socket.userId, ExternalId[MessageThread](threadId), emailAddresses)
+      messagingCommander.addParticipantsToThread(socket.userId, ExternalId[MessageThread](threadId), users, emailAddresses)
     },
     "get_unread_notifications_count" -> { _ =>
       val numUnreadUnmuted = messagingCommander.getUnreadUnmutedThreadCount(socket.userId)

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
@@ -168,7 +168,7 @@ class MessagingTest extends Specification with DbTestInjector {
         Await.result(notificationCommander.getLatestSendableNotifications(user3, 1), Duration(4, "seconds")).jsons.length === 0
 
         val user3ExtId = Await.result(shoebox.getUser(user3), Duration(4, "seconds")).get.externalId
-        messagingCommander.addUsersToThread(user1, thread.externalId, Seq(user3ExtId))
+        messagingCommander.addParticipantsToThread(user1, thread.externalId, Seq(user3ExtId), Seq.empty)
         Thread.sleep(200) //See comment for same above
         Await.result(notificationCommander.getLatestSendableNotifications(user3, 1), Duration(4, "seconds")).jsons.length === 1
       }


### PR DESCRIPTION
previously when adding a non user and a user at the same time the two
modifications would happen concurrently, causing the change the thread
in question of one to override the change of the other.
