### PR TITLE
enabling drag&drop on IE

### DIFF
--- a/kifi-backend/modules/shoebox/angular-black/src/tags/tagItem.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/tags/tagItem.js
@@ -153,7 +153,7 @@ angular.module('kifi.tagItem', ['kifi.tagService', 'kifi.dragService'])
 
         element.on('dragstart', function (e) {
           // Firefox requires data to be set
-          e.dataTransfer.setData('text/plain', '');
+          e.dataTransfer.setData('text', '');
           //e.dataTransfer.effectAllowed = 'none';
           scope.$apply(function () {
             if (!scope.watchTagReorder()) { return; }
@@ -177,7 +177,9 @@ angular.module('kifi.tagItem', ['kifi.tagService', 'kifi.dragService'])
               .addClass('kf-dragged-clone-mask');
             element.addClass('kf-dragged')
               .after(clone, cloneMask);
-            e.dataTransfer.setDragImage(clone[0], 0, 0);
+            if (typeof(e.dataTransfer.setDragImage) === 'function') {
+              e.dataTransfer.setDragImage(clone[0], 0, 0);
+            }
           });
         })
         .on('dragend', function (e) {

--- a/kifi-backend/modules/shoebox/angular-black/src/tags/tagItem.tpl.html
+++ b/kifi-backend/modules/shoebox/angular-black/src/tags/tagItem.tpl.html
@@ -11,7 +11,7 @@
         <div class="kf-tag-waiting" ng-show="isWaiting"></div>
       </div>
       <div class="kf-tag-tool kf-tag-dropdown-toggle" ng-click="toggleDropdown($event)"></div>
-      <div class="kf-tag-tool kf-tag-handle" ng-show="watchTagReorder()"></div>
+      <div class="kf-tag-tool kf-tag-handle" ng-if="watchTagReorder()"></div>
       <ul class="kf-dropdown-menu" ng-show="isDropdownOpen" ng-click="cancelNavigation($event)">
         <li>
           <a href="javascript:" ng-mousedown="setRenaming()">Rename</a>

--- a/kifi-backend/modules/shoebox/angular-black/src/tags/tags.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/tags/tags.js
@@ -292,7 +292,7 @@ angular.module('kifi.tags', ['util', 'dom', 'kifi.tagService', 'kifi.tagItem'])
         tagService.fetchAll();
 
         scope.watchTagReorder = function () {
-          return !util.isIE() && !getFilterValue();
+          return !getFilterValue();
         };
 
         scope.removeTag = function (tag) {

--- a/kifi-backend/modules/shoebox/angular-black/src/tags/tags.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/tags/tags.js
@@ -310,17 +310,14 @@ angular.module('kifi.tags', ['util', 'dom', 'kifi.tagService', 'kifi.tagItem'])
         };
 
         scope.disableClearFilter = function () {
-          console.log('disabling');
           preventClearFilter = true;
         };
 
         scope.enableClearFilter = function () {
-          console.log('enabling');
           preventClearFilter = false;
         };
 
         scope.blurFilter = function () {
-          console.log('blurring');
           scope.isFilterFocused = false;
           if (!preventClearFilter) {
             scope.dehighlight();

--- a/kifi-backend/modules/shoebox/angular-black/src/tags/tags.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/tags/tags.js
@@ -49,6 +49,7 @@ angular.module('kifi.tags', ['util', 'dom', 'kifi.tagService', 'kifi.tagItem'])
         };
         scope.filter = {};
 
+        var preventClearFilter = false;
         var w = angular.element($window);
         var scrollableTagList = element.find('.kf-scrollable-tags');
         var tagList = element.find('.kf-sidebar-tag-list');
@@ -308,10 +309,24 @@ angular.module('kifi.tags', ['util', 'dom', 'kifi.tagService', 'kifi.tagItem'])
           scope.isFilterFocused = true;
         };
 
+        scope.disableClearFilter = function () {
+          console.log('disabling');
+          preventClearFilter = true;
+        };
+
+        scope.enableClearFilter = function () {
+          console.log('enabling');
+          preventClearFilter = false;
+        };
+
         scope.blurFilter = function () {
+          console.log('blurring');
           scope.isFilterFocused = false;
-          scope.dehighlight();
-          scope.clearFilter();
+          if (!preventClearFilter) {
+            scope.dehighlight();
+            scope.clearFilter();
+          }
+
         };
 
         scope.createTag = function () {


### PR DESCRIPTION
@2is10 It turned out to be fairly straightforward. It looks like IE only accepts "url" or "text" for the data transfer types, and as you mentioned the setDragImage function is not available (so I'm just using the original drag image, which is reasonable in this case). Thanks for convincing me to take another look :)

@andrewconner 
