### PR TITLE
remove lock form normalized uri save

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ScraperCallbackHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ScraperCallbackHelper.scala
@@ -85,10 +85,8 @@ class ScraperCallbackHelper @Inject()(
   }
 
   def saveNormalizedURI(normalizedUri: NormalizedURI): NormalizedURI = {
-    withLock(normalizedUriLock) {
-      db.readWrite(attempts = 1) { implicit s =>
-        normUriRepo.save(normalizedUri)
-      }
+    db.readWrite(attempts = 1) { implicit s =>
+      normUriRepo.save(normalizedUri)
     }
   }
 }


### PR DESCRIPTION
It seem to be starving the thread pool. We’ll need to come up with a good way of sequentializing these without blocking (e.g. actors).
Better yet might be sequentializing on the callers end, to get response acknowledgement without having to block anywhere (otherwise starvation might just move to the caller).

@andrewconner @eishay @ymatsuda @raymondng 
