### PR TITLE
show Names rather than IPs

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/DiscoveryModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/DiscoveryModule.scala
@@ -36,7 +36,7 @@ object DiscoveryModule {
 
   val LOCAL_AMZN_INFO = AmazonInstanceInfo(AmazonInstanceId("i-f168c1a8"),
     localHostname = "localhost",
-    name = None,
+    name = Some("dev"),
     service = None,
     publicHostname = "localhost",
     localIp = IpAddress("127.0.0.1"),

--- a/kifi-backend/modules/shoebox/app/views/admin/adminClustersView.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/adminClustersView.scala.html
@@ -11,12 +11,13 @@
         <small style="float:right;"> Auto Refresh: <input type="checkbox" checked id="autoRefresh"> </small>
         <table class="table table-condensed table-striped">
             <thead>
-              <th>Type</th> <th>ZK Id</th> <th>IPs</th> <th>State</th> <th>Compiled At</th><th>Commit</th> <th>Type</th> <th>AWS Details</th>
+              <th>Type</th> <th>Name</th> <th>ZK Id</th> <th>IPs</th> <th>State</th> <th>Compiled At</th><th>Commit</th> <th>Type</th> <th>AWS Details</th>
             </thead>
             <tbody>
             @for(cmi <- data) {
                 <tr class="@(if (!(cmi.state.name=="up" || cmi.state.name=="backing_up")) "error" else "")" style="font-weight: @(if (cmi.isLeader) "bold" else "normal");">
                     <td>@cmi.serviceType.name</td>
+                    <td>@cmi.instanceInfo.name.getOrElse("")</td>
                     <td>@cmi.zkid</td>
                     <td>@cmi.instanceInfo.localIp / @cmi.instanceInfo.publicIp </td>
                     <td>@cmi.state.name</td>

--- a/kifi-backend/modules/shoebox/app/views/admin/indexer.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/indexer.scala.html
@@ -6,7 +6,8 @@
   <table class="table table-condensed table-striped">
     <thead>
       <th> ZK Id</th>
-      <th>IPs</th>
+      <th>Name</th>
+      <th>Shards</th>
       <th style="text-align:right;">Total ArticleIndex Size</th>
       <th style="text-align:right;">Total Index Size</th>
     </thead>
@@ -14,7 +15,8 @@
     @totalSizeInfos.map{ case (cmi, asz, sz) =>
       <tr>
         <td>@{cmi.map(_.zkid).getOrElse("")}</td>
-        <td>@{cmi.map(_.instanceInfo.localIp).getOrElse("")} / @{cmi.map(_.instanceInfo.publicIp).getOrElse("")}</td>
+        <td>@{cmi.map(i => i.instanceInfo.name.getOrElse(i.instanceInfo.localIp + " / " + i.instanceInfo.publicIp)).getOrElse("")}</td>
+        <td>@{cmi.map(i => i.instanceInfo.tags.get("ShardSpec").getOrElse("-")).getOrElse("-")}</td>
         <td style="text-align:right;">@{asz}</td>
         <td style="text-align:right;">@{sz}</td>
       </tr>
@@ -25,8 +27,8 @@
   <table class="table table-condensed table-striped">
     <thead>
       <th> ZK Id</th>
-      <th>IPs</th>
       <th>Name</th>
+      <th>Index Name</th>
       <th style="text-align:right;">Number of Docs</th>
       <th style="text-align:right;">Index Size</th>
       <th style="text-align:right;">Sequence#</th>
@@ -35,7 +37,7 @@
     @indexInfos.map{ case (cmi, indexInfo) =>
       <tr>
         <td>@{cmi.map(_.zkid).getOrElse("")}</td>
-        <td>@{cmi.map(_.instanceInfo.localIp).getOrElse("")} / @{cmi.map(_.instanceInfo.publicIp).getOrElse("")}</td>
+        <td>@{cmi.map(i => i.instanceInfo.name.getOrElse(i.instanceInfo.localIp + " / " + i.instanceInfo.publicIp)).getOrElse("")}</td>
         <td>@{indexInfo.name}</td>
         <td style="text-align:right;">@{"%1$,d" format indexInfo.numDocs}</td>
         <td style="text-align:right;">@{indexInfo.indexSize.getOrElse("NA")}</td>


### PR DESCRIPTION
@eishay 

Showing Names (like search-spot-1) rather than IP addresses and added shard spec in the Index Info page. 
Also added Names to the Cluster Overview page.
