### PR TITLE
Invalidating caches that had bad screenshotUpdatedAt.

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
@@ -98,13 +98,13 @@ object NormalizedURI {
 case class UrlHash(hash: String) extends AnyVal
 
 case class NormalizedURIKey(id: Id[NormalizedURI]) extends Key[NormalizedURI] {
-  override val version = 5
+  override val version = 6
   val namespace = "uri_by_id"
   def toKey(): String = id.id.toString
 }
 
 case class NormalizedURIUrlHashKey(urlHash: UrlHash) extends Key[NormalizedURI] {
-  override val version = 4
+  override val version = 5
   val namespace = "uri_by_hash"
   def toKey(): String = urlHash.hash
 }


### PR DESCRIPTION
@martinraison 

@raymondng @eishay  If you see long waits, this is likely why. Our hottest cache.
