### PR TITLE
Ignore missing optional parameters in routes

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -14,29 +14,29 @@ import com.keepit.common.mail.EmailAddress
 trait Service
 
 case class ServiceRoute(method: Method, path: String, params: Param*) {
-  def url = path + (if(params.nonEmpty) "?" + params.map({ p =>
-    URLEncoder.encode(p.key, UTF8) + (if(p.value.value != "") "=" + URLEncoder.encode(p.value.value, UTF8) else "")
-  }).mkString("&") else "")
+  def url = path + (if(params.nonEmpty) "?" + params.collect { case Param(key, Some(value)) =>
+    URLEncoder.encode(key, UTF8) + (if(value.value != "") "=" + URLEncoder.encode(value.value, UTF8) else "")
+  }.mkString("&") else "")
 }
 
-case class Param(key: String, value: ParamValue = ParamValue("")) {
-  override def toString(): String = s"key->${value.value}"
+case class Param(key: String, value: Option[ParamValue] = None) {
+  override def toString(): String = s"key->${value.map(_.value)}"
 }
 
 case class ParamValue(value: String)
 
 object ParamValue {
-  implicit def stringToParam(i: String) = ParamValue(i)
-  implicit def longToParam(i: Long) = ParamValue(i.toString)
-  implicit def booleanToParam(b: Boolean) = ParamValue(b.toString)
-  implicit def intToParam(i: Int) = ParamValue(i.toString)
-  implicit def stateToParam[T](i: State[T]) = ParamValue(i.value)
-  implicit def externalIdToParam[T](i: ExternalId[T]) = ParamValue(i.id)
-  implicit def idToParam[T](i: Id[T]) = ParamValue(i.id.toString)
-  implicit def optionToParam[T](i: Option[T])(implicit e: T => ParamValue) = if(i.nonEmpty) e(i.get) else ParamValue("")
-  implicit def seqNumToParam[T](seqNum: SequenceNumber[T]) = ParamValue(seqNum.value.toString)
-  implicit def modelVersionToParam[M <: StatModel](modelVersion: ModelVersion[M]) = ParamValue(modelVersion.version.toString)
-  implicit def emailToParam(emailAddress: EmailAddress) = ParamValue(emailAddress.address)
+  implicit def stringToParam(i: String) = Some(ParamValue(i))
+  implicit def longToParam(i: Long) = Some(ParamValue(i.toString))
+  implicit def booleanToParam(b: Boolean) = Some(ParamValue(b.toString))
+  implicit def intToParam(i: Int) = Some(ParamValue(i.toString))
+  implicit def stateToParam[T](i: State[T]) = Some(ParamValue(i.value))
+  implicit def externalIdToParam[T](i: ExternalId[T]) = Some(ParamValue(i.id))
+  implicit def idToParam[T](i: Id[T]) = Some(ParamValue(i.id.toString))
+  implicit def optionToParam[T](i: Option[T])(implicit e: T => Option[ParamValue]) = i.flatMap(e)
+  implicit def seqNumToParam[T](seqNum: SequenceNumber[T]) = Some(ParamValue(seqNum.value.toString))
+  implicit def modelVersionToParam[M <: StatModel](modelVersion: ModelVersion[M]) = Some(ParamValue(modelVersion.version.toString))
+  implicit def emailToParam(emailAddress: EmailAddress) = Some(ParamValue(emailAddress.address))
 }
 
 abstract class Method(name: String)

--- a/kifi-backend/modules/common/test/com/keepit/common/routes/ServiceRouteTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/routes/ServiceRouteTest.scala
@@ -1,0 +1,12 @@
+package com.keepit.common.routes
+
+import org.specs2.mutable.Specification
+
+class ServiceRouteTest extends Specification {
+
+  ServiceRoute(GET, "/search", Param("q", "scala"), Param("maxHits", 10)).url === "/search?q=scala&maxHits=10"
+  ServiceRoute(GET, "/search", Param("q", "scala"), Param("maxHits", Some(10))).url === "/search?q=scala&maxHits=10"
+  ServiceRoute(GET, "/search", Param("q", "scala"), Param("maxHits", None)).url === "/search?q=scala"
+  ServiceRoute(GET, "/search", Param("q", ""), Param("maxHits", None)).url === "/search?q="
+  ServiceRoute(GET, "/search", Param("q", None), Param("maxHits", None)).url === "/search"
+}


### PR DESCRIPTION
@andrewconner @stkem @2is10 @eishay 

Please review carefully. 

Currently, an Option passed as a route parameter is converted to the empty string. So far, I guess all of these optional parameters must have been Strings, so no problem. 

But I have used an optional integer parameter in the following new routes:

  def prefixQuery(userId: Id[User], query: String, maxHits: Option[Int]) = ServiceRoute(GET, s"/internal/abook/${userId}/prefixQuery", Param("q", query), Param("maxHits", maxHits))
    def getContactsByUser(userId: Id[User], page: Int, pageSize: Option[Int]) = ServiceRoute(GET, s"/internal/abook/${userId}/getContacts", Param("page", page), Param("pageSize", pageSize))

Play! fails on the other side when the original parameter in None, as it tries to deserialize the empty String as an Int.
