### PR TITLE
2.9.48: fixing look here on medium (allowing dots in IDs)

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=2.9.47
+version=2.9.48

--- a/packrat/scripts/snapshot.js
+++ b/packrat/scripts/snapshot.js
@@ -220,10 +220,6 @@ var snapshot = function () {
         default: return null;
       }
 
-      // use tab instead of space to terminate unicode escape sequences so that space can always signify
-      // the descendant combinator
-      sel = sel.replace(/ /g, '\t');
-
       // We loosen up the selector slowly because multiple matches is failure.
 
       // 1. Allow a new ancestor to have been inserted in the parent chain.


### PR DESCRIPTION
There was a bad merge on Feb 28 that included two different solutions to the same problem. Only meant to commit one of them.
https://github.com/FortyTwoEng/keepit/commits/2979c142115bbd78df231920260b0438a5fd710c/packrat/scripts/snapshot.js
