### PR TITLE
use a better index in KeepRepo.getByUriAndUser

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
@@ -124,7 +124,7 @@ class KeepRepoImpl @Inject() (
 
   def getByUriAndUser(uriId: Id[NormalizedURI], userId: Id[User])(implicit session: RSession): Option[Keep] =
     bookmarkUriUserCache.getOrElseOpt(KeepUriUserKey(uriId, userId)) {
-      val bookmarks = (for(b <- rows if b.uriId === uriId && b.userId === userId && b.state === KeepStates.ACTIVE) yield b).list
+      val bookmarks = (for(b <- rows if b.uriId === uriId && b.userId === userId && b.isPrimary === true && b.state === KeepStates.ACTIVE) yield b).list
       assert(bookmarks.length <= 1, s"${bookmarks.length} bookmarks found for (uri, user) pair ${(uriId, userId)}")
       bookmarks.headOption
     }


### PR DESCRIPTION
@eishay @raymondng 

getByUriAndUser was using the index bookmark_f_uri which is defined on keep(uri_id), and the execution plan was an index range scan and post-filtered by user_id and state. The issue is that this query can get slower for popular pages.

We have a better index user_id_primary_uri_id which is defined on keep(user_id, is_primary, uri_id). Since is_primary should be true when state is active, we can include an additional condition, is_primary = true, without changing the result and let MySQL choose user_id_primary_uri_id.
