### PR TITLE
removing statsd timing from get by uri.

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/NormalizedURIRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/NormalizedURIRepo.scala
@@ -189,9 +189,7 @@ extends DbRepo[NormalizedURI] with NormalizedURIRepo with ExternalIdColumnDbFunc
   }
 
   def getByUri(url: String)(implicit session: RSession): Option[NormalizedURI] = {
-    statsd.time(key = "normalizedURIRepo.getByUri", ALWAYS) {
-      getByUriOrPrenormalize(url: String).map(_.left.toOption).toOption.flatten
-    }
+    getByUriOrPrenormalize(url: String).map(_.left.toOption).toOption.flatten
   }
 
   /**


### PR DESCRIPTION
its being called a lot and we're not using this monitoring
@andrewconner 
