### PR TITLE
ignoring bad image urls

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/images/ImageFetcher.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/images/ImageFetcher.scala
@@ -14,7 +14,7 @@ import com.google.inject.{Inject, Singleton, ImplementedBy}
 import com.keepit.common.healthcheck.{StackTrace, AirbrakeNotifier}
 import java.security.cert.CertificateExpiredException
 import java.nio.channels.ClosedChannelException
-import java.net.{URI, ConnectException}
+import java.net.{URISyntaxException, URI, ConnectException}
 import org.jboss.netty.channel.ConnectTimeoutException
 import java.security.GeneralSecurityException
 import java.io.IOException
@@ -46,7 +46,9 @@ class ImageFetcherImpl @Inject() (
     try {
       URI.create(url)
     } catch {
-      case e: IllegalArgumentException =>
+      case e @ (
+        _ : URISyntaxException |
+        _ : IllegalArgumentException) =>
         log.error(s"Url [$url] parsing error, ignoring image", e)
         Future.successful(None)//just ignore
     }

--- a/kifi-backend/modules/common/app/com/keepit/common/images/ImageFetcher.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/images/ImageFetcher.scala
@@ -14,7 +14,7 @@ import com.google.inject.{Inject, Singleton, ImplementedBy}
 import com.keepit.common.healthcheck.{StackTrace, AirbrakeNotifier}
 import java.security.cert.CertificateExpiredException
 import java.nio.channels.ClosedChannelException
-import java.net.ConnectException
+import java.net.{URI, ConnectException}
 import org.jboss.netty.channel.ConnectTimeoutException
 import java.security.GeneralSecurityException
 import java.io.IOException
@@ -43,6 +43,13 @@ class ImageFetcherImpl @Inject() (
   override def fetchRawImage(url: String): Future[Option[BufferedImage]] = {
     val trace = new StackTrace()
     val timer = accessLog.timer(Access.HTTP_OUT)
+    try {
+      URI.create(url)
+    } catch {
+      case e: IllegalArgumentException =>
+        log.error(s"Url [$url] parsing error, ignoring image", e)
+        Future.successful(None)//just ignore
+    }
     WS.url(url).withRequestTimeout(120000).get map { resp =>
       log.info(s"[fetchRawImage($url)] resp=${resp.statusText}")
       resp.status match {


### PR DESCRIPTION
Dealing with exceptions like this

URI.java:859:in java.lang.IllegalArgumentException: Illegal character in path at index 39: http://lib.cet.ac.il/storage/publishers\100_199\logo_benzvi.gif
URI.java:859:in java.net.URI#create
WS.scala:257:in play.api.libs.ws.WS$WSRequest#setUrl
WS.scala:462:in play.api.libs.ws.WS$WSRequestHolder#prepare
WS.scala:396:in play.api.libs.ws.WS$WSRequestHolder#get
ImageFetcher.scala:46:in com.keepit.common.images.ImageFetcherImpl#fetchRawImage
ScraperURISummaryCommander.scala:39:in com.keepit.commanders.ScraperURISummaryCommanderImpl#com$keepit$commanders$ScraperURISummaryCommanderImpl$$fetchAndInternImage
ScraperURISummaryCommander.scala:101:in com.keepit.commanders.ScraperURISummaryCommanderImpl[a]#apply
ScraperURISummaryCommander.scala:85:in com.keepit.commanders.ScraperURISummaryCommanderImpl[a]#apply
ScraperURISummaryCommander.scala:85:in com.keepit.commanders.ScraperURISummaryCommanderImpl[a]#apply
ScraperURISummaryCommander.scala:84:in com.keepit.commanders.ScraperURISummaryCommanderImpl[a]#apply
ScraperURISummaryCommander.scala:84:in com.keepit.commanders.ScraperURISummaryCommanderImpl[a]#apply
ScraperURISummaryCommander.scala:81:in com.keepit.commanders.ScraperURISummaryCommanderImpl[a]#apply
BatchingExecutor.scala:67:in akka.dispatch.BatchingExecutor$Batch[a]#processBatch$1
BatchingExecutor.scala:82:in akka.dispatch.BatchingExecutor$Batch[a]#apply$mcV$sp
BatchingExecutor.scala:59:in akka.dispatch.BatchingExecutor$Batch[a]#apply
BatchingExecutor.scala:59:in akka.dispatch.BatchingExecutor$Batch[a]#apply
BlockContext.scala:72:in scala.concurrent.BlockContext$#withBlockContext
BatchingExecutor.scala:58:in akka.dispatch.BatchingExecutor$Batch#run
========== Cause ========== java.net.URISyntaxException: Illegal character in path at index 39: http://lib.cet.ac.il/storage/publishers\100_199\logo_benzvi.gif:0:in
URI.java:2829:in java.net.URISyntaxException: Illegal character in path at index 39: http://lib.cet.ac.il/storage/publishers\100_199\logo_benzvi.gif
URI.java:2829:in java.net.URI$Parser#fail
URI.java:3002:in java.net.URI$Parser#checkChars
