### PR TITLE
Avoid submitting useless alternate normalization candidates

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -235,7 +235,10 @@ class ShoeboxController @Inject() (
         bestReference.normalization.map(ScrapedCandidate(scrapedUri.url, _)).foreach { bestCandidate =>
           alternateUrls.foreach { alternateUrl =>
             db.readWrite { implicit session =>
-              normUriRepo.internByUri(alternateUrl, bestCandidate)
+              normUriRepo.getByUri(alternateUrl).map(_.id.get) match {
+                case Some(bestReference.id.get) => // ignore
+                case _ => normUriRepo.internByUri(alternateUrl, bestCandidate)
+              }
             }
           }
         }


### PR DESCRIPTION
@eishay the increase in activity matches a change I did Yesterday to go intern alternate urls aggressively. I believe this should reduce the load on SQS. Note that we used to be more tolerant of trivial normalization candidates as they would be discarded early on by NormalizationService. But now that SQS sits in between, trivial candidates make for more messages there.
