### PR TITLE
don't redirect to /install after signup on IE + unit tests for isOldIE

### DIFF
--- a/kifi-backend/modules/common/test/com/keepit/common/net/UserAgentTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/net/UserAgentTest.scala
@@ -13,6 +13,7 @@ class UserAgentTest extends Specification {
       agent.isKifiIphoneApp === false
       agent.isWebsiteEnabled === true
       agent.isPreviewWebsiteEnabled === true
+      agent.isOldIE === false
     }
     "parse browser versions FF Mac" in {
       val str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:20.0) Gecko/20100101 Firefox/20.0"
@@ -23,6 +24,7 @@ class UserAgentTest extends Specification {
       agent.isKifiIphoneApp === false
       agent.isWebsiteEnabled === true
       agent.isPreviewWebsiteEnabled === true
+      agent.isOldIE === false
     }
     "parse browser versions Chrome Linux" in {
       val str = "Mozilla/5.0 (X11; CrOS armv7l 2913.260.0) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.99 Safari/537.11"
@@ -33,6 +35,7 @@ class UserAgentTest extends Specification {
       agent.isKifiIphoneApp === false
       agent.isWebsiteEnabled === true
       agent.isPreviewWebsiteEnabled === true
+      agent.isOldIE === false
     }
     "parse browser versions iphone app" in {
       val str = "iKeefee/1.0.12823 (Device-Type: iPhone, OS: iOS 7.0.6)"
@@ -43,6 +46,7 @@ class UserAgentTest extends Specification {
       agent.isIphone === true
       agent.isWebsiteEnabled === false
       agent.isPreviewWebsiteEnabled === false
+      agent.isOldIE === false
     }
     "parse browser versions Chromium Linux" in {
       val str = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.19 (KHTML, like Gecko) Ubuntu/11.10 Chromium/18.0.1025.142 Chrome/18.0.1025.142 Safari/535.19"
@@ -55,8 +59,21 @@ class UserAgentTest extends Specification {
       agent.isKifiIphoneApp === false
       agent.isWebsiteEnabled === true
       agent.isPreviewWebsiteEnabled === true
+      agent.isOldIE === false
     }
-    "parse browser versions IE on Windows" in {
+    "parse browser versions IE < 9 on Windows" in {
+      val str = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET CLR 2.0.50727; Media Center PC 6.0)"
+      val agent = UserAgent.fromString(str)
+      agent === UserAgent(str, "IE", "Windows", "Windows 7", "Browser", "9.0")
+      agent.isMobile === false
+      agent.isSupportedDesktop === false
+      agent.isKifiIphoneApp === false
+      agent.isIphone === false
+      agent.isWebsiteEnabled === true
+      agent.isPreviewWebsiteEnabled === true
+      agent.isOldIE === true
+    }
+    "parse browser version IE 9 on Windows" in {
       val str = "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; InfoPath.3; Creative AutoUpdate v1.40.02)"
       val agent = UserAgent.fromString(str)
       agent === UserAgent(str, "IE", "Windows", "Windows 7", "Browser", "7.0")
@@ -66,6 +83,31 @@ class UserAgentTest extends Specification {
       agent.isIphone === false
       agent.isWebsiteEnabled === true
       agent.isPreviewWebsiteEnabled === true
+      agent.isOldIE === true
+    }
+    "parse browser version IE 10 on Windows" in {
+      val str = "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/4.0; InfoPath.2; SV1; .NET CLR 2.0.50727; WOW64)"
+      val agent = UserAgent.fromString(str)
+      agent === UserAgent(str, "IE", "Windows", "Windows 7", "Browser", "10.0")
+      agent.isMobile === false
+      agent.isSupportedDesktop === false
+      agent.isKifiIphoneApp === false
+      agent.isIphone === false
+      agent.isWebsiteEnabled === true
+      agent.isPreviewWebsiteEnabled === true
+      agent.isOldIE === false
+    }
+    "parse browser version IE 11 on Windows" in {
+      val str = "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko"
+      val agent = UserAgent.fromString(str)
+      agent === UserAgent(str, "IE", "Windows", "Windows 8.1", "Browser", "11.0")
+      agent.isMobile === false
+      agent.isSupportedDesktop === false
+      agent.isKifiIphoneApp === false
+      agent.isIphone === false
+      agent.isWebsiteEnabled === true
+      agent.isPreviewWebsiteEnabled === true
+      agent.isOldIE === false
     }
     "parse browser versions Chrome on iPhone" in {
       val str = "Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3"
@@ -77,6 +119,7 @@ class UserAgentTest extends Specification {
       agent.isIphone === true
       agent.isWebsiteEnabled === false
       agent.isPreviewWebsiteEnabled === false
+      agent.isOldIE === false
     }
     "parse browser versions Safari on iPhone" in {
       val str = "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A293 Safari/6531.22.7"
@@ -88,6 +131,7 @@ class UserAgentTest extends Specification {
       agent.isIphone === true
       agent.isWebsiteEnabled === false
       agent.isPreviewWebsiteEnabled === false
+      agent.isOldIE === false
     }
     "parse browser versions Safari on iPad" in {
       val str = "Mozilla/5.0 (iPad; CPU OS 7_0_4 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11B554a Safari/9537.53"
@@ -99,6 +143,7 @@ class UserAgentTest extends Specification {
       agent.isIphone === false
       agent.isWebsiteEnabled === false
       agent.isPreviewWebsiteEnabled === true
+      agent.isOldIE === false
     }
     "parse browser versions Firefox on Android Tablet" in {
       val str = "Mozilla/5.0 (Android; Tablet; rv:28.0) Gecko/28.0 Firefox/28.0"
@@ -110,6 +155,7 @@ class UserAgentTest extends Specification {
       agent.isIphone === false
       agent.isWebsiteEnabled === false
       agent.isPreviewWebsiteEnabled === true
+      agent.isOldIE === false
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -160,9 +160,6 @@ class AuthController @Inject() (
     request.request.headers.get(USER_AGENT).map { agentString =>
       val agent = UserAgent.fromString(agentString)
       log.info(s"trying to log in via $agent. orig string: $agentString")
-      // All devices for which preview website is enabled can login, however they may not be able to
-      // access kifi.com or preview.kifi.com after logging in (redirected to "unsupported" page).
-      // Remove this when preview experiment is over.
       if (agent.isOldIE) {
         Some(Redirect(com.keepit.controllers.website.routes.HomeController.unsupported()))
       } else if (!agent.isWebsiteEnabled) {


### PR DESCRIPTION
@2is10 @andrewconner 
Fixing signup flow on IE and addressing #9409 feedback
