### PR TITLE
make email column nullable in delighted_user

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/189.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/189.sql
@@ -8,7 +8,7 @@ CREATE TABLE delighted_user (
     updated_at datetime NOT NULL, 
     delighted_ext_user_id varchar(32) NOT NULL,
     user_id bigint(20) NOT NULL,
-    email varchar(256) NOT NULL,
+    email varchar(256) NULL,
     user_last_interacted datetime NULL,
 
     PRIMARY KEY (id),


### PR DESCRIPTION
@eishay @stkem The email column should actually be nullable - we just need to give a placeholder email address to Delighted in order to be able to register a user. Another solution would be to store the placeholder email address, but I'm not sure it's better (the placeholder address is always delighted+<user external id>@kifi.com).
