### PR TITLE
update wordCount cache in scheduled scraping jobs

### DIFF
--- a/kifi-backend/modules/scraper/app/com/keepit/common/cache/ScraperCacheModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/common/cache/ScraperCacheModule.scala
@@ -142,4 +142,8 @@ case class ScraperCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Provides @Singleton
   def verifiedEmailUserIdCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new VerifiedEmailUserIdCache(stats, accessLog, (outerRepo, 7 days))
+
+  @Provides @Singleton
+  def uriWordCountCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new NormalizedURIWordCountCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/QueuedScrapeProcessor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/QueuedScrapeProcessor.scala
@@ -246,7 +246,7 @@ class QueuedScrapeProcessor @Inject() (
     scheduler.scheduleWithFixedDelay(terminator, TERMINATOR_FREQ, TERMINATOR_FREQ, TimeUnit.SECONDS)
   }
 
-  private def worker = new ScrapeWorker(airbrake, config, httpFetcher, httpClient, extractorFactory, articleStore, pornDetectorFactory, helper, shoeboxClient, wordCountCache: NormalizedURIWordCountCache)
+  private def worker = new ScrapeWorker(airbrake, config, httpFetcher, httpClient, extractorFactory, articleStore, pornDetectorFactory, helper, shoeboxClient, wordCountCache)
   def asyncScrape(nuri: NormalizedURI, scrapeInfo: ScrapeInfo, pageInfoOpt:Option[PageInfo], proxy: Option[HttpProxy]): Unit = {
     log.info(s"[QScraper.asyncScrape($fjPool)] uri=$nuri info=$scrapeInfo proxy=$proxy")
     try {

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/QueuedScrapeProcessor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/QueuedScrapeProcessor.scala
@@ -131,7 +131,8 @@ class QueuedScrapeProcessor @Inject() (
   schedulingProperties: SchedulingProperties,
   pornDetectorFactory: PornDetectorFactory,
   helper: SyncShoeboxDbCallbacks,
-  shoeboxClient: ShoeboxServiceClient) extends ScrapeProcessor with Logging with ScraperUtils {
+  shoeboxClient: ShoeboxServiceClient,
+  wordCountCache: NormalizedURIWordCountCache) extends ScrapeProcessor with Logging with ScraperUtils {
 
   val LONG_RUNNING_THRESHOLD = if (Play.isDev) 120000 else config.queueConfig.terminateThreshold
   val Q_SIZE_THRESHOLD = config.queueConfig.queueSizeThreshold
@@ -245,7 +246,7 @@ class QueuedScrapeProcessor @Inject() (
     scheduler.scheduleWithFixedDelay(terminator, TERMINATOR_FREQ, TERMINATOR_FREQ, TimeUnit.SECONDS)
   }
 
-  private def worker = new ScrapeWorker(airbrake, config, httpFetcher, httpClient, extractorFactory, articleStore, pornDetectorFactory, helper, shoeboxClient)
+  private def worker = new ScrapeWorker(airbrake, config, httpFetcher, httpClient, extractorFactory, articleStore, pornDetectorFactory, helper, shoeboxClient, wordCountCache: NormalizedURIWordCountCache)
   def asyncScrape(nuri: NormalizedURI, scrapeInfo: ScrapeInfo, pageInfoOpt:Option[PageInfo], proxy: Option[HttpProxy]): Unit = {
     log.info(s"[QScraper.asyncScrape($fjPool)] uri=$nuri info=$scrapeInfo proxy=$proxy")
     try {


### PR DESCRIPTION
@eishay  @raymondng  @martinraison 

update cache when:
1) successfully scraped article (new article or article changed)  ==> actual word count
2) unscrapable ==> -1
3) scrape error  ==> -1

do not upgrade if article is not changed. 
