### PR TITLE
making sure tag order is consistent for any given keep

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToCollectionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToCollectionRepo.scala
@@ -62,7 +62,7 @@ class KeepToCollectionRepoImpl @Inject() (
   def getCollectionsForKeep(bookmarkId: Id[Keep])(implicit session: RSession): Seq[Id[Collection]] =
     collectionsForKeepCache.getOrElse(CollectionsForKeepKey(bookmarkId)) {
       (for (c <- rows if c.bookmarkId === bookmarkId && c.state === KeepToCollectionStates.ACTIVE)
-      yield c).sortBy(c => c.updatedAt).map(_.collectionId).list
+      yield c).sortBy(c => c.updatedAt).map(_.collectionId).list // todo(martin): we should add a column for explicit ordering of tags
     }
 
   def getKeepsInCollection(collectionId: Id[Collection])(implicit session: RSession): Seq[Id[Keep]] =

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToCollectionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToCollectionRepo.scala
@@ -62,7 +62,7 @@ class KeepToCollectionRepoImpl @Inject() (
   def getCollectionsForKeep(bookmarkId: Id[Keep])(implicit session: RSession): Seq[Id[Collection]] =
     collectionsForKeepCache.getOrElse(CollectionsForKeepKey(bookmarkId)) {
       (for (c <- rows if c.bookmarkId === bookmarkId && c.state === KeepToCollectionStates.ACTIVE)
-      yield c.collectionId).list
+      yield c).sortBy(c => c.updatedAt).map(_.collectionId).list
     }
 
   def getKeepsInCollection(collectionId: Id[Collection])(implicit session: RSession): Seq[Id[Keep]] =


### PR DESCRIPTION
@andrewconner @stkem Right now if you add a tag to a keep and then refresh, the keep you just added jumps from the last position to the first
