### PR TITLE
cortexuser topic plugin

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/197.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/197.sql
@@ -8,6 +8,7 @@ CREATE TABLE user_lda_interests(
   updated_at datetime NOT NULL,
   user_id bigint(20) NOT NULL,
   version tinyint(3) unsigned NOT NULL,
+  num_of_evidence int(5) unsigned NOT NULL,
   user_topic_mean blob DEFAULT NULL,
   state varchar(20) NOT NULL,
 

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/CortexGlobal.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/CortexGlobal.scala
@@ -3,7 +3,7 @@ package com.keepit.cortex
 import com.keepit.FortyTwoGlobal
 import com.keepit.common.cache.{ FortyTwoCachePlugin, InMemoryCachePlugin }
 import com.keepit.common.healthcheck.HealthcheckPlugin
-import com.keepit.cortex.models.lda.{ LDADbUpdatePlugin, DenseLDATopicWords, LDAURIFeatureUpdatePlugin }
+import com.keepit.cortex.models.lda.{ LDAUserDbUpdatePlugin, LDADbUpdatePlugin, DenseLDATopicWords, LDAURIFeatureUpdatePlugin }
 import com.keepit.cortex.models.word2vec.RichWord2VecURIFeatureUpdatePlugin
 import com.keepit.cortex.nlp.POSTagger
 import play.api.Application
@@ -27,6 +27,7 @@ trait CortexServices { self: FortyTwoGlobal =>
     require(injector.instance[FortyTwoCachePlugin] != null)
     require(injector.instance[InMemoryCachePlugin] != null)
     require(injector.instance[LDADbUpdatePlugin] != null)
+    require(injector.instance[LDAUserDbUpdatePlugin] != null)
     require(injector.instance[RichWord2VecURIFeatureUpdatePlugin] != null)
     require(injector.instance[DenseLDATopicWords] != null)
     require(injector.instance[CortexDataIngestionPlugin] != null)

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/CortexModelModule.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/CortexModelModule.scala
@@ -14,6 +14,7 @@ case class CortexProdModelModule() extends CortexModelModule with Logging {
   def configure() {
     bind[RichWord2VecURIFeatureUpdatePlugin].to[RichWord2VecURIFeatureUpdatePluginImpl].in[AppScoped]
     bind[LDADbUpdatePlugin].to[LDADbUpdatePluginImpl].in[AppScoped]
+    bind[LDAUserDbUpdatePlugin].to[LDAUserDbUpdatePluginImpl].in[AppScoped]
   }
 
   @Singleton
@@ -39,6 +40,7 @@ case class CortexDevModelModule() extends CortexModelModule {
   def configure() {
     bind[RichWord2VecURIFeatureUpdatePlugin].to[RichWord2VecURIFeatureUpdatePluginImpl].in[AppScoped]
     bind[LDADbUpdatePlugin].to[LDADbUpdatePluginImpl].in[AppScoped]
+    bind[LDAUserDbUpdatePlugin].to[LDAUserDbUpdatePluginImpl].in[AppScoped]
   }
 
   @Singleton

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/UserLDAInterests.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/UserLDAInterests.scala
@@ -15,6 +15,7 @@ case class UserLDAInterests(
     updatedAt: DateTime = currentDateTime,
     userId: Id[User],
     version: ModelVersion[DenseLDA],
+    numOfEvidence: Int, // num of keeps used to compute userTopicMean. This affects the confidence of model.
     userTopicMean: Option[UserTopicMean],
     state: State[UserLDAInterests] = UserLDAInterestsStates.ACTIVE) extends ModelWithState[UserLDAInterests] {
   def withId(id: Id[UserLDAInterests]): UserLDAInterests = copy(id = Some(id))

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/UserLDAInterestsRepo.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/UserLDAInterestsRepo.scala
@@ -31,8 +31,9 @@ class UserLDAInterestsRepoImpl @Inject() (
   class UserLDATopicTable(tag: Tag) extends RepoTable[UserLDAInterests](db, tag, "user_lda_interests") {
     def userId = column[Id[User]]("user_id")
     def version = column[ModelVersion[DenseLDA]]("version")
+    def numOfEvidence = column[Int]("num_of_evidence")
     def userTopicMean = column[UserTopicMean]("user_topic_mean", O.Nullable)
-    def * = (id.?, createdAt, updatedAt, userId, version, userTopicMean.?, state) <> ((UserLDAInterests.apply _).tupled, UserLDAInterests.unapply _)
+    def * = (id.?, createdAt, updatedAt, userId, version, numOfEvidence, userTopicMean.?, state) <> ((UserLDAInterests.apply _).tupled, UserLDAInterests.unapply _)
   }
 
   def table(tag: Tag) = new UserLDATopicTable(tag)

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDADbUpdater.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDADbUpdater.scala
@@ -34,7 +34,6 @@ class LDADbUpdatePluginImpl @Inject() (
     actor: ActorInstance[LDADbUpdaterActor],
     discovery: ServiceDiscovery,
     val scheduling: SchedulingProperties) extends BaseFeatureUpdatePlugin(actor, discovery) with LDADbUpdatePlugin {
-  override val startTime: FiniteDuration = 60 seconds
   override val updateFrequency: FiniteDuration = 1 minutes
 }
 

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/plugins/FeatureUpdatePlugin.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/plugins/FeatureUpdatePlugin.scala
@@ -2,16 +2,9 @@ package com.keepit.cortex.plugins
 
 import com.keepit.cortex.core.StatModel
 import com.keepit.cortex.store.VersionedStore
-import com.keepit.cortex.core.Versionable
 import com.keepit.cortex.core.FeatureRepresenter
-import com.keepit.cortex.core.ModelVersion
-import org.joda.time.DateTime
-import play.api.libs.json._
-import play.api.libs.functional.syntax._
-import com.keepit.cortex.store.S3CommitInfoStore
 import com.keepit.common.time._
 import com.keepit.cortex.store.CommitInfoStore
-import com.keepit.common.db.ModelWithSeqNumber
 import com.keepit.common.db.SequenceNumber
 import com.keepit.cortex.core.FeatureRepresentation
 import com.keepit.common.healthcheck.AirbrakeNotifier
@@ -24,9 +17,10 @@ import com.keepit.cortex.store.FeatureStoreSequenceNumber
 import com.keepit.cortex.store.CommitInfo
 import com.keepit.cortex.store.CommitInfoKey
 import com.keepit.common.logging.Logging
+import scala.util.Random
 
 trait FeatureUpdatePlugin[T, M <: StatModel] extends SchedulerPlugin {
-  val startTime: FiniteDuration = 30 seconds
+  val startTime: FiniteDuration = (30 + Random.nextInt(60)) seconds
   val updateFrequency: FiniteDuration = 2 minutes
   def update(): Unit
 }

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/dbmodel/UserLDATopicRepoTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/dbmodel/UserLDATopicRepoTest.scala
@@ -13,7 +13,7 @@ class UserLDATopicRepoTest extends Specification with CortexTestInjector {
       withDb() { implicit injector =>
         val userTopicRepo = inject[UserLDAInterestsRepo]
 
-        val topic = UserLDAInterests(userId = Id[User](1), version = ModelVersion[DenseLDA](1), userTopicMean = Some(UserTopicMean(Array(0.5f, 0.25f, 0.15f, 0.1f))))
+        val topic = UserLDAInterests(userId = Id[User](1), version = ModelVersion[DenseLDA](1), numOfEvidence = 100, userTopicMean = Some(UserTopicMean(Array(0.5f, 0.25f, 0.15f, 0.1f))))
         db.readWrite { implicit s =>
           userTopicRepo.save(topic)
           userTopicRepo.getByUser(Id[User](1), ModelVersion[DenseLDA](1)).get.userTopicMean.get.mean.toSeq === Seq(0.5f, 0.25f, 0.15f, 0.1f)

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDAUserDbUpdaterTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDAUserDbUpdaterTest.scala
@@ -37,7 +37,9 @@ class LDAUserDbUpdaterTest extends Specification with CortexTestInjector with LD
         userTopicUpdater.update()
 
         db.readOnlyReplica { implicit s =>
-          val arr = userTopicRepo.getByUser(Id[User](1), uriRep.version).get.userTopicMean.get.mean
+          val model = userTopicRepo.getByUser(Id[User](1), uriRep.version).get
+          model.numOfEvidence === 5
+          val arr = model.userTopicMean.get.mean
           arr.take(5).toList === Array.fill(5)(1f / 5).toList
           arr.drop(5).toList === Array.fill(uriRep.dimension - 5)(0f).toList
 
@@ -73,6 +75,8 @@ class LDAUserDbUpdaterTest extends Specification with CortexTestInjector with LD
             userTopicRepo.getTopicMeanByUser(Id[User](1), uriRep.version) === None
             userTopicRepo.getByUser(Id[User](1), uriRep.version).get.state === UserLDAInterestsStates.NOT_APPLICABLE
             commitRepo.getByModelAndVersion(StatModelName.LDA_USER, 1).get.seq === 5
+            val model = userTopicRepo.getByUser(Id[User](1), uriRep.version).get
+            model.numOfEvidence === 0
           }
         }
       }


### PR DESCRIPTION
@stkem 

I added a column to user_topic_table, to track how many keeps are used in computing the topic_mean for a user. This is different from the num of keeps the user has. This could be useful in estimating the 'confidence' of the model. 
