### PR TITLE
New look here parser for emailing

### DIFF
--- a/kifi-backend/modules/eliza/app/views/emailMessageBlock.scala.html
+++ b/kifi-backend/modules/eliza/app/views/emailMessageBlock.scala.html
@@ -41,7 +41,7 @@
                                   @if(segment.kind=="tlh") {
                                     @emailTextLookHereBlock(shortName, segment.asInstanceOf[com.keepit.eliza.commanders.TextLookHereSegment])
                                   }
-                                  @if(segment.kind=="ihl"){
+                                  @if(segment.kind=="ilh"){
                                     @emailImageLookHereBlock(shortName, segment.asInstanceOf[com.keepit.eliza.commanders.ImageLookHereSegment])
                                   }
                                 }


### PR DESCRIPTION
Simplicity comes at the cost of not allowing real tabs (“\t”) in messages and repeated matching with the regex. We may want to revisit this at some point when we have more time/need it to be faster. I'm considering sending a pull request to Scala with a split method that can preserve the delimiters.

@martinraison @andrewconner @leogrim 
