### PR TITLE
Remove EContact from NonUserThread

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -8,7 +8,7 @@ import com.keepit.common.akka.{SafeFuture, TimeoutFuture}
 import com.keepit.common.db.{Id, ExternalId}
 import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
-import com.keepit.common.mail.{BasicContact, EmailAddress}
+import com.keepit.common.mail.{BasicContact}
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.time._
 import com.keepit.heimdal.HeimdalContext
@@ -186,8 +186,8 @@ class MessagingCommander @Inject() (
   private def constructNonUserRecipients(userId: Id[User], nonUsers: Seq[BasicContact]): Future[Seq[NonUserParticipant]] = {
     val pimpedParticipants = nonUsers.map { emailContact =>
       abookServiceClient.internContact(userId, emailContact).map {
-        case Success(eContact) => NonUserEmailParticipant(eContact.email, eContact.id)
-        case Failure(_) => NonUserEmailParticipant(emailContact.email, None)
+        case Success(eContact) => NonUserEmailParticipant(eContact.email) // todo(Léo) we may want to get a name here, otherwise don't really need to wait for this call
+        case Failure(_) => NonUserEmailParticipant(emailContact.email)
       }
     }
     Future.sequence(pimpedParticipants)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NonUserThread.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NonUserThread.scala
@@ -33,8 +33,7 @@ object NonUserParticipant {
       (json \ "k").validate[String].flatMap {
         case NonUserKinds.email.name => for {
           email <- (json \ "i").validate[EmailAddress]
-          eContact <- (json \ "r").validate[Option[Id[EContact]]]
-        } yield NonUserEmailParticipant(email, eContact)
+        } yield NonUserEmailParticipant(email)
         case unsupportedKind => JsError(s"Unsupported NonUserKind: $unsupportedKind")
       }
     }
@@ -49,9 +48,9 @@ object NonUserParticipant {
   }
 }
 
-case class NonUserEmailParticipant(address: EmailAddress, econtactId: Option[Id[EContact]]) extends NonUserParticipant {
+case class NonUserEmailParticipant(address: EmailAddress) extends NonUserParticipant {
   val identifier = address.address
-  val referenceId = econtactId.map(_.id.toString)
+  val referenceId = Some(address.address)
   val kind = NonUserKinds.email
 
   def shortName = identifier


### PR DESCRIPTION
@stkem @martinraison 
Making EmailAddress the default identifier to get stuff from ABook, I'm trying to get rid of EContact as a cross-service model, in favor of BasicContact.
