### PR TITLE
remove "add" cursor when doing tag drag&drop

### DIFF
--- a/kifi-backend/modules/shoebox/angular-black/src/tags/tagItem.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/tags/tagItem.js
@@ -131,6 +131,7 @@ angular.module('kifi.tagItem', ['kifi.tagService', 'kifi.dragService'])
         element.on('dragstart', function (e) {
           // Firefox requires data to be set
           e.dataTransfer.setData('text/plain', '');
+          e.dataTransfer.effectAllowed = 'none';
           scope.$apply(function () {
             if (!scope.watchTagReorder()) { return; }
             scope.tagDragSource = scope.tag;


### PR DESCRIPTION
@stkem @andrewconner the "plus" sign is still glitching sometimes at the very beginning of the drag and drop, but I couldn't really find a better way.
