### PR TITLE
reduce batch size for cleanNormalizedURIsByBookmarks (100 -> 10)

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/OrphanCleaner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/OrphanCleaner.scala
@@ -156,7 +156,7 @@ class OrphanCleaner @Inject() (
 
     log.info("start processing Bookmarks")
     while (!done) {
-      val bookmarks = db.readOnly{ implicit s => keepRepo.getBookmarksChanged(seq, 100) }
+      val bookmarks = db.readOnly{ implicit s => keepRepo.getBookmarksChanged(seq, 10) }
       done = bookmarks.isEmpty
 
       db.readWrite{ implicit s =>


### PR DESCRIPTION
@ymatsuda 

This one shows up quite a bit in the "session too long" logs -- likely related to bookmark imports. 

I noticed that there are other similar code (e.g. cleanNormalizedURIsByNormalizedURIs with fetch size also set to 100). I haven't changed them but they might need to be tweaked as well.

(cc: @stkem @eishay @leo)
