### PR TITLE
byte offset/size vs short word offset/size, and more tests

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/util/join/DataBuffer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/util/join/DataBuffer.scala
@@ -5,10 +5,12 @@ import scala.collection.mutable.ArrayBuffer
 object DataBuffer {
   type Page = Array[Short]
 
-  val PAGE_SIZE = 1024 // 2KBytes
+  private[join] val PAGE_SHORT_ARRAY_SIZE = 1024 // short array size
+  val PAGE_SIZE = PAGE_SHORT_ARRAY_SIZE << 1
 
   // We encode the record type and the record size together into one short word (16-bit)
   // The first bit of the code is used as flag that indicates there is a record, so...
+  val DESCRIPTOR_SIZE = 2
   val MAX_RECTYPEID = 100 // this needs to fit in 7-bit
   val MAX_DATASIZE = 500 // this (byte size) divided by two (-> the number of short words) needs to fits in 8-bit
 }
@@ -18,14 +20,14 @@ class DataBuffer {
 
   import com.keepit.search.util.join.DataBuffer._
 
-  private[this] var _localOffset = 0
   private[this] var _numRecords = 0
-  private[this] var _freeSpace = 0
+  private[this] var _localOffset = 0 // bytes
+  private[this] var _freeSpace = 0 // bytes
   private[this] var _currentPage: Page = null
   private[this] val _dataBuf = new ArrayBuffer[Page]()
 
   private[this] def addPage(): Unit = {
-    _currentPage = new Page(DataBuffer.PAGE_SIZE)
+    _currentPage = new Page(DataBuffer.PAGE_SHORT_ARRAY_SIZE)
     _dataBuf += _currentPage
     _freeSpace = DataBuffer.PAGE_SIZE
     _localOffset = 0
@@ -34,42 +36,43 @@ class DataBuffer {
   def alloc(writer: DataBufferWriter, recType: Int, byteSize: Int): DataBufferWriter = {
     if (byteSize >= MAX_DATASIZE) throw new DataBufferException(s"data size too big: $byteSize")
     if (recType >= MAX_RECTYPEID) throw new DataBufferException(s"record type id too big: $recType")
-
-    val size = ((byteSize + 1) / 2)
+    if (byteSize % 2 != 0) throw new DataBufferException(s"data size not aligned")
 
     // add a page if not enough room
-    if (_freeSpace - size - 1 < 0) addPage()
+    if (_freeSpace - byteSize - DESCRIPTOR_SIZE < 0) addPage()
 
-    writer.set(recType, size, _currentPage, _localOffset)
-    _freeSpace -= (size + 1)
-    _localOffset += (size + 1)
+    val total = writer.set(recType, byteSize, _currentPage, _localOffset)
+    _freeSpace -= total
+    _localOffset += total
     _numRecords += 1
     writer
   }
 
-  def set(reader: DataBufferReader, offset: Int): DataBufferReader = {
-    val page = _dataBuf(offset / DataBuffer.PAGE_SIZE)
-    val off = offset % DataBuffer.PAGE_SIZE
-    reader.set(offset, page, off)
+  def set(reader: DataBufferReader, globalOffset: Int): DataBufferReader = {
+    val page = _dataBuf(globalOffset / DataBuffer.PAGE_SIZE)
+    val byteOffset = (globalOffset % DataBuffer.PAGE_SIZE)
+    reader.set(globalOffset, page, byteOffset)
     reader
   }
 
   def scan[T](reader: DataBufferReader)(f: DataBufferReader => T): Unit = {
-    var pageOffset = 0
+    var pageGlobalOffset = 0
     _dataBuf.foreach { page =>
-      var offset = 0
-      while (offset < DataBuffer.PAGE_SIZE && reader.set(pageOffset + offset, page, offset)) {
+      var byteOffset = 0
+      while (byteOffset < DataBuffer.PAGE_SIZE && reader.set(pageGlobalOffset + byteOffset, page, byteOffset)) {
         val next = reader.next
         f(reader)
-        offset = next
+        byteOffset = next
       }
-      pageOffset += DataBuffer.PAGE_SIZE
+      pageGlobalOffset += DataBuffer.PAGE_SIZE
     }
   }
 
   // number of records
   def size: Int = _numRecords
+
+  // number of pages
+  def numPages: Int = _dataBuf.size
 }
 
 class DataBufferException(msg: String) extends Exception(msg)
-

--- a/kifi-backend/modules/search/app/com/keepit/search/util/join/DataBufferReader.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/util/join/DataBufferReader.scala
@@ -4,14 +4,15 @@ class DataBufferReader {
   import DataBuffer.Page
 
   private[this] var _type: Int = 0
-  private[this] var _size: Int = 0
+  private[this] var _size: Int = 0 // record size in terms of short words
   private[this] var _page: Page = null
-  private[this] var _globalOffset: Int = 0 // global offset in terms of short
-  private[this] var _offset: Int = 0 // offset within the current page in terms of short
-  private[this] var _current: Int = 0 // offset within the current page in terms of short
+  private[this] var _globalOffset: Int = 0 // global byte offset
+  private[this] var _offset: Int = 0 // offset within the current page in terms of short words
+  private[this] var _current: Int = 0 // offset within the current page in terms of short words
 
-  private[join] def set(globalOffset: Int, page: Page, offset: Int): Boolean = {
+  private[join] def set(globalOffset: Int, page: Page, byteOffset: Int): Boolean = {
     _globalOffset = globalOffset
+    val offset = byteOffset >> 1
     val tag = page(offset)
 
     if ((tag & 0x8000) != 0) { // validity check
@@ -26,11 +27,11 @@ class DataBufferReader {
     }
   }
 
-  private[util] def next: Int = _offset + _size // offset (in terms of short) of next record
+  private[util] def next: Int = (_offset + _size) << 1 // byte offset of next record
 
   def recordType: Int = _type // record type
 
-  def recordOffset: Int = _globalOffset // global offset in terms of short
+  def recordOffset: Int = _globalOffset // global byte offset
 
   def hasMore(): Boolean = _current < _offset + _size
 

--- a/kifi-backend/modules/search/app/com/keepit/search/util/join/DataBufferWriter.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/util/join/DataBufferWriter.scala
@@ -5,21 +5,24 @@ class DataBufferWriter {
 
   private[this] var _type: Int = 0
   private[this] var _page: Page = null
-  private[this] var _offset: Int = 0 // offset within the current page in terms of short
-  private[this] var _endoff: Int = 0 // end offset of the allocation
-  private[this] var _current: Int = 0 // offset within the current page in terms of short
+  private[this] var _offset: Int = 0 // offset within the current page in terms of short words
+  private[this] var _endoff: Int = 0 // end offset of the allocation in terms of short words
+  private[this] var _current: Int = 0 // offset within the current page in terms of short words
 
-  private[join] def set(recType: Int, size: Int, page: Page, offset: Int): Boolean = {
+  private[join] def set(recType: Int, byteSize: Int, page: Page, byteOffset: Int): Int = {
     // bit 0: record flag (0: no record, 1: there is a record)
     // bit 1-7: record type id
     // bit 9-15: size in short words
+    val size = byteSize >> 1
+    val offset = byteOffset >> 1
     page(offset) = (0x8000 | (recType << 8) | (size & 0xff)).toShort
     _type = recType
     _page = page
     _offset = offset + 1 // beginning of the data
     _endoff = offset + 1 + size // end of the allocation
     _current = offset + 1
-    true
+
+    byteSize + DataBuffer.DESCRIPTOR_SIZE // total allocated
   }
 
   // Long

--- a/kifi-backend/modules/search/test/com/keepit/search/util/join/DataBufferTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/util/join/DataBufferTest.scala
@@ -25,6 +25,7 @@ class DataBufferTest extends Specification {
         recType = (recType + 1) % DataBuffer.MAX_RECTYPEID
         datum
       }
+      buf.numPages === 3
 
       var result = new ArrayBuffer[(Int, Boolean)]()
       buf.scan(new DataBufferReader) { reader =>
@@ -41,7 +42,7 @@ class DataBufferTest extends Specification {
       val writer = new DataBufferWriter
 
       var recType = 0
-      val expected = (0 until 300).map { id =>
+      val expected = (0 until 200).map { id =>
         val datum = (recType, true, rand.nextLong, rand.nextInt, rand.nextInt.toShort, rand.nextFloat(), false)
         buf.alloc(writer, recType, 18)
         writer.putLong(datum._3)
@@ -51,6 +52,7 @@ class DataBufferTest extends Specification {
         recType = (recType + 1) % DataBuffer.MAX_RECTYPEID
         datum
       }
+      buf.numPages === 2
 
       var result = new ArrayBuffer[(Int, Boolean, Long, Int, Short, Float, Boolean)]()
       buf.scan(new DataBufferReader) { reader =>
@@ -77,6 +79,7 @@ class DataBufferTest extends Specification {
         recType = (recType + 1) % DataBuffer.MAX_RECTYPEID
         datum
       }
+      buf.numPages === 1
 
       var result = new ArrayBuffer[(Int, Long, Float, Boolean)]()
       buf.scan(new DataBufferReader) { reader =>
@@ -86,7 +89,7 @@ class DataBufferTest extends Specification {
       (result == expected.map(d => (d._1, d._2, taggedFloatValueFromFloat(d._3), d._4))) === true
 
       (result.map(_._3) zip expected.map(_._3)).forall {
-        case (f1, f2) => abs((f1 - f2) / f2) < (1.0f / (0x7fff.toFloat))
+        case (f1, f2) => abs((f1 - f2) / f2) <= (1.0f / (0x7fff.toFloat))
       } === true
     }
   }


### PR DESCRIPTION
@leogrim 
Units of offset and size were confusing. Now we use byte offset/size externally and use short word offsets only in DataBufferReader and DataBufferWriter.
