### PR TITLE
option to return only new keeps from the backend

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
@@ -146,13 +146,13 @@ class KeepsController @Inject() (
     }
   }
 
-  def keepMultiple() = JsonAction.authenticated { request =>
+  def keepMultiple(returnExisting: Boolean = true) = JsonAction.authenticated { request =>
     try {
       request.body.asJson.flatMap(Json.fromJson[KeepInfosWithCollection](_).asOpt) map { fromJson =>
         val source = KeepSource.site
         implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, source).build
-        val (keeps, addedToCollection) = bookmarksCommander.keepMultiple(fromJson, request.userId, source)
-        log.info(s"kept ${keeps.size} new keeps")
+        val (keeps, addedToCollection) = bookmarksCommander.keepMultiple(fromJson, request.userId, source, returnExisting)
+        log.info(s"kept ${keeps.size} keeps")
         Ok(Json.obj(
           "keeps" -> keeps,
           "addedToCollection" -> addedToCollection

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -225,7 +225,7 @@ POST    /users/pics/update          @com.keepit.controllers.assets.UserPictureCo
 
 
 GET     /site/keeps/all             @com.keepit.controllers.website.KeepsController.allKeeps(before: Option[String], after: Option[String], collection: Option[String], helprank: Option[String], count: Int ?= Integer.MAX_VALUE, withPageInfo: Boolean ?= false)
-POST    /site/keeps/add             @com.keepit.controllers.website.KeepsController.keepMultiple()
+POST    /site/keeps/add             @com.keepit.controllers.website.KeepsController.keepMultiple(returnExisting: Boolean ?= true)
 POST    /site/keeps/remove          @com.keepit.controllers.website.KeepsController.unkeepMultiple()
 POST    /site/keeps/delete          @com.keepit.controllers.website.KeepsController.unkeepBatch()
 GET     /site/keeps/count           @com.keepit.controllers.website.KeepsController.numKeeps()


### PR DESCRIPTION
@eishay @andrewconner This way the front-end knows whether the created keep already exists or not. After this is in production I can add logic to the frontend
