### PR TITLE
processing /images/ URLs in our extension stylesheets

### DIFF
--- a/packrat/adapters/chrome/manifest.json
+++ b/packrat/adapters/chrome/manifest.json
@@ -100,6 +100,9 @@
     "<all_urls>"
   ],
   "web_accessible_resources": [
+    "images/*.gif",
+    "images/*.jpg",
+    "images/*.png",
     "styles/iframes/login.css",
     "scripts/html/iframes/login.js",
     "scripts/iframes/login.js",

--- a/packrat/bin/build.sh
+++ b/packrat/bin/build.sh
@@ -47,7 +47,9 @@ for d in $(find styles -type d); do
 done
 for f in $(find styles -name '*.css' -not -name 'insulate.css' -not -path 'styles/iframes/*'); do
   # repeat the first class name that occurs in each selector outside of parentheses since repetition is not allowed within :not(...)
-  sed -E -e 's/ *\/\*.*\*\/$//g' -e '/^[^@]*[,{]$/ s/(^|[^(])(\.[a-zA-Z0-9_-]*)/\1\2\2\2/' $f | tee "out/chrome/$f" > "out/firefox/data/$f"
+  css=$(sed -E -e 's/ *\/\*.*\*\/$//g' -e '/^[^@]*[,{]$/ s/(^|[^(])(\.[a-zA-Z0-9_-]*)/\1\2\2\2/' $f)
+  echo "${css//\/images\//chrome-extension://__MSG_@@extension_id__/images/}" > "out/chrome/$f"
+  echo "${css//\/images\//resource://kifi-at-42go-dot-com/kifi-beta/data/images/}" > "out/firefox/data/$f"
 done
 for f in $(find styles -name 'insulate.css' -or -path 'styles/iframes/*'); do
   cp $f "out/chrome/$f"


### PR DESCRIPTION
This way we can finally style with background images normally, instead of creating `data:` URLs or using inline styles.

@andrewconner 
cc @martinraison 
