### PR TITLE
temporary bandaid for all the user image requests form eliza

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaEmailCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaEmailCommander.scala
@@ -159,7 +159,11 @@ class ElizaEmailCommander @Inject() (
 
     val allUserIds: Set[Id[User]] = thread.participants.map(_.allUsers).getOrElse(Set.empty)
     val allUsersFuture: Future[Map[Id[User], User]] = new SafeFuture(shoebox.getUsers(allUserIds.toSeq).map(s => s.map(u => u.id.get -> u).toMap))
-    val allUserImageUrlsFuture: Future[Map[Id[User], String]] = new SafeFuture(FutureHelpers.map(allUserIds.map(u => u -> shoebox.getUserImageUrl(u, 73)).toMap))
+    val allUserImageUrlsFuture: Future[Map[Id[User], String]] = allUsersFuture.map { allUsers =>
+      allUsers.mapValues { u =>
+        "//djty7jcqog9qu.cloudfront.net/users/" + u.externalId + "/pics/100/" + u.pictureName.getOrElse("0") + ".jpg"
+      }
+    } //new SafeFuture(FutureHelpers.map(allUserIds.map(u => u -> shoebox.getUserImageUrl(u, 73)).toMap))
     val uriSummaryBigFuture = getSummaryBig(thread)
 
     for {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaEmailNotifier.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaEmailNotifier.scala
@@ -131,7 +131,13 @@ class ElizaEmailNotifierActor @Inject() (
     val allUsersFuture : Future[Map[Id[User], User]] = new SafeFuture(
       shoebox.getUsers(allUserIds).map( s => s.map(u => u.id.get -> u).toMap)
     )
-    val allUserImageUrlsFuture: Future[Map[Id[User], String]] = new SafeFuture(FutureHelpers.map(allUserIds.map(u => u -> shoebox.getUserImageUrl(u, 73)).toMap))
+    val allUserImageUrlsFuture: Future[Map[Id[User], String]] = allUsersFuture.map { allUsers =>
+      allUsers.mapValues { u =>
+        "//djty7jcqog9qu.cloudfront.net/users/" + u.externalId + "/pics/100/" + u.pictureName.getOrElse("0") + ".jpg"
+      }
+    }//new SafeFuture(FutureHelpers.map(allUserIds.map(u => u -> shoebox.getUserImageUrl(u, 73)).toMap))
+
+
     val uriSummaryFuture = elizaEmailCommander.getSummarySmall(thread)
     val deepUrlFuture: Future[String] = shoebox.getDeepUrl(thread.deepLocator, recipientUserId)
 


### PR DESCRIPTION
until we add a cache.

I won't be able to monitor this at all as I will be, so it would be great if someone will take it upon themselves to merge and deploy this (if it passes muster). _Not_ a permanent solution by any means (that would be a cache) but it should stop the bleeding.

@martinraison @eishay @leogrim @andrewconner 
(cc @jaredpetker since you are on call)
