### PR TITLE
remove customized fetch size for lda feature

### DIFF
--- a/kifi-backend/modules/graph/app/com/keepit/graph/manager/GraphManagerPlugin.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/manager/GraphManagerPlugin.scala
@@ -69,7 +69,7 @@ class GraphManagerPlugin @Inject() (
 
   override def onStart() {
     log.info(s"starting $this")
-    scheduleTaskOnAllMachines(actor.system, 2 minutes, 1 minutes, actor.ref, UpdateGraph(Map(SparseLDAGraphUpdate -> 500), 100))
+    scheduleTaskOnAllMachines(actor.system, 2 minutes, 1 minutes, actor.ref, UpdateGraph(Map(), 100))
     scheduleTaskOnAllMachines(actor.system, 30 minutes, 2 hours, actor.ref, BackupGraph)
   }
 }


### PR DESCRIPTION
@eishay @leogrim 

we introduced this when there was a flaw in ingesting cortex data. This is no longer needed. 
This should also help in reducing timeout alerts. 

In the long run, cache or db support is needed. 
