### PR TITLE
grouping email notifications by thread

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeNotifier.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeNotifier.scala
@@ -131,7 +131,7 @@ trait AirbrakeNotifier extends Logging {
     val pass: Boolean = condition
     if (!pass) {
       log.error(s"[condition fail] $message")
-//      notify(message)
+      notify(message)
     }
     pass
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaEmailNotifier.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaEmailNotifier.scala
@@ -132,7 +132,6 @@ class ElizaEmailNotifierActor @Inject() (
         //if user is not active, skip it!
         val recipient = allUsers(recipientUserId)
         if (recipient.state == UserStates.ACTIVE && recipient.primaryEmailId.nonEmpty) {
-          val otherParticipants = allUsers.filter(_._1 != recipientUserId).values.toSeq
 
           for {
             destinationEmail <- shoebox.getEmailAddressById(recipient.primaryEmailId.get)
@@ -140,13 +139,12 @@ class ElizaEmailNotifierActor @Inject() (
           } yield {
             val threadEmailInfo: ThreadEmailInfo = elizaEmailCommander.getThreadEmailInfo(thread, uriSummary, allUsers, allUserImageUrls, Some(unsubUrl)).copy(pageUrl = deepUrl)
 
-            val authorFirst = otherParticipants.map(_.firstName).sorted.mkString(", ")
             val magicAddress = EmailAddresses.discussion(userThread.accessToken.token)
             val email = ElectronicMail(
               from = magicAddress,
               fromName = Some("Kifi Notifications"),
               to = Seq(GenericEmailAddress(destinationEmail)),
-              subject = s"""New messages on "${threadEmailInfo.pageTitle}" with $authorFirst""",
+              subject = s"""New messages on "${threadEmailInfo.pageTitle}"""",
               htmlBody = views.html.userDigestEmail(threadEmailInfo, extendedThreadItems).body,
               category = NotificationCategory.User.MESSAGE
             )

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaEmailNotifier.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaEmailNotifier.scala
@@ -80,7 +80,7 @@ class ElizaEmailNotifierActor @Inject() (
             val batch = userThreadBatchQueue.dequeue()
             log.info(s"userThreadBatchQueue size: ${userThreadBatchQueue.size}")
             processing = true
-            emailUnreadMessagesForNextNonUserThreadBatch(batch)
+            emailUnreadMessagesForNonUserThreadBatch(batch)
           })
           tasks.onComplete { result =>
             result match {
@@ -133,7 +133,7 @@ class ElizaEmailNotifierActor @Inject() (
   /**
    * Sends email update to all specified user threads corresponding to the same MessageThread
    */
-  private def emailUnreadMessagesForNextNonUserThreadBatch(batch: UserThreadBatch): Future[Unit] = {
+  private def emailUnreadMessagesForNonUserThreadBatch(batch: UserThreadBatch): Future[Unit] = {
     val userThreads = batch.userThreads
     val threadId = batch.threadId
     val thread = db.readOnly { implicit session => threadRepo.get(threadId) }


### PR DESCRIPTION
@leogrim @eishay I believe this should make the ElizaEmailNotifier much more efficient. Instead of processing each UserThread independently, it groups them by MessageThread, and only fetches the MessageThread's information once.

Side-note: I am still very intrigued by the design of ElizaEmailNotifier. Each Eliza instance retrieves the whole list of UserThreads that require email notifications, and then processes the whole batch. It seems to me that if sending emails takes a long time, several Eliza instances may end up sending duplicate email updates. I'd rather imagine something where the "master" Eliza instance fetches the whole list and puts it into a queue (SQS?). Then all Eliza instances consume messages from that common queue.
