### PR TITLE
Admin method to delete UserEmailAddress

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -830,4 +830,13 @@ class AdminUserController @Inject() (
     }
     Ok(json)
   }}
+
+  def deactivateUserEmailAddress(id: Id[UserEmailAddress]) = AdminHtmlAction.authenticated { implicit request =>
+    db.readWrite { implicit session =>
+      val userEmail = emailRepo.get(id)
+      emailRepo.save(userEmail.withState(UserEmailAddressStates.INACTIVE))
+      userRepo.save(userRepo.get(userEmail.userId)) // bump up sequence number for reindexing
+    }
+    Ok("Done!")
+  }
 }

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -430,6 +430,7 @@ GET     /admin/users/bumpConnSeq     @com.keepit.controllers.admin.AdminUserCont
 GET    /admin/users/mixpanel/reset          @com.keepit.controllers.admin.AdminUserController.resetAllMixpanelProfiles()
 GET    /admin/users/mixpanel/delete          @com.keepit.controllers.admin.AdminUserController.deleteAllMixpanelProfiles()
 
+GET     /admin/user/deactivateEmailAddress     @com.keepit.controllers.admin.AdminUserController.deactivateUserEmailAddress(id: Id[UserEmailAddress])
 GET     /admin/users/fixFortyTwoConnections    @com.keepit.controllers.admin.AdminUserController.fixMissingFortyTwoSocialConnections(readOnly: Boolean ?= true)
 
 GET     /admin/social_users/:page   @com.keepit.controllers.admin.AdminSocialUserController.socialUsersView(page: Int)


### PR DESCRIPTION
@ymatsuda I haven't found any evidence that the User sequence number (which drives the UserIndexer) is increased whenever there is a modification to UserEmailAddress. In this admin method I do bump it up but otherwise modifications to emails are scattered around the code and I'm not sure we do it. I'm not familiar enough with our TypeAheads to know whether there is something to consider there as well.
