### PR TITLE
Dispatcher

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/RemoteService.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/RemoteService.scala
@@ -15,6 +15,8 @@ object RemoteService {
 
 case class RemoteService(amazonInstanceInfo: AmazonInstanceInfo, status: ServiceStatus, serviceType: ServiceType) {
   def healthyStatus: ServiceStatus = serviceType.healthyStatus(amazonInstanceInfo)
+
+  def getShardSpec: Option[String] = amazonInstanceInfo.tags.get("ShardSpec")
 }
 
 

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
@@ -158,9 +158,8 @@ class ServiceCluster(val serviceType: ServiceType, airbrake: Provider[AirbrakeNo
 
   private def resetRoutingList() = {
     routingList = Vector(instances.values.toSeq: _*)
-    val myRouter = customRouter // copy the pointer for safety
 
-    if (myRouter != null) {
+    customRouter.foreach{ myRouter =>
       try {
         myRouter.update(routingList, forceUpdateTopology)
       } catch {
@@ -172,14 +171,14 @@ class ServiceCluster(val serviceType: ServiceType, airbrake: Provider[AirbrakeNo
   }
 
   @volatile
-  private[this] var customRouter: CustomRouter = null
+  private[this] var customRouter: Option[CustomRouter] = None
 
-  def setCustomRouter(myRouter: CustomRouter): Unit = synchronized {
-    myRouter.update(routingList, forceUpdateTopology)
+  def setCustomRouter(myRouter: Option[CustomRouter]): Unit = synchronized {
+    myRouter.foreach(_.update(routingList, forceUpdateTopology))
     customRouter = myRouter
   }
 
-  def getCustomRouter: CustomRouter = customRouter
+  def getCustomRouter: Option[CustomRouter] = customRouter
 
   def refresh() = forceUpdateTopology()
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
@@ -159,7 +159,16 @@ class ServiceCluster(val serviceType: ServiceType, airbrake: Provider[AirbrakeNo
   private def resetRoutingList() = {
     routingList = Vector(instances.values.toSeq: _*)
     val myRouter = customRouter // copy the pointer for safety
-    if (myRouter != null) myRouter.update(routingList, forceUpdateTopology)
+
+    if (myRouter != null) {
+      try {
+        myRouter.update(routingList, forceUpdateTopology)
+      } catch {
+        case e: Throwable =>
+          log.error("custom router update failed", e)
+          airbrake.get.notify(s"custom router update failed: serviceType=$serviceType customRouter=${customRouter.getClass.getSimpleName}")
+      }
+    }
   }
 
   @volatile

--- a/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClient.scala
@@ -95,7 +95,7 @@ class SearchServiceClientImpl(
 
   private lazy val distRouter = {
     val router = new DistributedSearchRouter(this)
-    serviceCluster.setCustomRouter(router)
+    serviceCluster.setCustomRouter(Some(router))
     router
   }
 

--- a/kifi-backend/modules/common/app/com/keepit/search/sharding/Dispatcher.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/sharding/Dispatcher.scala
@@ -1,0 +1,172 @@
+package com.keepit.search.sharding
+
+import com.keepit.common.db.Id
+import com.keepit.common.logging.Logging
+import com.keepit.common.zookeeper.ServiceInstance
+import scala.collection.mutable.ArrayBuffer
+import scala.util.Random
+
+class ShardedServiceInstance[T](val serviceInstance: ServiceInstance) {
+  val shards: Set[Shard[T]] = serviceInstance.remoteService.getShardSpec match {
+    case Some(spec) => Dispatcher.shardSpecParser.parse[T](spec)
+    case None => Set()
+  }
+}
+
+object Dispatcher {
+  private[sharding] val shardSpecParser = new ShardSpecParser
+
+  def apply[T](instances: Vector[ServiceInstance], forceReload: ()=>Unit): Dispatcher[T] = {
+    new Dispatcher[T](instances.map(new ShardedServiceInstance[T](_)), forceReload)
+  }
+}
+
+class Dispatcher[T](instances: Vector[ShardedServiceInstance[T]], forceReload: ()=>Unit) extends Logging {
+
+  // invert the instance list to shard->instances map filter unreachable instances out
+  private def invert(): Map[Shard[T], ArrayBuffer[ShardedServiceInstance[T]]] = {
+    val upList = instances.filter(i => i.serviceInstance.isUp)
+    val availableCount = instances.count(i => i.serviceInstance.isAvailable && !i.serviceInstance.reportedSentServiceUnavailable)
+    val list = if (upList.length < availableCount / 2.0) {
+      instances.filter(i => i.serviceInstance.isAvailable && !i.serviceInstance.reportedSentServiceUnavailable)
+    } else {
+      upList
+    }
+    var shardToInstances = Map.empty[Shard[T], ArrayBuffer[ShardedServiceInstance[T]]]
+    list.foreach{ instance =>
+      instance.shards.foreach{ s =>
+        shardToInstances.get(s) match {
+          case Some(buf) => buf += instance
+          case None => shardToInstances += (s -> ArrayBuffer(instance))
+        }
+      }
+    }
+    shardToInstances
+  }
+
+  private[this] var routingTable = invert()
+
+  private[this] def reload(): Unit = synchronized{ routingTable = invert() }
+
+  private[this] val rnd = new Random()
+
+  def call[R](id: Id[T])(body: (ServiceInstance) => R): R = call(id, body, 1, 3)
+
+  private def call[R](id: Id[T], body: (ServiceInstance) => R, attempts: Int, maxAttempts: Int): R = {
+
+    val table = routingTable // for safety
+
+    var i = 0
+    val candidate: ShardedServiceInstance[T] = {
+      // first choose a <shard,instances> pair. there is a single shard per sharding strategy.
+      // using the reservoir algorithm
+      var candidateShard: Shard[T] = null
+      table.iterator.foreach{ case (shard, instances) =>
+        val size = instances.size
+        i += size
+        if (rnd.nextInt(i) < size) candidateShard = shard
+      }
+      if (candidateShard == null) {
+        log.error(s"no shard found for id=$id")
+        throw new DispatchFailedException(s"no shard found for id=$id")
+      } else {
+        // now choose an instance
+        val instances = table(candidateShard)
+        if (instances.size > 0) instances(rnd.nextInt(instances.size)) else null
+      }
+    }
+
+    if (candidate != null && !candidate.serviceInstance.reportedSentServiceUnavailable) {
+      body(candidate.serviceInstance)
+    } else {
+      if (attempts < maxAttempts) {
+        // failed to find an instance. there may an unreachable instance. reload shard->instances map and try again
+        reload()
+        return call(id, body, attempts + 1, maxAttempts) // retry
+      } else {
+        log.error(s"no instance found for id=$id")
+        forceReload()
+        throw new DispatchFailedException(s"no instance found for id=$id")
+      }
+    }
+  }
+
+  def dispatch[R](allShards: Set[Shard[T]], maxShardsPerInstance: Int = Int.MaxValue)(body: (ServiceInstance, Set[Shard[T]]) => R): Seq[R] = {
+    var results = new ArrayBuffer[R]
+    dispatch(allShards, maxShardsPerInstance, body, results, 1, 3)
+  }
+
+  private def dispatch[R](allShards: Set[Shard[T]], maxShardsPerInstance: Int, body: (ServiceInstance, Set[Shard[T]]) => R, results: ArrayBuffer[R], attempts: Int, maxAttempts: Int): Seq[R] = {
+
+    val table = routingTable // for safety
+
+    var remaining = allShards
+    while (remaining.nonEmpty) {
+      next(table, remaining, maxShardsPerInstance) match {
+        case (Some(instance), shards) =>
+          if (!instance.serviceInstance.reportedSentServiceUnavailable) {
+            results += body(instance.serviceInstance, shards)
+            remaining --= shards
+          } else {
+            if (attempts < maxAttempts) {
+              // failed to find an instance. there may an unreachable instance. reload shard->instances map and try again
+              reload()
+              return dispatch(remaining, maxShardsPerInstance, body, results, attempts + 1, maxAttempts) // retry
+            } else {
+              log.error(s"no instance found")
+              forceReload()
+              throw new DispatchFailedException(s"no instance found")
+            }
+          }
+        case (None, _) =>
+          log.error("no instance found")
+          forceReload()
+          throw new DispatchFailedException("no instance found")
+      }
+    }
+    results
+  }
+
+  private def next(instMap: Map[Shard[T], ArrayBuffer[ShardedServiceInstance[T]]], shards: Set[Shard[T]], maxShardsPerInstance: Int, numTrials: Int = 1): (Option[ShardedServiceInstance[T]], Set[Shard[T]]) = {
+    var numEntries = 0
+    val table = shards.toSeq.map{ shard =>
+      instMap.get(shard) match {
+        case Some(instances) =>
+          numEntries += instances.size
+          (numEntries, instances)
+        case None =>
+          log.error(s"shard not found: $shard")
+          (numEntries, ArrayBuffer[ShardedServiceInstance[T]]())
+      }
+    }
+    var bestInstance: Option[ShardedServiceInstance[T]] = None
+    var bestCoverage = Set.empty[Shard[T]]
+    var trials = numTrials
+    while (trials > 0 && bestCoverage.size < maxShardsPerInstance) {
+      getCandidate(table, numEntries) match {
+        case candidate @ Some(inst) =>
+          val thisCoverage = (inst.shards intersect shards).take(maxShardsPerInstance)
+          if (thisCoverage.size > bestCoverage.size) {
+            bestInstance = candidate
+            bestCoverage = thisCoverage
+          }
+        case None =>
+      }
+      trials -= 1
+    }
+    (bestInstance, bestCoverage)
+  }
+
+  private def getCandidate(table: Seq[(Int, ArrayBuffer[ShardedServiceInstance[T]])], numEntries: Int): Option[ShardedServiceInstance[T]] = {
+    if (numEntries > 0) {
+      val n = rnd.nextInt(numEntries)
+      table.find(_._1 > n).map{ case (num, instances) =>
+        instances(instances.size - (num - n))
+      }
+    } else {
+      None
+    }
+  }
+}
+
+class DispatchFailedException(msg: String) extends Exception(msg)

--- a/kifi-backend/modules/common/app/com/keepit/search/sharding/Dispatcher.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/sharding/Dispatcher.scala
@@ -84,10 +84,12 @@ class Dispatcher[T](instances: Vector[ShardedServiceInstance[T]], forceReload: (
       // first choose a <shard,instances> pair. there is a single shard per sharding strategy.
       // using the reservoir algorithm
       var candidateShard: Shard[T] = null
-      table.iterator.foreach{ case (shard, instances) =>
-        val size = instances.size
-        i += size
-        if (rnd.nextInt(i) < size) candidateShard = shard
+      table.foreach{ case (shard, instances) =>
+        if (shard.contains(id)) {
+          val size = instances.size
+          i += size
+          if (rnd.nextInt(i) < size) candidateShard = shard
+        }
       }
       if (candidateShard == null) {
         log.error(s"no shard found for id=$id")

--- a/kifi-backend/modules/common/app/com/keepit/search/sharding/DistributedSearchRouter.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/sharding/DistributedSearchRouter.scala
@@ -1,0 +1,43 @@
+package com.keepit.search.sharding
+
+import com.keepit.common.db.Id
+import com.keepit.common.net.ClientResponse
+import com.keepit.common.routes.ServiceRoute
+import com.keepit.common.zookeeper.{ServiceInstance, CustomRouter}
+import com.keepit.model.NormalizedURI
+import com.keepit.search.SearchServiceClient
+import play.api.libs.json.{JsObject, JsString, JsNull, JsValue}
+import scala.concurrent.Future
+
+class DistributedSearchRouter(client: SearchServiceClient) extends CustomRouter {
+
+  type T = NormalizedURI
+
+  @volatile
+  private[this] var dispatcher = Dispatcher[T](Vector.empty[ServiceInstance], ()=>())
+
+  def update(instances: Vector[ServiceInstance], forceReload: ()=>Unit): Unit = {
+    dispatcher = Dispatcher[T](instances.filter(_.isUp), forceReload)
+  }
+
+  def plan(shards: Set[Shard[T]], maxShardsPerInstance: Int = Int.MaxValue): Seq[(ServiceInstance, Set[Shard[T]])] = {
+    dispatcher.dispatch(shards, maxShardsPerInstance){ (instance, shards) => (instance, shards) }
+  }
+
+  def dispatch(plan: Seq[(ServiceInstance, Set[Shard[T]])], url: ServiceRoute, request: JsValue): Seq[Future[ClientResponse]] = {
+    plan.map{ case (instance, shards) =>
+      val body = JsObject(List("shards" -> JsString(ShardSpec.toString(shards)), "request" -> request))
+      client.call(instance, url, body)
+    }
+  }
+
+  def dispatch(shards: Set[Shard[T]], url: ServiceRoute, request: JsValue, maxShardsPerInstance: Int = Int.MaxValue): (Seq[Future[ClientResponse]]) = {
+    dispatch(plan(shards, maxShardsPerInstance), url, request)
+  }
+
+  def call[R](uriId: Id[T], url: ServiceRoute, body: JsValue = JsNull): Future[ClientResponse] = {
+    dispatcher.call(uriId){
+      instance => client.call(instance, url, body)
+    }
+  }
+}

--- a/kifi-backend/modules/common/app/com/keepit/search/sharding/DistributedSearchRouter.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/sharding/DistributedSearchRouter.scala
@@ -24,15 +24,15 @@ class DistributedSearchRouter(client: SearchServiceClient) extends CustomRouter 
     dispatcher.dispatch(shards, maxShardsPerInstance){ (instance, shards) => (instance, shards) }
   }
 
+  def planRemoteOnly(maxShardsPerInstance: Int = Int.MaxValue): Seq[(ServiceInstance, Set[Shard[T]])] = {
+    dispatcher.dispatch(maxShardsPerInstance){ (instance, shards) => (instance, shards) }
+  }
+
   def dispatch(plan: Seq[(ServiceInstance, Set[Shard[T]])], url: ServiceRoute, request: JsValue): Seq[Future[ClientResponse]] = {
     plan.map{ case (instance, shards) =>
       val body = JsObject(List("shards" -> JsString(ShardSpec.toString(shards)), "request" -> request))
       client.call(instance, url, body)
     }
-  }
-
-  def dispatch(shards: Set[Shard[T]], url: ServiceRoute, request: JsValue, maxShardsPerInstance: Int = Int.MaxValue): (Seq[Future[ClientResponse]]) = {
-    dispatch(plan(shards, maxShardsPerInstance), url, request)
   }
 
   def call[R](uriId: Id[T], url: ServiceRoute, body: JsValue = JsNull): Future[ClientResponse] = {

--- a/kifi-backend/modules/search/test/com/keepit/search/sharding/DispatcherTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/sharding/DispatcherTest.scala
@@ -32,8 +32,8 @@ class DispatcherTest extends Specification {
   val allInstances = smallInstances ++ largeInstances
 
   val insufficientInstances = Vector[ServiceInstance](
-    new ServiceInstance(Node("/g"), false, new TstRemoteService("0,3,6,9/12")),
-    new ServiceInstance(Node("/h"), false, new TstRemoteService("1,4,7,10/12"))
+    new ServiceInstance(Node("/g"), false, new TstRemoteService("0,3,6,9/10")),
+    new ServiceInstance(Node("/h"), false, new TstRemoteService("1,4,7/10"))
   )
 
   val allShards = Set(
@@ -111,6 +111,19 @@ class DispatcherTest extends Specification {
       try{ disp.dispatch(allShards){ (inst, shards) => 1 } } catch { case _: Throwable => }
 
       forceReloadCalled === true
+    }
+
+    "find safe sharding" in {
+      var forceReloadCalled = false
+      val disp = Dispatcher[T](smallInstances ++ insufficientInstances, ()=>{ forceReloadCalled = true })
+      var results = Set.empty[Int]
+
+      (0 until 10).foreach{ i =>
+        disp.dispatch(){ (inst, shards) => results ++= shards.map(_.numShards) }
+      }
+
+      results === Set(12)
+      forceReloadCalled === false
     }
   }
 }

--- a/kifi-backend/modules/search/test/com/keepit/search/sharding/DispatcherTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/sharding/DispatcherTest.scala
@@ -1,0 +1,116 @@
+package com.keepit.search.sharding
+
+import org.specs2.mutable._
+import com.keepit.common.service.{ServiceType, ServiceStatus}
+import com.keepit.common.zookeeper.{RemoteService, Node, ServiceInstance}
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+
+class DispatcherTest extends Specification {
+
+  type T = Int
+  type R = (Node, Set[Shard[T]])
+
+  class TstRemoteService(spec: String) extends RemoteService(null, ServiceStatus.UP, ServiceType.SEARCH) {
+    override def healthyStatus: ServiceStatus = ServiceStatus.UP
+    override def getShardSpec: Option[String] = Some(spec)
+  }
+
+  val smallInstances = Vector[ServiceInstance](
+    new ServiceInstance(Node("/a"), false, new TstRemoteService("0,1,2/12")),
+    new ServiceInstance(Node("/b"), false, new TstRemoteService("3,4,5/12")),
+    new ServiceInstance(Node("/c"), false, new TstRemoteService("6,7,8/12")),
+    new ServiceInstance(Node("/d"), false, new TstRemoteService("9,10,11/12")),
+    new ServiceInstance(Node("/g"), false, new TstRemoteService("0,3,6,9/12")),
+    new ServiceInstance(Node("/h"), false, new TstRemoteService("1,4,7,10/12")),
+    new ServiceInstance(Node("/i"), false, new TstRemoteService("2,5,8,11/12"))
+  )
+  val largeInstances = Vector[ServiceInstance](
+    new ServiceInstance(Node("/e"), false, new TstRemoteService("0,1,2,3,4,5/12")),
+    new ServiceInstance(Node("/f"), false, new TstRemoteService("6,7,8,9,10,11/12"))
+  )
+  val allInstances = smallInstances ++ largeInstances
+
+  val insufficientInstances = Vector[ServiceInstance](
+    new ServiceInstance(Node("/g"), false, new TstRemoteService("0,3,6,9/12")),
+    new ServiceInstance(Node("/h"), false, new TstRemoteService("1,4,7,10/12"))
+  )
+
+  val allShards = Set(
+    Shard[T](0, 12), Shard[T](1, 12), Shard[T](2, 12),
+    Shard[T](3, 12), Shard[T](4, 12), Shard[T](5, 12),
+    Shard[T](6, 12), Shard[T](7, 12), Shard[T](8, 12),
+    Shard[T](9, 12), Shard[T](10,12), Shard[T](11,12)
+  )
+  val myShardsArray = Array(
+    Set(Shard[T](0, 12), Shard[T](3, 12), Shard[T](6, 12), Shard[T](9, 12)),
+    Set(Shard[T](0, 12), Shard[T](1, 12), Shard[T](2, 12), Shard[T](3, 12))
+  )
+
+  "Dispatcher" should {
+    "dispatch the request to shards without duplicate" in {
+      (0 until 10).foreach{ i =>
+        var forceReloadCalled = false
+        var processedShards = Set.empty[Shard[T]]
+        var processedTotalCount = 0
+        var instanceUsed = Set.empty[ServiceInstance]
+        var callCount = 0
+
+        val disp = Dispatcher[T](allInstances, ()=>{ forceReloadCalled = true })
+        disp.dispatch(allShards){ (inst, shards) =>
+          (inst, shards)
+        }.map{ case (inst, shards) =>
+          processedShards ++= shards
+          processedTotalCount += shards.size
+          instanceUsed += inst
+          callCount += 1
+        }
+
+        processedShards === allShards
+        processedTotalCount === allShards.size
+        instanceUsed.size === callCount
+        forceReloadCalled === false
+      }
+      1===1
+    }
+
+    "dispatch the request with maxShardsPerInstance" in {
+      var forceReloadCalled = false
+      var processedShards = Set.empty[Shard[T]]
+      var processedTotalCount = 0
+      var instanceUsed = Set.empty[ServiceInstance]
+
+      val disp = Dispatcher[T](largeInstances, ()=>{ forceReloadCalled = true })
+      val plan = disp.dispatch(allShards, maxShardsPerInstance = 3){ (inst, shards) =>
+        (inst, shards)
+      }.map{ case (inst, shards) =>
+        processedShards ++= shards
+        processedTotalCount += shards.size
+        instanceUsed += inst
+      }
+
+      plan.size === 4
+      processedShards === allShards
+      processedTotalCount === allShards.size
+      instanceUsed.size === 2
+      forceReloadCalled === false
+    }
+
+    "fail with insufficient instances" in {
+      var forceReloadCalled = false
+
+      val disp = Dispatcher[T](insufficientInstances, ()=>{ forceReloadCalled = true })
+
+      disp.dispatch(allShards, maxShardsPerInstance = 3){ (inst, shards) => 1 } must throwA[DispatchFailedException]
+      forceReloadCalled === true
+    }
+
+    "call forceReload when no instance was found" in {
+      var forceReloadCalled = false
+      val disp = Dispatcher[T](Vector[ServiceInstance](), ()=>{ forceReloadCalled = true })
+      try{ disp.dispatch(allShards){ (inst, shards) => 1 } } catch { case _: Throwable => }
+
+      forceReloadCalled === true
+    }
+  }
+}


### PR DESCRIPTION
@raymondng @eishay 

Please review.

Dispatcher computes the routing table. dispatch methods find instances and their shards. Dispatcher supports a cluster with mixed sharding (ex. 4-way sharding and 8-way sharding in the same cluster).

What it actually does for each instance depends on an function given as an argument. 

DistributedSearchRouter wraps Dispatcher.
plan method decides a distribution plan (which instances to call), and dispatch method uses it to actually send messages to remote machines.

So, if search needs to do two or more scatter-gather operations to process a single search request, it can use the same plan to use the same set of instances. This will help us use cache efficiently.
