### PR TITLE
refactor scraper config

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/scraper/ScraperSchedulerConfig.scala
+++ b/kifi-backend/modules/common/app/com/keepit/scraper/ScraperSchedulerConfig.scala
@@ -1,0 +1,78 @@
+package com.keepit.scraper
+
+import scala.util.Random
+import net.codingwell.scalaguice.ScalaModule
+import com.keepit.inject.AppScoped
+import com.google.inject.{Provides, Singleton}
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import play.api.{Play, Configuration}
+
+case class ScraperIntervalConfig(
+  initialBackoff: Double,     //hours
+  maxBackoff: Double,         //hours
+  maxRandomDelay: Int,        // seconds
+  minInterval: Double,        //hours
+  maxInterval: Double,        //hours
+  intervalIncrement: Double,  //hours
+  intervalDecrement: Double   //hours
+)
+
+case class ScraperSchedulerConfig(
+  intervalConfig: ScraperIntervalConfig,
+  actorTimeout: Int,
+  scrapePendingFrequency: Int,          // seconds
+  checkOverdueCountFrequency: Int,      // minutes
+  pendingOverdueThreshold: Int,         // minutes
+  overdueCountThreshold: Int
+) {
+  private[this] val rnd = new Random
+  def randomDelay(): Int = rnd.nextInt(intervalConfig.maxRandomDelay)     // seconds
+}
+
+trait ScrapeSchedulerConfigModule extends ScalaModule {
+  protected def conf: Configuration
+}
+
+case class ProdScrapeSchedulerConfigModule() extends ScrapeSchedulerConfigModule {
+  def configure() {}
+
+  override protected def conf: Configuration = Play.current.configuration
+
+  @Singleton
+  @Provides
+  def scraperIntervalConfig: ScraperIntervalConfig = {
+    ScraperIntervalConfig(
+      initialBackoff = conf.getDouble("scraper.initialBackoff").get, //hours
+      maxBackoff = conf.getDouble("scraper.maxBackoff").get, //hours
+      maxRandomDelay = conf.getInt("scraper.maxRandomDelay").get, // seconds
+      minInterval = conf.getDouble("scraper.interval.min").get, //hours
+      maxInterval = conf.getDouble("scraper.interval.max").get, //hours
+      intervalIncrement = conf.getDouble("scraper.interval.increment").get, //hours
+      intervalDecrement = conf.getDouble("scraper.interval.decrement").get //hours
+    )
+  }
+
+  @Singleton
+  @Provides
+  def schedulerConfig(intervalConfig: ScraperIntervalConfig): ScraperSchedulerConfig = {
+    ScraperSchedulerConfig(
+      intervalConfig,
+      actorTimeout = conf.getInt("scraper.actorTimeout").get,
+      scrapePendingFrequency = conf.getInt("scraper.scrapePendingFrequency").get,
+      checkOverdueCountFrequency = conf.getInt("scraper.checkOverdueCountFrequency").get,
+      pendingOverdueThreshold = conf.getInt("scraper.pendingOverdueThreshold").get,
+      overdueCountThreshold = conf.getInt("scraper.overdueCountThreshold").get
+    )
+  }
+}
+
+case class TestScrapeSchedulerConfigModule() extends ScrapeSchedulerConfigModule {
+  def configure() {}
+
+  override protected def conf: Configuration = new Configuration(Configuration.empty.underlying) {
+    override def getInt(key: String): Option[Int] = Some(0)
+    override def getDouble(key: String): Option[Double] = Some(0)
+    override def getBoolean(key: String): Option[Boolean] = Some(true)
+  }
+}
+

--- a/kifi-backend/modules/common/conf/prod/prod.conf
+++ b/kifi-backend/modules/common/conf/prod/prod.conf
@@ -154,9 +154,9 @@ ws {
   useragent = "Play42"
 }
 
-# ~~~~~~~~~~~~~~~~~~~~~~
-#      Scraper config
-# ~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+#  Scraper Schedule config
+# ~~~~~~~~~~~~~~~~~~~~~~~~
 
 scraper {
 
@@ -167,31 +167,11 @@ scraper {
     decrement = 2                   # hours
   }
 
-  queue {
-    terminateThreshold = 120000
-    sizeThreshold = 100
-    terminatorFreq = 5
-  }
-
-  http {
-    fetcherEnforcerFreq = 5
-    fetcherQSizeThreshold = 100
-  }
-
   initialBackoff = 3                 # hours
   maxBackoff = 1024                  # hours
   maxRandomDelay = 600               # seconds
-  changeThreshold = 0.5
-  pullMultiplier = 8
-  pullFrequency = 5                  # seconds
   scrapePendingFrequency = 30        # seconds
-  queued = true
-  async = false
   actorTimeout = 20000
-  syncAwaitTimeout = 20000
-  serviceCallTimeout = 20000
-  batchSize = 10
-  batchMax = 50
   pendingOverdueThreshold = 20       # minutes
   checkOverdueCountFrequency = 20    # minutes
   overdueCountThreshold = 1000

--- a/kifi-backend/modules/common/conf/prod/scraper.conf
+++ b/kifi-backend/modules/common/conf/prod/scraper.conf
@@ -22,6 +22,49 @@ cdn {
 }
 
 # ~~~~~~~~~~~~~~~~~~~~~~
+#      Scraper config
+# ~~~~~~~~~~~~~~~~~~~~~~
+
+scraper {
+
+  interval {
+    min = 24                        # hours
+    max = 1024                      # hours
+    increment = 6                   # hours
+    decrement = 2                   # hours
+  }
+
+  queue {
+    terminateThreshold = 120000
+    sizeThreshold = 100
+    terminatorFreq = 5
+  }
+
+  http {
+    fetcherEnforcerFreq = 5
+    fetcherQSizeThreshold = 100
+  }
+
+  initialBackoff = 3                 # hours
+  maxBackoff = 1024                  # hours
+  maxRandomDelay = 600               # seconds
+  changeThreshold = 0.5
+  pullMultiplier = 8
+  pullFrequency = 5                  # seconds
+  scrapePendingFrequency = 30        # seconds
+  queued = true
+  async = false
+  actorTimeout = 20000
+  syncAwaitTimeout = 20000
+  serviceCallTimeout = 20000
+  batchSize = 10
+  batchMax = 50
+  pendingOverdueThreshold = 20       # minutes
+  checkOverdueCountFrequency = 20    # minutes
+  overdueCountThreshold = 1000
+}
+
+# ~~~~~~~~~~~~~~~~~~~~~~
 # ForkJoin Pool
 # ~~~~~~~~~~~~~~~~~~~~~~
 fork-join-pool {

--- a/kifi-backend/modules/common/conf/prod/scraper.conf
+++ b/kifi-backend/modules/common/conf/prod/scraper.conf
@@ -27,13 +27,6 @@ cdn {
 
 scraper {
 
-  interval {
-    min = 24                        # hours
-    max = 1024                      # hours
-    increment = 6                   # hours
-    decrement = 2                   # hours
-  }
-
   queue {
     terminateThreshold = 120000
     sizeThreshold = 100
@@ -45,23 +38,15 @@ scraper {
     fetcherQSizeThreshold = 100
   }
 
-  initialBackoff = 3                 # hours
-  maxBackoff = 1024                  # hours
-  maxRandomDelay = 600               # seconds
   changeThreshold = 0.5
   pullMultiplier = 8
   pullFrequency = 5                  # seconds
-  scrapePendingFrequency = 30        # seconds
   queued = true
   async = false
-  actorTimeout = 20000
   syncAwaitTimeout = 20000
   serviceCallTimeout = 20000
   batchSize = 10
   batchMax = 50
-  pendingOverdueThreshold = 20       # minutes
-  checkOverdueCountFrequency = 20    # minutes
-  overdueCountThreshold = 1000
 }
 
 # ~~~~~~~~~~~~~~~~~~~~~~

--- a/kifi-backend/modules/common/conf/prod/shoebox.conf
+++ b/kifi-backend/modules/common/conf/prod/shoebox.conf
@@ -70,11 +70,17 @@ airbrake {
   key = "701215c3c9029a56df52250ce2c5750f"
 }
 
+# ~~~~~~~~~~~~~~~~~~
+# scraper schedule
+# ~~~~~~~~~~~~~~~~~~
 
-# ~~~~~~~~~~~~~~~~~~~~~~
-# Embedly
-# ~~~~~~~~~~~~~~~~~~~~~~
-embedly {
-  enabled = true
-  key = "e46ecae2611d4cb29342fddb0e666a29"
+scraper {
+  actorTimeout = 20000
+  scrapePendingFrequency = 30        # seconds
+  pendingOverdueThreshold = 20       # minutes
+  checkOverdueCountFrequency = 20    # minutes
+  overdueCountThreshold = 1000
 }
+
+
+

--- a/kifi-backend/modules/common/conf/prod/shoebox.conf
+++ b/kifi-backend/modules/common/conf/prod/shoebox.conf
@@ -69,18 +69,3 @@ urban-airship {
 airbrake {
   key = "701215c3c9029a56df52250ce2c5750f"
 }
-
-# ~~~~~~~~~~~~~~~~~~
-# scraper schedule
-# ~~~~~~~~~~~~~~~~~~
-
-scraper {
-  actorTimeout = 20000
-  scrapePendingFrequency = 30        # seconds
-  pendingOverdueThreshold = 20       # minutes
-  checkOverdueCountFrequency = 20    # minutes
-  overdueCountThreshold = 1000
-}
-
-
-

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeProcessorModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeProcessorModule.scala
@@ -18,16 +18,17 @@ case class ProdScraperProcessorModule() extends ScrapeProcessorModule {
     bind[SyncShoeboxDbCallbacks].to[ShoeboxDbCallbackHelper].in[AppScoped]
     bind[PullerPlugin].to[PullerPluginImpl].in[AppScoped]
     install(ProdScraperConfigModule())
+    install(ProdScrapeSchedulerConfigModule())
   }
 
   @Singleton
   @Provides
-  def httpFetcher(airbrake:AirbrakeNotifier, schedulingProperties:SchedulingProperties, scraperConfig: ScraperConfig): HttpFetcher = {
+  def httpFetcher(airbrake:AirbrakeNotifier, schedulingProperties:SchedulingProperties, scraperConfig: ScraperConfig, scheduler: ScraperSchedulerConfig): HttpFetcher = {
     new HttpFetcherImpl(
       airbrake,
       userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17",
-      connectionTimeout = scraperConfig.scrapePendingFrequency * 1000, // todo: revisit
-      soTimeOut = scraperConfig.scrapePendingFrequency * 1000,
+      connectionTimeout = scheduler.scrapePendingFrequency * 1000, // todo: revisit
+      soTimeOut = scheduler.scrapePendingFrequency * 1000,
       trustBlindly = true,
       schedulingProperties,
       scraperConfig.httpConfig

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeWorker.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeWorker.scala
@@ -27,6 +27,7 @@ import com.keepit.scraper.embedly.EmbedlyCommander
 class ScrapeWorker(
   airbrake: AirbrakeNotifier,
   config: ScraperConfig,
+  schedulerConfig: ScraperSchedulerConfig,
   httpFetcher: HttpFetcher,
   httpClient: HttpClient,
   extractorFactory: ExtractorFactory,
@@ -39,6 +40,7 @@ class ScrapeWorker(
 ) extends Logging {
 
   implicit val myConfig = config
+  implicit val scheduleConfig = schedulerConfig
   val awaitTTL = (myConfig.syncAwaitTimeout seconds)
 
   private[scraper] def safeProcessURI(uri: NormalizedURI, info:ScrapeInfo, pageInfoOpt:Option[PageInfo], proxyOpt:Option[HttpProxy]): Option[Article] = try {
@@ -95,7 +97,7 @@ class ScrapeWorker(
     def restrictionChanged = latestUri.restriction != redirectProcessedUri.restriction
     def scrapeFailed = latestUri.state == NormalizedURIStates.SCRAPE_FAILED
     def activeURI = latestUri.state == NormalizedURIStates.ACTIVE
-    def signatureChanged = signature.similarTo(Signature(info.signature)) < (1.0d - config.changeThreshold * (config.intervalConfig.minInterval / info.interval))
+    def signatureChanged = signature.similarTo(Signature(info.signature)) < (1.0d - config.changeThreshold * (schedulerConfig.intervalConfig.minInterval / info.interval))
 
     titleChanged || restrictionChanged || scrapeFailed || activeURI || signatureChanged
   }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperConfig.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperConfig.scala
@@ -13,30 +13,11 @@ case class ScraperHttpConfig(
   httpFetcherQSizeThreshold: Int
 )
 
-case class ScraperIntervalConfig(
-  minInterval: Double, //hours
-  maxInterval: Double, //hours
-  intervalIncrement: Double, //hours
-  intervalDecrement: Double //hours
-)
-
-case class ScraperSchedulerConfig(
-  actorTimeout: Int,
-  scrapePendingFrequency: Int,          // seconds
-  checkOverdueCountFrequency: Int,      // minutes
-  pendingOverdueThreshold: Int,         // minutes
-  overdueCountThreshold: Int
-)
 
 case class ScraperConfig(
-  intervalConfig: ScraperIntervalConfig,
-  initialBackoff: Double, //hours
-  maxBackoff: Double, //hours
-  maxRandomDelay: Int, // seconds
   changeThreshold: Double,
   pullMultiplier:Int,
   pullFrequency: Int, // seconds
-  scrapePendingFrequency: Int, // seconds
   queued: Boolean,
   async: Boolean,
   syncAwaitTimeout: Int,
@@ -45,12 +26,7 @@ case class ScraperConfig(
   batchMax: Int,
   httpConfig: ScraperHttpConfig,
   queueConfig: ScraperQueueConfig
-) {
-
-  private[this] val rnd = new Random
-
-  def randomDelay(): Int = rnd.nextInt(maxRandomDelay) // seconds
-}
+)
 
 object ScraperConfig {
   val BATCH_SIZE = 100

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperConfig.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperConfig.scala
@@ -1,7 +1,6 @@
 package com.keepit.scraper
 
 import scala.util.Random
-import play.api.Play
 
 case class ScraperQueueConfig(
   terminateThreshold: Int,
@@ -21,6 +20,14 @@ case class ScraperIntervalConfig(
   intervalDecrement: Double //hours
 )
 
+case class ScraperSchedulerConfig(
+  actorTimeout: Int,
+  scrapePendingFrequency: Int,          // seconds
+  checkOverdueCountFrequency: Int,      // minutes
+  pendingOverdueThreshold: Int,         // minutes
+  overdueCountThreshold: Int
+)
+
 case class ScraperConfig(
   intervalConfig: ScraperIntervalConfig,
   initialBackoff: Double, //hours
@@ -32,14 +39,10 @@ case class ScraperConfig(
   scrapePendingFrequency: Int, // seconds
   queued: Boolean,
   async: Boolean,
-  actorTimeout: Int,
   syncAwaitTimeout: Int,
   serviceCallTimeout: Int,
   batchSize: Int,
   batchMax: Int,
-  pendingOverdueThreshold: Int, // minutes
-  checkOverdueCountFrequency: Int, // minutes
-  overdueCountThreshold: Int,
   httpConfig: ScraperHttpConfig,
   queueConfig: ScraperQueueConfig
 ) {

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperConfigModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperConfigModule.scala
@@ -3,25 +3,12 @@ package com.keepit.scraper
 import net.codingwell.scalaguice.ScalaModule
 import com.google.inject.{Provides, Singleton}
 import play.api.{Play, Configuration}
-import com.keepit.scraper.ScraperQueueConfig
-import com.keepit.scraper.ScraperIntervalConfig
-import com.keepit.scraper.ScraperHttpConfig
-import com.keepit.scraper.ScraperConfig
 
 trait ScraperConfigModule extends ScalaModule {
 
   protected def conf: Configuration
 
-  @Singleton
-  @Provides
-  def scraperIntervalConfig: ScraperIntervalConfig = {
-    ScraperIntervalConfig(
-      minInterval = conf.getDouble("scraper.interval.min").get, //hours
-      maxInterval = conf.getDouble("scraper.interval.max").get, //hours
-      intervalIncrement = conf.getDouble("scraper.interval.increment").get, //hours
-      intervalDecrement = conf.getDouble("scraper.interval.decrement").get //hours
-    )
-  }
+
 
   @Singleton
   @Provides
@@ -48,14 +35,9 @@ trait ScraperConfigModule extends ScalaModule {
   @Provides
   def scraperConfig(queueConfig: ScraperQueueConfig, httpConfig: ScraperHttpConfig, intervalConfig: ScraperIntervalConfig): ScraperConfig = {
     ScraperConfig(
-      intervalConfig = intervalConfig,
-      initialBackoff = conf.getDouble("scraper.initialBackoff").get, //hours
-      maxBackoff = conf.getDouble("scraper.maxBackoff").get, //hours
-      maxRandomDelay = conf.getInt("scraper.maxRandomDelay").get, // seconds
       changeThreshold = conf.getInt("scraper.changeThreshold").get,
       pullMultiplier = conf.getInt("scraper.pullMultiplier").get,
       pullFrequency = conf.getInt("scraper.pullFrequency").get, // seconds
-      scrapePendingFrequency = conf.getInt("scraper.scrapePendingFrequency").get, // seconds
       queued = conf.getBoolean("scraper.queued").get,
       async = conf.getBoolean("scraper.async").get,
       syncAwaitTimeout = conf.getInt("scraper.syncAwaitTimeout").get,
@@ -70,7 +52,9 @@ trait ScraperConfigModule extends ScalaModule {
 
 case class ProdScraperConfigModule() extends ScraperConfigModule {
 
-  def configure() {}
+  def configure() {
+    install(ProdScrapeSchedulerConfigModule())
+  }
 
   override protected def conf: Configuration = Play.current.configuration
 }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperConfigModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperConfigModule.scala
@@ -8,8 +8,6 @@ trait ScraperConfigModule extends ScalaModule {
 
   protected def conf: Configuration
 
-
-
   @Singleton
   @Provides
   def scraperQueueConfig: ScraperQueueConfig = {

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperConfigModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperConfigModule.scala
@@ -3,6 +3,10 @@ package com.keepit.scraper
 import net.codingwell.scalaguice.ScalaModule
 import com.google.inject.{Provides, Singleton}
 import play.api.{Play, Configuration}
+import com.keepit.scraper.ScraperQueueConfig
+import com.keepit.scraper.ScraperIntervalConfig
+import com.keepit.scraper.ScraperHttpConfig
+import com.keepit.scraper.ScraperConfig
 
 trait ScraperConfigModule extends ScalaModule {
 
@@ -54,14 +58,10 @@ trait ScraperConfigModule extends ScalaModule {
       scrapePendingFrequency = conf.getInt("scraper.scrapePendingFrequency").get, // seconds
       queued = conf.getBoolean("scraper.queued").get,
       async = conf.getBoolean("scraper.async").get,
-      actorTimeout = conf.getInt("scraper.actorTimeout").get,
       syncAwaitTimeout = conf.getInt("scraper.syncAwaitTimeout").get,
       serviceCallTimeout = conf.getInt("scraper.serviceCallTimeout").get,
       batchSize = conf.getInt("scraper.batchSize").get,
       batchMax = conf.getInt("scraper.batchMax").get,
-      pendingOverdueThreshold = conf.getInt("scraper.pendingOverdueThreshold").get, // minutes
-      checkOverdueCountFrequency = conf.getInt("scraper.checkOverdueCountFrequency").get, // minutes
-      overdueCountThreshold = conf.getInt("scraper.overdueCountThreshold").get,
       httpConfig = httpConfig,
       queueConfig = queueConfig
     )

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/embedly/EmbedlyClient.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/embedly/EmbedlyClient.scala
@@ -82,6 +82,6 @@ class EmbedlyClientImpl @Inject() extends EmbedlyClient with Logging {
 
 class DevEmbedlyClient extends EmbedlyClient {
   override def embedlyUrl(url: String): String = "http://dev.ezkeep.com"
-  override def getEmbedlyInfo(url: String): Future[Option[EmbedlyInfo]] = ???
+  override def getEmbedlyInfo(url: String): Future[Option[EmbedlyInfo]] = Future.successful(None)
   override def getImageInfos(uriId: Id[NormalizedURI], url: String): Future[Seq[ImageInfo]] = Future.successful(Seq())
 }

--- a/kifi-backend/modules/scraper/test/com/keepit/scraper/TestScraperProcessorModule.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/scraper/TestScraperProcessorModule.scala
@@ -15,6 +15,7 @@ case class TestScraperProcessorModule() extends ScrapeProcessorModule {
     bind[SyncShoeboxDbCallbacks].to[ShoeboxDbCallbackHelper].in[AppScoped]
     bind[PullerPlugin].to[PullerPluginImpl].in[AppScoped]
     install(TestScraperConfigModule())
+    install(TestScrapeSchedulerConfigModule())
   }
 
   @Singleton

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/EmailNotificationsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/EmailNotificationsController.scala
@@ -3,7 +3,6 @@ package com.keepit.controllers.internal
 import com.keepit.common.time.internalTime.DateTimeJsonLongFormat
 import com.google.inject.Inject
 import com.keepit.common.time.Clock
-import com.keepit.scraper.ScraperConfig
 import com.keepit.common.service.FortyTwoServices
 import com.keepit.common.controller.ShoeboxServiceController
 import com.keepit.common.logging.Logging

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/EmailNotificationsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/EmailNotificationsController.scala
@@ -17,7 +17,6 @@ import org.joda.time.DateTime
 class EmailNotificationsController @Inject() (
    emailNotificationsCommander: EmailNotificationsCommander
 )  (implicit private val clock: Clock,
-    implicit private val scraperConfig: ScraperConfig,
     private val fortyTwoServices: FortyTwoServices)
   extends ShoeboxServiceController with Logging {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -70,7 +70,6 @@ class ShoeboxController @Inject() (
   verifiedEmailUserIdCache: VerifiedEmailUserIdCache
 )
   (implicit private val clock: Clock,
-   implicit private val scraperConfig: ScraperConfig,
    private val fortyTwoServices: FortyTwoServices)
   extends ShoeboxServiceController with Logging {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerModule.scala
@@ -4,6 +4,7 @@ import net.codingwell.scalaguice.ScalaModule
 import com.keepit.inject.AppScoped
 import com.google.inject.{Provides, Singleton}
 import com.keepit.common.healthcheck.AirbrakeNotifier
+import play.api.{Play, Configuration}
 
 trait ScrapeSchedulerModule extends ScalaModule
 
@@ -11,7 +12,7 @@ case class ProdScrapeSchedulerModule() extends ScrapeSchedulerModule {
 
   def configure {
     bind[ScrapeSchedulerPlugin].to[ScrapeSchedulerPluginImpl].in[AppScoped]
-    install(ProdScraperConfigModule())
+    install(ProdScrapeSchedulerConfigModule())
   }
 }
 
@@ -19,7 +20,39 @@ case class DevScrapeSchedulerModule() extends ScrapeSchedulerModule {
 
   def configure {
     bind[ScrapeSchedulerPlugin].to[ScrapeSchedulerPluginImpl].in[AppScoped]
-    install(ProdScraperConfigModule())
+    install(ProdScrapeSchedulerConfigModule())
+  }
+}
+
+trait ScrapeSchedulerConfigModule extends ScalaModule {
+  protected def conf: Configuration
+}
+
+case class ProdScrapeSchedulerConfigModule() extends ScrapeSchedulerConfigModule {
+  def configure() {}
+
+  override protected def conf: Configuration = Play.current.configuration
+
+  @Singleton
+  @Provides
+  def schedulerConfig(): ScraperSchedulerConfig = {
+    ScraperSchedulerConfig(
+      actorTimeout = conf.getInt("scraper.actorTimeout").get,
+      scrapePendingFrequency = conf.getInt("scraper.scrapePendingFrequency").get,
+      checkOverdueCountFrequency = conf.getInt("scraper.checkOverdueCountFrequency").get,
+      pendingOverdueThreshold = conf.getInt("scraper.pendingOverdueThreshold").get,
+      overdueCountThreshold = conf.getInt("scraper.overdueCountThreshold").get
+    )
+  }
+}
+
+case class TestScrapeSchedulerConfigModule() extends ScrapeSchedulerConfigModule {
+  def configure() {}
+
+  override protected def conf: Configuration = new Configuration(Configuration.empty.underlying) {
+    override def getInt(key: String): Option[Int] = Some(0)
+    override def getDouble(key: String): Option[Double] = Some(0)
+    override def getBoolean(key: String): Option[Boolean] = Some(true)
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerModule.scala
@@ -24,35 +24,3 @@ case class DevScrapeSchedulerModule() extends ScrapeSchedulerModule {
   }
 }
 
-trait ScrapeSchedulerConfigModule extends ScalaModule {
-  protected def conf: Configuration
-}
-
-case class ProdScrapeSchedulerConfigModule() extends ScrapeSchedulerConfigModule {
-  def configure() {}
-
-  override protected def conf: Configuration = Play.current.configuration
-
-  @Singleton
-  @Provides
-  def schedulerConfig(): ScraperSchedulerConfig = {
-    ScraperSchedulerConfig(
-      actorTimeout = conf.getInt("scraper.actorTimeout").get,
-      scrapePendingFrequency = conf.getInt("scraper.scrapePendingFrequency").get,
-      checkOverdueCountFrequency = conf.getInt("scraper.checkOverdueCountFrequency").get,
-      pendingOverdueThreshold = conf.getInt("scraper.pendingOverdueThreshold").get,
-      overdueCountThreshold = conf.getInt("scraper.overdueCountThreshold").get
-    )
-  }
-}
-
-case class TestScrapeSchedulerConfigModule() extends ScrapeSchedulerConfigModule {
-  def configure() {}
-
-  override protected def conf: Configuration = new Configuration(Configuration.empty.underlying) {
-    override def getInt(key: String): Option[Int] = Some(0)
-    override def getDouble(key: String): Option[Double] = Some(0)
-    override def getBoolean(key: String): Option[Boolean] = Some(true)
-  }
-}
-

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerModule.scala
@@ -14,6 +14,7 @@ case class ProdScrapeSchedulerModule() extends ScrapeSchedulerModule {
     bind[ScrapeSchedulerPlugin].to[ScrapeSchedulerPluginImpl].in[AppScoped]
     install(ProdScrapeSchedulerConfigModule())
   }
+
 }
 
 case class DevScrapeSchedulerModule() extends ScrapeSchedulerModule {
@@ -23,4 +24,3 @@ case class DevScrapeSchedulerModule() extends ScrapeSchedulerModule {
     install(ProdScrapeSchedulerConfigModule())
   }
 }
-

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPluginImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPluginImpl.scala
@@ -25,13 +25,7 @@ case object CheckOverdues
 case object CheckOverdueCount
 
 
-case class ScraperSchedulerConfig(
-  actorTimeout: Int,
-  scrapePendingFrequency: Int,          // seconds
-  checkOverdueCountFrequency: Int,      // minutes
-  pendingOverdueThreshold: Int,         // minutes
-  overdueCountThreshold: Int
-)
+
 
 private[scraper] class ScrapeScheduler @Inject() (
     scraperConfig: ScraperSchedulerConfig,

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPluginImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPluginImpl.scala
@@ -24,8 +24,17 @@ import scala.util.Try
 case object CheckOverdues
 case object CheckOverdueCount
 
+
+case class ScraperSchedulerConfig(
+  actorTimeout: Int,
+  scrapePendingFrequency: Int,          // seconds
+  checkOverdueCountFrequency: Int,      // minutes
+  pendingOverdueThreshold: Int,         // minutes
+  overdueCountThreshold: Int
+)
+
 private[scraper] class ScrapeScheduler @Inject() (
-    scraperConfig: ScraperConfig,
+    scraperConfig: ScraperSchedulerConfig,
     airbrake: AirbrakeNotifier,
     db: Database,
     serviceDiscovery: ServiceDiscovery,
@@ -113,7 +122,7 @@ class ScrapeSchedulerPluginImpl @Inject() (
     scrapeInfoRepo: ScrapeInfoRepo,
     urlPatternRuleRepo: UrlPatternRuleRepo,
     actor: ActorInstance[ScrapeScheduler],
-    scraperConfig: ScraperConfig,
+    scraperConfig: ScraperSchedulerConfig,
     scraperClient: ScraperServiceClient,
     val scheduling: SchedulingProperties) //only on leader
   extends ScrapeSchedulerPlugin with SchedulerPlugin with Logging {

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/shoebox/ShoeboxControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/shoebox/ShoeboxControllerTest.scala
@@ -23,7 +23,7 @@ import com.keepit.common.actor.TestActorSystemModule
 import com.keepit.common.healthcheck.FakeAirbrakeModule
 import scala.concurrent.ExecutionContext.Implicits.global
 import com.keepit.abook.TestABookServiceClientModule
-import com.keepit.scraper.{TestScraperServiceClientModule, TestScraperConfigModule, FakeScrapeSchedulerModule}
+import com.keepit.scraper.{TestScraperServiceClientModule, FakeScrapeSchedulerModule}
 import com.keepit.common.db.SequenceNumber
 import com.keepit.common.external.FakeExternalServiceModule
 import com.keepit.cortex.FakeCortexServiceClientModule
@@ -44,7 +44,6 @@ class ShoeboxControllerTest extends Specification with ShoeboxApplicationInjecto
     TestABookServiceClientModule(),
     FakeSocialGraphModule(),
     FakeScrapeSchedulerModule(),
-    TestScraperConfigModule(),
     FakeExternalServiceModule(),
     FakeCortexServiceClientModule(),
     TestScraperServiceClientModule()

--- a/kifi-backend/modules/shoebox/test/com/keepit/scraper/DuplicateDocumentDetectionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/scraper/DuplicateDocumentDetectionTest.scala
@@ -14,7 +14,7 @@ class DuplicateDocumentDetectionTest extends Specification with ShoeboxTestInjec
   "Signature" should {
 
     "find similar documents of different thresholds" in {
-      withDb(TestMailModule(), FakeScrapeSchedulerModule(), TestScraperConfigModule()) { implicit injector: Injector =>
+      withDb(TestMailModule(), FakeScrapeSchedulerModule()) { implicit injector: Injector =>
 
         val builder1 = new SignatureBuilder(3)
         val builder2 = new SignatureBuilder(3)
@@ -38,8 +38,6 @@ class DuplicateDocumentDetectionTest extends Specification with ShoeboxTestInjec
           scrapeRepo.save(ScrapeInfo(uriId = nuri3.id.get))
           scrapeRepo.save(ScrapeInfo(uriId = nuri4.id.get))
           scrapeRepo.save(ScrapeInfo(uriId = nuri5.id.get))
-
-          implicit val conf = inject[ScraperConfig]
 
           scrapeRepo.save(scrapeRepo.getByUriId(nuri1.id.get).get.copy(signature = sig1.toBase64))
           scrapeRepo.save(scrapeRepo.getByUriId(nuri2.id.get).get.copy(signature = sig1.toBase64))

--- a/kifi-backend/modules/shoebox/test/com/keepit/shoebox/ShoeboxModuleTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/shoebox/ShoeboxModuleTest.scala
@@ -25,7 +25,7 @@ import com.keepit.common.analytics.TestAnalyticsModule
 import com.keepit.model.TestSliderHistoryTrackerModule
 import com.keepit.classify.FakeDomainTagImporterModule
 import com.keepit.eliza.FakeElizaServiceClientModule
-import com.keepit.scraper.{TestScraperConfigModule, TestScraperServiceClientModule, FakeScrapeSchedulerModule}
+import com.keepit.scraper.{TestScraperServiceClientModule, FakeScrapeSchedulerModule}
 import com.keepit.common.healthcheck.FakeAirbrakeModule
 import com.keepit.heimdal.TestHeimdalServiceClientModule
 import com.keepit.abook.TestABookServiceClientModule
@@ -67,7 +67,6 @@ class ShoeboxModuleTest extends Specification with Logging with ShoeboxApplicati
         TestHeimdalServiceClientModule(),
         TestABookServiceClientModule(),
         TestScraperServiceClientModule(),
-        TestScraperConfigModule(),
         KeepImportsModule(),
         FakeExternalServiceModule()
       )) {


### PR DESCRIPTION
@eishay @raymondng 

factor out a `ScraperSchedulerConfig`. With current code, this HAS to be accessible by both shoebox and scraper. (shoebox uses this to schedule scraping. Scraper uses it to set nextScrapeTime, etc.)

I am not sure this really simplifies things. Moving ScrapeInfo table to Scraper is the right solution. 
