### PR TITLE
3.0.10: more reliable handling of replaced tabs

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -31,10 +31,28 @@ var api = (function createApi() {
     this.forEach(function(f) {f.apply(null, args)});
   }
 
+  var gcPagesLastRun = Date.now();
+  function gcPages(now) {
+    for (var id in pages) {
+      if (!(id in normalTab)) {
+        var page = pages[id];
+        if (now - page.created > 300000) {
+          log('#666', '[gcPages]', page);
+          delete pages[id];
+        }
+      }
+    }
+  }
+
   function createPage(id, url, skipOnLoading) {
-    var page = pages[id] = {id: id, url: url};
+    var now = Date.now();
+    var page = pages[id] = {id: id, url: url, created: now};
     if (!skipOnLoading && httpRe.test(url)) {
       dispatch.call(api.tabs.on.loading, page);
+    }
+    if (now - gcPagesLastRun > 300000) {
+      gcPagesLastRun = now;
+      gcPages(now);
     }
     return page;
   }

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.0.9
+version=3.0.10


### PR DESCRIPTION
worth knowing:
- things that can happen in a preloading page (before `onReplaced`):
  - `chrome.webNavigation` events fire (e.g. `onCommitted`, `onDOMContentLoaded`)
  - content scripts from the manifest get injected
  - content scripts can open ports and send/receive messages
- things that cannot happen in a preloading page
  - use `chrome.tabs` APIs, including `executeScript` and `insertCSS`
  - use `chrome.pageAction`
