### PR TITLE
reducing most common logs entries. 

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/concurrent/ForkJoinExecContextMonitor.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/concurrent/ForkJoinExecContextMonitor.scala
@@ -25,7 +25,7 @@ class ForkJoinExecContextMonitor @Inject() (
 
   def checkFJContext():Unit = {
     val fj = com.keepit.common.concurrent.ExecutionContext.fjPool
-    log.info(s"[checkFJContext] #queuedSubmission=${fj.getQueuedSubmissionCount} #queuedTasks=${fj.getQueuedTaskCount} fj=${fj}")
+    log.debug(s"[checkFJContext] #queuedSubmission=${fj.getQueuedSubmissionCount} #queuedTasks=${fj.getQueuedTaskCount} fj=${fj}")
     if (fj.getQueuedSubmissionCount > Runtime.getRuntime.availableProcessors * 5) { // todo: tweak; airbrake if this proves useful
       systemAdminMailSender.sendMail(ElectronicMail(from = EmailAddresses.ENG,
         to = Seq(EmailAddresses.RAY),

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -322,7 +322,7 @@ class ShoeboxServiceClientImpl @Inject() (
     implicit val idFormat = Id.format[User]
     val payload = JsArray(userIds.map{ x => Json.toJson(x)})
     call(Shoebox.internal.getEmailAddressesForUsers(), payload).map{ res =>
-      log.info(s"[res.request.trackingId] getEmailAddressesForUsers for users $userIds returns json ${res.json}")
+      log.debug(s"[res.request.trackingId] getEmailAddressesForUsers for users $userIds returns json ${res.json}")
       res.json.as[Map[String, Seq[String]]].map{ case (id, emails) => Id[User](id.toLong) -> emails }.toMap
     }
   }
@@ -687,10 +687,10 @@ class ShoeboxServiceClientImpl @Inject() (
 
   def isUnscrapableP(url: String, destinationUrl: Option[String]): Future[Boolean] = {
     val destUrl = if (destinationUrl.isDefined && url == destinationUrl.get) {
-      log.info(s"[isUnscrapableP] url==destUrl ${url}; ignored") // todo: fix calling code
+      log.debug(s"[isUnscrapableP] url==destUrl ${url}; ignored") // todo: fix calling code
       None
     } else destinationUrl map { dUrl =>
-      log.info(s"[isUnscrapableP] url($url) != destUrl($dUrl)")
+      log.debug(s"[isUnscrapableP] url($url) != destUrl($dUrl)")
       dUrl
     }
     val payload = JsArray(destUrl match {

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/HttpFetcher.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/HttpFetcher.scala
@@ -138,7 +138,7 @@ class HttpFetcherImpl(val airbrake:AirbrakeNotifier, userAgent: String, connecti
   val enforcer = new Runnable {
     def run():Unit = {
       try {
-        log.info(s"[enforcer] checking for long running fetch requests ... q.size=${q.size}")
+        log.debug(s"[enforcer] checking for long running fetch requests ... q.size=${q.size}")
         if (!q.isEmpty) {
           val iter = q.iterator
           while (iter.hasNext) {
@@ -157,7 +157,7 @@ class HttpFetcherImpl(val airbrake:AirbrakeNotifier, userAgent: String, connecti
                   log.warn(msg)
                   ft.htpGet.abort() // inform scraper
                   ft.killCount.incrementAndGet()
-                  log.info(s"[enforcer] ${ft.htpGet.getURI} isAborted=${ft.htpGet.isAborted}")
+                  log.debug(s"[enforcer] ${ft.htpGet.getURI} isAborted=${ft.htpGet.isAborted}")
                   if (!ft.htpGet.isAborted) {
                     log.warn(s"[enforcer] failed to abort long ($runMillis ms) fetch task $ft; calling interrupt ...")
                     ft.thread.interrupt
@@ -174,7 +174,7 @@ class HttpFetcherImpl(val airbrake:AirbrakeNotifier, userAgent: String, connecti
                 } else if (runMillis > LONG_RUNNING_THRESHOLD) {
                   log.warn(s"[enforcer] potential long ($runMillis ms) running task: $ft; stackTrace=${ft.thread.getStackTrace.mkString("|")}")
                 } else {
-                  log.info(s"[enforcer] $ft has been running for $runMillis ms")
+                  log.debug(s"[enforcer] $ft has been running for $runMillis ms")
                 }
               }
             } orElse {
@@ -197,7 +197,7 @@ class HttpFetcherImpl(val airbrake:AirbrakeNotifier, userAgent: String, connecti
   val scheduler = Executors.newSingleThreadScheduledExecutor(new ThreadFactory {
     def newThread(r: Runnable): Thread = {
       val thread = new Thread(r, "HttpFetcher-Enforcer")
-      log.info(s"[HttpFetcher] $thread created")
+      log.debug(s"[HttpFetcher] $thread created")
       thread
     }
   })

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/SyncScraper.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/SyncScraper.scala
@@ -66,14 +66,14 @@ class SyncScraper @Inject() (
       pageInfoOpt match {
         case None =>
           // may need marker if embedly fails
-          log.info(s"[shouldUpdateImage(${uri.id},${uri.state},${uri.url})] pageInfo=None; update.")
+          log.debug(s"[shouldUpdateImage(${uri.id},${uri.state},${uri.url})] pageInfo=None; update.")
           true
         case Some(pageInfo) =>
           if (Days.daysBetween(currentDateTime, pageInfo.updatedAt).getDays >= 5) {
-            log.info(s"[shouldUpdateImage(${uri.id},${uri.state},${uri.url})] it's been 5 days; pageInfo=$pageInfo; update.")
+            log.debug(s"[shouldUpdateImage(${uri.id},${uri.state},${uri.url})] it's been 5 days; pageInfo=$pageInfo; update.")
             true
           } else {
-            log.info(s"[shouldUpdateImage(${uri.id},${uri.state},${uri.url})] it's not been 5 days; pageInfo=$pageInfo; skipped.")
+            log.debug(s"[shouldUpdateImage(${uri.id},${uri.state},${uri.url})] it's not been 5 days; pageInfo=$pageInfo; skipped.")
             false
           }
       }
@@ -81,7 +81,7 @@ class SyncScraper @Inject() (
   }
 
   private def processURI(uri: NormalizedURI, info: ScrapeInfo, pageInfoOpt:Option[PageInfo], proxyOpt:Option[HttpProxy]): (NormalizedURI, Option[Article]) = {
-    log.info(s"[processURI] scraping ${uri.url} $info")
+    log.debug(s"[processURI] scraping ${uri.url} $info")
     val fetchedArticle = fetchArticle(uri, info, proxyOpt)
     val latestUri = helper.syncGetNormalizedUri(uri).get
     if (latestUri.state == NormalizedURIStates.INACTIVE) (latestUri, None)
@@ -97,7 +97,7 @@ class SyncScraper @Inject() (
         ) {
           // the article does not need to be reindexed update the scrape schedule, uri is not changed
           helper.syncSaveScrapeInfo(info.withDocumentUnchanged())
-          log.info(s"[processURI] (${uri.url}) no change detected")
+          log.debug(s"[processURI] (${uri.url}) no change detected")
           (latestUri, None)
         } else {
           // the article needs to be reindexed
@@ -117,7 +117,7 @@ class SyncScraper @Inject() (
           // Report canonical url
           article.canonicalUrl.foreach(recordCanonicalUrl(latestUri, signature, _, article.alternateUrls))
 
-          log.info(s"[processURI] fetched uri ${scrapedURI.url} => article(${article.id}, ${article.title})")
+          log.debug(s"[processURI] fetched uri ${scrapedURI.url} => article(${article.id}, ${article.title})")
 
           def shouldUpdateScreenshot(uri: NormalizedURI) = {
             uri.screenshotUpdatedAt map { update =>
@@ -130,12 +130,12 @@ class SyncScraper @Inject() (
 
           if (shouldUpdateImage(uri, scrapedURI, pageInfoOpt)) {
             shoeboxClient.getURIImage(uri) map { res => // todo: updateImage
-              log.info(s"[processURI(${uri.id},${uri.url})] (asyncGetImageUrl) imageUrl=$res")
+              log.debug(s"[processURI(${uri.id},${uri.url})] (asyncGetImageUrl) imageUrl=$res")
               res
             }
           }
 
-          log.info(s"[processURI] (${uri.url}) needs re-indexing; scrapedURI=(${scrapedURI.id}, ${scrapedURI.state}, ${scrapedURI.url})")
+          log.debug(s"[processURI] (${uri.url}) needs re-indexing; scrapedURI=(${scrapedURI.id}, ${scrapedURI.state}, ${scrapedURI.url})")
           (scrapedURI, Some(article))
         }
       case NotScrapable(destinationUrl, redirects) =>
@@ -144,12 +144,12 @@ class SyncScraper @Inject() (
           val toBeSaved = processRedirects(latestUri, redirects).withState(NormalizedURIStates.UNSCRAPABLE)
           helper.syncSaveNormalizedUri(toBeSaved)
         }
-        log.info(s"[processURI] (${uri.url}) not scrapable; unscrapableURI=(${unscrapableURI.id}, ${unscrapableURI.state}, ${unscrapableURI.url}})")
+        log.debug(s"[processURI] (${uri.url}) not scrapable; unscrapableURI=(${unscrapableURI.id}, ${unscrapableURI.state}, ${unscrapableURI.url}})")
         (unscrapableURI, None)
-      case com.keepit.scraper.NotModified =>
+      case NotModified =>
         // update the scrape schedule, uri is not changed
         helper.syncSaveScrapeInfo(info.withDocumentUnchanged())
-        log.info(s"[processURI] (${uri.url} not modified; latestUri=(${latestUri.id}, ${latestUri.state}, ${latestUri.url}})")
+        log.debug(s"[processURI] (${uri.url} not modified; latestUri=(${latestUri.id}, ${latestUri.state}, ${latestUri.url}})")
         (latestUri, None)
       case Error(httpStatus, msg) =>
         // store a fallback article in a store map
@@ -192,10 +192,9 @@ class SyncScraper @Inject() (
         case _ => fetchArticle(normalizedUri, httpFetcher, info, proxyOpt)
       }
     } catch {
-      case t: Throwable => {
+      case t: Throwable =>
         log.error(s"[fetchArticle] Caught exception: $t; Cause: ${t.getCause}; \nStackTrace:\n${t.getStackTrace.mkString("|")}")
         fetchArticle(normalizedUri, httpFetcher, info, proxyOpt)
-      }
     }
   }
 
@@ -213,7 +212,7 @@ class SyncScraper @Inject() (
   private def fetchArticle(normalizedUri: NormalizedURI, httpFetcher: HttpFetcher, info: ScrapeInfo, proxyOpt:Option[HttpProxy]): ScraperResult = {
     val url = normalizedUri.url
     val extractor = extractorFactory(url)
-    log.info(s"[fetchArticle] url=${normalizedUri.url} ${extractor.getClass}")
+    log.debug(s"[fetchArticle] url=${normalizedUri.url} ${extractor.getClass}")
     val ifModifiedSince = getIfModifiedSince(normalizedUri, info)
 
     try {
@@ -250,7 +249,7 @@ class SyncScraper @Inject() (
                   }
                 }
               } else {
-                log.info(s"uri ${normalizedUri} is exempted from sensitive check!")
+                log.debug(s"uri ${normalizedUri} is exempted from sensitive check!")
               }
             }
 
@@ -272,7 +271,7 @@ class SyncScraper @Inject() (
               contentLang = Some(contentLang),
               destinationUrl = fetchStatus.destinationUrl)
             val res = Scraped(article, signature, fetchStatus.redirects)
-            log.info(s"[fetchArticle] result=(Scraped(dstUrl=${fetchStatus.destinationUrl} redirects=${fetchStatus.redirects}) article=(${article.id}, ${article.title}, content.len=${article.content.length}})")
+            log.debug(s"[fetchArticle] result=(Scraped(dstUrl=${fetchStatus.destinationUrl} redirects=${fetchStatus.redirects}) article=(${article.id}, ${article.title}, content.len=${article.content.length}})")
             res
           }
         case HttpStatus.SC_NOT_MODIFIED =>
@@ -318,7 +317,7 @@ class SyncScraper @Inject() (
         updateRedirectRestriction(uri, redirect)
       }
       case Some(permanentRedirect) if permanentRedirect.isAbsolute => {
-        log.info(s"Found permanent $permanentRedirect for $uri")
+        log.debug(s"Found permanent $permanentRedirect for $uri")
         helper.syncRecordPermanentRedirect(removeRedirectRestriction(uri), permanentRedirect)
       }
       case relativePermanentRedirectOption =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -201,11 +201,7 @@ class KeepsCommander @Inject() (
         val picName = keeper.pictureName.getOrElse("0")
         imageStore.getPictureUrl(userImageSize, keeper, picName) map { userImage =>
           log.info(s"""[WKMK] $keeper using image $userImage""")
-          val pageImageSize = 42
-          val pageImage: String = db.readOnly { implicit s =>
-            imageRepo.getByUriWithSize(uri.id.get, ImageSize(pageImageSize, pageImageSize)).headOption.map(_.url).flatten.getOrElse("")
-          }
-          val bodyHtml = s"""<img src="$pageImage" style="float:left" width="$pageImageSize" height="$pageImageSize"/><b>${keeper.fullName}</b> also kept "${uri.title.getOrElse(uri.url)}"."""
+          val bodyHtml = s"""<b>${keeper.fullName}</b> also kept your keep!"""
           val category = NotificationCategory.User.WHO_KEPT_MY_KEEP
           val title = uri.title.get.abbreviate(80)
           eliza.sendGlobalNotification(otherKeepers, title, bodyHtml, title, uri.url, userImage, sticky = false, category) onComplete {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ScraperCallbackHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ScraperCallbackHelper.scala
@@ -49,7 +49,7 @@ class ScraperCallbackHelper @Inject()(
             val pageInfoOpt = pageInfoRepo.getByUri(nuri.id.get)
             val proxy = urlPatternRuleRepo.getProxy(nuri.url)
             val savedInfo = scrapeInfoRepo.save(info.withWorkerId(zkId).withState(ScrapeInfoStates.ASSIGNED))
-            log.info(s"[assignTasks($zkId,$max)] #${count} assigned (${nuri.id.get},${savedInfo.id.get},${nuri.url}) to worker $zkId")
+            log.debug(s"[assignTasks($zkId,$max)] #${count} assigned (${nuri.id.get},${savedInfo.id.get},${nuri.url}) to worker $zkId")
             count += 1
             builder += ScrapeRequest(nuri, savedInfo, pageInfoOpt, proxy)
           } else {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -138,7 +138,7 @@ class ShoeboxController @Inject() (
     val saved = db.readWrite(attempts = 1) { implicit s =>
       normUriRepo.save(normalizedUri)
     }
-    log.info(s"[saveNormalizedURI] time-lapsed:${System.currentTimeMillis - ts} url=(${normalizedUri.url}) result=$saved")
+    log.debug(s"[saveNormalizedURI] time-lapsed:${System.currentTimeMillis - ts} url=(${normalizedUri.url}) result=$saved")
     Ok(Json.toJson(saved))
   }
 
@@ -199,7 +199,7 @@ class ShoeboxController @Inject() (
     val json = request.body
     val uriOpt  = (json \ "uri").asOpt[NormalizedURI]
     val infoOpt = (json \ "info").asOpt[ScrapeInfo]
-    log.info(s"[scrapeFailed] uri=$uriOpt info=$infoOpt")
+    log.warn(s"[scrapeFailed] uri=$uriOpt info=$infoOpt")
     if (!(uriOpt.isDefined && infoOpt.isDefined)) BadRequest(s"Illegal arguments: arguments($uriOpt, $infoOpt) cannot be null")
     else {
       val (savedUri, savedInfo) = {
@@ -218,7 +218,7 @@ class ShoeboxController @Inject() (
             }
           }
           val savedInfo = scrapeInfoRepo.save(info.withFailure)
-          log.info(s"[scrapeFailed(uri(${uri.id}).url=${uri.url},info(${info.id}).state=${info.state})] time-lapsed:${System.currentTimeMillis - ts} updated: savedUri(${savedUri.id}).state=${savedUri.state}; savedInfo(${savedInfo.id}).state=${savedInfo.state}")
+          log.warn(s"[scrapeFailed(uri(${uri.id}).url=${uri.url},info(${info.id}).state=${info.state})] time-lapsed:${System.currentTimeMillis - ts} updated: savedUri(${savedUri.id}).state=${savedUri.state}; savedInfo(${savedInfo.id}).state=${savedInfo.state}")
           (savedUri, savedInfo)
         }
       }
@@ -229,7 +229,7 @@ class ShoeboxController @Inject() (
   // todo: revisit
   def recordPermanentRedirect() = Action.async(parse.tolerantJson) { request =>
     val ts = System.currentTimeMillis
-    log.info(s"[recordPermanentRedirect] body=${request.body}")
+    log.debug(s"[recordPermanentRedirect] body=${request.body}")
     val args = request.body.as[JsArray].value
     require(!args.isEmpty && args.length == 2, "Both uri and redirect need to be supplied")
     val uri = args(0).as[NormalizedURI]
@@ -260,18 +260,18 @@ class ShoeboxController @Inject() (
       updateFuture.map {
         case Some(update) => {
           val redirectedUri = db.readOnly() { implicit session => normUriRepo.get(uri.id.get) }
-          log.info(s"[recordedPermanentRedirect($uri, $redirect)] time-lapsed: ${System.currentTimeMillis - ts} result=$redirectedUri")
+          log.debug(s"[recordedPermanentRedirect($uri, $redirect)] time-lapsed: ${System.currentTimeMillis - ts} result=$redirectedUri")
           redirectedUri
         }
         case None => {
-          log.info(s"[failedToRecordPermanentRedirect($uri, $redirect)] Normalization update failed - time-lapsed: ${System.currentTimeMillis - ts} result=$uri")
+          log.warn(s"[failedToRecordPermanentRedirect($uri, $redirect)] Normalization update failed - time-lapsed: ${System.currentTimeMillis - ts} result=$uri")
           uri
         }
       }
     }
 
     val resFuture = resFutureOption getOrElse {
-        log.info(s"[failedToRecordPermanentRedirect($uri, $redirect)] Redirection normalization empty - time-lapsed: ${System.currentTimeMillis - ts} result=$uri")
+        log.warn(s"[failedToRecordPermanentRedirect($uri, $redirect)] Redirection normalization empty - time-lapsed: ${System.currentTimeMillis - ts} result=$uri")
         Future.successful(uri)
       }
 
@@ -302,7 +302,7 @@ class ShoeboxController @Inject() (
     val httpProxyOpt = db.readOnly(2, Slave) { implicit session =>
       urlPatternRuleRepo.getProxy(url)
     }
-    log.info(s"[getProxy($url): result=$httpProxyOpt")
+    log.debug(s"[getProxy($url): result=$httpProxyOpt")
     Ok(Json.toJson(httpProxyOpt))
   }
 
@@ -312,7 +312,7 @@ class ShoeboxController @Inject() (
     val httpProxyOpt = db.readOnly(2, Slave) { implicit session =>
       urlPatternRuleRepo.getProxy(url)
     }
-    log.info(s"[getProxyP] time-lapsed:${System.currentTimeMillis - ts} url=$url result=$httpProxyOpt")
+    log.debug(s"[getProxyP] time-lapsed:${System.currentTimeMillis - ts} url=$url result=$httpProxyOpt")
     Ok(Json.toJson(httpProxyOpt))
   }
 
@@ -320,7 +320,7 @@ class ShoeboxController @Inject() (
     val res = db.readOnly { implicit s => //using cache
       (urlPatternRuleRepo.isUnscrapable(url) || (destinationUrl.isDefined && urlPatternRuleRepo.isUnscrapable(destinationUrl.get)))
     }
-    log.info(s"[isUnscrapable($url, $destinationUrl)] result=$res")
+    log.debug(s"[isUnscrapable($url, $destinationUrl)] result=$res")
     Ok(JsBoolean(res))
   }
 
@@ -333,7 +333,7 @@ class ShoeboxController @Inject() (
     val res = db.readOnly { implicit s => //using cache
       (urlPatternRuleRepo.isUnscrapable(url) || (destinationUrl.isDefined && urlPatternRuleRepo.isUnscrapable(destinationUrl.get)))
     }
-    log.info(s"[isUnscrapableP] time-lapsed:${System.currentTimeMillis - ts} url=$url dstUrl=${destinationUrl.getOrElse("")} result=$res")
+    log.debug(s"[isUnscrapableP] time-lapsed:${System.currentTimeMillis - ts} url=$url dstUrl=${destinationUrl.getOrElse("")} result=$res")
     Ok(JsBoolean(res))
   }
 
@@ -398,7 +398,7 @@ class ShoeboxController @Inject() (
         scrapeInfoRepo.save(ScrapeInfo(uriId = uri.id.get))
       }
     }
-    log.info(s"[getScrapeInfo] time-lapsed:${System.currentTimeMillis - ts} url=${uri.url} result=$info")
+    log.debug(s"[getScrapeInfo] time-lapsed:${System.currentTimeMillis - ts} url=${uri.url} result=$info")
     Ok(Json.toJson(info))
   }
 
@@ -406,7 +406,7 @@ class ShoeboxController @Inject() (
     val imageInfo = db.readOnly { implicit ro =>
       imageInfoRepo.get(id)
     }
-    log.info(s"[getImageInfo($id)] result=$imageInfo")
+    log.debug(s"[getImageInfo($id)] result=$imageInfo")
     Ok(Json.toJson(imageInfo))
   }
 
@@ -414,7 +414,7 @@ class ShoeboxController @Inject() (
     val json = request.body
     val info = json.as[ImageInfo]
     val saved = scraperHelper.saveImageInfo(info)
-    log.info(s"[saveImageInfo] result=$saved")
+    log.debug(s"[saveImageInfo] result=$saved")
     Ok(Json.toJson(saved))
   }
 
@@ -423,7 +423,7 @@ class ShoeboxController @Inject() (
     val info = json.as[PageInfo]
     val toSave = db.readOnly { implicit ro => pageInfoRepo.getByUri(info.uriId) } map { p => info.withId(p.id.get) } getOrElse info
     val saved = scraperHelper.savePageInfo(toSave)
-    log.info(s"[savePageInfo] result=$saved")
+    log.debug(s"[savePageInfo] result=$saved")
     Ok(Json.toJson(saved))
   }
 
@@ -434,7 +434,7 @@ class ShoeboxController @Inject() (
     val saved = db.readWrite(attempts = 3) { implicit s =>
       scrapeInfoRepo.save(info)
     }
-    log.info(s"[saveScrapeInfo] time-lapsed:${System.currentTimeMillis - ts} result=$saved")
+    log.debug(s"[saveScrapeInfo] time-lapsed:${System.currentTimeMillis - ts} result=$saved")
     Ok(Json.toJson(saved))
   }
 
@@ -457,7 +457,7 @@ class ShoeboxController @Inject() (
     val bookmarks = db.readOnly(2, Slave) { implicit session =>
       keepRepo.getByUriWithoutTitle(uriId)
     }
-    log.info(s"[getBookmarksByUriWithoutTitle($uriId)] time-lapsed:${System.currentTimeMillis - ts} bookmarks(len=${bookmarks.length}):${bookmarks.mkString}")
+    log.debug(s"[getBookmarksByUriWithoutTitle($uriId)] time-lapsed:${System.currentTimeMillis - ts} bookmarks(len=${bookmarks.length}):${bookmarks.mkString}")
     Ok(Json.toJson(bookmarks))
   }
 
@@ -466,7 +466,7 @@ class ShoeboxController @Inject() (
     val bookmarkOpt = db.readOnly(2, Database.Slave) { implicit session => // using cache + Slate database for scanning older keeps
       keepRepo.latestKeep(url)
     }
-    log.info(s"[getLatestKeep($url)] $bookmarkOpt")
+    log.debug(s"[getLatestKeep($url)] $bookmarkOpt")
     Ok(Json.toJson(bookmarkOpt))
   }
 
@@ -475,7 +475,7 @@ class ShoeboxController @Inject() (
     val saved = db.readWrite(attempts = 3) { implicit session =>
       keepRepo.save(bookmark)
     }
-    log.info(s"[saveBookmark] saved=$saved")
+    log.debug(s"[saveBookmark] saved=$saved")
     Ok(Json.toJson(saved))
   }
 
@@ -518,7 +518,7 @@ class ShoeboxController @Inject() (
       userIds.map{userId => userId.id.toString -> emailAddressRepo.getAllByUser(userId).map{_.address}}.toMap
     }
     val json = Json.toJson(emails)
-    log.info(s"json emails for users [$userIds] are $json")
+    log.debug(s"json emails for users [$userIds] are $json")
     Ok(json)
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
@@ -192,7 +192,7 @@ class UriIntegrityActor @Inject()(
     log.info(s"batch merge uris: ${toMerge.size} pairs of uris to be merged")
 
     if (toMerge.size == 0){
-      log.info("no active changed_uris were founded. Check if we have applied changed_uris generated during urlRenormalization")
+      log.debug("no active changed_uris were founded. Check if we have applied changed_uris generated during urlRenormalization")
       val lowSeq = centralConfig(URIMigrationSeqNumKey) getOrElse SequenceNumber.ZERO
       val applied = db.readOnly{ implicit s => changedUriRepo.getChangesSince(lowSeq, batchSize, state = ChangedURIStates.APPLIED)}
       if (applied.size == batchSize){   // make sure a full batch of applied ones
@@ -260,7 +260,7 @@ class UriIntegrityActor @Inject()(
   private def fixDuplicateKeeps(): Unit = {
     val seq = centralConfig(FixDuplicateKeepsSeqNumKey) getOrElse SequenceNumber.ZERO
 
-    log.info(s"start deduping keeps: fetching tasks from seqNum ${seq}")
+    log.debug(s"start deduping keeps: fetching tasks from seqNum ${seq}")
     try {
       var dedupedSuccessCount = 0
       val keeps = db.readOnly{ implicit s => keepRepo.getBookmarksChanged(seq, 1000) }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/NormalizedURIRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/NormalizedURIRepo.scala
@@ -169,7 +169,7 @@ extends DbRepo[NormalizedURI] with NormalizedURIRepo with ExternalIdColumnDbFunc
           case uri if uri.state == NormalizedURIStates.REDIRECTED => get(uri.redirect.get)
           case uri => uri
         }
-      log.info(s"[getByUriOrPrenormalize($url)] located normalized uri $normalizedUri for prenormalizedUrl $prenormalizedUrl")
+      log.debug(s"[getByUriOrPrenormalize($url)] located normalized uri $normalizedUri for prenormalizedUrl $prenormalizedUrl")
       normalizedUri.map(Left.apply).getOrElse(Right(prenormalizedUrl))
     }
   }
@@ -198,7 +198,7 @@ extends DbRepo[NormalizedURI] with NormalizedURIRepo with ExternalIdColumnDbFunc
    * todo(eishay): use RequestConsolidator on a controller level that calls the repo level instead of locking.
    */
   def internByUri(url: String, candidates: NormalizationCandidate*)(implicit session: RWSession): NormalizedURI = urlLocks.get(url).synchronized {
-    log.info(s"[internByUri($url,candidates:(sz=${candidates.length})${candidates.mkString(",")})]")
+    log.debug(s"[internByUri($url,candidates:(sz=${candidates.length})${candidates.mkString(",")})]")
     Statsd.time(key = "normalizedURIRepo.internByUri") {
       val resUri = getByUriOrPrenormalize(url) match {
         case Success(Left(uri)) =>
@@ -222,7 +222,7 @@ extends DbRepo[NormalizedURI] with NormalizedURIRepo with ExternalIdColumnDbFunc
           newUri
         }
       }
-      log.info(s"[internByUri($url)] resUri=$resUri")
+      log.debug(s"[internByUri($url)] resUri=$resUri")
       resUri
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/normalizer/ContentCheck.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/normalizer/ContentCheck.scala
@@ -18,7 +18,7 @@ trait ContentCheck extends PartialFunction[NormalizationCandidate, Future[Boolea
 case class SignatureCheck(referenceUrl: String, referenceSignature: Option[Signature] = None, trustedDomain: Option[String] = None)(implicit scraperPlugin: ScrapeSchedulerPlugin) extends ContentCheck with Logging {
 
   Try { java.net.URI.create(referenceUrl) } match { // for debugging bad reference urls
-    case Success(uri) => log.info(s"[SignatureCheck] refUrl=$referenceUrl uri=$uri")
+    case Success(uri) => log.debug(s"[SignatureCheck] refUrl=$referenceUrl uri=$uri")
     case Failure(t)   => throw new IllegalArgumentException(s"SignatureCheck -- failed to parse refUrl=$referenceUrl; Exception=$t; Cause=${t.getCause}", t)
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationWorker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationWorker.scala
@@ -39,17 +39,17 @@ class NormalizationWorker @Inject()(
       case Failure(t) =>
         airbrake.notify(s"Caught exception $t while consuming messages from $updateQ",t)
       case Success(messages) =>
-        log.info(s"[consume] messages:(len=${messages.length})[${messages.mkString(",")}]")
+        log.debug(s"[consume] messages:(len=${messages.length})[${messages.mkString(",")}]")
         for (m <- messages) {
-          log.info(s"[consume] received msg $m")
+          log.debug(s"[consume] received msg $m")
           val task = m.body
           val nuri = db.readOnly { implicit ro =>
             nuriRepo.get(task.uriId)
           }
           val ref = NormalizationReference(nuri, task.isNew)
-          log.info(s"[consume] nuri=$nuri ref=$ref candidates=${task.candidates}")
+          log.debug(s"[consume] nuri=$nuri ref=$ref candidates=${task.candidates}")
           for (nuriOpt <- normalizationService.update(ref, task.candidates:_*)) { // sends out-of-band requests to scraper
-            log.info(s"[consume] normalizationService.update result: $nuriOpt")
+            log.debug(s"[consume] normalizationService.update result: $nuriOpt")
           }
           m.consume()
         }


### PR DESCRIPTION
@ymatsuda @raymondng @stkem @andrewconner 
We are spitting tons of logs to logentries, a bit inefficient and many are not useful now (they did make sense back then). Our quota is almost up and we're only mid-month. I removed some logs, we can always put them back.

Using "tail -100000 app.log | sed 's/\* (c._) -._/\1/' | grep -v "at " | sort | uniq -c | sort -n -k 1 | less" to find them
