### PR TITLE
Renamed (Refactor) all Database.readOnly => Database.readOnlyMaster

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/abook/ABookCommander.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/ABookCommander.scala
@@ -314,7 +314,7 @@ class ABookCommander @Inject() (
   }
 
   def getContactNameByEmail(userId: Id[User], email: EmailAddress): Option[String] = {
-    db.readOnly { implicit session =>
+    db.readOnlyMaster { implicit session =>
       econtactRepo.getByUserIdAndEmail(userId, email).collectFirst { case contact if contact.name.isDefined => contact.name.get }
     }
   }

--- a/kifi-backend/modules/abook/app/com/keepit/abook/ABookController.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/ABookController.scala
@@ -116,7 +116,7 @@ class ABookController @Inject() (
   def getEContactsByIds() = Action(parse.tolerantJson) { request =>
     val jsArray = request.body.asOpt[JsArray] getOrElse JsArray()
     val contactIds = jsArray.value map { x => Id[EContact](x.as[Long]) }
-    val contacts = db.readOnly { implicit ro =>
+    val contacts = db.readOnlyMaster { implicit ro =>
       econtactRepo.getByIds(contactIds)
     }
     Ok(Json.toJson[Seq[EContact]](contacts))
@@ -172,7 +172,7 @@ class ABookController @Inject() (
   }
 
   def getABookInfoByExternalId(externalId: ExternalId[ABookInfo]) = Action { request =>
-    db.readOnly { implicit session =>
+    db.readOnlyMaster { implicit session =>
       Ok(Json.toJson(abookInfoRepo.getByExternalId(externalId)))
     }
   }

--- a/kifi-backend/modules/abook/app/com/keepit/abook/typeahead/EContactABookTypeahead.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/typeahead/EContactABookTypeahead.scala
@@ -22,7 +22,7 @@ class EContactABookTypeahead @Inject() (
 
   def refreshAll():Future[Unit] = {
     log.info("[refreshAll] begin re-indexing ...")
-    val abookInfos = db.readOnly { implicit ro =>
+    val abookInfos = db.readOnlyMaster { implicit ro =>
       abookInfoRepo.all() // only retrieve users with existing abooks (todo: deal with deletes)
     }
     log.info(s"[refreshAll] ${abookInfos.length} to be re-indexed; abooks=${abookInfos.take(20).mkString(",")} ...")

--- a/kifi-backend/modules/abook/app/com/keepit/commanders/EmailAccountUpdaterPlugin.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/commanders/EmailAccountUpdaterPlugin.scala
@@ -36,7 +36,7 @@ class EmailAccountUpdaterActor @Inject() (
   def receive = {
 
     case FetchEmailUpdates(fetchSize: Int) => if (!updating) {
-      val seqNum = db.readOnly { implicit session => sequenceNumberRepo.get() }
+      val seqNum = db.readOnlyMaster { implicit session => sequenceNumberRepo.get() }
       shoebox.getEmailAccountUpdates(seqNum, fetchSize).onComplete {
         case Success(updates) => {
           log.info(s"${updates.length} EmailAccountUpdates were successfully fetched.")

--- a/kifi-backend/modules/abook/app/com/keepit/commanders/WTICommander.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/commanders/WTICommander.scala
@@ -13,8 +13,8 @@ import com.keepit.common.mail.EmailAddress
 @Singleton
 class WTICommander @Inject() (richSocialConnectionRepo: RichSocialConnectionRepo, db: Database) extends Logging {
 
-  def ripestFruit(userId: Id[User], howMany: Int): Seq[Id[SocialUserInfo]] = db.readOnly { implicit session => richSocialConnectionRepo.dedupedWTIForUser(userId, howMany) }
-  def countInvitationsSent(userId: Id[User], friend: Either[Id[SocialUserInfo], EmailAddress]) = db.readOnly { implicit session => richSocialConnectionRepo.countInvitationsSent(userId, friend) }
+  def ripestFruit(userId: Id[User], howMany: Int): Seq[Id[SocialUserInfo]] = db.readOnlyMaster { implicit session => richSocialConnectionRepo.dedupedWTIForUser(userId, howMany) }
+  def countInvitationsSent(userId: Id[User], friend: Either[Id[SocialUserInfo], EmailAddress]) = db.readOnlyMaster { implicit session => richSocialConnectionRepo.countInvitationsSent(userId, friend) }
   def blockRichConnection(userId: Id[User], friend: Either[Id[SocialUserInfo], EmailAddress]): Unit = db.readWrite { implicit session => richSocialConnectionRepo.block(userId, friend) }
-  def getRipestFruitsByCommonKifiFriendsCount(userId: Id[User], page: Int, pageSize: Int): Seq[RichSocialConnection] = db.readOnly { implicit session => richSocialConnectionRepo.getRipestFruitsByCommonKifiFriendsCount(userId, page, pageSize) }
+  def getRipestFruitsByCommonKifiFriendsCount(userId: Id[User], page: Int, pageSize: Int): Seq[RichSocialConnection] = db.readOnlyMaster { implicit session => richSocialConnectionRepo.getRipestFruitsByCommonKifiFriendsCount(userId, page, pageSize) }
 }

--- a/kifi-backend/modules/abook/test/com/keepit/abook/ABookCommanderTest.scala
+++ b/kifi-backend/modules/abook/test/com/keepit/abook/ABookCommanderTest.scala
@@ -41,7 +41,7 @@ class ABookCommanderTest extends Specification with DbTestInjector with ABookTes
       withDb(modules: _*) { implicit injector =>
         val (commander) = inject[ABookCommander] //setup()
 
-      db.readOnly(inject[ABookInfoRepo].count(_))
+      db.readOnlyMaster(inject[ABookInfoRepo].count(_))
         // empty abook upload
         val emptyABookRawInfo = ABookRawInfo(None, ABookOrigins.IOS, None, None, None, JsArray(Seq.empty))
         val emptyABookOpt = commander.processUpload(u42, ABookOrigins.IOS, None, None, Json.toJson(emptyABookRawInfo))
@@ -173,7 +173,7 @@ class ABookCommanderTest extends Specification with DbTestInjector with ABookTes
         val result1 = commander.hideEmailFromUser(u42, e1Res.email)
         result1 === true
 
-        db.readOnly { implicit session =>
+        db.readOnlyMaster { implicit session =>
             val e2 = econRepo.get(e1Res.id.get)
             e2.state should_== EContactStates.HIDDEN
         }

--- a/kifi-backend/modules/abook/test/com/keepit/abook/model/RichSocialConnectionTest.scala
+++ b/kifi-backend/modules/abook/test/com/keepit/abook/model/RichSocialConnectionTest.scala
@@ -75,7 +75,7 @@ class RichSocialConnectionTest extends Specification with ABookTestInjector  {
       stephenToMarvin.kifiFriendsCount === 2
       stephenToMarvin.commonKifiFriendsCount === 0
 
-      val léoToMarvin = db.readOnly { implicit session => richConnectionRepo.getByUserAndSocialFriend(kifiLéo, Left(facebookMarvin.id.get)).get }
+      val léoToMarvin = db.readOnlyMaster { implicit session => richConnectionRepo.getByUserAndSocialFriend(kifiLéo, Left(facebookMarvin.id.get)).get }
       léoToMarvin.kifiFriendsCount === 2
       léoToMarvin.commonKifiFriendsCount === 0
     }
@@ -86,7 +86,7 @@ class RichSocialConnectionTest extends Specification with ABookTestInjector  {
         richConnectionRepo.internRichConnection(kifiStephen, fortytwoStephen.id, Left(fortytwoLéo))
       }
 
-      db.readOnly { implicit session =>
+      db.readOnlyMaster { implicit session =>
         val léoToMarvin = richConnectionRepo.getByUserAndSocialFriend(kifiLéo, Left(facebookMarvin.id.get)).get
         val stephenToMarvin = richConnectionRepo.getByUserAndSocialFriend(kifiStephen, Left(facebookMarvin.id.get)).get
         stephenToMarvin.kifiFriendsCount === 2
@@ -109,7 +109,7 @@ class RichSocialConnectionTest extends Specification with ABookTestInjector  {
       léoToEishay.kifiFriendsCount === 2
       léoToEishay.commonKifiFriendsCount === 1
 
-      val updatedStephenToEishay = db.readOnly { implicit session => richConnectionRepo.getByUserAndSocialFriend(kifiStephen, Left(facebookEishay.id.get)).get }
+      val updatedStephenToEishay = db.readOnlyMaster { implicit session => richConnectionRepo.getByUserAndSocialFriend(kifiStephen, Left(facebookEishay.id.get)).get }
       updatedStephenToEishay.kifiFriendsCount === 2
       updatedStephenToEishay.commonKifiFriendsCount === 1
     }
@@ -139,7 +139,7 @@ class RichSocialConnectionTest extends Specification with ABookTestInjector  {
     "keep track of invitations" in {
       db.readWrite { implicit session => richConnectionRepo.recordInvitation(kifiLéo, Left(facebookMarvin.id.get)) }
 
-      db.readOnly { implicit session =>
+      db.readOnlyMaster { implicit session =>
         val stephenToMarvin = richConnectionRepo.getByUserAndSocialFriend(kifiStephen, Left(facebookMarvin.id.get)).get
         stephenToMarvin.invitationsSent === 0
         stephenToMarvin.invitedBy === 1
@@ -151,7 +151,7 @@ class RichSocialConnectionTest extends Specification with ABookTestInjector  {
 
       db.readWrite { implicit session => richConnectionRepo.recordInvitation(kifiStephen, Left(facebookMarvin.id.get)) }
 
-      db.readOnly { implicit session =>
+      db.readOnlyMaster { implicit session =>
         val stephenToMarvin = richConnectionRepo.getByUserAndSocialFriend(kifiStephen, Left(facebookMarvin.id.get)).get
         stephenToMarvin.invitationsSent === 1
         stephenToMarvin.invitedBy === 2
@@ -163,7 +163,7 @@ class RichSocialConnectionTest extends Specification with ABookTestInjector  {
 
       db.readWrite { implicit session => richConnectionRepo.recordInvitation(kifiLéo, Right(contact42.email)) }
 
-      db.readOnly { implicit session =>
+      db.readOnlyMaster { implicit session =>
         val léoToGrassfed42 = richConnectionRepo.getByUserAndSocialFriend(kifiLéo, Right(contact42.email)).get
         léoToGrassfed42.invitationsSent === 1
         léoToGrassfed42.invitedBy === 1
@@ -175,7 +175,7 @@ class RichSocialConnectionTest extends Specification with ABookTestInjector  {
     }
 
     "have correct queries" in { //This is for running straight up sql queries to make sure they are correctly formatted
-      db.readOnly { implicit session => richConnectionRepo.dedupedWTIForUser(Id[User](243), 50)}
+      db.readOnlyMaster { implicit session => richConnectionRepo.dedupedWTIForUser(Id[User](243), 50)}
       1===1
     }
   }

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/CortexDataIngestionPlugin.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/CortexDataIngestionPlugin.scala
@@ -98,7 +98,7 @@ private class CortexDataIngestionUpdater @Inject()(
   private val DB_BATCH_SIZE = 50
 
   def updateURIRepo(fetchSize: Int): Future[Int] = {
-    val seq = db.readOnly{ implicit s => uriRepo.getMaxSeq}
+    val seq = db.readOnlyMaster{ implicit s => uriRepo.getMaxSeq}
 
     shoebox.getIndexable(seq, fetchSize).map { uris =>
       uris.map { CortexURI.fromURI(_) } grouped (DB_BATCH_SIZE) foreach { uris =>
@@ -117,7 +117,7 @@ private class CortexDataIngestionUpdater @Inject()(
 
   def updateKeepRepo(fetchSize: Int): Future[Int] = {
 
-    val seq = db.readOnly{ implicit s => keepRepo.getMaxSeq}
+    val seq = db.readOnlyMaster{ implicit s => keepRepo.getMaxSeq}
 
     shoebox.getBookmarksChanged(seq, fetchSize).map { keeps =>
       keeps.map { CortexKeep.fromKeep(_) } grouped (DB_BATCH_SIZE) foreach { keeps =>

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/plugins/URIFeatureUpdaterPlugin.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/plugins/URIFeatureUpdaterPlugin.scala
@@ -32,7 +32,7 @@ class URIPullerImpl @Inject()(
 
   // scraped uris only
   def getSince(lowSeq: SequenceNumber[NormalizedURI], limit: Int): Seq[NormalizedURI] = {
-    db.readOnly{ implicit s =>
+    db.readOnlyMaster{ implicit s =>
       uriRepo.getSince(lowSeq, limit).filter(_.state.value == NormalizedURIStates.SCRAPED.value).map{convertToNormalizedURI(_)}
     }
   }

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/dbmodel/CortexDataIngestionUpdaterTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/dbmodel/CortexDataIngestionUpdaterTest.scala
@@ -31,7 +31,7 @@ class CortexDataIngestionUpdaterTest extends Specification with CortexTestInject
         var updates = Await.result(updater.updateURIRepo(100), FiniteDuration(5, SECONDS))
         updates === 3
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           cortexURIRepo.all.size === 3
           cortexURIRepo.getSince(SequenceNumber[CortexURI](-1), 100).map{_.seq.value} === List(1, 2, 3)
         }
@@ -40,7 +40,7 @@ class CortexDataIngestionUpdaterTest extends Specification with CortexTestInject
         updates = Await.result(updater.updateURIRepo(100), FiniteDuration(5, SECONDS))
         updates === 1
 
-        var changed = db.readOnly{ implicit s =>
+        var changed = db.readOnlyMaster{ implicit s =>
           cortexURIRepo.all.size === 3
           cortexURIRepo.getSince(SequenceNumber[CortexURI](3), 100)
         }.headOption.get
@@ -58,7 +58,7 @@ class CortexDataIngestionUpdaterTest extends Specification with CortexTestInject
 
         Await.result(updater.updateKeepRepo(100), FiniteDuration(5, SECONDS)) === 2
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           cortexKeepRepo.all.map{_.source} === List(KeepSource.keeper, KeepSource.bookmarkImport)
         }
 

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/dbmodel/CortexKeepTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/dbmodel/CortexKeepTest.scala
@@ -19,7 +19,7 @@ class CortexKeepTest extends Specification with CortexTestInjector{
       withDb() { implicit injector =>
         val keepRepo = inject[CortexKeepRepo]
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           keepRepo.getMaxSeq.value === 0L
         }
 
@@ -40,7 +40,7 @@ class CortexKeepTest extends Specification with CortexTestInjector{
           }
         }
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           keepRepo.getSince(SequenceNumber[CortexKeep](5), 10).map{_.keepId.id} === Range(6,11).toList
           keepRepo.getMaxSeq.value === 10L
         }

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/dbmodel/CortexURITest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/dbmodel/CortexURITest.scala
@@ -26,7 +26,7 @@ class CortexURITest extends Specification with CortexTestInjector{
          )
         }
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.getMaxSeq.value === 0L
         }
 
@@ -34,7 +34,7 @@ class CortexURITest extends Specification with CortexTestInjector{
           uris.foreach{ uriRepo.save(_)}
         }
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.getSince(SequenceNumber[CortexURI](5), 10).map{_.uriId.id} === Range(6, 11).toList
           uriRepo.getMaxSeq.value === 10L
         }

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/dbmodel/URILDARepoTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/dbmodel/URILDARepoTest.scala
@@ -38,7 +38,7 @@ class URILDATopicRepoTest extends Specification with CortexTestInjector {
           uriTopicRepo.save(feat2)
         }
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriTopicRepo.getFeature(Id[NormalizedURI](1), ModelVersion[DenseLDA](1)).get.value.toList === List(0.3f, 0.5f, 0.1f, 0.1f)
           uriTopicRepo.getUpdateTimeAndState(Id[NormalizedURI](1), ModelVersion[DenseLDA](1)).get._2 === URILDATopicStates.ACTIVE
 
@@ -96,7 +96,7 @@ class URILDATopicRepoTest extends Specification with CortexTestInjector {
           }
         }
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriTopicRepo.getHighestSeqNumber(ModelVersion[DenseLDA](1)).value === 5
           uriTopicRepo.getHighestSeqNumber(ModelVersion[DenseLDA](2)).value === 10
           uriTopicRepo.getHighestSeqNumber(ModelVersion[DenseLDA](3)).value === 0

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDADbUpdaterTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDADbUpdaterTest.scala
@@ -33,7 +33,7 @@ class LDADbUpdaterTest extends Specification with CortexTestInjector with LDADbT
         val updater = new LDADbUpdaterImpl(uriRep, db, uriRepo, topicRepo, commitRepo)
         updater.update
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           topicRepo.all.size === num
           commitRepo.getByModelAndVersion(StatModelName.LDA, uriRep.version.version).get.seq === 5L
           (0 until num).foreach{ i =>
@@ -66,7 +66,7 @@ class LDADbUpdaterTest extends Specification with CortexTestInjector with LDADbT
         val updater = new LDADbUpdaterImpl(uriRep, db, uriRepo, topicRepo, commitRepo)
         updater.update
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           topicRepo.all.size === num
           commitRepo.getByModelAndVersion(StatModelName.LDA, uriRep.version.version).get.seq === 2L
           topicRepo.getByURI(uris(1).id.get, version).get.state === URILDATopicStates.ACTIVE
@@ -79,7 +79,7 @@ class LDADbUpdaterTest extends Specification with CortexTestInjector with LDADbT
 
         updater.update
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           topicRepo.all.size === num
           commitRepo.getByModelAndVersion(StatModelName.LDA, uriRep.version.version).get.seq === 3L
           topicRepo.getByURI(uris(1).id.get, version).get.state === URILDATopicStates.INACTIVE
@@ -103,7 +103,7 @@ class LDADbUpdaterTest extends Specification with CortexTestInjector with LDADbT
         val updater = new LDADbUpdaterImpl(uriRep, db, uriRepo, topicRepo, commitRepo)
         updater.update
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           topicRepo.all.size === num
           commitRepo.getByModelAndVersion(StatModelName.LDA, uriRep.version.version).get.seq === 2L
           topicRepo.getByURI(uris(1).id.get, version).get.state === URILDATopicStates.NOT_APPLICABLE
@@ -125,7 +125,7 @@ class LDADbUpdaterTest extends Specification with CortexTestInjector with LDADbT
         val updater = new LDADbUpdaterImpl(uriRep, db, uriRepo, topicRepo, commitRepo)
         updater.update
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           topicRepo.all.size === 0
           commitRepo.getByModelAndVersion(StatModelName.LDA, uriRep.version.version).get.seq === 2L
         }

--- a/kifi-backend/modules/eliza/app/com/keepit/controllers/site/ChatterController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/controllers/site/ChatterController.scala
@@ -28,7 +28,7 @@ class ChatterController @Inject() (
     messagingCommander.getChatter(request.user.id.get, Seq(url)).map { res =>
       Ok(res.headOption.map { case (url, msgs) =>
         if (msgs.size == 1) {
-          db.readOnly { implicit session =>
+          db.readOnlyMaster { implicit session =>
             Json.obj("threads" -> 1, "threadId" -> threadRepo.get(msgs.head).externalId.id)
           }
         } else {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/UriNormalizationUpdater.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/UriNormalizationUpdater.scala
@@ -38,7 +38,7 @@ class UriNormalizationUpdater @Inject() (
 
   centralConfig.onChange(URIMigrationSeqNumKey)(checkAndUpdate)
 
-  def localSequenceNumber(): SequenceNumber[ChangedURI] = db.readOnly{ implicit session => renormRepo.getCurrentSequenceNumber() }
+  def localSequenceNumber(): SequenceNumber[ChangedURI] = db.readOnlyMaster{ implicit session => renormRepo.getCurrentSequenceNumber() }
 
   def checkAndUpdate(remoteSequenceNumberOpt: Option[SequenceNumber[ChangedURI]]) : Unit = synchronized {
     var localSeqNum = localSequenceNumber()
@@ -62,7 +62,7 @@ class UriNormalizationUpdater @Inject() (
   }
 
   private def applyUpdates(updates: Seq[(Id[NormalizedURI], NormalizedURI)], reapply: Boolean = false) : Unit = {
-    val userThreadUpdates = db.readOnly { implicit session => updates.map{ //Note: This will need to change when we have detached threads!
+    val userThreadUpdates = db.readOnlyMaster { implicit session => updates.map{ //Note: This will need to change when we have detached threads!
         case (oldId, newNUri) => (userThreadRepo.getByUriId(oldId), newNUri.url)
       }
     }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaEmailCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaEmailCommander.scala
@@ -88,7 +88,7 @@ class ElizaEmailCommander @Inject() (
     muteUrl: Option[String] = None,
     readTimeMinutes: Option[Int] = None): ThreadEmailInfo = {
 
-    val (nuts, starterUserId) = db.readOnly { implicit session => (
+    val (nuts, starterUserId) = db.readOnlyMaster { implicit session => (
       nonUserThreadRepo.getByMessageThreadId(thread.id.get),
       userThreadRepo.getThreadStarter(thread.id.get)
     )}
@@ -191,7 +191,7 @@ class ElizaEmailCommander @Inject() (
 
   def notifyEmailUsers(thread: MessageThread): Unit = if (thread.participants.exists(_.allNonUsers.nonEmpty)) {
     getThreadEmailData(thread) map { threadEmailData =>
-      val nuts = db.readOnly { implicit session =>
+      val nuts = db.readOnlyMaster { implicit session =>
         nonUserThreadRepo.getByMessageThreadId(thread.id.get)
       }
 
@@ -207,7 +207,7 @@ class ElizaEmailCommander @Inject() (
 
   def notifyAddedEmailUsers(thread: MessageThread, addedNonUsers: Seq[NonUserParticipant]): Unit = if (thread.participants.exists(!_.allNonUsers.isEmpty)) {
     getThreadEmailData(thread) map { threadEmailData =>
-      val nuts = db.readOnly { implicit session => //redundant right now but I assume we will want to let everyone in the thread know that someone was added?
+      val nuts = db.readOnlyMaster { implicit session => //redundant right now but I assume we will want to let everyone in the thread know that someone was added?
         nonUserThreadRepo.getByMessageThreadId(thread.id.get).map { nut =>
           nut.participant.identifier -> nut
         }.toMap
@@ -273,7 +273,7 @@ class ElizaEmailCommander @Inject() (
   }
 
   def getEmailPreview(msgExtId: ExternalId[Message]): Future[Html] = {
-    val (msg, thread) = db.readOnly{ implicit session =>
+    val (msg, thread) = db.readOnlyMaster{ implicit session =>
       val msg = messageRepo.get(msgExtId)
       val thread = threadRepo.get(msg.thread)
       (msg, thread)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaStatsCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaStatsCommander.scala
@@ -13,11 +13,11 @@ class ElizaStatsCommander @Inject() (
   db: Database) extends Logging {
 
   def getUserThreadStats(userId: Id[User]): UserThreadStats = {
-    db.readOnly { implicit s =>
+    db.readOnlyMaster { implicit s =>
       userThreadRepo.getUserStats(userId)
     }
   }
 
-  def getCurrentRenormalizationSequenceNumber(): SequenceNumber[ChangedURI] = db.readOnly { implicit session => renormalizationRepo.getCurrentSequenceNumber() }
+  def getCurrentRenormalizationSequenceNumber(): SequenceNumber[ChangedURI] = db.readOnlyMaster { implicit session => renormalizationRepo.getCurrentSequenceNumber() }
 
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
@@ -35,7 +35,7 @@ class MessageFetchingCommander @Inject() (
     modifyMessageWithAuxData(MessageWithBasicUser(id, createdAt, text, source, auxData, url, nUrl, user, participants))
   }
 
-  def getThreadMessages(thread: MessageThread) : Seq[Message] =  db.readOnly { implicit session =>
+  def getThreadMessages(thread: MessageThread) : Seq[Message] =  db.readOnlyMaster { implicit session =>
     log.info(s"[get_thread] trying to get thread messages for thread extId ${thread.externalId}")
     messageRepo.get(thread.id.get, 0)
   }
@@ -71,7 +71,7 @@ class MessageFetchingCommander @Inject() (
   }
 
   def getThreadMessagesWithBasicUser(threadExtId: ExternalId[MessageThread]): Future[(MessageThread, Seq[MessageWithBasicUser])] = {
-    val thread = db.readOnly(threadRepo.get(threadExtId)(_))
+    val thread = db.readOnlyMaster(threadRepo.get(threadExtId)(_))
     getThreadMessagesWithBasicUser(thread)
   }
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageSearchCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageSearchCommander.scala
@@ -39,7 +39,7 @@ class MessageSearchCommander @Inject() (
       }
     }
     resultExtIdsFut.flatMap{ protoExtIds =>
-      val notifs = db.readOnly { implicit session =>
+      val notifs = db.readOnlyMaster { implicit session =>
         val threads = protoExtIds.map{ s => threadRepo.get(ExternalId[MessageThread](s))}
         threads.map{ thread =>
           userThreadRepo.getNotificationByThread(userId, thread.id.get)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingAnalytics.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingAnalytics.scala
@@ -156,7 +156,7 @@ class MessagingAnalytics @Inject() (
       val action = if (mute) "mutedConversation" else "unmutedConversation"
       contextBuilder += ("action", action)
       contextBuilder += ("threadId", threadExternalId.id)
-      val thread = db.readOnly { implicit session => threadRepo.get(threadExternalId) }
+      val thread = db.readOnlyMaster { implicit session => threadRepo.get(threadExternalId) }
       thread.participants.foreach(addParticipantsInfo(contextBuilder, _))
       heimdal.trackEvent(UserEvent(userId, contextBuilder.build, UserEventTypes.CHANGED_SETTINGS, changedAt))
     }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/MessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/MessagingController.scala
@@ -106,8 +106,8 @@ class MessagingController @Inject() (
     //currently only verifies
     SafeFuture{
       log.warn("Starting notification verification!")
-      val userThreads : Seq[UserThread] = db.readOnly{ implicit session => userThreadRepo.all }
-      val nUrls : Map[Id[MessageThread], Option[String]] = db.readOnly{ implicit session => threadRepo.all } map { thread => (thread.id.get, thread.url) } toMap
+      val userThreads : Seq[UserThread] = db.readOnlyMaster{ implicit session => userThreadRepo.all }
+      val nUrls : Map[Id[MessageThread], Option[String]] = db.readOnlyMaster{ implicit session => threadRepo.all } map { thread => (thread.id.get, thread.url) } toMap
 
       userThreads.foreach{ userThread =>
         if (userThread.uriId.isDefined) {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaNonUserEmailNotifierActor.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaNonUserEmailNotifierActor.scala
@@ -23,7 +23,7 @@ class ElizaNonUserEmailNotifierActor @Inject() (
   import ElizaEmailNotifierActor._
 
   protected def emailUnreadMessagesForParticipantThreadBatch(batch: ParticipantThreadBatch[NonUserThread]): Future[Unit] = {
-    val thread = db.readOnly { implicit session => threadRepo.get(batch.threadId) }
+    val thread = db.readOnlyMaster { implicit session => threadRepo.get(batch.threadId) }
     elizaEmailCommander.getThreadEmailData(thread) flatMap { threadEmailData =>
       val notificationFutures = batch.participantThreads.map {
         case emailParticipantThread if emailParticipantThread.participant.kind == NonUserKinds.email => {
@@ -48,7 +48,7 @@ class ElizaNonUserEmailNotifierActor @Inject() (
     val now = clock.now
     val lastNotifiedBefore = now.minus(MIN_TIME_BETWEEN_NOTIFICATIONS.toMillis)
     val lastUpdatedByOtherAfter = now.minus(RECENT_ACTIVITY_WINDOW.toMillis)
-    val unseenNonUserThreads = db.readOnly { implicit session =>
+    val unseenNonUserThreads = db.readOnlyMaster { implicit session =>
       nonUserThreadRepo.getNonUserThreadsForEmailing(lastNotifiedBefore, lastUpdatedByOtherAfter)
     }
     unseenNonUserThreads

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaUserEmailNotifierActor.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaUserEmailNotifierActor.scala
@@ -36,7 +36,7 @@ class ElizaUserEmailNotifierActor @Inject() (
   protected def getParticipantThreadsToProcess(): Seq[UserThread] = {
     val now = clock.now
     val lastNotifiedBefore = now.minus(MIN_TIME_BETWEEN_NOTIFICATIONS.toMillis)
-    val unseenUserThreads = db.readOnly { implicit session =>
+    val unseenUserThreads = db.readOnlyMaster { implicit session =>
       userThreadRepo.getUserThreadsForEmailing(lastNotifiedBefore)
     }
     val notificationUpdatedAts = unseenUserThreads.map { t => t.id.get -> t.notificationUpdatedAt } toMap;
@@ -50,7 +50,7 @@ class ElizaUserEmailNotifierActor @Inject() (
   protected def emailUnreadMessagesForParticipantThreadBatch(batch: ParticipantThreadBatch[UserThread]): Future[Unit] = {
     val userThreads = batch.participantThreads
     val threadId = batch.threadId
-    val thread = db.readOnly { implicit session => threadRepo.get(threadId) }
+    val thread = db.readOnlyMaster { implicit session => threadRepo.get(threadId) }
     val allUserIds = thread.participants.map(_.allUsers).getOrElse(Set()).toSeq
     val allUsersFuture : Future[Map[Id[User], User]] = new SafeFuture(
       shoebox.getUsers(allUserIds).map( s => s.map(u => u.id.get -> u).toMap)

--- a/kifi-backend/modules/eliza/app/com/keepit/realtime/UrbanAirship.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/realtime/UrbanAirship.scala
@@ -134,7 +134,7 @@ class UrbanAirshipImpl @Inject()(
       }
     }
     future {
-      val devices = db.readOnly { implicit s => deviceRepo.getByUserId(userId) }
+      val devices = db.readOnlyMaster { implicit s => deviceRepo.getByUserId(userId) }
       devices foreach updateDeviceState
     }
     device
@@ -145,7 +145,7 @@ class UrbanAirshipImpl @Inject()(
     // UserNotifyPreferenceRepo.canSend(userId, someIdentifierRepresentingMobileNotificationType)
     log.info(s"Notifying user: $userId")
     for {
-      d <- db.readOnly { implicit s => deviceRepo.getByUserId(userId) }
+      d <- db.readOnlyMaster { implicit s => deviceRepo.getByUserId(userId) }
       device <- updateDeviceState(d) if device.state == DeviceStates.ACTIVE
     } {
       sendNotification(false, device, notification)

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
@@ -182,7 +182,7 @@ class MessagingTest extends Specification with DbTestInjector {
         val messagingCommander = inject[MessagingCommander]
         val (thread1, msg1) = messagingCommander.sendNewMessage(user1, user2n3Seq, Nil, Json.obj("url" -> "https://kifi.com"), Some("title"), "Search!", None)
 
-        val user2Threads = db.readOnly { implicit ro => userThreadRepo.getUserThreads(user2, thread1.uriId.get)  }
+        val user2Threads = db.readOnlyMaster { implicit ro => userThreadRepo.getUserThreads(user2, thread1.uriId.get)  }
         user2Threads.size === 1
         messagingCommander.setLastSeen(user2, user2Threads.head.threadId)
 

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/ext/ExtMessagingControllerTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/ext/ExtMessagingControllerTest.scala
@@ -83,11 +83,11 @@ class ExtMessagingControllerTest extends Specification with ElizaApplicationInje
         val result = route(request).get
         status(result) must equalTo(OK)
         contentType(result) must beSome("application/json")
-        val messages = inject[Database].readOnly { implicit s => inject[MessageRepo].all }
+        val messages = inject[Database].readOnlyMaster { implicit s => inject[MessageRepo].all }
         messages.size === 1
         val message = messages.head
         println(s"message = $message")
-        val threads = inject[Database].readOnly { implicit s => inject[MessageThreadRepo].all }
+        val threads = inject[Database].readOnlyMaster { implicit s => inject[MessageThreadRepo].all }
         threads.size === 1
         val thread = threads.head
         println(s"thread = $thread")
@@ -180,8 +180,8 @@ class ExtMessagingControllerTest extends Specification with ElizaApplicationInje
           """)
         status(route(FakeRequest("POST", "/eliza/messages").withJsonBody(createThreadJson)).get) must equalTo(OK)
 
-        val message = inject[Database].readOnly { implicit s => inject[MessageRepo].all } head
-        val thread = inject[Database].readOnly { implicit s => inject[MessageThreadRepo].all } head
+        val message = inject[Database].readOnlyMaster { implicit s => inject[MessageRepo].all } head
+        val thread = inject[Database].readOnlyMaster { implicit s => inject[MessageThreadRepo].all } head
 
         val path = com.keepit.eliza.controllers.ext.routes.ExtMessagingController.sendMessageReplyAction(thread.externalId).toString
         path === s"/eliza/messages/${thread.externalId}"
@@ -200,7 +200,7 @@ class ExtMessagingControllerTest extends Specification with ElizaApplicationInje
         status(result) must equalTo(OK)
         contentType(result) must beSome("application/json")
 
-        val messages = inject[Database].readOnly { implicit s => inject[MessageRepo].all }
+        val messages = inject[Database].readOnlyMaster { implicit s => inject[MessageRepo].all }
         messages.size === 2
         val replys = messages filter {m => m.id != message.id}
         replys.size === 1

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/mobile/MobileMessagingControllerTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/mobile/MobileMessagingControllerTest.scala
@@ -55,8 +55,8 @@ class MobileMessagingControllerTest extends Specification with ElizaApplicationI
 
     "send correctly" in {
       running(new ElizaApplication(modules:_*)) {
-        inject[Database].readOnly { implicit s => inject[UserThreadRepo].count } === 0
-        inject[Database].readOnly { implicit s => inject[MessageRepo].count } === 0
+        inject[Database].readOnlyMaster { implicit s => inject[UserThreadRepo].count } === 0
+        inject[Database].readOnlyMaster { implicit s => inject[MessageRepo].count } === 0
         val shanee = User(id = Some(Id[User](42)), firstName = "Shanee", lastName = "Smith", externalId = ExternalId[User]("a9f67559-30fa-4bcd-910f-4c2fc8bbde85"))
         val shachaf = User(id = Some(Id[User](43)), firstName = "Shachaf", lastName = "Smith", externalId = ExternalId[User]("2be9e0e7-212e-4081-a2b0-bfcaf3e61484"))
         inject[ShoeboxServiceClient].asInstanceOf[FakeShoeboxServiceClientImpl].saveUsers(shanee)
@@ -79,10 +79,10 @@ class MobileMessagingControllerTest extends Specification with ElizaApplicationI
         val result = route(request).get
         status(result) must equalTo(OK)
         contentType(result) must beSome("application/json")
-        val messages = inject[Database].readOnly { implicit s => inject[MessageRepo].all }
+        val messages = inject[Database].readOnlyMaster { implicit s => inject[MessageRepo].all }
         messages.size === 1
         val message = messages.head
-        val threads = inject[Database].readOnly { implicit s => inject[MessageThreadRepo].all }
+        val threads = inject[Database].readOnlyMaster { implicit s => inject[MessageThreadRepo].all }
         threads.size === 1
         val thread = threads.head
 
@@ -145,8 +145,8 @@ class MobileMessagingControllerTest extends Specification with ElizaApplicationI
 
     "getCompactThread" in {
       running(new ElizaApplication(modules:_*)) {
-        inject[Database].readOnly { implicit s => inject[UserThreadRepo].count } === 0
-        inject[Database].readOnly { implicit s => inject[MessageRepo].count } === 0
+        inject[Database].readOnlyMaster { implicit s => inject[UserThreadRepo].count } === 0
+        inject[Database].readOnlyMaster { implicit s => inject[MessageRepo].count } === 0
         val shanee = User(id = Some(Id[User](42)), firstName = "Shanee", lastName = "Smith", externalId = ExternalId[User]("a9f67559-30fa-4bcd-910f-4c2fc8bbde85"))
         val shachaf = User(id = Some(Id[User](43)), firstName = "Shachaf", lastName = "Smith", externalId = ExternalId[User]("2be9e0e7-212e-4081-a2b0-bfcaf3e61484"))
         val fakeClient = inject[ShoeboxServiceClient].asInstanceOf[FakeShoeboxServiceClientImpl]
@@ -170,7 +170,7 @@ class MobileMessagingControllerTest extends Specification with ElizaApplicationI
             "title": "Search Experiments", "text": "message #5", "recipients":["${shachaf.externalId.toString}"],
             "url": "https://admin.kifi.com/admin/searchExperiments", "extVersion": "2.6.65" } """))).get) must equalTo(OK)
 
-        val thread = inject[Database].readOnly { implicit s => inject[MessageThreadRepo].all.head }
+        val thread = inject[Database].readOnlyMaster { implicit s => inject[MessageThreadRepo].all.head }
 
         val path = com.keepit.eliza.controllers.mobile.routes.MobileMessagingController.getCompactThread(thread.externalId.toString).toString
         path === s"/m/1/eliza/thread/${thread.externalId.toString}"
@@ -181,7 +181,7 @@ class MobileMessagingControllerTest extends Specification with ElizaApplicationI
 
         contentType(result) must beSome("application/json")
 
-        val messages = inject[Database].readOnly { implicit s => inject[MessageRepo].all }
+        val messages = inject[Database].readOnlyMaster { implicit s => inject[MessageRepo].all }
         messages.size === 5
 
         val expected = Json.parse(s"""
@@ -232,8 +232,8 @@ class MobileMessagingControllerTest extends Specification with ElizaApplicationI
 
     "getPagedThread" in {
       running(new ElizaApplication(modules:_*)) {
-        inject[Database].readOnly { implicit s => inject[UserThreadRepo].count } === 0
-        inject[Database].readOnly { implicit s => inject[MessageRepo].count } === 0
+        inject[Database].readOnlyMaster { implicit s => inject[UserThreadRepo].count } === 0
+        inject[Database].readOnlyMaster { implicit s => inject[MessageRepo].count } === 0
         val shanee = User(id = Some(Id[User](42)), firstName = "Shanee", lastName = "Smith", externalId = ExternalId[User]("a9f67559-30fa-4bcd-910f-4c2fc8bbde85"))
         val shachaf = User(id = Some(Id[User](43)), firstName = "Shachaf", lastName = "Smith", externalId = ExternalId[User]("2be9e0e7-212e-4081-a2b0-bfcaf3e61484"))
         val fakeClient = inject[ShoeboxServiceClient].asInstanceOf[FakeShoeboxServiceClientImpl]
@@ -257,8 +257,8 @@ class MobileMessagingControllerTest extends Specification with ElizaApplicationI
             "title": "Search Experiments", "text": "message #5", "recipients":["${shachaf.externalId.toString}"],
             "url": "https://admin.kifi.com/admin/searchExperiments", "extVersion": "2.6.65" } """))).get) must equalTo(OK)
 
-        val thread = inject[Database].readOnly { implicit s => inject[MessageThreadRepo].all.head }
-        val messages = inject[Database].readOnly { implicit s => inject[MessageRepo].all }
+        val thread = inject[Database].readOnlyMaster { implicit s => inject[MessageThreadRepo].all.head }
+        val messages = inject[Database].readOnlyMaster { implicit s => inject[MessageRepo].all }
         messages.size === 5
 
         {
@@ -397,8 +397,8 @@ class MobileMessagingControllerTest extends Specification with ElizaApplicationI
 
     "sendMessageReplyAction" in {
       running(new ElizaApplication(modules:_*)) {
-        inject[Database].readOnly { implicit s => inject[UserThreadRepo].count } === 0
-        inject[Database].readOnly { implicit s => inject[MessageRepo].count } === 0
+        inject[Database].readOnlyMaster { implicit s => inject[UserThreadRepo].count } === 0
+        inject[Database].readOnlyMaster { implicit s => inject[MessageRepo].count } === 0
         val shanee = User(id = Some(Id[User](42)), firstName = "Shanee", lastName = "Smith", externalId = ExternalId[User]("a9f67559-30fa-4bcd-910f-4c2fc8bbde85"))
         val shachaf = User(id = Some(Id[User](43)), firstName = "Shachaf", lastName = "Smith", externalId = ExternalId[User]("2be9e0e7-212e-4081-a2b0-bfcaf3e61484"))
         inject[ShoeboxServiceClient].asInstanceOf[FakeShoeboxServiceClientImpl].saveUsers(shanee)
@@ -417,8 +417,8 @@ class MobileMessagingControllerTest extends Specification with ElizaApplicationI
           """)
         status(route(FakeRequest("POST", "/m/1/eliza/messages").withJsonBody(createThreadJson)).get) must equalTo(OK)
 
-        val message = inject[Database].readOnly { implicit s => inject[MessageRepo].all } head
-        val thread = inject[Database].readOnly { implicit s => inject[MessageThreadRepo].all } head
+        val message = inject[Database].readOnlyMaster { implicit s => inject[MessageRepo].all } head
+        val thread = inject[Database].readOnlyMaster { implicit s => inject[MessageThreadRepo].all } head
 
         val path = com.keepit.eliza.controllers.mobile.routes.MobileMessagingController.sendMessageReplyAction(thread.externalId).toString
         path === s"/m/1/eliza/messages/${thread.externalId}"
@@ -438,7 +438,7 @@ class MobileMessagingControllerTest extends Specification with ElizaApplicationI
         contentType(result) must beSome("application/json")
         println(s"thread = $thread")
 
-        val messages = inject[Database].readOnly { implicit s => inject[MessageRepo].all }
+        val messages = inject[Database].readOnlyMaster { implicit s => inject[MessageRepo].all }
         messages.size === 2
         val replys = messages filter {m => m.id != message.id}
         replys.size === 1

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/model/UserThreadRepoTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/model/UserThreadRepoTest.scala
@@ -48,7 +48,7 @@ class UserThreadRepoTest extends Specification with DbTestInjector {
           toMail.size === 1
           toMail.head.id.get === thread1.id.get
         }
-        db.readOnly {implicit s =>
+        db.readOnlyMaster {implicit s =>
           userThreadRepo.getUserStats(user1) === UserThreadStats(1, 0, 0)
           userThreadRepo.getUserStats(user2) === UserThreadStats(0, 0, 0)
           userThreadRepo.getUserThreadsForEmailing(clock.now()).size === 1
@@ -73,7 +73,7 @@ class UserThreadRepoTest extends Specification with DbTestInjector {
             lastActive = Some(inject[Clock].now)
           ))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           userThreadRepo.getUserStats(user1) === UserThreadStats(2, 1, 0)
           userThreadRepo.getUserStats(user2) === UserThreadStats(0, 0, 0)
           val toMail = userThreadRepo.getUserThreadsForEmailing(clock.now().plusMinutes(16))
@@ -102,7 +102,7 @@ class UserThreadRepoTest extends Specification with DbTestInjector {
             replyable = true
           ))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           userThreadRepo.getUserStats(user1) === UserThreadStats(3, 2, 1)
           userThreadRepo.getUserStats(user2) === UserThreadStats(0, 0, 0)
           val toMail = userThreadRepo.getUserThreadsForEmailing(clock.now().plusMinutes(16))

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminAttributionController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminAttributionController.scala
@@ -38,7 +38,7 @@ class AdminAttributionController @Inject()(
   implicit val execCtx = fj
 
   def keepDiscoveriesView(page:Int, size:Int, showImage:Boolean) = AdminHtmlAction.authenticated { request =>
-    val (t, count) = db.readOnly { implicit ro =>
+    val (t, count) = db.readOnlyMaster { implicit ro =>
       val t = keepDiscoveryRepo.page(page, size, Set(KeepDiscoveryStates.INACTIVE)).map { c =>
         val rc = RichKeepDiscovery(c.id, c.createdAt, c.updatedAt, c.state, c.hitUUID, c.numKeepers, userRepo.get(c.keeperId), keepRepo.get(c.keepId), uriRepo.get(c.uriId), c.origin)
         val pageInfoOpt = pageInfoRepo.getByUri(c.uriId)
@@ -55,7 +55,7 @@ class AdminAttributionController @Inject()(
   }
 
   def rekeepsView(page:Int, size:Int, showImage:Boolean) = AdminHtmlAction.authenticated { request =>
-    val (t, count) = db.readOnly { implicit ro =>
+    val (t, count) = db.readOnlyMaster { implicit ro =>
       val t = rekeepRepo.page(page, size, Set(ReKeepStates.INACTIVE)).map { k =>
         val rk = RichReKeep(k.id, k.createdAt, k.updatedAt, k.state, userRepo.get(k.keeperId), keepRepo.get(k.keepId), uriRepo.get(k.uriId), userRepo.get(k.srcUserId), keepRepo.get(k.srcKeepId), k.attributionFactor)
         val pageInfoOpt = pageInfoRepo.getByUri(k.uriId)
@@ -72,7 +72,7 @@ class AdminAttributionController @Inject()(
   }
 
   private def getKeepInfos(userId:Id[User]):(User, Seq[RichKeepDiscovery], Seq[RichReKeep], Seq[RichReKeep]) = {
-    db.readOnly { implicit ro =>
+    db.readOnlyMaster { implicit ro =>
       val u = userRepo.get(userId)
       val rc = keepDiscoveryRepo.getDiscoveriesByKeeper(userId).take(10) map { c =>
         RichKeepDiscovery(c.id, c.createdAt, c.updatedAt, c.state, c.hitUUID, c.numKeepers, u, keepRepo.get(c.keepId), uriRepo.get(c.uriId), c.origin)

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminAuthController.scala
@@ -24,7 +24,7 @@ class AdminAuthController @Inject() (
   }
 
   def impersonate(id: Id[User]) = AdminJsonAction.authenticated { request =>
-    val user = db.readOnly { implicit s =>
+    val user = db.readOnlyMaster { implicit s =>
       userRepo.get(id)
     }
     log.info(s"impersonating user $user")

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminDashboardController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminDashboardController.scala
@@ -30,7 +30,7 @@ class AdminDashboardController @Inject() (
 
   implicit val timeout = BabysitterTimeout(1 minutes, 2 minutes)
 
-  private lazy val userCountByDate = calcCountByDate(db.readOnly(implicit session => userRepo.allActiveTimes).map(_.toLocalDateInZone))
+  private lazy val userCountByDate = calcCountByDate(db.readOnlyMaster(implicit session => userRepo.allActiveTimes).map(_.toLocalDateInZone))
 
   private def calcCountByDate(dates: => Seq[LocalDate]) = {
     val day0 = if(dates.isEmpty) currentDate else dates.min

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminExperimentController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminExperimentController.scala
@@ -31,13 +31,13 @@ class AdminExperimentController @Inject() (
 
 
   def overview = AdminHtmlAction.authenticated { request =>
-    val (totalUserCount, experimentsWithCount) = db.readOnly { implicit session =>
+    val (totalUserCount, experimentsWithCount) = db.readOnlyMaster { implicit session =>
       (userRepo.countIncluding(UserStates.PENDING, UserStates.INACTIVE, UserStates.BLOCKED),
       experimentRepo.getDistinctExperimentsWithCounts().toMap)
     }
 
     val experimentInfos = (ExperimentType._ALL.zip(ExperimentType._ALL.map(_ => 0)).toMap ++ experimentsWithCount).map{ case (experimentType, userCount) =>
-      db.readOnly { implicit session =>
+      db.readOnlyMaster { implicit session =>
         val defaultDensity = generatorRepo.getByName(Name[ProbabilisticExperimentGenerator](experimentType.value + "-default"), None).map(_.density.density.map{
           case (cond, prob) => (cond.value, prob)
         })

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminFeedController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminFeedController.scala
@@ -37,7 +37,7 @@ class AdminFeedController @Inject()(
       Ok(html.admin.feeds(userId, limit, feeds, elapsedSeconds))
     } else {
       val uriToFeed = feeds.map{ f => (f.uri.id.get, f)}.toMap
-      val userKeeps = db.readOnly{ implicit s =>
+      val userKeeps = db.readOnlyMaster{ implicit s =>
         keepRepo.getByUser(userId)
       }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminInvitationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminInvitationController.scala
@@ -30,7 +30,7 @@ class AdminInvitationController @Inject() (
       case InvitationStates.INACTIVE.value => Some(InvitationStates.INACTIVE)
       case "all" => None
     }
-    val (invitesWithSocial, count) = db.readOnly { implicit session =>
+    val (invitesWithSocial, count) = db.readOnlyMaster { implicit session =>
       val count = invitationRepo.count
       val invitesWithSocial = invitationRepo.invitationsPage(page, pageSize, showState) map {
         case (invite, sui) => (invite.map(i => (i, i.senderUserId.map(userRepo.get))), sui)

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLDAController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLDAController.scala
@@ -109,7 +109,7 @@ class AdminLDAController @Inject()(
   }
 
   def userTopicDump(userId: Id[User], limit: Int) = AdminHtmlAction.authenticatedAsync{ implicit request =>
-    val uris = db.readOnly{ implicit s => keepRepo.getLatestKeepsURIByUser(userId, limit, includePrivate = false) }
+    val uris = db.readOnlyMaster{ implicit s => keepRepo.getLatestKeepsURIByUser(userId, limit, includePrivate = false) }
     cortex.getLDAFeatures(uris).map{ feats =>
       Ok(Json.toJson(feats))
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminPageInfoController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminPageInfoController.scala
@@ -17,14 +17,14 @@ class AdminPageInfoController @Inject()
   extends AdminController(actionAuthenticator) {
 
   def pageInfo(id:Id[PageInfo]) = AdminHtmlAction.authenticated { request =>
-    val pageInfo = db.readOnly { implicit ro =>
+    val pageInfo = db.readOnlyMaster { implicit ro =>
       pageInfoRepo.get(id)
     }
     Ok(html.admin.pageInfo(pageInfo))
   }
 
   def pageInfos(page:Int, size:Int) = AdminHtmlAction.authenticated { request =>
-    val pageInfos = db.readOnly { implicit ro =>
+    val pageInfos = db.readOnlyMaster { implicit ro =>
       pageInfoRepo.page(page, size).sortBy(_.id.get.id)
     }
     // add pagination

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminPornDetectorController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminPornDetectorController.scala
@@ -45,7 +45,7 @@ class AdminPornDetectorController @Inject()(
   }
 
   def pornUrisView(page: Int, publicOnly: Boolean) = AdminHtmlAction.authenticated{ implicit request =>
-    val uris = db.readOnly{implicit s => uriRepo.getRestrictedURIs(Restriction.ADULT)}.sortBy(-_.updatedAt.getMillis())
+    val uris = db.readOnlyMaster{implicit s => uriRepo.getRestrictedURIs(Restriction.ADULT)}.sortBy(-_.updatedAt.getMillis())
     val PAGE_SIZE = 100
 
     val retUris = publicOnly match {
@@ -54,7 +54,7 @@ class AdminPornDetectorController @Inject()(
         val need = (page + 1) * PAGE_SIZE
         val buf = new ArrayBuffer[NormalizedURI]()
         var (i, cnt) = (0, 0)
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           while (i < uris.size && cnt < need){
             val bms = bmRepo.getByUri(uris(i).id.get)
             if (bms.exists(_.isPrivate == false)){

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminSearchController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminSearchController.scala
@@ -48,7 +48,7 @@ class AdminSearchController @Inject() (
   }
 
   private def getConfigsForBlindTest: Seq[SearchConfigExperiment] = {
-    db.readOnly{ implicit s =>
+    db.readOnlyMaster{ implicit s =>
       searchConfigRepo.getActive()
     }.filter(_.description.contains("[blind test]"))
   }
@@ -87,7 +87,7 @@ class AdminSearchController @Inject() (
     val id2 = body.get("id2").get.toLong
     val shuffle = body.get("shuffle").get.toBoolean
 
-    val (config1, config2) = db.readOnly{ implicit s =>
+    val (config1, config2) = db.readOnlyMaster{ implicit s =>
       (searchConfigRepo.get(Id[SearchConfigExperiment](id1)), searchConfigRepo.get(Id[SearchConfigExperiment](id2)))
     }
 
@@ -122,7 +122,7 @@ class AdminSearchController @Inject() (
   def articleSearchResult(id: ExternalId[ArticleSearchResult]) = AdminHtmlAction.authenticated { implicit request =>
 
     val result = articleSearchResultStore.get(id).get
-    val metas: Seq[ArticleSearchResultHitMeta] = db.readOnly { implicit s =>
+    val metas: Seq[ArticleSearchResultHitMeta] = db.readOnlyMaster { implicit s =>
       result.hits.zip(result.scorings) map { tuple =>
         val hit = tuple._1
         val scoring = tuple._2

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminSocialUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminSocialUserController.scala
@@ -47,7 +47,7 @@ class AdminSocialUserController @Inject() (
   }
 
   def disconnectSocialUser(suiId: Id[SocialUserInfo], revoke: Boolean = false) = AdminHtmlAction.authenticated { implicit request =>
-    val sui = db.readOnly(socialUserInfoRepo.get(suiId)(_))
+    val sui = db.readOnlyMaster(socialUserInfoRepo.get(suiId)(_))
     if (revoke) {
       socialGraphPlugin.asyncRevokePermissions(sui)
     }
@@ -61,7 +61,7 @@ class AdminSocialUserController @Inject() (
   }
 
   def refreshSocialInfo(socialUserInfoId: Id[SocialUserInfo]) = AdminHtmlAction.authenticated { implicit request =>
-    val socialUserInfo = db.readOnly { implicit s => socialUserInfoRepo.get(socialUserInfoId) }
+    val socialUserInfo = db.readOnlyMaster { implicit s => socialUserInfoRepo.get(socialUserInfoId) }
     if (socialUserInfo.credentials.isEmpty) throw new Exception("can't fetch user info for user with missing credentials: %s".format(socialUserInfo))
     socialGraphPlugin.asyncFetch(socialUserInfo)
     Redirect(com.keepit.controllers.admin.routes.AdminSocialUserController.socialUserView(socialUserInfoId))
@@ -71,7 +71,7 @@ class AdminSocialUserController @Inject() (
     val user: Id[User] = if (userId==0) request.userId else Id[User](userId)
     val howManyReally = if (howMany==0) 20 else howMany
     abook.ripestFruit(user, howManyReally).map{ socialIds =>
-      val socialUsers = db.readOnly { implicit session => socialIds.map(socialUserInfoRepo.get(_)) }
+      val socialUsers = db.readOnlyMaster { implicit session => socialIds.map(socialUserInfoRepo.get(_)) }
       Ok(html.admin.socialUsers(socialUsers, 0))
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminURIGraphController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminURIGraphController.scala
@@ -24,12 +24,12 @@ class AdminURIGraphController @Inject()(
 
   def update(userId: Id[User]) = AdminHtmlAction.authenticated { implicit request =>
     // bump up seqNum
-    val bookmarks = db.readOnly { implicit s => keepRepo.getByUser(userId) }
+    val bookmarks = db.readOnlyMaster { implicit s => keepRepo.getByUser(userId) }
     bookmarks.grouped(1000).foreach { group =>
       db.readWrite { implicit s => group.foreach(keepRepo.save) }
     }
 
-    val collections = db.readOnly(implicit s => collectionRepo.getUnfortunatelyIncompleteTagsByUser(userId))
+    val collections = db.readOnlyMaster(implicit s => collectionRepo.getUnfortunatelyIncompleteTagsByUser(userId))
     collections.grouped(1000).foreach{group =>
       db.readWrite( implicit s => group.foreach(collectionRepo.save))
     }
@@ -48,7 +48,7 @@ class AdminURIGraphController @Inject()(
   }
 
   def dumpCollectionLuceneDocument(id: Id[Collection]) =  AdminHtmlAction.authenticatedAsync { implicit request =>
-    val collection = db.readOnly { implicit s => collectionRepo.get(id) }
+    val collection = db.readOnlyMaster { implicit s => collectionRepo.get(id) }
     searchClient.dumpLuceneCollection(id, collection.userId).map(Ok(_))
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -132,7 +132,7 @@ class AdminUserController @Inject() (
       userSessionRepo.invalidateByUser(fromUserId)
     }
 
-    for (su <- db.readOnly { implicit s => socialUserInfoRepo.getByUser(toUserId) }) {
+    for (su <- db.readOnlyMaster { implicit s => socialUserInfoRepo.getByUser(toUserId) }) {
       socialGraphPlugin.asyncFetch(su)
     }
 
@@ -142,7 +142,7 @@ class AdminUserController @Inject() (
   def moreUserInfoView(userId: Id[User], showPrivates:Boolean = false) = AdminHtmlAction.authenticatedAsync { implicit request =>
     val abookInfoF = abookClient.getABookInfos(userId)
     val econtactsF = if (showPrivates) abookClient.getEContacts(userId, 40000000) else Future.successful(Seq.empty[EContact])
-    val (user, socialUserInfos, socialConnections) = db.readOnly { implicit s =>
+    val (user, socialUserInfos, socialConnections) = db.readOnlyMaster { implicit s =>
       val user = userRepo.get(userId)
       val socialConnections = socialConnectionRepo.getUserConnections(userId).sortWith((a,b) => a.fullName < b.fullName)
       val socialUserInfos = socialUserInfoRepo.getByUser(user.id.get)
@@ -199,7 +199,7 @@ class AdminUserController @Inject() (
       doUserViewById(Id[User](id), showPrivates)
     } orElse {
       ExternalId.asOpt[User](userIdStr) flatMap { userExtId =>
-        db.readOnly { implicit session =>
+        db.readOnlyMaster { implicit session =>
           userRepo.getOpt(userExtId)
         }
       } map { user =>
@@ -209,7 +209,7 @@ class AdminUserController @Inject() (
   }
 
   private def doUserViewById(userId: Id[User], showPrivates: Boolean)(implicit request: AuthenticatedRequest[AnyContent]): Future[SimpleResult] = {
-    db.readOnly { implicit session =>
+    db.readOnlyMaster { implicit session =>
       userRepo.getOpt(userId)
     } map { user =>
       doUserView(user, showPrivates)
@@ -222,7 +222,7 @@ class AdminUserController @Inject() (
     val econtactCountF = abookClient.getEContactCount(userId)
     val econtactsF = if (showPrivateContacts) abookClient.getEContacts(userId, 500) else Future.successful(Seq.empty[EContact])
 
-    val (bookmarkCount, socialUsers, fortyTwoConnections, kifiInstallations, allowedInvites, emails, invitedByUsers) = db.readOnly {implicit s =>
+    val (bookmarkCount, socialUsers, fortyTwoConnections, kifiInstallations, allowedInvites, emails, invitedByUsers) = db.readOnlyMaster {implicit s =>
       val bookmarkCount = keepRepo.getCountByUser(userId)
       val socialUsers = socialUserInfoRepo.getByUser(userId)
       val fortyTwoConnections = userConnectionRepo.getConnectedUsers(userId).map { userId =>
@@ -235,7 +235,7 @@ class AdminUserController @Inject() (
       (bookmarkCount, socialUsers, fortyTwoConnections, kifiInstallations, allowedInvites, emails, invitedByUsers)
     }
 
-    val experiments = db.readOnly { implicit s => userExperimentRepo.getUserExperiments(user.id.get) }
+    val experiments = db.readOnlyMaster { implicit s => userExperimentRepo.getUserExperiments(user.id.get) }
 
     for {
       abookInfos <- abookInfoF
@@ -254,7 +254,7 @@ class AdminUserController @Inject() (
       log.warn(s"${request.user.firstName} ${request.user.firstName} (${request.userId}) is viewing user $userId's private keeps and contacts")
     }
 
-    val (user, bookmarks) = db.readOnly {implicit s =>
+    val (user, bookmarks) = db.readOnlyMaster {implicit s =>
       val user = userRepo.get(userId)
       val bookmarks = keepRepo.getByUser(userId, Some(KeepStates.INACTIVE)).filter(b => showPrivates || !b.isPrivate)
       val uris = bookmarks map (_.uriId) map normalizedURIRepo.get
@@ -268,9 +268,9 @@ class AdminUserController @Inject() (
       case cid if cid.toLong > 0 => Id[Collection](cid.toLong)
     }
     val bookmarkFilter = collectionFilter.map { collId =>
-      db.readOnly { implicit s => keepToCollectionRepo.getKeepsInCollection(collId) }
+      db.readOnlyMaster { implicit s => keepToCollectionRepo.getKeepsInCollection(collId) }
     }
-    val filteredBookmarks = db.readOnly { implicit s =>
+    val filteredBookmarks = db.readOnlyMaster { implicit s =>
       val query = bookmarkSearch.getOrElse("").toLowerCase()
       (if (query.trim.length == 0) {
         bookmarks
@@ -282,7 +282,7 @@ class AdminUserController @Inject() (
           (mark, uri, colls)
       }
     }
-    val collections = db.readOnly { implicit s => collectionRepo.getUnfortunatelyIncompleteTagsByUser(userId) }
+    val collections = db.readOnlyMaster { implicit s => collectionRepo.getUnfortunatelyIncompleteTagsByUser(userId) }
 
     Ok(html.admin.userKeeps(user, bookmarks.size, filteredBookmarks, bookmarkSearch, collections, collectionFilter))
   }
@@ -323,7 +323,7 @@ class AdminUserController @Inject() (
 
   def userStatisticsPage(page: Int = 0, userViewType: UserViewType) = {
     val PAGE_SIZE: Int = 50
-    val (users, userCount) = db.readOnly { implicit s =>
+    val (users, userCount) = db.readOnlyMaster { implicit s =>
       userViewType match {
         case AllUsersViewType => (userRepo.pageIncluding(UserStates.ACTIVE)(page, PAGE_SIZE) map userStatistics,
                                   userRepo.countIncluding(UserStates.ACTIVE))
@@ -337,7 +337,7 @@ class AdminUserController @Inject() (
     }
 
     val newUsers = userViewType match {
-      case RegisteredUsersViewType => db.readOnly { implicit s => Some(userRepo.countNewUsers) }
+      case RegisteredUsersViewType => db.readOnlyMaster { implicit s => Some(userRepo.countNewUsers) }
       case _ => None
     }
 
@@ -372,7 +372,7 @@ class AdminUserController @Inject() (
       case None => Redirect(routes.AdminUserController.usersView(0))
       case Some(queryText) =>
         val userIds = Await.result(searchClient.searchUsers(userId = None, query = queryText, maxHits = 100), 15 seconds).hits.map{_.id}
-        val users = db.readOnly { implicit s =>
+        val users = db.readOnlyMaster { implicit s =>
           userIds map userRepo.get map userStatistics
         }
         val userThreadStats = (users.par.map { u =>
@@ -506,7 +506,7 @@ class AdminUserController @Inject() (
             userValueRepo.clearValue(userId, name).toString
           })
         case (Some(name), _, _) => // get it
-          db.readOnly { implicit session =>
+          db.readOnlyMaster { implicit session =>
             userValueRepo.getValueStringOpt(userId, name)
           }
         case _=>
@@ -548,7 +548,7 @@ class AdminUserController @Inject() (
   }
 
   def refreshAllSocialInfo(userId: Id[User]) = AdminHtmlAction.authenticated { implicit request =>
-    val socialUserInfos = db.readOnly {implicit s =>
+    val socialUserInfos = db.readOnlyMaster {implicit s =>
       val user = userRepo.get(userId)
       socialUserInfoRepo.getByUser(user.id.get)
     }
@@ -591,7 +591,7 @@ class AdminUserController @Inject() (
       users =>
         eliza.sendGlobalNotification(users.toSet, title, bodyHtml, linkText, url.getOrElse(""), image, isSticky, category)
     } getOrElse {
-      val users = db.readOnly {
+      val users = db.readOnlyMaster {
         implicit session => userRepo.getAllIds()
       } //Note: Need to revisit when we have >50k users.
       eliza.sendGlobalNotification(users, title, bodyHtml, linkText, url.getOrElse(""), image, isSticky, category)
@@ -610,7 +610,7 @@ class AdminUserController @Inject() (
 
   def resetMixpanelProfile(userId: Id[User]) = AdminHtmlAction.authenticatedAsync { implicit request =>
     SafeFuture {
-      val user = db.readOnly { implicit session => userRepo.get(userId) }
+      val user = db.readOnlyMaster { implicit session => userRepo.get(userId) }
       doResetMixpanelProfile(user)
       Redirect(routes.AdminUserController.userView(userId))
     }
@@ -618,7 +618,7 @@ class AdminUserController @Inject() (
 
   def deleteAllMixpanelProfiles() = AdminHtmlAction.authenticatedAsync { implicit request =>
     SafeFuture {
-      val allUsers = db.readOnly { implicit s => userRepo.all }
+      val allUsers = db.readOnlyMaster { implicit s => userRepo.all }
       allUsers.foreach(user => heimdal.deleteUser(user.id.get))
       Ok("All user profiles have been deleted from Mixpanel")
     }
@@ -626,7 +626,7 @@ class AdminUserController @Inject() (
 
   def resetAllMixpanelProfiles() = AdminHtmlAction.authenticatedAsync { implicit request =>
     SafeFuture {
-      val allUsers = db.readOnly { implicit s => userRepo.all }
+      val allUsers = db.readOnlyMaster { implicit s => userRepo.all }
       allUsers.foreach(doResetMixpanelProfile)
       Ok("All user profiles have been reset in Mixpanel")
     }
@@ -639,7 +639,7 @@ class AdminUserController @Inject() (
       heimdal.deleteUser(userId)
     else {
       val properties = new HeimdalContextBuilder
-      db.readOnly { implicit session =>
+      db.readOnlyMaster { implicit session =>
         properties += ("$first_name", user.firstName)
         properties += ("$last_name", user.lastName)
         properties += ("$created", user.createdAt)
@@ -668,7 +668,7 @@ class AdminUserController @Inject() (
 
   def bumpUpSeqNumForConnections() = AdminHtmlAction.authenticatedAsync { implicit request =>
     SafeFuture{
-      val conns = db.readOnly{ implicit s =>
+      val conns = db.readOnlyMaster{ implicit s =>
         userConnectionRepo.all()
       }
 
@@ -678,7 +678,7 @@ class AdminUserController @Inject() (
         }
       }
 
-      val friends = db.readOnly{ implicit s =>
+      val friends = db.readOnlyMaster{ implicit s =>
         searchFriendRepo.all()
       }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/ElectronicMailController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/ElectronicMailController.scala
@@ -22,7 +22,7 @@ class ElectronicMailController @Inject() (
 
   def electronicMailsView(page: Int = 0) = AdminHtmlAction.authenticated { request =>
     val PAGE_SIZE = 200
-    val (count, electronicMails) = db.readOnly { implicit s =>
+    val (count, electronicMails) = db.readOnlyMaster { implicit s =>
       val electronicMails = repo.page(page, PAGE_SIZE)
       val count = repo.count(s)
       (count, electronicMails)

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/PhraseController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/PhraseController.scala
@@ -20,7 +20,7 @@ class PhraseController @Inject() (
   val pageSize = 50
 
   def displayPhrases(page: Int = 0) = AdminHtmlAction.authenticated { implicit request =>
-    val (phrasesOpt, count) = db.readOnly { implicit session =>
+    val (phrasesOpt, count) = db.readOnlyMaster { implicit session =>
       val count = 10//phraseRepo.count
       val phrasesOpt = if(!PhraseImporter.isInProgress) {
         Some(phraseRepo.page(page, pageSize))

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/ScraperAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/ScraperAdminController.scala
@@ -70,12 +70,12 @@ class ScraperAdminController @Inject() (
 
   def getScraped(id: Id[NormalizedURI]) = AdminHtmlAction.authenticated { implicit request =>
     val articleOption = articleStore.get(id)
-    val (uri, scrapeInfoOption) = db.readOnly { implicit s => (normalizedURIRepo.get(id), scrapeInfoRepo.getByUriId(id)) }
+    val (uri, scrapeInfoOption) = db.readOnlyMaster { implicit s => (normalizedURIRepo.get(id), scrapeInfoRepo.getByUriId(id)) }
     Ok(html.admin.article(articleOption, uri, scrapeInfoOption))
   }
 
   def getProxies = AdminHtmlAction.authenticated { implicit request =>
-    val proxies = db.readOnly { implicit session => httpProxyRepo.all() }
+    val proxies = db.readOnlyMaster { implicit session => httpProxyRepo.all() }
     Ok(html.admin.proxies(proxies))
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainClassifier.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainClassifier.scala
@@ -136,7 +136,7 @@ class DomainClassifierImpl @Inject()(
       Right(true)
     } else {
       val domainName = domainParts.dropWhile(_ == "www").mkString(".")
-      val domainOpt = db.readOnly { implicit s => domainRepo.get(domainName) }
+      val domainOpt = db.readOnlyMaster { implicit s => domainRepo.get(domainName) }
       domainOpt.flatMap { domain =>
         domain.sensitive.orElse(db.readWrite { implicit s => updater.calculateSensitivity(domain) })
       } match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
@@ -131,7 +131,7 @@ class AuthCommander @Inject()(
 
     val userIdFromEmailIdentity = for {
       identity <- identityOpt
-      socialUserInfo <- db.readOnly { implicit s =>
+      socialUserInfo <- db.readOnlyMaster { implicit s =>
         socialUserInfoRepo.getOpt(SocialId(newIdentity.identityId.userId), SocialNetworks.FORTYTWO)
       }
       userId <- socialUserInfo.userId
@@ -142,7 +142,7 @@ class AuthCommander @Inject()(
 
     val confusedCompilerUserId = userIdFromEmailIdentity getOrElse {
       val userIdOpt = for {
-        socialUserInfo <- db.readOnly { implicit s => socialUserInfoRepo.getOpt(SocialId(newIdentity.identityId.userId), SocialNetworks.FORTYTWO) }
+        socialUserInfo <- db.readOnlyMaster { implicit s => socialUserInfoRepo.getOpt(SocialId(newIdentity.identityId.userId), SocialNetworks.FORTYTWO) }
         userId <- socialUserInfo.userId
       } yield userId
       userIdOpt.get
@@ -173,7 +173,7 @@ class AuthCommander @Inject()(
       val (emailPassIdentity, userId) = saveUserPasswordIdentity(None, Some(socialIdentity),
         email = sfi.email, passwordInfo = pInfo, firstName = sfi.firstName, lastName = sfi.lastName, isComplete = true)
 
-      val user = db.readOnly { implicit session =>
+      val user = db.readOnlyMaster { implicit session =>
         userRepo.get(userId)
       }
 
@@ -194,14 +194,14 @@ class AuthCommander @Inject()(
     log.info(s"[finalizeEmailPassAccount] efi=$efi, userId=$userId, extUserId=$externalUserId, identity=$identityOpt, inviteExtId=$inviteExtIdOpt")
 
     val resultFuture = SafeFuture {
-      val identity = db.readOnly { implicit session =>
+      val identity = db.readOnlyMaster { implicit session =>
         socialUserInfoRepo.getByUser(userId).find(_.networkType == SocialNetworks.FORTYTWO).flatMap(_.credentials)
       } getOrElse identityOpt.get
 
       val passwordInfo = identity.passwordInfo.get
       val email = identity.email.get
       val (newIdentity, _) = saveUserPasswordIdentity(Some(userId), identityOpt, email = email, passwordInfo = passwordInfo, firstName = efi.firstName, lastName = efi.lastName, isComplete = true)
-      val user = db.readOnly(userRepo.get(userId)(_))
+      val user = db.readOnlyMaster(userRepo.get(userId)(_))
 
       reportUserRegistration(user, inviteExtIdOpt)
 
@@ -209,7 +209,7 @@ class AuthCommander @Inject()(
     }
 
     val imageFuture = SafeFuture {
-      val user = db.readOnly(userRepo.get(userId)(_))
+      val user = db.readOnlyMaster(userRepo.get(userId)(_))
       val cropAttributes = parseCropForm(efi.picHeight, efi.picWidth, efi.cropX, efi.cropY, efi.cropSize) tap (r => log.info(s"Cropped attributes for ${userId}: " + r))
       efi.picToken.map { token =>
         s3ImageStore.copyTempFileToUserPic(userId, externalUserId, token, cropAttributes)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
@@ -50,7 +50,7 @@ class CollectionCommander @Inject() (
 
   def allCollections(sort: String, userId: Id[User]) = {
     log.info(s"Getting all collections for $userId (sort $sort)")
-    val unsortedCollections = db.readOnly { implicit s =>
+    val unsortedCollections = db.readOnlyMaster { implicit s =>
       val colls = collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(userId)
       val bmCounts = collectionRepo.getBookmarkCounts(colls.map(_.id).toSet)
       colls.map { c => BasicCollection.fromCollection(c, bmCounts.get(c.id).orElse(Some(0))) }
@@ -203,7 +203,7 @@ class CollectionCommander @Inject() (
   }
 
   def getBasicCollections(ids: Seq[Id[Collection]]): Seq[BasicCollection] = { //ZZZ needs a cache for he basic collection by id
-    db.readOnly{ implicit session =>
+    db.readOnlyMaster{ implicit session =>
       ids.map{ id =>
         basicCollectionCache.getOrElse(BasicCollectionByIdKey(id)){
           val collection = collectionRepo.get(id)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/FeatureWaitlistCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/FeatureWaitlistCommander.scala
@@ -36,7 +36,7 @@ class FeatureWaitlistCommander @Inject() (db: Database, waitlistRepo: FeatureWai
   }
 
   def waitList(email: String, feature: String, userAgent: String, extIdOpt: Option[ExternalId[FeatureWaitlistEntry]] = None) : ExternalId[FeatureWaitlistEntry] = {
-    val existingOpt : Option[FeatureWaitlistEntry] = extIdOpt.flatMap{ db.readOnly{ implicit session => waitlistRepo.getOpt(_) } }
+    val existingOpt : Option[FeatureWaitlistEntry] = extIdOpt.flatMap{ db.readOnlyMaster{ implicit session => waitlistRepo.getOpt(_) } }
     val extId = existingOpt.map{ existing =>
       db.readWrite{ implicit session => waitlistRepo.save(existing.copy(email=email, feature=feature, userAgent=userAgent)) }.externalId
     } getOrElse {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/InviteCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/InviteCommander.scala
@@ -232,7 +232,7 @@ class InviteCommander @Inject() (
 
   private def notifyClientsOfConnection(user1Id: Id[User], user2Id: Id[User]) = {
     delay {
-      val (user1, user2) = db.readOnly { implicit session => basicUserRepo.load(user1Id) -> basicUserRepo.load(user2Id) }
+      val (user1, user2) = db.readOnlyMaster { implicit session => basicUserRepo.load(user1Id) -> basicUserRepo.load(user2Id) }
       eliza.sendToUser(user1Id, Json.arr("new_friends", Set(user2)))
       eliza.sendToUser(user2Id, Json.arr("new_friends", Set(user1)))
     }
@@ -270,7 +270,7 @@ class InviteCommander @Inject() (
 
   private def sendEmailInvitation(inviteInfo:InviteInfo): InviteStatus = {
     val invite = getInvitation(inviteInfo)
-    val invitingUser = db.readOnly { implicit session => userRepo.get(inviteInfo.userId) }
+    val invitingUser = db.readOnlyMaster { implicit session => userRepo.get(inviteInfo.userId) }
     val c = inviteInfo.friend.right.get
     val acceptLink = baseUrl + routes.InviteController.acceptInvite(invite.externalId).url
 
@@ -303,7 +303,7 @@ class InviteCommander @Inject() (
   private def sendInvitationForLinkedIn(inviteInfo: InviteInfo): Future[InviteStatus] = {
     val invite = getInvitation(inviteInfo)
     val userId = inviteInfo.userId
-    val me = db.readOnly { implicit s => socialUserInfoRepo.getByUser(userId).find(_.networkType == SocialNetworks.LINKEDIN).get }
+    val me = db.readOnlyMaster { implicit s => socialUserInfoRepo.getByUser(userId).find(_.networkType == SocialNetworks.LINKEDIN).get }
     val socialUserInfo = inviteInfo.friend.left.get
     val path = routes.InviteController.acceptInvite(invite.externalId).url
     val subject = inviteInfo.subject.getOrElse(s"Kifi -- ${me.fullName.split(' ')(0)} invites you to Kifi") // todo: same for email
@@ -376,7 +376,7 @@ class InviteCommander @Inject() (
       val friendId = activeInvite.recipientSocialUserId.get
       log.info(s"[confirmFacebookInvite(${id})] Confirmed ${inviteStatus}")
       countInvitationsSent(userId, Left(friendId), existingInvitation).map { invitationsSent =>
-        val friendSocialUserInfo = db.readOnly { implicit session => socialUserInfoRepo.get(friendId) }
+        val friendSocialUserInfo = db.readOnlyMaster { implicit session => socialUserInfoRepo.get(friendId) }
         val inviteInfo = InviteInfo(userId, Left(friendSocialUserInfo), invitationsSent + 1, None, None, source)
         reportSentInvitation(activeInvite, inviteInfo)
       }
@@ -420,7 +420,7 @@ class InviteCommander @Inject() (
   private def countInvitationsSent(userId: Id[User], friendId: Either[Id[SocialUserInfo], EmailAddress], knownInvitation: Option[Invitation] = None): Future[Int] = {
     // Optimization to avoid calling ABook in the most common cases (ie first time social invites)
     val mayHaveBeenInvitedAlready = friendId match {
-      case Left(socialUserId) => (knownInvitation orElse db.readOnly { implicit session =>
+      case Left(socialUserId) => (knownInvitation orElse db.readOnlyMaster { implicit session =>
         invitationRepo.getBySenderIdAndRecipientSocialUserId(userId, socialUserId)
       }).exists(_.state != InvitationStates.INACTIVE)
       case Right(emailAddress) => knownInvitation.isEmpty || knownInvitation.get.state != InvitationStates.INACTIVE
@@ -502,7 +502,7 @@ class InviteCommander @Inject() (
   def getRipestInvitees(userId: Id[User], page: Int, pageSize: Int): Future[Seq[Invitee]] = {
     abook.getRipestFruits(userId, page, pageSize).map { ripestFruits =>
       val (emailConnections, socialConnections) = (ripestFruits.partition(_.connectionType == SocialNetworks.EMAIL))
-      db.readOnly { implicit session =>
+      db.readOnlyMaster { implicit session =>
         val lastInvitedAtByEmailAddress = invitationRepo.getLastInvitedAtBySenderIdAndRecipientEmailAddresses(userId, emailConnections.flatMap(_.friendEmailAddress))
         val lastInvitedAtBySocialUserId = invitationRepo.getLastInvitedAtBySenderIdAndRecipientSocialUserIds(userId, socialConnections.flatMap(_.friendSocialId))
         ripestFruits.map { richConnection => richConnection.connectionType match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsAbuseMonitor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsAbuseMonitor.scala
@@ -22,7 +22,7 @@ class KeepsAbuseMonitor @Inject() (
   implicit val dbMasterSlave = Database.Slave
 
   def inspect(userId: Id[User], newKeepCount: Int): Unit = {
-    val existingBookmarksCount = db.readOnly { implicit s => keepRepo.getCountByUser(userId) }
+    val existingBookmarksCount = db.readOnlyMaster { implicit s => keepRepo.getCountByUser(userId) }
     val afterAdding = newKeepCount + existingBookmarksCount
     if (afterAdding > absoluteError) {
       throw new AbuseMonitorException(s"user $userId tried to add $newKeepCount keeps while having $existingBookmarksCount. max allowed is $absoluteError")

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LocalUserExperimentCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LocalUserExperimentCommander.scala
@@ -38,11 +38,11 @@ class LocalUserExperimentCommander @Inject() (
   extends UserExperimentCommander with Logging {
 
   def getExperimentGenerators() : Future[Seq[ProbabilisticExperimentGenerator]] = Future {
-    db.readOnly { implicit session => generatorRepo.allActive() }
+    db.readOnlyMaster { implicit session => generatorRepo.allActive() }
   }
 
   def getExperimentsByUser(userId: Id[User]): Set[ExperimentType] = {
-    val staticExperiments = db.readOnly { implicit session => userExperimentRepo.getUserExperiments(userId) }
+    val staticExperiments = db.readOnlyMaster { implicit session => userExperimentRepo.getUserExperiments(userId) }
     addDynamicExperiments(userId, staticExperiments)
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/SendgridCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/SendgridCommander.scala
@@ -71,7 +71,7 @@ class SendgridCommander @Inject() (
       }
 
       val relevantUsers = if (NotificationCategory.User.all.contains(email.category)) {
-        db.readOnly{ implicit s => emailAddressRepo.getByAddress(address).map(_.userId).toSet }(Database.Slave, captureLocation)
+        db.readOnlyMaster{ implicit s => emailAddressRepo.getByAddress(address).map(_.userId).toSet }(Database.Slave, captureLocation)
       } else Set.empty
 
       if (relevantUsers.nonEmpty) relevantUsers.foreach { userId =>
@@ -86,7 +86,7 @@ class SendgridCommander @Inject() (
     val emailOpt = timing(s"sendgrid (fetch email for alert) eventType(${event.event}}) mailId(${event.mailId}}) ") {
       for {
         mailId <- event.mailId
-        mail <- db.readOnly{ implicit s => electronicMailRepo.getOpt(mailId) }(Database.Slave, captureLocation)
+        mail <- db.readOnlyMaster{ implicit s => electronicMailRepo.getOpt(mailId) }(Database.Slave, captureLocation)
       } yield mail
     }
     emailAlert(event, emailOpt)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/ShoeboxRichConnectionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/ShoeboxRichConnectionCommander.scala
@@ -134,7 +134,7 @@ class ShoeboxRichConnectionCommander @Inject() (
 
   def block(userId: Id[User], fullSocialId: FullSocialId): Unit = {
     val friendId = fullSocialId.identifier.left.map { socialId =>
-      db.readOnly { implicit session =>
+      db.readOnlyMaster { implicit session =>
         socialUserInfoRepo.get.get(socialId, fullSocialId.network).id.get
       }
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/URISummaryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/URISummaryCommander.scala
@@ -47,7 +47,7 @@ class URISummaryCommander @Inject()(
    * Gets the default URI Summary
    */
   def getDefaultURISummary(uriId: Id[NormalizedURI], waiting: Boolean): Future[URISummary] = {
-    val uri = db.readOnly { implicit session => normalizedUriRepo.get(uriId) }
+    val uri = db.readOnlyMaster { implicit session => normalizedUriRepo.get(uriId) }
     getDefaultURISummary(uri, waiting)
   }
 
@@ -100,7 +100,7 @@ class URISummaryCommander @Inject()(
 
   private def getNormalizedURIForRequest(request: URISummaryRequest): Option[NormalizedURI] = {
     if (request.silent)
-      db.readOnly { implicit session => normalizedURIInterner.getByUri(request.url) }
+      db.readOnlyMaster { implicit session => normalizedURIInterner.getByUri(request.url) }
     else
       db.readWrite { implicit session => Some(normalizedURIInterner.internByUri(request.url)) }
   }
@@ -121,7 +121,7 @@ class URISummaryCommander @Inject()(
       case ImageType.SCREENSHOT => Some(ImageProvider.PAGEPEEKER)
       case ImageType.IMAGE => Some(ImageProvider.EMBEDLY)
     }
-    db.readOnly { implicit session =>
+    db.readOnlyMaster { implicit session =>
       val storedImageInfos = nUri.id flatMap { id =>
         imageInfoRepo.getByUriWithPriority(id, minSize, targetProvider)
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
@@ -142,7 +142,7 @@ class UserCommander @Inject() (
 
 
   def getConnectionsPage(userId: Id[User], page: Int, pageSize: Int): (Seq[ConnectionInfo], Int) = {
-    val infos = db.readOnly { implicit s =>
+    val infos = db.readOnlyMaster { implicit s =>
       val searchFriends = searchFriendRepo.getSearchFriends(userId)
       val connectionIds = userConnectionRepo.getConnectedUsers(userId)
       val unfriendedIds = userConnectionRepo.getUnfriendedUsers(userId)
@@ -155,7 +155,7 @@ class UserCommander @Inject() (
   }
 
   def getFriends(user: User, experiments: Set[ExperimentType]): Set[BasicUser] = {
-    val basicUsers = db.readOnly { implicit s =>
+    val basicUsers = db.readOnlyMaster { implicit s =>
       if (canMessageAllUsers(user.id.get)) {
         userRepo.allExcluding(UserStates.PENDING, UserStates.BLOCKED, UserStates.INACTIVE)
           .collect { case u if u.id.get != user.id.get => BasicUser.fromUser(u) }.toSet
@@ -188,7 +188,7 @@ class UserCommander @Inject() (
     userExperimentCommander.userHasExperiment(userId, ExperimentType.CAN_MESSAGE_ALL_USERS)
   }
 
-  def socialNetworkInfo(userId: Id[User]) = db.readOnly { implicit s =>
+  def socialNetworkInfo(userId: Id[User]) = db.readOnlyMaster { implicit s =>
     socialUserInfoRepo.getByUser(userId).map(BasicSocialUser.from)
   }
 
@@ -199,7 +199,7 @@ class UserCommander @Inject() (
   }
 
   def getUserInfo(user: User): BasicUserInfo = {
-    val (basicUser, description, emails, pendingPrimary, notAuthed) = db.readOnly { implicit session =>
+    val (basicUser, description, emails, pendingPrimary, notAuthed) = db.readOnlyMaster { implicit session =>
       val basicUser = basicUserRepo.load(user.id.get)
       val description =  userValueRepo.getValueStringOpt(user.id.get, "user_description")
       val emails = emailRepo.getAllByUser(user.id.get)
@@ -222,7 +222,7 @@ class UserCommander @Inject() (
 
   def getHelpCounts(user: Id[User]): (Int, Int) = {
     //unique keeps, total clicks
-    db.readOnly { implicit session => bookmarkClicksRepo.getClickCounts(user) }
+    db.readOnlyMaster { implicit session => bookmarkClicksRepo.getClickCounts(user) }
   }
 
   def getKeepAttributionCounts(userId: Id[User]): (Int, Int, Int) = { // (discoveryCount, rekeepCount, rekeepTotalCount)
@@ -234,7 +234,7 @@ class UserCommander @Inject() (
   }
 
   def getUserSegment(userId: Id[User]): UserSegment = {
-    val (numBms, numFriends) = db.readOnly{ implicit s => //using cache
+    val (numBms, numFriends) = db.readOnlyMaster{ implicit s => //using cache
       (keepRepo.getCountByUser(userId), userConnectionRepo.getConnectionCount(userId))
     }
 
@@ -258,9 +258,9 @@ class UserCommander @Inject() (
 
   def tellAllFriendsAboutNewUserImmediate(newUserId: Id[User], additionalRecipients: Seq[Id[User]]): Unit = synchronized {
     val guardKey = "friendsNotifiedAboutJoining"
-    if (!db.readOnly{ implicit session => userValueRepo.getValueStringOpt(newUserId, guardKey).exists(_=="true") }) {
+    if (!db.readOnlyMaster{ implicit session => userValueRepo.getValueStringOpt(newUserId, guardKey).exists(_=="true") }) {
       db.readWrite { implicit session => userValueRepo.setValue(newUserId, guardKey, true) }
-      val (newUser, toNotify, id2Email) = db.readOnly { implicit session =>
+      val (newUser, toNotify, id2Email) = db.readOnlyMaster { implicit session =>
         val newUser = userRepo.get(newUserId)
         val toNotify = userConnectionRepo.getConnectedUsers(newUserId) ++ additionalRecipients
         val id2Email = toNotify.map { userId =>
@@ -307,7 +307,7 @@ class UserCommander @Inject() (
 
   def sendWelcomeEmail(newUser: User, withVerification: Boolean = false, targetEmailOpt: Option[EmailAddress] = None): Unit = {
     val olderUser : Boolean = newUser.createdAt.isBefore(currentDateTime.minus(24*3600*1000)) //users older than 24h get the long form welcome email
-    if (!db.readOnly{ implicit session => userValueRepo.getValue(newUser.id.get, UserValues.welcomeEmailSent) }) {
+    if (!db.readOnlyMaster{ implicit session => userValueRepo.getValue(newUser.id.get, UserValues.welcomeEmailSent) }) {
       db.readWrite { implicit session => userValueRepo.setValue(newUser.id.get, UserValues.welcomeEmailSent.name, true) }
 
       if (withVerification) {
@@ -367,7 +367,7 @@ class UserCommander @Inject() (
   }
 
   def doChangePassword(userId:Id[User], oldPassword:String, newPassword:String):Try[Identity] = Try {
-    val resOpt = db.readOnly { implicit session =>
+    val resOpt = db.readOnlyMaster { implicit session =>
       socialUserInfoRepo.getByUser(userId).find(_.networkType == SocialNetworks.FORTYTWO)
     } map { sui =>
       val hasher = Registry.hashers.currentHasher
@@ -387,7 +387,7 @@ class UserCommander @Inject() (
   def queryContacts(userId:Id[User], search: Option[String], after:Option[String], limit: Int):Future[Seq[JsObject]] = { // TODO: optimize
     @inline def mkId(email: EmailAddress) = s"email/${email.address}"
     @inline def getEInviteStatus(contactEmail: EmailAddress): String = { // todo: batch
-      db.readOnly { implicit s =>
+      db.readOnlyMaster { implicit s =>
         invitationRepo.getBySenderIdAndRecipientEmailAddress(userId, contactEmail) map { inv =>
           if (inv.state != InvitationStates.INACTIVE) "invited" else ""
         }
@@ -446,7 +446,7 @@ class UserCommander @Inject() (
       }
     }
 
-    val connections = db.readOnly { implicit s =>
+    val connections = db.readOnlyMaster { implicit s =>
       val infos = socialConnectionRepo.getSocialConnectionInfosByUser(userId).filterKeys(networkType => network.forall(_ == networkType.name))
       val filteredConnections = infos.values.map(getFilteredConnections).flatten.toSeq.sorted.map(_.info)
 
@@ -604,7 +604,7 @@ class UserCommander @Inject() (
         userConnectionRepo.unfriendConnections(userId, user.id.toSet) > 0
       }
       if (success) {
-        db.readOnly{ implicit session =>
+        db.readOnlyMaster{ implicit session =>
           elizaServiceClient.sendToUser(userId, Json.arr("lost_friends", Set(basicUserRepo.load(user.id.get))))
           elizaServiceClient.sendToUser(user.id.get, Json.arr("lost_friends", Set(basicUserRepo.load(userId))))
         }
@@ -643,7 +643,7 @@ class UserCommander @Inject() (
 
   def disconnect(userId:Id[User], networkString: String):(Option[SocialUserInfo], String) = {
     val network = SocialNetworkType(networkString)
-    val (thisNetwork, otherNetworks) = db.readOnly { implicit s =>
+    val (thisNetwork, otherNetworks) = db.readOnlyMaster { implicit s =>
       userCache.remove(SocialUserInfoUserKey(userId))
       socialUserInfoRepo.getByUser(userId).partition(_.networkType == network)
     }
@@ -772,7 +772,7 @@ class UserCommander @Inject() (
   }
 
   def getUserImageUrl(userId: Id[User], width: Int): Future[String] = {
-    val user = db.readOnly { implicit session => userRepo.get(userId) }
+    val user = db.readOnlyMaster { implicit session => userRepo.get(userId) }
     implicit val txn = TransactionalCaching.Implicits.directCacheAccess
     userImageUrlCache.getOrElseFuture(UserImageUrlCacheKey(userId, width)) {
       s3ImageStore.getPictureUrl(Some(width), user, user.pictureName.getOrElse("0"))

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventStream.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/analytics/EventStream.scala
@@ -78,7 +78,7 @@ class EventWriter @Inject() (
   def wrapEvent(event: Event): Option[WrappedUserEvent] = {
       event match {
         case Event(_,UserEventMetadata(eventFamily, eventName, externalUser, _, experiments, metaData, _), createdAt, _) =>
-          val user = db.readOnly { implicit session => userRepo.get(externalUser) }
+          val user = db.readOnlyMaster { implicit session => userRepo.get(externalUser) }
           val avatarUrl = imageStore.getPictureUrl(Some(150), user, "0.jpg").value.flatMap(_.toOption)
           Some(WrappedUserEvent(event, user, avatarUrl, eventName, eventFamily, createdAt))
         case _ => None

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/integration/AutogenReaper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/integration/AutogenReaper.scala
@@ -67,7 +67,7 @@ private[integration] class AutogenReaper @Inject() (
       for (threshold <- Play.maybeApplication map { app => // todo: inject
         if (Play.isDev) currentDateTime.minusSeconds(15) else currentDateTime.minusMinutes(15)
       }) {
-        val dues = db.readOnly { implicit rw =>
+        val dues = db.readOnlyMaster { implicit rw =>
           // a variant of this could live in UserCommander
           val generated = userExperimentRepo.getByType(ExperimentType.AUTO_GEN)
           val dues = generated filter (e => e.updatedAt.isBefore(threshold))
@@ -112,7 +112,7 @@ private[integration] class AutogenReaper @Inject() (
           }
         }
         for (exp <- dues) {
-          val user = db.readOnly{ implicit s => userRepo.get(exp.userId) }
+          val user = db.readOnlyMaster{ implicit s => userRepo.get(exp.userId) }
           log.info(s"[reap] processing $user")
 
           db.readWrite { implicit s =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailToKeepPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/MailToKeepPlugin.scala
@@ -165,7 +165,7 @@ class MailToKeepMessageParser @Inject() (
   }
 
   def getUser(senderAddress: EmailAddress): Option[User] = {
-    db.readOnly { implicit s =>
+    db.readOnlyMaster { implicit s =>
       emailAddressRepo.getVerifiedOwner(senderAddress).map { userId =>
         userRepo.get(userId)
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/SendgridMailProvider.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/SendgridMailProvider.scala
@@ -113,7 +113,7 @@ class SendgridMailProvider @Inject() (
    */
   def sendMail(mail: ElectronicMail) {
     if (mail.isReadyToSend) {
-      val checkAgain = db.readOnly(mailRepo.getOpt(mail.id.get)(_)).exists(_.isReadyToSend)
+      val checkAgain = db.readOnlyMaster(mailRepo.getOpt(mail.id.get)(_)).exists(_.isReadyToSend)
       if(checkAgain) {
         val now = clock.now
         airbrake.verify(mail.createdAt.isAfter(now.minusMinutes(10)),
@@ -200,7 +200,7 @@ class SendgridMailProvider @Inject() (
     Play.configuration.getString("fortytwo.username") getOrElse System.getProperty("user.name")
 
   private def mailError(mailId: ExternalId[ElectronicMail], message: String, transport: Transport): ElectronicMail = {
-    val mail = db.readOnly {implicit s =>
+    val mail = db.readOnlyMaster {implicit s =>
       mailRepo.get(mailId)
     }
     mailError(mail, message, transport)

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphPluginImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphPluginImpl.scala
@@ -55,12 +55,12 @@ private[social] class SocialGraphActor @Inject() (
 
     case RefreshAll =>
       log.info("going to check which SocialUserInfo was not fetched lately")
-      val needToBeRefreshed = db.readOnly { implicit s => socialRepo.getNeedToBeRefreshed }
+      val needToBeRefreshed = db.readOnlyMaster { implicit s => socialRepo.getNeedToBeRefreshed }
       log.info(s"find ${needToBeRefreshed.size} users that need to be refreshed")
       needToBeRefreshed.foreach(self ! FetchUserInfoQuietly(_))
 
     case FetchAll =>
-      val unprocessedUsers = db.readOnly {implicit s =>
+      val unprocessedUsers = db.readOnlyMaster {implicit s =>
         socialRepo.getUnprocessed()
       }
       unprocessedUsers foreach { user =>
@@ -68,7 +68,7 @@ private[social] class SocialGraphActor @Inject() (
       }
 
     case FetchUserInfo(socialUserInfoId) =>
-      val socialUserInfo = db.readOnly { implicit session =>
+      val socialUserInfo = db.readOnlyMaster { implicit session =>
         socialRepo.get(socialUserInfoId)
       }
       fetchUserInfo(socialUserInfo)
@@ -138,7 +138,7 @@ private[social] class SocialGraphActor @Inject() (
   }
 
   private def isImportAlreadyInProcess(userId: Id[User], networkType: SocialNetworkType): Boolean = {
-    val stateOpt = db.readOnly { implicit session =>
+    val stateOpt = db.readOnlyMaster { implicit session =>
       userValueRepo.getUserValue(userId, s"import_in_progress_${networkType.name}")
     }
     stateOpt match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialUserImportFriends.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialUserImportFriends.scala
@@ -31,7 +31,7 @@ class SocialUserImportFriends @Inject() (
 
   def importFriends(socialUserInfo: SocialUserInfo, friends: Seq[SocialUserInfo]): Seq[SocialUserInfo] = {
     val deDuped = deDupe(friends)
-    val socialUserInfosNeedToUpdate = db.readOnly { implicit s =>
+    val socialUserInfosNeedToUpdate = db.readOnlyMaster { implicit s =>
       deDuped.flatMap { case friend =>
         getIfUpdateNeeded(friend)
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/UserConnectionCreator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/UserConnectionCreator.scala
@@ -47,7 +47,7 @@ class UserConnectionCreator @Inject() (
     }
   }
 
-  def getConnectionsLastUpdated(userId: Id[User]): Option[DateTime] = db.readOnly { implicit s =>
+  def getConnectionsLastUpdated(userId: Id[User]): Option[DateTime] = db.readOnlyMaster { implicit s =>
     userValueRepo.getValueStringOpt(userId, UserConnectionCreator.UpdatedUserConnectionsKey) map parseStandardTime
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/store/ImageDataIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/store/ImageDataIntegrityPlugin.scala
@@ -39,7 +39,7 @@ private[store] class ImageDataIntegrityActor @Inject() (
         log.info("Not verifying pictures since we are not storing images in S3")
       } else {
         log.info("Verifying pictures for all users")
-        for (user <- db.readOnly { implicit s =>
+        for (user <- db.readOnlyMaster { implicit s =>
           userRepo.allExcluding(UserStates.BLOCKED, UserStates.INACTIVE)
         }) yield {
           for (((url, response), cloudfrontInfo) <- findPictures(user)) {
@@ -63,7 +63,7 @@ private[store] class ImageDataIntegrityActor @Inject() (
   private def findPictures(user: User): Seq[ImageResponseInfo] = {
     val urls: Seq[(String, String)] =  {
       S3UserPictureConfig.ImageSizes.map { size =>
-        val pics = db.readOnly { implicit session =>
+        val pics = db.readOnlyMaster { implicit session =>
           userPictureRepo.getByUser(user.id.get)
         }
         pics.map { pic =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/assets/UserPictureController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/assets/UserPictureController.scala
@@ -29,7 +29,7 @@ class UserPictureController @Inject() (
 
   def getPic(size: String, id: ExternalId[User], picName: String) = Action.async { request =>
     val trimmedName = if (picName.endsWith(".jpg")) picName.dropRight(4) else picName
-    db.readOnly { implicit s => userRepo.getOpt(id) } collect {
+    db.readOnlyMaster { implicit s => userRepo.getOpt(id) } collect {
       case user if Set(UserStates.ACTIVE, UserStates.PENDING, UserStates.INCOMPLETE_SIGNUP) contains user.state =>
         val optSize = if (size == "original") None else Try(size.toInt).toOption
         imageStore.getPictureUrl(optSize, user, trimmedName) map (Redirect(_))
@@ -39,7 +39,7 @@ class UserPictureController @Inject() (
   }
 
   def get(size: Int, id: ExternalId[User]) = Action.async { request =>
-    db.readOnly { implicit s => userRepo.getOpt(id) } collect {
+    db.readOnlyMaster { implicit s => userRepo.getOpt(id) } collect {
       case user if Set(UserStates.ACTIVE, UserStates.PENDING, UserStates.INCOMPLETE_SIGNUP) contains user.state =>
         val optSize = Some(size)
         user.pictureName.map { pictureName =>
@@ -55,9 +55,9 @@ class UserPictureController @Inject() (
   def update() = HtmlAction.authenticatedAsync { request =>
     if (request.experiments.contains(ExperimentType.ADMIN)) {
       Future.sequence(for {
-        user <- db.readOnly { implicit s => userRepo.allExcluding(UserStates.INACTIVE) }
+        user <- db.readOnlyMaster { implicit s => userRepo.allExcluding(UserStates.INACTIVE) }
       } yield {
-        val socialUser = db.readOnly { implicit s => suiRepo.getByUser(user.id.get) }.head
+        val socialUser = db.readOnlyMaster { implicit s => suiRepo.getByUser(user.id.get) }.head
         imageStore.uploadPictureFromSocialNetwork(socialUser, user.externalId, setDefault = false).map(_ => socialUser.socialId)
       }).map { results =>
         Ok(results.mkString(","))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -92,7 +92,7 @@ class AuthController @Inject() (
   }, unauthenticatedAction = { implicit request =>
     if (request.identityOpt.isDefined) {
       // User tried to log in (not sign up) with social network.
-      request.identityOpt.get.email.flatMap(e => db.readOnly(emailAddressRepo.getByAddressOpt(EmailAddress(e))(_))) match {
+      request.identityOpt.get.email.flatMap(e => db.readOnlyMaster(emailAddressRepo.getByAddressOpt(EmailAddress(e))(_))) match {
         case Some(addr) =>
           // A user with this email address exists in the system, but it is not yet linked to this social identity.
           Ok(views.html.auth.connectToAuthenticate(
@@ -151,7 +151,7 @@ class AuthController @Inject() (
   // --
 
   private def hasSeenInstall(implicit request: AuthenticatedRequest[_]): Boolean = {
-    db.readOnly { implicit s => userValueRepo.getValue(request.userId, UserValues.hasSeenInstall) }
+    db.readOnlyMaster { implicit s => userValueRepo.getValue(request.userId, UserValues.hasSeenInstall) }
   }
 
   def loginPage() = HtmlAction(allowPending = true)(authenticatedAction = { request =>
@@ -186,7 +186,7 @@ class AuthController @Inject() (
   private def doSignupPage(implicit request: Request[_]): SimpleResult = {
     def emailAddressMatchesSomeKifiUser(identity: Identity): Boolean = {
       identity.email.flatMap { addr =>
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           emailAddressRepo.getByAddressOpt(EmailAddress(addr))
         }
       }.isDefined

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/NetworkInfoLoader.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/NetworkInfoLoader.scala
@@ -30,7 +30,7 @@ class NetworkInfoLoader @Inject() (
   socialUserInfoRepo: SocialUserInfoRepo) extends Logging {
 
   private def load(mySocialUsers: Seq[SocialUserInfo], friendId: Id[User]): Map[SocialNetworkType, NetworkInfo] = timing(s"loadNetworkInfo friendId($friendId) mySocialUsers:(len=${mySocialUsers.length})") {
-    db.readOnly { implicit s =>
+    db.readOnlyMaster { implicit s =>
       for (su <- socialUserInfoRepo.getByUser(friendId)) yield {
         su.networkType -> NetworkInfo(
           profileUrl = su.getProfileUrl,
@@ -44,7 +44,7 @@ class NetworkInfoLoader @Inject() (
   }
 
   def load(userId: Id[User], friendId: ExternalId[User]): Map[SocialNetworkType, NetworkInfo] = {
-    db.readOnly { implicit s =>
+    db.readOnlyMaster { implicit s =>
       userRepo.getOpt(friendId).map(f => socialUserInfoRepo.getByUser(userId) -> f.id.get)
     } map { case (sus, fid) => load(sus, fid) } getOrElse Map.empty
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
@@ -97,7 +97,7 @@ class ExtAuthController @Inject() (
 
         if (isInstall) {
           contextBuilder += ("action", "installedExtension")
-          val installedExtensions = db.readOnly { implicit session => installationRepo.all(user.id.get, Some(KifiInstallationStates.INACTIVE)).length }
+          val installedExtensions = db.readOnlyMaster { implicit session => installationRepo.all(user.id.get, Some(KifiInstallationStates.INACTIVE)).length }
           contextBuilder += ("installation", installedExtensions)
           heimdal.setUserProperties(userId, "installedExtensions" -> ContextDoubleData(installedExtensions))
         } else
@@ -150,7 +150,7 @@ class ExtAuthController @Inject() (
   }
 
   def whois = JsonAction.authenticated { request =>
-    val user = db.readOnly(implicit s => userRepo.get(request.userId))
+    val user = db.readOnlyMaster(implicit s => userRepo.get(request.userId))
     Ok(Json.obj("externalUserId" -> user.externalId.toString))
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtBookmarksController.scala
@@ -93,7 +93,7 @@ class ExtBookmarksController @Inject() (
   }
 
   def tags() = JsonAction.authenticated { request =>
-    val tags = db.readOnly { implicit s =>
+    val tags = db.readOnlyMaster { implicit s =>
       collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(request.userId)
     }
     Ok(Json.toJson(tags.map(SendableTag.from)))
@@ -108,7 +108,7 @@ class ExtBookmarksController @Inject() (
   // deprecated: use unkeep
   def remove() = JsonAction.authenticatedParseJson { request =>
     val url = (request.body \ "url").as[String]
-    db.readOnly { implicit s =>
+    db.readOnlyMaster { implicit s =>
       normalizedURIInterner.getByUri(url).flatMap { uri =>
         keepRepo.getByUriAndUser(uri.id.get, request.userId)
       }
@@ -147,7 +147,7 @@ class ExtBookmarksController @Inject() (
     val privateKeep =  (json \ "private").asOpt[Boolean]
     val title = (json \ "title").asOpt[String]
 
-    val bookmarkOpt = db.readOnly { implicit s =>
+    val bookmarkOpt = db.readOnlyMaster { implicit s =>
       normalizedURIInterner.getByUri(url).flatMap { uri =>
         keepRepo.getByUriAndUser(uri.id.get, request.userId)
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtDeepLinkController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtDeepLinkController.scala
@@ -48,7 +48,7 @@ class ExtDeepLinkController @Inject() (
     val req = request.body.asInstanceOf[JsObject]
     val locator = (req \ "locator").as[String]
     val recipient = Id[User]((req \ "recipient").as[Long])
-    val link = db.readOnly { implicit session =>
+    val link = db.readOnlyMaster { implicit session =>
       try {
         deepLinkRepo.getByLocatorAndUser(DeepLocator(locator), recipient).token.value
       } catch {
@@ -136,7 +136,7 @@ class ExtDeepLinkController @Inject() (
   }
 
   private def getDeepLinkAndUrl(token: DeepLinkToken): Option[(DeepLink, NormalizedURI)] = {
-    db.readOnly { implicit s =>
+    db.readOnlyMaster { implicit s =>
       for {
         deepLink <- deepLinkRepo.getByToken(token)
         uriId <- deepLink.uriId

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtEventController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtEventController.scala
@@ -43,7 +43,7 @@ class ExtEventController @Inject() (
       val metaData = (o \ "metaData").asOpt[JsObject].getOrElse(Json.obj())
       val prevEvents = (o \ "prevEvents").asOpt[Seq[String]].getOrElse(Seq.empty).map(ExternalId[Event])
       val experiments = (o \ "experiments").as[Seq[ExperimentType]].toSet
-      val user = db.readOnly { implicit s => userRepo.get(userId) }
+      val user = db.readOnlyMaster { implicit s => userRepo.get(userId) }
       val event = Events.userEvent(eventFamily, eventName, user, experiments, installId, metaData, prevEvents, eventTime)
       log.debug(s"Created new event: $event")
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtPreferenceController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtPreferenceController.scala
@@ -51,13 +51,13 @@ class ExtPreferenceController @Inject() (
   private val ipkey = crypt.stringToKey("dontshowtheiptotheclient")
 
   def normalize(url: String) = JsonAction.authenticated { request =>
-    val normalizedUrl: String = db.readOnly { implicit session => normalizedURIInterner.normalize(url) getOrElse url }
+    val normalizedUrl: String = db.readOnlyMaster { implicit session => normalizedURIInterner.normalize(url) getOrElse url }
     val json = Json.arr(normalizedUrl)
     Ok(json)
   }
 
   def getRules(version: String) = JsonAction.authenticated { request =>
-    db.readOnly { implicit s =>
+    db.readOnlyMaster { implicit s =>
       val group = sliderRuleRepo.getGroup("default")
       if (version != group.version) {
         Ok(Json.obj("slider_rules" -> group.compactJson, "url_patterns" -> urlPatternRepo.getActivePatterns()))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/URISummaryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/URISummaryController.scala
@@ -19,13 +19,13 @@ class URISummaryController @Inject() (
   db: Database) extends ShoeboxServiceController {
 
   def updateUriScreenshotsForUriId(id: Id[NormalizedURI]) = Action { request =>
-    val nUri = db.readOnly{ implicit session => normalizedUriRepo.get(id) }
+    val nUri = db.readOnlyMaster{ implicit session => normalizedUriRepo.get(id) }
     uriSummaryCommander.updateScreenshots(nUri)
     Status(202)("0")
   }
 
   def getUriImageForUriId(id: Id[NormalizedURI]) = Action.async { request =>
-    val nUri = db.readOnly{ implicit session => normalizedUriRepo.get(id) }
+    val nUri = db.readOnlyMaster{ implicit session => normalizedUriRepo.get(id) }
     val urlFut = uriSummaryCommander.getURIImage(nUri)
     urlFut map { urlOpt => Ok(Json.toJson(urlOpt)) }
   }
@@ -41,7 +41,7 @@ class URISummaryController @Inject() (
     val waiting = (request.body \ "waiting").asOpt[Boolean].getOrElse(false)
     val silent = (request.body \ "silent").asOpt[Boolean].getOrElse(false)
     val uriIds = Json.fromJson[Seq[Id[NormalizedURI]]](uriIdsJson).get
-    val nUris = db.readOnly{ implicit session =>
+    val nUris = db.readOnlyMaster{ implicit session =>
       uriIds map (normalizedUriRepo.get(_))
     }
     val uriSummariesFut = if (withDescription && !silent) {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileAuthController.scala
@@ -61,7 +61,7 @@ class MobileAuthController @Inject() (
 
   private def registerMobileVersion[T <: KifiVersion with Ordered[T]](installationIdOpt: Option[ExternalId[KifiInstallation]], version: T, agent: UserAgent, userId: Id[User], platform: KifiInstallationPlatform) = {
     val (installation, newInstallation) = installationIdOpt map {id =>
-      db.readOnly { implicit s => installationRepo.get(id) }
+      db.readOnlyMaster { implicit s => installationRepo.get(id) }
     } match {
       case None =>
         db.readWrite { implicit s =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileDiscoveryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileDiscoveryController.scala
@@ -33,7 +33,7 @@ class MobileDiscoveryController @Inject() (
       val relevantUris = if (limit > 0) sortedUriCollisions.take(limit) else sortedUriCollisions
       val (uriIds, scores) = relevantUris.unzip
       val sharingInfosFuture = searchClient.sharingUserInfo(userId, uriIds)
-      val uris = db.readOnly { implicit session => uriIds.map(uriRepo.get) }
+      val uris = db.readOnlyMaster { implicit session => uriIds.map(uriRepo.get) }
       val pageInfosFuture = Future.sequence(uris.map { uri =>
         if (withPageInfo) {
           val request = URISummaryRequest(
@@ -54,7 +54,7 @@ class MobileDiscoveryController @Inject() (
         pageInfos <- pageInfosFuture
       } yield {
 
-        val idToBasicUser = db.readOnly { implicit s =>
+        val idToBasicUser = db.readOnlyMaster { implicit s =>
           basicUserRepo.loadAll(sharingInfos.flatMap(_.sharingUserIds).toSet)
         }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/EmailOptOutController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/EmailOptOutController.scala
@@ -25,7 +25,7 @@ class EmailOptOutController @Inject() (
 
     email match {
       case Success(addr) =>
-        val opts = db.readOnly { implicit session =>
+        val opts = db.readOnlyMaster { implicit session =>
           emailOptOutRepo.getByEmailAddress(addr).collect { case c => NotificationCategory(c.category.category) }
         }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
@@ -53,7 +53,7 @@ class HomeController @Inject() (
   extends WebsiteController(actionAuthenticator) with ShoeboxServiceController with Logging {
 
   private def hasSeenInstall(implicit request: AuthenticatedRequest[_]): Boolean = {
-    db.readOnly { implicit s => userValueRepo.getValue(request.userId, UserValues.hasSeenInstall) }
+    db.readOnlyMaster { implicit s => userValueRepo.getValue(request.userId, UserValues.hasSeenInstall) }
   }
 
   private def setHasSeenInstall()(implicit request: AuthenticatedRequest[_]): Unit = {
@@ -225,7 +225,7 @@ class HomeController @Inject() (
   def pendingHome()(implicit request: AuthenticatedRequest[_]) = {
     val user = request.user
 
-    val (email, friendsOnKifi) = db.readOnly { implicit session =>
+    val (email, friendsOnKifi) = db.readOnlyMaster { implicit session =>
       val email = emailRepo.getAllByUser(user.id.get).sortBy(a => a.id.get.id).lastOption.map(_.address)
       val friendsOnKifi = userConnectionRepo.getConnectedUsers(user.id.get).map { u =>
         val user = userRepo.get(u)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
@@ -120,7 +120,7 @@ class KeepsController @Inject() (
     urlOpt match {
       case None => Future.successful(BadRequest(Json.obj("code" -> "illegal_argument")))
       case Some(url) => {
-        val (uriOpt, pageInfoOpt) = db.readOnly{ implicit ro =>
+        val (uriOpt, pageInfoOpt) = db.readOnlyMaster{ implicit ro =>
           val uriOpt = normalizedURIInterner.getByUri(url)
           val pageInfoOpt = uriOpt flatMap { uri => pageInfoRepo.getByUri(uri.id.get) }
           (uriOpt, pageInfoOpt)
@@ -141,13 +141,13 @@ class KeepsController @Inject() (
     urlsOpt match {
       case None => Future.successful(BadRequest(Json.obj("code" -> "illegal_arguments")))
       case Some(urls) => {
-        val tuples = db.readOnly { implicit ro =>
+        val tuples = db.readOnlyMaster { implicit ro =>
           urls.map { s =>
             s -> normalizedURIInterner.getByUri(s)
           }
         }
         val tuplesF = tuples map { case (url, uriOpt) =>
-          val (uriOpt, pageInfoOpt) = db.readOnly{ implicit ro =>
+          val (uriOpt, pageInfoOpt) = db.readOnlyMaster{ implicit ro =>
             val uriOpt = normalizedURIInterner.getByUri(url)
             val pageInfoOpt = uriOpt flatMap { uri => pageInfoRepo.getByUri(uri.id.get) }
             (uriOpt, pageInfoOpt)
@@ -166,7 +166,7 @@ class KeepsController @Inject() (
   }
 
   def exportKeeps() = AnyAction.authenticated { request =>
-    val exports : Seq[KeepExport] = db.readOnly { implicit ro =>
+    val exports : Seq[KeepExport] = db.readOnlyMaster { implicit ro =>
       keepRepo.getKeepExports(request.userId)
     }
 
@@ -289,7 +289,7 @@ class KeepsController @Inject() (
         }
       }
     } else {
-      db.readOnly { implicit s => keepRepo.getOpt(id) } filter { _.isActive } map { b =>
+      db.readOnlyMaster { implicit s => keepRepo.getOpt(id) } filter { _.isActive } map { b =>
         Future.successful(Ok(Json.toJson(KeepInfo.fromBookmark(b))))
       }
     }
@@ -305,7 +305,7 @@ class KeepsController @Inject() (
 
     toBeUpdated match {
       case None | Some((None, None)) => BadRequest(Json.obj("error" -> "Could not parse JSON keep info from body"))
-      case Some((isPrivate, title)) => db.readOnly { implicit s => keepRepo.getOpt(id) } map { bookmark =>
+      case Some((isPrivate, title)) => db.readOnlyMaster { implicit s => keepRepo.getOpt(id) } map { bookmark =>
         implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
         bookmarksCommander.updateKeep(bookmark, isPrivate, title) getOrElse bookmark
       } match {
@@ -337,7 +337,7 @@ class KeepsController @Inject() (
   }
 
   def allCollections(sort: String) = JsonAction.authenticatedAsync { request =>
-    val numKeepsFuture = SafeFuture { db.readOnly { implicit s => keepRepo.getCountByUser(request.userId) } }
+    val numKeepsFuture = SafeFuture { db.readOnlyMaster { implicit s => keepRepo.getCountByUser(request.userId) } }
     val collectionsFuture = SafeFuture { collectionCommander.allCollections(sort, request.userId) }
     for {
       numKeeps <- numKeepsFuture
@@ -359,7 +359,7 @@ class KeepsController @Inject() (
   }
 
   def deleteCollection(id: ExternalId[Collection]) = JsonAction.authenticated { request =>
-    db.readOnly { implicit s => collectionRepo.getByUserAndExternalId(request.userId, id) } map { coll =>
+    db.readOnlyMaster { implicit s => collectionRepo.getByUserAndExternalId(request.userId, id) } map { coll =>
       implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
       collectionCommander.deleteCollection(coll)
       Ok(Json.obj("deleted" -> coll.name))
@@ -369,7 +369,7 @@ class KeepsController @Inject() (
   }
 
   def undeleteCollection(id: ExternalId[Collection]) = JsonAction.authenticated { request =>
-    db.readOnly { implicit s => collectionRepo.getByUserAndExternalId(request.userId, id, Some(CollectionStates.ACTIVE)) } map { coll =>
+    db.readOnlyMaster { implicit s => collectionRepo.getByUserAndExternalId(request.userId, id, Some(CollectionStates.ACTIVE)) } map { coll =>
       implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
       collectionCommander.undeleteCollection(coll)
       Ok(Json.obj("undeleted" -> coll.name))
@@ -380,9 +380,9 @@ class KeepsController @Inject() (
 
   def removeKeepsFromCollection(id: ExternalId[Collection]) = JsonAction.authenticated { request =>
     implicit val externalIdFormat = ExternalId.format[Keep]
-    db.readOnly { implicit s => collectionRepo.getByUserAndExternalId(request.userId, id) } map { collection =>
+    db.readOnlyMaster { implicit s => collectionRepo.getByUserAndExternalId(request.userId, id) } map { collection =>
       request.body.asJson.flatMap(Json.fromJson[Seq[ExternalId[Keep]]](_).asOpt) map { keepExtIds =>
-        val keeps = db.readOnly { implicit s => keepExtIds.flatMap(keepRepo.getOpt(_)) }
+        val keeps = db.readOnlyMaster { implicit s => keepExtIds.flatMap(keepRepo.getOpt(_)) }
         implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
         val removed = bookmarksCommander.removeFromCollection(collection, keeps)
         Ok(Json.obj("removed" -> removed.size))
@@ -396,11 +396,11 @@ class KeepsController @Inject() (
 
   def keepToCollection(id: ExternalId[Collection]) = JsonAction.authenticated { request =>
     implicit val externalIdFormat = ExternalId.format[Keep]
-    db.readOnly { implicit s =>
+    db.readOnlyMaster { implicit s =>
       collectionRepo.getByUserAndExternalId(request.userId, id)
     } map { collection =>
       request.body.asJson.flatMap(Json.fromJson[Seq[ExternalId[Keep]]](_).asOpt) map { keepExtIds =>
-        val keeps = db.readOnly { implicit session => keepExtIds.map(keepRepo.get) }
+        val keeps = db.readOnlyMaster { implicit session => keepExtIds.map(keepRepo.get) }
         implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
         val added = bookmarksCommander.addToCollection(collection.id.get, keeps)
         Ok(Json.obj("added" -> added.size))
@@ -414,12 +414,12 @@ class KeepsController @Inject() (
 
   def numKeeps() = JsonAction.authenticated { request =>
     Ok(Json.obj(
-      "numKeeps" -> db.readOnly { implicit s => keepRepo.getCountByUser(request.userId) }
+      "numKeeps" -> db.readOnlyMaster { implicit s => keepRepo.getCountByUser(request.userId) }
     ))
   }
 
   def importStatus() = JsonAction.authenticated { request =>
-    val values = db.readOnly { implicit session =>
+    val values = db.readOnlyMaster { implicit session =>
       userValueRepo.getValues(request.user.id.get, "bookmark_import_last_start", "bookmark_import_done", "bookmark_import_total")
     }
     val lastStartOpt = values("bookmark_import_last_start")

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -73,7 +73,7 @@ class UserController @Inject() (
 
   def friends(page: Int, pageSize: Int) = JsonAction.authenticated { request =>
     val (connectionsPage, total) = userCommander.getConnectionsPage(request.userId, page, pageSize)
-    val friendsJsons = db.readOnly { implicit s =>
+    val friendsJsons = db.readOnlyMaster { implicit s =>
       connectionsPage.map { case ConnectionInfo(friend, friendId, unfriended, unsearched) =>
         Json.toJson(friend).asInstanceOf[JsObject] ++ Json.obj(
           "searchFriend" -> unsearched,
@@ -89,7 +89,7 @@ class UserController @Inject() (
   }
 
   def friendCount() = JsonAction.authenticated { request =>
-    db.readOnly { implicit s =>
+    db.readOnlyMaster { implicit s =>
       Ok(Json.obj(
         "friends" -> userConnectionRepo.getConnectionCount(request.userId),
         "requests" -> friendRequestRepo.getCountByRecipient(request.userId)
@@ -197,7 +197,7 @@ class UserController @Inject() (
   }
 
   def getEmailInfo(email: EmailAddress) = JsonAction.authenticated(allowPending = true) { implicit request =>
-    db.readOnly { implicit session =>
+    db.readOnlyMaster { implicit session =>
       emailRepo.getByAddressOpt(email) match {
         case Some(emailRecord) =>
           val pendingPrimary = userValueRepo.getValueStringOpt(request.user.id.get, "pending_primary_email")
@@ -234,7 +234,7 @@ class UserController @Inject() (
   }
 
   private def getUserInfo[T](userId: Id[User]) = {
-    val user = db.readOnly { implicit session => userRepo.get(userId) }
+    val user = db.readOnlyMaster { implicit session => userRepo.get(userId) }
     val experiments = userExperimentCommander.getExperimentsByUser(userId)
     val pimpedUser = userCommander.getUserInfo(user)
     val json = toJson(pimpedUser.basicUser).as[JsObject] ++
@@ -255,7 +255,7 @@ class UserController @Inject() (
   private val SitePrefNames = Set("site_left_col_width", "site_welcomed", "onboarding_seen")
 
   def getPrefs() = JsonAction.authenticated { request =>
-    Ok(db.readOnly { implicit s =>
+    Ok(db.readOnlyMaster { implicit s =>
       val values = userValueRepo.getValues(request.userId, SitePrefNames.toSeq: _*)
       JsObject(SitePrefNames.toSeq.map { name =>
         name -> values(name).map(value => {
@@ -287,7 +287,7 @@ class UserController @Inject() (
   }
 
   def getInviteCounts() = JsonAction.authenticated { request =>
-    db.readOnly { implicit s =>
+    db.readOnlyMaster { implicit s =>
       val availableInvites = userValueRepo.getValue(request.userId, UserValues.availableInvites)
       val invitesLeft = availableInvites - invitationRepo.getByUser(request.userId).length
       Ok(Json.obj(
@@ -394,7 +394,7 @@ class UserController @Inject() (
     val networks = Seq("facebook", "linkedin")
 
     val networkStatuses = Future {
-      JsObject(db.readOnly { implicit session =>
+      JsObject(db.readOnlyMaster { implicit session =>
         networks.map { network =>
           userValueRepo.getValueStringOpt(request.userId, s"import_in_progress_${network}").flatMap { r =>
             if (r == "false") {
@@ -438,7 +438,7 @@ class UserController @Inject() (
     val importHasHappened = new AtomicBoolean(false)
     val finishedImportAnnounced = new AtomicBoolean(false)
     def check(): Option[JsValue] = {
-      val v = db.readOnly { implicit session =>
+      val v = db.readOnlyMaster { implicit session =>
         userValueRepo.getValueStringOpt(request.userId, s"import_in_progress_${network}")
       }
       if (v.isEmpty && clock.now.minusSeconds(20).compareTo(startTime) > 0) {
@@ -464,7 +464,7 @@ class UserController @Inject() (
     def poller(): Future[Option[JsValue]] = PlayPromise.timeout(check, 2 seconds)
     def script(msg: JsValue) = Html(s"<script>$callback(${msg.toString});</script>")
 
-    db.readOnly { implicit session =>
+    db.readOnlyMaster { implicit session =>
       socialUserRepo.getByUser(request.userId).find(_.networkType.name == network)
     } match {
       case Some(sui) =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/DuplicateDocumentDetection.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/DuplicateDocumentDetection.scala
@@ -36,7 +36,7 @@ class DuplicateDocumentDetection @Inject() (
     "4k3jinEqzd67np/61CIsuYfehiUCvjwaL+3feeAe+OyBKmzWX9pOiBmttIu6uSSBVocxwdSxGnc4w6xO8cbPxL2K/lrNxL71Bwq51m4/B5fvhmNIhe81wb1cMO6w/Xo4mq8PA==" // Google docs
   */)
 
-  lazy val documentSignatures = db.readOnly { implicit session =>
+  lazy val documentSignatures = db.readOnlyMaster { implicit session =>
     scrapeInfoRepo.allActive.map { s =>
       if (IGNORED_DOCUMENTS.contains(s.signature)) None
       else Some((s.uriId, parseBase64Binary(s.signature)))
@@ -60,7 +60,7 @@ class DuplicateDocumentDetection @Inject() (
   }
 
   def processDocument(currentDoc: (Id[NormalizedURI], Array[Byte]), threshold: Double) = {
-    db.readOnly { implicit session =>
+    db.readOnlyMaster { implicit session =>
       documentSignatures.map { case (otherId, otherSig) =>
         if (currentDoc._1.id >= otherId.id) {
           None

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/DuplicateDocumentsProcessor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/DuplicateDocumentsProcessor.scala
@@ -33,10 +33,10 @@ class DuplicateDocumentsProcessor @Inject()(
 
   def handleDuplicates(dupId: Either[Id[DuplicateDocument], Id[NormalizedURI]], dupAction: HandleDuplicatesAction) = {
     val dups = dupId match {
-      case Left(id) => db.readOnly{ implicit s =>
+      case Left(id) => db.readOnlyMaster{ implicit s =>
         List(duplicateDocumentRepo.get(id))     // handle one
       }
-      case Right(id) => db.readOnly{ implicit s =>
+      case Right(id) => db.readOnlyMaster{ implicit s =>
         duplicateDocumentRepo.getSimilarTo(id)  // handle all
       }
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/OrphanCleaner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/OrphanCleaner.scala
@@ -108,7 +108,7 @@ class OrphanCleaner @Inject() (
 
     log.info("start processing RenormalizedURL")
     while (!done) {
-      val renormalizedURLs = db.readOnly{ implicit s => renormalizedURLRepo.getChangesSince(seq, 10) } // get applied changes
+      val renormalizedURLs = db.readOnlyMaster{ implicit s => renormalizedURLRepo.getChangesSince(seq, 10) } // get applied changes
       done = renormalizedURLs.isEmpty
 
       def collector(renormalizedURL: RenormalizedURL, result: (Boolean, Boolean)): Unit = {
@@ -137,7 +137,7 @@ class OrphanCleaner @Inject() (
 
     log.info("start processing ChangedURIs")
     while (!done) {
-      val changedURIs = db.readOnly{ implicit s => changedURIRepo.getChangesSince(seq, 10) } // get applied changes
+      val changedURIs = db.readOnlyMaster{ implicit s => changedURIRepo.getChangesSince(seq, 10) } // get applied changes
       done = changedURIs.isEmpty
 
       def collector(changedUri: ChangedURI, result: (Boolean, Boolean)): Unit = {
@@ -166,7 +166,7 @@ class OrphanCleaner @Inject() (
 
     log.info("start processing Bookmarks")
     while (!done) {
-      val bookmarks = db.readOnly{ implicit s => keepRepo.getBookmarksChanged(seq, 10) }
+      val bookmarks = db.readOnlyMaster{ implicit s => keepRepo.getBookmarksChanged(seq, 10) }
       done = bookmarks.isEmpty
 
       def collector(bookmark: Keep, result: (Boolean, Boolean)): Unit = {
@@ -200,7 +200,7 @@ class OrphanCleaner @Inject() (
 
     log.info("start processing NormalizedURIs")
     while (!done) {
-      val normalizedURIs = db.readOnly{ implicit s => nuriRepo.getChanged(seq, Set(NormalizedURIStates.SCRAPED, NormalizedURIStates.SCRAPE_FAILED), 10) }
+      val normalizedURIs = db.readOnlyMaster{ implicit s => nuriRepo.getChanged(seq, Set(NormalizedURIStates.SCRAPED, NormalizedURIStates.SCRAPE_FAILED), 10) }
       done = normalizedURIs.isEmpty
 
       def collector(uri: NormalizedURI, result: (Boolean, Boolean)): Unit = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/SequenceNumberChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/SequenceNumberChecker.scala
@@ -32,7 +32,7 @@ class ElizaSequenceNumberChecker @Inject() (
 
   protected def checkRenormalizationSequenceNumber(): Unit = {
     val elizaRenormalizationSequenceNumber = elizaServiceClient.getRenormalizationSequenceNumber()
-    val shoeboxRenormalizationSequenceNumber = db.readOnly { implicit session => changedUriRepo.getHighestSeqNum().get }
+    val shoeboxRenormalizationSequenceNumber = db.readOnlyMaster { implicit session => changedUriRepo.getHighestSeqNum().get }
     elizaRenormalizationSequenceNumber.foreach { elizaSeq =>
       log.info(s"[Renormalization] Sequence Numbers of Shoebox: $shoeboxRenormalizationSequenceNumber vs Eliza: $elizaSeq")
       if (shoeboxRenormalizationSequenceNumber - elizaSeq > threshold) {

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/URLRenormalizeCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/URLRenormalizeCommander.scala
@@ -38,7 +38,7 @@ class URLRenormalizeCommander @Inject()(
   def doRenormalize(readOnly: Boolean = true, clearSeq: Boolean = false, regex: DomainOrURLRegex = DomainOrURLRegex(None, None)) = {
 
     def getUrlList() = {
-      val urls = db.readOnly { implicit s =>
+      val urls = db.readOnlyMaster { implicit s =>
         if (regex.isEmpty) urlRepo.all
         else if (regex.isDomainRegex) urlRepo.getByDomainRegex(regex.domainRegex.get)
         else if (regex.isUrlRegex) urlRepo.getByURLRegex(regex.urlRegex.get)
@@ -120,7 +120,7 @@ class URLRenormalizeCommander @Inject()(
     } else{
       // we only retrieved a subset S of urls. For any uri, it's possible some referencing url is not in set S.
       val ref = mutable.Map.empty[Id[NormalizedURI], Set[Id[URL]]]
-      db.readOnly{ implicit s =>
+      db.readOnlyMaster{ implicit s =>
         urls.map{_.normalizedUriId}.toSet.foreach{ uriId: Id[NormalizedURI] =>
           val urls = urlRepo.getByNormUri(uriId).filter(_.state == URLStates.ACTIVE)
           ref += uriId -> urls.map{_.id.get}.toSet

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
@@ -223,7 +223,7 @@ class UriIntegrityActor @Inject()(
     if (toMerge.size == 0){
       log.debug("no active changed_uris were founded. Check if we have applied changed_uris generated during urlRenormalization")
       val lowSeq = centralConfig(URIMigrationSeqNumKey) getOrElse SequenceNumber.ZERO
-      val applied = db.readOnly{ implicit s => changedUriRepo.getChangesSince(lowSeq, batchSize, state = ChangedURIStates.APPLIED)}
+      val applied = db.readOnlyMaster{ implicit s => changedUriRepo.getChangesSince(lowSeq, batchSize, state = ChangedURIStates.APPLIED)}
       if (applied.size == batchSize){   // make sure a full batch of applied ones
         applied.sortBy(_.seq).lastOption.map{ x => centralConfig.update(URIMigrationSeqNumKey, x.seq) }
         log.info(s"${applied.size} applied changed_uris are found!")
@@ -240,7 +240,7 @@ class UriIntegrityActor @Inject()(
           db.readWrite{ implicit s => changedUriRepo.save((change.withState(ChangedURIStates.ACTIVE)))}   // bump up seqNum. Will be retried.
 
           try{
-            db.readOnly{ implicit s => List(uriRepo.get(change.oldUriId), uriRepo.get(change.newUriId)) foreach {uriRepo.deleteCache} }
+            db.readOnlyMaster{ implicit s => List(uriRepo.get(change.oldUriId), uriRepo.get(change.newUriId)) foreach {uriRepo.deleteCache} }
           } catch{
             case e: Exception => airbrake.notify(s"error in getting uri ${change.oldUriId} or ${change.newUriId} from db by id.")
           }
@@ -256,7 +256,7 @@ class UriIntegrityActor @Inject()(
   private def getOverDueList(fetchSize: Int = -1) = {
     val lowSeq = centralConfig(URIMigrationSeqNumKey) getOrElse SequenceNumber.ZERO
     log.info(s"batch uri migration: fetching tasks from seqNum ${lowSeq}")
-    db.readOnly{ implicit s => changedUriRepo.getChangesSince(lowSeq, fetchSize, state = ChangedURIStates.ACTIVE)}
+    db.readOnlyMaster{ implicit s => changedUriRepo.getChangesSince(lowSeq, fetchSize, state = ChangedURIStates.ACTIVE)}
   }
 
   private def batchURLMigration(batchSize: Int) = {
@@ -283,7 +283,7 @@ class UriIntegrityActor @Inject()(
 
   private def getOverDueURLMigrations(fetchSize: Int = -1) = {
     val lowSeq = centralConfig(URLMigrationSeqNumKey) getOrElse SequenceNumber.ZERO
-    db.readOnly{ implicit s => renormRepo.getChangesSince(lowSeq, fetchSize, state = RenormalizedURLStates.ACTIVE)}
+    db.readOnlyMaster{ implicit s => renormRepo.getChangesSince(lowSeq, fetchSize, state = RenormalizedURLStates.ACTIVE)}
   }
 
   private def fixDuplicateKeeps(): Unit = {
@@ -292,7 +292,7 @@ class UriIntegrityActor @Inject()(
     log.debug(s"start deduping keeps: fetching tasks from seqNum ${seq}")
     try {
       var dedupedSuccessCount = 0
-      val keeps = db.readOnly{ implicit s => keepRepo.getBookmarksChanged(seq, 1000) }
+      val keeps = db.readOnlyMaster{ implicit s => keepRepo.getBookmarksChanged(seq, 1000) }
       if (keeps.nonEmpty) {
         db.readWriteBatch(keeps, 3){ (session, keep) =>
           normalizedURIInterner.getByUri(keep.url)(session) match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/SliderHistoryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/SliderHistoryRepo.scala
@@ -79,7 +79,7 @@ class SliderHistoryTrackerImpl(sliderHistoryRepo: SliderHistoryRepo, db: Databas
   }
 
   def getMultiHashFilter(userId: Id[User]) = {
-    db.readOnly { implicit session =>
+    db.readOnlyMaster { implicit session =>
       sliderHistoryRepo.getByUserId(userId) match {
         case Some(sliderHistory) =>
           new MultiHashFilter(sliderHistory.tableSize, sliderHistory.filter, sliderHistory.numHashFuncs, sliderHistory.minHits)

--- a/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationService.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationService.scala
@@ -91,7 +91,7 @@ class NormalizationServiceImpl @Inject() (
     allCandidates.filter(isRelevant(currentReference, _))
   }
 
-  private def findVariations(referenceUrl: String): Seq[(Normalization, NormalizedURI)] = db.readOnly { implicit session =>
+  private def findVariations(referenceUrl: String): Seq[(Normalization, NormalizedURI)] = db.readOnlyMaster { implicit session =>
     for {
       (normalization, urlVariation) <- SchemeNormalizer.generateVariations(referenceUrl)
       uri <- normalizedURIRepo.getByNormalizedUrl(urlVariation)
@@ -116,7 +116,7 @@ class NormalizationServiceImpl @Inject() (
           assert(weakerCandidates.isEmpty || weakerCandidates.head.normalization <= strongerCandidate.normalization, s"Normalization candidates ${weakerCandidates.head} and $strongerCandidate have not been sorted properly for ${currentReference}")
           assert(currentReference.normalization.isEmpty || currentReference.normalization.get <= strongerCandidate.normalization, s"Normalization candidate $strongerCandidate has not been filtered properly for $currentReference")
 
-          db.readOnly { implicit session =>
+          db.readOnlyMaster { implicit session =>
             action(strongerCandidate) match {
               case Accept => Future.successful((Some(strongerCandidate), weakerCandidates))
               case Reject => findCandidate(weakerCandidates)
@@ -198,7 +198,7 @@ class NormalizationServiceImpl @Inject() (
     }
   }
 
-  private def getURIsToBeFurtherUpdated(currentReference: NormalizationReference, newReference: NormalizationReference): Set[NormalizedURI] = db.readOnly { implicit session =>
+  private def getURIsToBeFurtherUpdated(currentReference: NormalizationReference, newReference: NormalizationReference): Set[NormalizedURI] = db.readOnlyMaster { implicit session =>
     val haveBeenUpdated = Set(currentReference.url, newReference.url)
     val toBeUpdated = for {
       url <- haveBeenUpdated

--- a/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationWorker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationWorker.scala
@@ -43,7 +43,7 @@ class NormalizationWorker @Inject()(
         for (m <- messages) {
           log.debug(s"[consume] received msg $m")
           m.consume { task =>
-            val nuri = db.readOnly { implicit ro =>
+            val nuri = db.readOnlyMaster { implicit ro =>
               nuriRepo.get(task.uriId)
             }
             val ref = NormalizationReference(nuri, task.isNew)

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPluginImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPluginImpl.scala
@@ -156,7 +156,7 @@ class ScrapeSchedulerPluginImpl @Inject() (
 
   def scrapeBasicArticle(url: String, extractorProviderType:Option[ExtractorProviderType]): Future[Option[BasicArticle]] = {
     require(url != null, "[scrapeBasicArticle] <url> cannot be null")
-    val proxyOpt = db.readOnly { implicit s =>
+    val proxyOpt = db.readOnlyMaster { implicit s =>
       urlPatternRuleRepo.getProxy(url)
     }
     log.info(s"[scrapeBasicArticle] invoke (remote) Scraper service; url=$url proxy=$proxyOpt extractorProviderType=$extractorProviderType")
@@ -166,7 +166,7 @@ class ScrapeSchedulerPluginImpl @Inject() (
   def getSignature(url: String, extractorProviderType: Option[ExtractorProviderType]): Future[Option[Signature]] = {
     Try {
       val uri = java.net.URI.create(url) // given current impl of HttpFetcher, java.net.URI is needed
-      val proxyOpt = db.readOnly { implicit s => urlPatternRuleRepo.getProxy(url) }
+      val proxyOpt = db.readOnlyMaster { implicit s => urlPatternRuleRepo.getProxy(url) }
       log.info(s"[getSignature] invoke (remote) Scraper service; url=$url uri=$uri proxy=$proxyOpt extractorProviderType=$extractorProviderType")
       scraperClient.getSignature(url, proxyOpt, extractorProviderType)
     } recover {

--- a/kifi-backend/modules/shoebox/app/com/keepit/social/SecureSocialUserServiceImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/social/SecureSocialUserServiceImpl.scala
@@ -51,7 +51,7 @@ class SecureSocialUserPluginImpl @Inject() (
   }
 
   def find(id: IdentityId): Option[SocialUser] = reportExceptions {
-    db.readOnly { implicit s =>
+    db.readOnlyMaster { implicit s =>
       socialUserInfoRepo.getOpt(SocialId(id.userId), SocialNetworkType(id.providerId))
     } match {
       case None if id.providerId == SocialNetworks.FORTYTWO.authProvider =>
@@ -59,7 +59,7 @@ class SecureSocialUserPluginImpl @Inject() (
         // Since we support multiple email addresses, if we do not
         // find a SUI with the correct email address, we go searching.
         val email = EmailAddress(id.userId)
-        db.readOnly { implicit session =>
+        db.readOnlyMaster { implicit session =>
           emailRepo.getByAddressOpt(email).flatMap { emailAddr =>
             // todo(andrew): Don't let unverified people log in. For now, we are, but come up with something better.
             socialUserInfoRepo.getByUser(emailAddr.userId).find(_.networkType == SocialNetworks.FORTYTWO).flatMap { sui =>
@@ -160,7 +160,7 @@ class SecureSocialUserPluginImpl @Inject() (
 
     log.debug(s"[internUser] socialId=$socialId snType=$socialNetworkType socialUser=$socialUser userId=$userId isComplete=$isComplete")
 
-    val (suiOpt, existingUserOpt) = db.readOnly { implicit session => (
+    val (suiOpt, existingUserOpt) = db.readOnlyMaster { implicit session => (
       socialUserInfoRepo.getOpt(socialId, socialNetworkType),
       userId orElse {
       // Automatically connect accounts with existing emails
@@ -199,7 +199,7 @@ class SecureSocialUserPluginImpl @Inject() (
 
         //social user info with user must be FETCHED_USING_SELF, so setting user should trigger a pull
         //todo(eishay): send a direct fetch request
-        for (user <- userOpt; su <- db.readOnly { implicit session => socialUserInfoRepo.getByUser(user.id.get) }
+        for (user <- userOpt; su <- db.readOnlyMaster { implicit session => socialUserInfoRepo.getByUser(user.id.get) }
             if su.networkType == socialUserInfo.networkType && su.id.get != socialUserInfo.id.get) {
           throw new IllegalStateException(
             s"Can't connect $socialUserInfo to user ${user.id.get}. " +
@@ -270,7 +270,7 @@ class SecureSocialUserPluginImpl @Inject() (
   }
 
   def findByEmailAndProvider(email: String, providerId: String): Option[SocialUser] = reportExceptions {
-    db.readOnly { implicit s =>
+    db.readOnlyMaster { implicit s =>
       providerId match {
         case UsernamePasswordProvider.UsernamePassword =>
           val cred = userCredRepo.findByEmailOpt(email)
@@ -329,7 +329,7 @@ class SecureSocialAuthenticatorPluginImpl @Inject()(
     val snType = SocialNetworkType(authenticator.identityId.providerId) // userpass -> fortytwo
     val (socialId, provider) = (SocialId(authenticator.identityId.userId), snType)
     log.debug(s"[sessionFromAuthenticator] auth=$authenticator socialId=$socialId, provider=$provider")
-    val userId = db.readOnly {
+    val userId = db.readOnlyMaster {
       implicit s => socialUserInfoRepo.get(socialId, provider).userId // another dependency on socialUserInfo
     }
     UserSession(
@@ -358,7 +358,7 @@ class SecureSocialAuthenticatorPluginImpl @Inject()(
   private def internSession(newSession: UserSession): UserSession = loadSession(newSession) getOrElse persistSession(newSession)
 
   private def loadSession(newSession: UserSession): Option[UserSession] = timing(s"loadSession ${newSession.socialId}") {
-    db.readOnly { implicit s => //from cache
+    db.readOnlyMaster { implicit s => //from cache
       sessionRepo.getOpt(newSession.externalId)
     }
   }
@@ -387,7 +387,7 @@ class SecureSocialAuthenticatorPluginImpl @Inject()(
     }
 
     val res = externalIdOpt flatMap { externalId =>
-      db.readOnly { implicit s =>
+      db.readOnlyMaster { implicit s =>
         val sess = sessionRepo.getOpt(externalId)
         log.debug(s"[find] sessionRepo.get($externalId)=$sess")
         sess

--- a/kifi-backend/modules/shoebox/app/com/keepit/typeahead/socialusers/KifiUserTypeahead.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/typeahead/socialusers/KifiUserTypeahead.scala
@@ -30,7 +30,7 @@ class KifiUserTypeahead @Inject()(
 ) extends Typeahead[User, User] with Logging { // User as info might be too heavy
 
   def refreshAll(): Future[Unit] = {
-    val userIds = db.readOnly { implicit ro =>
+    val userIds = db.readOnlyMaster { implicit ro =>
       userRepo.getAllActiveIds()
     }
     refreshByIds(userIds)
@@ -50,7 +50,7 @@ class KifiUserTypeahead @Inject()(
   protected def extractId(info: User): Id[User] = info.id.get
 
   protected def getAllInfosForUser(id: Id[User]): Seq[User] = {
-    val ids = db.readOnly { implicit ro =>
+    val ids = db.readOnlyMaster { implicit ro =>
       userConnectionRepo.getConnectedUsers(id)
     }
     log.info(s"[getAllInfosForUser($id)] connectedUsers:(len=${ids.size}):${ids.mkString(",")}")
@@ -60,7 +60,7 @@ class KifiUserTypeahead @Inject()(
   protected def getInfos(ids: Seq[Id[User]]): Seq[User] = {
     if (ids.isEmpty) Seq.empty
     else {
-      db.readOnly { implicit ro =>
+      db.readOnlyMaster { implicit ro =>
         userRepo.getUsers(ids).valuesIterator.toVector
       }
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/typeahead/socialusers/SocialUserTypeahead.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/typeahead/socialusers/SocialUserTypeahead.scala
@@ -50,7 +50,7 @@ class SocialUserTypeahead @Inject() (
   override protected def getInfos(ids: Seq[Id[SocialUserInfo]]): Seq[SocialUserBasicInfo] = {
     if (ids.isEmpty) Seq.empty[SocialUserBasicInfo]
     else {
-      db.readOnly { implicit session =>
+      db.readOnlyMaster { implicit session =>
         socialUserRepo.getSocialUserBasicInfos(ids).valuesIterator.toVector // do NOT use toSeq (=> toStream (lazy))
       }
     }
@@ -58,7 +58,7 @@ class SocialUserTypeahead @Inject() (
 
   override protected def getAllInfosForUser(id: Id[User]): Seq[SocialUserBasicInfo] = {
     val builder = new mutable.ArrayBuffer[SocialUserBasicInfo]
-    db.readOnly { implicit session =>
+    db.readOnlyMaster { implicit session =>
       val infos = socialUserRepo.getSocialUserBasicInfosByUser(id) // todo: filter out fortytwo?
       log.debug(s"[social.getAllInfosForUser($id)] res(len=${infos.length}):${infos.mkString(",")}")
       for (info <- infos) {
@@ -86,7 +86,7 @@ class SocialUserTypeahead @Inject() (
   }
 
   def refreshAll(): Future[Unit] = {
-    val userIds = db.readOnly { implicit ro =>
+    val userIds = db.readOnlyMaster { implicit ro =>
       userRepo.getAllActiveIds()
     }
     refreshByIds(userIds)

--- a/kifi-backend/modules/shoebox/test/com/keepit/classify/DomainTagImporterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/classify/DomainTagImporterTest.scala
@@ -58,7 +58,7 @@ class DomainTagImporterTest extends TestKit(ActorSystem()) with SpecificationLik
             .map(domainRepo.get(_).get).map(inject[SensitivityUpdater].calculateSensitivity)
         }
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           domainRepo.get("apple.com").get.sensitive === Some(true)
           domainRepo.get("amazon.com").get.sensitive === Some(false)
           domainRepo.get("google.com").get.sensitive === Some(false)
@@ -92,7 +92,7 @@ class DomainTagImporterTest extends TestKit(ActorSystem()) with SpecificationLik
               .map(domainRepo.get(_).get).map(inject[SensitivityUpdater].calculateSensitivity)
         }
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           domainRepo.get("apple.com").get.sensitive === Some(false)
           domainRepo.get("amazon.com").get.sensitive === Some(false)
           domainRepo.get("google.com").get.sensitive === Some(false)
@@ -121,7 +121,7 @@ class DomainTagImporterTest extends TestKit(ActorSystem()) with SpecificationLik
           domainRepo.get("cnn.com").get.sensitive === Some(false)
           domainRepo.save(domainRepo.get("cnn.com").get.withManualSensitive(Some(true)))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           domainRepo.get("cnn.com").get.sensitive === Some(true)
         }
 
@@ -133,7 +133,7 @@ class DomainTagImporterTest extends TestKit(ActorSystem()) with SpecificationLik
           domainRepo.get("cnn.com").get.sensitive === Some(true)
           domainRepo.save(domainRepo.get("cnn.com").get.withManualSensitive(None))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           domainRepo.get("cnn.com").get.sensitive === Some(false)
         }
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/classify/DomainTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/classify/DomainTest.scala
@@ -17,7 +17,7 @@ DomainTest extends Specification with ShoeboxTestInjector {
         val d2 = Domain(hostname = "facebook.com", autoSensitive = Some(false))
         val d3 = Domain(hostname = "yahoo.com", autoSensitive = Some(false))
 
-        inject[Database].readOnly { implicit c =>
+        inject[Database].readOnlyMaster { implicit c =>
           domainRepo.get("google.com") === None
           domainRepo.get("facebook.com") === None
           domainRepo.get("yahoo.com") === None
@@ -25,7 +25,7 @@ DomainTest extends Specification with ShoeboxTestInjector {
         val Seq(sd1, sd2, sd3) = inject[Database].readWrite { implicit c =>
           Seq(d1, d2, d3).map(domainRepo.save(_))
         }
-        inject[Database].readOnly { implicit c =>
+        inject[Database].readOnlyMaster { implicit c =>
           domainRepo.get("google.com").get === sd1
           domainRepo.get("facebook.com").get === sd2
           domainRepo.get("yahoo.com").get === sd3

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
@@ -55,7 +55,7 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
           (user1, collections, bookmark1, bookmark2)
         }
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           val tagId = collections(0).id.get
           collectionRepo.get(tagId).state.value === "active"
           val bookmarksWithTags = keepRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
@@ -63,26 +63,26 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
           (bookmarksWithTags map {b => b.id.get}).toSet === Set(bookmark1.id.get, bookmark2.id.get)
         }
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           collectionRepo.get(collections(1).id.get).state.value === "active"
           val bookmarksWithTags = keepRepo.getByUserAndCollection(user.id.get, collections(1).id.get, None, None, 1000)
           bookmarksWithTags.size === 1
           bookmarksWithTags.head.id.get === bookmark1.id.get
         }
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           collectionRepo.get(collections(2).id.get).state.value === "active"
 //          keepRepo.getByUser(user.id.get, None, None, Some(collections(2).id.get), 1000) === 0
         }
 
         inject[CollectionCommander].deleteCollection(collections(0))
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           collectionRepo.get(collections(0).id.get).state.value === "inactive"
 //          keepRepo.getByUser(user.id.get, None, None, Some(collections(0).id.get), 1000) === 0
         }
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           collectionRepo.get(collections(1).id.get).state.value === "active"
 //          val bookmarksWithTags = keepRepo.getByUser(user.id.get, None, None, Some(collections(1).id.get), 1000)
 //          bookmarksWithTags.size === 1
@@ -91,19 +91,19 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
 
         inject[CollectionCommander].deleteCollection(collections(1))
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           collectionRepo.get(collections(1).id.get).state.value === "inactive"
 //          keepRepo.getByUser(user.id.get, None, None, Some(collections(0).id.get), 1000) === 0
         }
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           collectionRepo.get(collections(1).id.get).state.value === "inactive"
 //          keepRepo.getByUser(user.id.get, None, None, Some(collections(1).id.get), 1000) === 0
         }
 
         inject[CollectionCommander].deleteCollection(collections(2))
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           collectionRepo.get(collections(2).id.get).state.value === "inactive"
 //          keepRepo.getByUser(user.id.get, None, None, Some(collections(2).id.get), 1000) === 0
         }
@@ -137,7 +137,7 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
         }
 
         // First check collections were placed in DB correctly
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           val allCollectionIds = collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user.id.get).map(_.externalId)
           allCollectionIds === oldOrdering
         }
@@ -146,7 +146,7 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
         db.readWrite { implicit s =>
           inject[CollectionCommander].setCollectionIndexOrdering(user.id.get, tagA.externalId, 2)
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           val ordering = userValueRepo.getUserValue(user.id.get, CollectionOrderingKey).get
           val newOrdering = tagB.externalId :: tagC.externalId :: tagA.externalId :: tagD.externalId :: Nil
           ordering.value === Json.stringify(Json.toJson(newOrdering))
@@ -156,7 +156,7 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
         db.readWrite { implicit session =>
           inject[CollectionCommander].setCollectionIndexOrdering(user.id.get, tagA.externalId, 0)
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           val ordering = userValueRepo.getUserValue(user.id.get, CollectionOrderingKey).get
           val newOrdering = tagA.externalId :: tagB.externalId :: tagC.externalId :: tagD.externalId :: Nil
           ordering.value === Json.stringify(Json.toJson(newOrdering))
@@ -166,7 +166,7 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
         db.readWrite { implicit s =>
           inject[CollectionCommander].setCollectionIndexOrdering(user.id.get, tagA.externalId, 3)
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           val ordering = userValueRepo.getUserValue(user.id.get, CollectionOrderingKey).get
           val newOrdering = tagB.externalId :: tagC.externalId :: tagD.externalId :: tagA.externalId :: Nil
           ordering.value === Json.stringify(Json.toJson(newOrdering))

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/FeatureWaitlistCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/FeatureWaitlistCommanderTest.scala
@@ -31,7 +31,7 @@ class FeatureWaitlistCommanderTest extends Specification with ShoeboxApplication
         outbox.size === 1
         outbox(0).to.length === 1
         outbox(0).to(0).address === "stephen@42go.com"
-        val data1 = db.readOnly{ implicit session => repo.all() }
+        val data1 = db.readOnlyMaster{ implicit session => repo.all() }
         data1.length === 1
         val datum1 = data1(0)
         datum1.email === "stephen@42go.com"
@@ -40,7 +40,7 @@ class FeatureWaitlistCommanderTest extends Specification with ShoeboxApplication
 
         commander.waitList("stephen+waitlist@42go.com", "mobile_app", "Test Browser/0.42", Some(extId))
         outbox.size === 2
-        val data2 = db.readOnly{ implicit session => repo.all() }
+        val data2 = db.readOnlyMaster{ implicit session => repo.all() }
         data2.length === 1
         val datum2 = data2(0)
         datum2.email === "stephen+waitlist@42go.com"
@@ -49,7 +49,7 @@ class FeatureWaitlistCommanderTest extends Specification with ShoeboxApplication
 
         commander.waitList("stephen+other@42go.com", "lynx_support", "curl")
         outbox.size === 2
-        val data3 = db.readOnly{ implicit session => repo.all() }
+        val data3 = db.readOnlyMaster{ implicit session => repo.all() }
         data3.length === 2
         val datum3 = data3(1)
         datum3.email === "stephen+other@42go.com"

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
@@ -322,15 +322,15 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
         kbd1(1) === Set(keeps3(0).id.get)
         kbd1(2) === Set(keeps4(0).id.get)
 
-        db.readOnly { implicit ro => userBookmarkClicksRepo.getByUserUri(u1.id.get, keeps1(1).uriId) } === None
+        db.readOnlyMaster { implicit ro => userBookmarkClicksRepo.getByUserUri(u1.id.get, keeps1(1).uriId) } === None
         val bc1 = Await.result(attrCmdr.updateUserReKeepStatus(u1.id.get), Duration.Inf)
         bc1.nonEmpty === true
         bc1.length === 1
         bc1(0).rekeepCount === 1
         bc1(0).rekeepTotalCount === 2
 
-        db.readOnly { implicit ro => userBookmarkClicksRepo.getByUserUri(u2.id.get, keeps2(0).uriId) } === None
-        db.readOnly { implicit ro => userBookmarkClicksRepo.getByUserUri(u3.id.get, keeps3(0).uriId) } === None
+        db.readOnlyMaster { implicit ro => userBookmarkClicksRepo.getByUserUri(u2.id.get, keeps2(0).uriId) } === None
+        db.readOnlyMaster { implicit ro => userBookmarkClicksRepo.getByUserUri(u3.id.get, keeps3(0).uriId) } === None
 
         val bc3 = Await.result(attrCmdr.updateUserReKeepStatus(u3.id.get), Duration.Inf)
         bc3(0).rekeepCount === 1
@@ -347,11 +347,11 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
         allStats(2)(0).rekeepCount === bc3(0).rekeepCount
         allStats(2)(0).rekeepTotalCount === bc3(0).rekeepTotalCount
 
-        val (rkc1, rktc1) = db.readOnly { implicit ro => userBookmarkClicksRepo.getReKeepCounts(u1.id.get) }
+        val (rkc1, rktc1) = db.readOnlyMaster { implicit ro => userBookmarkClicksRepo.getReKeepCounts(u1.id.get) }
         bc1.foldLeft(0) {(a,c) => a + c.rekeepCount} === rkc1
         bc1.foldLeft(0) {(a,c) => a + c.rekeepTotalCount} === rktc1
 
-        val (rkc3, rktc3) = db.readOnly { implicit ro => userBookmarkClicksRepo.getReKeepCounts(u3.id.get) }
+        val (rkc3, rktc3) = db.readOnlyMaster { implicit ro => userBookmarkClicksRepo.getReKeepCounts(u3.id.get) }
         bc3.foldLeft(0) {(a,c) => a + c.rekeepCount} === rkc3
         bc3.foldLeft(0) {(a,c) => a + c.rekeepTotalCount} === rktc3
       }
@@ -380,14 +380,14 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
         keeps1.size === 2
         keeps2.size === 3
         keeps1(1).uriId === keeps2(0).uriId
-        val clicks1 = db.readOnly { implicit rw =>
+        val clicks1 = db.readOnlyMaster { implicit rw =>
           keepDiscoveryRepo.getByKeepId(keeps1(1).id.get)
         }
         clicks1.size === 1
         clicks1.headOption.exists { click =>
           click.keeperId == u1.id.get && click.keepId == keeps1(1).id.get
         } === true
-        val rekeeps1 = db.readOnly { implicit ro =>
+        val rekeeps1 = db.readOnlyMaster { implicit ro =>
           rekeepRepo.getAllReKeepsByKeeper(u1.id.get)
         }
       }
@@ -619,15 +619,15 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
         kbd1(1) === Set(keeps2(0).id.get, keeps3(0).id.get) // chat & search
         kbd1(2) === Set(keeps4(0).id.get)
 
-        db.readOnly { implicit ro => userBookmarkClicksRepo.getByUserUri(u1.id.get, keeps1(1).uriId) } === None
+        db.readOnlyMaster { implicit ro => userBookmarkClicksRepo.getByUserUri(u1.id.get, keeps1(1).uriId) } === None
         val bc1 = Await.result(attrCmdr.updateUserReKeepStatus(u1.id.get), Duration.Inf)
         bc1.nonEmpty === true
         bc1.length === 1
         bc1(0).rekeepCount === 2
         bc1(0).rekeepTotalCount === 3
 
-        db.readOnly { implicit ro => userBookmarkClicksRepo.getByUserUri(u2.id.get, keeps2(0).uriId) } === None
-        db.readOnly { implicit ro => userBookmarkClicksRepo.getByUserUri(u3.id.get, keeps3(0).uriId) } === None
+        db.readOnlyMaster { implicit ro => userBookmarkClicksRepo.getByUserUri(u2.id.get, keeps2(0).uriId) } === None
+        db.readOnlyMaster { implicit ro => userBookmarkClicksRepo.getByUserUri(u3.id.get, keeps3(0).uriId) } === None
 
         val bc3 = Await.result(attrCmdr.updateUserReKeepStatus(u3.id.get), Duration.Inf)
         bc3(0).rekeepCount === 1
@@ -644,11 +644,11 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
         allStats(2)(0).rekeepCount === bc3(0).rekeepCount
         allStats(2)(0).rekeepTotalCount === bc3(0).rekeepTotalCount
 
-        val (rkc1, rktc1) = db.readOnly { implicit ro => userBookmarkClicksRepo.getReKeepCounts(u1.id.get) }
+        val (rkc1, rktc1) = db.readOnlyMaster { implicit ro => userBookmarkClicksRepo.getReKeepCounts(u1.id.get) }
         bc1.foldLeft(0) {(a,c) => a + c.rekeepCount} === rkc1
         bc1.foldLeft(0) {(a,c) => a + c.rekeepTotalCount} === rktc1
 
-        val (rkc3, rktc3) = db.readOnly { implicit ro => userBookmarkClicksRepo.getReKeepCounts(u3.id.get) }
+        val (rkc3, rktc3) = db.readOnlyMaster { implicit ro => userBookmarkClicksRepo.getReKeepCounts(u3.id.get) }
         bc3.foldLeft(0) {(a,c) => a + c.rekeepCount} === rkc3
         bc3.foldLeft(0) {(a,c) => a + c.rekeepTotalCount} === rktc3
       }
@@ -726,7 +726,7 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
           "url" -> "http://42go.com/",
           "isPrivate" -> true
         ))), user.id.get, KeepSource.keeper, true)
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           bookmarks.size === 1
           keepRepo.all.size === 1
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepsCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepsCommanderTest.scala
@@ -69,7 +69,7 @@ class KeepsCommanderTest extends Specification with ShoeboxTestInjector {
           keepToCollectionRepo.save(KeepToCollection(keepId = keep1.id.get, collectionId = col1.id.get))
         }
 
-        val keepExports = db.readOnly { implicit s => keepRepo.getKeepExports(Id[User](1)) }
+        val keepExports = db.readOnlyMaster { implicit s => keepRepo.getKeepExports(Id[User](1)) }
         keepExports.length === 3
         keepExports(0) === KeepExport(title = Some("k3"), createdAt = t1.plusMinutes(6), url = site3)
         keepExports(1) === KeepExport(title = Some("k2"), createdAt = t1.plusMinutes(9), url = site2)

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/mail/ElectronicMailTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/mail/ElectronicMailTest.scala
@@ -23,7 +23,7 @@ class ElectronicMailTest extends Specification with ShoeboxTestInjector {
                       Nil
           mails map {mail => electronicMailRepo.save(mail) }
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           electronicMailRepo.page(0, 10).size === 3
           electronicMailRepo.page(0, 2).size === 3
           mails foreach { mail =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/mail/SendgridMailProviderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/mail/SendgridMailProviderTest.scala
@@ -36,7 +36,7 @@ class SendgridMailProviderTest extends Specification with ShoeboxTestInjector {
 
 //         usually using instance[PostOffice].sendMail(mail
 //        instance[SendgridMailProvider].sendMailToSendgrid(mail)
-        inject[Database].readOnly { implicit s =>
+        inject[Database].readOnlyMaster { implicit s =>
           val loaded = inject[ElectronicMailRepo].get(mail.id.get)
           loaded.from === mail.from
           loaded.fromName === mail.fromName

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtAuthControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtAuthControllerTest.scala
@@ -72,7 +72,7 @@ class ExtAuthControllerTest extends Specification with ShoeboxApplicationInjecto
         val authRequest1 = AuthenticatedRequest(null, user.id.get, user, fakeRequest1)
         val result1 = inject[ExtAuthController].start(authRequest1)
         status(result1) must equalTo(OK)
-        val kifiInstallation1 = db.readOnly {implicit s =>
+        val kifiInstallation1 = db.readOnlyMaster {implicit s =>
           val all = installationRepo.all()(s)
           all.size === 1
           all.head
@@ -94,7 +94,7 @@ class ExtAuthControllerTest extends Specification with ShoeboxApplicationInjecto
         val authRequest2 = AuthenticatedRequest(null, user.id.get, user, fakeRequest2)
         val result2 = inject[ExtAuthController].start(authRequest2)
         status(result2) must equalTo(OK)
-        val kifiInstallation2 = db.readOnly {implicit s =>
+        val kifiInstallation2 = db.readOnlyMaster {implicit s =>
           val all = installationRepo.all()(s)
           all.size === 1
           all.head

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtDeepLinkControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtDeepLinkControllerTest.scala
@@ -50,12 +50,12 @@ class ExtDeepLinkControllerTest extends Specification with ApplicationInjector {
           status(result) must equalTo(OK)
         }
 
-        val deepLinks = db.readOnly {implicit s => deepLinkRepo.all()}
+        val deepLinks = db.readOnlyMaster {implicit s => deepLinkRepo.all()}
         deepLinks.size === 1
         val deepLink = deepLinks.head
         deepLink.deepLocator.value === "/my/location"
 
-        db.readOnly {implicit s => deepLinkRepo.getByLocatorAndUser(deepLink.deepLocator, deepLink.recipientUserId.get)} === deepLink
+        db.readOnlyMaster {implicit s => deepLinkRepo.getByLocatorAndUser(deepLink.deepLocator, deepLink.recipientUserId.get)} === deepLink
 
         {
           val path = com.keepit.controllers.ext.routes.ExtDeepLinkController.handle(deepLink.token.value).toString()

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtKeepsControllerTest.scala
@@ -82,12 +82,12 @@ class ExtKeepsControllerTest extends Specification with ApplicationInjector {
           (user1, k1, collections)
         }
 
-        val bookmarksWithTags = db.readOnly { implicit s =>
+        val bookmarksWithTags = db.readOnlyMaster { implicit s =>
           keepRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
         }
         bookmarksWithTags.size === 1
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           keepRepo.getByUser(user.id.get, None, None, 100).size === 2
           val uris = uriRepo.all
           println(uris mkString "\n")
@@ -106,7 +106,7 @@ class ExtKeepsControllerTest extends Specification with ApplicationInjector {
         val expected = Json.obj("id" -> k1.externalId, "title" -> "G1", "url" -> "http://www.google.com", "isPrivate" -> false)
         Json.parse(contentAsString(result)) must equalTo(expected)
 
-        val bookmarks = db.readOnly { implicit s =>
+        val bookmarks = db.readOnlyMaster { implicit s =>
           keepRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
         }
         bookmarks.size === 0
@@ -148,12 +148,12 @@ class ExtKeepsControllerTest extends Specification with ApplicationInjector {
           (user1, collections)
         }
 
-        val bookmarksWithTags = db.readOnly { implicit s =>
+        val bookmarksWithTags = db.readOnlyMaster { implicit s =>
           keepRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
         }
         bookmarksWithTags.size === 1
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           keepRepo.getByUser(user.id.get, None, None, 100).size === 2
           val uris = uriRepo.all
           println(uris mkString "\n")
@@ -171,7 +171,7 @@ class ExtKeepsControllerTest extends Specification with ApplicationInjector {
 
         Json.parse(contentAsString(result)) must equalTo(Json.obj())
 
-        val bookmarks = db.readOnly { implicit s =>
+        val bookmarks = db.readOnlyMaster { implicit s =>
           keepRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
         }
         bookmarks.size === 0
@@ -214,7 +214,7 @@ class ExtKeepsControllerTest extends Specification with ApplicationInjector {
           (user1, bookmark1, bookmark2, collections)
         }
 
-        db.readOnly {implicit s =>
+        db.readOnlyMaster {implicit s =>
           keepRepo.getByUser(user.id.get, None, None, 100).size === 2
           val uris = uriRepo.all
           println(uris mkString "\n")
@@ -239,7 +239,7 @@ class ExtKeepsControllerTest extends Specification with ApplicationInjector {
           keeps.size === 2
         }
 
-        val bookmarks = db.readOnly { implicit s =>
+        val bookmarks = db.readOnlyMaster { implicit s =>
           keepRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
         }
         bookmarks.size === 1
@@ -272,7 +272,7 @@ class ExtKeepsControllerTest extends Specification with ApplicationInjector {
           (user1, collections)
         }
 
-        db.readOnly {implicit s =>
+        db.readOnlyMaster {implicit s =>
           keepRepo.getByUser(user.id.get, None, None, 100).size === 0
           val uris = uriRepo.all
           uris.size === 0
@@ -296,7 +296,7 @@ class ExtKeepsControllerTest extends Specification with ApplicationInjector {
           keeps.size === 1
         }
 
-        val bookmarks = db.readOnly { implicit s =>
+        val bookmarks = db.readOnlyMaster { implicit s =>
           keepRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
         }
         bookmarks.size === 1

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileAuthControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileAuthControllerTest.scala
@@ -91,13 +91,13 @@ class MobileAuthControllerTest extends Specification with ApplicationInjector {
           {"installation":"${existing.externalId}","newInstallation":false}
         """)
         Json.parse(contentAsString(result)) must equalTo(expected)
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           installationRepo.count === 1
           installationRepo.all().head.version.toString === "1.2.3"
         }
       }
       {
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           installationRepo.get(existing.externalId).version.toString === "1.2.3"
           installationRepo.get(existing.externalId) === existing
         }
@@ -180,13 +180,13 @@ class MobileAuthControllerTest extends Specification with ApplicationInjector {
           {"installation":"${existing.externalId}","newInstallation":false}
         """)
         Json.parse(contentAsString(result)) must equalTo(expected)
-        db.readOnly {implicit s =>
+        db.readOnlyMaster {implicit s =>
           installationRepo.count === 1
           installationRepo.all().head.version.toString === "1.2.3"
         }
       }
       {
-        db.readOnly {implicit s =>
+        db.readOnlyMaster {implicit s =>
           installationRepo.get(existing.externalId).version.toString === "1.2.3"
           installationRepo.get(existing.externalId) === existing
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -143,12 +143,12 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
         (user1, bookmark1, bookmark2, collections)
       }
 
-      val bookmarksWithTags = db.readOnly { implicit s =>
+      val bookmarksWithTags = db.readOnlyMaster { implicit s =>
         keepRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
       }
       bookmarksWithTags.size === 1
 
-      db.readOnly {implicit s =>
+      db.readOnlyMaster {implicit s =>
         keepRepo.getByUser(user.id.get, None, None, 100).size === 2
         val uris = uriRepo.all
         println(uris mkString "\n")
@@ -166,7 +166,7 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
 
       Json.parse(contentAsString(result)) must equalTo(Json.obj())
 
-      val bookmarks = db.readOnly { implicit s =>
+      val bookmarks = db.readOnlyMaster { implicit s =>
         keepRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
       }
       bookmarks.size === 0
@@ -209,7 +209,7 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
         (user1, bookmark1, bookmark2, collections)
       }
 
-      db.readOnly {implicit s =>
+      db.readOnlyMaster {implicit s =>
         keepRepo.getByUser(user.id.get, None, None, 100).size === 2
         val uris = uriRepo.all
         println(uris mkString "\n")
@@ -236,7 +236,7 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
         keeps.size === 2
       }
 
-      val bookmarks = db.readOnly { implicit s =>
+      val bookmarks = db.readOnlyMaster { implicit s =>
         keepRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
       }
 
@@ -270,7 +270,7 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
         (user1, collections)
       }
 
-      db.readOnly {implicit s =>
+      db.readOnlyMaster {implicit s =>
         keepRepo.getByUser(user.id.get, None, None, 100).size === 0
         val uris = uriRepo.all
         uris.size === 0
@@ -296,7 +296,7 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
         keeps.size === 1
       }
 
-      val bookmarks = db.readOnly { implicit s =>
+      val bookmarks = db.readOnlyMaster { implicit s =>
         keepRepo.getByUserAndCollection(user.id.get, collections(0).id.get, None, None, 1000)
       }
       bookmarks.size === 1
@@ -462,7 +462,7 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
 
       val (keeps4, _) = bookmarkInterner.internRawBookmarks(raw4, u4.id.get, KeepSource.default, true)
 
-      val (keeps, clickCount, rekeepCount, clicks, rekeeps) = db.readOnly {implicit s =>
+      val (keeps, clickCount, rekeepCount, clicks, rekeeps) = db.readOnlyMaster {implicit s =>
         val keeps = keepRepo.getByUser(u1.id.get, None, None, 100)
         val clickCount = keepDiscoveryRepo.getDiscoveryCountByKeeper(u1.id.get)
         val clicks = keepDiscoveryRepo.getDiscoveryCountsByKeeper(u1.id.get)
@@ -606,7 +606,7 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
 
       val (keeps4, _) = bookmarkInterner.internRawBookmarks(raw4, u4.id.get, KeepSource.default, true)
 
-      val (keeps, clickCount, rekeepCount, clicks, rekeeps) = db.readOnly {implicit s =>
+      val (keeps, clickCount, rekeepCount, clicks, rekeeps) = db.readOnlyMaster {implicit s =>
         val keeps = keepRepo.getByUser(u1.id.get, None, None, 100)
         val clickCount = keepDiscoveryRepo.getDiscoveryCountByKeeper(u1.id.get)
         val clicks = keepDiscoveryRepo.getDiscoveryCountsByKeeper(u1.id.get)

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobilePageControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobilePageControllerTest.scala
@@ -73,7 +73,7 @@ class MobilePageControllerTest extends Specification with ShoeboxApplicationInje
           (user1, uri)
         }
 
-        db.readOnly {implicit s =>
+        db.readOnlyMaster {implicit s =>
           normalizedURIInterner.getByUri(googleUrl) match {
             case Some(nUri) =>
               nUri === uri

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/shoebox/ShoeboxControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/shoebox/ShoeboxControllerTest.scala
@@ -100,7 +100,7 @@ class ShoeboxControllerTest extends Specification with ShoeboxApplicationInjecto
         val (user1965, friends) = setupSomeUsers()
         val users = user1965::friends
         val basicUserRepo = inject[BasicUserRepo]
-        val basicUsersJson = inject[Database].readOnly { implicit s =>
+        val basicUsersJson = inject[Database].readOnlyMaster { implicit s =>
           users.map{ u => (u.id.get.id.toString -> Json.toJson(basicUserRepo.load(u.id.get))) }.toMap
         }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
@@ -318,7 +318,7 @@ class KeepsControllerTest extends Specification with ApplicationInjector {
 
         val (keeps4, _) = bookmarkInterner.internRawBookmarks(raw4, u4.id.get, KeepSource.default, true)
 
-        val (keeps, clickCount, rekeepCount, clicks, rekeeps) = db.readOnly {implicit s =>
+        val (keeps, clickCount, rekeepCount, clicks, rekeeps) = db.readOnlyMaster {implicit s =>
           val keeps = keepRepo.getByUser(u1.id.get, None, None, 100)
           val clickCount = keepDiscoveryRepo.getDiscoveryCountByKeeper(u1.id.get)
           val clicks = keepDiscoveryRepo.getDiscoveryCountsByKeeper(u1.id.get)
@@ -462,7 +462,7 @@ class KeepsControllerTest extends Specification with ApplicationInjector {
 
         val (keeps4, _) = bookmarkInterner.internRawBookmarks(raw4, u4.id.get, KeepSource.default, true)
 
-        val (keeps, clickCount, rekeepCount, clicks, rekeeps) = db.readOnly {implicit s =>
+        val (keeps, clickCount, rekeepCount, clicks, rekeeps) = db.readOnlyMaster {implicit s =>
           val keeps = keepRepo.getByUser(u1.id.get, None, None, 100)
           val clickCount = keepDiscoveryRepo.getDiscoveryCountByKeeper(u1.id.get)
           val clicks = keepDiscoveryRepo.getDiscoveryCountsByKeeper(u1.id.get)

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/OrphanCleanerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/OrphanCleanerTest.scala
@@ -74,7 +74,7 @@ class OrphanCleanerTest extends Specification with ShoeboxApplicationInjector{
 
         // initial state
         cleaner.cleanNormalizedURIsByChangedURIs(readOnly = false)
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.get(uris(0).id.get).state === NormalizedURIStates.SCRAPED
           uriRepo.get(uris(1).id.get).state === NormalizedURIStates.SCRAPE_FAILED
           uriRepo.get(uris(2).id.get).state === NormalizedURIStates.SCRAPED
@@ -98,7 +98,7 @@ class OrphanCleanerTest extends Specification with ShoeboxApplicationInjector{
           uris.drop(1).map{ uri => changedURIRepo.save(ChangedURI(oldUriId = uri.id.get, newUriId = uris(0).id.get, state=ChangedURIStates.APPLIED)) }
         }
         cleaner.cleanNormalizedURIsByChangedURIs(readOnly = false)
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           uriRepo.get(uris(0).id.get).state === NormalizedURIStates.SCRAPED
           uriRepo.get(uris(1).id.get).state === NormalizedURIStates.SCRAPE_FAILED
           uriRepo.get(uris(2).id.get).state === NormalizedURIStates.ACTIVE
@@ -163,7 +163,7 @@ class OrphanCleanerTest extends Specification with ShoeboxApplicationInjector{
         }
 
         // initial states
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.get(uris(0).id.get).state === NormalizedURIStates.SCRAPED
           uriRepo.get(uris(1).id.get).state === NormalizedURIStates.SCRAPE_FAILED
           uriRepo.get(uris(2).id.get).state === NormalizedURIStates.ACTIVE
@@ -178,7 +178,7 @@ class OrphanCleanerTest extends Specification with ShoeboxApplicationInjector{
         }
 
         cleaner.clean(readOnly = false)
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.get(uris(0).id.get).state === NormalizedURIStates.ACTIVE
           uriRepo.get(uris(1).id.get).state === NormalizedURIStates.ACTIVE
           uriRepo.get(uris(2).id.get).state === NormalizedURIStates.ACTIVE
@@ -202,7 +202,7 @@ class OrphanCleanerTest extends Specification with ShoeboxApplicationInjector{
           Seq(bmRepo.save(Keep(title = Some("Yahoo"), userId = user.id.get, url = urls(2).url, urlId = urls(2).id.get,  uriId = uris(2).id.get, source = hover)))
         }
         cleaner.clean(readOnly = false)
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.get(uris(0).id.get).state === NormalizedURIStates.SCRAPED
           uriRepo.get(uris(1).id.get).state === NormalizedURIStates.SCRAPE_FAILED
           uriRepo.get(uris(2).id.get).state === NormalizedURIStates.ACTIVE
@@ -220,11 +220,11 @@ class OrphanCleanerTest extends Specification with ShoeboxApplicationInjector{
         bms ++= db.readWrite { implicit session =>
           Seq(bmRepo.save(Keep(title = Some("AltaVista"), userId = user.id.get, url = urls(3).url, urlId = urls(3).id.get,  uriId = uris(3).id.get, source = hover)))
         }
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.get(uris(3).id.get).state === NormalizedURIStates.INACTIVE
         }
         cleaner.clean(readOnly = false)
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.get(uris(0).id.get).state === NormalizedURIStates.SCRAPED
           uriRepo.get(uris(1).id.get).state === NormalizedURIStates.SCRAPE_FAILED
           uriRepo.get(uris(2).id.get).state === NormalizedURIStates.ACTIVE
@@ -243,7 +243,7 @@ class OrphanCleanerTest extends Specification with ShoeboxApplicationInjector{
           bms.foreach{ bm => bmRepo.save(bm.copy(state = KeepStates.INACTIVE)) }
         }
         cleaner.clean(readOnly = false)
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.get(uris(0).id.get).state === NormalizedURIStates.ACTIVE
           uriRepo.get(uris(1).id.get).state === NormalizedURIStates.ACTIVE
           uriRepo.get(uris(2).id.get).state === NormalizedURIStates.ACTIVE
@@ -270,7 +270,7 @@ class OrphanCleanerTest extends Specification with ShoeboxApplicationInjector{
           )
         }
         cleaner.clean(readOnly = false)
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.get(uris(0).id.get).state === NormalizedURIStates.SCRAPED
           uriRepo.get(uris(1).id.get).state === NormalizedURIStates.SCRAPE_FAILED
           uriRepo.get(uris(2).id.get).state === NormalizedURIStates.ACTIVE
@@ -291,7 +291,7 @@ class OrphanCleanerTest extends Specification with ShoeboxApplicationInjector{
           bmRepo.save(obms(0).copy(state = KeepStates.INACTIVE))
         }
         cleaner.clean(readOnly = false)
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.get(uris(0).id.get).state === NormalizedURIStates.SCRAPED
           uriRepo.get(uris(1).id.get).state === NormalizedURIStates.SCRAPE_FAILED
           uriRepo.get(uris(2).id.get).state === NormalizedURIStates.ACTIVE
@@ -311,7 +311,7 @@ class OrphanCleanerTest extends Specification with ShoeboxApplicationInjector{
           bmRepo.save(obms(1).copy(state = KeepStates.INACTIVE))
         }
         cleaner.clean(readOnly = false)
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.get(uris(0).id.get).state === NormalizedURIStates.SCRAPED
           uriRepo.get(uris(1).id.get).state === NormalizedURIStates.ACTIVE
           uriRepo.get(uris(2).id.get).state === NormalizedURIStates.ACTIVE
@@ -378,7 +378,7 @@ class OrphanCleanerTest extends Specification with ShoeboxApplicationInjector{
         }
 
         // initial state
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.get(uris(0).id.get).state === NormalizedURIStates.SCRAPED
           uriRepo.get(uris(1).id.get).state === NormalizedURIStates.SCRAPE_FAILED
           uriRepo.get(uris(2).id.get).state === NormalizedURIStates.SCRAPED
@@ -404,7 +404,7 @@ class OrphanCleanerTest extends Specification with ShoeboxApplicationInjector{
         }
 
         cleaner.cleanNormalizedURIsByNormalizedURIs(readOnly = false)
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.get(uris(0).id.get).state === NormalizedURIStates.SCRAPED
           uriRepo.get(uris(1).id.get).state === NormalizedURIStates.SCRAPE_FAILED
           uriRepo.get(uris(2).id.get).state === NormalizedURIStates.ACTIVE

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/URLRenormalizeCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/URLRenormalizeCommanderTest.scala
@@ -41,7 +41,7 @@ class URLRenormalizeCommanderTest extends Specification with ShoeboxApplicationI
         }
 
         commander.doRenormalize(readOnly = false, clearSeq = false, regex = DomainOrURLRegex(None, None))
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           changedUriRepo.all().size === 1
           val changedUri = changedUriRepo.all().head
           changedUri.oldUriId === uri0.id.get

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
@@ -53,7 +53,7 @@ class UriIntegrityPluginTest extends Specification with ShoeboxApplicationInject
         val (uris, urls, bms) = setup()
 
         // check init status
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           uriRepo.getByState(NormalizedURIStates.ACTIVE, -1).size === 2
           uriRepo.getByState(NormalizedURIStates.SCRAPED, -1).size === 2
 
@@ -72,7 +72,7 @@ class UriIntegrityPluginTest extends Specification with ShoeboxApplicationInject
         plugin.batchURIMigration()
 
         // check redirection
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.getByState(NormalizedURIStates.REDIRECTED, -1).size === 1
 
           urlRepo.getByNormUri(uris(1).id.get).head.url === urls(0).url
@@ -91,7 +91,7 @@ class UriIntegrityPluginTest extends Specification with ShoeboxApplicationInject
 
         plugin.handleChangedUri(URLMigration(urls(2), uris(3).id.get))
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           uriRepo.getByState(NormalizedURIStates.REDIRECTED, -1).size === 1
           urlRepo.getByNormUri(uris(2).id.get).head.url === urls(1).url
           urlRepo.getByNormUri(uris(3).id.get).head.url === urls(2).url
@@ -183,7 +183,7 @@ class UriIntegrityPluginTest extends Specification with ShoeboxApplicationInject
 
         val (uris, betterUris, bms, betterBms) = setup()
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           keepToCollectionRepo.getByKeep(bms(0).id.get).size === 1
           keepToCollectionRepo.getByKeep(bms(1).id.get).size === 1
           keepToCollectionRepo.getByKeep(bms(2).id.get).size === 1
@@ -199,7 +199,7 @@ class UriIntegrityPluginTest extends Specification with ShoeboxApplicationInject
 
         plugin.batchURIMigration()
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           keepToCollectionRepo.getByKeep(bms(0).id.get).size === 0
           keepToCollectionRepo.getByKeep(bms(1).id.get).size === 0
           keepToCollectionRepo.getByKeep(bms(2).id.get).size === 0

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/ChangedURITest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/ChangedURITest.scala
@@ -14,7 +14,7 @@ class ChangedURITest extends Specification with ShoeboxTestInjector{
        withDb() { implicit injector =>
          val t = new DateTime(2013, 2, 14, 21, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
 
-         db.readOnly{ implicit s =>
+         db.readOnlyMaster{ implicit s =>
            changedURIRepo.getHighestSeqNum() === Some(SequenceNumber.ZERO)
          }
 
@@ -26,7 +26,7 @@ class ChangedURITest extends Specification with ShoeboxTestInjector{
            }
          }
 
-         var changes = db.readOnly{ implicit s =>
+         var changes = db.readOnlyMaster{ implicit s =>
            changedURIRepo.getChangesSince(SequenceNumber.ZERO, -1, ChangedURIStates.ACTIVE)
          }
          changes.size === 5
@@ -39,13 +39,13 @@ class ChangedURITest extends Specification with ShoeboxTestInjector{
            }
          }
 
-         changes = db.readOnly{ implicit s =>
+         changes = db.readOnlyMaster{ implicit s =>
            changedURIRepo.getChangesSince(lastSeq, -1, ChangedURIStates.ACTIVE)
          }
 
          changes.size === 3
 
-         db.readOnly { implicit s =>
+         db.readOnlyMaster { implicit s =>
            changedURIRepo.getHighestSeqNum() === Some(SequenceNumber(8))
            changedURIRepo.getChangesSince(SequenceNumber(0), -1, ChangedURIStates.ACTIVE).map{_.seq.value}.toArray === (1 to 8).toArray
            changedURIRepo.getChangesBetween(SequenceNumber(2), SequenceNumber(6), ChangedURIStates.ACTIVE).map(_.seq.value).toArray === (3 to 6).toArray

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/CollectionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/CollectionTest.scala
@@ -71,7 +71,7 @@ class CollectionTest extends Specification with ShoeboxTestInjector {
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark2.id.get, collectionId = coll1.id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark2.id.get, collectionId = coll2.id.get))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name).toSet === Set("Apparel", "Cooking", "Scala")
           collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name).toSet === Set("Apparel", "Cooking", "Scala")
           keepRepo.getByUserAndCollection(user1.id.get, coll1.id.get, None, None, 5) must haveLength(2)
@@ -91,10 +91,10 @@ class CollectionTest extends Specification with ShoeboxTestInjector {
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark2.id.get, collectionId = coll3.id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark2.id.get, collectionId = coll1.id.get))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           collectionRepo.getBookmarkCounts(Set(coll1.id.get, coll2.id.get, coll3.id.get)) === Map(coll1.id.get -> 2, coll2.id.get -> 0, coll3.id.get -> 1)
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           keepToCollectionRepo.getKeepsInCollection(coll1.id.get).toSet === Set(bookmark1.id.get, bookmark2.id.get)
           keepToCollectionRepo.getUriIdsInCollection(coll1.id.get).toSet === Set(KeepUriAndTime(bookmark1.uriId, bookmark1.createdAt), KeepUriAndTime(bookmark2.uriId, bookmark2.createdAt))
           collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name).toSet === Set("Cooking", "Scala", "Apparel")
@@ -104,18 +104,18 @@ class CollectionTest extends Specification with ShoeboxTestInjector {
         db.readWrite { implicit s =>
           keepRepo.save(bookmark1.withActive(false))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           keepToCollectionRepo.count(coll1.id.get) === 1
         }
         db.readWrite { implicit s =>
           keepToCollectionRepo.getCollectionsForKeep(bookmark1.id.get).foreach(collectionRepo.collectionChanged(_))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           collectionRepo.getBookmarkCount(coll1.id.get) === 1
           collectionRepo.getBookmarkCounts(Set(coll1.id.get, coll2.id.get, coll3.id.get)) === Map(coll1.id.get -> 1, coll2.id.get -> 0, coll3.id.get -> 1)
         }
         sessionProvider.doWithoutCreatingSessions {
-          db.readOnly { implicit s =>
+          db.readOnlyMaster { implicit s =>
             collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name).toSet === Set("Cooking", "Apparel", "Scala")
             collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name).toSet === Set("Cooking", "Apparel", "Scala")
           }
@@ -168,7 +168,7 @@ class CollectionTest extends Specification with ShoeboxTestInjector {
             Set(coll1.id.get, coll2.id.get, coll3.id.get)
         }
         sessionProvider.doWithoutCreatingSessions {
-          db.readOnly { implicit s =>
+          db.readOnlyMaster { implicit s =>
             keepToCollectionRepo.getCollectionsForKeep(bookmark1.id.get).toSet ===
               Set(coll1.id.get, coll2.id.get, coll3.id.get)
           }
@@ -204,13 +204,13 @@ class CollectionTest extends Specification with ShoeboxTestInjector {
           seq
         }
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           collectionRepo.getCollectionsChanged(SequenceNumber(newSeqNum), 1000).map(_.id.get) === Seq(coll1.id.get)
         }
         db.readWrite { implicit s =>
           keepRepo.save(bookmark1.withNormUriId(bookmark2.uriId))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           collectionRepo.getCollectionsChanged(SequenceNumber(latestSeqNum), 1000).map(_.id.get) === Seq(coll1.id.get)
         }
       }
@@ -221,7 +221,7 @@ class CollectionTest extends Specification with ShoeboxTestInjector {
         implicit val applicationInjector = current.global.asInstanceOf[FortyTwoGlobal].injector
         // TODO: figure out why this works but not withDb() - this is not even using the application injector
         val (user1, user2, bookmark1, bookmark2, coll1, coll2, coll3, coll4) = setup()
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           collectionRepo.getByUserAndName(user1.id.get, "scala") ===
               collectionRepo.getByUserAndName(user1.id.get, "Scala")
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/FailedContentCheckTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/FailedContentCheckTest.scala
@@ -17,7 +17,7 @@ class FailedContentCheckTest extends Specification with ShoeboxTestInjector{
           failedContentCheckRepo.createOrIncrease(u2, u1)
         }
 
-        db.readOnly{ implicit s =>
+        db.readOnlyMaster{ implicit s =>
           var r = failedContentCheckRepo.getByUrls(u1, u2)
           r.get.counts === 5
           r.get.state === FailedContentCheckStates.ACTIVE

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/FriendRequestTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/FriendRequestTest.scala
@@ -18,7 +18,7 @@ class FriendRequestTest extends Specification with ShoeboxTestInjector {
           friendRequestRepo.save(FriendRequest(senderId = users(0), recipientId = users(1), messageHandle = None)),
           friendRequestRepo.save(FriendRequest(senderId = users(0), recipientId = users(2), messageHandle = None))
         )}
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           friendRequestRepo.getBySender(users(0)).map(_.recipientId) must haveTheSameElementsAs(Seq(users(1), users(2)))
           friendRequestRepo.getByRecipient(users(1)).map(_.senderId) must haveTheSameElementsAs(Seq(users(0)))
           friendRequestRepo.getByRecipient(users(2)).map(_.senderId) must haveTheSameElementsAs(Seq(users(0)))
@@ -27,7 +27,7 @@ class FriendRequestTest extends Specification with ShoeboxTestInjector {
         db.readWrite { implicit s =>
           friendRequestRepo.save(fr1.copy(state = FriendRequestStates.ACCEPTED))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           friendRequestRepo.getBySender(users(0)).map(_.recipientId) must haveTheSameElementsAs(Seq(users(2)))
           friendRequestRepo.getByRecipient(users(1)) must beEmpty
           friendRequestRepo.getCountByRecipient(users(2)) must_== 1
@@ -37,7 +37,7 @@ class FriendRequestTest extends Specification with ShoeboxTestInjector {
         db.readWrite { implicit s =>
           friendRequestRepo.save(fr2.copy(state = FriendRequestStates.IGNORED))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           friendRequestRepo.getBySender(users(0)) must beEmpty
           friendRequestRepo.getBySender(users(0), states = Set(FriendRequestStates.ACCEPTED,
             FriendRequestStates.IGNORED)).map(_.recipientId) must haveTheSameElementsAs(Seq(users(1), users(2)))
@@ -60,7 +60,7 @@ class FriendRequestTest extends Specification with ShoeboxTestInjector {
           friendRequestRepo.save(FriendRequest(senderId = users(0), recipientId = users(2), messageHandle = Some(Id[MessageHandle](22))))
         )}
         eliza.unsentNotificationIds.size === 0
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           friendRequestRepo.get(fr1.id.get).messageHandle.get.id === 1
           friendRequestRepo.get(fr2.id.get).messageHandle.get.id === 22
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/HttpProxyTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/HttpProxyTest.scala
@@ -22,7 +22,7 @@ class HttpProxyTest extends Specification with ShoeboxTestInjector {
 
         httpProxyCache.get(HttpProxyAllKey()).isDefined === false
 
-        db.readOnly { implicit session => httpProxyRepo.allActive().length === 1 }
+        db.readOnlyMaster { implicit session => httpProxyRepo.allActive().length === 1 }
         httpProxyCache.get(HttpProxyAllKey()).isDefined
         httpProxyCache.get(HttpProxyAllKey()).get.length === 1
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepToCollectionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepToCollectionTest.scala
@@ -54,7 +54,7 @@ class KeepToCollectionTest  extends Specification with ShoeboxTestInjector {
           (bookmark1, bookmark2, collections)
         }
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           val uris = keepToCollectionRepo.getUriIdsInCollection(collections(0).id.get)
           uris.length === 2
           uris === Seq(KeepUriAndTime(bookmark1.uriId, bookmark1.createdAt), KeepUriAndTime(bookmark2.uriId, bookmark2.createdAt))

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KifiInstallationRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KifiInstallationRepoTest.scala
@@ -23,7 +23,7 @@ class KifiInstallationRepoTest extends Specification with ShoeboxTestInjector {
           (user, installExt)
         }
 
-        db.readOnly {implicit s =>
+        db.readOnlyMaster {implicit s =>
           installationRepo.get(installExt.id.get) === installExt
           val all = installationRepo.all(user.id.get)
           all.size === 1
@@ -44,7 +44,7 @@ class KifiInstallationRepoTest extends Specification with ShoeboxTestInjector {
             platform = KifiInstallationPlatform.Extension))
         }
 
-        db.readOnly {implicit s =>
+        db.readOnlyMaster {implicit s =>
           val all = installationRepo.all(user.id.get)
           all.size === 2
           val versions = installationRepo.getLatestActiveExtensionVersions(20)
@@ -76,7 +76,7 @@ class KifiInstallationRepoTest extends Specification with ShoeboxTestInjector {
         installExt.platform === KifiInstallationPlatform.Extension
 
         //we're not mixing iphone and extension platforms!
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           val all = installationRepo.all(user.id.get)
           all.size === 4
           val versions = installationRepo.getLatestActiveExtensionVersions(20)

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/NormalizedURIRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/NormalizedURIRepoTest.scala
@@ -197,7 +197,7 @@ class NormalizedURIRepoTest extends Specification with ShoeboxTestInjector {
   "internByUri" should {
     "Find an existing uri without creating a new one" in {
       withDb() { implicit injector =>
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           uriRepo.count === 0
         }
         val xkcd = db.readWrite { implicit s =>
@@ -210,7 +210,7 @@ class NormalizedURIRepoTest extends Specification with ShoeboxTestInjector {
         db.readWrite { implicit s =>
           normalizedURIInterner.internByUri("http://blag.xkcd.com/2006/12/11/the-map-of-the-internet/") === xkcd
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           uriRepo.count === 1
         }
       }
@@ -223,7 +223,7 @@ class NormalizedURIRepoTest extends Specification with ShoeboxTestInjector {
           normalizedURIInterner.getByUri("http://www.arte.tv/fr/3482046.html").isEmpty === true
           normalizedURIInterner.internByUri("http://www.arte.tv/fr/3482046.html")
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           uriRepo.count === 1
           blowup.url === "http://www.arte.tv/fr/3482046.html"
         }
@@ -241,7 +241,7 @@ class NormalizedURIRepoTest extends Specification with ShoeboxTestInjector {
           uriRepo.save(uri1.withRedirect(uri2.id.get, t))
           (uri0, uri1, uri2)
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           val updated = uriRepo.get(uri1.id.get)
           updated.redirect === uri2.id
           updated.redirectTime === Some(t)

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/RenormalizedURLTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/RenormalizedURLTest.scala
@@ -23,7 +23,7 @@ class RenormalizedURLTest extends Specification with ShoeboxTestInjector{
 
         implicit def intToSeq(x : Int) = SequenceNumber(x)
 
-        val records = db.readOnly{ implicit s =>
+        val records = db.readOnlyMaster{ implicit s =>
           val records = repo.getChangesBetween(SequenceNumber(0), SequenceNumber(5), state = RenormalizedURLStates.ACTIVE)
           records.size === 5
           records

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/SearchFriendTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/SearchFriendTest.scala
@@ -66,7 +66,7 @@ class SearchFriendTest extends Specification with ShoeboxTestInjector {
           searchFriendRepo.excludeFriend(users(0), users(1))
         }
         sessionProvider.doWithoutCreatingSessions {
-          db.readOnly { implicit s =>
+          db.readOnlyMaster { implicit s =>
             searchFriendRepo.getSearchFriends(users(0)) === Set(users(2))
           }
         }
@@ -77,7 +77,7 @@ class SearchFriendTest extends Specification with ShoeboxTestInjector {
           searchFriendRepo.getSearchFriends(users(0)) === Set(users(2))
         }
         sessionProvider.doWithoutCreatingSessions {
-          db.readOnly { implicit s => searchFriendRepo.getSearchFriends(users(0)) } === Set(users(2))
+          db.readOnlyMaster { implicit s => searchFriendRepo.getSearchFriends(users(0)) } === Set(users(2))
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/SliderRuleTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/SliderRuleTest.scala
@@ -28,7 +28,7 @@ class SliderRuleTest extends Specification with ShoeboxTestInjector {
         foo.rules.map(_.id) === Seq(r1.id, r2.id)
         bar.rules.map(_.id) === Seq(r3.id, r4.id)
 
-        inject[Database].readOnly{ implicit session =>
+        inject[Database].readOnlyMaster{ implicit session =>
           repo.getGroup("foo") must be(foo)  // in-memory cache should work
           repo.getGroup("bar") must be(bar)
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/SocialConnectionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/SocialConnectionTest.scala
@@ -85,7 +85,7 @@ class SocialConnectionTest extends Specification with ShoeboxApplicationInjector
         connections.createConnections(eishaySocialUserInfo, extractFacebookFriendIds(eishayJson), SocialNetworks.FACEBOOK)
         connections.createConnections(andrewSocialUserInfo, extractFacebookFriendIds(andrewJson), SocialNetworks.FACEBOOK)
 
-        val (eishayFortyTwoConnection, andrewFortyTwoConnection) = inject[Database].readOnly{ implicit s =>
+        val (eishayFortyTwoConnection, andrewFortyTwoConnection) = inject[Database].readOnlyMaster{ implicit s =>
           connectionRepo.count === 18
           (connectionRepo.getFortyTwoUserConnections(eishaySocialUserInfo.userId.get),
            connectionRepo.getFortyTwoUserConnections(andrewSocialUserInfo.userId.get))
@@ -125,7 +125,7 @@ class SocialConnectionTest extends Specification with ShoeboxApplicationInjector
         loadJsonImportFriends("facebook_graph_andrew_min.json")
         loadJsonImportFriends("facebook_graph_eishay_min.json")
 
-        inject[Database].readOnly{ implicit s =>
+        inject[Database].readOnlyMaster{ implicit s =>
           println("Connections: " + inject[SocialUserInfoRepo].all.size)
         }
 
@@ -164,7 +164,7 @@ class SocialConnectionTest extends Specification with ShoeboxApplicationInjector
 
         val connectionRepo = inject[SocialConnectionRepo]
 
-        val (eishayFortyTwoConnection, andrewFortyTwoConnection) = inject[Database].readOnly{ implicit s =>
+        val (eishayFortyTwoConnection, andrewFortyTwoConnection) = inject[Database].readOnlyMaster{ implicit s =>
           connectionRepo.all.size === 18
           (connectionRepo.getFortyTwoUserConnections(eishaySocialUserInfo.userId.get),
            connectionRepo.getFortyTwoUserConnections(andrewSocialUserInfo.userId.get))
@@ -206,7 +206,7 @@ class SocialConnectionTest extends Specification with ShoeboxApplicationInjector
 
         loadJsonImportFriends(Seq("facebook_graph_eishay_min_page1.json", "facebook_graph_eishay_min_page2.json"))
 
-        inject[Database].readOnly{ implicit s =>
+        inject[Database].readOnlyMaster{ implicit s =>
           println("Connections: " + inject[SocialUserInfoRepo].all.size)
         }
 
@@ -239,7 +239,7 @@ class SocialConnectionTest extends Specification with ShoeboxApplicationInjector
         inject[UserConnectionCreator].createConnections(eishaySocialUserInfo,
           Seq(eishay1Json, eishay2Json) flatMap extractFacebookFriendIds, SocialNetworks.FACEBOOK)
 
-        val eishayFortyTwoConnection = inject[Database].readOnly{ implicit s =>
+        val eishayFortyTwoConnection = inject[Database].readOnlyMaster{ implicit s =>
           connectionRepo.all.size === 12
           connectionRepo.getFortyTwoUserConnections(eishaySocialUserInfo.userId.get)
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/SocialUserInfoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/SocialUserInfoTest.scala
@@ -86,9 +86,9 @@ class SocialUserInfoTest extends Specification with ShoeboxTestInjector with Tes
     "use cache properly" in {
       withDb() { implicit injector =>
         val user = setup()
-        def isInCache = db.readOnly { implicit c => inject[SocialUserInfoRepoImpl].userCache.get(SocialUserInfoUserKey(user.id.get)).isDefined }
+        def isInCache = db.readOnlyMaster { implicit c => inject[SocialUserInfoRepoImpl].userCache.get(SocialUserInfoUserKey(user.id.get)).isDefined }
 
-        val origSocialUser = db.readOnly { implicit c =>
+        val origSocialUser = db.readOnlyMaster { implicit c =>
           socialUserInfoRepo.getByUser(user.id.get).head
         }
         isInCache === true
@@ -98,7 +98,7 @@ class SocialUserInfoTest extends Specification with ShoeboxTestInjector with Tes
         }
         isInCache must beFalse
 
-        val newSocialUser = db.readOnly { implicit c =>
+        val newSocialUser = db.readOnlyMaster { implicit c =>
          socialUserInfoRepo.getByUser(user.id.get).head
         }
         isInCache === true
@@ -107,14 +107,14 @@ class SocialUserInfoTest extends Specification with ShoeboxTestInjector with Tes
 
         val networkCache = inject[SocialUserInfoRepoImpl].networkCache
         val cacheKey = SocialUserInfoNetworkKey(SocialNetworks.FACEBOOK, SocialId("eishay"))
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           networkCache.get(cacheKey) === None
           val sui = socialUserInfoRepo.get(SocialId("eishay"), SocialNetworks.FACEBOOK)
           sui.fullName === "John Smith"
           networkCache.get(cacheKey).isDefined === true
         }
         val socialUserOpt = inject[TestSlickSessionProvider].doWithoutCreatingSessions {
-          db.readOnly { implicit s => socialUserInfoRepo.getOpt(SocialId("eishay"), SocialNetworks.FACEBOOK) }
+          db.readOnlyMaster { implicit s => socialUserInfoRepo.getOpt(SocialId("eishay"), SocialNetworks.FACEBOOK) }
         }
         socialUserOpt.map(_.fullName) must beSome("John Smith")
       }
@@ -123,12 +123,12 @@ class SocialUserInfoTest extends Specification with ShoeboxTestInjector with Tes
     "get pages" in {
       withDb() { implicit injector =>
         setup()
-        val page0 = db.readOnly { implicit c =>
+        val page0 = db.readOnlyMaster { implicit c =>
           socialUserInfoRepo.page(0, 2)
         }
         page0.size === 2
         page0(0).fullName === "Bob User3"
-        val page2 = db.readOnly { implicit c =>
+        val page2 = db.readOnlyMaster { implicit c =>
           socialUserInfoRepo.page(2, 2)
         }
         page2.size === 2
@@ -139,7 +139,7 @@ class SocialUserInfoTest extends Specification with ShoeboxTestInjector with Tes
     "get large page" in {
       withDb() { implicit injector =>
         setup()
-        val page0 = db.readOnly { implicit s =>
+        val page0 = db.readOnlyMaster { implicit s =>
           socialUserInfoRepo.page(0, 2000)
         }
         page0.size === 6
@@ -149,12 +149,12 @@ class SocialUserInfoTest extends Specification with ShoeboxTestInjector with Tes
     "get larger page" in {
       withDb() { implicit injector =>
         setup()
-        val page0 = db.readOnly { implicit s =>
+        val page0 = db.readOnlyMaster { implicit s =>
           socialUserInfoRepo.page(0, 4)
         }
         page0(0).fullName === "Bob User3"
         page0.size === 4
-        val page1 = db.readOnly { implicit s =>
+        val page1 = db.readOnlyMaster { implicit s =>
           socialUserInfoRepo.page(1, 4)
         }
         page1.size === 2
@@ -163,7 +163,7 @@ class SocialUserInfoTest extends Specification with ShoeboxTestInjector with Tes
 
     "import friends" in {
       withDb(FakeClockModule()) { implicit injector =>
-        val none_unprocessed = db.readOnly { implicit s =>
+        val none_unprocessed = db.readOnlyMaster { implicit s =>
           socialUserInfoRepo.getUnprocessed()
         }
 
@@ -171,7 +171,7 @@ class SocialUserInfoTest extends Specification with ShoeboxTestInjector with Tes
 
         setup()
         inject[Clock].asInstanceOf[FakeClock] += Hours.ONE
-        val unprocessed = db.readOnly { implicit s =>
+        val unprocessed = db.readOnlyMaster { implicit s =>
           socialUserInfoRepo.getUnprocessed()
         }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/SystemValueTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/SystemValueTest.scala
@@ -22,14 +22,14 @@ class SystemValueTest extends Specification with ShoeboxTestInjector {
           (name, value)
         }
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           systemValueRepo.getValue(test).isDefined === true
           // systemValueRepo.valueCache.get(SystemValueKey(test)).get === "this right here!"
         }
         db.readWrite { implicit s =>
           systemValueRepo.save(systemValueRepo.get(value.id.get).withState(SystemValueStates.INACTIVE))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           systemValueRepo.valueCache.get(SystemValueKey(test)).isDefined === false
         }
 
@@ -38,10 +38,10 @@ class SystemValueTest extends Specification with ShoeboxTestInjector {
         }
 
         sessionProvider.doWithoutCreatingSessions {
-          db.readOnly { implicit s => systemValueRepo.getValue(Name("test1")) }
+          db.readOnlyMaster { implicit s => systemValueRepo.getValue(Name("test1")) }
         } should throwAn[IllegalStateException]
 
-        db.readOnly { implicit s => systemValueRepo.getValue(test) } === Some("this right here!")
+        db.readOnlyMaster { implicit s => systemValueRepo.getValue(test) } === Some("this right here!")
         // sessionProvider.doWithoutCreatingSessions {
         //   db.readOnly { implicit s => systemValueRepo.getValue(test) } === Some("this right here!")
         // }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/URLPatternTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/URLPatternTest.scala
@@ -17,7 +17,7 @@ class URLPatternTest extends Specification with ShoeboxTestInjector {
            repo.save(URLPattern(None, """://(www\.|)hulu\.com/watch/""", None)))
         }
 
-        inject[Database].readOnly{ implicit session =>
+        inject[Database].readOnlyMaster{ implicit session =>
           repo.get(p1.id.get) === p1
           repo.get(p2.id.get) === p2
           repo.get(p1.pattern) === Some(p1)

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UrlPatternRuleTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UrlPatternRuleTest.scala
@@ -27,7 +27,7 @@ class UrlPatternRuleTest extends Specification with ShoeboxTestInjector {
           urlPatternRuleRepo.save(UrlPatternRule(pattern = "^https*://.*.google.com.*/ServiceLogin.*$", isUnscrapable = true))
         }
 
-        db.readOnly { implicit session =>
+        db.readOnlyMaster { implicit session =>
           urlPatternRuleCache.get(UrlPatternRuleAllKey()).get.isEmpty === false
           urlPatternRuleRepo.rules().rules.length === 2
           urlPatternRuleCache.get(UrlPatternRuleAllKey()).isDefined === true
@@ -38,7 +38,7 @@ class UrlPatternRuleTest extends Specification with ShoeboxTestInjector {
           urlPatternRuleRepo.save(UrlPatternRule(pattern = "^https*://app.asana.com.*$", isUnscrapable = true))
         }
 
-        db.readOnly { implicit session =>
+        db.readOnlyMaster { implicit session =>
           urlPatternRuleCache.get(UrlPatternRuleAllKey()).get.isEmpty === false
         }
         urlPatternRuleRepo.rules.isUnscrapable("http://www.google.com/") === false

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UrlTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UrlTest.scala
@@ -30,7 +30,7 @@ class UrlTest extends Specification with ShoeboxTestInjector {
           (url1, nuri1, url2, nuri2, nuri3, nuri4)
         }
 
-        inject[Database].readOnly{ implicit session =>
+        inject[Database].readOnlyMaster{ implicit session =>
           println(repo.all)
           repo.get("http://cnn.com", nuri4.id.get).isDefined === false
           repo.get("http://www.google.com/#1", nuri1.id.get).isDefined === true

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UserBookmarkClicksTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UserBookmarkClicksTest.scala
@@ -25,7 +25,7 @@ class UserBookmarkClicksTest extends Specification with ShoeboxTestInjector{
         }
 
         (userIds zip uriIds) foreach { case (userId, uriId) =>
-          val record = db.readOnly{ implicit s =>
+          val record = db.readOnlyMaster{ implicit s =>
             repo.getByUserUri(userId, uriId)
           }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UserExperimentTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UserExperimentTest.scala
@@ -25,7 +25,7 @@ class UserExperimentTest extends Specification with ShoeboxTestInjector {
           expRepo.save(UserExperiment(userId = shanee.id.get, experimentType = ExperimentType.ADMIN))
         }
 
-        inject[Database].readOnly { implicit session =>
+        inject[Database].readOnlyMaster { implicit session =>
           expRepo.get(shanee.id.get, ExperimentType.ADMIN) must beSome
           expRepo.get(shanee.id.get, ExperimentType.FAKE) must beNone
           expRepo.get(santa.id.get, ExperimentType.ADMIN) must beNone
@@ -105,11 +105,11 @@ class UserExperimentTest extends Specification with ShoeboxTestInjector {
 
         val (savedFirstGen, savedSecondGen) = db.readWrite { implicit session => (repo.save(firstGen), repo.save(secondGen)) }
 
-        val allGen = db.readOnly { implicit session => repo.allActive() }
+        val allGen = db.readOnlyMaster { implicit session => repo.allActive() }
         allGen === Seq(savedFirstGen, savedSecondGen)
         cache.get(ProbabilisticExperimentGeneratorAllKey) === Some(allGen)
 
-       db.readOnly { implicit session => repo.getByName(savedFirstGen.name) } === Some(savedFirstGen)
+       db.readOnlyMaster { implicit session => repo.getByName(savedFirstGen.name) } === Some(savedFirstGen)
       }
     }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UserTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UserTest.scala
@@ -26,15 +26,15 @@ class UserTest extends Specification with ShoeboxTestInjector {
           userRepoImpl.idCache.get(UserIdKey(Id[User](1))).get === user
           userRepo.save(user.copy(lastName = "NotMyLastName"))
         }
-        db.readOnly { implicit session =>
+        db.readOnlyMaster { implicit session =>
           userRepoImpl.idCache.get(UserIdKey(Id[User](1))).get !== user
           userRepoImpl.idCache.get(UserIdKey(Id[User](1))).get === updatedUser
         }
 
         sessionProvider.doWithoutCreatingSessions {
-          db.readOnly { implicit s => userRepoImpl.get(Id[User](1)) }
+          db.readOnlyMaster { implicit s => userRepoImpl.get(Id[User](1)) }
         }
-        Try(db.readOnly { implicit s => userRepoImpl.get(Id[User](2)) })
+        Try(db.readOnlyMaster { implicit s => userRepoImpl.get(Id[User](2)) })
         sessionProvider.readOnlySessionsCreated === 1
       }
     }
@@ -47,7 +47,7 @@ class UserTest extends Specification with ShoeboxTestInjector {
           userRepo.save(User(firstName = "Martin", lastName = "Raison"))
         }
 
-        db.readOnly { implicit session =>
+        db.readOnlyMaster { implicit session =>
           userRepoImpl.pageIncludingWithoutExp(UserStates.ACTIVE)(ExperimentType.FAKE)().head === user
           userRepoImpl.pageIncludingWithExp(UserStates.ACTIVE)(ExperimentType.FAKE)().length === 0
           userRepoImpl.countIncludingWithoutExp(UserStates.ACTIVE)(ExperimentType.FAKE) === 1
@@ -58,7 +58,7 @@ class UserTest extends Specification with ShoeboxTestInjector {
           userExperimentRepo.save(UserExperiment(userId = user.id.get, experimentType = ExperimentType.FAKE))
         }
 
-        db.readOnly { implicit session =>
+        db.readOnlyMaster { implicit session =>
           val updatedUser = userRepo.get(user.id.get)
           userRepoImpl.pageIncludingWithoutExp(UserStates.ACTIVE)(ExperimentType.FAKE)().length === 0
           userRepoImpl.pageIncludingWithExp(UserStates.ACTIVE)(ExperimentType.FAKE)().head === updatedUser

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UserToDomainTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UserToDomainTest.scala
@@ -24,7 +24,7 @@ class UserToDomainTest extends Specification with ShoeboxTestInjector {
            repo.save(UserToDomain(None, u2.id.get, d2.id.get, UserToDomainKinds.NEVER_SHOW, None)))
         }
 
-        inject[Database].readOnly{ implicit session =>
+        inject[Database].readOnlyMaster{ implicit session =>
           repo.get(u1.id.get, d1.id.get, UserToDomainKinds.NEVER_SHOW) === Some(u1d1)
           repo.get(u1.id.get, d2.id.get, UserToDomainKinds.NEVER_SHOW) === Some(u1d2)
           repo.get(u2.id.get, d1.id.get, UserToDomainKinds.NEVER_SHOW) === None

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UserValueTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UserValueTest.scala
@@ -25,7 +25,7 @@ class UserValueTest extends Specification with ShoeboxTestInjector {
           (user1, uv)
         }
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           userValueRepo.valueCache.get(UserValueKey(user1.id.get, "test")).isDefined === false
           userValueRepo.getValue(user1.id.get, test) === "this right here!"
           userValueRepo.valueCache.get(UserValueKey(user1.id.get, "test")).get === "this right here!"
@@ -33,7 +33,7 @@ class UserValueTest extends Specification with ShoeboxTestInjector {
         db.readWrite { implicit s =>
           userValueRepo.save(userValueRepo.get(uv.id.get).withState(UserValueStates.INACTIVE))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           userValueRepo.valueCache.get(UserValueKey(user1.id.get, "test")).isDefined === false
         }
 
@@ -42,22 +42,22 @@ class UserValueTest extends Specification with ShoeboxTestInjector {
         }
 
         sessionProvider.doWithoutCreatingSessions {
-          db.readOnly { implicit s => userValueRepo.getValue(user1.id.get, test1) }
+          db.readOnlyMaster { implicit s => userValueRepo.getValue(user1.id.get, test1) }
         } should throwAn[IllegalStateException]
 
-        db.readOnly { implicit s => userValueRepo.getValue(user1.id.get, test) } === "this right here!"
+        db.readOnlyMaster { implicit s => userValueRepo.getValue(user1.id.get, test) } === "this right here!"
         sessionProvider.doWithoutCreatingSessions {
-          db.readOnly { implicit s => userValueRepo.getValue(user1.id.get, test) } === "this right here!"
+          db.readOnlyMaster { implicit s => userValueRepo.getValue(user1.id.get, test) } === "this right here!"
         }
 
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           userValueRepo.getValues(user1.id.get, "test", "test1")
         } === Map("test" -> Some("this right here!"), "test1" -> None)
 
         db.readWrite { implicit s =>
           userValueRepo.save(UserValue(userId = user1.id.get, name = "test2", value = "this right there!"))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           userValueRepo.getValues(user1.id.get, "test", "test1", "test2")
         } === Map(
           "test" -> Some("this right here!"),

--- a/kifi-backend/modules/shoebox/test/com/keepit/normalizer/NormalizationServiceTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/normalizer/NormalizationServiceTest.scala
@@ -43,7 +43,7 @@ class NormalizationServiceTest extends TestKitScope with SpecificationLike with 
     val uriIntegrityPlugin = inject[UriIntegrityPlugin]
     val id = Await.result(normalizationService.update(NormalizationReference(uri), candidates: _*), 1 seconds)
     uriIntegrityPlugin.batchURIMigration()
-    id.map { db.readOnly { implicit session => uriRepo.get(_) }}
+    id.map { db.readOnlyMaster { implicit session => uriRepo.get(_) }}
   }
 
   val modules = Seq(
@@ -69,52 +69,52 @@ class NormalizationServiceTest extends TestKitScope with SpecificationLike with 
         val httpUri = db.readWrite { implicit session => uriRepo.save(NormalizedURI.withHash("http://vimeo.com/48578814")) }
         httpUri.normalization === None
         updateNormalizationNow(httpUri)
-        val latestHttpUri = db.readOnly { implicit session => uriRepo.get(httpUri.id.get) }
+        val latestHttpUri = db.readOnlyMaster { implicit session => uriRepo.get(httpUri.id.get) }
         latestHttpUri.normalization === Some(Normalization.HTTP)
       }
 
       "does not normalize an http:// url to HTTP twice" in {
-        val httpUri = db.readOnly { implicit session => uriRepo.getByNormalizedUrl("http://vimeo.com/48578814") }.get
+        val httpUri = db.readOnlyMaster { implicit session => uriRepo.getByNormalizedUrl("http://vimeo.com/48578814") }.get
         httpUri.normalization === Some(Normalization.HTTP)
         updateNormalizationNow(httpUri, VerifiedCandidate("http://vimeo.com/48578814", Normalization.HTTP)) === None
       }
 
       "redirect an existing http url to a new https:// url" in {
-        val httpUri = db.readOnly { implicit session => uriRepo.getByNormalizedUrl("http://vimeo.com/48578814") }.get
+        val httpUri = db.readOnlyMaster { implicit session => uriRepo.getByNormalizedUrl("http://vimeo.com/48578814") }.get
 
         val httpsUri = db.readWrite { implicit session => uriRepo.save(NormalizedURI.withHash("https://vimeo.com/48578814")) }
         updateNormalizationNow(httpsUri)
-        val latestHttpsUri = db.readOnly { implicit session => uriRepo.get(httpsUri.id.get) }
+        val latestHttpsUri = db.readOnlyMaster { implicit session => uriRepo.get(httpsUri.id.get) }
         latestHttpsUri.normalization === Some(Normalization.HTTPS)
 
-        val latestHttpUri = db.readOnly { implicit session => uriRepo.get(httpUri.id.get) }
+        val latestHttpUri = db.readOnlyMaster { implicit session => uriRepo.get(httpUri.id.get) }
         latestHttpUri.redirect === Some(latestHttpsUri.id.get)
         latestHttpUri.state === NormalizedURIStates.REDIRECTED
-        db.readOnly { implicit session => normalizedURIInterner.getByUri("http://vimeo.com/48578814") } === Some(latestHttpsUri)
+        db.readOnlyMaster { implicit session => normalizedURIInterner.getByUri("http://vimeo.com/48578814") } === Some(latestHttpsUri)
       }
 
       "redirect a new http://www url to an existing https:// url" in {
-        val httpsUri = db.readOnly { implicit session => uriRepo.getByNormalizedUrl("https://vimeo.com/48578814") }.get
+        val httpsUri = db.readOnlyMaster { implicit session => uriRepo.getByNormalizedUrl("https://vimeo.com/48578814") }.get
 
         val httpWWWUri = db.readWrite { implicit session => uriRepo.save(NormalizedURI.withHash("http://www.vimeo.com/48578814")) }
         updateNormalizationNow(httpWWWUri)
-        val latestHttpWWWUri = db.readOnly { implicit session => uriRepo.get(httpWWWUri.id.get) }
+        val latestHttpWWWUri = db.readOnlyMaster { implicit session => uriRepo.get(httpWWWUri.id.get) }
         latestHttpWWWUri.normalization === Some(Normalization.HTTPWWW)
         latestHttpWWWUri.redirect === Some(httpsUri.id.get)
         latestHttpWWWUri.state === NormalizedURIStates.REDIRECTED
-        db.readOnly { implicit session => normalizedURIInterner.getByUri("http://www.vimeo.com/48578814") }.map(_.id) === Some(httpsUri.id)
+        db.readOnlyMaster { implicit session => normalizedURIInterner.getByUri("http://www.vimeo.com/48578814") }.map(_.id) === Some(httpsUri.id)
       }
 
       "upgrade an existing https:// url to a better normalization" in {
-        val httpsUri = db.readOnly { implicit session => uriRepo.getByNormalizedUrl("https://vimeo.com/48578814") }.get
+        val httpsUri = db.readOnlyMaster { implicit session => uriRepo.getByNormalizedUrl("https://vimeo.com/48578814") }.get
         httpsUri.normalization === Some(Normalization.HTTPS)
         updateNormalizationNow(httpsUri, VerifiedCandidate("https://vimeo.com/48578814", Normalization.CANONICAL))
-        val latestHttpsUri = db.readOnly { implicit session => uriRepo.get(httpsUri.id.get) }
+        val latestHttpsUri = db.readOnlyMaster { implicit session => uriRepo.get(httpsUri.id.get) }
         latestHttpsUri.normalization === Some(Normalization.CANONICAL)
       }
 
       "redirect an existing canonical normalization to a most recent one" in {
-        val canonicalUri = db.readOnly { implicit session => uriRepo.getByNormalizedUrl("https://vimeo.com/48578814") }.get
+        val canonicalUri = db.readOnlyMaster { implicit session => uriRepo.getByNormalizedUrl("https://vimeo.com/48578814") }.get
         canonicalUri.normalization === Some(Normalization.CANONICAL)
 
         val moreRecentCanonicalUri = updateNormalizationNow(canonicalUri, VerifiedCandidate("http://vimeo.com/48578814", Normalization.CANONICAL)).get
@@ -122,13 +122,13 @@ class NormalizationServiceTest extends TestKitScope with SpecificationLike with 
         moreRecentCanonicalUri.redirect === None
         moreRecentCanonicalUri.redirectTime === None
 
-        val redirectedCanonicalUri = db.readOnly { implicit session => uriRepo.get(canonicalUri.id.get) }
+        val redirectedCanonicalUri = db.readOnlyMaster { implicit session => uriRepo.get(canonicalUri.id.get) }
         redirectedCanonicalUri.redirect === Some(moreRecentCanonicalUri.id.get)
         redirectedCanonicalUri.state === NormalizedURIStates.REDIRECTED
       }
 
       "ignore a random untrusted candidate" in {
-        val httpsUri = db.readOnly { implicit session => uriRepo.getByNormalizedUrl("https://vimeo.com/48578814") }.get
+        val httpsUri = db.readOnlyMaster { implicit session => uriRepo.getByNormalizedUrl("https://vimeo.com/48578814") }.get
         val newReference = updateNormalizationNow(httpsUri, UntrustedCandidate("http://www.iamrandom.com", Normalization.CANONICAL), UntrustedCandidate("http://www.iamsociallyrandom.com", Normalization.OPENGRAPH))
         newReference === None
       }
@@ -140,10 +140,10 @@ class NormalizationServiceTest extends TestKitScope with SpecificationLike with 
 
       "normalize a LinkedIn private profile to its public url if ids match" in {
         val httpsPublicUri = db.readWrite { implicit session => uriRepo.save(NormalizedURI.withHash("https://www.linkedin.com/pub/leo\u002dgrimaldi/12/42/2b3", normalization = Some(Normalization.HTTPSWWW))) }
-        val privateUri = db.readOnly { implicit session => uriRepo.getByNormalizedUrl("https://www.linkedin.com/profile/view?id=17558679").get }
+        val privateUri = db.readOnlyMaster { implicit session => uriRepo.getByNormalizedUrl("https://www.linkedin.com/profile/view?id=17558679").get }
         val publicUri = updateNormalizationNow(privateUri, UntrustedCandidate("http://www.linkedin.com/pub/leo\u002dgrimaldi/12/42/2b3", Normalization.CANONICAL)).get
-        val latestPrivateUri = db.readOnly { implicit session => uriRepo.get(privateUri.id.get) }
-        val latestHttpsPublicUri = db.readOnly { implicit session => uriRepo.get(httpsPublicUri.id.get) }
+        val latestPrivateUri = db.readOnlyMaster { implicit session => uriRepo.get(privateUri.id.get) }
+        val latestHttpsPublicUri = db.readOnlyMaster { implicit session => uriRepo.get(httpsPublicUri.id.get) }
         publicUri.normalization === Some(Normalization.CANONICAL)
         latestPrivateUri.redirect === Some(publicUri.id.get)
         latestPrivateUri.state === NormalizedURIStates.REDIRECTED
@@ -152,12 +152,12 @@ class NormalizationServiceTest extends TestKitScope with SpecificationLike with 
       }
 
       "normalize a LinkedIn public profile to a vanity public url if this url is trusted" in {
-        val publicUri = db.readOnly { implicit session => uriRepo.getByNormalizedUrl("http://www.linkedin.com/pub/leo\u002dgrimaldi/12/42/2b3").get }
+        val publicUri = db.readOnlyMaster { implicit session => uriRepo.getByNormalizedUrl("http://www.linkedin.com/pub/leo\u002dgrimaldi/12/42/2b3").get }
         updateNormalizationNow(publicUri, UntrustedCandidate("http://www.linkedin.com/in/leo/", Normalization.CANONICAL)) === None
         db.readWrite { implicit session => urlPatternRuleRepo.save(UrlPatternRule(pattern = LinkedInNormalizer.linkedInCanonicalPublicProfile.toString(), trustedDomain = Some("""^https?://([a-z]{2,3})\.linkedin\.com/.*"""))) }
         val vanityUri = updateNormalizationNow(publicUri, UntrustedCandidate("http://www.linkedin.com/in/leo/", Normalization.CANONICAL)).get
-        val latestPublicUri = db.readOnly { implicit session => uriRepo.get(publicUri.id.get) }
-        val latestPrivateUri = db.readOnly { implicit session => uriRepo.getByNormalizedUrl("https://www.linkedin.com/profile/view?id=17558679").get }
+        val latestPublicUri = db.readOnlyMaster { implicit session => uriRepo.get(publicUri.id.get) }
+        val latestPrivateUri = db.readOnlyMaster { implicit session => uriRepo.getByNormalizedUrl("https://www.linkedin.com/profile/view?id=17558679").get }
 
         vanityUri.normalization === Some(Normalization.CANONICAL)
         vanityUri.url === "http://www.linkedin.com/in/leo"
@@ -170,7 +170,7 @@ class NormalizationServiceTest extends TestKitScope with SpecificationLike with 
       "normalize a French LinkedIn private profile to a vanity public url" in {
         val privateUri = db.readWrite { implicit session => uriRepo.save(NormalizedURI.withHash("http://fr.linkedin.com/profile/view?id=136123062")) }
         val vanityUri = updateNormalizationNow(privateUri, UntrustedCandidate("http://fr.linkedin.com/in/viviensaulue", Normalization.CANONICAL)).get
-        val latestPrivateUri = db.readOnly { implicit session => uriRepo.get(privateUri.id.get) }
+        val latestPrivateUri = db.readOnlyMaster { implicit session => uriRepo.get(privateUri.id.get) }
         vanityUri.normalization === Some(Normalization.CANONICAL)
         vanityUri.url === "http://www.linkedin.com/in/viviensaulue"
         latestPrivateUri.redirect === Some(vanityUri.id.get)
@@ -178,10 +178,10 @@ class NormalizationServiceTest extends TestKitScope with SpecificationLike with 
       }
 
       "find a variation with an upgraded normalization" in {
-        val canonicalVariation = db.readOnly { implicit session => uriRepo.getByNormalizedUrl("http://www.linkedin.com/in/viviensaulue").get }
+        val canonicalVariation = db.readOnlyMaster { implicit session => uriRepo.getByNormalizedUrl("http://www.linkedin.com/in/viviensaulue").get }
         val httpsUri = db.readWrite { implicit session => uriRepo.save(NormalizedURI.withHash("https://www.linkedin.com/in/viviensaulue")) }
         updateNormalizationNow(httpsUri, UntrustedCandidate("http://fr.linkedin.com/in/viviensaulue", Normalization.CANONICAL)).map(_.id) === Some(canonicalVariation.id)
-        val latestHttpsUri = db.readOnly { implicit session => uriRepo.get(httpsUri.id.get) }
+        val latestHttpsUri = db.readOnlyMaster { implicit session => uriRepo.get(httpsUri.id.get) }
         latestHttpsUri.redirect === Some(canonicalVariation.id.get)
         latestHttpsUri.state === NormalizedURIStates.REDIRECTED
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/social/SecureSocialAuthenticatorPluginTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/social/SecureSocialAuthenticatorPluginTest.scala
@@ -87,7 +87,7 @@ class SecureSocialAuthenticatorPluginTest extends Specification with ShoeboxAppl
           // we should have an old session in the cache and we shouldn't care about updating the last used time
           plugin.save(authenticator.copy(lastUsed = authenticator.lastUsed.plusDays(1)))
         }
-        db.readOnly { implicit s =>
+        db.readOnlyMaster { implicit s =>
           userSessionRepo.get(id).userId.get === user.id.get
         }
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/social/SocialUserImportEmailTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/social/SocialUserImportEmailTest.scala
@@ -32,7 +32,7 @@ class SocialUserImportEmailTest extends Specification with ShoeboxTestInjector {
     val email = inject[FacebookSocialGraph].extractEmails(json)
       .map(em => inject[SocialUserImportEmail].importEmail(user.id.get, em)).head
     email.address === emailAddress
-    db.readOnly{ implicit session =>
+    db.readOnlyMaster{ implicit session =>
       emailAddressRepo.get(email.id.get).address === emailAddress
     }
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/social/UserConnectionCreatorTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/social/UserConnectionCreatorTest.scala
@@ -62,7 +62,7 @@ class UserConnectionCreatorTest extends Specification with ShoeboxApplicationInj
 
         connections.size === 12
 
-        inject[Database].readOnly { implicit s =>
+        inject[Database].readOnlyMaster { implicit s =>
           val fortyTwoConnections = inject[SocialConnectionRepo].getFortyTwoUserConnections(user.id.get)
           val userConnections = inject[UserConnectionRepo].getConnectedUsers(user.id.get)
           val connectionCount = inject[UserConnectionRepo].getConnectionCount(user.id.get)
@@ -120,7 +120,7 @@ class UserConnectionCreatorTest extends Specification with ShoeboxApplicationInj
         val connectionsAfter = inject[UserConnectionCreator]
             .createConnections(socialUserInfo, extractedFriends2.map(_.socialId), SocialNetworks.FACEBOOK)
 
-        inject[Database].readOnly { implicit s =>
+        inject[Database].readOnlyMaster { implicit s =>
           val fortyTwoConnections = inject[SocialConnectionRepo].getFortyTwoUserConnections(user.id.get)
           val userConnections = inject[UserConnectionRepo].getConnectedUsers(user.id.get)
           val connectionCount = inject[UserConnectionRepo].getConnectionCount(user.id.get)

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/DbSequenceAssigner.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/DbSequenceAssigner.scala
@@ -27,7 +27,7 @@ abstract class DbSequenceAssigner[M <: ModelWithSeqNumber[M]](
 
   override def sanityCheck(): Unit = {
     val minDeferredSeqNumOpt = try {
-      db.readOnly{ implicit session => repo.minDeferredSequenceNumber() }
+      db.readOnlyMaster{ implicit session => repo.minDeferredSequenceNumber() }
     } catch {
       case e: UnsupportedOperationException =>
         reportUnsupported(e)

--- a/kifi-backend/modules/sqldb/test/com/keepit/common/db/DataBaseComponentTest.scala
+++ b/kifi-backend/modules/sqldb/test/com/keepit/common/db/DataBaseComponentTest.scala
@@ -15,7 +15,7 @@ class DataBaseComponentTest extends Specification with DbTestInjector {
     "not create real sessions if not used" in {
       withDb() { implicit injector: Injector =>
         inject[TestSlickSessionProvider].doWithoutCreatingSessions {
-          db.readOnly { implicit s =>
+          db.readOnlyMaster { implicit s =>
             1 === 1
           }
         }

--- a/kifi-backend/modules/sqldb/test/com/keepit/common/db/SlickTest.scala
+++ b/kifi-backend/modules/sqldb/test/com/keepit/common/db/SlickTest.scala
@@ -96,14 +96,14 @@ class SlickTest extends Specification with DbTestInjector {
           repo.getCurrentSeqNum().value === 2
         }
 
-        inject[Database].readOnly{ implicit session =>
+        inject[Database].readOnlyMaster{ implicit session =>
           repo.count(session) === 2
           val a = repo.getByName("A")
           a.size === 1
           a.head.name === "A"
         }
 
-        inject[Database].readOnly{ implicit session =>
+        inject[Database].readOnlyMaster{ implicit session =>
           val a = repo.getByNameSqlInterpulation("A")
           a.size === 1
           a.head === "A"
@@ -117,11 +117,11 @@ class SlickTest extends Specification with DbTestInjector {
           repo.count(session) === 2
         }
 
-        inject[Database].readOnly{ implicit session =>
+        inject[Database].readOnlyMaster{ implicit session =>
           repo.count(session) === 2
         }(Database.Slave, Location.capture)
 
-        inject[Database].readOnly{ implicit session =>
+        inject[Database].readOnlyMaster{ implicit session =>
           repo.getByNameSqlInterpulationSqlInjection("A';drop table foo;select * from foo where name ='") must throwA[JdbcSQLException]
         }
 
@@ -157,7 +157,7 @@ class SlickTest extends Specification with DbTestInjector {
           session.rollback()
         }
 
-        db.readOnly{ implicit session =>
+        db.readOnlyMaster{ implicit session =>
           q.firstOption === None
         }
 
@@ -171,7 +171,7 @@ class SlickTest extends Specification with DbTestInjector {
           session.rollback()
         }
 
-        db.readOnly{ implicit session =>
+        db.readOnlyMaster{ implicit session =>
           q.firstOption === Some(1)
         }
 
@@ -185,7 +185,7 @@ class SlickTest extends Specification with DbTestInjector {
           case _: Throwable => //ignore
         }
 
-        db.readOnly{ implicit session =>
+        db.readOnlyMaster{ implicit session =>
           q.firstOption === Some(1)
         }
 
@@ -193,7 +193,7 @@ class SlickTest extends Specification with DbTestInjector {
           rows.map(s => s).delete
         }
 
-        db.readOnly{ implicit session =>
+        db.readOnlyMaster{ implicit session =>
           q.firstOption === None
         }
       }
@@ -249,7 +249,7 @@ class SlickTest extends Specification with DbTestInjector {
           (repo.save(Bar(name = "A")), repo.save(Bar(name = "B")))
         }
 
-        inject[Database].readOnly{ implicit session =>
+        inject[Database].readOnlyMaster{ implicit session =>
           repo.count(session) === 2
           repo.get(b1.externalId) === b1
           repo.get(b2.externalId) === b2


### PR DESCRIPTION
Refactoring Database.readOnly to split readOnly's for easier choices between reading from Master or Slaves

@eishay @andrewconner @martinraison @leogrim @lawzlo @stkem 
