### PR TITLE
Using PublicIdConfiguration to house static lazy AES cipher instance.

### DIFF
--- a/kifi-backend/project/Build.scala
+++ b/kifi-backend/project/Build.scala
@@ -226,7 +226,6 @@ object ApplicationBuild extends Build {
     // incOptions := incOptions.value.withNameHashing(true) // see https://groups.google.com/forum/#!msg/play-framework/S_-wYW5Tcvw/OjJuB4iUwD8J
     ScalariformKeys.preferences := ScalariformKeys.preferences.value
       .setPreference(DoubleIndentClassDeclaration, true),
-    lessEntryPoints := Nil,
     coffeescriptEntryPoints := Nil,
     javascriptEntryPoints := Nil
     //,     offline := true


### PR DESCRIPTION
@2is10 Switched the `Success` to a `Try`, so if the decryption fails (by throwing an exception), it's handled inside.
