### PR TITLE
aggressively remove retries on db calls that touch nuri seq. num

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -141,7 +141,7 @@ class KeepInterner @Inject() (
 
   private def internUriAndBookmarkBatch(bms: Seq[RawBookmarkRepresentation], userId: Id[User], source: KeepSource,
                                         mutatePrivacy: Boolean, installationId: Option[ExternalId[KifiInstallation]] = None) = {
-    val (persisted, failed) = db.readWriteBatch(bms, attempts = 3) { (session, bm) =>
+    val (persisted, failed) = db.readWriteBatch(bms, attempts = 1) { (session, bm) =>
       internUriAndBookmark(bm, userId, source, mutatePrivacy, installationId)(session)
     } map {
       case (bm, res) => bm -> res.flatten

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventListener.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventListener.scala
@@ -48,7 +48,7 @@ class SliderShownListener @Inject() (
 
   def onEvent: PartialFunction[Event, Unit] = {
     case Event(_, UserEventMetadata(EventFamilies.SLIDER, "sliderShown", externalUser, _, experiments, metaData, _), _, _) =>
-      val (user, normUri) = db.readWrite(attempts = 3) { implicit s =>
+      val (user, normUri) = db.readWrite(attempts = 1) { implicit s =>
         val user = userRepo.get(externalUser)
         val normUri = (metaData \ "url").asOpt[String].map { url =>
           normalizedURIRepo.internByUri(url, NormalizationCandidate(metaData): _*)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ScraperCallbackHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ScraperCallbackHelper.scala
@@ -39,7 +39,7 @@ class ScraperCallbackHelper @Inject()(
   def assignTasks(zkId:Id[ScraperWorker], max:Int):Seq[ScrapeRequest] = timingWithResult(s"assignTasks($zkId,$max)", {r:Seq[ScrapeRequest] => s"${r.length} uris assigned: ${r.mkString(",")}"}) {
     withLock(assignLock) {
       val builder = Seq.newBuilder[ScrapeRequest]
-      val res = db.readWrite(attempts = 2) { implicit rw =>
+      val res = db.readWrite(attempts = 1) { implicit rw =>
         val limit = if (max < 10) max * 2 else max
         val overdues = timingWithResult[Seq[ScrapeInfo]](s"assignTasks($zkId,$max) getOverdueList(${limit})", {r:Seq[ScrapeInfo] => s"${r.length} overdues: ${r.map(_.toShortString).mkString(",")}"}) { scrapeInfoRepo.getOverdueList(limit) }
         var count = 0

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/URLRenormalizeCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/URLRenormalizeCommander.scala
@@ -122,7 +122,7 @@ class URLRenormalizeCommander @Inject()(
 
     batchUrls.map { urls =>
       log.info(s"begin a new batch of renormalization. lastId from zookeeper: ${centralConfig(RenormalizationCheckKey)}")
-      db.readWrite(attempts = 2) { implicit s =>
+      db.readWrite(attempts = 1) { implicit s =>
         urls.foreach { url =>
           try {
             needRenormalization(url) match {


### PR DESCRIPTION
This is to fail fast when there is a problem with a lock on a row. Intentionally left `attempts = 1` to find them again easily when debugging.
@raymondng 
(cc @eishay @andrewconner @leogrim)
