### PR TITLE
trying to filter out blank images

### DIFF
--- a/kifi-backend/modules/scraper/app/com/keepit/commanders/ScraperURISummaryCommander.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/commanders/ScraperURISummaryCommander.scala
@@ -121,11 +121,13 @@ class ScraperURISummaryCommanderImpl @Inject()(
 
 object ScraperURISummaryCommander {
 
+  val IMAGE_EXCLUSION_LIST = Seq("/blank.jpg", "/blank.png", "/blank.gif")
+
   def filterImageByUrl(url: String): Boolean = {
     URI.parse(url) match {
       case Success(imageUri) => {
         imageUri.path map { path =>
-          !path.endsWith("/blank.jpg") && !path.endsWith("/blank.png")
+          IMAGE_EXCLUSION_LIST exists (path.toLowerCase.endsWith(_))
         } getOrElse true
       }
       case Failure(imageUrl) => true

--- a/kifi-backend/modules/scraper/test/com/keepit/commander/ScraperURISummaryCommanderTest.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/commander/ScraperURISummaryCommanderTest.scala
@@ -1,0 +1,29 @@
+package com.keepit.commander
+
+import org.specs2.mutable.Specification
+import com.keepit.commanders.ScraperURISummaryCommander
+
+class ScraperURISummaryCommanderTest extends Specification {
+  "ScraperURISummaryCommander.filterImageByUrl" should {
+
+    "accept reasonable image url" in {
+      val result = ScraperURISummaryCommander.filterImageByUrl("http://blogs.sacurrent.com/wp-content/uploads/2013/11/beatles-white-album.jpg")
+      result === true
+    }
+
+    "accept reasonable image url with arguments" in {
+      val result = ScraperURISummaryCommander.filterImageByUrl("http://blogs.sacurrent.com/wp-content/uploads/2013/11/beatles-white-album.jpg?test=true&anotherargument=theargument")
+      result === true
+    }
+
+    "filter likely blank images" in {
+      val result = ScraperURISummaryCommander.filterImageByUrl("http://wordpress.com/i/blank.jpg")
+      result === false
+    }
+
+    "filter likely blank images with arguments" in {
+      val result = ScraperURISummaryCommander.filterImageByUrl("http://wordpress.com/i/blank.jpg?m=1383295312g")
+      result === false
+    }
+  }
+}


### PR DESCRIPTION
@eishay @stkem @andrewconner After looking a bit, it turns out there are interesting images that are under 1.5kb. However the problem that both me and Eishay had was with images named "blank.jpg". So for now I'm just filtering out images that are named "blank.jpg" or "blank.png" - I think we'll have fewer false negatives this way.
