### PR TITLE
stop calling embedly for the same uri over and over

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/scraper/embedly/EmbedlyInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/scraper/embedly/EmbedlyInfo.scala
@@ -59,7 +59,7 @@ case class EmbedlyInfo(
       id = None,
       uriId = nuriId,
       title = this.title,
-      description = this.description,
+      description = this.description.orElse(Some("")),
       safe = this.safe,
       lang = this.lang,
       faviconUrl = (this.faviconUrl.collect{ case f:String if f.startsWith("http") => f }) // embedly bug


### PR DESCRIPTION
@martinraison 

I observed that we are calling embedly for the same uri over and over and inserting duplicate image_info rows, and I think I found the cause. It can happen when embedly returns no description (= None). There are pages for which embedly returns no description. URISummaryCommander thinks the URI summary is incomplete when processing a request (silent=false and withDescription=true), and call embedly to fill in the missing description. Embedly returns no description again, and we will do the same for subsequent requests.

The changed code sets Some("") instead of None to PageInfo to stop this. This should stop repeating calls. I am not entire sure this is the right thing. So, Martin, please review. Thanks.
