### PR TITLE
strip out rand param

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/normalizer/DefaultNormalizer.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/normalizer/DefaultNormalizer.scala
@@ -9,7 +9,7 @@ object DefaultNormalizer extends StaticNormalizer with Logging {
   val stopParams = Set(
     "jsessionid", "phpsessid", "aspsessionid",
     "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
-    "trk", "goback", "icid", "ncid", "zenid")
+    "trk", "goback", "icid", "ncid", "zenid", "rand")
 
   val validSchemes = Normalization.schemes.flatMap(_.scheme.split("://").headOption)
 


### PR DESCRIPTION
Source: Pager alert. We were swamped with urls with "rand" (random?) param, such as:

http://www.oystermag.com/watch-bill-murray-wes-anderson-reminisce-on-the-life-aquatic?rand=7b1pr

Added a rule to exclude this. 

@ymatsuda @leogrim @eishay 
