### PR TITLE
Library index

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -125,6 +125,7 @@ trait ShoeboxServiceClient extends ServiceClient {
   def getIndexableSocialConnections(seqNum: SequenceNumber[SocialConnection], fetchSize: Int): Future[Seq[IndexableSocialConnection]]
   def getIndexableSocialUserInfos(seqNum: SequenceNumber[SocialUserInfo], fetchSize: Int): Future[Seq[SocialUserInfo]]
   def getEmailAccountUpdates(seqNum: SequenceNumber[EmailAccountUpdate], fetchSize: Int): Future[Seq[EmailAccountUpdate]]
+  def getLibrariesWithMembersChanged(seqNum: SequenceNumber[Library], fetchSize: Int): Future[Seq[(Library, Seq[LibraryMembership])]] = Future.successful(Seq.empty) // todo(Léo): implement
 }
 
 case class ShoeboxCacheProvider @Inject() (

--- a/kifi-backend/modules/common/conf/prod/search.conf
+++ b/kifi-backend/modules/common/conf/prod/search.conf
@@ -28,6 +28,7 @@ index {
   message.directory = "../../index/message"
   userGraph.directory = "../../index/userGraph"
   searchFriend.directory = "../../index/searchFriend"
+  library.directory = "../../index/library"
   config = "../../index/config"
   shards = "0,1,2,3/4"
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/SearchGlobal.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/SearchGlobal.scala
@@ -14,6 +14,7 @@ import com.keepit.search.phrasedetector.PhraseIndexerPlugin
 import com.keepit.search.spellcheck.SpellIndexerPlugin
 import com.keepit.search.graph.collection.CollectionGraphPlugin
 import com.keepit.search.graph.user._
+import com.keepit.search.graph.library.LibraryIndexerPlugin
 
 object SearchGlobal extends FortyTwoGlobal(Prod) with SearchServices {
   val module = SearchProdModule()
@@ -42,6 +43,7 @@ trait SearchServices { self: FortyTwoGlobal =>
     require(injector.instance[UserGraphPlugin] != null)
     require(injector.instance[SearchFriendGraphPlugin] != null)
     require(injector.instance[LoadBalancerCheckPlugin] != null) //make sure its not lazy loaded
+    require(injector.instance[LibraryIndexerPlugin] != null) //make sure its not lazy loaded
     require(NlpParser.enabled)
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/SearchGlobal.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/SearchGlobal.scala
@@ -43,7 +43,7 @@ trait SearchServices { self: FortyTwoGlobal =>
     require(injector.instance[UserGraphPlugin] != null)
     require(injector.instance[SearchFriendGraphPlugin] != null)
     require(injector.instance[LoadBalancerCheckPlugin] != null) //make sure its not lazy loaded
-    require(injector.instance[LibraryIndexerPlugin] != null) //make sure its not lazy loaded
+    // require(injector.instance[LibraryIndexerPlugin] != null) //make sure its not lazy loaded todo(Léo): activate once Shoebox is ready
     require(NlpParser.enabled)
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexer.scala
@@ -1,9 +1,12 @@
 package com.keepit.search.graph.library
 
-import com.keepit.model.{User, Library}
-import com.keepit.common.db.Id
-import com.keepit.search.index.{DefaultAnalyzer, Indexable}
+import com.keepit.model.{ User, Library }
+import com.keepit.common.db.{ SequenceNumber, Id }
+import com.keepit.search.index._
 import com.keepit.search.LangDetector
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import scala.concurrent.Future
+import com.keepit.shoebox.ShoeboxServiceClient
 
 object LibraryFields {
   val nameField = "n"
@@ -13,6 +16,8 @@ object LibraryFields {
   val visibilityField = "v"
   val usersField = "u"
   val recordField = "rec"
+
+  val decoders: Map[String, FieldDecoder] = Map.empty
 }
 
 class LibraryIndexable(library: Library, users: Seq[Id[User]]) extends Indexable[Library, Library] {
@@ -42,5 +47,30 @@ class LibraryIndexable(library: Library, users: Seq[Id[User]]) extends Indexable
     doc.add(buildBinaryDocValuesField(recordField, record))
 
     doc
+  }
+}
+
+class LibraryIndexer(indexDirectory: IndexDirectory, shoebox: ShoeboxServiceClient, val airbrake: AirbrakeNotifier) extends Indexer[Library, Library, LibraryIndexer](indexDirectory, LibraryFields.decoders) {
+
+  def update(): Int = throw new UnsupportedOperationException()
+
+  import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+  def fetchUpdates(seq: SequenceNumber[Library], fetchSize: Int): Future[Seq[Indexable[Library, Library]]] = {
+    shoebox.getLibrariesWithMembersChanged(seq, fetchSize).map {
+      case libraries =>
+        libraries.map {
+          case (library, memberships) =>
+            val users = memberships.flatMap { membership =>
+              if (membership.libraryId != library.id.get) { throw new IllegalArgumentException(s"Inconsistent membership for library ${library.id.get}: $membership") }
+              Some(membership.userId) //todo(Léo): filter this once LibraryMembership tracks searchability
+            }
+            new LibraryIndexable(library, users)
+        }
+    }
+  }
+
+  def processUpdates(updates: Seq[Indexable[Library, Library]]): Int = updateLock.synchronized {
+    doUpdate("LibraryIndex")(updates.iterator)
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexer.scala
@@ -1,0 +1,44 @@
+package com.keepit.search.graph.library
+
+import com.keepit.model.{User, Library}
+import com.keepit.common.db.Id
+import com.keepit.search.index.{DefaultAnalyzer, Indexable}
+import com.keepit.search.LangDetector
+
+object LibraryFields {
+  val nameField = "n"
+  val nameStemmedField = "ns"
+  val descriptionField = "d"
+  val descriptionStemmedField = "ds"
+  val usersField = "u"
+  val recordField = "rec"
+}
+
+class LibraryIndexable(library: Library, members: Seq[Id[User]]) extends Indexable[Library, Library] {
+
+  val id = library.id.get
+  val sequenceNumber = library.seq
+  val isDeleted: Boolean = members.isEmpty
+
+  override def buildDocument = {
+    import LibraryFields._
+    val doc = super.buildDocument
+
+    val nameLang = LangDetector.detect(library.name)
+    doc.add(buildTextField(nameField, library.name, DefaultAnalyzer.getAnalyzer(nameLang)))
+    doc.add(buildTextField(nameStemmedField, library.name, DefaultAnalyzer.getAnalyzerWithStemmer(nameLang)))
+
+    library.description.foreach { description =>
+      val descriptionLang = LangDetector.detect(description)
+      doc.add(buildTextField(descriptionField, description, DefaultAnalyzer.getAnalyzer(descriptionLang)))
+      doc.add(buildTextField(descriptionStemmedField, description, DefaultAnalyzer.getAnalyzerWithStemmer(descriptionLang)))
+    }
+
+    doc.add(buildIteratorField(usersField, members.iterator) { id => id.id.toString })
+
+    val record = LibraryRecord(library.name, library.description, library.id.get)
+    doc.add(buildBinaryDocValuesField(recordField, record))
+
+    doc
+  }
+}

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexer.scala
@@ -10,15 +10,16 @@ object LibraryFields {
   val nameStemmedField = "ns"
   val descriptionField = "d"
   val descriptionStemmedField = "ds"
+  val visibilityField = "v"
   val usersField = "u"
   val recordField = "rec"
 }
 
-class LibraryIndexable(library: Library, members: Seq[Id[User]]) extends Indexable[Library, Library] {
+class LibraryIndexable(library: Library, users: Seq[Id[User]]) extends Indexable[Library, Library] {
 
   val id = library.id.get
   val sequenceNumber = library.seq
-  val isDeleted: Boolean = members.isEmpty
+  val isDeleted: Boolean = users.isEmpty
 
   override def buildDocument = {
     import LibraryFields._
@@ -34,7 +35,8 @@ class LibraryIndexable(library: Library, members: Seq[Id[User]]) extends Indexab
       doc.add(buildTextField(descriptionStemmedField, description, DefaultAnalyzer.getAnalyzerWithStemmer(descriptionLang)))
     }
 
-    doc.add(buildIteratorField(usersField, members.iterator) { id => id.id.toString })
+    doc.add(buildKeywordField(visibilityField, library.visibility.value))
+    doc.add(buildIteratorField(usersField, users.iterator) { id => id.id.toString })
 
     val record = LibraryRecord(library.name, library.description, library.id.get)
     doc.add(buildBinaryDocValuesField(recordField, record))

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexerPlugin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexerPlugin.scala
@@ -1,0 +1,68 @@
+package com.keepit.search.graph.library
+
+import com.keepit.search.index._
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.akka.UnsupportedActorMessage
+import com.keepit.common.logging.Logging
+import com.keepit.model.Library
+import com.google.inject.Inject
+import com.keepit.common.actor.ActorInstance
+import com.keepit.common.zookeeper.ServiceDiscovery
+import com.keepit.common.plugin.SchedulingProperties
+import scala.util.Success
+import scala.util.Failure
+
+trait LibraryIndexerPlugin extends IndexerPlugin[Library, LibraryIndexer]
+
+class LibraryIndexerPluginImpl @Inject() (
+  actor: ActorInstance[LibraryIndexerActor],
+  indexer: LibraryIndexer,
+  airbrake: AirbrakeNotifier,
+  serviceDiscovery: ServiceDiscovery,
+  val scheduling: SchedulingProperties) extends IndexerPluginImpl(indexer, actor, serviceDiscovery) with LibraryIndexerPlugin
+
+class LibraryIndexerActor @Inject() (
+    airbrake: AirbrakeNotifier,
+    indexer: LibraryIndexer) extends IndexerActor(airbrake, indexer) with Logging {
+
+  import IndexerPluginMessages._
+
+  private case class ProcessUpdates(updates: Seq[Indexable[Library, Library]], fetchSize: Int)
+  private case object CancelUpdate
+
+  private var updating = false
+
+  implicit val executionContext = com.keepit.common.concurrent.ExecutionContext.immediate
+
+  private def update(): Unit = if (!updating) {
+    updating = true
+    val fetchSize = indexer.commitBatchSize
+    indexer.fetchUpdates(indexer.sequenceNumber, fetchSize).onComplete {
+      case Success(updates) =>
+        self ! ProcessUpdates(updates, fetchSize)
+      case Failure(ex) =>
+        airbrake.notify(s"Failed to fetch updates for ${indexer}", ex)
+        self ! CancelUpdate
+    }
+  }
+
+  private def cancelUpdate(): Unit = { updating = false }
+
+  override def receive() = {
+    case UpdateIndex => update()
+    case CancelUpdate => cancelUpdate()
+    case ProcessUpdates(updates, fetchSize) => {
+      if (updates.nonEmpty) { indexer.processUpdates(updates) }
+      if (updates.length < fetchSize) { cancelUpdate() }
+      else { update() }
+    }
+    case BackUpIndex => {
+      val minBackupInterval = 600000 // 10 minutes
+      if (System.currentTimeMillis - indexer.lastBackup > minBackupInterval) indexer.backup()
+    }
+    case RefreshSearcher => indexer.refreshSearcher()
+    case RefreshWriter => indexer.refreshWriter()
+    case WarmUpIndexDirectory => indexer.warmUpIndexDirectory()
+    case m => throw new UnsupportedActorMessage(m)
+  }
+}

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryRecord.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryRecord.scala
@@ -1,11 +1,11 @@
 package com.keepit.search.graph.library
 
-import com.keepit.common.db.ExternalId
+import com.keepit.common.db.Id
 import com.keepit.model.Library
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import org.apache.lucene.store.{InputStreamDataInput, OutputStreamDataOutput}
 
-case class LibraryRecord(title: String, description: String, id: ExternalId[Library])
+case class LibraryRecord(name: String, description: Option[String], id: Id[Library])
 
 object LibraryRecord {
   implicit def toByteArray(record: LibraryRecord): Array[Byte] = {
@@ -13,9 +13,9 @@ object LibraryRecord {
     val out = new OutputStreamDataOutput(baos)
 
     out.writeByte(1) // version
-    out.writeString(record.title)
-    out.writeString(record.description)
-    out.writeString(record.id.id)
+    out.writeString(record.name)
+    out.writeString(record.description.getOrElse(""))
+    out.writeLong(record.id.id)
 
     out.close()
     baos.close()
@@ -32,8 +32,8 @@ object LibraryRecord {
       throw new Exception(s"invalid data [version=${version}]")
     }
     val title = in.readString()
-    val description = in.readString()
-    val id = ExternalId[Library](in.readString())
+    val description = Some(in.readString()).filter(_.nonEmpty)
+    val id = Id[Library](in.readLong())
     LibraryRecord(title, description, id)
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryRecord.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryRecord.scala
@@ -1,0 +1,39 @@
+package com.keepit.search.graph.library
+
+import com.keepit.common.db.ExternalId
+import com.keepit.model.Library
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import org.apache.lucene.store.{InputStreamDataInput, OutputStreamDataOutput}
+
+case class LibraryRecord(title: String, description: String, id: ExternalId[Library])
+
+object LibraryRecord {
+  implicit def toByteArray(record: LibraryRecord): Array[Byte] = {
+    val baos = new ByteArrayOutputStream()
+    val out = new OutputStreamDataOutput(baos)
+
+    out.writeByte(1) // version
+    out.writeString(record.title)
+    out.writeString(record.description)
+    out.writeString(record.id.id)
+
+    out.close()
+    baos.close()
+
+    val bytes = baos.toByteArray()
+    bytes
+  }
+
+  implicit def fromByteArray(bytes: Array[Byte], offset: Int, length: Int): LibraryRecord = {
+    val in = new InputStreamDataInput(new ByteArrayInputStream(bytes, offset, length))
+
+    val version = in.readByte().toInt
+    if (version > 1) {
+      throw new Exception(s"invalid data [version=${version}]")
+    }
+    val title = in.readString()
+    val description = in.readString()
+    val id = ExternalId[Library](in.readString())
+    LibraryRecord(title, description, id)
+  }
+}

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryRecord.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryRecord.scala
@@ -2,8 +2,8 @@ package com.keepit.search.graph.library
 
 import com.keepit.common.db.Id
 import com.keepit.model.Library
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
-import org.apache.lucene.store.{InputStreamDataInput, OutputStreamDataOutput}
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
+import org.apache.lucene.store.{ InputStreamDataInput, OutputStreamDataOutput }
 
 case class LibraryRecord(name: String, description: Option[String], id: Id[Library])
 

--- a/kifi-backend/modules/search/app/com/keepit/search/index/IndexModule.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/IndexModule.scala
@@ -66,7 +66,7 @@ trait IndexModule extends ScalaModule with Logging {
     bind[SpellIndexerPlugin].to[SpellIndexerPluginImpl].in[AppScoped]
     bind[UserGraphPlugin].to[UserGraphPluginImpl].in[AppScoped]
     bind[SearchFriendGraphPlugin].to[SearchFriendGraphPluginImpl].in[AppScoped]
-    bind[LibraryIndexerPlugin].to[LibraryIndexerPluginImpl].in[AppScoped]
+    // bind[LibraryIndexerPlugin].to[LibraryIndexerPluginImpl].in[AppScoped] todo(Léo): activate once Shoebox is ready
   }
 
   private[this] val noShard = Shard[Any](0, 1)

--- a/kifi-backend/modules/search/app/com/keepit/search/index/IndexModule.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/IndexModule.scala
@@ -24,6 +24,7 @@ import com.google.inject.{ Inject, Provides, Singleton }
 import org.apache.commons.io.FileUtils
 import java.io.File
 import play.api.Play._
+import com.keepit.search.graph.library.{ LibraryIndexer, LibraryIndexerPluginImpl, LibraryIndexerPlugin }
 
 trait IndexModule extends ScalaModule with Logging {
 
@@ -65,6 +66,7 @@ trait IndexModule extends ScalaModule with Logging {
     bind[SpellIndexerPlugin].to[SpellIndexerPluginImpl].in[AppScoped]
     bind[UserGraphPlugin].to[UserGraphPluginImpl].in[AppScoped]
     bind[SearchFriendGraphPlugin].to[SearchFriendGraphPluginImpl].in[AppScoped]
+    bind[LibraryIndexerPlugin].to[LibraryIndexerPluginImpl].in[AppScoped]
   }
 
   private[this] val noShard = Shard[Any](0, 1)
@@ -192,6 +194,13 @@ trait IndexModule extends ScalaModule with Logging {
   def spellIndexer(backup: IndexStore, shardedArticleIndexer: ShardedArticleIndexer): SpellIndexer = {
     val spellDir = getIndexDirectory("index.spell.directory", noShard, backup)
     SpellIndexer(spellDir, shardedArticleIndexer)
+  }
+
+  @Provides @Singleton
+  def libraryIndexer(backup: IndexStore, shoebox: ShoeboxServiceClient, airbrake: AirbrakeNotifier): LibraryIndexer = {
+    val libraryDir = getIndexDirectory("index.library.directory", noShard, backup)
+    log.info(s"storing library index in $libraryDir")
+    new LibraryIndexer(libraryDir, shoebox, airbrake)
   }
 
 }


### PR DESCRIPTION
@ymatsuda 
I have extended / overridden IndexerActor so that you can review the new fully asynchronous indexing logic I propose. If you think that makes sense, I make it the primary IndexerActor implementation and retrofit the existing indexers.

fetchUpdates would be added to the IndexManager trait
processUpdates would likely be a simple modification of doUpdate, maybe extracting "name" as property on the indexer.
