### PR TITLE
Always create deep link even if initiator is not a user

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -88,7 +88,7 @@ trait ShoeboxServiceClient extends ServiceClient {
   def getSearchFriends(userId: Id[User]): Future[Set[Id[User]]]
   def getFriends(userId: Id[User]): Future[Set[Id[User]]]
   def logEvent(userId: Id[User], event: JsObject) : Unit
-  def createDeepLink(initiator: Id[User], recipient: Id[User], uriId: Id[NormalizedURI], locator: DeepLocator) : Unit
+  def createDeepLink(initiator: Option[Id[User]], recipient: Id[User], uriId: Id[NormalizedURI], locator: DeepLocator) : Unit
   def getDeepUrl(locator: DeepLocator, recipient: Id[User]): Future[String]
   def getNormalizedUriUpdates(lowSeq: SequenceNumber[ChangedURI], highSeq: SequenceNumber[ChangedURI]): Future[Seq[(Id[NormalizedURI], NormalizedURI)]]
   def kifiHit(clicker: Id[User], hit:SanitizedKifiHit):Future[Unit]
@@ -532,7 +532,7 @@ class ShoeboxServiceClientImpl @Inject() (
     call(Shoebox.internal.logEvent, payload)
   }
 
-  def createDeepLink(initiator: Id[User], recipient: Id[User], uriId: Id[NormalizedURI], locator: DeepLocator) : Unit = {
+  def createDeepLink(initiator: Option[Id[User]], recipient: Id[User], uriId: Id[NormalizedURI], locator: DeepLocator) : Unit = {
     implicit val userFormatter = Id.format[User]
     implicit val uriFormatter = Id.format[NormalizedURI]
     val payload = Json.obj(

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -507,7 +507,7 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
 
   def logEvent(userId: Id[User], event: JsObject) = {}
 
-  def createDeepLink(initiator: Id[User], recipient: Id[User], uriId: Id[NormalizedURI], locator: DeepLocator) : Unit = {}
+  def createDeepLink(initiator: Option[Id[User]], recipient: Id[User], uriId: Id[NormalizedURI], locator: DeepLocator) : Unit = {}
 
   def getDeepUrl(locator: DeepLocator, recipient: Id[User]): Future[String] = ???
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
@@ -323,9 +323,7 @@ class NotificationCommander @Inject() (
       }
 
       messagingAnalytics.sentNotificationForMessage(userId, message, thread, muted)
-      message.from.asUser.map(
-        shoebox.createDeepLink(_, userId, thread.uriId.get, thread.deepLocator)
-      )
+      shoebox.createDeepLink(message.from.asUser, userId, thread.uriId.get, thread.deepLocator)
 
       notificationRouter.sendToUser(userId, Json.arr("notification", notifJson))
       notificationRouter.sendToUser(userId, Json.arr("unread_notifications_count", unreadCount))
@@ -409,9 +407,7 @@ class NotificationCommander @Inject() (
       }
 
       messagingAnalytics.sentNotificationForMessage(userId, message, thread, false)
-      message.from.asUser.map(
-        shoebox.createDeepLink(_, userId, thread.uriId.get, thread.deepLocator)
-      )
+      shoebox.createDeepLink(message.from.asUser, userId, thread.uriId.get, thread.deepLocator)
 
       notifJson
     })

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtDeepLinkController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtDeepLinkController.scala
@@ -27,14 +27,14 @@ class ExtDeepLinkController @Inject() (
 
   def createDeepLink() = Action(parse.tolerantJson) { request =>
     val req = request.body.asInstanceOf[JsObject]
-    val initiator = Id[User]((req \ "initiator").as[Long])
+    val initiator = (req \ "initiator").asOpt[Long].map(Id[User](_))
     val recipient = Id[User]((req \ "recipient").as[Long])
     val uriId = Id[NormalizedURI]((req \ "uriId").as[Long])
     val locator = (req \ "locator").as[String]
 
     db.readWrite{ implicit session => deepLinkRepo.save(
       DeepLink(
-        initiatorUserId = Some(initiator),
+        initiatorUserId = initiator,
         recipientUserId = Some(recipient),
         uriId = Some(uriId),
         urlId = None,


### PR DESCRIPTION
@stkem @leogrim @eishay 
It looks like if a non-user replies to a conversation, no deep link is created, which is a problem since we need one for emailing notifications to users. The code below systematically creates one (with initiator ID = None)

BTW unless I'm mistaken it looks like we are creating deep links for every single notification - I'm not sure why.
