### PR TITLE
stop logging cache access log to ease on the log throughput.

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/logging/AccessLogEvent.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/logging/AccessLogEvent.scala
@@ -130,13 +130,14 @@ class AccessLog @Inject() (clock: Clock) {
 
   def add(e: AccessLogEvent): AccessLogEvent = {
     if (!e.eventType.ignore) {
-      future {
-        e.eventType match {
-          case Access.CACHE => //todo(eishay) create in memory stats and reporting since we kill the log
-          case _ => accessLog.info(format(e))
-        }
-
-      }(ExecutionContext.singleThread)
+      e.eventType match {
+        case Access.CACHE =>
+        //todo(eishay) create in memory stats and reporting since we kill the log
+        case _ =>
+          future {
+            accessLog.info(format(e))
+          }(ExecutionContext.singleThread)
+      }
     }
     e
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/LibraryMembershipTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/LibraryMembershipTest.scala
@@ -17,7 +17,7 @@ class LibraryMembershipTest extends Specification with ShoeboxTestInjector {
       val user1 = userRepo.save(u1)
       val user2 = userRepo.save(u2)
       val library1 = libraryRepo.save(Library(name = "Lib1", ownerId = user1.id.get, createdAt = t1.plusMinutes(2),
-         visibility = LibraryVisibility.ANYONE, slug = LibrarySlug("A")))
+        visibility = LibraryVisibility.ANYONE, slug = LibrarySlug("A")))
       val library2 = libraryRepo.save(Library(name = "Lib2", ownerId = user2.id.get, createdAt = t1.plusMinutes(5),
         visibility = LibraryVisibility.ANYONE, slug = LibrarySlug("B")))
       val lm1 = libraryMemberRepo.save(LibraryMembership(libraryId = library1.id.get, userId = user1.id.get,
@@ -44,21 +44,21 @@ class LibraryMembershipTest extends Specification with ShoeboxTestInjector {
     "invalidate cache when delete" in {
       withDb() { implicit injector =>
         val (lib1, lib2, user1, user2, lm1, lm2, lm3, lm4) = setup()
-        db.readWrite{ implicit s =>
+        db.readWrite { implicit s =>
           libraryMemberRepo.count === 4
           val libMem = libraryMemberRepo.get(lm1.id.get)
           libraryMemberRepo.delete(libMem)
         }
-        db.readWrite{ implicit s =>
+        db.readWrite { implicit s =>
           libraryMemberRepo.all.size === 3
           libraryMemberRepo.count === 3
         }
-        db.readWrite{ implicit s =>
+        db.readWrite { implicit s =>
           val t1 = new DateTime(2014, 7, 4, 21, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
           libraryMemberRepo.save(LibraryMembership(libraryId = lib1.id.get, userId = user1.id.get,
             access = LibraryAccess.READ_WRITE, createdAt = t1.plusHours(1)))
         }
-        db.readWrite{ implicit s =>
+        db.readWrite { implicit s =>
           libraryMemberRepo.count === 4
         }
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/LibraryTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/LibraryTest.scala
@@ -28,9 +28,8 @@ class LibraryTest extends Specification with ShoeboxTestInjector {
     }
   }
 
-
   "LibraryRepo" should {
-    "basically work" in {       // test read/write/save
+    "basically work" in { // test read/write/save
       withDb() { implicit injector =>
         setup()
         val all = db.readOnlyMaster(implicit session => libraryRepo.all)
@@ -43,21 +42,21 @@ class LibraryTest extends Specification with ShoeboxTestInjector {
     "invalidate cache when delete" in {
       withDb() { implicit injector =>
         val (l1, l2, l3, user1, user2) = setup()
-        db.readWrite{ implicit s =>
+        db.readWrite { implicit s =>
           libraryRepo.count === 3
           val lib = libraryRepo.get(l1.id.get)
           libraryRepo.delete(lib)
         }
-        db.readWrite{ implicit s =>
+        db.readWrite { implicit s =>
           libraryRepo.all.size === 2
           libraryRepo.count === 2
         }
-        db.readWrite{ implicit s =>
+        db.readWrite { implicit s =>
           val t1 = new DateTime(2014, 7, 4, 22, 0, 0, 0, DEFAULT_DATE_TIME_ZONE)
           libraryRepo.save(Library(name = "lib1A", ownerId = user1.id.get, createdAt = t1.plusMinutes(1),
             slug = LibrarySlug("A"), visibility = LibraryVisibility.SECRET))
         }
-        db.readWrite{ implicit s =>
+        db.readWrite { implicit s =>
           libraryRepo.count === 3
         }
       }

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
@@ -83,7 +83,7 @@ trait FortyTwoGenericTypeMappers { self: { val db: DataBaseComponent } =>
   }, { value =>
     SearchConfig(Json.parse(value).asInstanceOf[JsObject].fields.map { case (k, v) => k -> v.as[String] }.toMap)
   })
-  
+
   implicit val seqURLHistoryMapper = MappedColumnType.base[Seq[URLHistory], String]({ value =>
     Json.stringify(Json.toJson(value))
   }, { value =>


### PR DESCRIPTION
next step is to aggregate the stats in memory
