### PR TITLE
only return active collections in pageDetails

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
@@ -62,7 +62,7 @@ class PageCommander @Inject() (
       val tags: Seq[Collection] = keep.map { bm =>
         keepToCollectionRepo.getCollectionsForKeep(bm.id.get).map { collId =>
           collectionRepo.get(collId)
-        }
+        } filter (_.isActive)
       }.getOrElse(Seq())
 
       val host: Option[String] = URI.parse(nUriStr).get.host.map(_.name)


### PR DESCRIPTION
@andrewconner @eishay 

We should require both the `keep_to_collection` and the `collection` rows to be `active` in order for a keep tag to be considered in effect.
