### PR TITLE
Fixing tag drag&drop in Firefox

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -42,6 +42,7 @@ angular.module('kifi', [
   'kifi.undo',
   'kifi.addKeeps',
   'kifi.installService',
+  'kifi.dragService',
   'jun.facebook',
   'ngDragDrop',
   'ui.slider',

--- a/kifi-backend/modules/shoebox/angular/src/common/services/dragService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/dragService.js
@@ -1,0 +1,30 @@
+/**
+ * This service is here because Firefox doesn't provide the
+ * mouse position information in drag events
+ */
+
+'use strict';
+
+angular.module('kifi.dragService', [])
+
+.factory('dragService', [
+  '$document',
+  function ($document) {
+    var pageX, pageY;
+
+    $document.on('dragover', function (e) {
+      e = e.originalEvent;
+      pageX = e.clientX || e.pageX;
+      pageY = e.clientY || e.pageY;
+    });
+
+    return {
+      getDragPosition: function () {
+        return {
+          pageX: pageX,
+          pageY: pageY
+        };
+      }
+    };
+  }
+]);

--- a/kifi-backend/modules/shoebox/angular/src/tags/tagItem.js
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tagItem.js
@@ -1,10 +1,10 @@
 'use strict';
 
-angular.module('kifi.tagItem', ['kifi.tagService'])
+angular.module('kifi.tagItem', ['kifi.tagService', 'kifi.dragService'])
 
 .directive('kfTagItem', [
-  '$timeout', '$document', 'tagService', 'keyIndices',
-  function ($timeout, $document, tagService, keyIndices) {
+  '$timeout', '$document', 'tagService', 'keyIndices', 'dragService',
+  function ($timeout, $document, tagService, keyIndices, dragService) {
     return {
       restrict: 'A',
       scope: {
@@ -127,6 +127,8 @@ angular.module('kifi.tagItem', ['kifi.tagService'])
         });
 
         element.on('dragstart', function (e) {
+          // Firefox requires data to be set
+          e.dataTransfer.setData('text/plain', '');
           scope.$apply(function () {
             if (!scope.watchTagReorder()) { return; }
             scope.tagDragSource = scope.tag;
@@ -152,7 +154,8 @@ angular.module('kifi.tagItem', ['kifi.tagService'])
             e.dataTransfer.setDragImage(clone[0], 0, 0);
           });
         })
-        .on('dragend', function () {
+        .on('dragend', function (e) {
+          e.preventDefault();
           tagList.removeClass('kf-tag-list-reordering');
           function removeAnimate() {
             element.removeClass('animate');
@@ -164,11 +167,11 @@ angular.module('kifi.tagItem', ['kifi.tagService'])
           element.removeClass('kf-dragged');
           if (clone) { clone.remove(); }
           if (cloneMask) { cloneMask.remove(); }
-          //scope.tagDragTarget = null;
         })
-        .on('drag', function (e) {
-          var x = e.originalEvent.pageX,
-            y = e.originalEvent.pageY,
+        .on('drag', function () {
+          var dragPosition = dragService.getDragPosition(),
+            x = dragPosition.pageX,
+            y = dragPosition.pageY,
             top = tagList.offset().top,
             left = tagList.offset().left,
             right = left + tagList.width(),
@@ -180,7 +183,8 @@ angular.module('kifi.tagItem', ['kifi.tagService'])
         .on('dragover', function (e) {
           e.preventDefault();
         })
-        .on('drop', function () {
+        .on('drop', function (e) {
+          e.preventDefault();
           scope.reorderTag({srcTag: scope.tagDragSource, dstTag: scope.tagDragTarget, isAfter: false});
         })
         .on('mouseenter', function () {

--- a/kifi-backend/modules/shoebox/angular/src/tags/tagItem.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tagItem.tpl.html
@@ -18,7 +18,6 @@
         <a href="javascript:" ng-mousedown="removeTag(tag)">Remove</a>
       </li>
     </ul>
-    <div class="kf-tag-drag-background-mask hidden"></div>
     <div class="kf-drag-mask"></div>
     <div class="kf-tag-drag-mask"></div>
     <div class="kf-tag-new-location-mask hidden"></div>

--- a/kifi-backend/modules/shoebox/angular/src/tags/tags.styl
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tags.styl
@@ -4,8 +4,10 @@ highlightColor = #eeeeee
 .kf-tag
   position: relative
   margin-right: 20px
-  border-radius: 4px
+  border-radius: 2px
   height: kfTagHeight
+  border: 1px dashed transparent
+  box-sizing: border-box
 
   &.renaming
     background-color: #f6f6f6
@@ -32,9 +34,8 @@ highlightColor = #eeeeee
     .hover
       background-color: transparent
     &.kf-dragged
-      .kf-tag-drag-background-mask
-        background-color: editYellowColor
-        border-color: #cccccc
+      background-color: editYellowColor
+      border-color: #cccccc
     .kf-tag-tool
       display: none
 
@@ -42,28 +43,17 @@ highlightColor = #eeeeee
     display: block
 
 .kf-tag-drag-mask
-.kf-tag-drag-background-mask
   position: absolute
   top: 0
   left: 0
   width: 100%
   height: 100%
-  
-.kf-tag-drag-mask
   z-index: 1
   display: none
 
-.kf-tag-drag-background-mask
-  background-color: transparent
-  border: 1px dashed transparent
-  border-radius: 2px
-  z-index: -1
-  box-sizing: border-box
-
 .kf-tag.animate
-  .kf-tag-drag-background-mask
-    -webkit-animation: tag-blink 0.2s 3
-    animation: tag-blink 0.2s 3
+  -webkit-animation: tag-blink 0.2s 3
+  animation: tag-blink 0.2s 3
 
 @keyframes tag-blink {
   0% {
@@ -120,6 +110,9 @@ highlightColor = #eeeeee
 
 .antiscroll-inner
   position: relative // necessary to scroll with keyboard
+
+.kf-tag-list
+  user-select: none
 
 .kf-tag-list:not(:hover)
   .highlight


### PR DESCRIPTION
@stkem @andrewconner It turns out the Mozilla guys decided that 'drag' events should not be populated with mouse coordinates (otherwise it's too easy) - and also that some data should always been carried during the drag. If miracles exist it may magically start working in your Chrome browsers but my hopes are not too high.
