### PR TITLE
remove dead codes

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
@@ -121,41 +121,7 @@ object NormalizedURIStates extends States[NormalizedURI] {
   val UNSCRAPABLE = State[NormalizedURI]("unscrapable")
   val REDIRECTED = State[NormalizedURI]("redirected")
 
-  type Transitions = Map[State[NormalizedURI], Set[State[NormalizedURI]]]
-
-  val ALL_TRANSITIONS: Transitions = Map(
-      (ACTIVE -> Set(REDIRECTED)),
-      (SCRAPED -> Set(INACTIVE, REDIRECTED)),
-      (SCRAPE_FAILED -> Set(INACTIVE, REDIRECTED)),
-      (UNSCRAPABLE -> Set(INACTIVE, REDIRECTED)),
-      (INACTIVE -> Set(ACTIVE, INACTIVE, REDIRECTED)),
-      (REDIRECTED -> Set(ACTIVE, INACTIVE, REDIRECTED)))
-
-  val ADMIN_TRANSITIONS: Transitions = Map(
-      (ACTIVE -> Set.empty),
-      (SCRAPED -> Set(ACTIVE)),
-      (SCRAPE_FAILED -> Set(ACTIVE)),
-      (UNSCRAPABLE -> Set(ACTIVE)),
-      (INACTIVE -> Set.empty))
-
   val DO_NOT_SCRAPE = Set(INACTIVE, UNSCRAPABLE, REDIRECTED)
-
-  def transitionByAdmin[T](transition: (State[NormalizedURI], Set[State[NormalizedURI]]))(f:State[NormalizedURI]=>T) = {
-    f(validate(transition, ADMIN_TRANSITIONS))
-  }
-
-  def findNextState(transition: (State[NormalizedURI], Set[State[NormalizedURI]])) = validate(transition, ALL_TRANSITIONS)
-
-  private def validate(transition: (State[NormalizedURI], Set[State[NormalizedURI]]), transitions: Transitions): State[NormalizedURI] = {
-    transition match {
-      case (from, to) =>
-        transitions.get(from) match {
-          case Some(possibleStates) =>
-            (possibleStates intersect to).headOption.getOrElse(throw new StateException("invalid transition: %s -> %s".format(from, to)))
-          case None => throw new StateException("no such state: %s".format(from))
-        }
-    }
-  }
 }
 
 case class IndexableUri(

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminArticleIndexerController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminArticleIndexerController.scala
@@ -28,16 +28,6 @@ class AdminArticleIndexerController @Inject()(
     Ok("reindexing started")
   }
 
-  def indexByState(state: State[NormalizedURI]) = AdminHtmlAction.authenticated { implicit request =>
-    transitionByAdmin(state -> Set(SCRAPED, SCRAPE_FAILED)) { newState =>
-      db.readWrite { implicit s =>
-        normUriRepo.getByState(state).foreach{ uri => normUriRepo.save(uri.withState(newState)) }
-      }
-      searchClient.index()
-      Ok("indexed articles")
-    }
-  }
-
   def getSequenceNumber = AdminJsonAction.authenticatedAsync { implicit request =>
     searchClient.articleIndexerSequenceNumber().map { number =>
       Ok(JsObject(Seq("sequenceNumber" -> JsNumber(number))))

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -359,7 +359,6 @@ POST    /admin/data/clearRestriction    @com.keepit.controllers.admin.UrlControl
 GET     /admin/article/index        @com.keepit.controllers.admin.AdminArticleIndexerController.index
 GET     /admin/article/reindex      @com.keepit.controllers.admin.AdminArticleIndexerController.reindex
 GET     /admin/article/sequenceNumber @com.keepit.controllers.admin.AdminArticleIndexerController.getSequenceNumber
-GET     /admin/article/index/:state @com.keepit.controllers.admin.AdminArticleIndexerController.indexByState(state: State[NormalizedURI])
 GET     /admin/article/refreshSearcher @com.keepit.controllers.admin.AdminArticleIndexerController.refreshSearcher
 GET     /admin/article/dumpDoc/:uriId  @com.keepit.controllers.admin.AdminArticleIndexerController.dumpLuceneDocument(uriId: Id[NormalizedURI])
 


### PR DESCRIPTION
@ymatsuda  @andrewconner  @eishay 

The validation of state transition is only used in `AdminArticleIndexerController`, and that endpoint I believe is dead. 

Since we don't do any validation of state transition in our code, it's time to remove them all? 
