### PR TITLE
Take out EmailParser from ContactsUpdaterActor

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/abook/ContactsUpdaterActor.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/ContactsUpdaterActor.scala
@@ -7,7 +7,7 @@ import com.keepit.model._
 import com.keepit.common.db.Id
 import scala.collection.mutable
 import com.keepit.abook.store.ABookRawInfoStore
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.{JsError, JsSuccess, JsValue, Json}
 import com.keepit.common.logging.{LogPrefix, Logging}
 import com.keepit.common.db.slick.Database
 import play.api.{Play, Plugin}
@@ -25,7 +25,7 @@ import com.keepit.common.performance._
 import scala.util.{Try, Failure, Success}
 import com.keepit.abook.typeahead.EContactABookTypeahead
 import com.keepit.shoebox.ShoeboxServiceClient
-import com.keepit.common.mail.{EmailAddress, EmailAddressParser}
+import com.keepit.common.mail.{EmailAddress}
 
 
 trait ContactsUpdaterPlugin extends Plugin {
@@ -81,7 +81,7 @@ class ContactsUpdater @Inject() (
     def trimOpt = o collect { case s:String if (s!= null && !s.trim.isEmpty) => s }
   }
 
-  private def mkName(name:Option[String], firstName:Option[String], lastName:Option[String], email:String) = name orElse (
+  private def mkName(name:Option[String], firstName:Option[String], lastName:Option[String]) = name orElse (
     (firstName, lastName) match {
       case (Some(f), Some(l)) => Some(s"$f $l")
       case (Some(f), None) => Some(f)
@@ -90,17 +90,16 @@ class ContactsUpdater @Inject() (
     }
     )
 
-  private def existingEmailSet(userId: Id[User], origin: ABookOriginType, abookInfo: ABookInfo) = timing(s"existingEmailSet($userId,$origin,$abookInfo)") {
+  private def existingEmailSet(userId: Id[User], origin: ABookOriginType, abookInfo: ABookInfo): mutable.TreeSet[EmailAddress] = timing(s"existingEmailSet($userId,$origin,$abookInfo)") {
     val existingContacts = db.readOnly(attempts = 2) { implicit s =>
         econtactRepo.getByUserId(userId) // optimistic; gc; h2-iter issue
     }
-    val existingEmailSet = new mutable.TreeSet[String] // todo: use parsed email
+    val existingEmailSet = new mutable.TreeSet[EmailAddress]
     for (e <- existingContacts) {
-      EmailAddressParser.parseOpt(e.email.address) match { // handle 'dirty' data
-        case Some(addr) =>
-          existingEmailSet += addr.toString
-        case None =>
-          log.warn(s"[upload($userId, $origin, ${abookInfo.id})] cannot parse existing email ${e.email} for contact ${e}") // move along
+      if (EmailAddress.isValid(e.email.address)) {
+        existingEmailSet += e.email
+      } else {
+        log.warn(s"[upload($userId, $origin, ${abookInfo.id})] invalid email ${e.email} for contact ${e}") // move along
       }
     }
     log.info(s"[upload($userId, $origin, ${abookInfo.id})] existing contacts(sz=${existingEmailSet.size}): ${existingEmailSet.mkString(",")}")
@@ -142,33 +141,28 @@ class ContactsUpdater @Inject() (
             g.foreach { contact =>
               val fName = (contact \ "firstName").asOpt[String] trimOpt
               val lName = (contact \ "lastName").asOpt[String] trimOpt
-              val emails = (contact \ "emails").validate[Seq[String]].fold(
-                valid = ( res => res),
-                invalid = ( e => {
-                  log.warn(s"[upload($userId,$origin)] Cannot parse $e")
-                  Seq.empty[String]
-                })
-              )
+              val emails = (contact \ "emails").asOpt[Seq[JsValue]].getOrElse(Seq.empty[JsValue]).foldLeft(Seq[EmailAddress]()) { case (validEmails, nextValue) =>
+                nextValue.validate[EmailAddress] match {
+                  case JsSuccess(validEmail, _) => validEmails :+ validEmail
+                  case JsError(errors) =>
+                    log.warn(s"[upload($userId,$origin)] Json parsing errors: $errors")
+                    validEmails
+                }
+              }
+
               emails.foreach { email =>
-                EmailAddressParser.parseOpt(email) match {
-                  case Some(addr) =>
-                    if (addr.host.domain.length <= 1) {
-                      log.warnP(s"$email domain=${addr.host.domain} not supported; discarded")
-                    } else if (existingEmails.contains(addr.toString)) {
-                      log.infoP(s"DUP $email; discarded")
-                    } else {
-                      val nameOpt = mkName((contact \ "name").asOpt[String] trimOpt, fName, lName, email)
-                      val e = EContact(userId = userId, email = addr, name = nameOpt, firstName = fName, lastName = lName)
-                      existingEmails += addr.toString
-                      econtactsToAddBuilder += e
-                    }
-                  case None =>
-                    log.warnP(s"cannot parse $email; discarded") // todo: revisit
+                if (existingEmails.contains(email)) {
+                  log.infoP(s"DUP $email; discarded")
+                } else {
+                  val nameOpt = mkName((contact \ "name").asOpt[String] trimOpt, fName, lName)
+                  val e = EContact(userId = userId, email = email, name = nameOpt, firstName = fName, lastName = lName)
+                  existingEmails += email
+                  econtactsToAddBuilder += e
                 }
               }
 
               for (email <- emails.headOption) {
-                val nameOpt = mkName((contact \ "name").asOpt[String] trimOpt, fName, lName, email)
+                val nameOpt = mkName((contact \ "name").asOpt[String] trimOpt, fName, lName)
                 val c = Contact.newInstance(userId, abookInfo.id.get, email, emails.tail, origin, nameOpt, fName, lName, None)
                 log.debugP(s"$c")
                 cBuilder += c

--- a/kifi-backend/modules/common/app/com/keepit/model/Contact.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Contact.scala
@@ -8,6 +8,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import com.keepit.common.db.Id
 import com.keepit.common.logging.Logging
+import com.keepit.common.mail.EmailAddress
 
 case class Contact(
                     id: Option[Id[Contact]] = None,
@@ -15,7 +16,7 @@ case class Contact(
                     updatedAt: DateTime = currentDateTime,
                     userId: Id[User],
                     abookId: Id[ABookInfo],
-                    email: String,
+                    email: EmailAddress,
                     altEmails: Option[String] = None,
                     origin: ABookOriginType,
                     name: Option[String] = None,
@@ -29,7 +30,7 @@ case class Contact(
 }
 
 object Contact extends Logging {
-  def newInstance(userId:Id[User], abookId:Id[ABookInfo], email:String, altEmails:Seq[String], origin:ABookOriginType, name:Option[String], firstName:Option[String], lastName:Option[String], pictureUrl:Option[String]):Contact = {
+  def newInstance(userId:Id[User], abookId:Id[ABookInfo], email:EmailAddress, altEmails:Seq[EmailAddress], origin:ABookOriginType, name:Option[String], firstName:Option[String], lastName:Option[String], pictureUrl:Option[String]):Contact = {
     if (altEmails.isEmpty) {
       new Contact(userId = userId, abookId = abookId, email = email, origin = origin, name = name, firstName = firstName, lastName = lastName, pictureUrl = pictureUrl)
     } else {
@@ -42,7 +43,7 @@ object Contact extends Logging {
       (__ \ 'updatedAt).format[DateTime] and
       (__ \ 'userId).format(Id.format[User]) and
       (__ \ 'abookId).format(Id.format[ABookInfo]) and
-      (__ \ 'email).format[String] and
+      (__ \ 'email).format[EmailAddress] and
       (__ \ 'altEmails).formatNullable[String] and
       (__ \ 'origin).format[ABookOriginType] and
       (__ \ 'name).formatNullable[String] and


### PR DESCRIPTION
@eishay @raymondng @2is10 @ymatsuda 
I want to revisit these classes as I allow duplicate emails from different address books in EContact, but for now this ensures that no invalid email makes it to the table. I'll run the cleanup once this guard is in production.
