### PR TITLE
passing extendedEmbedlyInfo in controller

### DIFF
--- a/kifi-backend/modules/scraper/app/com/keepit/controllers/scraper/EmbedlyController.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/controllers/scraper/EmbedlyController.scala
@@ -17,7 +17,7 @@ extends ScraperServiceController{
 
   def getImbedlyInfo() = Action.async(parse.tolerantJson){ request =>
     val url = (request.body \ "url").as[String]
-    val infoFut = embedly.getEmbedlyInfo(url)
+    val infoFut = embedly.getExtendedEmbedlyInfo(url)
     infoFut.map{ infoOpt =>
       Ok(Json.toJson(infoOpt))
     }

--- a/kifi-backend/modules/scraper/test/com/keepit/scraper/embedly/EmbedlyTest.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/scraper/embedly/EmbedlyTest.scala
@@ -13,5 +13,13 @@ class EmbedlyTest extends Specification {
       extEmbInfo.keywords.map{ key => (key.score, key.name)}.take(3) === Seq((120, "oneplus"), (66, "devices"), (53, "nexus"))
       extEmbInfo.entities.map{ ent => (ent.count, ent.name)}.take(2) === Seq((4, "Google"), (1, "RAM"))
     }
+
+    "backward compatible" in {
+      val extInfo = ExtendedEmbedlyInfo.EMPTY.copy(url = Option("abc"), keywords = Seq(EmbedlyKeyword(1, "key")))
+      val js = Json.toJson(extInfo)
+      val info = js.as[EmbedlyInfo]
+      EmbedlyInfo.fromExtendedEmbedlyInfo(extInfo) === info
+      info.url === Some("abc")
+    }
   }
 }


### PR DESCRIPTION
@raymondng  @martinraison 

this is the preparation to consolidate embedlyInfo. old embedlyInfo will be removed.

I first enable this on scraper side, so scraper starts sending ExtendedEmbedlyInfo. Shoebox can handle it (cast it to EmbedlyInfo, see test)
