### PR TITLE
Include full tags with Keeps send down to the client...

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -11,6 +11,7 @@ import com.keepit.common.usersegment.UserSegmentCache
 import com.keepit.eliza.model.UserThreadStatsForUserIdCache
 import com.keepit.typeahead.socialusers.{KifiUserTypeaheadCache, SocialUserTypeaheadCache}
 import com.keepit.typeahead.abook.EContactTypeaheadCache
+import com.keepit.commanders.BasicCollectionByIdCache
 
 case class
 ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends CacheModule(cachePluginModules:_*) {
@@ -54,6 +55,11 @@ ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends CacheModule(c
   @Provides
   def userCollectionCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
     new UserCollectionsCache(stats, accessLog, (outerRepo, 7 day))
+
+  @Singleton
+  @Provides
+  def basicCollectionByIdCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
+    new BasicCollectionByIdCache(stats, accessLog, (outerRepo, 7 day))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -353,6 +353,7 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
             "clickCount":-1,
             "rekeepCount":-1,
             "collections":[],
+            "tags":[],
             "siteName":"Amazon"},
           {
             "id":"${bookmark1.externalId.toString}",
@@ -365,6 +366,7 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
             "clickCount":-1,
             "rekeepCount":-1,
             "collections":[],
+            "tags":[],
             "siteName":"Google"}
         ]}
       """)
@@ -436,6 +438,7 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
               "clickCount":-1,
               "rekeepCount":-1,
               "collections":[],
+              "tags":[],
               "siteName":"Amazon"
             }
           ]

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
@@ -155,6 +155,7 @@ class KeepsControllerTest extends Specification with ApplicationInjector {
               "clickCount":-1,
               "rekeepCount":-1,
               "collections":[],
+              "tags":[],
               "siteName":"Amazon"},
             {
               "id":"${bookmark1.externalId.toString}",
@@ -167,6 +168,7 @@ class KeepsControllerTest extends Specification with ApplicationInjector {
               "clickCount":-1,
               "rekeepCount":-1,
               "collections":[],
+              "tags":[],
               "siteName":"Google"}
           ]}
         """)
@@ -238,6 +240,7 @@ class KeepsControllerTest extends Specification with ApplicationInjector {
                 "clickCount":-1,
                 "rekeepCount":-1,
                 "collections":[],
+                "tags":[],
                 "siteName":"Amazon"
               }
             ]


### PR DESCRIPTION
…not just external Ids. There is a new “tags” field in the json that is
send down, which will replace the “collections” field once we are
transitioned everywhere. Here it can be relied upon to have an “id”
field - with the external id of the tag - and a “name” field.

@andrewconner @martinraison 
