### PR TITLE
custom router

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/CustomRouter.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/CustomRouter.scala
@@ -1,0 +1,5 @@
+package com.keepit.common.zookeeper
+
+trait CustomRouter {
+  def update(routingList: Vector[ServiceInstance], refresh: ()=>Unit): Unit
+}

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
@@ -156,8 +156,21 @@ class ServiceCluster(val serviceType: ServiceType, airbrake: Provider[AirbrakeNo
     }
   }
 
-  private def resetRoutingList() =
+  private def resetRoutingList() = {
     routingList = Vector(instances.values.toSeq: _*)
+    val myRouter = customRouter // copy the pointer for safety
+    if (myRouter != null) myRouter.update(routingList, forceUpdateTopology)
+  }
+
+  @volatile
+  private[this] var customRouter: CustomRouter = null
+
+  def setCustomRouter(myRouter: CustomRouter): Unit = synchronized {
+    myRouter.update(routingList, forceUpdateTopology)
+    customRouter = myRouter
+  }
+
+  def getCustomRouter: CustomRouter = customRouter
 
   def refresh() = forceUpdateTopology()
 }


### PR DESCRIPTION
@eishay @raymondng 

added CustomRouter trait.
ServiceCluster calls CustomRouter.update whenever routingList changes.
Distributed Search will use this mechanism to maintain its own routing table.
