### PR TITLE
Cleanup wrapping subtitles

### DIFF
--- a/kifi-backend/modules/shoebox/angular-black/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/keep/keep.js
@@ -400,14 +400,15 @@ angular.module('kifi.keep', ['kifi.keepWhoPics', 'kifi.keepWhoText', 'kifi.tagSe
           var asideWidthPercent = Math.floor(((cardWidth - bestRes.guess) / cardWidth) * 100);
           var calcTextWidth = 100 - asideWidthPercent;
           var linesToShow = Math.floor((bestRes.hi / 23)); // line height
-          var calcTextHeight = linesToShow * 23 + 25; // 25px subtitle
+          var calcTextHeight = linesToShow * 23 + 22; // 22px subtitle
 
           scope.keep.sizeCard = function () {
             var $content = element.find('.kf-keep-content-line');
             $content.height(Math.floor(bestRes.hi) + 4); // 4px padding on image
             $content.find('.kf-keep-small-image').width(asideWidthPercent + '%');
             element.find('.kf-keep-info').css({
-              'height': calcTextHeight + 'px'
+              'height': calcTextHeight + 'px',
+              'width': 'calc(100% - 30px)'
             }).addClass('kf-dyn-positioned');
 
             $content.find('.kf-keep-image').on('error', function () {

--- a/kifi-backend/modules/shoebox/angular-black/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/keep/keep.js
@@ -407,8 +407,7 @@ angular.module('kifi.keep', ['kifi.keepWhoPics', 'kifi.keepWhoText', 'kifi.tagSe
             $content.height(Math.floor(bestRes.hi) + 4); // 4px padding on image
             $content.find('.kf-keep-small-image').width(asideWidthPercent + '%');
             element.find('.kf-keep-info').css({
-              'height': calcTextHeight + 'px',
-              'width': 'calc(100% - 30px)'
+              'height': calcTextHeight + 'px'
             }).addClass('kf-dyn-positioned');
 
             $content.find('.kf-keep-image').on('error', function () {

--- a/kifi-backend/modules/shoebox/angular-black/src/keep/keep.styl
+++ b/kifi-backend/modules/shoebox/angular-black/src/keep/keep.styl
@@ -270,7 +270,6 @@ keepBorderRadius = 3px
 .kf-dyn-positioned
   position: absolute
   overflow: hidden
-  margin-right: 30px
 
 .kf-keep-description-sizer
   position: absolute
@@ -287,7 +286,7 @@ keepBorderRadius = 3px
   font-smoothing: antialiased
   font-weight: 500
   long-text()
-  max-width: 340px
+  max-width: calc(100% - 100px)
   overflow: hidden
 
   .kf-keep.example &

--- a/kifi-backend/modules/shoebox/angular-black/src/keep/keep.styl
+++ b/kifi-backend/modules/shoebox/angular-black/src/keep/keep.styl
@@ -236,10 +236,12 @@ keepBorderRadius = 3px
 
 .kf-keep-info-wrap
   position: relative
+  margin-right: 30px
 
 .kf-keep-info
   vertical-align: top
   display: table-cell
+  width: 100%
 
 .kf-keep-title
   max-width: 100%


### PR DESCRIPTION
Previously we were vulnerable to a long subtitle (ie, long url) making the absolutely positioned element have a width, breaking the layout.

This explicitly sets the width to 100%, and handles the margin outside.

@martinraison 
