### PR TITLE
3.0.2: attempting to avoid installing a Kifi Firefox extension update if not actually newer

### DIFF
--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -223,12 +223,38 @@ exports.requestUpdateCheck = function () {
   log('[requestUpdateCheck]');
   if (addon) {
     var appVer = Cc['@mozilla.org/xre/app-info;1'].getService(Ci.nsIXULAppInfo).version;
+    var compareVersions = Cc['@mozilla.org/xpcom/version-comparator;1'].getService(Ci.nsIVersionComparator);
     addon.findUpdates({
         onCompatibilityUpdateAvailable: exports.noop,
         onNoCompatibilityUpdateAvailable: exports.noop,
         onUpdateAvailable: function (addon, install) {
-          log('[onUpdateAvailable] installing', install.version);
-          install.install();
+          log('[onUpdateAvailable]', self.version, '=>', install.version, install.state);
+          if (compareVersions(self.version, install.version) < 0) {
+            var listener = {
+              onNewInstall: exports.noop,
+              onDownloadStarted: exports.noop,
+              onDownloadProgress: exports.noop,
+              onDownloadEnded: onDownloadEnded,
+              onDownloadCancelled: exports.noop,
+              onDownloadFailed: exports.noop,
+              onInstallStarted: exports.noop,
+              onInstallEnded: stopListening,
+              onInstallCancelled: stopListening,
+              onInstallFailed: stopListening,
+              onExternalInstall: exports.noop
+            };
+            install.addListener(listener);
+            install.install();
+          }
+          function onDownloadEnded(install) {
+            log('[onDownloadEnded]', self.version, '=>', install.version, install.state);
+            if (compareVersions(self.version, install.version) >= 0) {
+              install.cancel();
+            }
+          }
+          function stopListening() {
+            install.removeListener(listener);
+          }
         },
         onNoUpdateAvailable: function (addon) {
           log('[onNoUpdateAvailable]');

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.0.1
+version=3.0.2


### PR DESCRIPTION
Not sure if `install.version` will change to reflect the version number in the downloaded .xpi (rather than the update.rdf file) once it has finished downloading, but hoping it will.

The relevant documentation is at:
https://developer.mozilla.org/en-US/Add-ons/Add-on_Manager/Addon#findUpdates()
https://developer.mozilla.org/en-US/Add-ons/Add-on_Manager/UpdateListener

@martinraison 
cc @eishay 
