### PR TITLE
enabling tablet access to www.kifi.com

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/net/UserAgent.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/UserAgent.scala
@@ -15,7 +15,7 @@ case class UserAgent(
   lazy val isKifiIphoneApp: Boolean = typeName == UserAgent.KifiAppTypeName
   lazy val isIphone: Boolean = (operatingSystemFamily == "iOS" && userAgent.contains("CPU iPhone OS")) || isKifiIphoneApp
   lazy val isMobile: Boolean = UserAgent.MobileOses.contains(operatingSystemFamily) || isKifiIphoneApp
-  lazy val screenCanFitWebApp: Boolean = !isMobile || UserAgent.TabletIndicators.exists(userAgent.contains(_))
+  lazy val screenCanFitWebApp: Boolean = !isMobile // || UserAgent.TabletIndicators.exists(userAgent.contains(_))  // TODO: let people use web app on tablet
   lazy val canRunExtensionIfUpToDate: Boolean = !isMobile && UserAgent.ExtensionBrowserNames.contains(name)
   lazy val isOldIE: Boolean = name == "IE" && (try { version.toDouble.toInt } catch { case _:NumberFormatException => Double.MaxValue }) < 10
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/net/UserAgent.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/UserAgent.scala
@@ -14,21 +14,19 @@ case class UserAgent(
   version: String) {
   lazy val isKifiIphoneApp: Boolean = typeName == UserAgent.KifiAppTypeName
   lazy val isIphone: Boolean = (operatingSystemFamily == "iOS" && userAgent.contains("CPU iPhone OS")) || isKifiIphoneApp
-  lazy val isMobile: Boolean = UserAgent.MobileOs.contains(operatingSystemFamily) || isKifiIphoneApp
-  lazy val isWebsiteEnabled: Boolean = !isMobile || UserAgent.WebsiteEnabled.exists(userAgent.contains(_))
-  lazy val isPreviewWebsiteEnabled: Boolean = !isMobile || UserAgent.PreviewWebsiteEnabled.exists(userAgent.contains(_))
-  lazy val isSupportedDesktop: Boolean = !isMobile && UserAgent.SupportedDesktopBrowsers.contains(name)
+  lazy val isMobile: Boolean = UserAgent.MobileOses.contains(operatingSystemFamily) || isKifiIphoneApp
+  lazy val screenCanFitWebApp: Boolean = !isMobile || UserAgent.TabletIndicators.exists(userAgent.contains(_))
+  lazy val canRunExtensionIfUpToDate: Boolean = !isMobile && UserAgent.ExtensionBrowserNames.contains(name)
   lazy val isOldIE: Boolean = name == "IE" && (try { version.toDouble.toInt } catch { case _:NumberFormatException => Double.MaxValue }) < 10
 }
 
 object UserAgent extends Logging {
 
-  val KifiAppTypeName = "kifi app"
+  private val KifiAppTypeName = "kifi app"
 
-  val MobileOs = Set("Android", "iOS", "Bada", "DangerOS", "Firefox OS", "Mac OS", "Palm OS", "BlackBerry OS", "Symbian OS", "webOS")
-  val WebsiteEnabled = Set()
-  val PreviewWebsiteEnabled = Set("iPad", "Tablet")
-  val SupportedDesktopBrowsers = Set("Chrome", "Firefox")
+  private val MobileOses = Set("Android", "iOS", "Bada", "DangerOS", "Firefox OS", "Mac OS", "Palm OS", "BlackBerry OS", "Symbian OS", "webOS")
+  private val TabletIndicators = Set("iPad", "Tablet")
+  private val ExtensionBrowserNames = Set("Chrome", "Firefox")
 
   private val MAX_USER_AGENT_LENGTH = 512
   lazy val parser = UADetectorServiceFactory.getResourceModuleParser()
@@ -52,10 +50,12 @@ object UserAgent extends Logging {
     }
   }
 
-  private def trim(str: String) = if(str.length > MAX_USER_AGENT_LENGTH) {
+  private def trim(str: String) = {
+    if (str.length > MAX_USER_AGENT_LENGTH) {
       log.warn(s"trunking user agent string since its too long: $str")
       str.substring(0, MAX_USER_AGENT_LENGTH - 3) + "..."
     } else {
       str
     }
+  }
 }

--- a/kifi-backend/modules/common/test/com/keepit/common/net/UserAgentTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/net/UserAgentTest.scala
@@ -130,7 +130,7 @@ class UserAgentTest extends Specification {
       agent.canRunExtensionIfUpToDate === false
       agent.isKifiIphoneApp === false
       agent.isIphone === false
-      agent.screenCanFitWebApp === true
+      agent.screenCanFitWebApp === false // TODO: make true
       agent.isOldIE === false
     }
     "parse browser versions Firefox on Android Tablet" in {
@@ -141,7 +141,7 @@ class UserAgentTest extends Specification {
       agent.canRunExtensionIfUpToDate === false
       agent.isKifiIphoneApp === false
       agent.isIphone === false
-      agent.screenCanFitWebApp === true
+      agent.screenCanFitWebApp === false // TODO: make true
       agent.isOldIE === false
     }
   }

--- a/kifi-backend/modules/common/test/com/keepit/common/net/UserAgentTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/net/UserAgentTest.scala
@@ -9,10 +9,9 @@ class UserAgentTest extends Specification {
       val agent = UserAgent.fromString(str)
       agent === UserAgent(str, "", "" ,"", "", "")
       agent.isMobile === false
-      agent.isSupportedDesktop === false
+      agent.canRunExtensionIfUpToDate === false
       agent.isKifiIphoneApp === false
-      agent.isWebsiteEnabled === true
-      agent.isPreviewWebsiteEnabled === true
+      agent.screenCanFitWebApp === true
       agent.isOldIE === false
     }
     "parse browser versions FF Mac" in {
@@ -20,10 +19,9 @@ class UserAgentTest extends Specification {
       val agent = UserAgent.fromString(str)
       agent === UserAgent(str, "Firefox", "OS X" ,"OS X 10.8 Mountain Lion", "Browser", "20.0")
       agent.isMobile === false
-      agent.isSupportedDesktop === true
+      agent.canRunExtensionIfUpToDate === true
       agent.isKifiIphoneApp === false
-      agent.isWebsiteEnabled === true
-      agent.isPreviewWebsiteEnabled === true
+      agent.screenCanFitWebApp === true
       agent.isOldIE === false
     }
     "parse browser versions Chrome Linux" in {
@@ -31,10 +29,9 @@ class UserAgentTest extends Specification {
       val agent = UserAgent.fromString(str)
       agent === UserAgent(str, "Chrome", "Linux", "Chrome OS", "Browser", "23.0.1271.99")
       agent.isMobile === false
-      agent.isSupportedDesktop === true
+      agent.canRunExtensionIfUpToDate === true
       agent.isKifiIphoneApp === false
-      agent.isWebsiteEnabled === true
-      agent.isPreviewWebsiteEnabled === true
+      agent.screenCanFitWebApp === true
       agent.isOldIE === false
     }
     "parse browser versions iphone app" in {
@@ -44,8 +41,7 @@ class UserAgentTest extends Specification {
       agent.isMobile === true
       agent.isKifiIphoneApp === true
       agent.isIphone === true
-      agent.isWebsiteEnabled === false
-      agent.isPreviewWebsiteEnabled === false
+      agent.screenCanFitWebApp === false
       agent.isOldIE === false
     }
     "parse browser versions Chromium Linux" in {
@@ -55,34 +51,31 @@ class UserAgentTest extends Specification {
       agent.name === manual.name
       agent === manual
       agent.isMobile === false
-      agent.isSupportedDesktop === true
+      agent.canRunExtensionIfUpToDate === true
       agent.isKifiIphoneApp === false
-      agent.isWebsiteEnabled === true
-      agent.isPreviewWebsiteEnabled === true
+      agent.screenCanFitWebApp === true
       agent.isOldIE === false
     }
     "parse browser versions IE < 9 on Windows" in {
-      val str = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET CLR 2.0.50727; Media Center PC 6.0)"
-      val agent = UserAgent.fromString(str)
-      agent === UserAgent(str, "IE", "Windows", "Windows 7", "Browser", "9.0")
-      agent.isMobile === false
-      agent.isSupportedDesktop === false
-      agent.isKifiIphoneApp === false
-      agent.isIphone === false
-      agent.isWebsiteEnabled === true
-      agent.isPreviewWebsiteEnabled === true
-      agent.isOldIE === true
-    }
-    "parse browser version IE 9 on Windows" in {
       val str = "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; InfoPath.3; Creative AutoUpdate v1.40.02)"
       val agent = UserAgent.fromString(str)
       agent === UserAgent(str, "IE", "Windows", "Windows 7", "Browser", "7.0")
       agent.isMobile === false
-      agent.isSupportedDesktop === false
+      agent.canRunExtensionIfUpToDate === false
       agent.isKifiIphoneApp === false
       agent.isIphone === false
-      agent.isWebsiteEnabled === true
-      agent.isPreviewWebsiteEnabled === true
+      agent.screenCanFitWebApp === true
+      agent.isOldIE === true
+    }
+    "parse browser version IE 9 on Windows" in {
+      val str = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET CLR 2.0.50727; Media Center PC 6.0)"
+      val agent = UserAgent.fromString(str)
+      agent === UserAgent(str, "IE", "Windows", "Windows 7", "Browser", "9.0")
+      agent.isMobile === false
+      agent.canRunExtensionIfUpToDate === false
+      agent.isKifiIphoneApp === false
+      agent.isIphone === false
+      agent.screenCanFitWebApp === true
       agent.isOldIE === true
     }
     "parse browser version IE 10 on Windows" in {
@@ -90,11 +83,10 @@ class UserAgentTest extends Specification {
       val agent = UserAgent.fromString(str)
       agent === UserAgent(str, "IE", "Windows", "Windows 7", "Browser", "10.0")
       agent.isMobile === false
-      agent.isSupportedDesktop === false
+      agent.canRunExtensionIfUpToDate === false
       agent.isKifiIphoneApp === false
       agent.isIphone === false
-      agent.isWebsiteEnabled === true
-      agent.isPreviewWebsiteEnabled === true
+      agent.screenCanFitWebApp === true
       agent.isOldIE === false
     }
     "parse browser version IE 11 on Windows" in {
@@ -102,11 +94,10 @@ class UserAgentTest extends Specification {
       val agent = UserAgent.fromString(str)
       agent === UserAgent(str, "IE", "Windows", "Windows 8.1", "Browser", "11.0")
       agent.isMobile === false
-      agent.isSupportedDesktop === false
+      agent.canRunExtensionIfUpToDate === false
       agent.isKifiIphoneApp === false
       agent.isIphone === false
-      agent.isWebsiteEnabled === true
-      agent.isPreviewWebsiteEnabled === true
+      agent.screenCanFitWebApp === true
       agent.isOldIE === false
     }
     "parse browser versions Chrome on iPhone" in {
@@ -114,11 +105,10 @@ class UserAgentTest extends Specification {
       val agent = UserAgent.fromString(str)
       agent === UserAgent(str,"Chrome Mobile", "iOS", "iOS 5", "Mobile Browser", "19.0.1084.60")
       agent.isMobile === true
-      agent.isSupportedDesktop === false
+      agent.canRunExtensionIfUpToDate === false
       agent.isKifiIphoneApp === false
       agent.isIphone === true
-      agent.isWebsiteEnabled === false
-      agent.isPreviewWebsiteEnabled === false
+      agent.screenCanFitWebApp === false
       agent.isOldIE === false
     }
     "parse browser versions Safari on iPhone" in {
@@ -126,11 +116,10 @@ class UserAgentTest extends Specification {
       val agent = UserAgent.fromString(str)
       agent === UserAgent(str, "Mobile Safari", "iOS", "iOS 4", "Mobile Browser", "4.0.5")
       agent.isMobile === true
-      agent.isSupportedDesktop === false
+      agent.canRunExtensionIfUpToDate === false
       agent.isKifiIphoneApp === false
       agent.isIphone === true
-      agent.isWebsiteEnabled === false
-      agent.isPreviewWebsiteEnabled === false
+      agent.screenCanFitWebApp === false
       agent.isOldIE === false
     }
     "parse browser versions Safari on iPad" in {
@@ -138,11 +127,10 @@ class UserAgentTest extends Specification {
       val agent = UserAgent.fromString(str)
       agent === UserAgent(str, "Mobile Safari", "iOS", "iOS 7", "Mobile Browser", "7.0")
       agent.isMobile === true
-      agent.isSupportedDesktop === false
+      agent.canRunExtensionIfUpToDate === false
       agent.isKifiIphoneApp === false
       agent.isIphone === false
-      agent.isWebsiteEnabled === false
-      agent.isPreviewWebsiteEnabled === true
+      agent.screenCanFitWebApp === true
       agent.isOldIE === false
     }
     "parse browser versions Firefox on Android Tablet" in {
@@ -150,11 +138,10 @@ class UserAgentTest extends Specification {
       val agent = UserAgent.fromString(str)
       agent === UserAgent(str, "Firefox", "Android", "Android", "Browser", "28.0")
       agent.isMobile === true
-      agent.isSupportedDesktop === false
+      agent.canRunExtensionIfUpToDate === false
       agent.isKifiIphoneApp === false
       agent.isIphone === false
-      agent.isWebsiteEnabled === false
-      agent.isPreviewWebsiteEnabled === true
+      agent.screenCanFitWebApp === true
       agent.isOldIE === false
     }
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/AuthenticatedWebSocketsController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/AuthenticatedWebSocketsController.scala
@@ -233,7 +233,7 @@ trait AuthenticatedWebSocketsController extends ElizaServiceController {
   }
 
   private def updateNeeded(streamSession: StreamSession, versionOpt: Option[String]): Boolean = {
-    if (UserAgent.fromString(streamSession.userAgent).isSupportedDesktop) {
+    if (UserAgent.fromString(streamSession.userAgent).canRunExtensionIfUpToDate) {
       versionOpt.flatMap(v => Try(KifiExtVersion(v)).toOption).map { ver =>
         val details = kifInstallationStore.get()
         if (ver < details.gold) {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -162,7 +162,7 @@ class AuthController @Inject() (
       log.info(s"trying to log in via $agent. orig string: $agentString")
       if (agent.isOldIE) {
         Some(Redirect(com.keepit.controllers.website.routes.HomeController.unsupported()))
-      } else if (!agent.isWebsiteEnabled) {
+      } else if (!agent.screenCanFitWebApp) {
         Some(Redirect(com.keepit.controllers.website.routes.HomeController.mobileLanding()))
       } else None
     }.flatten.getOrElse(Ok(views.html.auth.authGrey("login")))
@@ -197,7 +197,7 @@ class AuthController @Inject() (
     }
     if (agentOpt.exists(_.isOldIE)) {
       Redirect(com.keepit.controllers.website.routes.HomeController.unsupported())
-    } else if (agentOpt.exists(!_.isWebsiteEnabled)) {
+    } else if (agentOpt.exists(!_.screenCanFitWebApp)) {
       Redirect(com.keepit.controllers.website.routes.HomeController.mobileLanding())
     } else {
       (request.userOpt, request.identityOpt) match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -182,7 +182,7 @@ class AuthHelper @Inject() (
     val uri = request.session.get(SecureSocial.OriginalUrlKey) getOrElse {
       request.request.headers.get(USER_AGENT).flatMap { agentString =>
         val agent = UserAgent.fromString(agentString)
-        if (agent.isSupportedDesktop) Some("/install") else None
+        if (agent.canRunExtensionIfUpToDate) Some("/install") else None
       } getOrElse "/" // In case the user signs up on a browser that doesn't support the extension
     }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
@@ -70,7 +70,7 @@ class HomeController @Inject() (
       val agent = UserAgent.fromString(agentString)
       if (agent.isOldIE) {
         Some(Redirect(com.keepit.controllers.website.routes.HomeController.unsupported()))
-      } else if (!agent.isWebsiteEnabled) {
+      } else if (!agent.screenCanFitWebApp) {
         Some(Redirect(com.keepit.controllers.website.routes.HomeController.mobileLanding()))
       } else None
     }.flatten.getOrElse(Ok(views.html.marketing.about(isLoggedIn)))
@@ -82,7 +82,7 @@ class HomeController @Inject() (
       val agent = UserAgent.fromString(agentString)
       if (agent.isOldIE) {
         None
-      } else if (!agent.isWebsiteEnabled) {
+      } else if (!agent.screenCanFitWebApp) {
         Some(true)
       } else {
         Some(false)
@@ -98,7 +98,7 @@ class HomeController @Inject() (
       val agent = UserAgent.fromString(agentString)
       if (agent.isOldIE) {
         None
-      } else if (!agent.isWebsiteEnabled) {
+      } else if (!agent.screenCanFitWebApp) {
         Some(true)
       } else {
         Some(false)
@@ -153,7 +153,7 @@ class HomeController @Inject() (
       Redirect(com.keepit.controllers.core.routes.AuthController.signupPage())
     } else if (request.kifiInstallationId.isEmpty && !hasSeenInstall) {
       Redirect(routes.HomeController.install())
-    } else if (agentOpt.exists(_.isWebsiteEnabled)) {
+    } else if (agentOpt.exists(_.screenCanFitWebApp)) {
       Status(200).chunked(Enumerator.fromStream(Play.resourceAsStream("angular/index.html").get)) as HTML
     } else {
       Redirect(routes.HomeController.unsupported())
@@ -175,7 +175,7 @@ class HomeController @Inject() (
         UserAgent.fromString(agent)
       }
       temporaryReportLandingLoad()
-      if (agentOpt.exists(!_.isWebsiteEnabled)) {
+      if (agentOpt.exists(!_.screenCanFitWebApp)) {
         val ua = agentOpt.get.userAgent
         val isIphone = ua.contains("iPhone") && !ua.contains("iPad")
         if (isIphone) {
@@ -264,9 +264,9 @@ class HomeController @Inject() (
     request.request.headers.get(USER_AGENT).map { agentString =>
       val agent = UserAgent.fromString(agentString)
       log.info(s"trying to log in via $agent. orig string: $agentString")
-      if (!agent.isWebsiteEnabled) {
+      if (!agent.screenCanFitWebApp) {
         Some(Redirect(com.keepit.controllers.website.routes.HomeController.mobileLanding()))
-      } else if (!agent.isSupportedDesktop) {
+      } else if (!agent.canRunExtensionIfUpToDate) {
         Some(Redirect(com.keepit.controllers.website.routes.HomeController.unsupported()))
       } else None
     }.flatten.getOrElse(Ok(views.html.website.install(request.user)))


### PR DESCRIPTION
@martinraison 

Also renaming some `UserAgent` predicates to eliminate (reduce) ambiguity.
