### PR TITLE
Database for analytics + repos for Delighted

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -227,7 +227,7 @@ object Heimdal extends Service {
     def incrementUserProperties(userId: Id[User]) = ServiceRoute(POST, s"/internal/heimdal/user/increment", Param("userId", userId))
     def setUserProperties(userId: Id[User]) = ServiceRoute(POST, s"/internal/heimdal/user/set", Param("userId", userId))
     def setUserAlias(userId: Id[User], externalId: ExternalId[User]) = ServiceRoute(GET, "/internal/heimdal/user/alias", Param("userId", userId), Param("externalId", externalId))
-    def getLastDelightedAnswerDate(userId: Id[User]) = ServiceRoute(POST, s"/internal/heimdal/user/lastDelightedAnswerDate", Param("userId", userId))
+    def getLastDelightedAnswerDate(userId: Id[User]) = ServiceRoute(GET, s"/internal/heimdal/user/lastDelightedAnswerDate", Param("userId", userId))
   }
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -227,6 +227,7 @@ object Heimdal extends Service {
     def incrementUserProperties(userId: Id[User]) = ServiceRoute(POST, s"/internal/heimdal/user/increment", Param("userId", userId))
     def setUserProperties(userId: Id[User]) = ServiceRoute(POST, s"/internal/heimdal/user/set", Param("userId", userId))
     def setUserAlias(userId: Id[User], externalId: ExternalId[User]) = ServiceRoute(GET, "/internal/heimdal/user/alias", Param("userId", userId), Param("externalId", externalId))
+    def getLastDelightedAnswerDate(userId: Id[User]) = ServiceRoute(POST, s"/internal/heimdal/user/lastDelightedAnswerDate", Param("userId", userId))
   }
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/time/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/time/package.scala
@@ -133,12 +133,13 @@ package object time {
   lazy val START_OF_TIME = parseStandardTime("0000-01-01 00:00:00.000 -0800")
   lazy val END_OF_TIME = parseStandardTime("9999-01-01 00:00:00.000 -0800")
 
-  implicit class RichDateTime(val date: DateTime) extends AnyVal {
+  implicit class RichDateTime(val date: DateTime) extends AnyVal with Ordered[DateTime] {
     def toLocalDateInZone(implicit zone: DateTimeZone): LocalDate = date.withZone(zone).toLocalDate
     def toLocalTimeInZone(implicit zone: DateTimeZone): LocalTime = date.withZone(zone).toLocalTime
     def toHttpHeaderString: String = HTTP_HEADER_DATETIME_FORMAT.print(date)
     def toStandardTimeString: String = STANDARD_DATETIME_FORMAT.print(date)
     def toStandardDateString: String = STANDARD_DATE_FORMAT.print(date)
+    def compare(that: DateTime): Int = dateTimeOrdering.compare(date, that)
   }
 
   implicit class RichLocalDate(val date: LocalDate) extends AnyVal {

--- a/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalServiceClient.scala
@@ -49,6 +49,8 @@ trait HeimdalServiceClient extends ServiceClient {
   def setUserProperties(userId: Id[User], properties: (String, ContextData)*): Unit
 
   def setUserAlias(userId: Id[User], externalId: ExternalId[User]): Unit
+
+  def getLastDelightedAnswerDate(userId: Id[User]): Future[Option[DateTime]]
 }
 
 object FlushEventQueue
@@ -142,4 +144,10 @@ class HeimdalServiceClientImpl @Inject() (
 
   def setUserAlias(userId: Id[User], externalId: ExternalId[User]): Unit =
     call(Heimdal.internal.setUserAlias(userId: Id[User], externalId: ExternalId[User]), callTimeouts = longTimeout)
+
+  def getLastDelightedAnswerDate(userId: Id[User]): Future[Option[DateTime]] = {
+    call(Heimdal.internal.getLastDelightedAnswerDate(userId)).map { response =>
+      Json.parse(response.body).asOpt[DateTime]
+    }
+  }
 }

--- a/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
@@ -65,6 +65,10 @@ object UserValues {
     def parse(valOpt: Option[String]): String = valOpt.getOrElse(default)
   }
 
+  case class UserValueDateTimeHandler(override val name: String, default: DateTime) extends UserValueHandler[DateTime] {
+    def parse(valOpt: Option[String]): DateTime = valOpt.map(parseStandardTime(_)).getOrElse(default)
+  }
+
   val lookHereMode = UserValueBooleanHandler("ext_look_here_mode", true)
   val enterToSend = UserValueBooleanHandler("enter_to_send", true)
   val maxResults = UserValueIntHandler("ext_max_results", 1)
@@ -75,5 +79,9 @@ object UserValues {
   val availableInvites = UserValueIntHandler("availableInvites", 1000)
   val hasSeenInstall = UserValueBooleanHandler("has_seen_install", false)
   val welcomeEmailSent = UserValueBooleanHandler("welcomeEmailSent", false)
+
+  val lastDelightedVote = UserValueDateTimeHandler("last_delighted_vote", START_OF_TIME)
+  val showDelightedQuestion = UserValueBooleanHandler("show_delighted_question", false)
+  val lastActive = UserValueDateTimeHandler("last_active", START_OF_TIME)
 
 }

--- a/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
@@ -80,7 +80,6 @@ object UserValues {
   val hasSeenInstall = UserValueBooleanHandler("has_seen_install", false)
   val welcomeEmailSent = UserValueBooleanHandler("welcomeEmailSent", false)
 
-  val lastDelightedVote = UserValueDateTimeHandler("last_delighted_vote", START_OF_TIME)
   val showDelightedQuestion = UserValueBooleanHandler("show_delighted_question", false)
   val lastActive = UserValueDateTimeHandler("last_active", START_OF_TIME)
 

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/189.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/189.sql
@@ -1,0 +1,37 @@
+# HEIMDAL
+
+# --- !Ups
+
+CREATE TABLE delighted_user (
+    id bigint(20) NOT NULL AUTO_INCREMENT,
+    created_at datetime NOT NULL,
+    updated_at datetime NOT NULL, 
+
+    user_id bigint(20) NOT NULL,
+
+    PRIMARY KEY (id),
+    KEY delighted_user_i_user_id (user_id)
+);
+
+CREATE TABLE delighted_answer (
+    id bigint(20) NOT NULL AUTO_INCREMENT,
+    created_at datetime NOT NULL,
+    updated_at datetime NOT NULL,
+
+    delighted_user_id bigint(20) NOT NULL,
+    date datetime NOT NULL,
+    score int NOT NULL,
+    comment varchar(3072) NULL,
+
+    PRIMARY KEY (id),
+
+    FOREIGN KEY (delighted_user_id)
+      REFERENCES delighted_user(id)
+      ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+insert into evolutions (name, description) values('189.sql', 'adding new tables for delighted integration');
+
+
+
+# --- !Downs

--- a/kifi-backend/modules/common/conf/prod/heimdal.conf
+++ b/kifi-backend/modules/common/conf/prod/heimdal.conf
@@ -12,7 +12,27 @@ statsd {
   stat.prefix = "heimdal"
 }
 
+# Database configuration
+# ~~~~~
+# db connection pool
 dbplugin=disabled
+db.shoebox {
+  maxPoolSize=40
+  minPoolSize=10
+  initialPoolSize=10
+  acquireIncrement=2
+  acquireRetryAttempts=50
+  acquireRetryDelay=200
+  maxIdleTime=600
+  idleConnectionTestPeriod=10
+  preferredTestQuery="SELECT 1"
+  checkoutTimeout=4000
+
+# heimdal database
+  driver=com.mysql.jdbc.Driver
+  url="jdbc:mysql://heimdal.c1jga8odi83l.us-west-1.rds.amazonaws.com:3306/heimdal?autoReconnect=true&useUnicode=yes"
+  user=heimdal
+}
 
 mongodb {
   heimdal {
@@ -21,9 +41,6 @@ mongodb {
     username = "fortytwo"
     password = "keepmyeventssecure"
   }
-}
-
-db{
 }
 
 mixpanel.token = "cff752ff16ee39eda30ae01bb6fa3bd6"

--- a/kifi-backend/modules/common/test/com/keepit/heimdal/FakeHeimdalServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/heimdal/FakeHeimdalServiceClientImpl.scala
@@ -5,6 +5,7 @@ import com.keepit.common.db.{ExternalId, Id}
 import com.keepit.common.service.ServiceType
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.zookeeper.ServiceCluster
+import org.joda.time.DateTime
 
 import scala.concurrent.{Future, Promise}
 
@@ -43,4 +44,6 @@ class FakeHeimdalServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
   def setUserProperties(userId: Id[User], properties: (String, ContextData)*): Unit = {}
 
   def setUserAlias(userId: Id[User], externalId: ExternalId[User]) = {}
+
+  def getLastDelightedAnswerDate(userId: Id[User]): Future[Option[DateTime]] = Future.successful(None)
 }

--- a/kifi-backend/modules/heimdal/app/com/keepit/common/cache/HeimdalCacheModule.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/common/cache/HeimdalCacheModule.scala
@@ -1,12 +1,13 @@
 package com.keepit.common.cache
 
+import com.keepit.model.{AnonymousEventDescriptorNameCache, UserEventDescriptorNameCache, SystemEventDescriptorNameCache, NonUserEventDescriptorNameCache}
+
 import scala.concurrent.duration._
 import com.keepit.common.logging.AccessLog
 import com.google.inject.{Provides, Singleton}
 import com.keepit.model._
 import com.keepit.social.BasicUserUserIdCache
 import com.keepit.search.ActiveExperimentsCache
-import com.keepit.heimdal.{NonUserEventDescriptorNameCache, AnonymousEventDescriptorNameCache, UserEventDescriptorNameCache, SystemEventDescriptorNameCache}
 import com.keepit.common.usersegment.UserSegmentCache
 
 case class HeimdalCacheModule(cachePluginModules: CachePluginModule*) extends CacheModule(cachePluginModules:_*) {

--- a/kifi-backend/modules/heimdal/app/com/keepit/controllers/AnalyticsController.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/controllers/AnalyticsController.scala
@@ -1,26 +1,21 @@
-package com.keepit.heimdal.controllers
-
-import com.keepit.common.controller.HeimdalServiceController
-import com.keepit.heimdal._
-import com.keepit.common.time._
-import com.keepit.common.akka.SafeFuture
-import org.joda.time.DateTime
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import com.keepit.heimdal.SpecificEventSet
-import com.keepit.model.User
-import com.keepit.common.db.{ExternalId, Id}
-
-//Might want to change this to a custom play one
-
-import play.api.mvc.Action
-import play.api.libs.json.{JsNumber, Json, JsObject}
+package com.keepit.controllers
 
 import com.google.inject.Inject
+import com.keepit.common.akka.SafeFuture
+import com.keepit.common.controller.HeimdalServiceController
+import com.keepit.common.db.{ExternalId, Id}
+import com.keepit.common.time._
+import com.keepit.model._
+import com.keepit.heimdal.{SpecificEventSet, _}
+import com.keepit.model.User
+import org.joda.time.DateTime
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.libs.json.{JsNumber, JsObject, Json}
+import play.api.mvc.Action
+import views.html
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future, Promise}
-
-import views.html
 
 
 class AnalyticsController @Inject() (

--- a/kifi-backend/modules/heimdal/app/com/keepit/controllers/DelightedController.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/controllers/DelightedController.scala
@@ -1,0 +1,21 @@
+package com.keepit.controllers
+
+import com.google.inject.Inject
+import com.keepit.common.controller.HeimdalServiceController
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.Database
+import com.keepit.model.{DelightedAnswerRepo, User}
+import play.api.libs.json.Json
+import play.api.mvc.Action
+
+class DelightedController @Inject() (
+  db: Database,
+  delightedAnswerRepo: DelightedAnswerRepo) extends HeimdalServiceController {
+
+  def getLastDelightedAnswerDate(userId: Id[User]) = Action { request =>
+    val lastDelightedAnswerDate = db.readOnly { implicit s =>
+      delightedAnswerRepo.getLastAnswerDateForUser(userId)
+    }
+    Ok(Json.toJson(lastDelightedAnswerDate))
+  }
+}

--- a/kifi-backend/modules/heimdal/app/com/keepit/controllers/EventTrackingController.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/controllers/EventTrackingController.scala
@@ -1,21 +1,16 @@
-package com.keepit.heimdal.controllers
+package com.keepit.controllers
 
-import com.keepit.common.controller.HeimdalServiceController
-import com.keepit.common.time._
-import com.keepit.heimdal._
-import com.keepit.common.akka.SafeFuture
-import com.keepit.common.akka.SlowRunningExecutionContext
-
-import play.api.mvc.Action
-import play.api.libs.json.JsValue
-
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import com.google.inject.Inject
-import play.api.libs.json.JsArray
-import scala.util.{Success, Failure}
-import scala.concurrent.duration._
-import com.kifi.franz.SQSQueue
+import com.keepit.common.controller.HeimdalServiceController
 import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.heimdal._
+import com.keepit.model.{AnonymousEventLoggingRepo, UserEventLoggingRepo, SystemEventLoggingRepo, NonUserEventLoggingRepo}
+import com.kifi.franz.SQSQueue
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.libs.json.{JsArray, JsValue}
+
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
 
 class EventTrackingController @Inject() (
   userEventLoggingRepo: UserEventLoggingRepo,

--- a/kifi-backend/modules/heimdal/app/com/keepit/heimdal/HeimdalGlobal.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/heimdal/HeimdalGlobal.scala
@@ -5,7 +5,7 @@ import com.keepit.common.cache.{InMemoryCachePlugin, FortyTwoCachePlugin}
 import com.keepit.common.healthcheck._
 import play.api.Mode._
 import play.api._
-import com.keepit.heimdal.controllers.EventTrackingController
+import com.keepit.controllers.EventTrackingController
 
 object HeimdalGlobal extends FortyTwoGlobal(Prod) with HeimdalServices {
   val module = HeimdalProdModule()

--- a/kifi-backend/modules/heimdal/app/com/keepit/heimdal/HeimdalModule.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/heimdal/HeimdalModule.scala
@@ -14,4 +14,5 @@ abstract class HeimdalModule(
   // Service clients
   val shoeboxServiceClientModule = ProdShoeboxServiceClientModule()
   val secureSocialModule = RemoteSecureSocialModule()
+  val heimdalSlickModule = HeimdalSlickModule()
 }

--- a/kifi-backend/modules/heimdal/app/com/keepit/heimdal/HeimdalMongoDBModule.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/heimdal/HeimdalMongoDBModule.scala
@@ -1,5 +1,6 @@
 package com.keepit.heimdal
 
+import com.keepit.model._
 import reactivemongo.api.MongoDriver
 
 import com.keepit.common.healthcheck.AirbrakeNotifier

--- a/kifi-backend/modules/heimdal/app/com/keepit/heimdal/HeimdalSlickModule.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/heimdal/HeimdalSlickModule.scala
@@ -1,0 +1,27 @@
+package com.keepit.heimdal
+
+import com.keepit.common.db.slick._
+import scala.util._
+import scala.slick.jdbc.JdbcBackend.{Database => SlickDatabase}
+
+import net.codingwell.scalaguice.ScalaModule
+
+import com.google.inject.{Provides, Singleton}
+import com.keepit.common.db.slick._
+import play.api.db.DB
+import play.api.Play
+import akka.actor.ActorSystem
+
+case class HeimdalDbInfo() extends DbInfo {
+  def masterDatabase = SlickDatabase.forDataSource(DB.getDataSource("shoebox")(Play.current))
+  // can't probe for existing (or not) db, must try and possibly fail.
+  override def slaveDatabase = None
+
+  def driverName = Play.current.configuration.getString("db.shoebox.driver").get
+}
+
+case class HeimdalSlickModule() extends SlickModule(HeimdalDbInfo()) {
+  @Provides @Singleton
+  def dbExecutionContextProvider(system: ActorSystem): DbExecutionContext =
+    DbExecutionContext(system.dispatchers.lookup("db-thread-pool-dispatcher"))
+}

--- a/kifi-backend/modules/heimdal/app/com/keepit/heimdal/MetricManager.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/heimdal/MetricManager.scala
@@ -1,5 +1,6 @@
 package com.keepit.heimdal
 
+import com.keepit.model.{MetricDescriptorRepo, UserEventLoggingRepo, MetricRepoFactory, MetricData}
 import org.joda.time.DateTime
 
 import com.keepit.common.time._

--- a/kifi-backend/modules/heimdal/app/com/keepit/heimdal/Metrics.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/heimdal/Metrics.scala
@@ -1,12 +1,13 @@
 package com.keepit.heimdal
 
+import com.keepit.model.CustomBSONHandlers
 import org.joda.time.DateTime
 
 import scala.concurrent.duration.Duration
 
 import reactivemongo.bson.{BSONValue, BSONDouble, BSONString, BSONDocument, BSONArray, BSONDateTime, BSONLong}
 import reactivemongo.core.commands.{PipelineOperator, Match, GroupField, SumValue, Unwind, Sort, Descending, AddToSet}
-import com.keepit.heimdal.CustomBSONHandlers.BSONContextDataHandler
+import CustomBSONHandlers.BSONContextDataHandler
 
 sealed trait ComparisonOperator {
   def toBSONMatchFragment: BSONValue

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/AnomymousEventRepos.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/AnomymousEventRepos.scala
@@ -1,15 +1,17 @@
-package com.keepit.heimdal
+package com.keepit.model
 
-import reactivemongo.bson.BSONDocument
-import reactivemongo.api.collections.default.BSONCollection
-
+import com.keepit.common.KestrelCombinator
+import com.keepit.common.cache.{CacheStatistics, FortyTwoCachePlugin, JsonCacheImpl, Key}
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.cache.{Key, JsonCacheImpl, FortyTwoCachePlugin, CacheStatistics}
 import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 import com.keepit.common.logging.AccessLog
-import scala.concurrent.duration.Duration
-import com.keepit.common.KestrelCombinator
+import com.keepit.heimdal.{EventType, EventDescriptor, MixpanelClient, AnonymousEvent}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import reactivemongo.api.collections.default.BSONCollection
+import reactivemongo.bson.BSONDocument
+
+import scala.concurrent.duration.Duration
 
 trait AnonymousEventLoggingRepo extends EventRepo[AnonymousEvent]
 

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/DelightedAnswer.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/DelightedAnswer.scala
@@ -1,0 +1,17 @@
+package com.keepit.model
+
+import com.keepit.common.db.{Model, Id}
+import com.keepit.common.time._
+import org.joda.time.DateTime
+
+case class DelightedAnswer(
+  id: Option[Id[DelightedAnswer]] = None,
+  createdAt: DateTime = currentDateTime,
+  updatedAt: DateTime = currentDateTime,
+  delightedUserId: Id[DelightedUser],
+  date: DateTime,
+  score: Int,
+  comment: Option[String]) extends Model[DelightedAnswer] {
+  def withId(id: Id[DelightedAnswer]) = this.copy(id = Some(id))
+  def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
+}

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/DelightedAnswerRepo.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/DelightedAnswerRepo.scala
@@ -1,0 +1,44 @@
+package com.keepit.model
+
+import com.google.inject.{Inject, Singleton, ImplementedBy}
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.DBSession.{RWSession, RSession}
+import com.keepit.common.db.slick._
+import com.keepit.common.time.Clock
+import org.joda.time.DateTime
+
+@ImplementedBy(classOf[DelightedAnswerRepoImpl])
+trait DelightedAnswerRepo extends Repo[DelightedAnswer] {
+  def getLastAnswerDateForUser(userId: Id[User])(implicit session: RSession): Option[DateTime]
+}
+
+@Singleton
+class DelightedAnswerRepoImpl @Inject() (
+  val db: DataBaseComponent,
+  val clock: Clock,
+  delightedUserRepo: DelightedUserRepoImpl) extends DbRepo[DelightedAnswer] with DelightedAnswerRepo {
+
+  import db.Driver.simple._
+
+  type RepoImpl = DelightedAnswerTable
+  class DelightedAnswerTable(tag: Tag) extends RepoTable[DelightedAnswer](db, tag, "delighted_answer") {
+    def delightedUserId = column[Id[DelightedUser]]("delighted_user_id", O.NotNull)
+    def date = column[DateTime]("date", O.NotNull)
+    def score = column[Int]("score", O.NotNull)
+    def comment = column[String]("comment", O.Nullable)
+    def * = (id.?, createdAt, updatedAt, delightedUserId, date, score, comment.?) <> ((DelightedAnswer.apply _).tupled, DelightedAnswer.unapply _)
+  }
+
+  def table(tag: Tag) = new DelightedAnswerTable(tag)
+  initTable()
+
+  override def deleteCache(model: DelightedAnswer)(implicit session: RSession): Unit = {}
+  override def invalidateCache(model: DelightedAnswer)(implicit session: RSession): Unit = {}
+
+  def getLastAnswerDateForUser(userId: Id[User])(implicit session: RSession): Option[DateTime] = {
+    Query((for {
+      u <- delightedUserRepo.rows
+      a <- rows if a.delightedUserId == u.id
+    } yield a.date).max).first
+  }
+}

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/DelightedUser.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/DelightedUser.scala
@@ -1,0 +1,14 @@
+package com.keepit.model
+
+import com.keepit.common.db.{Model, Id}
+import com.keepit.common.time._
+import org.joda.time.DateTime
+
+case class DelightedUser(
+  id: Option[Id[DelightedUser]] = None,
+  createdAt: DateTime = currentDateTime,
+  updatedAt: DateTime = currentDateTime,
+  userId: Id[User]) extends Model[DelightedUser] {
+  def withId(id: Id[DelightedUser]) = this.copy(id = Some(id))
+  def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
+}

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/DelightedUserRepo.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/DelightedUserRepo.scala
@@ -1,0 +1,29 @@
+package com.keepit.model
+
+import com.google.inject.{Inject, Singleton, ImplementedBy}
+import com.keepit.common.db.slick.DBSession.RSession
+import com.keepit.common.db.slick._
+import com.keepit.common.db.Id
+import com.keepit.common.time._
+
+@ImplementedBy(classOf[DelightedUserRepoImpl])
+trait DelightedUserRepo extends Repo[DelightedUser]
+
+@Singleton
+class DelightedUserRepoImpl @Inject() (val db: DataBaseComponent, val clock: Clock)
+  extends DbRepo[DelightedUser] with DelightedUserRepo {
+
+  import db.Driver.simple._
+
+  type RepoImpl = DelightedUserTable
+  class DelightedUserTable(tag: Tag) extends RepoTable[DelightedUser](db, tag, "delighted_user") {
+    def userId = column[Id[User]]("user_id", O.NotNull)
+    def * = (id.?, createdAt, updatedAt, userId) <> ((DelightedUser.apply _).tupled, DelightedUser.unapply _)
+  }
+
+  def table(tag: Tag) = new DelightedUserTable(tag)
+  initTable()
+
+  override def deleteCache(model: DelightedUser)(implicit session: RSession): Unit = {}
+  override def invalidateCache(model: DelightedUser)(implicit session: RSession): Unit = {}
+}

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/EventDescriptorRepo.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/EventDescriptorRepo.scala
@@ -1,11 +1,11 @@
-package com.keepit.heimdal
+package com.keepit.model
 
+import com.keepit.common.akka.SafeFuture
+import com.keepit.heimdal.{EventDescriptor, EventType, HeimdalEvent}
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import reactivemongo.bson.{BSONDocument, Macros}
 
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
 import scala.concurrent.Future
-import com.keepit.common.akka.SafeFuture
 import CustomBSONHandlers._
 
 trait EventDescriptorRepo[E <: HeimdalEvent] {

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/EventRepo.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/EventRepo.scala
@@ -1,14 +1,16 @@
-package com.keepit.heimdal
+package com.keepit.model
 
-import scala.concurrent.{Promise, Future}
-import reactivemongo.bson._
-import play.modules.reactivemongo.json.ImplicitBSONHandlers.JsValueReader
-import play.api.libs.json.{Json, JsArray}
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import reactivemongo.core.commands.PipelineOperator
-import com.keepit.common.time._
-import com.keepit.heimdal.CustomBSONHandlers.{BSONDateTimeHandler, BSONEventTypeHandler, BSONEventContextHandler}
 import com.keepit.common.logging.Logging
+import com.keepit.common.time._
+import CustomBSONHandlers.{BSONDateTimeHandler, BSONEventContextHandler, BSONEventTypeHandler}
+import com.keepit.heimdal._
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.libs.json.{JsArray, Json}
+import play.modules.reactivemongo.json.ImplicitBSONHandlers.JsValueReader
+import reactivemongo.bson._
+import reactivemongo.core.commands.PipelineOperator
+
+import scala.concurrent.{Future, Promise}
 
 trait EventRepo[E <: HeimdalEvent] {
   def persist(event: E) : Unit

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/MetricDescriptorRepo.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/MetricDescriptorRepo.scala
@@ -1,8 +1,8 @@
-package com.keepit.heimdal
+package com.keepit.model
 
 import com.keepit.common.healthcheck.AirbrakeNotifier
-
 import reactivemongo.core.commands.{LastError, PipelineOperator}
+import com.keepit.heimdal.MetricDescriptor
 import reactivemongo.api.collections.default.BSONCollection
 import reactivemongo.bson.{BSONDocument, BSONArray, Macros}
 import CustomBSONHandlers._

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/MetricRepo.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/MetricRepo.scala
@@ -1,17 +1,13 @@
-package com.keepit.heimdal
-
-import org.joda.time.DateTime
+package com.keepit.model
 
 import com.keepit.common.healthcheck.AirbrakeNotifier
-
+import org.joda.time.DateTime
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.api.libs.json.{JsObject, JsNull, JsArray, Json, Writes, JsValue}
-
-import reactivemongo.bson.{BSONDocument, BSONDateTime, BSONArray, BSONBoolean}
+import play.api.libs.json.{JsValue, Json, Writes}
 import reactivemongo.api.collections.default.BSONCollection
+import reactivemongo.bson.{BSONArray, BSONBoolean, BSONDateTime, BSONDocument}
 
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration._
+import scala.concurrent.Future
 
 
 case class MetricData(dt: DateTime, data: Seq[BSONDocument])

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/MongoRepo.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/MongoRepo.scala
@@ -1,21 +1,17 @@
-package com.keepit.heimdal
+package com.keepit.model
 
-import com.keepit.common.healthcheck.{AirbrakeNotifier, AirbrakeError}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
+
+import com.keepit.common.healthcheck.{AirbrakeError, AirbrakeNotifier}
+import com.keepit.common.logging.Logging
+import org.joda.time.DateTime
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import reactivemongo.api.collections.default.BSONCollection
 import reactivemongo.bson._
-import reactivemongo.core.commands.{PipelineOperator, Aggregate, LastError}
+import reactivemongo.core.commands.{Aggregate, LastError, PipelineOperator}
+import com.keepit.heimdal._
 
 import scala.concurrent.Future
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import reactivemongo.bson.BSONDouble
-import reactivemongo.bson.BSONString
-import reactivemongo.api.collections.default.BSONCollection
-import org.joda.time.DateTime
-import com.keepit.common.logging.Logging
-
-//Might want to change this to a custom play one
-import java.util.concurrent.atomic.{AtomicLong, AtomicBoolean}
-
-import play.modules.statsd.api.Statsd
 
 case class MongoInsertBufferFullException() extends java.lang.Throwable
 

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/NonUserEventRepos.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/NonUserEventRepos.scala
@@ -1,7 +1,4 @@
-package com.keepit.heimdal
-
-import reactivemongo.bson.BSONDocument
-import reactivemongo.api.collections.default.BSONCollection
+package com.keepit.model
 
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.cache.{Key, JsonCacheImpl, FortyTwoCachePlugin, CacheStatistics}
@@ -10,6 +7,10 @@ import com.keepit.common.logging.AccessLog
 import scala.concurrent.duration.Duration
 import com.keepit.common.KestrelCombinator
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import reactivemongo.api.collections.default.BSONCollection
+import reactivemongo.bson.BSONDocument
+import com.keepit.heimdal._
+
 import scala.concurrent.Future
 
 trait NonUserEventLoggingRepo extends EventRepo[NonUserEvent]

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/SystemEventRepos.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/SystemEventRepos.scala
@@ -1,12 +1,15 @@
-package com.keepit.heimdal
+package com.keepit.model
 
-import reactivemongo.bson.BSONDocument
-import reactivemongo.api.collections.default.BSONCollection
-
+import com.keepit.common.cache.{CacheStatistics, FortyTwoCachePlugin, JsonCacheImpl, Key}
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.cache.{Key, JsonCacheImpl, FortyTwoCachePlugin, CacheStatistics}
 import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 import com.keepit.common.logging.AccessLog
+import com.keepit.heimdal.SystemEvent
+import reactivemongo.api.collections.default.BSONCollection
+import reactivemongo.bson.BSONDocument
+import com.keepit.heimdal._
+
 import scala.concurrent.duration.Duration
 import com.keepit.common.KestrelCombinator
 import play.api.libs.concurrent.Execution.Implicits.defaultContext

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/UserEventRepos.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/UserEventRepos.scala
@@ -1,19 +1,22 @@
-package com.keepit.heimdal
+package com.keepit.model
 
+import com.keepit.common.cache.{CacheStatistics, FortyTwoCachePlugin, JsonCacheImpl, Key}
+import com.keepit.common.db.{ExternalId, Id}
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import reactivemongo.bson.{BSONDocument, BSONLong}
 import reactivemongo.api.collections.default.BSONCollection
-import com.keepit.common.cache.{JsonCacheImpl, FortyTwoCachePlugin, CacheStatistics, Key}
+import com.keepit.common.cache.{Key, JsonCacheImpl, FortyTwoCachePlugin, CacheStatistics}
 import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 import com.keepit.common.logging.AccessLog
 import com.keepit.common.KestrelCombinator
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import com.keepit.model.{Gender, KifiInstallation, User}
-import com.keepit.common.db.{ExternalId, Id}
+import com.keepit.common.usersegment.UserSegment
+import com.keepit.heimdal.{HeimdalContext, UserEvent}
 import com.keepit.shoebox.ShoeboxServiceClient
+import com.keepit.heimdal._
+
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
-import com.keepit.common.usersegment.UserSegment
 
 
 trait UserEventLoggingRepo extends EventRepo[UserEvent] {

--- a/kifi-backend/modules/heimdal/conf/heimdal.routes
+++ b/kifi-backend/modules/heimdal/conf/heimdal.routes
@@ -2,34 +2,37 @@
 
 
 ##########################################
-#INTERNAL ROUTES/Eliza
+#INTERNAL ROUTES/Heimdal
 ##########################################
 
-GET   /internal/heimdal/:repo/adhocMetric       @com.keepit.heimdal.controllers.AnalyticsController.adhocMetric(repo: String, from: String ?= "", to: String ?= "now", events: String ?="all", groupBy: String ?="_", breakDown : String ?= "false", mode: String ?= "count", filter: String ?="none", as: String?="pie")
+GET   /internal/heimdal/:repo/adhocMetric              @com.keepit.controllers.AnalyticsController.adhocMetric(repo: String, from: String ?= "", to: String ?= "now", events: String ?="all", groupBy: String ?="_", breakDown : String ?= "false", mode: String ?= "count", filter: String ?="none", as: String?="pie")
 
-GET   /internal/heimdal/:repo/rawEvents         @com.keepit.heimdal.controllers.AnalyticsController.rawEvents(repo:String, events: String ?="all", limit: Int ?= 10, window: Int ?= 24)
+GET   /internal/heimdal/:repo/rawEvents                @com.keepit.controllers.AnalyticsController.rawEvents(repo:String, events: String ?="all", limit: Int ?= 10, window: Int ?= 24)
 
-GET   /internal/heimdal/:repo/createMetric      @com.keepit.heimdal.controllers.AnalyticsController.createMetric(repo: String, name: String ?= "default", start: String ?= "2013-10-1", window: Int ?= 24, step: Int ?=24, description: String ?= "No Description Given.", events: String ?= "all", groupBy: String ?="_", breakDown: String ?="false", mode: String ?= "count", filter: String ?= "none", uniqueField: String ?= "_")
+GET   /internal/heimdal/:repo/createMetric             @com.keepit.controllers.AnalyticsController.createMetric(repo: String, name: String ?= "default", start: String ?= "2013-10-1", window: Int ?= 24, step: Int ?=24, description: String ?= "No Description Given.", events: String ?= "all", groupBy: String ?="_", breakDown: String ?="false", mode: String ?= "count", filter: String ?= "none", uniqueField: String ?= "_")
 
-GET  /internal/heimdal/updateMetrics                 @com.keepit.heimdal.controllers.AnalyticsController.updateMetrics()
+GET  /internal/heimdal/updateMetrics                   @com.keepit.controllers.AnalyticsController.updateMetrics()
 
-GET  /internal/heimdal/:repo/getAvailableMetrics @com.keepit.heimdal.controllers.AnalyticsController.getAvailableMetrics(repo: String)
+GET  /internal/heimdal/:repo/getAvailableMetrics       @com.keepit.controllers.AnalyticsController.getAvailableMetrics(repo: String)
 
-GET  /internal/heimdal/:repo/getMetric           @com.keepit.heimdal.controllers.AnalyticsController.getMetric(repo: String, name: String ?= "all", as: String ?="line")
+GET  /internal/heimdal/:repo/getMetric                 @com.keepit.controllers.AnalyticsController.getMetric(repo: String, name: String ?= "all", as: String ?="line")
 
-GET  /internal/heimdal/:repo/getMetricData       @com.keepit.heimdal.controllers.AnalyticsController.getMetricData(repo: String, name: String)
+GET  /internal/heimdal/:repo/getMetricData             @com.keepit.controllers.AnalyticsController.getMetricData(repo: String, name: String)
 
-GET  /internal/heimdal/:repo/eventDescriptors    @com.keepit.heimdal.controllers.AnalyticsController.getEventDescriptors(repo: String)
+GET  /internal/heimdal/:repo/eventDescriptors          @com.keepit.controllers.AnalyticsController.getEventDescriptors(repo: String)
 
-POST /internal/heimdal/:repo/eventDescriptors    @com.keepit.heimdal.controllers.AnalyticsController.updateEventDescriptors(repo: String)
+POST /internal/heimdal/:repo/eventDescriptors          @com.keepit.controllers.AnalyticsController.updateEventDescriptors(repo: String)
 
-GET /internal/heimdal/user/delete               @com.keepit.heimdal.controllers.AnalyticsController.deleteUser(userId: Id[User])
+GET /internal/heimdal/user/delete                      @com.keepit.controllers.AnalyticsController.deleteUser(userId: Id[User])
 
-POST /internal/heimdal/user/set               @com.keepit.heimdal.controllers.AnalyticsController.setUserProperties(userId: Id[User])
+POST /internal/heimdal/user/set                        @com.keepit.controllers.AnalyticsController.setUserProperties(userId: Id[User])
 
-POST /internal/heimdal/user/increment               @com.keepit.heimdal.controllers.AnalyticsController.incrementUserProperties(userId: Id[User])
+POST /internal/heimdal/user/increment                  @com.keepit.controllers.AnalyticsController.incrementUserProperties(userId: Id[User])
 
-GET /internal/heimdal/user/alias             @com.keepit.heimdal.controllers.AnalyticsController.setUserAlias(userId: Id[User], externalId: ExternalId[User])
+GET /internal/heimdal/user/alias                       @com.keepit.controllers.AnalyticsController.setUserAlias(userId: Id[User], externalId: ExternalId[User])
+
+GET /internal/heimdal/user/lastDelightedAnswerDate     @com.keepit.controllers.DelightedController.getLastDelightedAnswerDate(userId: Id[User])
+
 ->  / common.Routes
 
 

--- a/kifi-backend/modules/heimdal/test/com/keepit/controllers/EventTrackingTest.scala
+++ b/kifi-backend/modules/heimdal/test/com/keepit/controllers/EventTrackingTest.scala
@@ -1,5 +1,6 @@
-package com.keepit.heimdal.controllers
+package com.keepit.controllers
 
+import com.keepit.model.{AnonymousEventLoggingRepo, UserEventLoggingRepo, SystemEventLoggingRepo, NonUserEventLoggingRepo}
 import org.specs2.mutable._
 
 import com.keepit.common.db.LargeString._

--- a/kifi-backend/modules/heimdal/test/com/keepit/controllers/EventTrackingTest.scala
+++ b/kifi-backend/modules/heimdal/test/com/keepit/controllers/EventTrackingTest.scala
@@ -1,6 +1,6 @@
 package com.keepit.controllers
 
-import com.keepit.model.{AnonymousEventLoggingRepo, UserEventLoggingRepo, SystemEventLoggingRepo, NonUserEventLoggingRepo}
+import com.keepit.model._
 import org.specs2.mutable._
 
 import com.keepit.common.db.LargeString._

--- a/kifi-backend/modules/heimdal/test/com/keepit/heimdal/TestMongoDBModule.scala
+++ b/kifi-backend/modules/heimdal/test/com/keepit/heimdal/TestMongoDBModule.scala
@@ -1,6 +1,7 @@
 package com.keepit.heimdal
 
 import com.google.inject.{Provides, Singleton}
+import com.keepit.model.{AnonymousEventLoggingRepo, UserEventLoggingRepo, SystemEventLoggingRepo, NonUserEventLoggingRepo}
 
 
 case class TestMongoModule() extends MongoModule {

--- a/kifi-backend/modules/heimdal/test/com/keepit/heimdal/TestUserEventRepo.scala
+++ b/kifi-backend/modules/heimdal/test/com/keepit/heimdal/TestUserEventRepo.scala
@@ -1,5 +1,7 @@
 package com.keepit.heimdal
 
+import com.keepit.model.{DevAnonymousEventLoggingRepo, DevUserEventLoggingRepo, DevSystemEventLoggingRepo, DevNonUserEventLoggingRepo}
+
 class TestUserEventLoggingRepo extends DevUserEventLoggingRepo {
 
   var events: Vector[UserEvent] = Vector()

--- a/kifi-backend/modules/heimdal/test/com/keepit/heimdal/UserEventAugmentorsTest.scala
+++ b/kifi-backend/modules/heimdal/test/com/keepit/heimdal/UserEventAugmentorsTest.scala
@@ -1,5 +1,6 @@
 package com.keepit.heimdal
 
+import com.keepit.model.{UserIdAugmentor, UserValuesAugmentor, ExtensionVersionAugmentor, EventAugmentor}
 import org.specs2.mutable.Specification
 import com.keepit.shoebox.FakeShoeboxServiceClientImpl
 import scala.concurrent.{Await, Future}

--- a/kifi-backend/modules/heimdal/test/com/keepit/model/TestMongoDBModule.scala
+++ b/kifi-backend/modules/heimdal/test/com/keepit/model/TestMongoDBModule.scala
@@ -1,7 +1,7 @@
-package com.keepit.heimdal
+package com.keepit.model
 
 import com.google.inject.{Provides, Singleton}
-import com.keepit.model.{AnonymousEventLoggingRepo, UserEventLoggingRepo, SystemEventLoggingRepo, NonUserEventLoggingRepo}
+import com.keepit.heimdal._
 
 
 case class TestMongoModule() extends MongoModule {

--- a/kifi-backend/modules/heimdal/test/com/keepit/model/TestUserEventRepo.scala
+++ b/kifi-backend/modules/heimdal/test/com/keepit/model/TestUserEventRepo.scala
@@ -1,6 +1,6 @@
-package com.keepit.heimdal
+package com.keepit.model
 
-import com.keepit.model.{DevAnonymousEventLoggingRepo, DevUserEventLoggingRepo, DevSystemEventLoggingRepo, DevNonUserEventLoggingRepo}
+import com.keepit.heimdal._
 
 class TestUserEventLoggingRepo extends DevUserEventLoggingRepo {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtPreferenceController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtPreferenceController.scala
@@ -2,6 +2,7 @@ package com.keepit.controllers.ext
 
 import com.google.inject.Inject
 import com.keepit.classify.{DomainRepo, Domain, DomainStates}
+import com.keepit.commanders.UserCommander
 import com.keepit.common.controller.{BrowserExtensionController, ShoeboxServiceController, ActionAuthenticator}
 import com.keepit.common.crypto.RatherInsecureDESCrypt
 import com.keepit.common.db.Id
@@ -29,7 +30,8 @@ class ExtPreferenceController @Inject() (
   notifyPreferenceRepo: UserNotifyPreferenceRepo,
   domainRepo: DomainRepo,
   userToDomainRepo: UserToDomainRepo,
-  normalizedURIInterner: NormalizedURIInterner)
+  normalizedURIInterner: NormalizedURIInterner,
+  userCommander: UserCommander)
   extends BrowserExtensionController(actionAuthenticator) with ShoeboxServiceController {
 
   private case class UserPrefs(
@@ -95,7 +97,9 @@ class ExtPreferenceController @Inject() (
   def getPrefs(version: Int) = JsonAction.authenticatedAsync { request =>
     val ip = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
     val encryptedIp: String = scala.util.Try(crypt.crypt(ipkey, ip)).getOrElse("")
-    loadUserPrefs(request.user.id.get, request.experiments) map {prefs =>
+    val userId = request.user.id.get
+    userCommander.setLastUserActive(userId)
+    loadUserPrefs(userId, request.experiments) map {prefs =>
       if (version == 1) {
         Ok(Json.arr("prefs", prefs, encryptedIp))
       } else {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtPreferenceController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtPreferenceController.scala
@@ -98,7 +98,8 @@ class ExtPreferenceController @Inject() (
     val ip = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
     val encryptedIp: String = scala.util.Try(crypt.crypt(ipkey, ip)).getOrElse("")
     val userId = request.user.id.get
-    userCommander.setLastUserActive(userId)
+    userCommander.setLastUserActive(userId) // The extension doesn't display Delighted surveys for the moment, so we
+                                            // don't need to wait for that Future to complete before we move on
     loadUserPrefs(userId, request.experiments) map {prefs =>
       if (version == 1) {
         Ok(Json.arr("prefs", prefs, encryptedIp))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
@@ -192,6 +192,12 @@ class MobileUserController @Inject() (
     }
   }
 
+  private val MobilePrefNames = Set("show_delighted_question")
+
+  def getPrefs() = JsonAction.authenticated { request =>
+    userCommander.setLastUserActive(request.userId)
+    Ok(userCommander.getPrefs(MobilePrefNames, request.userId))
+  }
 }
 
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
@@ -194,9 +194,11 @@ class MobileUserController @Inject() (
 
   private val MobilePrefNames = Set("show_delighted_question")
 
-  def getPrefs() = JsonAction.authenticated { request =>
-    userCommander.setLastUserActive(request.userId)
-    Ok(userCommander.getPrefs(MobilePrefNames, request.userId))
+  def getPrefs() = JsonAction.authenticatedAsync { request =>
+    // Make sure the user's last active date has been updated before returning the result
+    userCommander.setLastUserActive(request.userId) map { _ =>
+      Ok(userCommander.getPrefs(MobilePrefNames, request.userId))
+    }
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -259,7 +259,10 @@ class UserController @Inject() (
       Ok(userCommander.getPrefs(SitePrefNames, request.userId))
     } recover {
       // todo(martin) - Remove this. This is to make sure I don't break prod for the moment
-      case _ => Ok(userCommander.getPrefs(SitePrefNames, request.userId))
+      case t: Throwable => {
+        airbrakeNotifier.notify(s"Exception occurred in setLastUserActive for user ${request.userId}", t)
+        Ok(userCommander.getPrefs(SitePrefNames, request.userId))
+      }
     }
   }
 

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -132,6 +132,7 @@ POST    /m/1/collections/create             @com.keepit.controllers.mobile.Mobil
 GET     /m/1/collections/all                @com.keepit.controllers.mobile.MobileBookmarksController.allCollections(sort: String ?= "last_kept")
 GET     /m/1/user/me                        @com.keepit.controllers.mobile.MobileUserController.currentUser()
 POST    /m/1/user/me                        @com.keepit.controllers.mobile.MobileUserController.updateCurrentUser()
+GET     /m/1/user/prefs                     @com.keepit.controllers.mobile.MobileUserController.getPrefs()
 GET     /m/1/keeps/all                      @com.keepit.controllers.mobile.MobileBookmarksController.allKeeps(before: Option[String], after: Option[String], collection: Option[String], helprank: Option[String], count: Int ?= Integer.MAX_VALUE, withPageInfo: Boolean ?= false)
 POST    /m/1/tags/:id/addToKeep             @com.keepit.controllers.mobile.MobileBookmarksController.addTag(id: ExternalId[Collection])
 POST    /m/1/tags/:id/removeFromKeep        @com.keepit.controllers.mobile.MobileBookmarksController.removeTag(id: ExternalId[Collection])

--- a/kifi-backend/project/Build.scala
+++ b/kifi-backend/project/Build.scala
@@ -252,7 +252,7 @@ object ApplicationBuild extends Build {
 
   lazy val heimdal = play.Project("heimdal", appVersion, heimdalDependencies, path=file("modules/heimdal")).settings(
     commonSettings ++ Seq(javaOptions in Test += "-Dconfig.resource=application-heimdal.conf"): _*
-  ).dependsOn(common % "test->test;compile->compile")
+  ).dependsOn(common % "test->test;compile->compile", sqldb % "test->test;compile->compile")
 
   lazy val abook = play.Project("abook", appVersion, abookDependencies, path=file("modules/abook")).settings(
     commonSettings ++ Seq(javaOptions in Test += "-Dconfig.resource=application-abook.conf"): _*

--- a/tools/etc/init.d/heimdal
+++ b/tools/etc/init.d/heimdal
@@ -29,7 +29,7 @@ classpathLine=`grep "classpath=" $applDir/start | sed 's/.*"\(.*\)".*/\1/'`
 #echo classpathLine=$classpathLine
 classpath=`echo "$classpathLine" | sed 's%$scriptdir%'$applDir'%g'`
 #echo classpath=$classpath
-javaArgs="$yourkit $newrelic $jmxArgs $javaGc -Dhttp.port=9000 -Xms512M -Xmx3072m -server -Dconfig.resource=prod/$serviceNameLo.conf -Duser.dir=$applDir/ -Dlogger.resource=prod/logger.prod.xml -cp $classpath play.core.server.NettyServer $applDir"
+javaArgs="$yourkit $newrelic $jmxArgs $javaGc -Ddb.heimdal.password=8wDU9wVrvTBaXizV -Dhttp.port=9000 -Xms512M -Xmx3072m -server -Dconfig.resource=prod/$serviceNameLo.conf -Duser.dir=$applDir/ -Dlogger.resource=prod/logger.prod.xml -cp $classpath play.core.server.NettyServer $applDir"
 javaCommandLine="$javaExe $javaArgs"                       # command line to start the Java service application
 javaCommandLineKeyword="prod/$serviceNameLo.conf"                     # a keyword that occurs on the commandline, used to detect an already running service process and to distinguish it from others
 

--- a/tools/etc/init.d/heimdal
+++ b/tools/etc/init.d/heimdal
@@ -29,7 +29,7 @@ classpathLine=`grep "classpath=" $applDir/start | sed 's/.*"\(.*\)".*/\1/'`
 #echo classpathLine=$classpathLine
 classpath=`echo "$classpathLine" | sed 's%$scriptdir%'$applDir'%g'`
 #echo classpath=$classpath
-javaArgs="$yourkit $newrelic $jmxArgs $javaGc -Ddb.heimdal.password=8wDU9wVrvTBaXizV -Dhttp.port=9000 -Xms512M -Xmx3072m -server -Dconfig.resource=prod/$serviceNameLo.conf -Duser.dir=$applDir/ -Dlogger.resource=prod/logger.prod.xml -cp $classpath play.core.server.NettyServer $applDir"
+javaArgs="$yourkit $newrelic $jmxArgs $javaGc -Ddb.shoebox.password=8wDU9wVrvTBaXizV -Dhttp.port=9000 -Xms512M -Xmx3072m -server -Dconfig.resource=prod/$serviceNameLo.conf -Duser.dir=$applDir/ -Dlogger.resource=prod/logger.prod.xml -cp $classpath play.core.server.NettyServer $applDir"
 javaCommandLine="$javaExe $javaArgs"                       # command line to start the Java service application
 javaCommandLineKeyword="prod/$serviceNameLo.conf"                     # a keyword that occurs on the commandline, used to detect an already running service process and to distinguish it from others
 


### PR DESCRIPTION
@andrewconner @stkem (@jaredpetker @davoda)

Things to look for:
- Heimdal now has a database
- Created two repos `DelightedUserRepo` and `DelightedAnswerRepo`
- keeping track of user activity ("last_active" in user_values table)
- mobile endpoint for user prefs
- returning "show_delighted_question" field in user prefs (this part may be revised in the future)

Other than that, all the import-related changes occurred when I refactored the code on Heimdal (moving classes between packages)
