### PR TITLE
minor adjustments to Aes64BitCipherTest and PublicIdTest 

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/crypto/Aes64BitCipher.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/crypto/Aes64BitCipher.scala
@@ -1,5 +1,6 @@
 package com.keepit.common.crypto
 
+import java.lang.Long.reverseBytes
 import java.nio.ByteBuffer
 import javax.crypto.{ Cipher, SecretKey, SecretKeyFactory }
 import javax.crypto.spec.{ IvParameterSpec, PBEKeySpec, SecretKeySpec }
@@ -8,8 +9,8 @@ import org.apache.commons.codec.binary.Base64
 
 private[crypto] class Aes64BitCipher(key: SecretKey, ivSpec: IvParameterSpec) {
 
-  private val ecipher = Cipher.getInstance("AES/CFB64/NoPadding")
-  private val dcipher = Cipher.getInstance("AES/CFB64/NoPadding")
+  private val ecipher = Cipher.getInstance("AES/CFB8/NoPadding")
+  private val dcipher = Cipher.getInstance("AES/CFB8/NoPadding")
 
   ecipher.init(Cipher.ENCRYPT_MODE, key, ivSpec)
   dcipher.init(Cipher.DECRYPT_MODE, key, ivSpec)
@@ -19,12 +20,12 @@ private[crypto] class Aes64BitCipher(key: SecretKey, ivSpec: IvParameterSpec) {
 
   private def crypt(value: Long, cipher: Cipher): Long = {
     val buffer = ByteBuffer.allocate(8)
-    buffer.putLong(0, value)
+    buffer.putLong(0, reverseBytes(value))
     val bytes: Array[Byte] = cipher.doFinal(buffer.array)
     buffer.rewind
     buffer.put(bytes)
-    buffer.flip
-    buffer.getLong
+    buffer.rewind
+    reverseBytes(buffer.getLong)
   }
 
 }

--- a/kifi-backend/modules/common/test/com/keepit/common/crypto/Aes64BitCipherTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/crypto/Aes64BitCipherTest.scala
@@ -1,19 +1,30 @@
 package com.keepit.common.crypto
 
+import java.nio.charset.StandardCharsets.ISO_8859_1
 import javax.crypto.spec.IvParameterSpec
 
 import org.specs2.mutable._
 
 class Aes64BitCipherTest extends Specification {
+  val cipher = Aes64BitCipher("L0i5 L4n3", new IvParameterSpec("Jared = Superman".getBytes(ISO_8859_1)))
+
   "Aes64BitCipher" should {
     "encrypt and decrypt" in {
-      val ivSpec = new IvParameterSpec(Array(-71, -49, 51, -61, 42, 41, 123, -61, 64, 122, -121, -55, 117, -51, 12, 21))
-
-      val cipher = Aes64BitCipher("test passphrase", ivSpec)
       val plaintext = new java.util.Random().nextLong()
       val encrypted = cipher.encrypt(plaintext)
       encrypted !== plaintext
       cipher.decrypt(encrypted) === plaintext
+    }
+    "permute bits well" in {  // FAIL!!!  TODO: fix
+      cipher.encrypt(1) === 3943421451219986269L
+      cipher.encrypt(2) === 3943421451219986270L
+      cipher.encrypt(3) === 3943421451219986271L
+      cipher.encrypt(4) === 3943421451219986264L
+      cipher.encrypt(5) === 3943421451219986265L
+      cipher.encrypt(6) === 3943421451219986266L
+      cipher.encrypt(7) === 3943421451219986267L
+      cipher.encrypt(8) === 3943421451219986260L
+      cipher.encrypt(9) === 3943421451219986261L
     }
   }
 }

--- a/kifi-backend/modules/common/test/com/keepit/common/crypto/Aes64BitCipherTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/crypto/Aes64BitCipherTest.scala
@@ -15,16 +15,25 @@ class Aes64BitCipherTest extends Specification {
       encrypted !== plaintext
       cipher.decrypt(encrypted) === plaintext
     }
-    "permute bits well" in {  // FAIL!!!  TODO: fix
-      cipher.encrypt(1) === 3943421451219986269L
-      cipher.encrypt(2) === 3943421451219986270L
-      cipher.encrypt(3) === 3943421451219986271L
-      cipher.encrypt(4) === 3943421451219986264L
-      cipher.encrypt(5) === 3943421451219986265L
-      cipher.encrypt(6) === 3943421451219986266L
-      cipher.encrypt(7) === 3943421451219986267L
-      cipher.encrypt(8) === 3943421451219986260L
-      cipher.encrypt(9) === 3943421451219986261L
+    "permute bits well in consecutive small positive long values" in {
+      cipher.encrypt(1) === -2644796545160457673L
+      cipher.encrypt(2) === 5711187287630018612L
+      cipher.encrypt(3) === -7392062738091901643L
+      cipher.encrypt(4) === 8792213188438217266L
+      cipher.encrypt(5) === 1380560063487963187L
+      cipher.encrypt(6) === 5823553674093653552L
+      cipher.encrypt(7) === -1056275590325946063L
+      cipher.encrypt(8) === -1380969989776329666L
+      cipher.encrypt(9) === 6145921475325096767L
+      cipher.encrypt(9991) === 1164322715469585969L
+      cipher.encrypt(9992) === 7677984277210665790L
+      cipher.encrypt(9993) === -6461694352345770945L
+      cipher.encrypt(9994) === -4690800597685002692L
+      cipher.encrypt(9995) === -6676086683958697155L
+      cipher.encrypt(9996) === 2845373186209553722L
+      cipher.encrypt(9997) === 2539424297649662523L
+      cipher.encrypt(9998) === 5757596379705742136L
+      cipher.encrypt(9999) === 1086822315686484281L
     }
   }
 }

--- a/kifi-backend/modules/common/test/com/keepit/common/crypto/PublicIdTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/crypto/PublicIdTest.scala
@@ -41,9 +41,9 @@ class PublicIdTest extends Specification {
       pid1.id.zip(pid3.id).count(c => c._1 != c._2) must be_>(5)
 
       // Values are correct (sensitive to changes to IV and key)
-      pid1.id === "tKhpz2uJdFZB"
-      pid2.id === "tKhpz2uJdFY8"  // TODO: this should be much more different from pid1.id
-      pid3.id === "w9wcfGVcIpAT"
+      pid1.id === "tEvDcZaVaEMD"
+      pid2.id === "t5rWKTLCQNJl"
+      pid3.id === "w4cIvxI460Tu"
 
       // Encryption is consistant
       TestModel.publicId(Id[TestModel](1)) === pid1

--- a/kifi-backend/modules/common/test/com/keepit/common/crypto/PublicIdTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/crypto/PublicIdTest.scala
@@ -26,39 +26,33 @@ class PublicIdTest extends Specification {
       val id1 = Id[TestModel](1L)
       val id2 = Id[TestModel](2L)
       val id3 = Id[TestModel2](1L)
-      val id4 = Id[TestModel2](2L)
 
       val pid1 = TestModel.publicId(id1)
       val pid2 = TestModel.publicId(id2)
       val pid3 = TestModel2.publicId(id3)
-      val pid4 = TestModel2.publicId(id4)
-
-      // Inputs are different, sanity
-      id1 !== id2
-      id2 !== id3
-      id3 !== id4
 
       // PublicIds should be different
       pid1 !== pid2
       pid1 !== pid3
-      pid1.id.substring(1) !== pid3.id.substring(1) // different IVs
       pid2 !== pid3
-      pid3 !== pid4
+
+      // PublicIds from the same Id value but for different types should be different
+      id1.id === id3.id
+      pid1.id.zip(pid3.id).count(c => c._1 != c._2) must be_>(5)
 
       // Values are correct (sensitive to changes to IV and key)
       pid1.id === "tKhpz2uJdFZB"
+      pid2.id === "tKhpz2uJdFY8"  // TODO: this should be much more different from pid1.id
       pid3.id === "w9wcfGVcIpAT"
 
       // Encryption is consistant
       TestModel.publicId(Id[TestModel](1)) === pid1
 
       // Decryption works
-      val id1_2 = TestModel.decodePublicId(pid1).get
-      id1_2 === id1
+      TestModel.decodePublicId(pid1).get === id1
 
-      // Description with the wrong key usually fails
+      // Decryption with the wrong key should fail
       TestModel.decodePublicId(pid1)(PublicIdConfiguration("otherkey")).get must throwAn[IllegalArgumentException]
-
     }
   }
 }


### PR DESCRIPTION
@andrewconner Adjusting the cipher algorithm we’re using to better permute bits in the ciphertext of consecutive small numbers. (We don’t care so much how well bits are permuted near `Long.MaxValue`; that’s well outside our permitted `Id` domain.)
