### PR TITLE
Endpoints for operations on sets of keeps

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
@@ -102,10 +102,10 @@ class MobileBookmarksController @Inject() (
     val idsOpt = (request.body \ "ids").asOpt[Seq[ExternalId[Keep]]]
     idsOpt map { ids =>
       implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
-      val (deactivatedKeepInfos, errors) = bookmarksCommander.unkeepBatch(ids, request.userId).partition(_._2.isDefined)
+      val (successes, failures) = bookmarksCommander.unkeepBatch(ids, request.userId)
       Ok(Json.obj(
-        "removedKeeps" -> deactivatedKeepInfos.map(s => s._2.get),
-        "errors" -> errors.map(e => Json.obj("id" -> e._1, "error" -> "not_found"))
+        "removedKeeps" -> successes,
+        "errors" -> failures.map(id => Json.obj("id" -> id, "error" -> "not_found"))
       ))
     } getOrElse {
       BadRequest(Json.obj("error" -> "parse_error"))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
@@ -207,10 +207,10 @@ class KeepsController @Inject() (
     }
   }
 
-  def unkeepSet() = JsonAction.authenticatedParseJson { request =>
+  def unkeepBulk() = JsonAction.authenticatedParseJson { request =>
     Json.fromJson[BulkKeepSelection](request.body).asOpt map { keepSet =>
       implicit val context = heimdalContextBuilder.withRequestInfo(request).build
-      val deactivatedKeepInfos = bookmarksCommander.unkeepSet(keepSet, request.userId)
+      val deactivatedKeepInfos = bookmarksCommander.unkeepBulk(keepSet, request.userId)
       Ok(Json.obj(
         "removedKeeps" -> deactivatedKeepInfos
       ))
@@ -219,39 +219,39 @@ class KeepsController @Inject() (
     }
   }
 
-  def rekeepSet() = JsonAction.authenticatedParseJson { request =>
+  def rekeepBulk() = JsonAction.authenticatedParseJson { request =>
     Json.fromJson[BulkKeepSelection](request.body).asOpt map { keepSet =>
       implicit val context = heimdalContextBuilder.withRequestInfo(request).build
-      val numRekept = bookmarksCommander.rekeepSet(keepSet, request.userId)
+      val numRekept = bookmarksCommander.rekeepBulk(keepSet, request.userId)
       Ok(Json.obj("numRekept" -> numRekept))
     } getOrElse {
       BadRequest(Json.obj("error" -> "Could not parse JSON keep set from request body"))
     }
   }
 
-  def makeSetPublic() = JsonAction.authenticatedParseJson { request =>
-    setKeepSetPrivacy(request, false)
+  def makePublicBulk() = JsonAction.authenticatedParseJson { request =>
+    setKeepPrivacyBulk(request, false)
   }
 
-  def makeSetPrivate() = JsonAction.authenticatedParseJson { request =>
-    setKeepSetPrivacy(request, true)
+  def makePrivateBulk() = JsonAction.authenticatedParseJson { request =>
+    setKeepPrivacyBulk(request, true)
   }
 
-  private def setKeepSetPrivacy(request: AuthenticatedRequest[JsValue], isPrivate: Boolean) = {
+  private def setKeepPrivacyBulk(request: AuthenticatedRequest[JsValue], isPrivate: Boolean) = {
     Json.fromJson[BulkKeepSelection](request.body).asOpt map { keepSet =>
       implicit val context = heimdalContextBuilder.withRequestInfo(request).build
-      val numUpdated = bookmarksCommander.setKeepSetPrivacy(keepSet, request.userId, isPrivate)
+      val numUpdated = bookmarksCommander.setKeepPrivacyBulk(keepSet, request.userId, isPrivate)
       Ok(Json.obj("numUpdated" -> numUpdated))
     } getOrElse {
       BadRequest(Json.obj("error" -> "Could not parse JSON keep set from request body"))
     }
   }
 
-  def tagKeepSet() = JsonAction.authenticatedParseJson(editKeepSetTag(_, true))
+  def tagKeepBulk() = JsonAction.authenticatedParseJson(editKeepTagBulk(_, true))
 
-  def untagKeepSet() = JsonAction.authenticatedParseJson(editKeepSetTag(_, false))
+  def untagKeepBulk() = JsonAction.authenticatedParseJson(editKeepTagBulk(_, false))
 
-  private def editKeepSetTag(request: AuthenticatedRequest[JsValue], isAdd: Boolean) = {
+  private def editKeepTagBulk(request: AuthenticatedRequest[JsValue], isAdd: Boolean) = {
     val collectionId = (request.body \ "collectionId").asOpt[ExternalId[Collection]]
     val keepSet = (request.body \ "keeps").asOpt[BulkKeepSelection]
     val res = for {
@@ -259,7 +259,7 @@ class KeepsController @Inject() (
       keepSet <- (request.body \ "keeps").asOpt[BulkKeepSelection]
     } yield {
       implicit val context = heimdalContextBuilder.withRequestInfo(request).build
-      val numEdited = bookmarksCommander.editKeepSetTag(collectionId, keepSet, request.userId, isAdd)
+      val numEdited = bookmarksCommander.editKeepTagBulk(collectionId, keepSet, request.userId, isAdd)
       Ok(Json.obj("numEdited" -> numEdited))
     }
     res getOrElse BadRequest(Json.obj("error" -> "Could not parse keep set and/or collection id from request body"))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
@@ -208,7 +208,7 @@ class KeepsController @Inject() (
   }
 
   def unkeepSet() = JsonAction.authenticatedParseJson { request =>
-    Json.fromJson[KeepSet](request.body).asOpt map { keepSet =>
+    Json.fromJson[BulkKeepSelection](request.body).asOpt map { keepSet =>
       implicit val context = heimdalContextBuilder.withRequestInfo(request).build
       val deactivatedKeepInfos = bookmarksCommander.unkeepSet(keepSet, request.userId)
       Ok(Json.obj(
@@ -220,7 +220,7 @@ class KeepsController @Inject() (
   }
 
   def rekeepSet() = JsonAction.authenticatedParseJson { request =>
-    Json.fromJson[KeepSet](request.body).asOpt map { keepSet =>
+    Json.fromJson[BulkKeepSelection](request.body).asOpt map { keepSet =>
       implicit val context = heimdalContextBuilder.withRequestInfo(request).build
       val numRekept = bookmarksCommander.rekeepSet(keepSet, request.userId)
       Ok(Json.obj("numRekept" -> numRekept))
@@ -238,7 +238,7 @@ class KeepsController @Inject() (
   }
 
   private def setKeepSetPrivacy(request: AuthenticatedRequest[JsValue], isPrivate: Boolean) = {
-    Json.fromJson[KeepSet](request.body).asOpt map { keepSet =>
+    Json.fromJson[BulkKeepSelection](request.body).asOpt map { keepSet =>
       implicit val context = heimdalContextBuilder.withRequestInfo(request).build
       val numUpdated = bookmarksCommander.setKeepSetPrivacy(keepSet, request.userId, isPrivate)
       Ok(Json.obj("numUpdated" -> numUpdated))
@@ -253,10 +253,10 @@ class KeepsController @Inject() (
 
   private def editKeepSetTag(request: AuthenticatedRequest[JsValue], isAdd: Boolean) = {
     val collectionId = (request.body \ "collectionId").asOpt[ExternalId[Collection]]
-    val keepSet = (request.body \ "keeps").asOpt[KeepSet]
+    val keepSet = (request.body \ "keeps").asOpt[BulkKeepSelection]
     val res = for {
       collectionId <- (request.body \ "collectionId").asOpt[ExternalId[Collection]]
-      keepSet <- (request.body \ "keeps").asOpt[KeepSet]
+      keepSet <- (request.body \ "keeps").asOpt[BulkKeepSelection]
     } yield {
       implicit val context = heimdalContextBuilder.withRequestInfo(request).build
       val numEdited = bookmarksCommander.editKeepSetTag(collectionId, keepSet, request.userId, isAdd)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
@@ -215,7 +215,7 @@ class KeepsController @Inject() (
         "removedKeeps" -> deactivatedKeepInfos
       ))
     } getOrElse {
-      BadRequest(Json.obj("error" -> "Could not parse JSON keep set from request body"))
+      BadRequest(Json.obj("error" -> "Could not parse JSON keep selection from request body"))
     }
   }
 
@@ -225,7 +225,7 @@ class KeepsController @Inject() (
       val numRekept = bookmarksCommander.rekeepBulk(keepSet, request.userId)
       Ok(Json.obj("numRekept" -> numRekept))
     } getOrElse {
-      BadRequest(Json.obj("error" -> "Could not parse JSON keep set from request body"))
+      BadRequest(Json.obj("error" -> "Could not parse JSON keep selection from request body"))
     }
   }
 
@@ -243,7 +243,7 @@ class KeepsController @Inject() (
       val numUpdated = bookmarksCommander.setKeepPrivacyBulk(keepSet, request.userId, isPrivate)
       Ok(Json.obj("numUpdated" -> numUpdated))
     } getOrElse {
-      BadRequest(Json.obj("error" -> "Could not parse JSON keep set from request body"))
+      BadRequest(Json.obj("error" -> "Could not parse JSON keep selection from request body"))
     }
   }
 
@@ -252,8 +252,6 @@ class KeepsController @Inject() (
   def untagKeepBulk() = JsonAction.authenticatedParseJson(editKeepTagBulk(_, false))
 
   private def editKeepTagBulk(request: AuthenticatedRequest[JsValue], isAdd: Boolean) = {
-    val collectionId = (request.body \ "collectionId").asOpt[ExternalId[Collection]]
-    val keepSet = (request.body \ "keeps").asOpt[BulkKeepSelection]
     val res = for {
       collectionId <- (request.body \ "collectionId").asOpt[ExternalId[Collection]]
       keepSet <- (request.body \ "keeps").asOpt[BulkKeepSelection]
@@ -262,7 +260,7 @@ class KeepsController @Inject() (
       val numEdited = bookmarksCommander.editKeepTagBulk(collectionId, keepSet, request.userId, isAdd)
       Ok(Json.obj("numEdited" -> numEdited))
     }
-    res getOrElse BadRequest(Json.obj("error" -> "Could not parse keep set and/or collection id from request body"))
+    res getOrElse BadRequest(Json.obj("error" -> "Could not parse keep selection and/or collection id from request body"))
   }
 
   def getKeepInfo(id: ExternalId[Keep], withFullInfo: Boolean) = JsonAction.authenticatedAsync { request =>

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -240,12 +240,12 @@ POST    /site/keeps/screenshot      @com.keepit.controllers.website.KeepsControl
 POST    /site/keeps/imageUrl        @com.keepit.controllers.website.KeepsController.getImageUrl()
 POST    /site/keeps/imageUrls       @com.keepit.controllers.website.KeepsController.getImageUrls()
 
-POST    /site/keeps/unkeep          @com.keepit.controllers.website.KeepsController.unkeepSet()
-POST    /site/keeps/rekeep          @com.keepit.controllers.website.KeepsController.rekeepSet()
-POST    /site/keeps/public          @com.keepit.controllers.website.KeepsController.makeSetPublic()
-POST    /site/keeps/private         @com.keepit.controllers.website.KeepsController.makeSetPrivate()
-POST    /site/keeps/tag             @com.keepit.controllers.website.KeepsController.tagKeepSet()
-POST    /site/keeps/untag           @com.keepit.controllers.website.KeepsController.untagKeepSet()
+POST    /site/keeps/unkeep          @com.keepit.controllers.website.KeepsController.unkeepBulk()
+POST    /site/keeps/rekeep          @com.keepit.controllers.website.KeepsController.rekeepBulk()
+POST    /site/keeps/public          @com.keepit.controllers.website.KeepsController.makePublicBulk()
+POST    /site/keeps/private         @com.keepit.controllers.website.KeepsController.makePrivateBulk()
+POST    /site/keeps/tag             @com.keepit.controllers.website.KeepsController.tagKeepBulk()
+POST    /site/keeps/untag           @com.keepit.controllers.website.KeepsController.untagKeepBulk()
 
 GET     /site/collections/all       @com.keepit.controllers.website.KeepsController.allCollections(sort: String ?= "last_kept")
 POST    /site/collections/ordering  @com.keepit.controllers.website.KeepsController.updateCollectionOrdering()

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -240,6 +240,13 @@ POST    /site/keeps/screenshot      @com.keepit.controllers.website.KeepsControl
 POST    /site/keeps/imageUrl        @com.keepit.controllers.website.KeepsController.getImageUrl()
 POST    /site/keeps/imageUrls       @com.keepit.controllers.website.KeepsController.getImageUrls()
 
+POST    /site/keeps/unkeep          @com.keepit.controllers.website.KeepsController.unkeepSet()
+POST    /site/keeps/rekeep          @com.keepit.controllers.website.KeepsController.rekeepSet()
+POST    /site/keeps/public          @com.keepit.controllers.website.KeepsController.makeSetPublic()
+POST    /site/keeps/private         @com.keepit.controllers.website.KeepsController.makeSetPrivate()
+POST    /site/keeps/tag             @com.keepit.controllers.website.KeepsController.tagKeepSet()
+POST    /site/keeps/untag           @com.keepit.controllers.website.KeepsController.untagKeepSet()
+
 GET     /site/collections/all       @com.keepit.controllers.website.KeepsController.allCollections(sort: String ?= "last_kept")
 POST    /site/collections/ordering  @com.keepit.controllers.website.KeepsController.updateCollectionOrdering()
 POST    /site/collections/create    @com.keepit.controllers.website.KeepsController.saveCollection(id = "")


### PR DESCRIPTION
@stkem @andrewconner the goal is to support operations on sets of keeps, such as "All keeps in tags A and B except keeps C, D and E". We should probably have a quick talk tomorrow before merging, because this can be quite database-intensive and we may need some additional optimizations/safeguards.
