### PR TITLE
fix ScraperURISummaryCommander

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -615,14 +615,14 @@ class ShoeboxServiceClientImpl @Inject() (
 
   @deprecated("Dangerous call. Use updateNormalizedURI instead.","2014-01-30")
   def saveNormalizedURI(uri: NormalizedURI): Future[NormalizedURI] = {
-    call(Shoebox.internal.saveNormalizedURI(), Json.toJson(uri), callTimeouts = longTimeout, routingStrategy = leaderPriority).map { r =>
+    call(Shoebox.internal.saveNormalizedURI(), Json.toJson(uri), callTimeouts = longTimeout).map { r =>
       r.json.as[NormalizedURI]
     }
   }
 
   def updateNormalizedURIState(uriId: Id[NormalizedURI], state: State[NormalizedURI]): Future[Unit] = {
     val json = Json.obj("state" -> state)
-    call(Shoebox.internal.updateNormalizedURI(uriId), json, callTimeouts = longTimeout, routingStrategy = leaderPriority).imap(_ => {})
+    call(Shoebox.internal.updateNormalizedURI(uriId), json, callTimeouts = longTimeout).imap(_ => {})
   }
 
   def updateNormalizedURI(uriId: => Id[NormalizedURI],

--- a/kifi-backend/modules/scraper/app/com/keepit/commanders/ScraperURISummaryCommander.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/commanders/ScraperURISummaryCommander.scala
@@ -53,7 +53,7 @@ class ScraperURISummaryCommanderImpl @Inject()(
         val (url, size) = result
         val imageInfoWithUrl = if (info.url.isEmpty) info.copy(url = Some(url), size = Some(size)) else info
 
-        callback.saveImageInfo(imageInfoWithUrl)
+        callback.syncSaveImageInfo(imageInfoWithUrl)
         Some(imageInfoWithUrl)
       }
       case Failure(ex) => {
@@ -86,7 +86,7 @@ class ScraperURISummaryCommanderImpl @Inject()(
         embedlyInfo <- embedlyInfoOpt
       } yield {
 
-        callback.savePageInfo(embedlyInfo.toPageInfo(nUriId))
+        callback.syncSavePageInfo(embedlyInfo.toPageInfo(nUriId))
 
         if (descriptionOnly) {
           Future.successful(Some(URISummary(None, embedlyInfo.title, embedlyInfo.description)))

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ShoeboxDbCallbacks.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ShoeboxDbCallbacks.scala
@@ -45,6 +45,8 @@ class ShoeboxDbCallbackHelper @Inject() (config: ScraperConfig, shoeboxServiceCl
     }
   }
   def syncSaveScrapeInfo(info:ScrapeInfo):ScrapeInfo = await(saveScrapeInfo(info))
+  def syncSavePageInfo(info:PageInfo): PageInfo = await(savePageInfo(info))
+  def syncSaveImageInfo(info:ImageInfo): ImageInfo = await(saveImageInfo(info))
   def syncGetBookmarksByUriWithoutTitle(uriId: Id[NormalizedURI]):Seq[Keep] = await(getBookmarksByUriWithoutTitle(uriId))
   def syncGetLatestKeep(url: String): Option[Keep] = await(getLatestKeep(url))
   def syncRecordPermanentRedirect(uri: NormalizedURI, redirect: HttpRedirect): NormalizedURI = {
@@ -95,6 +97,8 @@ trait SyncShoeboxDbCallbacks {
   def syncSaveNormalizedUri(uri:NormalizedURI):NormalizedURI
   def syncUpdateNormalizedURIState(uriId: Id[NormalizedURI], state: State[NormalizedURI]): Unit
   def syncSaveScrapeInfo(info:ScrapeInfo):ScrapeInfo
+  def syncSavePageInfo(info:PageInfo): PageInfo
+  def syncSaveImageInfo(info:ImageInfo): ImageInfo
   def syncGetBookmarksByUriWithoutTitle(uriId: Id[NormalizedURI]):Seq[Keep]
   def syncGetLatestKeep(url: String): Option[Keep]
   def syncRecordPermanentRedirect(uri: NormalizedURI, redirect: HttpRedirect): NormalizedURI

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ScraperCallbackHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ScraperCallbackHelper.scala
@@ -25,7 +25,6 @@ class ScraperCallbackHelper @Inject()(
   private val assignLock    = new ReentrantLock()
   private val pageInfoLock  = new ReentrantLock()
   private val imageInfoLock = new ReentrantLock()
-  private val normalizedUriLock = new ReentrantLock()
 
   def withLock[T](lock:ReentrantLock)(f: => T) = {
     try {


### PR DESCRIPTION
@yingjieMiao @raymondng 
- Put back sync version of saveImageInfo and savePageInfo and use them in ScraperURISummaryCommander.
- Removed leaderPriority from saveNormalizedURI and updateNormalizedURIState (shoebox client) because writes to NormalizedURI is supposed to be much more scalable.  
