### PR TITLE
tracking clicks on link to start guide

### DIFF
--- a/kifi-backend/modules/shoebox/angular-black/src/common/services/mixpanelService.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/common/services/mixpanelService.js
@@ -19,10 +19,12 @@
     var locations = {
       yourKeeps: /^\/$/,
       yourFriends: /^\/friends$/,
-      tagResults: /^\/tag/,
-      searchResults: /^\/find/,
-      addFriends: /^\/friends\/(invite|find)$/,
-      requests: /^\/friends\/requests$/
+      tagResults: /^\/tag\//,
+      searchResults: /^\/find\b/,
+      addFriends: /^\/invite$/,
+      requests: /^\/friends\/requests$/,
+      helpRankClicks: /^\/helprank\/clicks?$/,
+      helpRankReKeeps: /^\/helprank\/rekeeps?$/
     };
 
     function getLocation(path) {
@@ -94,20 +96,22 @@
       $analyticsProvider.registerPageTrack(function (path) {
         if (profileService && $window) {
           var mixpanel = $window.mixpanel;
-          var normalizedPath = getLocation(path);
           var origin = $window.location.origin;
-          pageTrackForVisitor(mixpanel, normalizedPath, origin);
-          pageTrackForUser(mixpanel, normalizedPath, origin);
+          pageTrackForVisitor(mixpanel, path, origin);
+          pageTrackForUser(mixpanel, path, origin);
         }
       });
     });
 
     angulartics.waitForVendorApi('mixpanel', 5000, function (/*mixpanel*/) {
-      $analyticsProvider.registerEventTrack(function (action, properties) {
+      $analyticsProvider.registerEventTrack(function (action, props) {
         if ($window) {
-          var mixpanel = $window.mixpanel;
-          $log.log('mixpanelService.eventTrack(' + action + ')', properties);
-          mixpanel.track(action, properties);
+          if ('path' in props && !props.type) {
+            props.type = getLocation(props.path);
+            delete props.path;
+          }
+          $log.log('mixpanelService.eventTrack(' + action + ')', props);
+          $window.mixpanel.track(action, props);
         }
       });
     });

--- a/kifi-backend/modules/shoebox/angular-black/src/friends/friendService.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/friends/friendService.js
@@ -6,8 +6,8 @@ angular.module('kifi.friendService', [
 ])
 
 .factory('friendService', [
-  '$http', 'env', '$q', 'routeService', '$analytics', 'Clutch', 'util',
-  function ($http, env, $q, routeService, $analytics, Clutch, util) {
+  '$http', 'env', '$q', 'routeService', '$analytics', '$location', 'Clutch', 'util',
+  function ($http, env, $q, routeService, $analytics, $location, Clutch, util) {
     /* Naming convention:
      *  - Kifi Friend is an existing connection on Kifi
      *  - Kifi User is a user of Kifi, may not be a friend.
@@ -79,7 +79,8 @@ angular.module('kifi.friendService', [
           kifiFriendsService.expireAll();
           api.getKifiFriends();
           $analytics.eventTrack('user_clicked_page', {
-            'action': 'hideFriendInSearch'
+            'action': 'hideFriendInSearch',
+            'path': $location.path()
           });
         });
       },
@@ -89,7 +90,8 @@ angular.module('kifi.friendService', [
           kifiFriendsService.expireAll();
           api.getKifiFriends();
           $analytics.eventTrack('user_clicked_page', {
-            'action': 'unHideFriendInSearch'
+            'action': 'unHideFriendInSearch',
+            'path': $location.path()
           });
         });
       },
@@ -101,7 +103,8 @@ angular.module('kifi.friendService', [
           api.getRequests();
           api.getKifiFriends();
           $analytics.eventTrack('user_clicked_page', {
-            'action': 'acceptRequest'
+            'action': 'acceptRequest',
+            'path': $location.path()
           });
         });
       },
@@ -111,7 +114,8 @@ angular.module('kifi.friendService', [
           kifiFriendsService.expireAll();
           api.getRequests();
           $analytics.eventTrack('user_clicked_page', {
-            'action': 'ignoreRequest'
+            'action': 'ignoreRequest',
+            'path': $location.path()
           });
         });
       },
@@ -121,7 +125,8 @@ angular.module('kifi.friendService', [
           kifiFriendsService.expireAll();
           api.getKifiFriends();
           $analytics.eventTrack('user_clicked_page', {
-            'action': 'unFriend'
+            'action': 'unFriend',
+            'path': $location.path()
           });
         });
       },

--- a/kifi-backend/modules/shoebox/angular-black/src/invite/inviteService.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/invite/inviteService.js
@@ -7,8 +7,8 @@ angular.module('kifi.inviteService', [
 ])
 
 .factory('inviteService', [
-  '$http', 'env', '$q', 'routeService', 'util', 'Clutch', '$window', '$log', '$analytics', '$FB',
-  function ($http, env, $q, routeService, util, Clutch, $window, $log, $analytics, $FB) {
+  '$http', 'env', '$q', 'routeService', 'util', 'Clutch', '$window', '$log', '$analytics', '$location', '$FB',
+  function ($http, env, $q, routeService, util, Clutch, $window, $log, $analytics, $location, $FB) {
     /* Naming convention:
      *  - Kifi Friend is an existing connection on Kifi
      *  - Kifi User is a user of Kifi, may not be a friend.
@@ -29,7 +29,8 @@ angular.module('kifi.inviteService', [
         var results = res.data;
         _.forEach(results, augmentSocialResult);
         $analytics.eventTrack('user_clicked_page', {
-          'action': 'searchContacts'
+          'action': 'searchContacts',
+          'path': $location.path()
         });
         return results;
       });
@@ -124,7 +125,8 @@ angular.module('kifi.inviteService', [
           }).then(function (res) {
             $analytics.eventTrack('user_clicked_page', {
               'action': 'inviteFriend',
-              'platform': platform
+              'platform': platform,
+              'path': $location.path()
             });
             if (res.data.url && platform === 'facebook') {
               $FB.ui({

--- a/kifi-backend/modules/shoebox/angular-black/src/keeps/keepService.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/keeps/keepService.js
@@ -162,7 +162,8 @@ angular.module('kifi.keepService', [
         });
         _.forEach(keeps, buildKeep);
         $analytics.eventTrack('user_clicked_page', {
-          'action': 'keep'
+          'action': 'keep',
+          'path': $location.path()
         });
         prependKeeps(keeps);
         return res.data;
@@ -251,7 +252,7 @@ angular.module('kifi.keepService', [
       list: list,
 
       buildKeep: buildKeep,
-      
+
       lastSearchContext: function () {
       return lastSearchContext;
       },
@@ -510,7 +511,8 @@ angular.module('kifi.keepService', [
           }
 
           $analytics.eventTrack('user_clicked_page', {
-            'action': 'unkeep'
+            'action': 'unkeep',
+            'path': $location.path()
           });
           return keeps;
         });
@@ -591,7 +593,8 @@ angular.module('kifi.keepService', [
           $analytics.eventTrack('user_clicked_page', {
             'action': 'searchKifi',
             'hits': hits.size,
-            'mayHaveMore': resData.mayHaveMore
+            'mayHaveMore': resData.mayHaveMore,
+            'path': $location.path()
           });
 
           _.forEach(hits, processHit);

--- a/kifi-backend/modules/shoebox/angular-black/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/layout/main/MainCtrl.js
@@ -108,7 +108,7 @@ angular.module('kifi.layout.main', [
       var fileInput = $rootElement.find('.bookmark-file-upload');
       fileInput.replaceWith(fileInput = fileInput.clone(true));
     }
-    
+
     function initAddKeep() {
       $scope.modal = 'add_keeps';
       $scope.data.initAddKeeps = true;
@@ -155,15 +155,10 @@ angular.module('kifi.layout.main', [
         return;
       }
 
-      var analyticsData = {
-        'type': 'bookmarkImport'
-      };
-      if (makePublic) {
-        analyticsData.action = 'ImportPublic';
-      } else {
-        analyticsData.action = 'ImportPrivate';
-      }
-      $analytics.eventTrack('user_clicked_page', analyticsData);
+      $analytics.eventTrack('user_clicked_page', {
+        'type': 'bookmarkImport',
+        'action': makePublic ? 'ImportPublic' : 'ImportPrivate'
+      });
 
       var event = $scope.msgEvent && $scope.msgEvent.origin && $scope.msgEvent.source && $scope.msgEvent;
       var message = 'import_bookmarks';
@@ -214,16 +209,11 @@ angular.module('kifi.layout.main', [
         var file = $file && $file[0] && $file[0].files && $file[0].files[0];
         if (file) {
           $scope.disableBookmarkImport = true;
-              
-          var analyticsData = {
-            'type': '3rdPartyImport'
-          };
-          if (makePublic) {
-            analyticsData.action = 'ImportPublic';
-          } else {
-            analyticsData.action = 'ImportPrivate';
-          }
-          $analytics.eventTrack('user_clicked_page', analyticsData);
+
+          $analytics.eventTrack('user_clicked_page', {
+            'type': '3rdPartyImport',
+            'action': makePublic ? 'ImportPublic' : 'ImportPrivate'
+          });
 
           var tooSlowTimer = $timeout(function () {
             $scope.importFileStatus = 'Your bookmarks are still uploading... Hang tight.';

--- a/kifi-backend/modules/shoebox/angular-black/src/layout/rightCol/RightColCtrl.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/layout/rightCol/RightColCtrl.js
@@ -31,6 +31,7 @@ angular.module('kifi.layout.rightCol', ['kifi.modal'])
     $scope.yesLikeHelpRank = function () {
       $scope.data.showHelpRankHelp = false;
       $analytics.eventTrack('user_clicked_page', {
+        'type': 'HelpRankHelp',
         'action': 'yesLikeHelpRank'
       });
     };
@@ -38,27 +39,22 @@ angular.module('kifi.layout.rightCol', ['kifi.modal'])
     $scope.noLikeHelpRank = function () {
       $scope.data.showHelpRankHelp = false;
       $analytics.eventTrack('user_clicked_page', {
+        'type': 'HelpRankHelp',
         'action': 'noLikeHelpRank'
       });
     };
 
-    $scope.showClicks = function() {
-      $location.path('/helprank/click');
+    $scope.trackClickOnClicks = function() {
       $analytics.eventTrack('user_clicked_page', {
-        'action': 'helpRankClicks'
-      });
-      $analytics.eventTrack('user_viewed_page', {
-        'action': 'helpRankClicks'
+        'action': 'helpRankClicks',
+        'path': $location.path()
       });
     };
 
-    $scope.showReKeeps = function() {
-      $location.path('/helprank/rekeep');
+    $scope.trackClickOnReKeeps = function() {
       $analytics.eventTrack('user_clicked_page', {
-        'action': 'helpRankReKeeps'
-      });
-      $analytics.eventTrack('user_viewed_page', {
-        'action': 'helpRankReKeeps'
+        'action': 'helpRankReKeeps',
+        'path': $location.path()
       });
     };
 
@@ -80,7 +76,7 @@ angular.module('kifi.layout.rightCol', ['kifi.modal'])
       });
     };
 
-    $scope.triggerGuide = function () {
+    $scope.triggerGuide = function (linkClicked) {
       $window.postMessage({
         type: 'start_guide',
         pages: [{
@@ -125,6 +121,12 @@ angular.module('kifi.layout.rightCol', ['kifi.modal'])
           matches: {title: [[0,5],[6,4]], url: [[25,5],[31,4]]}
         }]
       }, '*');
+      if (linkClicked) {
+        $analytics.eventTrack('user_clicked_page', {
+          'action': 'startGuide',
+          'path': $location.path()
+        });
+      }
       delete $window.document.documentElement.dataset.guide;
     };
     if ('guide' in $window.document.documentElement.dataset) {

--- a/kifi-backend/modules/shoebox/angular-black/src/layout/rightCol/rightCol.tpl.html
+++ b/kifi-backend/modules/shoebox/angular-black/src/layout/rightCol/rightCol.tpl.html
@@ -7,13 +7,13 @@
         <div class="kf-footer-help-rank-item">
           <span class="kf-footer-help-rank-number">{{me.clickCount}}</span>
           <span class="kf-footer-help-rank-description">
-            You've helped friends discover keeps <a class="kifi-footer-item-link" href="javascript:" ng-click="showClicks()">{{me.clickCount}} times</a> this month
+            You've helped friends discover keeps <a class="kifi-footer-item-link" href="/helprank/click" ng-click="trackClickOnClicks()">{{me.clickCount}} times</a> this month
           </span>
         </div>
         <div class="kf-footer-help-rank-item" ng-if="me.rekeepTotalCount > 0">
           <span class="kf-footer-help-rank-number">{{me.rekeepTotalCount}}</span>
           <span class="kf-footer-help-rank-description">
-            Your keeps have been rekept by others <a class="kifi-footer-item-link" href="javascript:" ng-click="showReKeeps()">{{me.rekeepTotalCount}} times</a>
+            Your keeps have been rekept by others <a class="kifi-footer-item-link" href="/helprank/rekeep" ng-click="trackClickOnReKeeps()">{{me.rekeepTotalCount}} times</a>
           </span>
         </div>
       </div>
@@ -29,7 +29,7 @@
     <h2 class="kf-footer-header">Essentials</h2>
     <ul class="kf-footer-essentials-list about-kifi">
       <li kf-min-version="3.0.13" min-canary="3.0.8" class="start-guide">
-        <a class="kf-footer-item-link kifi-tutorial" href="javascript:" ng-click="triggerGuide()">
+        <a class="kf-footer-item-link kifi-tutorial" href="javascript:" ng-click="triggerGuide(true)">
           <span class="sprite sprite-guide-icon"></span>Kifi Step-by-step guide
         </a>
       </li>

--- a/kifi-backend/modules/shoebox/angular-black/src/profile/profileImage.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/profile/profileImage.js
@@ -5,8 +5,8 @@ angular.module('kifi.profileImage', [
 ])
 
 .directive('kfProfileImage', [
-  '$document', '$timeout', '$compile', '$templateCache', '$window', '$q', '$http', 'env', 'profileService', '$analytics',
-  function ($document, $timeout, $compile, $templateCache, $window, $q, $http, env, profileService, $analytics) {
+  '$document', '$timeout', '$compile', '$templateCache', '$window', '$q', '$http', 'env', 'profileService', '$analytics', '$location',
+  function ($document, $timeout, $compile, $templateCache, $window, $q, $http, env, profileService, $analytics, $location) {
     return {
       restrict: 'A',
       replace: true,
@@ -249,7 +249,8 @@ angular.module('kifi.profileImage', [
                 scope.showImageUploadingModal.value = false;
                 scope.resetChooseImage();
                 $analytics.eventTrack('user_clicked_page', {
-                  'action': 'uploadImage'
+                  'action': 'uploadImage',
+                  'path': $location.path()
                 });
               }, imageUploadError);
             }, imageUploadError);

--- a/kifi-backend/modules/shoebox/angular-black/src/profile/profileService.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/profile/profileService.js
@@ -7,8 +7,8 @@ angular.module('kifi.profileService', [
 ])
 
 .factory('profileService', [
-  '$http', 'env', '$q', 'util', 'routeService', 'socialService', '$analytics', '$window', '$rootScope', 'Clutch',
-  function ($http, env, $q, util, routeService, socialService, $analytics, $window, $rootScope, Clutch) {
+  '$http', 'env', '$q', 'util', 'routeService', 'socialService', '$analytics', '$location', '$window', '$rootScope', 'Clutch',
+  function ($http, env, $q, util, routeService, socialService, $analytics, $location, $window, $rootScope, Clutch) {
 
     var me = {
       seqNum: 0
@@ -50,7 +50,8 @@ angular.module('kifi.profileService', [
     function postMe(data) {
       return $http.post(routeService.profileUrl, data).then(function (res) {
         $analytics.eventTrack('user_clicked_page', {
-          'action': 'updateProfile'
+          'action': 'updateProfile',
+          'path': $location.path()
         });
         return updateMe(res.data);
       });
@@ -193,7 +194,8 @@ angular.module('kifi.profileService', [
         newPassword: newPassword
       }).then(function () {
         $analytics.eventTrack('user_clicked_page', {
-          'action': 'changePassword'
+          'action': 'changePassword',
+          'path': $location.path()
         });
       });
     }

--- a/kifi-backend/modules/shoebox/angular-black/src/social/socialService.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/social/socialService.js
@@ -5,8 +5,8 @@ angular.module('kifi.socialService', [
 ])
 
 .factory('socialService', [
-  'routeService', '$http', 'util', '$rootScope', 'Clutch', '$window', '$q', '$analytics', '$timeout',
-  function (routeService, $http, util, $rootScope, Clutch, $window, $q, $analytics, $timeout) {
+  'routeService', '$http', 'util', '$rootScope', 'Clutch', '$window', '$q', '$analytics', '$location', '$timeout',
+  function (routeService, $http, util, $rootScope, Clutch, $window, $q, $analytics, $location, $timeout) {
 
     var networks = [],
         facebook = {},
@@ -127,21 +127,24 @@ angular.module('kifi.socialService', [
 
       connectFacebook: function () {
         $analytics.eventTrack('user_clicked_page', {
-          'action': 'connectFacebook'
+          'action': 'connectFacebook',
+          'path': $location.path()
         });
         $window.location.href = routeService.linkNetwork('facebook');
       },
 
       connectLinkedIn: function () {
         $analytics.eventTrack('user_clicked_page', {
-          'action': 'connectLinkedIn'
+          'action': 'connectLinkedIn',
+          'path': $location.path()
         });
         $window.location.href = routeService.linkNetwork('linkedin');
       },
 
       importGmail: function () {
         $analytics.eventTrack('user_clicked_page', {
-          'action': 'importGmail'
+          'action': 'importGmail',
+          'path': $location.path()
         });
         $window.location.href = routeService.importGmail();
       },
@@ -150,7 +153,8 @@ angular.module('kifi.socialService', [
         return $http.post(routeService.disconnectNetwork('facebook')).then(function (res) {
           util.replaceObjectInPlace(facebook, {});
           $analytics.eventTrack('user_clicked_page', {
-            'action': 'disconnectFacebook'
+            'action': 'disconnectFacebook',
+            'path': $location.path()
           });
           return res;
         });
@@ -160,7 +164,8 @@ angular.module('kifi.socialService', [
         return $http.post(routeService.disconnectNetwork('linkedin')).then(function (res) {
           util.replaceObjectInPlace(linkedin, {});
           $analytics.eventTrack('user_clicked_page', {
-            'action': 'disconnectLinkedin'
+            'action': 'disconnectLinkedin',
+            'path': $location.path()
           });
           return res;
         });

--- a/kifi-backend/modules/shoebox/angular-black/src/tags/tagService.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/tags/tagService.js
@@ -7,8 +7,8 @@ angular.module('kifi.tagService', [
 ])
 
 .factory('tagService', [
-  '$http', 'env', '$q', '$rootScope', 'undoService', 'routeService', '$analytics', 'util',
-  function ($http, env, $q, $rootScope, undoService, routeService, $analytics, util) {
+  '$http', 'env', '$q', '$rootScope', 'undoService', 'routeService', '$analytics', '$location', 'util',
+  function ($http, env, $q, $rootScope, undoService, routeService, $analytics, $location, util) {
     var allTags = [],
       list = [],
       tagsById = {},
@@ -42,10 +42,7 @@ angular.module('kifi.tagService', [
         collectionId: tag.id,
         keeps: keeps
       };
-      return $http.post(url, payload).then(function (res) {
-        $analytics.eventTrack('user_clicked_page', {
-          'action': 'addKeepsToTag'
-        });
+      var post = $http.post(url, payload).then(function (res) {
         if (res.data && res.data.addedToCollection) {
           keeps.forEach(function (keep) {
             if (!_.contains(_.pluck(keep.tagList, 'id'), tag.id)) {
@@ -56,6 +53,11 @@ angular.module('kifi.tagService', [
         }
         return res;
       });
+      $analytics.eventTrack('user_clicked_page', {
+        'action': 'addKeepsToTag',
+        'path': $location.path()
+      });
+      return post;
     }
 
     function persistOrdering() {
@@ -74,7 +76,8 @@ angular.module('kifi.tagService', [
       newSrcTag.id = srcTagId;
       persistOrdering();
       $analytics.eventTrack('user_clicked_page', {
-        'action': 'reorderTag'
+        'action': 'reorderTag',
+        'path': $location.path()
       });
     }
 
@@ -156,10 +159,7 @@ angular.module('kifi.tagService', [
 
       create: function (name) {
         var url = env.xhrBase + '/collections/create';
-        var payload = {
-          name: name
-        };
-        return $http.post(url, payload).then(function (res) {
+        var post = $http.post(url, {'name': name}).then(function (res) {
           var tag = res.data;
 
           tag.keeps = tag.keeps || 0;
@@ -169,17 +169,18 @@ angular.module('kifi.tagService', [
           api.refreshList();
 
           api.filterList('');
-
-          $analytics.eventTrack('user_clicked_page', {
-            'action': 'createTag'
-          });
           return tag;
         });
+        $analytics.eventTrack('user_clicked_page', {
+          'action': 'createTag',
+          'path': $location.path()
+        });
+        return post;
       },
 
       remove: function (tag) {
         var url = env.xhrBase + '/collections/' + tag.id + '/delete';
-        return $http.post(url).then(function () {
+        var post = $http.post(url).then(function () {
           var allIndex = indexById(allTags, tag.id);
           if (allIndex !== -1) {
             allTags.splice(allIndex, 1);
@@ -190,30 +191,34 @@ angular.module('kifi.tagService', [
             }
           }
           $rootScope.$emit('tags.remove', tag.id);
-          $analytics.eventTrack('user_clicked_page', {
-            'action': 'removeTag'
-          });
           undoService.add('Tag deleted.', function () {
             api.unremove(tag, allIndex);
           });
           return tag;
         });
+        $analytics.eventTrack('user_clicked_page', {
+          'action': 'removeTag',
+          'path': $location.path()
+        });
+        return post;
       },
 
       unremove: function (tag, index) {
         var url = env.xhrBase + '/collections/' + tag.id + '/undelete';
-        return $http.post(url).then(function () {
+        var post = $http.post(url).then(function () {
           if (index !== -1) {
             allTags.splice(index, 0, tag);
             api.refreshList();
           }
           $rootScope.$emit('tags.unremove', tag.id);
-          $analytics.eventTrack('user_clicked_page', {
-            'action': 'unremoveTag'
-          });
           persistOrdering();
           return tag;
         });
+        $analytics.eventTrack('user_clicked_page', {
+          'action': 'unremoveTag',
+          'path': $location.path()
+        });
+        return post;
       },
 
       getRemovedKeepsForTag: function (tagId) {
@@ -240,29 +245,33 @@ angular.module('kifi.tagService', [
         }
 
         var url = env.xhrBase + '/collections/' + tagId + '/update';
-        return $http.post(url, {
+        var post = $http.post(url, {
           name: name
         }).then(function (res) {
           var tag = res.data;
-          $analytics.eventTrack('user_clicked_page', {
-            'action': 'renameTag'
-          });
           return renameTag(tag.id, tag.name);
         });
+        $analytics.eventTrack('user_clicked_page', {
+          'action': 'renameTag',
+          'path': $location.path()
+        });
+        return post;
       },
 
       removeKeepsFromTag: function (tagId, keeps) {
         var url = env.xhrBase + '/collections/' + tagId + '/removeKeeps';
-        return $http.post(url, _.pluck(keeps, 'id')).then(function (res) {
+        var post = $http.post(url, _.pluck(keeps, 'id')).then(function (res) {
           updateKeepCount(tagId, -keeps.length);
           keeps.forEach(function (keep) {
             keep.removeTag(tagId);
           });
-          $analytics.eventTrack('user_clicked_page', {
-            'action': 'removeKeepsFromTag'
-          });
           return res;
         });
+        $analytics.eventTrack('user_clicked_page', {
+          'action': 'removeKeepsFromTag',
+          'path': $location.path()
+        });
+        return post;
       },
 
       addKeepsToTag: addKeepsToTag,


### PR DESCRIPTION
Also tracking which page each event occurs on. This used to be done on our pre-angular site, but was lost when we launched the original angular site.

We can’t do this automatically without modifying the angulartics source code, so I’m manually adding a `path` property for each event, then translating that to a `type` (page kind) when the event reaches our mixpanel code.

@martinraison @stkem 
