### PR TITLE
Fixing prod issue: Allowing hit.tags to be an empty array

### DIFF
--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -702,7 +702,7 @@ if (searchUrlRe.test(document.URL)) !function () {
       formatTitleFromUrl(hit.bookmark.url, matches.url, bolded);
     hit.descHtml = formatDesc(hit.bookmark.url, matches.url);
     hit.scoreText = ~response.experiments.indexOf('show_hit_scores') ? String(Math.round(hit.score * 100) / 100) : '';
-    if (hit.tags) {
+    if (hit.tags && hits.tags.length > 0) {
       hit.tags[hit.tags.length - 1].last = true;
     }
 


### PR DESCRIPTION
This was my mistake — tough to catch and only affecting Jen and Jeff on some queries.
1. The server now only returns the most recent 500 tags. Neither the server nor the client is prepared to deal with more. Even at all, type ahead is extremely laggy.
2. After a search, the server returns the ids of tags to apply to a keep.
3. The client replaces the tag id list with tag objects (with name, id). If there are no tags, `hit.tags` is undefined. If there are tags and the extension is aware of one or more, `hit.tags` is a non-empty array. If there are tags, but the extension is aware of none, `hit.tags` is an empty array.
4. `hit.tags` being a non-empty array is assumed in the following line changed in this PR. 

Because of this assumption, I felt the best way to fix this is to ignore empty arrays, rather than setting `hit.tags` back to undefined if it's empty. This is a partial solution, in anticipation that we can get resources to index and paginate tags, so we do not have this 500 cap limit.

@2is10 @eishay @JRuff42 
