### PR TITLE
Bug fixes in OrphanCleaner and NormalizedURIRepo

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/NormalizedURIRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/NormalizedURIRepo.scala
@@ -136,7 +136,7 @@ extends DbRepo[NormalizedURI] with NormalizedURIRepo with ExternalIdColumnDbFunc
 
     // todo: move out the logic modifying scrapeInfo table
     lazy val scrapeRepo = scrapeRepoProvider.get
-    uri.state match {
+    saved.state match {
       case e:State[NormalizedURI] if DO_NOT_SCRAPE.contains(e) => // ensure no ACTIVE scrapeInfo records
         scrapeRepo.getByUriId(saved.id.get) match {
           case Some(scrapeInfo) if scrapeInfo.state == ScrapeInfoStates.ACTIVE =>
@@ -151,7 +151,7 @@ extends DbRepo[NormalizedURI] with NormalizedURIRepo with ExternalIdColumnDbFunc
         }
       case ACTIVE => // do nothing
       case _ =>
-        throw new IllegalStateException(s"Unhandled state=${uri.state}; uri=$uri")
+        throw new IllegalStateException(s"Unhandled state=${saved.state}; uri=$uri")
     }
     saved
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/ScrapeInfoRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/ScrapeInfoRepo.scala
@@ -13,6 +13,7 @@ import Q.interpolation
 trait ScrapeInfoRepo extends Repo[ScrapeInfo] {
   def allActive(implicit session: RSession): Seq[ScrapeInfo]
   def getByUriId(uriId: Id[NormalizedURI])(implicit session: RSession): Option[ScrapeInfo]
+  def getActiveByUriId(uriId: Id[NormalizedURI])(implicit session: RSession): Option[ScrapeInfo]
   def getOverdueCount(due: DateTime = currentDateTime)(implicit session: RSession):Int
   def getOverdueList(limit: Int = -1, due: DateTime = currentDateTime)(implicit session: RSession): Seq[ScrapeInfo]
   def getAssignedCount()(implicit session: RSession):Int
@@ -61,6 +62,9 @@ class ScrapeInfoRepoImpl @Inject() (
 
   def getByUriId(uriId: Id[NormalizedURI])(implicit session: RSession): Option[ScrapeInfo] =
     (for(f <- rows if f.uriId === uriId) yield f).firstOption
+
+  def getActiveByUriId(uriId: Id[NormalizedURI])(implicit session: RSession): Option[ScrapeInfo] =
+    (for(f <- rows if f.uriId === uriId && f.state === ScrapeInfoStates.ACTIVE) yield f).firstOption
 
   def getOverdueCount(due: DateTime = currentDateTime)(implicit session: RSession):Int = {
     sql"select count(*) from scrape_info where state = '#${ScrapeInfoStates.ACTIVE.value}' and next_scrape < $due".as[Int].first

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPluginImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPluginImpl.scala
@@ -143,11 +143,7 @@ class ScrapeSchedulerPluginImpl @Inject() (
           case ScrapeInfoStates.ASSIGNED => s // no change
           case ScrapeInfoStates.INACTIVE => {
             val msg = s"[scheduleScrape($uri.url)] scheduling an INACTIVE ($s) for scraping"
-            log.warn(msg)
-//            systemAdminMailSender.sendMail(ElectronicMail(from = EmailAddresses.RAY, to = List(EmailAddresses.RAY),
-//              subject = s"ScrapeScheduler.scheduleScrape($uri)",
-//              htmlBody = s"$msg\n${Thread.currentThread.getStackTrace.mkString("\n")}",
-//              category = NotificationCategory.System.ADMIN))
+            log.warn(msg, new IllegalStateException(msg))
             s.withState(ScrapeInfoStates.ACTIVE).withNextScrape(date) // dangerous; revisit
           }
         }
@@ -176,10 +172,7 @@ class ScrapeSchedulerPluginImpl @Inject() (
     } recover {
       case t:Throwable =>
         val msg = s"Caught exception $t while parsing $url for getSignature; Cause=${t.getCause}"
-//        systemAdminMailSender.sendMail(ElectronicMail(from = EmailAddresses.RAY, to = List(EmailAddresses.ENG), // sorry about the spam -- will tweak
-//          subject = s"ScrapeScheduler.getSignature($url) -- $msg",
-//          htmlBody = s"$msg\n${t.getStackTraceString}",
-//          category = NotificationCategory.System.ADMIN))
+        log.warn(msg, t)
         Future.successful(None)
     } getOrElse Future.successful(None)
   }

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/Database.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/Database.scala
@@ -141,6 +141,7 @@ class Database @Inject() (
   }
 
   private[this] val READ_WRITE_BATCH_SESSION_REFRESH_INTERVAL = 500
+  private[this] val READ_WRITE_SEQ_SESSION_REFRESH_INTERVAL   = 50
 
   def readWriteSeq[D, T](batch: Seq[D])(f: (RWSession, D) => T)(implicit location: Location): Unit = {
     def sink(a: D, b: T): Unit = {}
@@ -148,8 +149,8 @@ class Database @Inject() (
   }
 
   def readWriteSeq[D, T](batch: Seq[D], collector: (D, T) => Unit)(f: (RWSession, D) => T)(implicit location: Location): Unit = {
-    batch.grouped(READ_WRITE_BATCH_SESSION_REFRESH_INTERVAL).foreach{ chunk =>
-      var rw = createReadWriteSession(location)
+    batch.grouped(READ_WRITE_SEQ_SESSION_REFRESH_INTERVAL).foreach{ chunk =>
+      val rw = createReadWriteSession(location)
       try {
         chunk.foreach{ item => collector(item, rw.withTransaction{ f(rw, item) }) }
       } finally { rw.close() }


### PR DESCRIPTION
Spotted some issues wrt state changes and side-effects. Please review.

NormalizedURIRepo.save: earlier added check for redirection but in the scrape_info update it's not taken into consideration. So it's possible that we saved URI in REDIRECT but still schedule for scraping.

OrphanCleaner: current code relies on a potentially outdated scrape info for scheduling; fixed that and added check to not schedule scrape if (updated) uri in DO_NOT_SCRAPE state.

cc: @eishay @ymatsuda @leogrim @yingjieMiao 
