### PR TITLE
More forgiving sequence number integrity checker

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
@@ -93,7 +93,7 @@ class ServiceDiscoveryImpl(
    */
   private var lastLeaderLogTime = 0L
 
-  def isLeader: Boolean = if (isCanary) false else zkClient.session{ zk =>
+  def isLeader(): Boolean = if (isCanary) false else zkClient.session{ zk =>
     if (!stillRegistered()) {
       log.warn(s"service did not register itself yet!")
       return false

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/UriNormalizationUpdater.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/UriNormalizationUpdater.scala
@@ -41,9 +41,9 @@ class UriNormalizationUpdater @Inject() (
 
   def checkAndUpdate(remoteSequenceNumberOpt: Option[SequenceNumber[ChangedURI]]) : Unit = synchronized {
     var localSeqNum = localSequenceNumber()
-    log.info(s"Renormalization: Checking if I need to update. Leader: ${serviceDiscovery.isLeader}. seqNum: ${remoteSequenceNumberOpt}. locSeqNum: ${localSeqNum}")
+    log.info(s"Renormalization: Checking if I need to update. Leader: ${serviceDiscovery.isLeader()}. seqNum: ${remoteSequenceNumberOpt}. locSeqNum: ${localSeqNum}")
     remoteSequenceNumberOpt match {
-      case Some(remoteSequenceNumber) if (remoteSequenceNumber>localSeqNum && serviceDiscovery.isLeader) => {
+      case Some(remoteSequenceNumber) if (remoteSequenceNumber>localSeqNum && serviceDiscovery.isLeader()) => {
         val upperBound = if (remoteSequenceNumber - localSequenceNumber > 500) localSequenceNumber + 500 else remoteSequenceNumber
         val thereIsMore = upperBound < remoteSequenceNumber
         val updatesFuture = shoebox.getNormalizedUriUpdates(localSequenceNumber, upperBound)

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/SequenceNumberChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/SequenceNumberChecker.scala
@@ -23,7 +23,7 @@ class ElizaSequenceNumberChecker @Inject() (
   airbrake: AirbrakeNotifier
 ) extends SequenceNumberChecker with Logging {
 
-  private val threshold = 100
+  private val threshold = 500
   val service = ServiceType.ELIZA
 
   def check(): Unit = {


### PR DESCRIPTION
also making the `isLeader` function signature and usage on the prod ServiceDiscovery consistent with the trait.
@leogrim 
