### PR TITLE
add back click_search_result tracking on new site

### DIFF
--- a/kifi-backend/modules/shoebox/angular-black/src/keeps/keeps.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/keeps/keeps.js
@@ -71,6 +71,8 @@ angular.module('kifi.keeps', ['kifi.profileService', 'kifi.keepService'])
             }
             scope.editMode.enabled = true;
             scope.toggleSelect(keep);
+          } else if (event.target.href && scope.keepClick) {
+            scope.keepClick(keep, event);
           }
         };
 


### PR DESCRIPTION
Looks like this bit got lost during the site re-write. Adding back.

@martinraison @stkem @eishay 
