### PR TITLE
fast json parser didn't like empty byte array

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/net/FastJsonParser.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/FastJsonParser.scala
@@ -50,7 +50,8 @@ class FastJsonParser() {
    */
   private def fastParse(bytes: Array[Byte]) = if (bytes.size <= 4) { //4 == "null".getBytes(UTF8).size
     val smallString = new String(bytes, UTF8)
-    if (smallString == FastJsonParser.emptyObjectString) FastJsonParser.emptyObject
+    if (bytes.isEmpty) FastJsonParser.nullVal
+    else if (smallString == FastJsonParser.emptyObjectString) FastJsonParser.emptyObject
     else if (smallString == FastJsonParser.emptyArrayString) FastJsonParser.emptyArray
     else if (smallString == FastJsonParser.nullString) FastJsonParser.nullVal
     else Json.parse(smallString)


### PR DESCRIPTION
@eishay  @raymondng 

we have many errors from scraper that were caused by this. This doesn't fix the whole problem though, in the shoebox client, we will have JsNull.as[SomeType]. We could handle that gracefully elsewhere.

But as a parser, FastJsonParser should handle empty byte array correctly. 
