### PR TITLE
removing unnecessary style declaration

### DIFF
--- a/packrat/styles/view_email_dialog.css
+++ b/packrat/styles/view_email_dialog.css
@@ -103,7 +103,6 @@
 .kifi-view-email-dialog-iframe {
   height: 100%;
   border-top: 41px solid transparent;
-  background: border-box;
 }
 .kifi-view-email-dialog-title {
   line-height: 41px;


### PR DESCRIPTION
@martinraison 

(`border-box` is the default value of `background-clip`, so this line simply resets all background properties on the element, which haven’t been set anywhere else, so this line can be removed.)
