### PR TITLE
Typeahead refactor -- remove (old) search

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/typeahead/Typeahead.scala
+++ b/kifi-backend/modules/common/app/com/keepit/typeahead/Typeahead.scala
@@ -14,16 +14,6 @@ import Logging.LoggerWithPrefix
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
-trait TypeaheadSearch[E, I] {
-
-  def asyncSearch(userId: Id[User], query: String)(implicit ord: Ordering[TypeaheadHit[I]]): Future[Option[Seq[I]]]
-  def search(userId: Id[User], query: String)(implicit ord: Ordering[TypeaheadHit[I]]): Option[Seq[I]]
-  def search(infos: Seq[I], queryTerms: Array[String])(implicit ord: Ordering[TypeaheadHit[I]]): Option[Seq[I]]
-  def asyncTopN(userId: Id[User], query: String, limit: Option[Int])(implicit ord: Ordering[TypeaheadHit[I]]): Future[Option[Seq[TypeaheadHit[I]]]]
-  def topN(infos:Seq[I], queryTerms:Array[String], limit: Option[Int])(implicit ord:Ordering[TypeaheadHit[I]]): Option[Seq[TypeaheadHit[I]]]
-
-}
-
 trait Typeahead[E, I] extends Logging {
 
   protected def airbrake: AirbrakeNotifier

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -690,20 +690,22 @@ class AdminUserController @Inject() (
   }
 
   // ad hoc testing only during dev phase
-  private def prefixSocialSearchDirect(userId:Id[User], query:String):Option[Seq[SocialUserBasicInfo]] = {
+  private def prefixSocialSearchDirect(userId:Id[User], query:String): Future[Option[Seq[SocialUserBasicInfo]]] = {
     implicit val ord = TypeaheadHit.defaultOrdering[SocialUserBasicInfo]
-    val resOpt = socialUserTypeahead.search(userId, query)
-    log.info(s"[prefixSearch($userId,$query)]: res=$resOpt")
-    resOpt
+    socialUserTypeahead.asyncSearch(userId, query) map { resOpt =>
+      log.info(s"[prefixSearch($userId,$query)]: res=$resOpt")
+      resOpt
+    }
   }
 
-  def prefixSocialSearch(userId:Id[User], query:String) = AdminHtmlAction.authenticated { request =>
-    val resOpt = prefixSocialSearchDirect(userId, query)
-    resOpt match {
-      case None =>
-        Ok(s"No social match found for $query")
-      case Some(res) =>
-        Ok(res.map{ info => s"SocialUser: id=${info.id} name=${info.fullName} network=${info.networkType} <br/>" }.mkString(""))
+  def prefixSocialSearch(userId:Id[User], query:String) = AdminHtmlAction.authenticatedAsync { request =>
+    prefixSocialSearchDirect(userId, query) map { resOpt =>
+      resOpt match {
+        case None =>
+          Ok(s"No social match found for $query")
+        case Some(res) =>
+          Ok(res.map { info => s"SocialUser: id=${info.id} name=${info.fullName} network=${info.networkType} <br/>"}.mkString(""))
+      }
     }
   }
 
@@ -724,20 +726,21 @@ class AdminUserController @Inject() (
   }
 
   def prefixSearch(userId:Id[User], query:String) = AdminHtmlAction.authenticatedAsync { request =>
-    val contactResF = prefixContactSearchDirect(userId, query)
-    val socialResOpt = prefixSocialSearchDirect(userId, query)
-    contactResF map { contactRes =>
+    for {
+      contactRes <- prefixContactSearchDirect(userId, query)
+      socialResOpt <- prefixSocialSearchDirect(userId, query)
+    } yield {
       socialResOpt match {
         case None =>
           if (contactRes.isEmpty)
             Ok(s"No match found for $query")
           else
-            Ok(contactRes.map{ e => s"Contact: email=${e.email} name=${e.name} userId=${e.userId}"}.mkString("<br/>"))
+            Ok(contactRes.map { e => s"Contact: email=${e.email} name=${e.name} userId=${e.userId}"}.mkString("<br/>"))
         case Some(socialRes) =>
           Ok((
-            socialRes.map{ info => s"SocialUser: id=${info.id} name=${info.fullName} network=${info.networkType}" } ++
-            contactRes.map{ e => s"Contact: email=${e.email} name=${e.name} userId=${e.userId}"}
-          ).mkString("<br/>"))
+            socialRes.map { info => s"SocialUser: id=${info.id} name=${info.fullName} network=${info.networkType}"} ++
+              contactRes.map { e => s"Contact: email=${e.email} name=${e.name} userId=${e.userId}"}
+            ).mkString("<br/>"))
       }
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/TypeaheadAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/TypeaheadAdminController.scala
@@ -80,16 +80,20 @@ class TypeaheadAdminController @Inject() (
     }
   }
 
-  def userSearch(userId:Id[User], query:String) = AdminHtmlAction.authenticated { request =>
+  def userSearch(userId:Id[User], query:String) = AdminHtmlAction.authenticatedAsync { request =>
     implicit val ord = TypeaheadHit.defaultOrdering[User]
-    val res = kifiUserTypeahead.search(userId, query) getOrElse Seq.empty[User]
-    Ok(res.map{ info => s"KifiUser: id=${info.id} name=${info.fullName} <br/>" }.mkString(""))
+    kifiUserTypeahead.asyncSearch(userId, query) map { resOpt =>
+      val res = resOpt getOrElse Seq.empty[User]
+      Ok(res.map { info => s"KifiUser: id=${info.id} name=${info.fullName} <br/>"}.mkString(""))
+    }
   }
 
-  def socialSearch(userId:Id[User], query:String) = AdminHtmlAction.authenticated { request =>
+  def socialSearch(userId:Id[User], query:String) = AdminHtmlAction.authenticatedAsync { request =>
     implicit val ord = TypeaheadHit.defaultOrdering[SocialUserBasicInfo]
-    val res = socialUserTypeahead.search(userId, query) getOrElse Seq.empty[SocialUserBasicInfo]
-    Ok(res.map{ info => s"SocialUser: id=${info.id} name=${info.fullName} network=${info.networkType} <br/>" }.mkString(""))
+    socialUserTypeahead.asyncSearch(userId, query) map { resOpt =>
+      val res = resOpt getOrElse Seq.empty[SocialUserBasicInfo]
+      Ok(res.map { info => s"SocialUser: id=${info.id} name=${info.fullName} network=${info.networkType} <br/>"}.mkString(""))
+    }
   }
 
   def contactSearch(userId:Id[User], query:String) = AdminHtmlAction.authenticatedAsync { request =>


### PR DESCRIPTION
Clean-up#1. More refactoring to come.

RIP search (older method)

@ymatsuda @eishay 
