### PR TITLE
DO NOT MERGE

### DIFF
--- a/kifi-backend/modules/shoebox/angular-black/src/common/services/routeService.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/common/services/routeService.js
@@ -53,6 +53,7 @@ angular.module('kifi.routeService', [])
       },
       removeKeeps: route('/keeps/remove'),
       tagOrdering: route('/collections/ordering'),
+      tagIndexOrdering: route('/collections/indexOrdering'),
       whoToInvite: route('/friends/wti'),
       blockWtiConnection: route('/friends/wti/block'),
       friends: function (page, pageSize) {

--- a/kifi-backend/modules/shoebox/angular-black/src/tags/tagService.js
+++ b/kifi-backend/modules/shoebox/angular-black/src/tags/tagService.js
@@ -60,13 +60,24 @@ angular.module('kifi.tagService', [
       return post;
     }
 
+    /*
     function persistOrdering() {
       $http.post(routeService.tagOrdering, _.pluck(allTags, 'id')).then(function () {
       });
       api.fetchAll();
     }
+    */
+    function persistIndexOrdering(id, newInd) {
+      var payload = {
+        tagId: id,
+        newIndex: newInd
+      };
+      $http.post(routeService.tagIndexOrdering, payload).then(function () {});
+      api.fetchAll();
+    }
 
     function reorderTag(srcTag, index) {
+      /*
       var newSrcTag = _.clone(srcTag);
       var srcTagId = srcTag.id;
       newSrcTag.id = -1;
@@ -74,7 +85,15 @@ angular.module('kifi.tagService', [
       _.remove(allTags, function (tag) { return tag.id === srcTagId; });
       api.refreshList();
       newSrcTag.id = srcTagId;
-      persistOrdering();
+      */
+
+      var oldIndex = _.indexOf(allTags, srcTag);
+      allTags.splice(index, 0, srcTag); // add to array
+      allTags.splice(oldIndex, 1);      // remove from array
+      api.refreshList();
+      var currentIndex = _.indexOf(allTags, srcTag)
+
+      persistIndexOrdering(srcTag.id, currentIndex);
       $analytics.eventTrack('user_clicked_page', {
         'action': 'reorderTag',
         'path': $location.path()

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
@@ -53,6 +53,24 @@ class KeepsController @Inject() (
     ))
   }
 
+
+  def updateCollectionIndexOrdering() = JsonAction.authenticatedParseJson { request =>
+    val (id, currInd) = {
+      val json = request.body
+      val tagId = (json \ "tagId").as[ExternalId[Collection]]
+      val currentIndex = (json \ "newIndex").as[Int]
+      (tagId, currentIndex)
+    }
+
+    val newCollectionIds = db.readWrite { implicit s =>
+      collectionCommander.setCollectionIndexOrdering(request.userId, id, currInd)
+    }
+
+    Ok(Json.obj(
+      "newCollection" -> newCollectionIds.map{ id => Json.toJson(id) }
+    ))
+  }
+
   def getScreenshotUrl() = JsonAction.authenticatedParseJsonAsync { request =>
     val urlOpt = (request.body \ "url").asOpt[String]
     val urlsOpt = (request.body \ "urls").asOpt[Seq[String]]

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -249,6 +249,7 @@ POST    /site/keeps/untag           @com.keepit.controllers.website.KeepsControl
 
 GET     /site/collections/all       @com.keepit.controllers.website.KeepsController.allCollections(sort: String ?= "last_kept")
 POST    /site/collections/ordering  @com.keepit.controllers.website.KeepsController.updateCollectionOrdering()
+POST    /site/collections/indexOrdering  @com.keepit.controllers.website.KeepsController.updateCollectionIndexOrdering()
 POST    /site/collections/create    @com.keepit.controllers.website.KeepsController.saveCollection(id = "")
 POST    /site/collections/:id/update @com.keepit.controllers.website.KeepsController.saveCollection(id: String)
 POST    /site/collections/:id/delete @com.keepit.controllers.website.KeepsController.deleteCollection(id: ExternalId[Collection])

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
@@ -7,6 +7,7 @@ import com.keepit.heimdal.HeimdalContext
 import org.joda.time.DateTime
 import com.keepit.common.time._
 import com.keepit.scraper.FakeScrapeSchedulerModule
+import play.api.libs.json.Json
 import scala.Some
 import com.keepit.model.KeepToCollection
 import com.keepit.normalizer.NormalizationService
@@ -105,6 +106,70 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
         db.readOnly { implicit s =>
           collectionRepo.get(collections(2).id.get).state.value === "inactive"
 //          keepRepo.getByUser(user.id.get, None, None, Some(collections(2).id.get), 1000) === 0
+        }
+      }
+    }
+
+    "reorder tags" in {
+      withDb(modules: _*) { implicit injector =>
+
+        val t1 = new DateTime(2013, 2, 14, 21, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
+        val userValueRepo = inject[UserValueRepo]
+        val CollectionOrderingKey = "user_collection_ordering"
+
+        val (user, oldOrdering, tagA, tagB, tagC, tagD) = db.readWrite { implicit s =>
+          val user1 = userRepo.save(User(firstName = "Mario", lastName = "Luigi", createdAt = t1))
+
+          val tagA = Collection(userId = user1.id.get, name = "tagA")
+          val tagB = Collection(userId = user1.id.get, name = "tagB")
+          val tagC = Collection(userId = user1.id.get, name = "tagC")
+          val tagD = Collection(userId = user1.id.get, name = "tagD")
+
+          val collections = collectionRepo.save(tagA) ::
+            collectionRepo.save(tagB) ::
+            collectionRepo.save(tagC) ::
+            collectionRepo.save(tagD) ::
+            Nil
+          val collectionIds = collections.map(_.externalId).toSeq
+
+          userValueRepo.save(UserValue(userId = user1.id.get, name = CollectionOrderingKey, value = collectionIds.toString()))
+          (user1, collectionIds, tagA, tagB, tagC, tagD)
+        }
+
+        // First check collections were placed in DB correctly
+        db.readOnly { implicit s =>
+          val allCollectionIds = collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user.id.get).map(_.externalId)
+          allCollectionIds === oldOrdering
+        }
+
+        // Move tagA to index 2 (move tag towards tail)
+        db.readWrite { implicit session =>
+          inject[CollectionCommander].setCollectionIndexOrdering(user.id.get, tagA.externalId, 2)
+        }
+        db.readOnly { implicit s =>
+          val ordering = userValueRepo.getUserValue(user.id.get, CollectionOrderingKey).get
+          val newOrdering = tagB.externalId :: tagC.externalId :: tagA.externalId :: tagD.externalId :: Nil
+          ordering.value === Json.stringify(Json.toJson(newOrdering))
+        }
+
+        // Move tagA to index 0 (move tag to head)
+        db.readWrite { implicit session =>
+          inject[CollectionCommander].setCollectionIndexOrdering(user.id.get, tagA.externalId, 0)
+        }
+        db.readOnly { implicit s =>
+          val ordering = userValueRepo.getUserValue(user.id.get, CollectionOrderingKey).get
+          val newOrdering = tagA.externalId :: tagB.externalId :: tagC.externalId :: tagD.externalId :: Nil
+          ordering.value === Json.stringify(Json.toJson(newOrdering))
+        }
+
+        // Move tagA to index 3 (move tag to tail)
+        db.readWrite { implicit session =>
+          inject[CollectionCommander].setCollectionIndexOrdering(user.id.get, tagA.externalId, 3)
+        }
+        db.readOnly { implicit s =>
+          val ordering = userValueRepo.getUserValue(user.id.get, CollectionOrderingKey).get
+          val newOrdering = tagB.externalId :: tagC.externalId :: tagD.externalId :: tagA.externalId :: Nil
+          ordering.value === Json.stringify(Json.toJson(newOrdering))
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepsCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepsCommanderTest.scala
@@ -1,8 +1,11 @@
 package com.keepit.commanders
 
+import com.keepit.common.controller.{FakeActionAuthenticatorModule, FakeActionAuthenticator, ActionAuthenticator}
 import com.keepit.common.db.Id
+import com.keepit.common.db.slick.Database
 import com.keepit.common.external.FakeExternalServiceModule
 import com.keepit.common.time._
+import com.keepit.controllers.website.KeepsController
 import com.keepit.cortex.FakeCortexServiceClientModule
 import com.keepit.model._
 import com.keepit.scraper.FakeScrapeSchedulerModule
@@ -10,8 +13,11 @@ import com.keepit.search.FakeSearchServiceClientModule
 import com.keepit.test.ShoeboxTestInjector
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
-import com.keepit.shoebox.FakeKeepImportsModule
+import com.keepit.shoebox.{FakeShoeboxServiceModule, FakeKeepImportsModule}
 import com.keepit.common.store.ShoeboxFakeStoreModule
+import play.api.libs.json.{JsArray, JsString, Json}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
 
 class KeepsCommanderTest extends Specification with ShoeboxTestInjector {
 
@@ -20,7 +26,10 @@ class KeepsCommanderTest extends Specification with ShoeboxTestInjector {
                 FakeExternalServiceModule() ::
                 FakeSearchServiceClientModule() ::
                 FakeCortexServiceClientModule() ::
-                FakeScrapeSchedulerModule() :: Nil
+                FakeScrapeSchedulerModule() ::
+                FakeShoeboxServiceModule() ::
+                FakeActionAuthenticatorModule() ::
+                Nil
 
   "KeepsCommander" should {
     "export keeps" in {


### PR DESCRIPTION
Tag reordering using (tagId, newIndex) pair instead of sending whole Seq[tagId] to server
Problem:
 I've written reorder tests for the CollectionCommander and the KeepsController
But, for some reason, while the database testing in the CollectionCommanderTest works fine, Keeps Controller does not return the correct JSON ordering
When I run the program, it doesn't seem the order is saved in between reorderings.

For example, if my starting position is ABCD
and I first move A to index 2, I should get BCAD.
and then I move D to index 0, I should get DBCA.

What I get is ABCD -> BCAD -> DABC (which is moving D to the front from the original ordering, instead of the latest ordering).
Maybe I might be missing something?

The file you'd like to look at is CollectionCommander.setCollectionIndexOrdering()

@martinraison @andrewconner @stkem 
