### PR TITLE
+ (NoCopy)LocalSerializer

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionLocalCache.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionLocalCache.scala
@@ -1,6 +1,6 @@
 package com.keepit.common.cache
 
-import com.keepit.serializer.Serializer
+import com.keepit.serializer.{SafeLocalSerializer, NoCopyLocalSerializer, LocalSerializer, Serializer}
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.Duration
 import scala.concurrent.Future
@@ -8,17 +8,20 @@ import play.api.libs.json._
 import com.keepit.common.performance._
 import com.keepit.common.logging.Logging
 
-
 class TransactionLocalCache[K <: Key[T], T] private(
   override val minTTL: Duration,
   override val maxTTL: Duration,
   override val outerCache: Option[ObjectCache[K, T]],
   underlying: ObjectCache[K, T],
-  serializer: Serializer[T]
+  serializer: Serializer[T],
+  localSerializerOpt: Option[LocalSerializer[T]]
 ) extends ObjectCache[K, T] with Logging {
 
   // outerCache is wrapped in ReadOnlyCacheWrapper to block updates silently
-  def this(underlying: ObjectCache[K, T], serializer: Serializer[T]) = this(Duration.Inf, Duration.Inf, Some(new ReadOnlyCacheWrapper(underlying)), underlying, serializer)
+  def this(underlying: ObjectCache[K, T], serializer: Serializer[T], localSerializerOpt:Option[LocalSerializer[T]]) =
+    this(Duration.Inf, Duration.Inf, Some(new ReadOnlyCacheWrapper(underlying)), underlying, serializer, localSerializerOpt)
+
+  val localSerializer:LocalSerializer[T] = localSerializerOpt.getOrElse(SafeLocalSerializer(serializer))
 
   sealed trait LocalObjectState
   case class LFound(value: Any) extends LocalObjectState
@@ -31,7 +34,7 @@ class TransactionLocalCache[K <: Key[T], T] private(
     txnLocalStore.get(key) match {
       case Some(state) =>
         state match {
-          case LFound(serialized) => Found(serializer.reads(serialized))
+          case LFound(serialized) => Found(localSerializer.localReads(serialized))
           case LNotFound() => NotFound()
           case LRemoved() => Removed()
         }
@@ -40,7 +43,7 @@ class TransactionLocalCache[K <: Key[T], T] private(
   }
 
   protected[cache] def setInnerCache(key: K, valueOpt: Option[T]) = {
-    txnLocalStore += (key -> LFound(serializer.writes(valueOpt)))
+    txnLocalStore += (key -> LFound(localSerializer.localWrites(valueOpt)))
   }
 
   protected[cache] def bulkGetFromInnerCache(keys: Set[K]): Map[K, ObjectState[T]] = {
@@ -48,7 +51,7 @@ class TransactionLocalCache[K <: Key[T], T] private(
       txnLocalStore.get(key) match {
         case Some(state) =>
           state match {
-            case LFound(serialized) => result + (key -> Found(serializer.reads(serialized)))
+            case LFound(serialized) => result + (key -> Found(localSerializer.localReads(serialized)))
             case LRemoved() => result + (key -> Removed())
             case state => throw new Exception(s"this state ($state) should not be in the cache")
           }
@@ -66,7 +69,9 @@ class TransactionLocalCache[K <: Key[T], T] private(
     txnLocalStore.foreach{ case (key, state) =>
       state match {
         case LFound(serialized) => {
-          val v = timing(s"TLCache-reads($key,${state.toString.take(500)})", 50) { serializer.reads(serialized) }
+          val v = timing(s"TLCache-reads($key,${state.toString.take(500)})", 50) {
+            localSerializer.localReads(serialized)
+          }
           timing(s"TLCache-writes($key,${state.toString.take(500)},$v)", 50) {
             underlying.set(key, v)
           }

--- a/kifi-backend/modules/common/app/com/keepit/social/BasicUser.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/BasicUser.scala
@@ -1,6 +1,6 @@
 package com.keepit.social
 
-import com.keepit.common.cache.{CacheStatistics, JsonCacheImpl, FortyTwoCachePlugin, Key}
+import com.keepit.common.cache._
 import com.keepit.common.db._
 import com.keepit.common.logging.AccessLog
 import com.keepit.model._
@@ -13,6 +13,9 @@ import play.api.libs.json._
 import org.apache.lucene.store.{InputStreamDataInput, OutputStreamDataOutput}
 
 import scala.concurrent.duration.Duration
+import com.keepit.serializer.NoCopyLocalSerializer
+import com.keepit.serializer.NoCopyLocalSerializer
+import scala.Some
 
 trait BasicUserLikeEntity {
   def asBasicUser: Option[BasicUser] = None
@@ -104,8 +107,7 @@ case class BasicUserUserIdKey(userId: Id[User]) extends Key[BasicUser] {
 }
 
 class BasicUserUserIdCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
-  extends JsonCacheImpl[BasicUserUserIdKey, BasicUser](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)
-
+  extends ImmutableJsonCacheImpl[BasicUserUserIdKey, BasicUser](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings:_*)
 
 case class BasicUserWithUserId(
   userId: Id[User],

--- a/kifi-backend/modules/common/test/com/keepit/common/cache/TransactionalCachingTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/cache/TransactionalCachingTest.scala
@@ -1,7 +1,7 @@
 package com.keepit.common.cache
 
 import com.keepit.common.logging.Logging
-import com.keepit.serializer.Serializer
+import com.keepit.serializer.{NoCopyLocalSerializer, Serializer}
 import org.specs2.mutable.Specification
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.Duration
@@ -55,7 +55,7 @@ class TransactionalCachingTest extends Specification {
   private val cache1 = new Cache1
   private val cache2 = new Cache2
 
-  class TxnCache1(c: Cache1) extends TransactionalCache(c, Serializer.string)
+  class TxnCache1(c: Cache1) extends TransactionalCache(c, Serializer.string, Some(NoCopyLocalSerializer[String]))
   class TxnCache2(c: Cache2) extends TransactionalCache(c, Serializer.string)
 
   val txnCache1 = new TxnCache1(cache1)


### PR DESCRIPTION
Reviewer: @ymatsuda 

There is significant overhead in JSON processing. In the case of TransactionalLocalCache we are hit very hard -- JSON processing overhead can easily dominate the actual work.

However, observe that in many (most?) cases where the objects are immutable, the serialization/de-serialization in the local cache are unnecessary -- this is a small step to get rid of such overhead in these cases.

cc: @eishay @andrewconner @stkem @leogrim 
