### PR TITLE
if we can't parse a url we should not let it get to the db. its scraping...

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationService.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationService.scala
@@ -39,7 +39,9 @@ class NormalizationServiceImpl @Inject() (
       val uriWithPreferredSchemeOption = priorKnowledge.getPreferredSchemeNormalizer(uriString).map(_.apply(uriWithStandardPrenormalization))
       val prenormalizedUri = uriWithPreferredSchemeOption getOrElse uriWithStandardPrenormalization
       prenormalizedUri.toString
-    }.recoverWith { case cause: Throwable => Failure(PrenormalizationException(cause)) }
+    }.recoverWith {
+      case cause: Throwable => Failure(PrenormalizationException(cause))
+    }
   }
 
   def update(currentReference: NormalizationReference, candidates: NormalizationCandidate*): Future[Option[Id[NormalizedURI]]] = {


### PR DESCRIPTION
... should stop as well and it will be removed from cache. an error should be thrown so we could examine the problem. in most cases its a user error so the exceptions may be caught upper in the stack.
