### PR TITLE
Using new delighted api to submit score and comment separately

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/heimdal/BasicDelightedAnswer.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/BasicDelightedAnswer.scala
@@ -1,6 +1,8 @@
 package com.keepit.heimdal
 
+import com.keepit.common.db.ExternalId
 import com.keepit.common.net.UserAgent
+import com.keepit.model.DelightedAnswer
 import com.kifi.macros.json
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
@@ -22,14 +24,19 @@ object DelightedAnswerSources {
   }
 }
 
-case class BasicDelightedAnswer(score: Int, comment: Option[String], source: DelightedAnswerSource)
+case class BasicDelightedAnswer(
+  score: Option[Int],
+  comment: Option[String],
+  source: DelightedAnswerSource,
+  answerId: Option[ExternalId[DelightedAnswer]] = None)
 
 object BasicDelightedAnswer {
 
   implicit def reads(implicit source: DelightedAnswerSource = DelightedAnswerSources.UNKNOWN): Reads[BasicDelightedAnswer] = (
-    (__ \ "score").read[Int](Reads.min(0) or Reads.max(10)) and
+    (__ \ "score").readNullable[Int](Reads.min(0) or Reads.max(10)) and
     (__ \ "comment").readNullable[String] and
-    (__ \ "source").readNullable[DelightedAnswerSource].map(_.getOrElse(source))
+    (__ \ "source").readNullable[DelightedAnswerSource].map(_.getOrElse(source)) and
+    (__ \ "answerId").readNullable[ExternalId[DelightedAnswer]]
   )(BasicDelightedAnswer.apply _)
 
   implicit val writes = Json.writes[BasicDelightedAnswer]

--- a/kifi-backend/modules/common/app/com/keepit/model/DelightedAnswer.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/DelightedAnswer.scala
@@ -1,6 +1,6 @@
 package com.keepit.model
 
-import com.keepit.common.db.{ Model, Id }
+import com.keepit.common.db.{ ExternalId, Id, ModelWithExternalId }
 import com.keepit.common.time._
 import com.keepit.heimdal.DelightedAnswerSource
 import org.joda.time.DateTime
@@ -9,12 +9,14 @@ case class DelightedAnswer(
     id: Option[Id[DelightedAnswer]] = None,
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime,
+    externalId: ExternalId[DelightedAnswer] = ExternalId(),
     delightedExtAnswerId: String, // Assigned by Delighted
     delightedUserId: Id[DelightedUser],
     date: DateTime,
     score: Int,
     comment: Option[String],
-    source: DelightedAnswerSource) extends Model[DelightedAnswer] {
+    source: DelightedAnswerSource) extends ModelWithExternalId[DelightedAnswer] {
   def withId(id: Id[DelightedAnswer]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
+  def withExternalId(id: ExternalId[DelightedAnswer]) = copy(externalId = id)
 }

--- a/kifi-backend/modules/common/app/com/keepit/model/DelightedUser.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/DelightedUser.scala
@@ -1,6 +1,6 @@
 package com.keepit.model
 
-import com.keepit.common.db.{ Model, Id }
+import com.keepit.common.db.{ Id, Model }
 import com.keepit.common.mail.EmailAddress
 import com.keepit.common.time._
 import org.joda.time.DateTime

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/201.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/201.sql
@@ -1,0 +1,13 @@
+# HEIMDAL
+
+# --- !Ups
+
+ALTER TABLE delighted_answer ADD COLUMN external_id varchar(36);
+ALTER TABLE delighted_answer ADD CONSTRAINT delighted_answer_u_external_id UNIQUE (external_id);
+-- UPDATE delighted_answer SET external_id = UUID(); -- Prod
+CREATE INDEX delighted_answer_i_ext_id ON delighted_answer (external_id); -- Dev
+-- CREATE INDEX delighted_answer_i_ext_id ON delighted_answer (external_id(8)); -- Prod
+
+insert into evolutions (name, description) values('201.sql', 'add external_id to delighted_answer table');
+
+# --- !Downs

--- a/kifi-backend/modules/common/test/com/keepit/heimdal/FakeHeimdalServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/heimdal/FakeHeimdalServiceClientImpl.scala
@@ -47,7 +47,7 @@ class FakeHeimdalServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
 
   def getLastDelightedAnswerDate(userId: Id[User]): Future[Option[DateTime]] = Future.successful(None)
 
-  def postDelightedAnswer(userId: Id[User], externalId: ExternalId[User], email: Option[EmailAddress], name: String, answer: BasicDelightedAnswer): Future[Boolean] = Future.successful(true)
+  def postDelightedAnswer(userId: Id[User], externalId: ExternalId[User], email: Option[EmailAddress], name: String, answer: BasicDelightedAnswer): Future[Option[BasicDelightedAnswer]] = Future.successful(None)
 
   def cancelDelightedSurvey(userId: Id[User], externalId: ExternalId[User], email: Option[EmailAddress], name: String): Future[Boolean] = Future.successful(true)
 }

--- a/kifi-backend/modules/heimdal/app/com/keepit/commander/DelightedCommander.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/commander/DelightedCommander.scala
@@ -61,8 +61,8 @@ class DelightedCommanderImpl @Inject() (
             "score" -> answer.score.map(s => Seq(s.toString)),
             "comment" -> answer.comment.map(Seq(_))
           )
-        val url = answer.answerId map { externalId =>
-          s"/v1/survey_responses/$externalId.json"
+        val url = answer.answerId map { answerId =>
+          s"/v1/survey_responses/$answerId.json"
         } getOrElse "/v1/survey_responses.json"
 
         delightedRequest(url).post(data).map { response =>

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/DelightedAnswerRepo.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/DelightedAnswerRepo.scala
@@ -17,19 +17,19 @@ trait DelightedAnswerRepo extends Repo[DelightedAnswer] {
 class DelightedAnswerRepoImpl @Inject() (
     val db: DataBaseComponent,
     val clock: Clock,
-    delightedUserRepo: DelightedUserRepoImpl) extends DbRepo[DelightedAnswer] with DelightedAnswerRepo {
+    delightedUserRepo: DelightedUserRepoImpl) extends DbRepo[DelightedAnswer] with DelightedAnswerRepo with ExternalIdColumnDbFunction[DelightedAnswer] {
 
   import db.Driver.simple._
 
   type RepoImpl = DelightedAnswerTable
-  class DelightedAnswerTable(tag: Tag) extends RepoTable[DelightedAnswer](db, tag, "delighted_answer") {
+  class DelightedAnswerTable(tag: Tag) extends RepoTable[DelightedAnswer](db, tag, "delighted_answer") with ExternalIdColumn[DelightedAnswer] {
     def delightedExtAnswerId = column[String]("delighted_ext_answer_id", O.NotNull)
     def delightedUserId = column[Id[DelightedUser]]("delighted_user_id", O.NotNull)
     def date = column[DateTime]("date", O.NotNull)
     def score = column[Int]("score", O.NotNull)
     def comment = column[String]("comment", O.Nullable)
     def source = column[DelightedAnswerSource]("source", O.NotNull)
-    def * = (id.?, createdAt, updatedAt, delightedExtAnswerId, delightedUserId, date, score, comment.?, source) <> ((DelightedAnswer.apply _).tupled, DelightedAnswer.unapply _)
+    def * = (id.?, createdAt, updatedAt, externalId, delightedExtAnswerId, delightedUserId, date, score, comment.?, source) <> ((DelightedAnswer.apply _).tupled, DelightedAnswer.unapply _)
   }
 
   def table(tag: Tag) = new DelightedAnswerTable(tag)

--- a/kifi-backend/modules/shoebox/angular/src/delighted/delighted.js
+++ b/kifi-backend/modules/shoebox/angular/src/delighted/delighted.js
@@ -13,6 +13,8 @@ angular.module('kifi.delighted', [])
         scope.delighted = {};
         scope.showSurvey = true;
 
+        var answerId = null;
+
         function analyticsStageName() {
           return {score: 'npsScore', comment: 'npsComment', end: 'npsThanks'}[scope.surveyStage];
         }
@@ -25,6 +27,7 @@ angular.module('kifi.delighted', [])
 
         scope.$watch('delighted.score', function () {
           if (scope.delighted.score) {
+            submitAnswer();
             scope.surveyStage = 'comment';
             $analytics.eventTrack('user_viewed_notification', {
               'source': 'site',
@@ -41,8 +44,8 @@ angular.module('kifi.delighted', [])
           scope.surveyStage = 'score';
         };
 
-        scope.submit = function () {
-          profileService.postDelightedAnswer(+scope.delighted.score, scope.delighted.comment || null);
+        scope.submitComment = function () {
+          submitAnswer();
           scope.surveyStage = 'end';
           $analytics.eventTrack('user_viewed_notification', {
             'source': 'site',
@@ -65,6 +68,16 @@ angular.module('kifi.delighted', [])
 
         function hideSurvey() {
           element.find('.kf-delighted-wrap').addClass('hide');
+        }
+
+        function submitAnswer() {
+          profileService.postDelightedAnswer(
+            +scope.delighted.score || null,
+            scope.delighted.comment || null,
+            answerId
+          ).then(function (id) {
+            answerId = id;
+          });
         }
       }
     };

--- a/kifi-backend/modules/shoebox/angular/src/delighted/delightedSurvey.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/delighted/delightedSurvey.tpl.html
@@ -28,7 +28,7 @@
         <textarea class="kf-delighted-comment-area-input" ng-model="delighted.comment" name="delighted-comment" placeholder="Enter a comment (optional)"></textarea>
         <div class="kf-delighted-comment-actions">
           <button class="kf-delighted-comment-back dialog-cancel" ng-click="goBack()">Change score</button>
-          <button class="kf-delighted-comment-submit" ng-click="submit()">Submit</button>
+          <button class="kf-delighted-comment-submit" ng-click="submitComment()">Submit</button>
         </div>
       </div>
       <div class="kf-delighted-end" ng-switch-when="end">

--- a/kifi-backend/modules/shoebox/angular/src/profile/profileService.js
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profileService.js
@@ -211,12 +211,15 @@ angular.module('kifi.profileService', [
       $window.location = routeService.logout;
     }
 
-    function postDelightedAnswer(score, comment) {
+    function postDelightedAnswer(score, comment, answerId) {
       var data = {
-        score: score,
-        comment: comment || undefined
+        score: score || undefined,
+        comment: comment || undefined,
+        answerId: answerId || undefined
       };
-      return $http.post(routeService.postDelightedAnswer, data);
+      return $http.post(routeService.postDelightedAnswer, data).then(function (res) {
+        return res.data && res.data.answerId;
+      });
     }
 
     function cancelDelightedSurvey() {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
@@ -762,9 +762,11 @@ class UserCommander @Inject() (
     }
   }
 
-  def postDelightedAnswer(userId: Id[User], answer: BasicDelightedAnswer): Future[Boolean] = {
+  def postDelightedAnswer(userId: Id[User], answer: BasicDelightedAnswer): Future[Option[ExternalId[DelightedAnswer]]] = {
     val user = db.readOnlyReplica { implicit s => userRepo.get(userId) }
-    heimdalClient.postDelightedAnswer(userId, user.externalId, user.primaryEmail, user.fullName, answer)
+    heimdalClient.postDelightedAnswer(userId, user.externalId, user.primaryEmail, user.fullName, answer) map { answerOpt =>
+      answerOpt flatMap (_.answerId)
+    }
   }
 
   def cancelDelightedSurvey(userId: Id[User]): Future[Boolean] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
@@ -154,8 +154,10 @@ class MobileUserController @Inject() (
   def postDelightedAnswer = JsonAction.authenticatedParseJsonAsync { request =>
     implicit val source = DelightedAnswerSources.fromUserAgent(request.userAgentOpt)
     Json.fromJson[BasicDelightedAnswer](request.body) map { answer =>
-      userCommander.postDelightedAnswer(request.userId, answer) map { success =>
-        if (success) Ok else BadRequest
+      userCommander.postDelightedAnswer(request.userId, answer) map { externalIdOpt =>
+        externalIdOpt map { externalId =>
+          Ok(Json.obj("answerId" -> externalId))
+        } getOrElse NotFound
       }
     } getOrElse Future.successful(BadRequest)
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -413,8 +413,10 @@ class UserController @Inject() (
   def postDelightedAnswer = JsonAction.authenticatedParseJsonAsync { request =>
     implicit val source = DelightedAnswerSources.fromUserAgent(request.userAgentOpt)
     Json.fromJson[BasicDelightedAnswer](request.body) map { answer =>
-      userCommander.postDelightedAnswer(request.userId, answer) map { success =>
-        if (success) Ok else BadRequest
+      userCommander.postDelightedAnswer(request.userId, answer) map { externalIdOpt =>
+        externalIdOpt map { externalId =>
+          Ok(Json.obj("answerId" -> externalId))
+        } getOrElse NotFound
       }
     } getOrElse Future.successful(BadRequest)
   }


### PR DESCRIPTION
@stkem @andrewconner ( @davoda @jaredpetker )

I'm adding an external id to the Delighted answer model, that I send back to the client. The client can then update the score/comment of an existing answer.
