### PR TITLE
Making deployment script deal gracefully with instances without a name

### DIFF
--- a/tools/eddie/eddie-deploy-marvin.py
+++ b/tools/eddie/eddie-deploy-marvin.py
@@ -77,7 +77,7 @@ class ServiceInstance(object):
   def __init__(self, instance):
     self.aws_instance = instance
 
-    self.name = instance.tags["Name"]
+    self.name = instance.tags.get("Name", None)
     self.service = instance.tags.get("Service", None)
     self.mode = instance.tags.get("Mode", "primary?")
     self.type = instance.instance_type

--- a/tools/eddie/eddie-deploy.py
+++ b/tools/eddie/eddie-deploy.py
@@ -54,7 +54,7 @@ class ServiceInstance(object):
   def __init__(self, instance):
     self.aws_instance = instance
 
-    self.name = instance.tags["Name"]
+    self.name = instance.tags.get("Name", None)
     self.service = instance.tags.get("Service", None)
     self.mode = instance.tags.get("Mode", "primary?")
     self.type = instance.instance_type


### PR DESCRIPTION
This happens temporarily when we loose a spot instance (i.e. AWS api temporarily returns the terminated spot instance without any tags, which causes the deployment to crash)
@eishay @andrewconner @ymatsuda 
