### PR TITLE
dragging keeps to tags

### DIFF
--- a/kifi-backend/modules/shoebox/angular-black/gruntfile.js
+++ b/kifi-backend/modules/shoebox/angular-black/gruntfile.js
@@ -66,7 +66,6 @@ module.exports = function (grunt) {
           'lib/angular-moment/angular-moment.js',
           'managed-lib/bootstrap/ui-bootstrap-custom-tpls-0.10.0.js',
           'lib/angular-facebook-api/dist/angular-facebook-api.js',
-          'lib/angular-dragdrop/draganddrop.js',
           'managed-lib/jquery-ui-1.10.4.custom/js/jquery-ui-1.10.4.custom.js',
           'managed-lib/ui-slider/slider.js',
           'lib/angulartics/dist/angulartics.min.js'
@@ -91,7 +90,6 @@ module.exports = function (grunt) {
           'lib/angular-moment/angular-moment.min.js',
           'managed-lib/bootstrap/ui-bootstrap-custom-tpls-0.10.0.min.js',
           'lib/angular-facebook-api/dist/angular-facebook-api.min.js',
-          'lib/angular-dragdrop/draganddrop.js',
           'managed-lib/jquery-ui-1.10.4.custom/js/jquery-ui-1.10.4.custom.min.js',
           'managed-lib/ui-slider/slider.js',
           'lib/angulartics/dist/angulartics.min.js'

--- a/kifi-backend/modules/shoebox/angular-black/src/app.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/app.js
@@ -46,7 +46,6 @@ angular.module('kifi', [
   'kifi.installService',
   'kifi.dragService',
   'jun.facebook',
-  'ngDragDrop',
   'ui.slider',
   'angulartics',
   'kifi.mixpanel',

--- a/kifi-backend/modules/shoebox/angular-black/src/common/classes.styl
+++ b/kifi-backend/modules/shoebox/angular-black/src/common/classes.styl
@@ -28,7 +28,7 @@
     &:active
       background: #cccccc
 
-.kf-drag-mask
+.kf-keep-drag-mask
 .kf-tag-new-location-mask
   display: none
   position: absolute
@@ -38,17 +38,10 @@
   height: 100%
   z-index: 1
   box-sizing: border-box
-  border-width: 1px
-  border-color: #c4d4e9
-  border-style: none
 
-.kf-candidate-drag-target
-  .kf-drag-mask
+.kf-dragging-keep
+  .kf-keep-drag-mask
     display: block
-
-.kf-dragged
-  .kf-drag-mask
-    border-style: solid
 
 .fill-parent
   width: 100%

--- a/kifi-backend/modules/shoebox/angular-black/src/keep/keep.styl
+++ b/kifi-backend/modules/shoebox/angular-black/src/keep/keep.styl
@@ -89,15 +89,13 @@ keepBorderRadius = 3px
   padding: 5px
 
 .kf-keep
+  position: relative
 
   &.detailed
     background-color: #eff2f7
 
   &.selected.detailed
     background-color: #F7F7F5
-
-  &.ui-draggable-dragging
-    border-top: none
 
   &.toggling
     overflow: hidden
@@ -149,10 +147,6 @@ keepBorderRadius = 3px
     content: "·"
     color: textGreyColor
     padding: 0 6px 0 5px
-
-.kf-shadow-keep-ellipsis
-  background-color: #fffcf1
-  border-color: #f0f0f0
 
 .kf-keep-time
   font-size: 13px
@@ -420,58 +414,6 @@ input.kf-keep-tag-input
 
 .kf-keep.detailed .kf-keep-button-preview
   display: none
-
-.kf-drag-target
-  background-color: #E2E6EC
-
-.kf-keep.kf-dragged-keep
-  box-sizing: border-box
-  border-width: 1px
-  border-color: #d2d2d2
-  border-style: solid
-
-.kf-shadow-keep-first
-.kf-shadow-keep-second
-.kf-shadow-keep-ellipsis
-.kf-shadow-keep-last
-  position: absolute
-  top: 0
-  left: 0
-  width: 100%
-
-.kf-shadow-keep-ellipsis
-  display: none
-  box-sizing: border-box
-  border-width: 1px
-  border-style: solid
-  border-bottom: none
-  border-color: #d2d2d2
-
-  &.active
-    display: inline
-
-.kf-shadow-keep-ellipsis-line
-  position: relative
-  top: 50%
-  height: 50%
-  width: 100%
-  border: inherit
-  border-left: none
-  border-right: none
-  margin-top: -1px
-
-.kf-shadow-keep-ellipsis-counter
-.kf-shadow-keep-ellipsis-counter-hidden
-  position: absolute
-  font-size: 13px
-  color: #818692
-  background-color: inherit
-  height: 80%
-  top: 20%
-  padding: 0 3px
-
-.kf-shadow-keep-ellipsis-counter-hidden
-  visibility: hidden
 
 .kf-keep-tag-list
   border-top: separatorBorder

--- a/kifi-backend/modules/shoebox/angular-black/src/keep/keep.tpl.html
+++ b/kifi-backend/modules/shoebox/angular-black/src/keep/keep.tpl.html
@@ -1,6 +1,4 @@
-<li class="kf-keep" ng-click="clickAction({keep: keep, event: $event})"
-  ng-hide="keep.unkept"
-  ui-draggable="true" drag-channel="keepDragChannel" ui-on-drop="onTagDrop($data)" drop-channel="tagDragChannel" drag-enter-class="kf-candidate-drag-target"
+<li class="kf-keep" ng-click="clickAction({keep: keep, event: $event})" ng-hide="keep.unkept"
   ng-class="{ 'kf-dragged': isDragging, 'kf-drag-target': isDragTarget , 'editing': editMode.enabled }">
   <div class="kf-keep-edit-tools">
     <div class="kf-keep-checkbox-icon sprite sprite-checkbox-icon" ng-if="!isSelected()" ng-click="toggleSelect({keep: keep})"></div>
@@ -46,5 +44,5 @@
     <span class="kf-keep-footer-link" ng-click="unkeep()"><a>Unkeep</a></span>
     <div class="kf-keep-private" ng-if="isPrivate()"><span class="kf-keep-private-label">Private</span><span class="sprite sprite-lock-private-icon"></span></div>
   </div>
-  <div class="kf-drag-mask"></div>
+  <div class="kf-keep-drag-mask"></div>
 </li>

--- a/kifi-backend/modules/shoebox/angular-black/src/keeps/keepService.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/keeps/keepService.js
@@ -144,6 +144,8 @@ angular.module('kifi.keepService', [
     var api = {
       list: list,
 
+      buildKeep: buildKeep,
+      
       lastSearchContext: function () {
         return lastSearchContext;
       },

--- a/kifi-backend/modules/shoebox/angular-black/src/keeps/keeps.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/keeps/keeps.js
@@ -3,10 +3,10 @@
 angular.module('kifi.keeps', ['kifi.profileService', 'kifi.keepService'])
 
 .controller('KeepsCtrl', [
-  '$scope', 'profileService', 'keepService', 'tagService',
-  function ($scope, profileService, keepService, tagService) {
+  '$scope', '$timeout', 'profileService', 'keepService', 'tagService',
+  function ($scope, $timeout, profileService, keepService, tagService) {
     $scope.me = profileService.me;
-    $scope.data = {draggedKeeps: null};
+    $scope.data = {draggedKeeps: []};
 
     $scope.$watch(function () {
       return ($scope.keeps && $scope.keeps.length || 0) + ',' + tagService.allTags.length;
@@ -17,15 +17,17 @@ angular.module('kifi.keeps', ['kifi.profileService', 'kifi.keepService'])
     });
 
     $scope.dragKeeps = function (keep, event, mouseX, mouseY) {
-      var draggedKeeps = [];//keepService.getSelected();
+      var draggedKeeps = keepService.getSelected();
       if (draggedKeeps.length === 0) {
         draggedKeeps = [keep];
       }
       $scope.data.draggedKeeps = draggedKeeps;
-      var draggedKeepsElement = $scope.getDraggedKeepsElement();
       var sendData = angular.toJson($scope.data.draggedKeeps);
       event.dataTransfer.setData('Text', sendData);
+      //event.dataTransfer.setData('text/plain', '');
+      var draggedKeepsElement = $scope.getDraggedKeepsElement();
       event.dataTransfer.setDragImage(draggedKeepsElement[0], mouseX, mouseY);
+      //event.dataTransfer.setDragImage(draggedKeepsElement[0], mouseX, mouseY);
     };
 
     $scope.stopDraggingKeeps = function () {
@@ -77,28 +79,26 @@ angular.module('kifi.keeps', ['kifi.profileService', 'kifi.keepService'])
         };
 
         scope.getDraggedKeepsElement = function () {
-          var ellipsis = element.find('.kf-shadow-keep-ellipsis');
-          var ellipsisCounter = element.find('.kf-shadow-keep-ellipsis-counter');
-          var ellipsisCounterHidden = element.find('.kf-shadow-keep-ellipsis-counter-hidden');
-          var second = element.find('.kf-shadow-keep-second');
-          var last = element.find('.kf-shadow-keep-last');
-          var keepHeaderHeight = 35;
-          var ellipsisHeight = 28;
-          if (scope.data.draggedKeeps.length === 2) {
-            last.css({top: keepHeaderHeight + 'px'});
-          } else if (scope.data.draggedKeeps.length === 3) {
-            second.css({top: keepHeaderHeight + 'px'});
-            last.css({top: 2 * keepHeaderHeight + 'px'});
-          } else if (scope.data.draggedKeeps.length >= 4) {
-            ellipsis.css({top: keepHeaderHeight + 'px', height: ellipsisHeight + 'px'});
+          if (scope.data.draggedKeeps.length >= 4) {
+            var ellipsis = element.find('.kf-shadow-keep-ellipsis');
+            var ellipsisCounter = element.find('.kf-shadow-keep-ellipsis-counter');
+            var ellipsisCounterHidden = element.find('.kf-shadow-keep-ellipsis-counter-hidden');
             ellipsisCounter.css({left: (parseInt(ellipsis.width(), 10) - parseInt(ellipsisCounterHidden.width(), 10)) / 2});
-            last.css({top: keepHeaderHeight + ellipsisHeight + 'px'});
           }
           return element.find('.kf-shadow-dragged-keeps');
         };
 
-        var shadowDraggedKeeps = element.find('.kf-shadow-dragged-keeps');
-        shadowDraggedKeeps.css({top: 0, width: element.find('.kf-my-keeps')[0].offsetWidth + 'px'});
+        scope.draggedTwo = function () {
+          return scope.data.draggedKeeps && scope.data.draggedKeeps.length === 2;
+        };
+
+        scope.draggedThree = function () {
+          return scope.data.draggedKeeps && scope.data.draggedKeeps.length === 3;
+        };
+
+        scope.draggedMore = function () {
+          return scope.data.draggedKeeps && scope.data.draggedKeeps.length > 3;
+        };
 
         angular.element($window).on('scroll', function () {
           var scrollMargin = $window.innerHeight;

--- a/kifi-backend/modules/shoebox/angular-black/src/keeps/keeps.styl
+++ b/kifi-backend/modules/shoebox/angular-black/src/keeps/keeps.styl
@@ -26,11 +26,79 @@
   margin: 21px 50%
 
 .kf-shadow-dragged-keeps
+.kf-my-keeps
+  padding: 0 25px 20px 30px
+
+.kf-shadow-dragged-keeps
   position: absolute
   left: 0
   top: 0
+  width: 100%
   z-index: -1
+  box-sizing: border-box
 
-.kf-my-keeps
-  padding: 0 25px 0 30px
-  padding-bottom: 20px
+  &.two
+    .kf-shadow-keep-last
+      top: 40px
+    
+  &.three
+    .kf-shadow-keep-second
+      top: 40px
+    .kf-shadow-keep-last
+      top: 80px
+    
+  &.more
+    .kf-shadow-keep-ellipsis
+      top: 40px
+    .kf-shadow-keep-last
+      top: 80px
+
+.kf-shadow-keep-ellipsis
+  display: none
+  position: absolute
+  height: 40px
+  top: 0
+  left: 3px
+  width: calc(100% - 28px)
+  border-radius: 3px 3px 0 0
+  border: defaultBorder
+  border-bottom: none
+  background-color: #fafafa
+  box-sizing: border-box
+
+  &.active
+    display: block
+
+.kf-shadow-keep-ellipsis-line
+  position: relative
+  top: 50%
+  height: 50%
+  width: 100%
+  border: inherit
+  border-left: none
+  border-right: none
+  margin-top: -1px
+
+.kf-shadow-keep-ellipsis-counter
+.kf-shadow-keep-ellipsis-counter-hidden
+  position: absolute
+  font-size: 16px
+  color: black
+  background-color: inherit
+  line-height: 40px
+  top: 0
+  padding: 0 3px
+  font-family: "Georgia", Arial, sans-serif
+
+.kf-shadow-keep-ellipsis-counter-hidden
+  visibility: hidden
+
+.kf-shadow-keep-first
+.kf-shadow-keep-second
+.kf-shadow-keep-last
+  position: absolute
+  top: 0
+  width: calc(100% - 55px) // (100% - total left/right padding)
+
+  .kf-keep
+    margin-top: 0

--- a/kifi-backend/modules/shoebox/angular-black/src/keeps/keeps.tpl.html
+++ b/kifi-backend/modules/shoebox/angular-black/src/keeps/keeps.tpl.html
@@ -19,26 +19,24 @@
     </div>
   </div>
   <ol class="kf-my-keeps">
-    <div ng-repeat="keep in keeps track by $index">
-    <div kf-keep is-selected="!!isSelected(keep)"
-        keep="keep" me="me" toggle-select="toggleSelect(keep)" click-action="onClickKeep(keep, event)" drag-keeps="dragKeeps(keep, event, mouseX, mouseY)" stop-dragging-keeps="stopDraggingKeeps()" edit-mode="editMode" select-keep="selectKeep" unselect-keep="unselectKeep"></div>
+    <div ng-repeat="keep in keeps track by $index" kf-keep is-selected="!!isSelected(keep)"
+      keep="keep" me="me" toggle-select="toggleSelect(keep)" click-action="onClickKeep(keep, event)" drag-keeps="dragKeeps(keep, event, mouseX, mouseY)" stop-dragging-keeps="stopDraggingKeeps()" edit-mode="editMode"></div>
+    <div class="kf-shadow-dragged-keeps" ng-class="{ two: draggedTwo(), three: draggedThree(), more: draggedMore() }">
+      <span class="kf-shadow-keep-first" ng-show="data.draggedKeeps.length >= 1">
+        <div kf-keep is-selected="!!isSelected(data.draggedKeeps[0])" keep="data.draggedKeeps[0]" me="me" edit-mode="editMode"></div>
+      </span>
+      <span class="kf-shadow-keep-second" ng-show="data.draggedKeeps.length === 3">
+        <div kf-keep is-selected="!!isSelected(data.draggedKeeps[1])" keep="data.draggedKeeps[1]" me="me" edit-mode="editMode"></div>
+      </span>
+      <span class="kf-shadow-keep-ellipsis" ng-class="{'active': data.draggedKeeps.length >= 4}">
+        <div class="kf-shadow-keep-ellipsis-line"></div>
+        <div class="kf-shadow-keep-ellipsis-counter">{{data.draggedKeeps.length - 2}} other keeps selected</div>
+      </span>
+      <div class="kf-shadow-keep-ellipsis-counter-hidden">{{data.draggedKeeps.length - 2}} other keeps selected</div>
+      <span class="kf-shadow-keep-last" ng-show="data.draggedKeeps.length >= 2">
+        <div kf-keep is-selected="!!isSelected(data.draggedKeeps[data.draggedKeeps.length-1])" keep="data.draggedKeeps[data.draggedKeeps.length-1]" me="me" edit-mode="editMode"></div>
+      </span>
     </div>
-  </ol>
-  <ol class="kf-shadow-dragged-keeps">
-    <span class="kf-shadow-keep-first">
-      <li ng-if="data.draggedKeeps.length >= 1" class="kf-dragged-keep" kf-keep kf-shadow-keep-first keep="data.draggedKeeps[0]" is-selected="!!isSelected(keep)"><li>
-    </span>
-    <span class="kf-shadow-keep-second">
-      <li ng-if="data.draggedKeeps.length === 3" class="kf-dragged-keep" kf-keep kf-shadow-keep-first keep="data.draggedKeeps[1]" is-selected="!!isSelected(keep)"><li>
-    </span>
-    <span class="kf-shadow-keep-ellipsis" ng-class="{'active': data.draggedKeeps.length >= 4}">
-      <div class="kf-shadow-keep-ellipsis-line"></div>
-      <div class="kf-shadow-keep-ellipsis-counter">{{data.draggedKeeps.length - 2}} other keeps selected</div>
-    </span>
-    <div class="kf-shadow-keep-ellipsis-counter-hidden">{{data.draggedKeeps.length - 2}} other keeps selected</div>
-    <span class="kf-shadow-keep-last">
-      <li ng-if="data.draggedKeeps.length >= 2" class="kf-dragged-keep" kf-keep kf-shadow-keep-last keep="data.draggedKeeps[data.draggedKeeps.length-1]" is-selected="!!isSelected(keep)"></li>
-    </span>
   </ol>
   <div class="kf-keep-group-title-fixed"></div>
   <img class="kf-keeps-loading" ng-show="keepsLoading" src="/img/wait.gif">

--- a/kifi-backend/modules/shoebox/angular-black/src/layout/main/main.styl
+++ b/kifi-backend/modules/shoebox/angular-black/src/layout/main/main.styl
@@ -55,6 +55,7 @@
 
 .kf-main-keeps
   overflow: hidden
+  position: relative
 
   .kf-main-search &
     top: 108px

--- a/kifi-backend/modules/shoebox/angular-black/src/tags/tagItem.tpl.html
+++ b/kifi-backend/modules/shoebox/angular-black/src/tags/tagItem.tpl.html
@@ -20,6 +20,6 @@
       </li>
     </ul>
   </div>
-  <div class="kf-drag-mask"></div>
+  <div class="kf-keep-drag-mask"></div>
   <div class="kf-tag-drag-mask"></div>
 </li>

--- a/kifi-backend/modules/shoebox/angular-black/src/tags/tags.styl
+++ b/kifi-backend/modules/shoebox/angular-black/src/tags/tags.styl
@@ -42,6 +42,11 @@ highlightColor = #eeeeee
   .kf-tag-drag-mask
     display: block
 
+.kf-tag-list-reordering.kf-dragged
+.kf-keep-dragover-tag
+  background-color: editYellowColor
+  border-color: #cccccc
+
 .kf-tag-drag-mask
   position: absolute
   top: 0


### PR DESCRIPTION
@andrewconner @stkem You should now be able to add one or more keeps to a tag by dragging them (in edit mode). Also I completely removed the angular drag&drop library (using custom code instead).

Some of the modifications in keep.js are really just here to make sure a `kfKeep` directive can be created without specifying a keep (otherwise the console is flooded with errors). There are some tricky aspects of html5 drag&drop which prevented me from just using `ngIf` to check that the keep is defined before creating the DOM node.
