### PR TITLE
fixing sidebar visible below short content

### DIFF
--- a/kifi-backend/modules/shoebox/angular-black/src/app.styl
+++ b/kifi-backend/modules/shoebox/angular-black/src/app.styl
@@ -72,11 +72,15 @@ a[href]
   zoom: 1
 
 .kf-cols
+  position: absolute
+  top: 0
+  left: 0
   min-width: 100%
-  height: 100%
+  min-height: 100%
   overflow: hidden
   text-align: left
   text-align: start
+  background-color: appBackgroundColor
 
 .kf-col
   display: inline-block

--- a/kifi-backend/modules/shoebox/angular-black/src/common/services/scrollbar.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/common/services/scrollbar.js
@@ -42,8 +42,8 @@ angular.module('kifi.scrollbar', [])
       return w1 - w2;
     }
 
-    var antiWidth = null,
-        $ = angular.element;
+    var antiWidth = null
+    //var $ = angular.element;
 
     function scrollbarSize() {
       /**

--- a/kifi-backend/modules/shoebox/angular-black/src/layout/scrollablePane/scrollablePane.styl
+++ b/kifi-backend/modules/shoebox/angular-black/src/layout/scrollablePane/scrollablePane.styl
@@ -1,5 +1,6 @@
 .kf-scrollable-pane
   width: calc(100% - 270px)
+  min-height: 100%
   padding-left: 270px
   background-color: appBackgroundColor
 


### PR DESCRIPTION
@stkem @andrewconner 
had to use absolute positioning because webkit is being slightly dumb with 'height' nested inside 'min-height'
