### PR TITLE
Changing image API for mobile

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/URISummaryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/URISummaryCommander.scala
@@ -42,9 +42,18 @@ class URISummaryCommander @Inject()(
    * Gets an image for the given URI. It can be an image on the page or a screenshot, and there are no size restrictions
    * If no image is available, fetching is triggered (silent=false) but the promise is immediately resolved (waiting=false)
    */
-  def getURIImage(nUri: NormalizedURI): Future[Option[String]] = {
-    val request = URISummaryRequest(nUri.url, ImageType.ANY, ImageSize(0,0), false, false, false)
-    getURISummaryForRequest(request, nUri) map { _.imageUrl }
+  def getURIImage(nUri: NormalizedURI, minSizeOpt: Option[ImageSize] = None): Future[Option[String]] = {
+    getImageURISummary(nUri, minSizeOpt) map { _.imageUrl }
+  }
+
+  /**
+   * Uses a URISummaryRequest to request an image for the page, for the given size constraints.
+   * If no image is available, fetching is triggered (silent=false) but the promise is immediately resolved (waiting=false)
+   */
+  def getImageURISummary(nUri: NormalizedURI, minSizeOpt: Option[ImageSize] = None): Future[URISummary] = {
+    val minSize = minSizeOpt getOrElse ImageSize(0,0)
+    val request = URISummaryRequest(nUri.url, ImageType.ANY, minSize, false, false, false)
+    getURISummaryForRequest(request, nUri)
   }
 
   /**

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
@@ -167,8 +167,8 @@ class MobileBookmarksController @Inject() (
     urlOpt match {
       case Some(url) => {
         var minSizeOpt = (for {
-          minWidth <- (request.body \ "width").asOpt[Int]
-          minHeight <- (request.body \ "height").asOpt[Int]
+          minWidth <- (request.body \ "minWidth").asOpt[Int]
+          minHeight <- (request.body \ "minHeight").asOpt[Int]
         } yield ImageSize(minWidth, minHeight))
         val uriOpt = db.readOnly{ implicit ro => uriRepo.getByUri(url) }
         uriOpt match {
@@ -199,9 +199,9 @@ class MobileBookmarksController @Inject() (
                 val urlOpt = (urlReq \ "url").asOpt[String]
                 urlOpt map { url =>
                   val minSizeOpt = for {
-                    width <- (urlReq \ "width").asOpt[Int]
-                    height <- (urlReq \ "height").asOpt[Int]
-                  } yield ImageSize(width, height)
+                    minWidth <- (urlReq \ "minWidth").asOpt[Int]
+                    minHeight <- (urlReq \ "minHeight").asOpt[Int]
+                  } yield ImageSize(minWidth, minHeight)
                   (url, uriRepo.getByUri(url), minSizeOpt)
                 }
               }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
@@ -7,13 +7,18 @@ import com.keepit.common.db._
 import com.keepit.common.db.slick._
 import com.keepit.model._
 
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json._
 
 import com.keepit.common.akka.SafeFuture
 import com.google.inject.Inject
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 import scala.util.{Success, Failure}
+import com.keepit.common.store.ImageSize
+import play.api.mvc.SimpleResult
+import com.keepit.commanders.CollectionSaveFail
+import scala.Some
+import play.api.libs.json.JsObject
 
 class MobileBookmarksController @Inject() (
   db: Database,
@@ -134,9 +139,15 @@ class MobileBookmarksController @Inject() (
     Ok(Json.obj())
   }
 
-  private def toJsObject(url: String, uri: NormalizedURI, screenshotUrlOpt: Option[String], imageUrlOpt: Option[String]): JsObject = {
+  private def toJsObject(
+    url: String,
+    uri: NormalizedURI,
+    screenshotUrlOpt: Option[String],
+    imageUrlOpt: Option[String],
+    imageWidthOpt: Option[Int],
+    imageHeightOpt: Option[Int]): JsObject = {
     log.info(s"[getImageUrl] returning screenshot $screenshotUrlOpt and image $imageUrlOpt")
-    (screenshotUrlOpt, imageUrlOpt) match {
+    val main = (screenshotUrlOpt, imageUrlOpt) match {
       case (None, None) =>
         Json.obj("url" -> url, "uriId" -> uri.id.get)
       case (None, Some(imgUrl)) =>
@@ -146,6 +157,9 @@ class MobileBookmarksController @Inject() (
       case (Some(ssUrl), Some(imgUrl)) =>
         Json.obj("url" -> url, "imgUrl" -> imgUrl, "screenshotUrl" -> ssUrl)
     }
+    val width =  (imageWidthOpt map { width => Json.obj("imgWidth" -> width) } getOrElse Json.obj())
+    val height =  (imageHeightOpt map { height => Json.obj("imgHeight" -> height) } getOrElse Json.obj())
+    main ++ width ++ height
   }
 
   // todo(ray): consolidate with web endpoint
@@ -154,46 +168,63 @@ class MobileBookmarksController @Inject() (
     val urlOpt = (request.body \ "url").asOpt[String]
     log.info(s"[getImageUrl] body=${request.body} url=${urlOpt}")
     urlOpt match {
-      case None => Future.successful(BadRequest(Json.obj("code" -> "illegal_argument")))
       case Some(url) => {
-        val (uriOpt) = db.readOnly{ implicit ro => uriRepo.getByUri(url) }
+        var minSizeOpt = (for {
+          minWidth <- (request.body \ "width").asOpt[Int]
+          minHeight <- (request.body \ "height").asOpt[Int]
+        } yield ImageSize(minWidth, minHeight))
+        val uriOpt = db.readOnly{ implicit ro => uriRepo.getByUri(url) }
         uriOpt match {
           case None => Future.successful(NotFound(Json.obj("code" -> "uri_not_found")))
           case Some(uri) => {
             val screenshotUrlOpt = uriSummaryCommander.getScreenshotURL(uri)
-            uriSummaryCommander.getURIImage(uri) map { imageUrlOpt =>
-              Ok(toJsObject(url, uri, screenshotUrlOpt, imageUrlOpt))
+            uriSummaryCommander.getImageURISummary(uri, minSizeOpt) map { uriSummary =>
+              Ok(toJsObject(url, uri, screenshotUrlOpt, uriSummary.imageUrl, uriSummary.imageWidth, uriSummary.imageHeight))
             }
           }
         }
       }
+      case None => Future.successful(BadRequest(Json.obj("code" -> "illegal_argument")))
     }
   }
 
   def getImageUrls() = JsonAction.authenticatedParseJsonAsync { request => // WIP; test-only
-    val urlsOpt = (request.body \ "urls").asOpt[Seq[String]]
+    val urlsOpt = (request.body \ "urls").asOpt[Seq[JsValue]]
     log.info(s"[getImageUrls] body=${request.body} urls=${urlsOpt}")
     urlsOpt match {
       case None => Future.successful(BadRequest(Json.obj("code" -> "illegal_arguments")))
       case Some(urls) => {
-        val tuples = db.readOnly { implicit ro =>
-          urls.map { s =>
-            s -> uriRepo.getByUri(s)
-          }
-        }
-        val tuplesF = tuples map { case (url, uriOpt) =>
-          val uriOpt = db.readOnly{ implicit ro => uriRepo.getByUri(url) }
-          uriOpt match {
-            case None => Future.successful(Json.obj("url" -> url, "code" -> "uri_not_found"))
-            case Some(uri) => {
-              val screenshotUrlOpt = uriSummaryCommander.getScreenshotURL(uri)
-              uriSummaryCommander.getURIImage(uri) map { imageUrlOpt =>
-                toJsObject(url, uri, screenshotUrlOpt, imageUrlOpt)
+        val uriOpts = db.readOnly { implicit ro =>
+          urls flatMap { urlReq =>
+            urlReq match {
+              case JsString(url) => Some((url, uriRepo.getByUri(url), None))
+              case _ => {
+                val urlOpt = (urlReq \ "url").asOpt[String]
+                urlOpt map { url =>
+                  val widthOpt = (urlReq \ "width").asOpt[Int]
+                  val heightOpt = (urlReq \ "height").asOpt[Int]
+                  val minSizeOpt = for {
+                    width <- widthOpt
+                    height <- heightOpt
+                  } yield ImageSize(width, height)
+                  (url, uriRepo.getByUri(url), minSizeOpt)
+                }
               }
             }
           }
         }
-        Future.sequence(tuplesF) map { res =>
+        val resFutSeq = uriOpts map { case (url, uriOpt, minSizeOpt) =>
+          uriOpt match {
+            case None => Future.successful(Json.obj("url" -> url, "code" -> "uri_not_found"))
+            case Some(uri) => {
+              val screenshotUrlOpt = uriSummaryCommander.getScreenshotURL(uri)
+              uriSummaryCommander.getImageURISummary(uri, minSizeOpt) map { uriSummary =>
+                toJsObject(url, uri, screenshotUrlOpt, uriSummary.imageUrl, uriSummary.imageWidth, uriSummary.imageHeight)
+              }
+            }
+          }
+        }
+        Future.sequence(resFutSeq) map { res =>
           Ok(Json.toJson(res))
         }
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
@@ -13,12 +13,9 @@ import com.keepit.common.akka.SafeFuture
 import com.google.inject.Inject
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
-import scala.util.{Success, Failure}
 import com.keepit.common.store.ImageSize
-import play.api.mvc.SimpleResult
 import com.keepit.commanders.CollectionSaveFail
 import scala.Some
-import play.api.libs.json.JsObject
 
 class MobileBookmarksController @Inject() (
   db: Database,
@@ -201,11 +198,9 @@ class MobileBookmarksController @Inject() (
               case _ => {
                 val urlOpt = (urlReq \ "url").asOpt[String]
                 urlOpt map { url =>
-                  val widthOpt = (urlReq \ "width").asOpt[Int]
-                  val heightOpt = (urlReq \ "height").asOpt[Int]
                   val minSizeOpt = for {
-                    width <- widthOpt
-                    height <- heightOpt
+                    width <- (urlReq \ "width").asOpt[Int]
+                    height <- (urlReq \ "height").asOpt[Int]
                   } yield ImageSize(width, height)
                   (url, uriRepo.getByUri(url), minSizeOpt)
                 }


### PR DESCRIPTION
@ebfio @davoda @stkem Should be completely backwards compatible
- /m/1/keeps/imageUrl now accepts "minWidth" and "minHeight" fields in addition to "url" field
- /m/1/keeps/imageUrl now accepts a "urls" array of elements with the following two formats:
  - just a url string (for backwards compatibility)
  - an object with "url" and optionally "minWidth" and "minHeight" fields to specify minimum size constraints

In addition, the response will contain (as much as possible) "imgWidth" and "imgHeight" fields that describe the size of the image pointed to by "imgUrl"
