### PR TITLE
a copy of embedly client in scraper

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/scraper/embedly/EmbedlyInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/scraper/embedly/EmbedlyInfo.scala
@@ -1,4 +1,4 @@
-package com.keepit.common.embedly
+package com.keepit.scraper.embedly
 
 import play.api.libs.functional.syntax._
 import com.keepit.model.PageMediaInfo

--- a/kifi-backend/modules/scraper/app/com/keepit/dev/ScraperDevModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/dev/ScraperDevModule.scala
@@ -6,12 +6,14 @@ import com.keepit.common.cache.HashMapMemoryCacheModule
 import com.keepit.inject.CommonDevModule
 import com.keepit.common.store.ScraperDevStoreModule
 import com.keepit.common.concurrent.DevForkJoinContextMonitorModule
+import com.keepit.scraper.embedly.DevEmbedlyModule
 
 case class ScraperDevModule() extends ScraperServiceModule (
   cacheModule = ScraperCacheModule(HashMapMemoryCacheModule()),
   storeModule = ScraperDevStoreModule(),
   fjMonitorModule = DevForkJoinContextMonitorModule(),
-  scrapeProcessorModule = DevScraperProcessorModule()
+  scrapeProcessorModule = DevScraperProcessorModule(),
+  embedlyModule = DevEmbedlyModule()
 ) with CommonDevModule {
 
 }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ProdScraperServiceModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ProdScraperServiceModule.scala
@@ -8,12 +8,14 @@ import com.keepit.common.cache.ScraperCacheModule
 import com.keepit.common.cache.MemcachedCacheModule
 import com.keepit.common.store.ScraperProdStoreModule
 import com.keepit.common.concurrent.ProdForkJoinContextMonitorModule
+import com.keepit.scraper.embedly.ProdEmbedlyModule
 
 case class ProdScraperServiceModule() extends ScraperServiceModule(
   cacheModule = ScraperCacheModule(MemcachedCacheModule(), EhCacheCacheModule()),
   storeModule = ScraperProdStoreModule(),
   fjMonitorModule = ProdForkJoinContextMonitorModule(),
-  scrapeProcessorModule = ProdScraperProcessorModule()
+  scrapeProcessorModule = ProdScraperProcessorModule(),
+  embedlyModule = ProdEmbedlyModule()
 ) with CommonProdModule {
   val discoveryModule = new ProdDiscoveryModule {
     def servicesToListenOn = ServiceType.SHOEBOX :: Nil

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperServiceModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperServiceModule.scala
@@ -7,12 +7,14 @@ import com.keepit.shoebox.ProdShoeboxServiceClientModule
 import com.keepit.common.store.{S3ImageConfig, StoreModule}
 import com.keepit.scraper.extractor.ExtractorFactory
 import com.keepit.common.concurrent.ForkJoinContextMonitorModule
+import com.keepit.scraper.embedly.EmbedlyModule
 
 abstract class ScraperServiceModule(
   val cacheModule: CacheModule,
   val storeModule: StoreModule,
   val fjMonitorModule: ForkJoinContextMonitorModule,
-  val scrapeProcessorModule: ScrapeProcessorModule
+  val scrapeProcessorModule: ScrapeProcessorModule,
+  val embedlyModule: EmbedlyModule
 ) extends ConfigurationModule with CommonServiceModule  {
   // Service clients
   val shoeboxServiceClientModule = ProdShoeboxServiceClientModule()

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/embedly/EmbedlyClient.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/embedly/EmbedlyClient.scala
@@ -1,25 +1,22 @@
-package com.keepit.common.embedly
+package com.keepit.scraper.embedly
 
-import com.keepit.model._
-import scala.concurrent._
-import scala.concurrent.Future
-import play.api.http.Status
-import play.api.libs.json._
-import com.keepit.common.service.RequestConsolidator
-import com.keepit.common.db.Id
-import play.api.libs.functional.syntax._
-import play.api.libs.ws.WS
+import java.net.URLEncoder
 import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+
+import com.google.inject.{Inject, Singleton}
 import com.keepit.common.concurrent.RetryFuture
 import com.keepit.common.logging.Logging
-import scala.concurrent.duration._
-import com.google.inject.{ImplementedBy, Singleton, Inject}
+import com.keepit.common.service.RequestConsolidator
+import com.keepit.common.strings.UTF8
+import com.keepit.model.{ImageInfo, NormalizedURI}
+
+import play.api.http.Status
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import java.net.URLEncoder
-import com.keepit.common.strings._
-import play.api.libs.ws.Response
-import scala.Some
-import com.keepit.scraper.embedly.EmbedlyInfo
+import play.api.libs.json.Json
+import play.api.libs.ws.{Response, WS}
 
 trait EmbedlyClient {
   def embedlyUrl(url: String): String

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/embedly/EmbedlyModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/embedly/EmbedlyModule.scala
@@ -1,0 +1,18 @@
+package com.keepit.scraper.embedly
+
+import net.codingwell.scalaguice.ScalaModule
+import com.keepit.inject.AppScoped
+
+trait EmbedlyModule extends ScalaModule
+
+case class ProdEmbedlyModule() extends EmbedlyModule {
+  def configure(){
+    bind[EmbedlyClient].to[EmbedlyClientImpl].in[AppScoped]
+  }
+}
+
+case class DevEmbedlyModule() extends EmbedlyModule {
+  def configure(){
+    bind[EmbedlyClient].to[DevEmbedlyClient].in[AppScoped]
+  }
+}

--- a/kifi-backend/modules/scraper/test/com/keepit/scraper/ScraperModuleTest.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/scraper/ScraperModuleTest.scala
@@ -19,14 +19,7 @@ import com.keepit.test.{DeprecatedTestRemoteGlobal, DeprecatedTestApplication}
 import java.io.File
 import com.keepit.common.controller.{ScraperServiceController, ShoeboxServiceController, ServiceController}
 import com.keepit.common.concurrent.DevForkJoinContextMonitorModule
-
-case class ScraperTestModule() extends ScraperServiceModule (
-  cacheModule = ScraperCacheModule(HashMapMemoryCacheModule()),
-  storeModule = ScraperTestStoreModule(),
-  fjMonitorModule = DevForkJoinContextMonitorModule(),
-  scrapeProcessorModule = ProdScraperProcessorModule()
-) with CommonDevModule { }
-
+import com.keepit.scraper.embedly.DevEmbedlyModule
 
 class DeprecatedScraperApplication(global: DeprecatedTestRemoteGlobal)
   extends DeprecatedTestApplication(global, useDb = false, path = new File("./modules/scraper/")) {
@@ -42,7 +35,7 @@ class ScraperModuleTest extends Specification with Logging with ApplicationInjec
     } else false
   }
 
-  val global = new DeprecatedTestRemoteGlobal(ScraperTestModule())
+  val global = new DeprecatedTestRemoteGlobal(TestScraperServiceModule())
 
   "Module" should {
     "instantiate controllers" in {

--- a/kifi-backend/modules/scraper/test/com/keepit/scraper/TestScraperServiceModule.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/scraper/TestScraperServiceModule.scala
@@ -5,12 +5,14 @@ import com.keepit.common.cache.HashMapMemoryCacheModule
 import com.keepit.inject.CommonDevModule
 import com.keepit.common.store.ScraperTestStoreModule
 import com.keepit.common.concurrent.DevForkJoinContextMonitorModule
+import com.keepit.scraper.embedly.DevEmbedlyModule
 
 case class TestScraperServiceModule() extends ScraperServiceModule (
   cacheModule = ScraperCacheModule(HashMapMemoryCacheModule()),
   storeModule = ScraperTestStoreModule(),
   fjMonitorModule = DevForkJoinContextMonitorModule(),
-  scrapeProcessorModule = TestScraperProcessorModule()
+  scrapeProcessorModule = TestScraperProcessorModule(),
+  embedlyModule = DevEmbedlyModule()
 ) with CommonDevModule {
 
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/URISummaryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/URISummaryCommanderTest.scala
@@ -5,7 +5,8 @@ import com.keepit.model._
 import scala.concurrent._
 import com.google.inject.Injector
 import com.keepit.common.store.{S3URIImageStore, FakeS3URIImageStore, ImageSize}
-import com.keepit.common.embedly.{EmbedlyImage, EmbedlyInfo, EmbedlyClient}
+import com.keepit.scraper.embedly._
+import com.keepit.common.embedly.EmbedlyClient
 import net.codingwell.scalaguice.ScalaModule
 import com.keepit.common.db.Id
 import scala.concurrent.ExecutionContext.Implicits.global


### PR DESCRIPTION
@raymondng @martinraison 

Just add a copy of embedly client in scraper. shoebox one is still running.

next step is to create endpoint on scraperServiceClient, let shoebox use it, and shutdown embedly on shoebox. 
