### PR TITLE
do not move kifi tile after script elements

### DIFF
--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -231,7 +231,7 @@ var tile = tile || function() {  // idempotent for Chrome
       var child = tileParent.lastElementChild;
       if (child !== tile && !document.documentElement.hasAttribute('kifi-pane-parent')) {
         while (child !== tile) {
-          if (!child.classList.contains('kifi-root')) {
+          if (!child.classList.contains('kifi-root') && !child.tagName.toLowerCase() === 'script') {
             tileParent.appendChild(tile);
             break;
           }


### PR DESCRIPTION
for Mendeley bookmarklet, which removes the last body child
https://app.asana.com/0/2456298849186/12092963529075
