### PR TITLE
remove basicArticle from ScrapeWorker

### DIFF
--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/QueuedScrapeProcessor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/QueuedScrapeProcessor.scala
@@ -236,7 +236,7 @@ class QueuedScrapeProcessor @Inject() (
         if (URI.parse(url).get.host.isEmpty) throw new IllegalArgumentException(s"url $url has no host!")
         val fetchStatus = httpFetcher.fetch(url, proxy = proxyOpt)(input => extractor.process(input))
         val res = fetchStatus.statusCode match {
-          case HttpStatus.SC_OK if !helper.syncIsUnscrapableP(url, fetchStatus.destinationUrl) => Some(worker.basicArticle(fetchStatus.destinationUrl getOrElse url, extractor))
+          case HttpStatus.SC_OK if !helper.syncIsUnscrapableP(url, fetchStatus.destinationUrl) => Some(extractor.basicArticle(fetchStatus.destinationUrl getOrElse url))
           case _ => None
         }
         res

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeWorker.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeWorker.scala
@@ -25,8 +25,6 @@ import com.keepit.scraper.embedly.EmbedlyCommander
 @ImplementedBy(classOf[ScrapeWorkerImpl])
 trait ScrapeWorker {
   def safeProcessURI(uri: NormalizedURI, info: ScrapeInfo, pageInfoOpt: Option[PageInfo], proxyOpt: Option[HttpProxy]): Option[Article]
-  def fetchArticle(normalizedUri: NormalizedURI, info: ScrapeInfo, proxyOpt: Option[HttpProxy]): ScraperResult
-  def basicArticle(destinationUrl: String, extractor: Extractor): BasicArticle
 }
 
 class ScrapeWorkerImpl @Inject() (
@@ -245,7 +243,7 @@ class ScrapeWorkerImpl @Inject() (
     }
   }
 
-  def fetchArticle(normalizedUri: NormalizedURI, info: ScrapeInfo, proxyOpt: Option[HttpProxy]): ScraperResult = {
+  private def fetchArticle(normalizedUri: NormalizedURI, info: ScrapeInfo, proxyOpt: Option[HttpProxy]): ScraperResult = {
     try {
       URI.parse(normalizedUri.url) match {
         case Success(uri) =>
@@ -354,18 +352,6 @@ class ScrapeWorkerImpl @Inject() (
       }
     }
   }
-
-  def basicArticle(destinationUrl: String, extractor: Extractor): BasicArticle = BasicArticle(
-    title = extractor.getTitle,
-    content = extractor.getContent,
-    canonicalUrl = extractor.getCanonicalUrl,
-    description = extractor.getDescription,
-    media = extractor.getMediaTypeString,
-    httpContentType = extractor.getMetadata("Content-Type"),
-    httpOriginalContentCharset = extractor.getMetadata("Content-Encoding"),
-    destinationUrl = destinationUrl,
-    signature = extractor.getSignature
-  )
 
   // Watch out: the NormalizedURI may come back as REDIRECTED
   private def processRedirects(uri: NormalizedURI, redirects: Seq[HttpRedirect]): NormalizedURI = {

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/Extractor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/Extractor.scala
@@ -2,7 +2,7 @@ package com.keepit.scraper.extractor
 
 import com.keepit.common.net.URI
 import com.keepit.scraper.mediatypes.MediaTypes
-import com.keepit.scraper.{ SignatureBuilder, Signature, HttpInputStream }
+import com.keepit.scraper.{ BasicArticle, SignatureBuilder, Signature, HttpInputStream }
 
 trait Extractor {
   def process(input: HttpInputStream): Unit
@@ -30,6 +30,18 @@ trait Extractor {
     )).build
   }
   def getMediaTypeString(): Option[String] = MediaTypes(this).getMediaTypeString(this)
+  def basicArticle(destinationUrl: String): BasicArticle =
+    BasicArticle(
+      title = getTitle,
+      content = getContent,
+      canonicalUrl = getCanonicalUrl,
+      description = getDescription,
+      media = getMediaTypeString,
+      httpContentType = getMetadata("Content-Type"),
+      httpOriginalContentCharset = getMetadata("Content-Encoding"),
+      destinationUrl = destinationUrl,
+      signature = getSignature
+    )
 }
 
 trait ExtractorFactory extends Function[String, Extractor]


### PR DESCRIPTION
ScrapeWorker now has only one method, which facilitate further clean-up
(basicArticle moved because it does not depend on anything in ScrapeWorker)

Puller now uses (injected) Mode

minor improvement ... continue to simplify Scraper 

@ymatsuda @yingjieMiao @eishay @leogrim 
