### PR TITLE
add index on seq column in image_info and page_info

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/187.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/187.sql
@@ -1,0 +1,8 @@
+# SHOEBOX
+
+# --- !Ups
+CREATE INDEX image_info_i_seq ON image_info(seq);
+CREATE INDEX page_info_i_seq ON page_info(seq);
+
+# --- !Downs
+


### PR DESCRIPTION
@eishay 

We may consider dropping seq columns from those two tables later. But I have a possible use cases for these. When Search decorates results, it fetches page info and image info from shoebox. Right now, this is very slow. If we cannot improve the performance, we may store them locally in Search instances. We need seq# to do that. So, I will keep them for now.
