### PR TITLE
redirecting 42go.com to new marketing pages + allow ".html"-less routes

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/inject/ConfigurationModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/inject/ConfigurationModule.scala
@@ -31,10 +31,10 @@ trait ConfigurationModule extends AbstractModuleAccessor with Logging {
 }
 
 trait CommonServiceModule {
-  val fortyTwoModule: FortyTwoModule
   val actorSystemModule: ActorSystemModule
   val discoveryModule: DiscoveryModule
 
+  val fortyTwoModule = FortyTwoModule()
   val cryptoModule = ShoeboxCryptoModule()
   val healthCheckModule = ProdHealthCheckModule()
   val httpClientModule = ProdHttpClientModule()
@@ -43,8 +43,6 @@ trait CommonServiceModule {
 }
 
 trait CommonProdModule extends CommonServiceModule {
-  val fortyTwoModule = ProdFortyTwoModule()
-
   val actorSystemModule = ProdActorSystemModule()
 
   val airbrakeModule = ProdAirbrakeModule()
@@ -52,8 +50,6 @@ trait CommonProdModule extends CommonServiceModule {
 }
 
 trait CommonDevModule extends CommonServiceModule {
-  val fortyTwoModule = ProdFortyTwoModule()
-
   val actorSystemModule = DevActorSystemModule()
   val discoveryModule = DevDiscoveryModule()
 

--- a/kifi-backend/modules/common/app/com/keepit/inject/ProdFortyTwoModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/inject/ProdFortyTwoModule.scala
@@ -12,7 +12,7 @@ case class FortyTwoConfig(
   applicationName: String,
   applicationBaseUrl: String)
 
-trait FortyTwoModule extends ScalaModule {
+case class FortyTwoModule() extends ScalaModule {
 
   def configure(): Unit = {
     val appScope = new AppScope
@@ -22,9 +22,6 @@ trait FortyTwoModule extends ScalaModule {
       def get(): play.api.Application = current
     }).in(classOf[AppScoped])
   }
-}
-
-case class ProdFortyTwoModule() extends FortyTwoModule {
 
   @Provides @Singleton
   def fortyTwoServices(clock: Clock, fortytwoConfig: FortyTwoConfig): FortyTwoServices =

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/AboutAssets.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/AboutAssets.scala
@@ -1,6 +1,31 @@
 package com.keepit.controllers.website
 
 import controllers.AssetsBuilder
-import play.api.mvc.Controller
+import play.api.mvc.{AnyContent, Action, Controller}
+import scala.concurrent.Future
+import com.google.inject.Inject
+import com.keepit.inject.FortyTwoConfig
 
-object AboutAssets extends AssetsBuilder with Controller
+class AboutAssets @Inject() (applicationConfig: FortyTwoConfig) extends AssetsBuilder with Controller {
+
+  val OLD_SITE_REDIRECT_MAP = Map(
+    "index.html" -> "mission.html",
+    "team.html" -> "team.html",
+    "culture.html" -> "culture.html",
+    "investors.html" -> "investors.html",
+    "join_us.html" -> "join_us.html")
+
+  override def at(path: String, file: String): Action[AnyContent] = Action.async { request =>
+    if (request.domain.contains("42go")) {
+      Future.successful(OLD_SITE_REDIRECT_MAP.get(file) map { redirectFile =>
+        MovedPermanently(applicationConfig.applicationBaseUrl + "/about/" + redirectFile)
+      } getOrElse NotFound)
+    } else if (path == "/public/about_us") {
+      val extension = ".html"
+      val fileWithExtension = if (!file.endsWith(extension) && !file.contains("/") && !file.contains(".")) {
+        file + extension
+      } else file
+      super.at(path, fileWithExtension).apply(request)
+    } else Future.successful(NotFound)
+  }
+}

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -677,6 +677,16 @@ GET     /ng                        com.keepit.controllers.website.AngularDistAss
 GET     /dist/*file                com.keepit.controllers.website.AngularDistAssets.at(path="/angular/dist", file)
 GET     /img/*file                 com.keepit.controllers.website.AngularImgAssets.at(path="/angular/img", file)
 
-GET     /about/*file               com.keepit.controllers.website.AboutAssets.at(path="/public/about_us", file)
+##########################################
+# Marketing site
+##########################################
+GET     /about/*file               @com.keepit.controllers.website.AboutAssets.at(path="/public/about_us", file)
+
+# Redirects for the old marketing site
+GET     /index.html                @com.keepit.controllers.website.AboutAssets.at(path="/", file="index.html")
+GET     /team.html                 @com.keepit.controllers.website.AboutAssets.at(path="/", file="team.html")
+GET     /culture.html              @com.keepit.controllers.website.AboutAssets.at(path="/", file="culture.html")
+GET     /investors.html            @com.keepit.controllers.website.AboutAssets.at(path="/", file="investors.html")
+GET     /join_us.html              @com.keepit.controllers.website.AboutAssets.at(path="/", file="join_us.html")
 
 ->  / common.Routes


### PR DESCRIPTION
@stkem @eishay Once this is in production I can point 42go.com to shoebox instead of b01
