### PR TITLE
Not persisting to cache when in db read only replica session.

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/cache/CacheStatistics.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/CacheStatistics.scala
@@ -19,10 +19,12 @@ import play.api.Plugin
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json._
 
+object CacheStatistics {
+  val cacheLog = Logger("com.keepit.cache")
+}
+
 class CacheStatistics @Inject() (global: GlobalCacheStatistics) extends Logging {
-
-  private val cacheLog = Logger("com.keepit.cache")
-
+  import CacheStatistics.cacheLog
   private def incrCount(key: String, m: ConcurrentMap[String, AtomicInteger]) {
     m.getOrElseUpdate(key, new AtomicInteger(0)).incrementAndGet()
   }

--- a/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionLocalCache.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionLocalCache.scala
@@ -1,10 +1,8 @@
 package com.keepit.common.cache
 
-import com.keepit.serializer.{SafeLocalSerializer, NoCopyLocalSerializer, LocalSerializer, Serializer}
+import com.keepit.serializer.{SafeLocalSerializer, LocalSerializer, Serializer}
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.Duration
-import scala.concurrent.Future
-import play.api.libs.json._
 import com.keepit.common.performance._
 import com.keepit.common.logging.Logging
 
@@ -83,15 +81,20 @@ class TransactionLocalCache[K <: Key[T], T] private(
   }
 }
 
-class ReadOnlyCacheWrapper[K <: Key[T], T](underlying: ObjectCache[K, T]) extends ObjectCache[K, T] {
+class ReadOnlyCacheWrapper[K <: Key[T], T](underlying: ObjectCache[K, T], logging: Boolean = false) extends ObjectCache[K, T] {
+  import CacheStatistics.cacheLog
   val minTTL: Duration = Duration.Inf
   val maxTTL: Duration = Duration.Inf
 
   protected[cache] def getFromInnerCache(key: K): ObjectState[T] = underlying.getFromInnerCache(key)
 
-  protected[cache] def setInnerCache(key: K, valueOpt: Option[T]) = { } // ignore silently
+  protected[cache] def setInnerCache(key: K, valueOpt: Option[T]) = {
+    if (logging) cacheLog.warn(s"cache ignoring set key $key")
+  } // ignore silently
 
   protected[cache] def bulkGetFromInnerCache(keys: Set[K]): Map[K, ObjectState[T]] = underlying.bulkGetFromInnerCache(keys)
 
-  def remove(key: K): Unit = { } // ignore silently
+  def remove(key: K): Unit = {
+    if (logging) cacheLog.warn(s"cache ignoring remove key $key")
+  } // ignore silently
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionalCache.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionalCache.scala
@@ -16,7 +16,11 @@ abstract class TransactionalCache[K <: Key[T], T](cache: ObjectCache[K, T], seri
     if (txn.inCacheTransaction) {
       txn.getOrCreate(cacheName){ new TransactionLocalCache(cache, serializer, localSerializerOpt) }
     } else {
-      cache
+      if (txn.isReadOnly) {
+        new ReadOnlyCacheWrapper[K, T](cache, logging = true)
+      } else {
+        cache
+      }
     }
   }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionalCaching.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/cache/TransactionalCaching.scala
@@ -6,6 +6,7 @@ import com.keepit.common.logging.Logging
 object TransactionalCaching {
   object Implicits {
     implicit val directCacheAccess = new TransactionalCaching with Logging {
+      val isReadOnly = false
       override def beginCacheTransaction() = {
         throw new Exception("transaction is not allowed")
       }
@@ -18,6 +19,7 @@ trait TransactionalCaching { self: Logging =>
 
   private[this] var inTxn: Boolean = false
   private[this] var bypassTransaction: Boolean = false
+  val isReadOnly: Boolean
 
   final def inCacheTransaction: Boolean = (inTxn && !bypassTransaction)
 

--- a/kifi-backend/modules/common/test/com/keepit/common/cache/TransactionalCachingTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/cache/TransactionalCachingTest.scala
@@ -61,10 +61,17 @@ class TransactionalCachingTest extends Specification {
   val txnCache1 = new TxnCache1(cache1)
   val txnCache2 = new TxnCache2(cache2)
 
-  implicit private val txn = new TransactionalCaching with Logging
+  private val masterTxn = new TransactionalCaching with Logging {
+    val isReadOnly = false
+  }
+
+  private val replicaTxn = new TransactionalCaching with Logging {
+    val isReadOnly = true
+  }
 
   "TransactionalCaching" should {
     "rollback cache data" in {
+      implicit val txn = masterTxn
       txn.beginCacheTransaction()
 
       txnCache1.set(TestKey1(1), "foo")
@@ -83,7 +90,21 @@ class TransactionalCachingTest extends Specification {
       cache2.get(TestKey2(1)) === None
     }
 
+    "don't write when readOnly txn" in {
+      implicit val txn = replicaTxn
+
+      txnCache1.set(TestKey1(1), "foo")
+      txnCache2.set(TestKey2(1), "bar")
+
+      txnCache1.get(TestKey1(1)) === None
+      txnCache2.get(TestKey2(1)) === None
+      cache1.get(TestKey1(1)) === None
+      cache2.get(TestKey2(1)) === None
+
+    }
+
     "commit cache data" in {
+      implicit val txn = masterTxn
       txn.beginCacheTransaction()
 
       txnCache1.set(TestKey1(1), "foo")
@@ -120,6 +141,7 @@ class TransactionalCachingTest extends Specification {
     }
 
     "remove cache data" in {
+      implicit val txn = masterTxn
       cache1.clear()
       cache2.clear()
       cache1.set(TestKey1(1), "foo")
@@ -162,6 +184,7 @@ class TransactionalCachingTest extends Specification {
     }
 
     "bulkGet cache data" in {
+      implicit val txn = masterTxn
       cache1.clear()
       cache2.clear()
 
@@ -201,6 +224,7 @@ class TransactionalCachingTest extends Specification {
     }
 
     "perform getOrElse" in {
+      implicit val txn = masterTxn
       cache1.clear()
       txn.beginCacheTransaction()
 
@@ -224,6 +248,7 @@ class TransactionalCachingTest extends Specification {
     }
 
     "skip the trasactional layer in directCacheAccess method" in {
+      implicit val txn = masterTxn
       cache1.clear()
 
       txnCache1.direct.remove(TestKey1(1))

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DBSession.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DBSession.scala
@@ -13,6 +13,7 @@ import scala.slick.jdbc.JdbcBackend.Session
 import scala.slick.driver.JdbcProfile
 import com.keepit.common.util.TrackingId
 import com.keepit.macros.Location
+import com.keepit.common.db.slick.Database.Master
 
 object DBSession {
   abstract class SessionWrapper(val name: String, val masterSlave: Database.DBMasterReplica, _session: => Session, location: Location) extends Session with Logging with TransactionalCaching {
@@ -33,6 +34,7 @@ object DBSession {
     }
     lazy val clock = new SystemClock
     val sessionId = TrackingId.get
+    val isReadOnly = masterSlave != Master
     def runningTime():Long = System.currentTimeMillis - startTime
     def timeCheck():Unit = {
       val t = runningTime()


### PR DESCRIPTION
In this case we only read from cache. On read only or read write to/from master, we do persist objects to cache.
We log ignore cache writes to references and analytics. They should not happen too frequently, if they will we'll consider more eager updates of caches from master.
This code was designed by @ymatsuda 
/cc @raymondng @stkem 
