### PR TITLE
3.0.13: first extension release containing the guide (experiment protected)

### DIFF
--- a/kifi-backend/modules/shoebox/angular-black/src/layout/rightCol/rightCol.tpl.html
+++ b/kifi-backend/modules/shoebox/angular-black/src/layout/rightCol/rightCol.tpl.html
@@ -28,7 +28,7 @@
 
     <h2 class="kf-footer-header">Essentials</h2>
     <ul class="kf-footer-essentials-list about-kifi">
-      <li kf-min-version="3.1" min-canary="3.0.8" class="start-guide">
+      <li kf-min-version="3.0.13" min-canary="3.0.8" class="start-guide">
         <a class="kf-footer-item-link kifi-tutorial" href="javascript:" ng-click="triggerGuide()">
           <span class="sprite sprite-guide-icon"></span>Kifi Step-by-step guide
         </a>

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.0.12
+version=3.0.13


### PR DESCRIPTION
@martinraison  We’ll want to increase `kf-min-version` again when we move angular-black to www.kifi.com.
