### PR TITLE
fixing the sidebar scrollbar on firefox

### DIFF
--- a/kifi-backend/modules/shoebox/angular-black/src/common/services/scrollbar.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/common/services/scrollbar.js
@@ -46,7 +46,17 @@ angular.module('kifi.scrollbar', [])
         $ = angular.element;
 
     function scrollbarSize() {
-      var div = $(
+      /**
+       * Overriding for now - seems like it doesn't work in Firefox anymore
+       * - the parent of 'antiscroll-inner' should have 'overflow: hidden'
+       * - children of 'antiscroll-inner' should have 'width: calc(100% - 30px)'
+       * 
+       * Known issue:
+       * - the scrollbar may remain in the 'thin' state all the time
+       */
+      return 30;
+
+      /*var div = $(
           '<div class="antiscroll-inner" style="width:50px;height:50px;overflow-y:scroll;' +
           'position:absolute;top:-200px;left:-200px;"><div style="height:100px;width:100%"/>' +
           '</div>'
@@ -57,7 +67,7 @@ angular.module('kifi.scrollbar', [])
       var w2 = $('div', div).innerWidth();
       $(div).remove();
 
-      return w1 - w2;
+      return w1 - w2;*/
     }
 
     return {

--- a/kifi-backend/modules/shoebox/angular-black/src/tags/tags.styl
+++ b/kifi-backend/modules/shoebox/angular-black/src/tags/tags.styl
@@ -216,6 +216,13 @@ input.kf-tag-rename
 .kf-scrollable-tags
   position: relative
 
+  // This is a hack to hide the scrollbar
+  // (cf. comments in scrollbar.js)
+  overflow: hidden
+  .antiscroll-inner
+    .kf-sidebar-tag-list
+      width: calc(100% - 30px)
+
 .kf-tag-tool
   position: absolute
   display: none


### PR DESCRIPTION
@andrewconner @stkem Seems like sidebar width detection doesn't work in Firefox anymore. I hacked a solution that makes it look reasonable in both Chrome and Firefox. The downside is that the scrollbar is now always in the "thin" state (not sure why) but it actually still looks good, I think.
