### PR TITLE
added getDefaultURISummary

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -204,14 +204,7 @@ class KeepsCommander @Inject() (
   }
 
   private def getKeepSummary(keep: Keep, waiting: Boolean = false): Future[URISummary] = {
-    val request = URISummaryRequest(
-      url = keep.url,
-      imageType = ImageType.ANY,
-      withDescription = true,
-      waiting = waiting,
-      silent = false
-    )
-    uriSummaryCommander.getURISummaryForRequest(request)
+    uriSummaryCommander.getDefaultURISummary(keep.uriId, waiting)
   }
 
   def allKeeps(

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/URISummaryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/URISummaryCommander.scala
@@ -1,5 +1,6 @@
 package com.keepit.commanders
 
+import com.keepit.common.cache.TransactionalCaching
 import com.keepit.common.logging.Logging
 import com.google.inject.Inject
 import scala.concurrent._
@@ -37,9 +38,27 @@ class URISummaryCommander @Inject()(
   embedlyStore: EmbedlyStore,
   articleStore: ArticleStore,
   imageFetcher: ImageFetcher,
+  uriSummaryCache: URISummaryCache,
   airbrake: AirbrakeNotifier,
   clock: Clock
 ) extends Logging {
+
+  /**
+   * Gets the default URI Summary
+   */
+  def getDefaultURISummary(uriId: Id[NormalizedURI], waiting: Boolean): Future[URISummary] = {
+    val uri = db.readOnly { implicit session => normalizedUriRepo.get(uriId) }
+    getDefaultURISummary(uri, waiting)
+  }
+
+  def getDefaultURISummary(uri: NormalizedURI, waiting: Boolean): Future[URISummary] = {
+    import TransactionalCaching.Implicits.directCacheAccess
+
+    uriSummaryCache.getOrElseFuture(URISummaryKey(uri.id.get)) {
+      val uriSummaryRequest = URISummaryRequest(uri.url, ImageType.ANY, ImageSize(0,0), withDescription = true, waiting = waiting, silent = false)
+      getURISummaryForRequest(uriSummaryRequest, uri)
+    }
+  }
 
   /**
    * Gets an image for the given URI. It can be an image on the page or a screenshot, and there are no size restrictions

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/ImageInfoRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/ImageInfoRepo.scala
@@ -24,6 +24,7 @@ trait ImageInfoRepo extends Repo[ImageInfo] with SeqNumberFunction[ImageInfo] {
 class ImageInfoRepoImpl @Inject() (
   val db: DataBaseComponent,
   val clock: Clock,
+  uriSummaryCache: URISummaryCache,
   airbrake: AirbrakeNotifier)
   extends DbRepo[ImageInfo] with ImageInfoRepo with SeqNumberDbFunction[ImageInfo] with Logging {
 
@@ -49,8 +50,12 @@ class ImageInfoRepoImpl @Inject() (
   def table(tag:Tag) = new ImageInfoTable(tag)
   initTable()
 
-  override def deleteCache(model: ImageInfo)(implicit session: RSession):Unit = {}
-  override def invalidateCache(model: ImageInfo)(implicit session: RSession):Unit = {}
+  override def deleteCache(model: ImageInfo)(implicit session: RSession): Unit = {
+    uriSummaryCache.remove(URISummaryKey(model.uriId))
+  }
+  override def invalidateCache(model: ImageInfo)(implicit session: RSession): Unit = {
+    uriSummaryCache.remove(URISummaryKey(model.uriId))
+  }
 
   override def save(model: ImageInfo)(implicit session: RWSession): ImageInfo = {
     val info = if (model.id.isDefined) {


### PR DESCRIPTION
@martinraison 
- added getDefaultURISummary for the most common case and use URISummaryCache
- use getDefaultURISummary in KeepsRepo (this enables caching)
- invalidating URISummaryCache on any image change
