### PR TITLE
admin endpoint for inactive keep

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
@@ -23,6 +23,7 @@ import play.api.mvc.{AnyContent, Action}
 import com.keepit.commanders.URISummaryCommander
 import com.keepit.commanders.RichWhoKeptMyKeeps
 import com.keepit.model.KeywordsSummary
+import com.keepit.model.KeepStates
 
 class AdminBookmarksController @Inject() (
   actionAuthenticator: ActionAuthenticator,
@@ -139,6 +140,14 @@ class AdminBookmarksController @Inject() (
     }
     log.info("updating changed users")
     Redirect(request.request.referer)
+  }
+
+  def inactive(id: Id[Keep]) = AdminHtmlAction.authenticated { request =>
+    db.readWrite{ implicit s =>
+      val keep = keepRepo.get(id)
+      keepRepo.save(keep.copy(state = KeepStates.INACTIVE))
+      Redirect(com.keepit.controllers.admin.routes.AdminBookmarksController.bookmarksView(0))
+    }
   }
 
   //this is an admin only task!!!

--- a/kifi-backend/modules/shoebox/app/views/admin/bookmark.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/bookmark.scala.html
@@ -97,4 +97,10 @@
        <input type="submit" value="Delete">
      }
    </p>
+
+   <p>
+     @helper.form(action = com.keepit.controllers.admin.routes.AdminBookmarksController.inactive(bookmark.id.get){
+       <input type="submit" value="Inactive">
+     }
+   </p>
 }

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -317,6 +317,7 @@ GET     /admin/bookmarks/editWithUri       @com.keepit.controllers.admin.AdminBo
 POST    /admin/bookmarks/rescrape   @com.keepit.controllers.admin.AdminBookmarksController.rescrape
 POST    /admin/bookmarks/update     @com.keepit.controllers.admin.AdminBookmarksController.updateBookmarks
 POST    /admin/bookmarks/delete     @com.keepit.controllers.admin.AdminBookmarksController.delete(id: Id[Keep])
+POST    /admin/bookmarks/inactive   @com.keepit.controllers.admin.AdminBookmarksController.inactive(id: Id[Keep])
 GET     /admin/bookmarks/userKeywords @com.keepit.controllers.admin.AdminBookmarksController.userBookmarkKeywords
 GET     /admin/bookmarksKeywords/page/:page @com.keepit.controllers.admin.AdminBookmarksController.bookmarksKeywordsPageView(page: Int)
 


### PR DESCRIPTION
this is better than delete, as search can catch up with seqNum changes

@martinraison 
