### PR TITLE
Use differed sequence number assignment in EmailAccountRepo

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/abook/ABookDbSequencingModule.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/ABookDbSequencingModule.scala
@@ -1,0 +1,11 @@
+package com.keepit.abook
+
+import com.keepit.inject.AppScoped
+import net.codingwell.scalaguice.ScalaModule
+import com.keepit.abook.model.{EmailAccountSequencingPluginImpl, EmailAccountSequencingPlugin}
+
+case class ABookDbSequencingModule() extends ScalaModule {
+  def configure {
+    bind[EmailAccountSequencingPlugin].to[EmailAccountSequencingPluginImpl].in[AppScoped]
+  }
+}

--- a/kifi-backend/modules/abook/app/com/keepit/abook/ABookGlobal.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/ABookGlobal.scala
@@ -6,6 +6,7 @@ import com.keepit.common.healthcheck._
 import com.keepit.commanders.{EmailAccountUpdaterPlugin, LocalRichConnectionCommander}
 import play.api.Mode._
 import play.api._
+import com.keepit.abook.model.EmailAccountSequencingPlugin
 
 object ABookGlobal extends FortyTwoGlobal(Prod) with ABookServices {
   val module = ABookProdModule()
@@ -27,5 +28,6 @@ trait ABookServices { self: FortyTwoGlobal =>
     require(injector.instance[HealthcheckPlugin] != null) //make sure its not lazy loaded
     require(injector.instance[FortyTwoCachePlugin] != null) //make sure its not lazy loaded
     require(injector.instance[InMemoryCachePlugin] != null) //make sure its not lazy loaded
+    require(injector.instance[EmailAccountSequencingPlugin] != null) //make sure its not lazy loaded
   }
 }

--- a/kifi-backend/modules/abook/app/com/keepit/abook/ABookModule.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/ABookModule.scala
@@ -22,4 +22,5 @@ abstract class ABookModule(
   val abookSlickModule = ABookSlickModule()
 
   val repoChangeListenerModule = AbookRepoChangeListenerModule()
+  val dbSequencingModule = ABookDbSequencingModule()
 }


### PR DESCRIPTION
@ymatsuda @stkem @eishay 

A bit of background here: 
1. Down the road, I would like to add an insertAll capability to all Repos, since we already have it for at least three repos with duplicated logic.
2. Doing so would imply overriding that new insertAll method for all repos with a sequence number, like we do for save.
3. So I was initially trying to move all the SequenceNumber logic (including the save overrides) to the SeqNumberDbFunction trait, so that we can handle it once and for all at the top level like we do for caching.
4. Turns out this gets tricky with two different sequence number assignment logics, and after trying out a couple of strategies, I realized that batch operations are easier with the deferred sequence number anyway. 
5. So for now, I'm just making sure I get ahead of the curve and use differed sequence numbers in ABook. I'll wait for us to have moved all repos to that logic before further generic refactoring. When we're there, I wonder if we can take the sequencing plugin logic into the SeqNumDbTrait trait as well, in order to avoid code duplication / having to define a plugin together with each sequenced repo. Basically, the plugin would be the repo itself. Do you think that makes sense or would that be a bad coupling design?
