### PR TITLE
3.0.4: stopping propagation of events on tile descendants up to page (as we do for pane)

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.0.3
+version=3.0.4

--- a/packrat/scripts/keeper.js
+++ b/packrat/scripts/keeper.js
@@ -284,6 +284,10 @@ var keeper = keeper || function () {  // idempotent for Chrome
         }
       });
     }, 400, true));
+
+    $(tile).on('mousedown click keydown keypress keyup', function (e) {
+      e.stopPropagation();
+    });
   }
 
   function showSlider(trigger) {


### PR DESCRIPTION
@martinraison 
fixes https://app.asana.com/0/0/12696187654129
