### PR TITLE
using the new shoebox DB (MySQL 5.6)

### DIFF
--- a/kifi-backend/modules/common/conf/prod/c_shoebox.conf
+++ b/kifi-backend/modules/common/conf/prod/c_shoebox.conf
@@ -33,7 +33,7 @@ db.shoebox {
 
 # shoebox database
   driver=com.mysql.jdbc.Driver
-  url="jdbc:mysql://shoebox.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
+  url="jdbc:mysql://shoebox-master.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
   user=shoebox
 }
 
@@ -51,7 +51,9 @@ db.shoeboxslave {
 
 # shoebox database
   driver=com.mysql.jdbc.Driver
-  url="jdbc:mysql://shoebox-rr2.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
+  ## with this change master == read replica
+  ## soon after we promote the new master we'll make a read replica to it and assign it in the line below
+  url="jdbc:mysql://shoebox-master.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
   user=shoebox
 }
 

--- a/kifi-backend/modules/common/conf/prod/c_shoebox.conf
+++ b/kifi-backend/modules/common/conf/prod/c_shoebox.conf
@@ -33,7 +33,8 @@ db.shoebox {
 
 # shoebox database
   driver=com.mysql.jdbc.Driver
-  url="jdbc:mysql://shoebox-master.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
+  ## next step is to use shoebox-master
+  url="jdbc:mysql://shoebox.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
   user=shoebox
 }
 
@@ -52,7 +53,7 @@ db.shoeboxslave {
 # shoebox database
   driver=com.mysql.jdbc.Driver
   ## with this change master == read replica
-  ## soon after we promote the new master we'll make a read replica to it and assign it in the line below
+  ## soon after we promote the new master we'll make a read replica (shoebox-rr1) to it and assign it in the line below
   url="jdbc:mysql://shoebox-master.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
   user=shoebox
 }

--- a/kifi-backend/modules/common/conf/prod/shoebox.conf
+++ b/kifi-backend/modules/common/conf/prod/shoebox.conf
@@ -30,7 +30,8 @@ db.shoebox {
 
 # shoebox database
   driver=com.mysql.jdbc.Driver
-  url="jdbc:mysql://shoebox-master.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
+  ## next step is to use shoebox-master
+  url="jdbc:mysql://shoebox.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
   user=shoebox
 }
 
@@ -49,7 +50,7 @@ db.shoeboxslave {
 # shoebox database
   driver=com.mysql.jdbc.Driver
   ## with this change master == read replica
-  ## soon after we promote the new master we'll make a read replica to it and assign it in the line below
+  ## soon after we promote the new master we'll make a read replica (shoebox-rr1) to it and assign it in the line below
   url="jdbc:mysql://shoebox-master.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
   user=shoebox
 }

--- a/kifi-backend/modules/common/conf/prod/shoebox.conf
+++ b/kifi-backend/modules/common/conf/prod/shoebox.conf
@@ -30,7 +30,7 @@ db.shoebox {
 
 # shoebox database
   driver=com.mysql.jdbc.Driver
-  url="jdbc:mysql://shoebox.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
+  url="jdbc:mysql://shoebox-master.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
   user=shoebox
 }
 
@@ -48,7 +48,9 @@ db.shoeboxslave {
 
 # shoebox database
   driver=com.mysql.jdbc.Driver
-  url="jdbc:mysql://shoebox-rr2.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
+  ## with this change master == read replica
+  ## soon after we promote the new master we'll make a read replica to it and assign it in the line below
+  url="jdbc:mysql://shoebox-master.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/shoebox?autoReconnect=true&useUnicode=yes"
   user=shoebox
 }
 


### PR DESCRIPTION
**\* DO NOT MERGE ***

There is a new mysql DB named "mysql-master" in prod now. 
Its on mysql 5.6, serving as a slave to our current master and is all up to date.
Tomorrow morning we will do the following after verifying its still up to date (`SHOW SLAVE STATUS`):
1. merge and update production, by that we'll use master - v5.5, and slave - v5.6
2. wait a bit and see that we're cool with that
3. shut down all shoeboxen (DOWNTIME)
4. promote shoebox-master to be the master
5. start shoeboxen having both master and slave urls pointing to the new master
6. start a new read replica (slave) of the new master
7. push new shoebox that has a read replica pointing to the new read replica
8. get external messaging out the door
