### PR TITLE
keep layout fix

### DIFF
--- a/kifi-backend/modules/shoebox/angular-black/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/keep/keep.js
@@ -404,7 +404,7 @@ angular.module('kifi.keep', ['kifi.keepWhoPics', 'kifi.keepWhoText', 'kifi.tagSe
 
           scope.keep.sizeCard = function () {
             var $content = element.find('.kf-keep-content-line');
-            $content.height(Math.floor(bestRes.hi) + 4); // 4px padding on image
+            //$content.height(Math.floor(bestRes.hi) + 4); // 4px padding on image
             $content.find('.kf-keep-small-image').width(asideWidthPercent + '%');
             element.find('.kf-keep-info').css({
               'height': calcTextHeight + 'px'

--- a/kifi-backend/modules/shoebox/angular-black/src/keep/keep.styl
+++ b/kifi-backend/modules/shoebox/angular-black/src/keep/keep.styl
@@ -125,6 +125,7 @@ keepBorderRadius = 3px
 
 .kf-keep-contents
   padding: 25px 0 10px
+  overflow: hidden
 
 .kf-keep-who
   padding: 6px 35px 5px 0
@@ -195,7 +196,6 @@ keepBorderRadius = 3px
 .kf-keep-content-line
   padding: 0
   width: 100%
-  display: table
   padding-top: 14px
   position: relative
 
@@ -210,10 +210,11 @@ keepBorderRadius = 3px
   margin-right: auto
 
 .kf-keep-small-image
-  display:table-cell
   width: 150px
   vertical-align: top
+  float: right
   padding-top: 5px
+  padding-left: 20px
   min-width: 90px
 
   @media screen and (min-width: 1150px) and (max-width: 1250px)
@@ -236,11 +237,12 @@ keepBorderRadius = 3px
 
 .kf-keep-info-wrap
   position: relative
+  display: block
+  overflow: hidden
   margin-right: 30px
 
 .kf-keep-info
   vertical-align: top
-  display: table-cell
   width: 100%
 
 .kf-keep-title
@@ -270,7 +272,6 @@ keepBorderRadius = 3px
   word-break: break-word
 
 .kf-dyn-positioned
-  position: absolute
   overflow: hidden
 
 .kf-keep-description-sizer

--- a/kifi-backend/modules/shoebox/angular-black/src/keep/keep.tpl.html
+++ b/kifi-backend/modules/shoebox/angular-black/src/keep/keep.tpl.html
@@ -15,6 +15,9 @@
         </a>
       </div>
       <div class="kf-keep-content-line">
+        <div class="kf-keep-small-image" ng-if="hasSmallImage()">
+          <a ng-href="{{keep.url}}" target="_blank"><img class="kf-keep-image" ng-src="{{keep.summary.imageUrl}}"></a>
+        </div>
         <div class="kf-keep-info-wrap">
           <div class="kf-keep-info">
             <div class="kf-keep-subtitle">
@@ -25,9 +28,6 @@
               {{keep.summary.description}}
             </div>
           </div>
-        </div>
-        <div class="kf-keep-small-image" ng-if="hasSmallImage()">
-          <a ng-href="{{keep.url}}" target="_blank"><img class="kf-keep-image" ng-src="{{keep.summary.imageUrl}}"></a>
         </div>
       </div>
       <a ng-href="{{keep.url}}" target="_blank"><img class="kf-keep-big-image" ng-if="hasBigImage()" ng-src="{{keep.summary.imageUrl}}"></a>


### PR DESCRIPTION
@andrewconner I noticed there were still some issues in the keep card layout (typically the text would overflow the keep card when there was no image at all). I got rid of the table layout - now the image is floating to the right and the description fills the remaining space.
