### PR TITLE
batching page information fetching for non user emails

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/UriNormalizationUpdater.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/UriNormalizationUpdater.scala
@@ -82,7 +82,7 @@ class UriNormalizationUpdater @Inject() (
     }
     userThread.lastMsgFromOther.foreach { msgId =>
       db.readWrite{ implicit session =>
-        userThreadRepo.updateLastNotificationForMessage(userThread.user, userThread.thread, msgId, newJson)
+        userThreadRepo.updateLastNotificationForMessage(userThread.user, userThread.threadId, msgId, newJson)
       }
     }
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -220,7 +220,7 @@ class MessagingCommander @Inject() (
         userParticipants.foreach { userId =>
           userThreadRepo.save(UserThread(
             user = userId,
-            thread = thread.id.get,
+            threadId = thread.id.get,
             uriId = uriIdOpt,
             lastSeen = None,
             lastMsgFromOther = None,
@@ -265,8 +265,8 @@ class MessagingCommander @Inject() (
   }
 
   def sendMessageWithUserThread(userThread: UserThread, messageText: String, source: Option[MessageSource], urlOpt: Option[String])(implicit context: HeimdalContext): (MessageThread, Message) = {
-    log.info(s"Sending message from user with id ${userThread.user} to thread ${userThread.thread}")
-    val thread = db.readOnly { implicit session => threadRepo.get(userThread.thread)}
+    log.info(s"Sending message from user with id ${userThread.user} to thread ${userThread.threadId}")
+    val thread = db.readOnly { implicit session => threadRepo.get(userThread.threadId)}
     sendMessage(MessageSender.User(userThread.user), thread, messageText, source, urlOpt)
   }
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
@@ -112,7 +112,7 @@ class NotificationCommander @Inject() (
           userThreadRepo.save(UserThread(
             id = None,
             user = pUserId,
-            thread = thread.id.get,
+            threadId = thread.id.get,
             uriId = thread.uriId,
             lastSeen = None,
             unread = true,
@@ -228,7 +228,7 @@ class NotificationCommander @Inject() (
             userThreadRepo.save(UserThread(
               id = None,
               user = userId,
-              thread = thread.id.get,
+              threadId = thread.id.get,
               uriId = None,
               lastSeen = None,
               unread = true,

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/MessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/MessagingController.scala
@@ -111,7 +111,7 @@ class MessagingController @Inject() (
 
       userThreads.foreach{ userThread =>
         if (userThread.uriId.isDefined) {
-          nUrls(userThread.thread).foreach{ correctNUrl =>
+          nUrls(userThread.threadId).foreach{ correctNUrl =>
             log.warn(s"Verifying notification on user thread ${userThread.id.get}")
             uriNormalizationUpdater.fixLastNotificationJson(userThread, correctNUrl)
           }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NonUserThread.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NonUserThread.scala
@@ -72,7 +72,7 @@ case class NonUserThread(
   muted: Boolean = false,
   state: State[NonUserThread] = NonUserThreadStates.ACTIVE,
   accessToken: ThreadAccessToken = ThreadAccessToken()
-) extends ModelWithState[NonUserThread] {
+) extends ModelWithState[NonUserThread] with ParticipantThread {
   def withId(id: Id[NonUserThread]): NonUserThread = this.copy(id = Some(id))
   def withUpdateTime(updateTime: DateTime) = this.copy(updatedAt = updateTime)
   def withState(state: State[NonUserThread]) = copy(state = state)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ParticipantThread.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ParticipantThread.scala
@@ -1,0 +1,7 @@
+package com.keepit.eliza.model
+
+import com.keepit.common.db.Id
+
+trait ParticipantThread {
+  val threadId: Id[MessageThread]
+}

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ThreadEmailData.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ThreadEmailData.scala
@@ -1,6 +1,7 @@
 package com.keepit.eliza.model
-import com.keepit.model.User
+import com.keepit.model.{URISummary, User}
 import com.keepit.eliza.util.MessageSegment
+import com.keepit.common.db.Id
 
 
 case class ThreadEmailInfo(
@@ -18,3 +19,13 @@ case class ThreadEmailInfo(
   readTimeMinutes: Option[Int])
 
 case class ExtendedThreadItem(senderShortName: String, senderFullName: String, imageUrl: Option[String], segments: Seq[MessageSegment])
+
+case class ThreadEmailData(
+  thread: MessageThread,
+  allUserIds: Set[Id[User]],
+  allUsers: Map[Id[User], User],
+  allUserImageUrls: Map[Id[User], String],
+  uriSummaryBig: URISummary,
+  uriSummarySmall: URISummary,
+  readTimeMinutesOpt: Option[Int]
+)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThread.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThread.scala
@@ -20,7 +20,7 @@ case class UserThread(
     createdAt: DateTime = currentDateTime,
     updateAt: DateTime = currentDateTime,
     user: Id[User],
-    thread: Id[MessageThread],
+    threadId: Id[MessageThread],
     uriId: Option[Id[NormalizedURI]],
     lastSeen: Option[DateTime],
     unread: Boolean = false,
@@ -35,12 +35,12 @@ case class UserThread(
     started: Boolean = false, //Whether or not this thread was started by this user
     accessToken: ThreadAccessToken = ThreadAccessToken()
   )
-  extends Model[UserThread] {
+  extends Model[UserThread] with ParticipantThread {
 
   def withId(id: Id[UserThread]): UserThread = this.copy(id = Some(id))
   def withUpdateTime(updateTime: DateTime) = this.copy(updateAt = updateTime)
 
-  lazy val summary = s"UserThread[id = $id, created = $createdAt, update = $updateAt, user = $user, thread = $thread, " +
+  lazy val summary = s"UserThread[id = $id, created = $createdAt, update = $updateAt, user = $user, thread = $threadId, " +
     s"uriId = $uriId, lastSeen = $lastSeen, unread = $unread, notificationUpdatedAt = $notificationUpdatedAt, " +
     s"notificationLastSeen = $notificationLastSeen, notificationEmailed = $notificationEmailed, replyable = $replyable]"
 }

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/model/UserThreadRepoTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/model/UserThreadRepoTest.scala
@@ -34,7 +34,7 @@ class UserThreadRepoTest extends Specification with DbTestInjector {
           ))
           userThreadRepo.save(UserThread(
             user = user1,
-            thread = thread1.id.get,
+            threadId = thread1.id.get,
             uriId = None,
             lastSeen = None,
             lastMsgFromOther = None,
@@ -65,7 +65,7 @@ class UserThreadRepoTest extends Specification with DbTestInjector {
           ))
           userThreadRepo.save(UserThread(
             user = user1,
-            thread = thread1.id.get,
+            threadId = thread1.id.get,
             uriId = None,
             lastSeen = None,
             lastMsgFromOther = None,
@@ -91,7 +91,7 @@ class UserThreadRepoTest extends Specification with DbTestInjector {
           ))
           userThreadRepo.save(UserThread(
             user = user1,
-            thread = thread1.id.get,
+            threadId = thread1.id.get,
             uriId = None,
             lastSeen = None,
             lastMsgFromOther = None,


### PR DESCRIPTION
@leogrim @eishay This should allows us to:
- fetch the page info only once per email digest for all non user participants in a discussion. The function that fetches the info is getThreadEmailData
- throttle concurrent requests using the same mechanism as for kifi users

Something we need to do is have a good strategy for when fetching the page information fails for some reason. In this case we need to avoid looping every two minutes on the corresponding message thread. This can be in another pull request.
