### PR TITLE
breaking air brake loops

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaEmailCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaEmailCommander.scala
@@ -235,7 +235,8 @@ class ElizaEmailCommander @Inject() (
       val htmlBodyMaker = (protoEmail: ProtoEmail) => if (emailParticipantThread.notifiedCount > 0) protoEmail.digestHtml.body else protoEmail.initialHtml.body
       safeProcessEmail(threadEmailData, emailParticipantThread, htmlBodyMaker, category)
     }
-    result.onSuccess { case _ =>
+    // todo(martin) replace with onSuccess when we have better error handling
+    result.onComplete { case _ =>
       db.readWrite { implicit session => nonUserThreadRepo.setLastNotifiedAndIncCount(emailParticipantThread.id.get) }
     }
     result

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaEmailCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaEmailCommander.scala
@@ -236,7 +236,7 @@ class ElizaEmailCommander @Inject() (
       safeProcessEmail(threadEmailData, emailParticipantThread, htmlBodyMaker, category)
     }
     // todo(martin) replace with onSuccess when we have better error handling
-    result.onComplete { case _ =>
+    result.onComplete { _ =>
       db.readWrite { implicit session => nonUserThreadRepo.setLastNotifiedAndIncCount(emailParticipantThread.id.get) }
     }
     result

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaUserEmailNotifierActor.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaUserEmailNotifierActor.scala
@@ -143,7 +143,7 @@ class ElizaUserEmailNotifierActor @Inject() (
     }
     log.info(s"processed user thread $userThread")
     // todo(martin) replace with onSuccess when we have better error handling
-    result.onComplete { case _ =>
+    result.onComplete { _ =>
       db.readWrite { implicit session => userThreadRepo.setNotificationEmailed(userThread.id.get, userThread.lastMsgFromOther) }
     }
     result

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaUserEmailNotifierActor.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaUserEmailNotifierActor.scala
@@ -142,7 +142,8 @@ class ElizaUserEmailNotifierActor @Inject() (
       }
     }
     log.info(s"processed user thread $userThread")
-    result.onSuccess { case _ =>
+    // todo(martin) replace with onSuccess when we have better error handling
+    result.onComplete { case _ =>
       db.readWrite { implicit session => userThreadRepo.setNotificationEmailed(userThread.id.get, userThread.lastMsgFromOther) }
     }
     result


### PR DESCRIPTION
@eishay  This should break the loop for now
@leogrim Even if ideally we shouldn't have message threads that consistently cause failures, in practice it will happen. So rather than causing an airbrake loop, I still think we should have an 'unsafe_for_emailing' boolean column, and do manual inspection of the problematic threads when errors happen.
