### PR TITLE
Ext source bugfix

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -980,6 +980,9 @@ api.port.on({
   settings: function(_, __, tab) {
     emitSettings(tab);
   },
+  browser: function (_, respond) {
+    respond(api.browser);
+  },
   save_setting: function(o, respond, tab) {
     if (o.name === 'emails') {
       ajax('POST', '/ext/pref/email/message/' + !!o.value, onSettingCommitted);

--- a/packrat/scripts/thread.js
+++ b/packrat/scripts/thread.js
@@ -38,7 +38,7 @@ panes.thread = function () {
     }
   };
 
-  var $who, $holder;
+  var $who, $holder, browserName;
   return {
     render: function ($paneBox, locator) {
       var threadId = locator.split('/')[2];
@@ -55,6 +55,9 @@ panes.thread = function () {
         if ($holder) {
           $holder.data('compose').reflectPrefs(prefs);
         }
+      });
+      api.port.emit('browser', function (data) {
+        browserName = data.name;
       });
 
       $paneBox.on('click', '.kifi-message-header-back', function () {
@@ -193,7 +196,8 @@ panes.thread = function () {
       id: '',
       createdAt: new Date().toISOString(),
       text: text,
-      user: me
+      user: me,
+      displayedSource: browserName
     }))
     .data('text', text);
     $holder.append($m).scrollToBottom();


### PR DESCRIPTION
@2is10 This fixes the bug where the source of the message is not shown after sending a message (because the message shown is locally generated, not actually sent by the server)
Theoretically there is a race condition (a message could be sent before the background page replies with the browser info) but this should not really happen, and the UI handles that gracefully anyway.
