### PR TITLE
factor out ScraperHealthMonitor

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/dev/ShoeboxDevModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/dev/ShoeboxDevModule.scala
@@ -16,7 +16,7 @@ import com.keepit.common.analytics.DevAnalyticsModule
 import com.keepit.common.store.ShoeboxDevStoreModule
 import com.keepit.inject.CommonDevModule
 import com.keepit.common.integration.DevReaperModule
-import com.keepit.scraper.{ ProdScraperServiceClientModule, DevScrapeSchedulerModule }
+import com.keepit.scraper.{ ProdScraperServiceClientModule, DevScraperHealthMonitorModule }
 import com.keepit.common.queue.{ ProdSimpleQueueModule, DevSimpleQueueModule }
 import com.keepit.queue.DevNormalizationUpdateJobQueueModule
 import com.keepit.common.concurrent.ProdForkJoinContextMonitorModule
@@ -35,7 +35,7 @@ case class ShoeboxDevModule() extends ShoeboxModule(
   analyticsModule = DevAnalyticsModule(),
   //  topicModelModule = DevTopicModelModule(),
   domainTagImporterModule = DevDomainTagImporterModule(),
-  scrapeSchedulerModule = DevScrapeSchedulerModule(),
+  scraperHealthMonitorModule = DevScraperHealthMonitorModule(),
   fjMonitorModule = ProdForkJoinContextMonitorModule(),
   cacheModule = ShoeboxCacheModule(HashMapMemoryCacheModule()),
   externalServiceModule = DevExternalServiceModule(),

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPluginImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScrapeSchedulerPluginImpl.scala
@@ -1,112 +1,16 @@
 package com.keepit.scraper
 
-import com.keepit.common.healthcheck.{ SystemAdminMailSender, AirbrakeNotifier }
-import com.keepit.common.actor.ActorInstance
 import com.google.inject.Inject
-import com.keepit.common.logging.Logging
-import com.keepit.common.net.URI
-import com.keepit.model._
-import scala.concurrent.Future
-import akka.util.Timeout
-import scala.concurrent.duration._
-import com.keepit.common.akka.{ FortyTwoActor, UnsupportedActorMessage }
-import com.keepit.scraper.extractor.ExtractorProviderType
-import com.keepit.common.db.slick.Database
 import com.keepit.common.db.slick.DBSession.RWSession
-import com.keepit.common.time._
-import com.keepit.common.plugin.{ SchedulerPlugin, SchedulingProperties }
-import com.keepit.common.mail.{ SystemEmailAddress, ElectronicMail }
-import com.keepit.common.zookeeper.ServiceDiscovery
-import com.keepit.common.service.ServiceType
-import com.keepit.common.db.slick.Database.Replica
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.{ AirbrakeNotifier, SystemAdminMailSender }
+import com.keepit.common.logging.Logging
+import com.keepit.model._
+import com.keepit.scraper.extractor.ExtractorProviderType
 import org.joda.time.DateTime
+
+import scala.concurrent.Future
 import scala.util.Try
-
-case object CheckOverdues
-case object CheckOverdueCount
-
-private[scraper] class ScrapeScheduler @Inject() (
-    scraperConfig: ScraperSchedulerConfig,
-    airbrake: AirbrakeNotifier,
-    db: Database,
-    serviceDiscovery: ServiceDiscovery,
-    systemAdminMailSender: SystemAdminMailSender,
-    scrapeInfoRepo: ScrapeInfoRepo,
-    normalizedURIRepo: NormalizedURIRepo,
-    urlPatternRuleRepo: UrlPatternRuleRepo,
-    scraperServiceClient: ScraperServiceClient) extends FortyTwoActor(airbrake) with Logging {
-
-  def receive() = {
-    case CheckOverdues =>
-      checkOverdues()
-    case CheckOverdueCount =>
-      checkOverdueCount()
-    case m => throw new UnsupportedActorMessage(m)
-  }
-
-  implicit val config = scraperConfig
-
-  def checkOverdues(): Unit = {
-    val assignedOverdues = db.readOnlyReplica(attempts = 2) { implicit s =>
-      scrapeInfoRepo.getAssignedList(due = currentDateTime.minusMinutes(config.pendingOverdueThreshold))
-    }
-    log.info(s"[checkOverdues]: assigned-overdues=${assignedOverdues.length}")
-
-    if (!assignedOverdues.isEmpty) {
-      val workers = serviceDiscovery.serviceCluster(ServiceType.SCRAPER).allMembers
-      if (workers.isEmpty) {
-        airbrake.panic("[ScrapeScheduler] Scraper cluster is EMPTY!")
-      } else {
-        val workerIds = workers.map(_.id.id).toSet
-        log.warn(s"[checkOverdues] #assigned-overdues=${assignedOverdues.length}; active workerIds=${workerIds}; assigned-overdues=${assignedOverdues.mkString(",")}")
-        val (assigned, orphaned) = assignedOverdues partition { info => info.workerId.isDefined }
-        if (!orphaned.isEmpty) {
-          val msg = s"[checkOverdues] orphaned scraper tasks(${orphaned.length}): ${orphaned.mkString(",")}"
-          log.error(msg) // shouldn't happen -- airbrake
-          systemAdminMailSender.sendMail(ElectronicMail(from = SystemEmailAddress.ENG, to = Seq(SystemEmailAddress.RAY), category = NotificationCategory.System.SCRAPER, subject = "scraper-scheduler-orphaned", htmlBody = msg))
-          db.readWrite(attempts = 2) { implicit rw =>
-            for (info <- orphaned) {
-              scrapeInfoRepo.save(info.withState(ScrapeInfoStates.ACTIVE).withNextScrape(currentDateTime))
-            }
-          }
-        }
-
-        val (stalled, abandoned) = assigned partition { info => workerIds.contains(info.workerId.get.id) }
-        if (!abandoned.isEmpty) {
-          val msg = s"[checkOverdues] abandoned scraper tasks(${abandoned.length}): ${abandoned.mkString(",")}"
-          log.warn(msg)
-          systemAdminMailSender.sendMail(ElectronicMail(from = SystemEmailAddress.ENG, to = Seq(SystemEmailAddress.RAY), category = NotificationCategory.System.SCRAPER, subject = "scraper-scheduler-abandoned", htmlBody = msg))
-          db.readWrite(attempts = 2) { implicit rw =>
-            for (info <- abandoned) {
-              scrapeInfoRepo.save(info.withState(ScrapeInfoStates.ACTIVE).withNextScrape(currentDateTime)) // todo(ray): ask worker for status
-            }
-          }
-        }
-        if (!stalled.isEmpty) { // likely due to failed db updates
-          val msg = s"[checkOverdues] stalled scraper tasks(${stalled.length}): ${stalled.mkString(",")}"
-          log.warn(msg)
-          systemAdminMailSender.sendMail(ElectronicMail(from = SystemEmailAddress.ENG, to = Seq(SystemEmailAddress.RAY), category = NotificationCategory.System.SCRAPER, subject = "scraper-scheduler-stalled", htmlBody = msg))
-          db.readWrite(attempts = 2) { implicit rw =>
-            for (info <- stalled) {
-              scrapeInfoRepo.save(info.withState(ScrapeInfoStates.ACTIVE).withNextScrape(currentDateTime.plusMinutes(util.Random.nextInt(30)))) // todo(ray): ask worker for status
-            }
-          }
-        }
-      }
-    }
-  }
-
-  def checkOverdueCount(): Unit = {
-    val overdueCount = db.readOnlyReplica(attempts = 2) { implicit s => scrapeInfoRepo.getOverdueCount() }
-    val msg = s"[checkOverdueCount]: overdue-count=${overdueCount}"
-    if (overdueCount > config.overdueCountThreshold) {
-      log.warn(msg)
-      systemAdminMailSender.sendMail(ElectronicMail(from = SystemEmailAddress.ENG, to = Seq(SystemEmailAddress.RAY, SystemEmailAddress.MARTIN), category = NotificationCategory.System.SCRAPER, subject = "scraper-many-overdues", htmlBody = msg))
-    } else {
-      log.info(msg)
-    }
-  }
-}
 
 class ScrapeSchedulerPluginImpl @Inject() (
   db: Database,
@@ -114,21 +18,9 @@ class ScrapeSchedulerPluginImpl @Inject() (
   systemAdminMailSender: SystemAdminMailSender,
   scrapeInfoRepo: ScrapeInfoRepo,
   urlPatternRuleRepo: UrlPatternRuleRepo,
-  actor: ActorInstance[ScrapeScheduler],
   scraperConfig: ScraperSchedulerConfig,
-  scraperClient: ScraperServiceClient,
-  val scheduling: SchedulingProperties) //only on leader
-    extends ScrapeSchedulerPlugin with SchedulerPlugin with Logging {
-
-  implicit val actorTimeout = Timeout(scraperConfig.actorTimeout)
-
-  // plugin lifecycle methods
-  override def enabled: Boolean = true
-  override def onStart() {
-    log.info(s"[onStart] starting ScraperPluginImpl with scraperConfig=$scraperConfig}")
-    scheduleTaskOnLeader(actor.system, 30 seconds, scraperConfig.scrapePendingFrequency seconds, actor.ref, CheckOverdues)
-    scheduleTaskOnLeader(actor.system, 30 seconds, scraperConfig.checkOverdueCountFrequency minutes, actor.ref, CheckOverdueCount)
-  }
+  scraperClient: ScraperServiceClient) //only on leader
+    extends ScrapeSchedulerPlugin with Logging {
 
   def scheduleScrape(uri: NormalizedURI, date: DateTime)(implicit session: RWSession): Unit = {
     require(uri != null && !uri.id.isEmpty, "[scheduleScrape] <uri> cannot be null and <uri.id> cannot be empty")

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperHealthMonitor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperHealthMonitor.scala
@@ -1,0 +1,126 @@
+package com.keepit.scraper
+
+import akka.util.Timeout
+import com.google.inject.Inject
+import com.keepit.common.actor.ActorInstance
+import com.keepit.common.akka.{ UnsupportedActorMessage, FortyTwoActor }
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.{ SystemAdminMailSender, AirbrakeNotifier }
+import com.keepit.common.logging.Logging
+import com.keepit.common.mail.{ SystemEmailAddress, ElectronicMail }
+import com.keepit.common.plugin.{ SchedulerPlugin, SchedulingProperties }
+import com.keepit.common.service.ServiceType
+import com.keepit.common.time._
+import com.keepit.common.zookeeper.ServiceDiscovery
+import com.keepit.model._
+import scala.concurrent.duration._
+
+import scala.concurrent.duration.FiniteDuration
+
+case object CheckOverdues
+case object CheckOverdueCount
+
+private[scraper] class ScraperHealthMonitor @Inject() (
+    scraperConfig: ScraperSchedulerConfig,
+    airbrake: AirbrakeNotifier,
+    db: Database,
+    serviceDiscovery: ServiceDiscovery,
+    systemAdminMailSender: SystemAdminMailSender,
+    scrapeInfoRepo: ScrapeInfoRepo,
+    normalizedURIRepo: NormalizedURIRepo,
+    urlPatternRuleRepo: UrlPatternRuleRepo,
+    scraperServiceClient: ScraperServiceClient) extends FortyTwoActor(airbrake) with Logging {
+
+  def receive() = {
+    case CheckOverdues =>
+      checkOverdues()
+    case CheckOverdueCount =>
+      checkOverdueCount()
+    case m => throw new UnsupportedActorMessage(m)
+  }
+
+  implicit val config = scraperConfig
+
+  def checkOverdues(): Unit = {
+    val assignedOverdues = db.readOnlyReplica(attempts = 2) { implicit s =>
+      scrapeInfoRepo.getAssignedList(due = currentDateTime.minusMinutes(config.pendingOverdueThreshold))
+    }
+    log.info(s"[checkOverdues]: assigned-overdues=${assignedOverdues.length}")
+
+    if (!assignedOverdues.isEmpty) {
+      val workers = serviceDiscovery.serviceCluster(ServiceType.SCRAPER).allMembers
+      if (workers.isEmpty) {
+        airbrake.panic("[ScrapeScheduler] Scraper cluster is EMPTY!")
+      } else {
+        val workerIds = workers.map(_.id.id).toSet
+        log.warn(s"[checkOverdues] #assigned-overdues=${assignedOverdues.length}; active workerIds=${workerIds}; assigned-overdues=${assignedOverdues.mkString(",")}")
+        val (assigned, orphaned) = assignedOverdues partition { info => info.workerId.isDefined }
+        if (!orphaned.isEmpty) {
+          val msg = s"[checkOverdues] orphaned scraper tasks(${orphaned.length}): ${orphaned.mkString(",")}"
+          log.error(msg) // shouldn't happen -- airbrake
+          systemAdminMailSender.sendMail(ElectronicMail(from = SystemEmailAddress.ENG, to = Seq(SystemEmailAddress.RAY), category = NotificationCategory.System.SCRAPER, subject = "scraper-scheduler-orphaned", htmlBody = msg))
+          db.readWrite(attempts = 2) { implicit rw =>
+            for (info <- orphaned) {
+              scrapeInfoRepo.save(info.withState(ScrapeInfoStates.ACTIVE).withNextScrape(currentDateTime))
+            }
+          }
+        }
+
+        val (stalled, abandoned) = assigned partition { info => workerIds.contains(info.workerId.get.id) }
+        if (!abandoned.isEmpty) {
+          val msg = s"[checkOverdues] abandoned scraper tasks(${abandoned.length}): ${abandoned.mkString(",")}"
+          log.warn(msg)
+          systemAdminMailSender.sendMail(ElectronicMail(from = SystemEmailAddress.ENG, to = Seq(SystemEmailAddress.RAY), category = NotificationCategory.System.SCRAPER, subject = "scraper-scheduler-abandoned", htmlBody = msg))
+          db.readWrite(attempts = 2) { implicit rw =>
+            for (info <- abandoned) {
+              scrapeInfoRepo.save(info.withState(ScrapeInfoStates.ACTIVE).withNextScrape(currentDateTime)) // todo(ray): ask worker for status
+            }
+          }
+        }
+        if (!stalled.isEmpty) { // likely due to failed db updates
+          val msg = s"[checkOverdues] stalled scraper tasks(${stalled.length}): ${stalled.mkString(",")}"
+          log.warn(msg)
+          systemAdminMailSender.sendMail(ElectronicMail(from = SystemEmailAddress.ENG, to = Seq(SystemEmailAddress.RAY), category = NotificationCategory.System.SCRAPER, subject = "scraper-scheduler-stalled", htmlBody = msg))
+          db.readWrite(attempts = 2) { implicit rw =>
+            for (info <- stalled) {
+              scrapeInfoRepo.save(info.withState(ScrapeInfoStates.ACTIVE).withNextScrape(currentDateTime.plusMinutes(util.Random.nextInt(30)))) // todo(ray): ask worker for status
+            }
+          }
+        }
+      }
+    }
+  }
+
+  def checkOverdueCount(): Unit = {
+    val overdueCount = db.readOnlyReplica(attempts = 2) { implicit s => scrapeInfoRepo.getOverdueCount() }
+    val msg = s"[checkOverdueCount]: overdue-count=${overdueCount}"
+    if (overdueCount > config.overdueCountThreshold) {
+      log.warn(msg)
+      systemAdminMailSender.sendMail(ElectronicMail(from = SystemEmailAddress.ENG, to = Seq(SystemEmailAddress.RAY, SystemEmailAddress.MARTIN), category = NotificationCategory.System.SCRAPER, subject = "scraper-many-overdues", htmlBody = msg))
+    } else {
+      log.info(msg)
+    }
+  }
+}
+
+trait ScraperHealthMonitorPlugin extends SchedulerPlugin
+
+class ScraperHealthMonitorPluginImpl @Inject() (
+    val actor: ActorInstance[ScraperHealthMonitor],
+    scraperConfig: ScraperSchedulerConfig,
+    val scheduling: SchedulingProperties) extends ScraperHealthMonitorPlugin {
+
+  val name: String = getClass.toString
+
+  implicit val actorTimeout = Timeout(5 seconds)
+
+  override def enabled: Boolean = true
+
+  val interval: FiniteDuration = 5 seconds
+
+  override def onStart() {
+    log.info(s"[onStart] starting ScraperHealthMonitorPlugin with scraperConfig=$scraperConfig}")
+    scheduleTaskOnLeader(actor.system, 30 seconds, scraperConfig.scrapePendingFrequency seconds, actor.ref, CheckOverdues)
+    scheduleTaskOnLeader(actor.system, 30 seconds, scraperConfig.checkOverdueCountFrequency minutes, actor.ref, CheckOverdueCount)
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperHealthMonitorModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/scraper/ScraperHealthMonitorModule.scala
@@ -6,20 +6,22 @@ import com.google.inject.{ Provides, Singleton }
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import play.api.{ Play, Configuration }
 
-trait ScrapeSchedulerModule extends ScalaModule
+trait ScraperHealthMonitorModule extends ScalaModule
 
-case class ProdScrapeSchedulerModule() extends ScrapeSchedulerModule {
+case class ProdScraperHealthMonitorModule() extends ScraperHealthMonitorModule {
 
   def configure {
+    bind[ScraperHealthMonitorPlugin].to[ScraperHealthMonitorPluginImpl].in[AppScoped]
     bind[ScrapeSchedulerPlugin].to[ScrapeSchedulerPluginImpl].in[AppScoped]
     install(ProdScrapeSchedulerConfigModule())
   }
 
 }
 
-case class DevScrapeSchedulerModule() extends ScrapeSchedulerModule {
+case class DevScraperHealthMonitorModule() extends ScraperHealthMonitorModule {
 
   def configure {
+    bind[ScraperHealthMonitorPlugin].to[ScraperHealthMonitorPluginImpl].in[AppScoped]
     bind[ScrapeSchedulerPlugin].to[ScrapeSchedulerPluginImpl].in[AppScoped]
     install(ProdScrapeSchedulerConfigModule())
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxModule.scala
@@ -6,7 +6,7 @@ import com.keepit.social.SecureSocialModule
 import com.keepit.common.mail.MailModule
 import com.keepit.common.analytics.AnalyticsModule
 import com.keepit.model.ProdSliderHistoryTrackerModule
-import com.keepit.scraper.{ ScraperServiceClientModule, ScrapeSchedulerModule, ProdScraperServiceClientModule }
+import com.keepit.scraper.{ ScraperServiceClientModule, ScraperHealthMonitorModule, ProdScraperServiceClientModule }
 import com.keepit.classify.DomainTagImporterModule
 import com.keepit.common.store.ShoeboxDevStoreModule
 import com.keepit.inject.{ CommonServiceModule, ConfigurationModule }
@@ -38,7 +38,7 @@ abstract class ShoeboxModule(
     val analyticsModule: AnalyticsModule,
     val domainTagImporterModule: DomainTagImporterModule,
     val cacheModule: ShoeboxCacheModule,
-    val scrapeSchedulerModule: ScrapeSchedulerModule,
+    val scraperHealthMonitorModule: ScraperHealthMonitorModule,
     val fjMonitorModule: ForkJoinContextMonitorModule,
     val externalServiceModule: ExternalServiceModule,
     val rekeepStatsUpdaterModule: ReKeepStatsUpdaterModule) extends ConfigurationModule with CommonServiceModule {

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxProdModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxProdModule.scala
@@ -14,7 +14,7 @@ import com.keepit.common.store.ShoeboxDevStoreModule
 import com.keepit.classify.ProdDomainTagImporterModule
 import com.keepit.inject.CommonProdModule
 import com.keepit.common.integration.ProdReaperModule
-import com.keepit.scraper.{ ProdScraperServiceClientModule, ProdScrapeSchedulerModule }
+import com.keepit.scraper.{ ProdScraperServiceClientModule, ProdScraperHealthMonitorModule }
 import com.keepit.common.zookeeper.{ DiscoveryModule, ProdDiscoveryModule }
 import com.keepit.common.service.ServiceType
 import com.keepit.common.queue.ProdSimpleQueueModule
@@ -35,7 +35,7 @@ case class ShoeboxProdModule() extends ShoeboxModule(
   analyticsModule = ProdAnalyticsModule(),
   //topicModelModule = LdaTopicModelModule(), //disable for now
   domainTagImporterModule = ProdDomainTagImporterModule(),
-  scrapeSchedulerModule = ProdScrapeSchedulerModule(),
+  scraperHealthMonitorModule = ProdScraperHealthMonitorModule(),
   fjMonitorModule = ProdForkJoinContextMonitorModule(),
   cacheModule = ShoeboxCacheModule(MemcachedCacheModule(), EhCacheCacheModule()),
   externalServiceModule = ProdExternalServiceModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
@@ -6,7 +6,7 @@ import com.keepit.model._
 import com.keepit.heimdal.HeimdalContext
 import org.joda.time.DateTime
 import com.keepit.common.time._
-import com.keepit.scraper.FakeScrapeSchedulerModule
+import com.keepit.scraper.FakeScraperHealthMonitorModule
 import play.api.libs.json.Json
 import scala.Some
 import com.keepit.model.KeepToCollection
@@ -19,7 +19,7 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
 
   implicit val context = HeimdalContext.empty
 
-  def modules = FakeScrapeSchedulerModule() :: FakeSearchServiceClientModule() :: Nil
+  def modules = FakeScraperHealthMonitorModule() :: FakeSearchServiceClientModule() :: Nil
 
   def prenormalize(url: String)(implicit injector: Injector): String = inject[NormalizationService].prenormalize(url).get
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
@@ -8,7 +8,7 @@ import org.specs2.mutable.Specification
 import com.keepit.model._
 import play.api.libs.json.Json
 import com.keepit.common.healthcheck._
-import com.keepit.scraper.FakeScrapeSchedulerModule
+import com.keepit.scraper.FakeScraperHealthMonitorModule
 import com.keepit.heimdal.{ KifiHitContext, SanitizedKifiHit, HeimdalContext }
 import com.keepit.shoebox.{ FakeKeepImportsModule, KeepImportsModule }
 import com.keepit.common.actor.{ StandaloneTestActorSystemModule, TestActorSystemModule }
@@ -29,7 +29,7 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
   implicit val system = ActorSystem("test")
   implicit val execCtx = fj
 
-  def modules: Seq[ScalaModule] = Seq(FakeKeepImportsModule(), FakeScrapeSchedulerModule())
+  def modules: Seq[ScalaModule] = Seq(FakeKeepImportsModule(), FakeScraperHealthMonitorModule())
 
   val keep42 = Json.obj("url" -> "http://42go.com", "isPrivate" -> false)
   val keepKifi = Json.obj("url" -> "http://kifi.com", "isPrivate" -> false)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepsCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepsCommanderTest.scala
@@ -8,7 +8,7 @@ import com.keepit.common.time._
 import com.keepit.controllers.website.KeepsController
 import com.keepit.cortex.FakeCortexServiceClientModule
 import com.keepit.model._
-import com.keepit.scraper.FakeScrapeSchedulerModule
+import com.keepit.scraper.FakeScraperHealthMonitorModule
 import com.keepit.search.FakeSearchServiceClientModule
 import com.keepit.test.ShoeboxTestInjector
 import org.joda.time.DateTime
@@ -26,7 +26,7 @@ class KeepsCommanderTest extends Specification with ShoeboxTestInjector {
     FakeExternalServiceModule() ::
     FakeSearchServiceClientModule() ::
     FakeCortexServiceClientModule() ::
-    FakeScrapeSchedulerModule() ::
+    FakeScraperHealthMonitorModule() ::
     FakeShoeboxServiceModule() ::
     FakeActionAuthenticatorModule() ::
     Nil

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -5,7 +5,7 @@ import com.keepit.common.crypto.TestCryptoModule
 import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.time._
 import com.keepit.model._
-import com.keepit.scraper.FakeScrapeSchedulerModule
+import com.keepit.scraper.FakeScraperHealthMonitorModule
 import com.keepit.search.FakeSearchServiceClientModule
 import com.keepit.test.ShoeboxTestInjector
 import org.joda.time.DateTime
@@ -13,7 +13,7 @@ import org.specs2.mutable.Specification
 
 class LibraryCommanderTest extends Specification with ShoeboxTestInjector {
 
-  def modules = FakeScrapeSchedulerModule() :: FakeSearchServiceClientModule() :: Nil
+  def modules = FakeScraperHealthMonitorModule() :: FakeSearchServiceClientModule() :: Nil
 
   def setup()(implicit injector: Injector) = {
     val t1 = new DateTime(2014, 7, 4, 12, 0, 0, 0, DEFAULT_DATE_TIME_ZONE)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/RawKeepImporterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/RawKeepImporterTest.scala
@@ -8,7 +8,7 @@ import com.keepit.model.{ RawKeepFactory, KeepSource, User }
 import play.api.libs.json.Json
 import akka.testkit.{ TestActorRef, TestKit }
 import play.api.test.Helpers._
-import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ FakeScraperHealthMonitorModule, TestScraperServiceClientModule }
 import com.keepit.shoebox.{ TestShoeboxServiceClientModule, KeepImportsModule, FakeKeepImportsModule }
 import com.keepit.common.actor.{ ActorBuilder, TestActorSystemModule }
 import com.keepit.search.TestSearchServiceClientModule
@@ -28,7 +28,7 @@ class RawKeepImporterTest extends TestKit(ActorSystem()) with SpecificationLike 
     TestSearchServiceClientModule(),
     TestShoeboxServiceClientModule(),
     FakeHttpClientModule(),
-    FakeScrapeSchedulerModule(),
+    FakeScraperHealthMonitorModule(),
     ShoeboxFakeStoreModule(),
     FakeExternalServiceModule(),
     FakeCortexServiceClientModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/UserCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/UserCommanderTest.scala
@@ -8,7 +8,7 @@ import com.keepit.common.mail.{ EmailAddress, FakeMailModule, FakeOutbox }
 import com.keepit.abook.TestABookServiceClientModule
 import com.keepit.common.social.FakeSocialGraphModule
 import com.keepit.search.FakeSearchServiceClientModule
-import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScraperHealthMonitorModule }
 import com.keepit.common.store.ShoeboxFakeStoreModule
 
 import play.api.test.Helpers.running
@@ -56,7 +56,7 @@ class UserCommanderTest extends Specification with ShoeboxApplicationInjector {
     TestABookServiceClientModule(),
     FakeSocialGraphModule(),
     FakeSearchServiceClientModule(),
-    FakeScrapeSchedulerModule(),
+    FakeScraperHealthMonitorModule(),
     ShoeboxFakeStoreModule(),
     FakeExternalServiceModule(),
     FakeCortexServiceClientModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/store/ImageDataIntegrityPluginTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/store/ImageDataIntegrityPluginTest.scala
@@ -17,7 +17,7 @@ import com.keepit.common.social.{ FakeSocialGraphModule, FakeShoeboxSecureSocial
 import com.keepit.common.healthcheck.{ FakeAirbrakeModule, FakeAirbrakeNotifier }
 import com.keepit.heimdal.TestHeimdalServiceClientModule
 import com.keepit.search.TestSearchServiceClientModule
-import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScraperHealthMonitorModule }
 import com.keepit.common.external.FakeExternalServiceModule
 import com.keepit.cortex.FakeCortexServiceClientModule
 
@@ -36,7 +36,7 @@ class ImageDataIntegrityPluginTest extends TestKit(ActorSystem()) with Specifica
       running(new ShoeboxApplication(
         FakeAirbrakeModule(),
         TestSearchServiceClientModule(),
-        FakeScrapeSchedulerModule(),
+        FakeScraperHealthMonitorModule(),
         imageDataIntegrityTestPluginModule,
         TestActorSystemModule(Some(system)),
         FakeShoeboxSecureSocialModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminAuthControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminAuthControllerTest.scala
@@ -15,7 +15,7 @@ import securesocial.core._
 import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.common.store.ShoeboxFakeStoreModule
 import com.keepit.shoebox.FakeShoeboxServiceModule
-import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScraperHealthMonitorModule }
 import com.keepit.common.actor.TestActorSystemModule
 import com.keepit.common.healthcheck.FakeAirbrakeModule
 import com.keepit.search.FakeSearchServiceClientModule
@@ -27,7 +27,7 @@ import com.keepit.cortex.FakeCortexServiceClientModule
 class AdminAuthControllerTest extends Specification with ShoeboxApplicationInjector {
 
   val modules = Seq(FakeShoeboxServiceModule(),
-    FakeScrapeSchedulerModule(),
+    FakeScraperHealthMonitorModule(),
     ShoeboxFakeStoreModule(),
     TestActorSystemModule(),
     FakeAirbrakeModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminDashboardControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminDashboardControllerTest.scala
@@ -22,7 +22,7 @@ import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.common.store.ShoeboxFakeStoreModule
 import com.keepit.common.healthcheck.FakeAirbrakeModule
 import com.keepit.search.TestSearchServiceClientModule
-import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScraperHealthMonitorModule }
 import com.keepit.common.external.FakeExternalServiceModule
 import com.keepit.cortex.FakeCortexServiceClientModule
 
@@ -30,7 +30,7 @@ class AdminDashboardControllerTest extends Specification with ShoeboxApplication
 
   def requiredModules = Seq(
     TestSearchServiceClientModule(),
-    FakeScrapeSchedulerModule(),
+    FakeScraperHealthMonitorModule(),
     ProdShoeboxSecureSocialModule(),
     FakeHttpClientModule(),
     ShoeboxFakeStoreModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/api/DeskControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/api/DeskControllerTest.scala
@@ -8,7 +8,7 @@ import com.keepit.common.controller.FakeActionAuthenticator
 import com.keepit.model._
 import play.api.test.Helpers._
 import com.keepit.heimdal.TestHeimdalServiceClientModule
-import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScraperHealthMonitorModule }
 import com.keepit.common.net.FakeHttpClientModule
 import play.api.libs.json.JsString
 import com.keepit.common.social.FakeShoeboxSecureSocialModule
@@ -25,7 +25,7 @@ class DeskControllerTest extends Specification with ShoeboxApplicationInjector {
 
   def requiredModules = Seq(
     TestSearchServiceClientModule(),
-    FakeScrapeSchedulerModule(),
+    FakeScraperHealthMonitorModule(),
     FakeShoeboxSecureSocialModule(),
     ShoeboxFakeStoreModule(),
     FakeHttpClientModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtAuthControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtAuthControllerTest.scala
@@ -25,7 +25,7 @@ import com.keepit.common.store.ShoeboxFakeStoreModule
 import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.common.mail.TestMailModule
 import com.keepit.search.TestSearchServiceClientModule
-import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScraperHealthMonitorModule }
 import com.keepit.common.external.FakeExternalServiceModule
 import com.keepit.cortex.FakeCortexServiceClientModule
 
@@ -33,7 +33,7 @@ class ExtAuthControllerTest extends Specification with ShoeboxApplicationInjecto
 
   def requiredModules = Seq(
     TestSearchServiceClientModule(),
-    FakeScrapeSchedulerModule(),
+    FakeScraperHealthMonitorModule(),
     FakeShoeboxSecureSocialModule(),
     ShoeboxFakeStoreModule(),
     FakeHttpClientModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtKeepsControllerTest.scala
@@ -4,7 +4,7 @@ import org.specs2.mutable.Specification
 
 import com.keepit.normalizer._
 import com.keepit.heimdal.TestHeimdalServiceClientModule
-import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ FakeScraperHealthMonitorModule, TestScraperServiceClientModule }
 import com.keepit.common.controller._
 import com.keepit.search._
 import com.keepit.common.time._
@@ -31,7 +31,7 @@ class ExtKeepsControllerTest extends Specification with ApplicationInjector {
 
   val controllerTestModules = Seq(
     FakeShoeboxServiceModule(),
-    FakeScrapeSchedulerModule(),
+    FakeScraperHealthMonitorModule(),
     ShoeboxFakeStoreModule(),
     TestActorSystemModule(),
     FakeAirbrakeModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileAuthControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileAuthControllerTest.scala
@@ -14,7 +14,7 @@ import play.api.test._
 import play.api.test.Helpers._
 import com.keepit.heimdal.TestHeimdalServiceClientModule
 import com.keepit.common.healthcheck.FakeAirbrakeModule
-import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScraperHealthMonitorModule }
 import com.keepit.common.actor.TestActorSystemModule
 import com.keepit.shoebox.FakeShoeboxServiceModule
 import com.keepit.search.FakeSearchServiceClientModule
@@ -30,7 +30,7 @@ class MobileAuthControllerTest extends Specification with ApplicationInjector {
 
   val controllerTestModules = Seq(
     FakeShoeboxServiceModule(),
-    FakeScrapeSchedulerModule(),
+    FakeScraperHealthMonitorModule(),
     ShoeboxFakeStoreModule(),
     TestActorSystemModule(),
     FakeAirbrakeModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -4,7 +4,7 @@ import org.specs2.mutable.Specification
 import net.codingwell.scalaguice.ScalaModule
 import com.keepit.normalizer._
 import com.keepit.heimdal.{ KifiHitContext, SanitizedKifiHit, HeimdalContext, TestHeimdalServiceClientModule }
-import com.keepit.scraper.FakeScrapeSchedulerModule
+import com.keepit.scraper._
 import com.keepit.commanders.KeepInfo._
 import com.keepit.commanders.KeepInfosWithCollection._
 import com.keepit.commanders._
@@ -42,7 +42,6 @@ import org.joda.time.DateTime
 import com.google.inject.Injector
 import com.keepit.common.db.slick.DBSession.RSession
 import com.keepit.common.external.FakeExternalServiceModule
-import com.keepit.scraper.TestScraperServiceClientModule
 import com.keepit.cortex.FakeCortexServiceClientModule
 import com.keepit.controllers.website.KeepsController
 import scala.concurrent.Await
@@ -56,8 +55,6 @@ import com.keepit.common.actor.TestActorSystemModule
 import com.keepit.model.KeepToCollection
 import com.keepit.shoebox.FakeShoeboxServiceModule
 import com.keepit.heimdal.TestHeimdalServiceClientModule
-import com.keepit.scraper.FakeScrapeSchedulerModule
-import com.keepit.scraper.TestScraperServiceClientModule
 import com.keepit.common.external.FakeExternalServiceModule
 import com.keepit.cortex.FakeCortexServiceClientModule
 import com.keepit.search.FakeSearchServiceClientModule
@@ -69,7 +66,7 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
 
   val controllerTestModules = Seq(
     FakeShoeboxServiceModule(),
-    FakeScrapeSchedulerModule(),
+    FakeScraperHealthMonitorModule(),
     ShoeboxFakeStoreModule(),
     TestActorSystemModule(),
     FakeAirbrakeModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserControllerTest.scala
@@ -32,7 +32,7 @@ import com.keepit.abook.TestABookServiceClientModule
 import com.keepit.shoebox.FakeShoeboxServiceModule
 import com.keepit.search.TestSearchServiceClientModule
 import com.keepit.common.store.ShoeboxFakeStoreModule
-import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScraperHealthMonitorModule }
 import com.keepit.cortex.FakeCortexServiceClientModule
 import com.keepit.common.external.FakeExternalServiceModule
 
@@ -40,7 +40,7 @@ class MobileUserControllerTest extends Specification with ShoeboxApplicationInje
 
   val mobileControllerTestModules = Seq(
     FakeShoeboxServiceModule(),
-    FakeScrapeSchedulerModule(),
+    FakeScraperHealthMonitorModule(),
     FakeMailModule(),
     FakeHttpClientModule(),
     TestAnalyticsModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/shoebox/ShoeboxControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/shoebox/ShoeboxControllerTest.scala
@@ -23,7 +23,7 @@ import com.keepit.common.actor.TestActorSystemModule
 import com.keepit.common.healthcheck.FakeAirbrakeModule
 import scala.concurrent.ExecutionContext.Implicits.global
 import com.keepit.abook.TestABookServiceClientModule
-import com.keepit.scraper.{ TestScrapeSchedulerConfigModule, TestScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ TestScrapeSchedulerConfigModule, TestScraperServiceClientModule, FakeScraperHealthMonitorModule }
 import com.keepit.common.db.SequenceNumber
 import com.keepit.common.external.FakeExternalServiceModule
 import com.keepit.cortex.FakeCortexServiceClientModule
@@ -44,7 +44,7 @@ class ShoeboxControllerTest extends Specification with ShoeboxApplicationInjecto
     FakeShoeboxSecureSocialModule(),
     TestABookServiceClientModule(),
     FakeSocialGraphModule(),
-    FakeScrapeSchedulerModule(),
+    FakeScraperHealthMonitorModule(),
     FakeExternalServiceModule(),
     FakeCortexServiceClientModule(),
     TestScraperServiceClientModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
@@ -3,7 +3,7 @@ package com.keepit.controllers.website
 import org.specs2.mutable.Specification
 import net.codingwell.scalaguice.ScalaModule
 import com.keepit.heimdal.{ HeimdalContext, KifiHitContext, SanitizedKifiHit, TestHeimdalServiceClientModule }
-import com.keepit.scraper.FakeScrapeSchedulerModule
+import com.keepit.scraper.{ FakeScraperHealthMonitorModule, TestScraperServiceClientModule }
 import com.keepit.commanders.KeepInfo._
 import com.keepit.commanders.KeepInfosWithCollection._
 import com.keepit.commanders._
@@ -41,14 +41,13 @@ import com.keepit.common.healthcheck.FakeAirbrakeModule
 import scala.concurrent.ExecutionContext.Implicits.global
 import com.keepit.social.{ SocialNetworkType, SocialId, SocialNetworks }
 import com.keepit.common.external.FakeExternalServiceModule
-import com.keepit.scraper.TestScraperServiceClientModule
 import com.keepit.cortex.FakeCortexServiceClientModule
 
 class KeepsControllerTest extends Specification with ApplicationInjector {
 
   val controllerTestModules = Seq(
     FakeShoeboxServiceModule(),
-    FakeScrapeSchedulerModule(),
+    FakeScraperHealthMonitorModule(),
     ShoeboxFakeStoreModule(),
     TestActorSystemModule(),
     FakeAirbrakeModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserControllerTest.scala
@@ -21,7 +21,7 @@ import com.keepit.common.mail.TestMailModule
 import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.common.social.{ FakeShoeboxSecureSocialModule, FakeSocialGraphModule }
 import com.keepit.search.TestSearchServiceClientModule
-import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ TestScraperServiceClientModule, FakeScraperHealthMonitorModule }
 
 import com.keepit.common.external.FakeExternalServiceModule
 import com.keepit.cortex.FakeCortexServiceClientModule
@@ -31,7 +31,7 @@ class UserControllerTest extends Specification with ApplicationInjector {
   val controllerTestModules = Seq(
     FakeShoeboxServiceModule(),
     TestSearchServiceClientModule(),
-    FakeScrapeSchedulerModule(),
+    FakeScraperHealthMonitorModule(),
     ShoeboxFakeStoreModule(),
     TestActorSystemModule(),
     FakeAirbrakeModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/OrphanCleanerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/OrphanCleanerTest.scala
@@ -8,14 +8,14 @@ import com.keepit.common.actor.{ ActorPlugin, TestActorSystemModule }
 import com.keepit.model._
 import com.keepit.common.db.slick.Database
 import com.keepit.common.db.Id
-import com.keepit.scraper.{ TestScraperServiceClientModule, ProdScrapeSchedulerModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ ProdScraperHealthMonitorModule, TestScraperServiceClientModule }
 import com.keepit.common.healthcheck.FakeAirbrakeModule
 import com.keepit.shoebox.{ ShoeboxSlickModule, FakeShoeboxServiceModule }
 import com.google.inject.Module
 
 class OrphanCleanerTest extends Specification with ShoeboxApplicationInjector {
 
-  val modules: Seq[Module] = Seq(TestActorSystemModule(), ProdScrapeSchedulerModule(), TestScraperServiceClientModule(), FakeShoeboxServiceModule(), FakeAirbrakeModule(), ShoeboxSlickModule())
+  val modules: Seq[Module] = Seq(TestActorSystemModule(), ProdScraperHealthMonitorModule(), TestScraperServiceClientModule(), FakeShoeboxServiceModule(), FakeAirbrakeModule(), ShoeboxSlickModule())
 
   "OphanCleaner" should {
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
@@ -10,7 +10,7 @@ import com.google.inject.Injector
 import com.keepit.model._
 import com.keepit.common.db.slick.Database
 import com.keepit.common.db.{ SequenceNumber, Id }
-import com.keepit.scraper.FakeScrapeSchedulerModule
+import com.keepit.scraper.FakeScraperHealthMonitorModule
 import com.keepit.common.zookeeper.CentralConfig
 import com.keepit.common.healthcheck.FakeAirbrakeModule
 
@@ -18,7 +18,7 @@ class UriIntegrityPluginTest extends Specification with ShoeboxApplicationInject
 
   "uri integrity plugin" should {
     "work" in {
-      running(new ShoeboxApplication(TestActorSystemModule(), FakeScrapeSchedulerModule(), FakeAirbrakeModule())) {
+      running(new ShoeboxApplication(TestActorSystemModule(), FakeScraperHealthMonitorModule(), FakeAirbrakeModule())) {
         val db = inject[Database]
         val urlRepo = inject[URLRepo]
         val uriRepo = inject[NormalizedURIRepo]
@@ -107,7 +107,7 @@ class UriIntegrityPluginTest extends Specification with ShoeboxApplicationInject
 
     "handle collections correctly when migrating bookmarks" in {
 
-      running(new ShoeboxApplication(TestActorSystemModule(), FakeScrapeSchedulerModule(), FakeAirbrakeModule())) {
+      running(new ShoeboxApplication(TestActorSystemModule(), FakeScraperHealthMonitorModule(), FakeAirbrakeModule())) {
         val db = inject[Database]
         val urlRepo = inject[URLRepo]
         val uriRepo = inject[NormalizedURIRepo]

--- a/kifi-backend/modules/shoebox/test/com/keepit/normalizer/NormalizationServiceTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/normalizer/NormalizationServiceTest.scala
@@ -54,7 +54,7 @@ class NormalizationServiceTest extends TestKitScope with SpecificationLike with 
   val modules = Seq(
     TestFortyTwoModule(),
     FakeDiscoveryModule(),
-    FakeScrapeSchedulerModule(Some(fakeArticles)),
+    FakeScraperHealthMonitorModule(Some(fakeArticles)),
     FakeAirbrakeModule(),
     StandaloneTestActorSystemModule(),
     FakeElizaServiceClientModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/scraper/DuplicateDocumentDetectionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/scraper/DuplicateDocumentDetectionTest.scala
@@ -14,7 +14,7 @@ class DuplicateDocumentDetectionTest extends Specification with ShoeboxTestInjec
   "Signature" should {
 
     "find similar documents of different thresholds" in {
-      withDb(TestMailModule(), FakeScrapeSchedulerModule()) { implicit injector: Injector =>
+      withDb(TestMailModule(), FakeScraperHealthMonitorModule()) { implicit injector: Injector =>
 
         val builder1 = new FakeSignatureBuilder(3)
         val builder2 = new FakeSignatureBuilder(3)

--- a/kifi-backend/modules/shoebox/test/com/keepit/scraper/FakeScraperHealthMonitorModule.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/scraper/FakeScraperHealthMonitorModule.scala
@@ -1,5 +1,7 @@
 package com.keepit.scraper
 
+import com.keepit.common.plugin.SchedulingProperties
+
 import scala.concurrent._
 import com.keepit.model.NormalizedURI
 import com.google.inject.{ Provides, Singleton }
@@ -8,15 +10,21 @@ import com.keepit.common.db.slick.DBSession.RWSession
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import org.joda.time.DateTime
 
-case class FakeScrapeSchedulerModule(fakeArticles: Option[PartialFunction[(String, Option[ExtractorProviderType]), BasicArticle]] = None) extends ScrapeSchedulerModule {
+case class FakeScraperHealthMonitorModule(fakeArticles: Option[PartialFunction[(String, Option[ExtractorProviderType]), BasicArticle]] = None) extends ScraperHealthMonitorModule {
   override def configure() {}
 
   @Provides @Singleton
-  def fakeScraperPlugin(): ScrapeSchedulerPlugin = new FakeScrapeSchedulerPlugin(fakeArticles)
+  def fakeScraperPlugin(): ScrapeSchedulerPlugin = new FakeScraperHealthMonitorPlugin(fakeArticles)
+
+  def fakeScraperHealthMonitorPlugin(): ScraperHealthMonitorPlugin = new ScraperHealthMonitorPlugin {
+    def scheduling = new SchedulingProperties {
+      def enabledOnlyForLeader = false
+      def enabled = false
+    }
+  }
 }
 
-class FakeScrapeSchedulerPlugin(fakeArticles: Option[PartialFunction[(String, Option[ExtractorProviderType]), BasicArticle]]) extends ScrapeSchedulerPlugin {
-  def scrapePending() = Future.successful(Seq())
+class FakeScraperHealthMonitorPlugin(fakeArticles: Option[PartialFunction[(String, Option[ExtractorProviderType]), BasicArticle]]) extends ScrapeSchedulerPlugin {
   def scheduleScrape(uri: NormalizedURI, date: DateTime)(implicit session: RWSession): Unit = {}
   def scrapeBasicArticle(url: String, extractorProviderType: Option[ExtractorProviderType] = None): Future[Option[BasicArticle]] = Future.successful(fakeArticles.map(_.apply((url, extractorProviderType))))
   def getSignature(url: String, extractorProviderType: Option[ExtractorProviderType] = None): Future[Option[Signature]] = scrapeBasicArticle(url, extractorProviderType).map(_.map(_.signature))

--- a/kifi-backend/modules/shoebox/test/com/keepit/shoebox/ShoeboxModuleTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/shoebox/ShoeboxModuleTest.scala
@@ -25,7 +25,7 @@ import com.keepit.common.analytics.TestAnalyticsModule
 import com.keepit.model.TestSliderHistoryTrackerModule
 import com.keepit.classify.FakeDomainTagImporterModule
 import com.keepit.eliza.FakeElizaServiceClientModule
-import com.keepit.scraper.{ TestScrapeSchedulerConfigModule, TestScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.scraper.{ TestScrapeSchedulerConfigModule, TestScraperServiceClientModule, FakeScraperHealthMonitorModule }
 import com.keepit.common.healthcheck.FakeAirbrakeModule
 import com.keepit.heimdal.TestHeimdalServiceClientModule
 import com.keepit.abook.TestABookServiceClientModule
@@ -65,7 +65,7 @@ class ShoeboxModuleTest extends Specification with Logging with ShoeboxApplicati
         TestGraphServiceClientModule(),
         GeckoboardModule(),
         FakeShoeboxServiceModule(), // This one should not be required once the Scraper is off Shoebox
-        FakeScrapeSchedulerModule(), // This one should not be required once the Scraper is off Shoebox
+        FakeScraperHealthMonitorModule(),
         TestScrapeSchedulerConfigModule(),
         FakeElizaServiceClientModule(),
         FakeAirbrakeModule(),


### PR DESCRIPTION
As most of Scraper has been moved out of Shoebox, and it's pull-based. For whatever is left, ScraperHealthMonitor is a much more accurate description at this point; I may in fact consider removing the ScrapeScheduler all together in the future

@ymatsuda @eishay @yingjieMiao @martinraison 
