### PR TITLE
Making UserValue names type-safe

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -43,6 +43,7 @@ object ParamValue {
   implicit def seqNumToParam[T](seqNum: SequenceNumber[T]) = ParamValue(Some(seqNum.value.toString))
   implicit def modelVersionToParam[M <: StatModel](modelVersion: ModelVersion[M]) = ParamValue(Some(modelVersion.version.toString))
   implicit def emailToParam(emailAddress: EmailAddress) = ParamValue(Some(emailAddress.address))
+  implicit def userValueNameToParam(userValueName: UserValueName) = ParamValue(Some(userValueName.name))
 }
 
 abstract class Method(name: String)
@@ -130,8 +131,8 @@ object Shoebox extends Service {
     //    def scraped() = ServiceRoute(POST, "/internal/shoebox/database/scraped")
     //    def scrapeFailed() = ServiceRoute(POST, "/internal/shoebox/database/scrapeFailed")
     def getFriendRequestBySender(senderId: Id[User]) = ServiceRoute(GET, "/internal/shoebox/database/getFriendRequestBySender", Param("senderId", senderId))
-    def getUserValue(userId: Id[User], key: String) = ServiceRoute(GET, "/internal/shoebox/database/userValue", Param("userId", userId), Param("key", key))
-    def setUserValue(userId: Id[User], key: String) = ServiceRoute(POST, "/internal/shoebox/database/userValue", Param("userId", userId), Param("key", key))
+    def getUserValue(userId: Id[User], key: UserValueName) = ServiceRoute(GET, "/internal/shoebox/database/userValue", Param("userId", userId), Param("key", key))
+    def setUserValue(userId: Id[User], key: UserValueName) = ServiceRoute(POST, "/internal/shoebox/database/userValue", Param("userId", userId), Param("key", key))
     def getUserSegment(userId: Id[User]) = ServiceRoute(GET, "/internal/shoebox/database/userSegment", Param("userId", userId))
     def getExtensionVersion(installationId: ExternalId[KifiInstallation]) = ServiceRoute(GET, "/internal/shoebox/database/extensionVersion", Param("installationId", installationId))
     def triggerRawKeepImport() = ServiceRoute(POST, "/internal/shoebox/database/triggerRawKeepImport")

--- a/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
@@ -38,9 +38,6 @@ object UserValueStates extends States[UserValue]
 @json case class UserValueName(name: String)
 
 object UserValueName {
-  /*
-   * Please use lower_underscore_case for new value names (and not lowerCamelCase)
-   */
   val LOOK_HERE_MODE = UserValueName("ext_look_here_mode")
   val ENTER_TO_SEND = UserValueName("enter_to_send")
   val MAX_RESULTS = UserValueName("ext_max_results")
@@ -67,6 +64,7 @@ object UserValueName {
   val ONBOARDING_SEEN = UserValueName("onboarding_seen")
   val NON_USER_IDENTIFIER = UserValueName("nonUserIdentifier")
   val NON_USER_KIND = UserValueName("nonUserKind")
+  // Please use lower_underscore_case for new value names (and not lowerCamelCase)
 
   def bookmarkImportContextName(newImportId: String) = UserValueName(s"bookmark_import_${newImportId}_context")
   def importInProgress(networkType: String) = UserValueName(s"import_in_progress_$networkType")

--- a/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
@@ -38,6 +38,9 @@ object UserValueStates extends States[UserValue]
 @json case class UserValueName(name: String)
 
 object UserValueName {
+  /*
+   * Please use lower_underscore_case for new value names (and not lowerCamelCase)
+   */
   val LOOK_HERE_MODE = UserValueName("ext_look_here_mode")
   val ENTER_TO_SEND = UserValueName("enter_to_send")
   val MAX_RESULTS = UserValueName("ext_max_results")

--- a/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
@@ -4,9 +4,11 @@ import com.keepit.common.db._
 import com.keepit.common.cache.CacheStatistics
 import com.keepit.common.logging.AccessLog
 import com.keepit.common.time._
+import com.kifi.macros.json
 import org.joda.time.DateTime
 import com.keepit.common.cache.{ StringCacheImpl, FortyTwoCachePlugin, Key }
 import play.api.libs.json.{ JsArray, Json, JsValue }
+import play.api.mvc.QueryStringBindable
 import scala.concurrent.duration.Duration
 import com.keepit.model.UserValues.UserValueStringHandler
 
@@ -15,7 +17,7 @@ case class UserValue(
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime,
     userId: Id[User],
-    name: String,
+    name: UserValueName,
     value: String,
     state: State[UserValue] = UserValueStates.ACTIVE) extends ModelWithState[UserValue] {
   def withId(id: Id[UserValue]) = this.copy(id = Some(id))
@@ -23,22 +25,68 @@ case class UserValue(
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
 }
 
-case class UserValueKey(userId: Id[User], key: String) extends Key[String] {
+case class UserValueKey(userId: Id[User], key: UserValueName) extends Key[String] {
   override val version = 2
   val namespace = "uservalue"
-  def toKey(): String = userId.id + "_" + key
+  def toKey(): String = userId.id + "_" + key.name
 }
 class UserValueCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
   extends StringCacheImpl[UserValueKey](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
 
 object UserValueStates extends States[UserValue]
 
+@json case class UserValueName(name: String)
+
+object UserValueName {
+  val LOOK_HERE_MODE = UserValueName("ext_look_here_mode")
+  val ENTER_TO_SEND = UserValueName("enter_to_send")
+  val MAX_RESULTS = UserValueName("ext_max_results")
+  val SHOW_EXT_MSG_INTRO = UserValueName("ext_show_ext_msg_intro")
+  val AVAILABLE_INVITES = UserValueName("availableInvites")
+  val HAS_SEEN_INSTALL = UserValueName("has_seen_install")
+  val WELCOME_EMAIL_SENT = UserValueName("welcomeEmailSent")
+  val SHOW_DELIGHTED_QUESTION = UserValueName("show_delighted_question")
+  val LAST_ACTIVE = UserValueName("last_active")
+  val GENDER = UserValueName("gender")
+  val USER_SEGMENT = UserValueName("userSegment")
+  val EXTENSION_VERSION = UserValueName("extensionVersion")
+  val USER_COLLECTION_ORDERING = UserValueName("user_collection_ordering")
+  val BOOKMARK_IMPORT_LAST_START = UserValueName("bookmark_import_last_start")
+  val BOOKMARK_IMPORT_DONE = UserValueName("bookmark_import_done")
+  val BOOKMARK_IMPORT_TOTAL = UserValueName("bookmark_import_total")
+  val USER_DESCRIPTION = UserValueName("user_description")
+  val PENDING_PRIMARY_EMAIL = UserValueName("pending_primary_email")
+  val EXT_SHOW_EXT_MSG_INTRO = UserValueName("ext_show_ext_msg_intro")
+  val FRIENDS_NOTIFIED_ABOUT_JOINING = UserValueName("friendsNotifiedAboutJoining")
+  val UPDATED_USER_CONNECTIONS = UserValueName("updated_user_connections")
+  val SITE_LEFT_COL_WIDTH = UserValueName("site_left_col_width")
+  val SITE_WELCOMED = UserValueName("site_welcomed")
+  val ONBOARDING_SEEN = UserValueName("onboarding_seen")
+  val NON_USER_IDENTIFIER = UserValueName("nonUserIdentifier")
+  val NON_USER_KIND = UserValueName("nonUserKind")
+
+  def bookmarkImportContextName(newImportId: String) = UserValueName(s"bookmark_import_${newImportId}_context")
+  def importInProgress(networkType: String) = UserValueName(s"import_in_progress_$networkType")
+
+  implicit def queryStringBinder[T](implicit stringBinder: QueryStringBindable[String]) = new QueryStringBindable[UserValueName] {
+    override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, UserValueName]] = {
+      stringBinder.bind(key, params) map {
+        case Right(address) => Right(UserValueName(address))
+        case Left(string) => Left(s"Unable to bind a valid UserValueName to string $string")
+      }
+    }
+    override def unbind(key: String, userValueName: UserValueName): String = {
+      stringBinder.unbind(key, userValueName.name)
+    }
+  }
+}
+
 trait Gender
 
 object Gender {
   case object Male extends Gender
   case object Female extends Gender
-  val key = "gender"
+  val key = UserValueName.GENDER
   def apply(gender: String): Gender = gender.toLowerCase match {
     case "male" => Male
     case "female" => Female
@@ -48,44 +96,44 @@ object Gender {
 object UserValues {
 
   trait UserValueHandler[T] {
-    def name: String
+    def name: UserValueName
     def parse(valOpt: Option[String]): T
-    def parseFromMap(valMap: Map[String, Option[String]]): T = parse(valMap(name))
+    def parseFromMap(valMap: Map[UserValueName, Option[String]]): T = parse(valMap(name))
   }
 
-  case class UserValueBooleanHandler(override val name: String, default: Boolean) extends UserValueHandler[Boolean] {
+  case class UserValueBooleanHandler(override val name: UserValueName, default: Boolean) extends UserValueHandler[Boolean] {
     def parse(valOpt: Option[String]): Boolean = valOpt.map(_.toBoolean).getOrElse(default)
   }
 
-  case class UserValueIntHandler(override val name: String, default: Int) extends UserValueHandler[Int] {
+  case class UserValueIntHandler(override val name: UserValueName, default: Int) extends UserValueHandler[Int] {
     def parse(valOpt: Option[String]): Int = valOpt.map(_.toInt).getOrElse(default)
   }
 
-  case class UserValueStringHandler(override val name: String, default: String) extends UserValueHandler[String] {
+  case class UserValueStringHandler(override val name: UserValueName, default: String) extends UserValueHandler[String] {
     def parse(valOpt: Option[String]): String = valOpt.getOrElse(default)
   }
 
-  case class UserValueDateTimeHandler(override val name: String, default: DateTime) extends UserValueHandler[DateTime] {
+  case class UserValueDateTimeHandler(override val name: UserValueName, default: DateTime) extends UserValueHandler[DateTime] {
     def parse(valOpt: Option[String]): DateTime = valOpt.map(parseStandardTime(_)).getOrElse(default)
   }
 
-  case class UserValueJsValueHandler(override val name: String, default: JsValue) extends UserValueHandler[JsValue] {
+  case class UserValueJsValueHandler(override val name: UserValueName, default: JsValue) extends UserValueHandler[JsValue] {
     def parse(valOpt: Option[String]): JsValue = valOpt.map(Json.parse).getOrElse(default)
   }
 
-  val lookHereMode = UserValueBooleanHandler("ext_look_here_mode", true)
-  val enterToSend = UserValueBooleanHandler("enter_to_send", true)
-  val maxResults = UserValueIntHandler("ext_max_results", 1)
-  val showExtMsgIntro = UserValueBooleanHandler("ext_show_ext_msg_intro", true)
+  val lookHereMode = UserValueBooleanHandler(UserValueName.LOOK_HERE_MODE, true)
+  val enterToSend = UserValueBooleanHandler(UserValueName.ENTER_TO_SEND, true)
+  val maxResults = UserValueIntHandler(UserValueName.MAX_RESULTS, 1)
+  val showExtMsgIntro = UserValueBooleanHandler(UserValueName.SHOW_EXT_MSG_INTRO, true)
 
-  val UserInitPrefs: Seq[String] = Seq(lookHereMode, enterToSend, maxResults, showExtMsgIntro).map(_.name)
+  val UserInitPrefs: Seq[UserValueName] = Seq(lookHereMode, enterToSend, maxResults, showExtMsgIntro).map(_.name)
 
-  val availableInvites = UserValueIntHandler("availableInvites", 1000)
-  val hasSeenInstall = UserValueBooleanHandler("has_seen_install", false)
-  val welcomeEmailSent = UserValueBooleanHandler("welcomeEmailSent", false)
+  val availableInvites = UserValueIntHandler(UserValueName.AVAILABLE_INVITES, 1000)
+  val hasSeenInstall = UserValueBooleanHandler(UserValueName.HAS_SEEN_INSTALL, false)
+  val welcomeEmailSent = UserValueBooleanHandler(UserValueName.WELCOME_EMAIL_SENT, false)
 
-  val showDelightedQuestion = UserValueBooleanHandler("show_delighted_question", false)
-  val lastActive = UserValueDateTimeHandler("last_active", START_OF_TIME)
+  val showDelightedQuestion = UserValueBooleanHandler(UserValueName.SHOW_DELIGHTED_QUESTION, false)
+  val lastActive = UserValueDateTimeHandler(UserValueName.LAST_ACTIVE, START_OF_TIME)
 
-  val tagOrdering = UserValueJsValueHandler("user_collection_ordering", JsArray())
+  val tagOrdering = UserValueJsValueHandler(UserValueName.USER_COLLECTION_ORDERING, JsArray())
 }

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -104,8 +104,8 @@ trait ShoeboxServiceClient extends ServiceClient {
   def getProxy(url: String): Future[Option[HttpProxy]]
   def getProxyP(url: String): Future[Option[HttpProxy]]
   def getFriendRequestsBySender(senderId: Id[User]): Future[Seq[FriendRequest]]
-  def getUserValue(userId: Id[User], key: String): Future[Option[String]]
-  def setUserValue(userId: Id[User], key: String, value: String): Unit
+  def getUserValue(userId: Id[User], key: UserValueName): Future[Option[String]]
+  def setUserValue(userId: Id[User], key: UserValueName, value: String): Unit
   def getUserSegment(userId: Id[User]): Future[UserSegment]
   def getExtensionVersion(installationId: ExternalId[KifiInstallation]): Future[String]
   def triggerRawKeepImport(): Unit
@@ -702,13 +702,13 @@ class ShoeboxServiceClientImpl @Inject() (
     }
   }
 
-  def getUserValue(userId: Id[User], key: String): Future[Option[String]] = {
+  def getUserValue(userId: Id[User], key: UserValueName): Future[Option[String]] = {
     cacheProvider.userValueCache.getOrElseFutureOpt(UserValueKey(userId, key)) {
       call(Shoebox.internal.getUserValue(userId, key)).map(_.json.asOpt[String])
     }
   }
 
-  def setUserValue(userId: Id[User], key: String, value: String): Unit = { call(Shoebox.internal.setUserValue(userId, key), JsString(value)) }
+  def setUserValue(userId: Id[User], key: UserValueName, value: String): Unit = { call(Shoebox.internal.setUserValue(userId, key), JsString(value)) }
 
   def getUserSegment(userId: Id[User]): Future[UserSegment] = {
     cacheProvider.userSegmentCache.getOrElseFuture(UserSegmentKey(userId)) {

--- a/kifi-backend/modules/common/app/com/keepit/social/SocialGraph.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/SocialGraph.scala
@@ -3,7 +3,7 @@ package com.keepit.social
 import scala.concurrent.Future
 import scala.util.Try
 
-import com.keepit.model.SocialUserInfo
+import com.keepit.model.{ UserValueName, SocialUserInfo }
 
 import net.codingwell.scalaguice.ScalaModule
 
@@ -22,7 +22,7 @@ trait SocialGraph {
   def extractFriends(parentJson: JsValue): Seq[SocialUserInfo]
   def updateSocialUserInfo(sui: SocialUserInfo, json: JsValue): SocialUserInfo
   def revokePermissions(socialUserInfo: SocialUserInfo): Future[Unit]
-  def extractUserValues(json: JsValue): Map[String, String]
+  def extractUserValues(json: JsValue): Map[UserValueName, String]
   def vetJsAccessToken(settings: OAuth2Settings, json: JsValue): Try[IdentityId]
 }
 

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -100,7 +100,7 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
   val allCollectionBookmarks = MutableMap[Id[Collection], Set[Id[Keep]]]()
   val allSearchExperiments = MutableMap[Id[SearchConfigExperiment], SearchConfigExperiment]()
   val allUserEmails = MutableMap[Id[User], Set[EmailAddress]]()
-  val allUserValues = MutableMap[(Id[User], String), String]()
+  val allUserValues = MutableMap[(Id[User], UserValueName), String]()
   val allFriendRequests = MutableMap[Id[FriendRequest], FriendRequest]()
   val allUserFriendRequests = MutableMap[Id[User], Seq[FriendRequest]]()
 
@@ -552,9 +552,9 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
     Future.successful(allUserFriendRequests.getOrElse(senderId, Seq()))
   }
 
-  def getUserValue(userId: Id[User], key: String): Future[Option[String]] = Future.successful(allUserValues.get((userId, key)))
+  def getUserValue(userId: Id[User], key: UserValueName): Future[Option[String]] = Future.successful(allUserValues.get((userId, key)))
 
-  def setUserValue(userId: Id[User], key: String, value: String): Unit = allUserValues((userId, key)) = value
+  def setUserValue(userId: Id[User], key: UserValueName, value: String): Unit = allUserValues((userId, key)) = value
 
   def getUserSegment(userId: Id[User]): Future[UserSegment] = Future.successful(UserSegment(Int.MaxValue))
 

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/NonUserEventRepos.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/NonUserEventRepos.scala
@@ -36,8 +36,8 @@ trait NonUserEventDescriptorRepo extends EventDescriptorRepo[NonUserEvent]
 object NonUserIdentifierAugmentor extends EventAugmentor[NonUserEvent] {
   def isDefinedAt(nonUserEvent: NonUserEvent) = true
   def apply(nonUserEvent: NonUserEvent): Future[Seq[(String, ContextData)]] = Future.successful(Seq(
-    "nonUserIdentifier" -> ContextStringData(nonUserEvent.identifier),
-    "nonUserKind" -> ContextStringData(nonUserEvent.kind.name)
+    UserValueName.NON_USER_IDENTIFIER.name -> ContextStringData(nonUserEvent.identifier),
+    UserValueName.NON_USER_KIND.name -> ContextStringData(nonUserEvent.kind.name)
   ))
 }
 

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/UserEventRepos.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/UserEventRepos.scala
@@ -60,12 +60,12 @@ class ProdUserEventLoggingRepo(
 }
 
 class ExtensionVersionAugmentor(shoeboxClient: ShoeboxServiceClient) extends EventAugmentor[UserEvent] {
-  def isDefinedAt(userEvent: UserEvent) = userEvent.context.get[String]("extensionVersion").filter(_.nonEmpty).isEmpty
+  def isDefinedAt(userEvent: UserEvent) = userEvent.context.get[String](UserValueName.EXTENSION_VERSION.name).filter(_.nonEmpty).isEmpty
   def apply(userEvent: UserEvent): Future[Seq[(String, ContextData)]] = {
     userEvent.context.data.get("kifiInstallationId") collect {
       case ContextStringData(id) => {
         shoeboxClient.getExtensionVersion(ExternalId[KifiInstallation](id)).map {
-          version => Seq("extensionVersion" -> ContextStringData(version))
+          version => Seq(UserValueName.EXTENSION_VERSION.name -> ContextStringData(version))
         }
       }
     } getOrElse Future.successful(Seq.empty)
@@ -76,7 +76,7 @@ class UserValuesAugmentor(shoeboxClient: ShoeboxServiceClient) extends EventAugm
   def isDefinedAt(userEvent: UserEvent) = true
   def apply(userEvent: UserEvent): Future[Seq[(String, ContextData)]] = {
     shoeboxClient.getUserValue(userEvent.userId, Gender.key).map(Seq(_).flatten.map { gender =>
-      Gender.key -> ContextStringData(Gender(gender).toString)
+      Gender.key.name -> ContextStringData(Gender(gender).toString)
     })
   }
 }
@@ -86,7 +86,7 @@ class UserSegmentAugmentor(shoeboxClient: ShoeboxServiceClient) extends EventAug
   def apply(userEvent: UserEvent): Future[Seq[(String, ContextData)]] = {
     val uid = userEvent.userId
     shoeboxClient.getUserSegment(uid).map { seg =>
-      Seq(("userSegment" -> ContextStringData(UserSegment.getDescription(seg))))
+      Seq((UserValueName.USER_SEGMENT.name -> ContextStringData(UserSegment.getDescription(seg))))
     }
   }
 }

--- a/kifi-backend/modules/heimdal/test/com/keepit/heimdal/UserEventAugmentorsTest.scala
+++ b/kifi-backend/modules/heimdal/test/com/keepit/heimdal/UserEventAugmentorsTest.scala
@@ -1,10 +1,9 @@
 package com.keepit.heimdal
 
-import com.keepit.model.{ UserIdAugmentor, UserValuesAugmentor, ExtensionVersionAugmentor, EventAugmentor }
+import com.keepit.model._
 import org.specs2.mutable.Specification
 import com.keepit.shoebox.FakeShoeboxServiceClientImpl
 import scala.concurrent.{ Await, Future }
-import com.keepit.model.{ KifiInstallation, Gender }
 import com.keepit.common.healthcheck.FakeAirbrakeNotifier
 import com.keepit.common.db.{ ExternalId, Id }
 import scala.concurrent.duration._
@@ -34,7 +33,7 @@ class UserEventAugmentorsTest extends Specification with FutureTestScope {
     "Augment event with gender when it's available" in {
       val event = new UserEvent(Id(134), new HeimdalContext(Map("name" -> ContextStringData("Léo"))), EventType("fake"))
       Await.result(userValuesAugmentor(event), 1 seconds) === Seq.empty
-      shoeboxClient.setUserValue(Id(134), "gender", "male")
+      shoeboxClient.setUserValue(Id(134), UserValueName.GENDER, "male")
       Await.result(userValuesAugmentor(event), 1 seconds) === Seq("gender" -> ContextStringData(Gender.Male.toString))
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -492,7 +492,7 @@ class AdminUserController @Inject() (
 
   def userValue(userId: Id[User]) = AdminJsonAction.authenticated { implicit request =>
     val req = request.body.asJson.map { json =>
-      ((json \ "name").asOpt[String], (json \ "value").asOpt[String], (json \ "clear").asOpt[Boolean]) match {
+      ((json \ "name").asOpt[UserValueName], (json \ "value").asOpt[String], (json \ "clear").asOpt[Boolean]) match {
         case (Some(name), Some(value), None) =>
           Some(db.readWrite { implicit session => // set it
             userValueRepo.setValue(userId, name, value)
@@ -655,7 +655,7 @@ class AdminUserController @Inject() (
 
         val allInstallations = kifiInstallationRepo.all(userId)
         if (allInstallations.nonEmpty) { properties += ("installedExtension", allInstallations.maxBy(_.updatedAt).version.toString) }
-        userValueRepo.getValueStringOpt(userId, Gender.key).foreach { gender => properties += (Gender.key, Gender(gender).toString) }
+        userValueRepo.getValueStringOpt(userId, Gender.key).foreach { gender => properties += (Gender.key.name, Gender(gender).toString) }
       }
       heimdal.setUserProperties(userId, properties.data.toSeq: _*)
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -76,10 +76,10 @@ class KeepInterner @Inject() (
       db.readWrite(attempts = 3) { implicit session =>
         // This isn't designed to handle multiple imports at once. When we need this, it'll need to be tweaked.
         // If it happens, the user will experience the % complete jumping around a bit until it's finished.
-        userValueRepo.setValue(userId, "bookmark_import_last_start", clock.now)
-        userValueRepo.setValue(userId, "bookmark_import_done", 0)
-        userValueRepo.setValue(userId, "bookmark_import_total", total)
-        userValueRepo.setValue(userId, s"bookmark_import_${newImportId}_context", Json.toJson(context))
+        userValueRepo.setValue(userId, UserValueName.BOOKMARK_IMPORT_LAST_START, clock.now)
+        userValueRepo.setValue(userId, UserValueName.BOOKMARK_IMPORT_DONE, 0)
+        userValueRepo.setValue(userId, UserValueName.BOOKMARK_IMPORT_TOTAL, total)
+        userValueRepo.setValue(userId, UserValueName.bookmarkImportContextName(newImportId), Json.toJson(context))
       }
 
       deduped.grouped(500).toList.map { rawKeepGroup =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/FacebookSocialGraph.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/FacebookSocialGraph.scala
@@ -166,7 +166,7 @@ class FacebookSocialGraph @Inject() (
     oAuth2Info.accessToken
   }
 
-  def extractUserValues(json: JsValue): Map[String, String] = Seq(
+  def extractUserValues(json: JsValue): Map[UserValueName, String] = Seq(
     (json \ "gender").asOpt[String].map(Gender.key -> Gender(_).toString)
   ).flatten.toMap
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/LinkedInSocialGraph.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/LinkedInSocialGraph.scala
@@ -17,7 +17,7 @@ import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
 import com.keepit.common.net.{ CallTimeouts, NonOKResponseException, HttpClient, DirectUrl }
 import com.keepit.model.SocialUserInfoStates._
-import com.keepit.model.{ SocialUserInfoRepo, SocialUserInfoStates, SocialUserInfo }
+import com.keepit.model.{ UserValueName, SocialUserInfoRepo, SocialUserInfoStates, SocialUserInfo }
 import com.keepit.social.{ SocialUserRawInfo, SocialNetworks, SocialId, SocialGraph }
 
 import play.api.http.Status._
@@ -127,7 +127,7 @@ class LinkedInSocialGraph @Inject() (
     s"https://api.linkedin.com/v1/people/$id:$ProfileFieldSelector?format=json&oauth2_access_token=$accessToken"
   }
 
-  def extractUserValues(json: JsValue): Map[String, String] = Map.empty
+  def extractUserValues(json: JsValue): Map[UserValueName, String] = Map.empty
 
   def updateSocialUserInfo(sui: SocialUserInfo, json: JsValue): SocialUserInfo = {
     (json \ "id").asOpt[String] map { id =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphPluginImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphPluginImpl.scala
@@ -110,7 +110,7 @@ private[social] class SocialGraphActor @Inject() (
           latestUserValues.collect {
             case (key, value) if userValueRepo.getValueStringOpt(userId, key) != Some(value) =>
               userValueRepo.setValue(userId, key, value)
-              heimdal.setUserProperties(userId, key -> ContextStringData(value))
+              heimdal.setUserProperties(userId, key.name -> ContextStringData(value))
           }
           socialRepo.save(updatedSui.withState(SocialUserInfoStates.FETCHED_USING_SELF).withLastGraphRefresh())
         }
@@ -126,7 +126,7 @@ private[social] class SocialGraphActor @Inject() (
     } finally {
       socialUserInfo.userId.foreach { userId =>
         db.readWrite(attempts = 3) { implicit session =>
-          userValueRepo.clearValue(userId, s"import_in_progress_${socialUserInfo.networkType.name}")
+          userValueRepo.clearValue(userId, UserValueName.importInProgress(socialUserInfo.networkType.name))
         }
       }
     }
@@ -134,13 +134,13 @@ private[social] class SocialGraphActor @Inject() (
 
   private def markGraphImportUserValue(userId: Id[User], networkType: SocialNetworkType, state: String) = {
     db.readWrite(attempts = 3) { implicit session =>
-      userValueRepo.setValue(userId, s"import_in_progress_${networkType.name}", state)
+      userValueRepo.setValue(userId, UserValueName.importInProgress(networkType.name), state)
     }
   }
 
   private def isImportAlreadyInProcess(userId: Id[User], networkType: SocialNetworkType): Boolean = {
     val stateOpt = db.readOnlyMaster { implicit session =>
-      userValueRepo.getUserValue(userId, s"import_in_progress_${networkType.name}")
+      userValueRepo.getUserValue(userId, UserValueName.importInProgress(networkType.name))
     }
     stateOpt match {
       case None => false

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/UserConnectionCreator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/UserConnectionCreator.scala
@@ -18,10 +18,6 @@ import play.api.libs.json.Json
 import com.keepit.heimdal.{ ContextDoubleData, HeimdalServiceClient }
 import com.keepit.common.performance.timing
 
-object UserConnectionCreator {
-  private val UpdatedUserConnectionsKey = "updated_user_connections"
-}
-
 class UserConnectionCreator @Inject() (
   db: Database,
   socialRepo: SocialUserInfoRepo,
@@ -48,7 +44,7 @@ class UserConnectionCreator @Inject() (
   }
 
   def getConnectionsLastUpdated(userId: Id[User]): Option[DateTime] = db.readOnlyMaster { implicit s =>
-    userValueRepo.getValueStringOpt(userId, UserConnectionCreator.UpdatedUserConnectionsKey) map parseStandardTime
+    userValueRepo.getValueStringOpt(userId, UserValueName.UPDATED_USER_CONNECTIONS) map parseStandardTime
   }
 
   def updateUserConnections(userId: Id[User]) = timing(s"updateUserConnections($userId)") {
@@ -58,7 +54,7 @@ class UserConnectionCreator @Inject() (
 
       val newConnections = socialConnections -- existingConnections
       userConnectionRepo.addConnections(userId, newConnections)
-      userValueRepo.setValue(userId, UserConnectionCreator.UpdatedUserConnectionsKey, clock.now.toStandardTimeString)
+      userValueRepo.setValue(userId, UserValueName.UPDATED_USER_CONNECTIONS, clock.now.toStandardTimeString)
 
       newConnections.foreach { connId =>
         log.info(s"Sending new connection to user $connId (to $userId)")

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -169,7 +169,7 @@ class AuthHelper @Inject() (
         emailAddressRepo.getByAddressOpt(emailAddress) map { emailAddr =>
           userRepo.save(user.copy(primaryEmail = Some(emailAddr.address)))
         }
-        userValueRepo.clearValue(user.id.get, "pending_primary_email")
+        userValueRepo.clearValue(user.id.get, UserValueName.PENDING_PRIMARY_EMAIL)
       }
       SafeFuture { userCommander.sendWelcomeEmail(user, withVerification = false) }
     }
@@ -346,7 +346,7 @@ class AuthHelper @Inject() (
     db.readWrite { implicit s =>
       emailAddressRepo.getByCode(code).map { address =>
         lazy val isPendingPrimaryEmail = {
-          val pendingEmail = userValueRepo.getValueStringOpt(address.userId, "pending_primary_email").map(EmailAddress(_))
+          val pendingEmail = userValueRepo.getValueStringOpt(address.userId, UserValueName.PENDING_PRIMARY_EMAIL).map(EmailAddress(_))
           pendingEmail.isDefined && address.address == pendingEmail.get
         }
         val user = userRepo.get(address.userId)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -585,13 +585,13 @@ class ShoeboxController @Inject() (
     Ok(JsArray(requests.map { x => Json.toJson(x) }))
   }
 
-  def setUserValue(userId: Id[User], key: String) = SafeAsyncAction(parse.tolerantJson) { request =>
+  def setUserValue(userId: Id[User], key: UserValueName) = SafeAsyncAction(parse.tolerantJson) { request =>
     val value = request.body.as[String]
     db.readWrite(attempts = 3) { implicit session => userValueRepo.setValue(userId, key, value) }
     Ok
   }
 
-  def getUserValue(userId: Id[User], key: String) = SafeAsyncAction { request =>
+  def getUserValue(userId: Id[User], key: UserValueName) = SafeAsyncAction { request =>
     val value = db.readOnlyMaster { implicit session => userValueRepo.getValueStringOpt(userId, key) } //using cache
     Ok(Json.toJson(value))
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
@@ -203,7 +203,7 @@ class MobileUserController @Inject() (
     }
   }
 
-  private val MobilePrefNames = Set("show_delighted_question")
+  private val MobilePrefNames = Set(UserValueName.SHOW_DELIGHTED_QUESTION)
 
   def getPrefs() = JsonAction.authenticatedAsync { request =>
     // Make sure the user's last active date has been updated before returning the result

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
@@ -425,11 +425,11 @@ class KeepsController @Inject() (
 
   def importStatus() = JsonAction.authenticated { request =>
     val values = db.readOnlyMaster { implicit session =>
-      userValueRepo.getValues(request.user.id.get, "bookmark_import_last_start", "bookmark_import_done", "bookmark_import_total")
+      userValueRepo.getValues(request.user.id.get, UserValueName.BOOKMARK_IMPORT_LAST_START, UserValueName.BOOKMARK_IMPORT_DONE, UserValueName.BOOKMARK_IMPORT_TOTAL)
     }
-    val lastStartOpt = values("bookmark_import_last_start")
-    val done = values("bookmark_import_done")
-    val total = values("bookmark_import_total")
+    val lastStartOpt = values(UserValueName.BOOKMARK_IMPORT_LAST_START)
+    val done = values(UserValueName.BOOKMARK_IMPORT_DONE)
+    val total = values(UserValueName.BOOKMARK_IMPORT_TOTAL)
     val lastStart = lastStartOpt.map { lastStart =>
       Seconds.secondsBetween(parseStandardTime(lastStart), clock.now).getSeconds
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserValueRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserValueRepo.scala
@@ -16,7 +16,6 @@ trait UserValueRepo extends Repo[UserValue] {
   def getUserValue(userId: Id[User], key: UserValueName)(implicit session: RSession): Option[UserValue]
   def setValue[T](userId: Id[User], name: UserValueName, value: T)(implicit session: RWSession): T
   def clearValue(userId: Id[User], name: UserValueName)(implicit session: RWSession): Boolean
-  def getLapsedUsers(before: DateTime, after: DateTime, maxCount: Int = 1000)(implicit session: RSession): Seq[Id[User]]
 }
 
 @Singleton

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserValueRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserValueRepo.scala
@@ -4,18 +4,19 @@ import com.google.inject.{ Inject, Singleton, ImplementedBy }
 import com.keepit.common.db.slick._
 import com.keepit.common.db.{ LargeString, State, Id }
 import com.keepit.common.db.slick.DBSession.{ RWSession, RSession }
-import com.keepit.common.time.{ Clock, DEFAULT_DATE_TIME_ZONE }
+import com.keepit.common.time._
 import org.joda.time.DateTime
 import com.keepit.model.UserValues.UserValueHandler
 
 @ImplementedBy(classOf[UserValueRepoImpl])
 trait UserValueRepo extends Repo[UserValue] {
   def getValue[T](userId: Id[User], handler: UserValueHandler[T])(implicit session: RSession): T
-  def getValueStringOpt(userId: Id[User], key: String)(implicit session: RSession): Option[String]
-  def getValues(userId: Id[User], keys: String*)(implicit session: RSession): Map[String, Option[String]]
-  def getUserValue(userId: Id[User], key: String)(implicit session: RSession): Option[UserValue]
-  def setValue[T](userId: Id[User], name: String, value: T)(implicit session: RWSession): T
-  def clearValue(userId: Id[User], name: String)(implicit session: RWSession): Boolean
+  def getValueStringOpt(userId: Id[User], key: UserValueName)(implicit session: RSession): Option[String]
+  def getValues(userId: Id[User], keys: UserValueName*)(implicit session: RSession): Map[UserValueName, Option[String]]
+  def getUserValue(userId: Id[User], key: UserValueName)(implicit session: RSession): Option[UserValue]
+  def setValue[T](userId: Id[User], name: UserValueName, value: T)(implicit session: RWSession): T
+  def clearValue(userId: Id[User], name: UserValueName)(implicit session: RWSession): Boolean
+  def getLapsedUsers(before: DateTime, after: DateTime, maxCount: Int = 1000)(implicit session: RSession): Seq[Id[User]]
 }
 
 @Singleton
@@ -31,16 +32,16 @@ class UserValueRepoImpl @Inject() (
   case class UserValueTable(tag: Tag) extends RepoTable[UserValue](db, tag, "user_value") {
     def userId = column[Id[User]]("user_id", O.NotNull)
     def value = column[LargeString]("value", O.NotNull)
-    def name = column[String]("name", O.NotNull)
+    def name = column[UserValueName]("name", O.NotNull)
 
     def * = (id.?, createdAt, updatedAt, userId, name, value, state) <> (rowToObj, objToRow)
   }
 
-  private val rowToObj: ((Option[Id[UserValue]], DateTime, DateTime, Id[User], String, LargeString, State[UserValue])) => UserValue = {
+  private val rowToObj: ((Option[Id[UserValue]], DateTime, DateTime, Id[User], UserValueName, LargeString, State[UserValue])) => UserValue = {
     case (id, createdAt, updatedAt, userId, name, LargeString(value), state) => UserValue(id, createdAt, updatedAt, userId, name, value, state)
   }
 
-  private val objToRow: UserValue => Option[(Option[Id[UserValue]], DateTime, DateTime, Id[User], String, LargeString, State[UserValue])] = {
+  private val objToRow: UserValue => Option[(Option[Id[UserValue]], DateTime, DateTime, Id[User], UserValueName, LargeString, State[UserValue])] = {
     case UserValue(id, createdAt, updatedAt, userId, name, value, state) => Some((id, createdAt, updatedAt, userId, name, LargeString(value), state))
     case _ => None
   }
@@ -55,11 +56,11 @@ class UserValueRepoImpl @Inject() (
     valueCache.remove(UserValueKey(userValue.userId, userValue.name))
   }
 
-  private def getValueUnsafeNoCache[T](userId: Id[User], key: String)(implicit session: RSession): Option[String] = {
+  private def getValueUnsafeNoCache[T](userId: Id[User], key: UserValueName)(implicit session: RSession): Option[String] = {
     (for (f <- rows if f.state === UserValueStates.ACTIVE && f.userId === userId && f.name === key) yield f.value).firstOption.map(_.value)
   }
 
-  def getValueStringOpt(userId: Id[User], key: String)(implicit session: RSession): Option[String] = {
+  def getValueStringOpt(userId: Id[User], key: UserValueName)(implicit session: RSession): Option[String] = {
     valueCache.getOrElseOpt(UserValueKey(userId, key)) {
       getValueUnsafeNoCache(userId, key)
     }
@@ -70,7 +71,7 @@ class UserValueRepoImpl @Inject() (
     handler.parse(value)
   }
 
-  def getValues(userId: Id[User], names: String*)(implicit session: RSession): Map[String, Option[String]] =
+  def getValues(userId: Id[User], names: UserValueName*)(implicit session: RSession): Map[UserValueName, Option[String]] =
     valueCache.bulkGetOrElseOpt(names map { name => UserValueKey(userId, name) } toSet) { missingNames =>
       val missingValues = missingNames map { missingName =>
         missingName -> getValueUnsafeNoCache(userId, missingName.key)
@@ -81,10 +82,10 @@ class UserValueRepoImpl @Inject() (
         k.key -> v
     }
 
-  def getUserValue(userId: Id[User], name: String)(implicit session: RSession): Option[UserValue] =
+  def getUserValue(userId: Id[User], name: UserValueName)(implicit session: RSession): Option[UserValue] =
     (for (f <- rows if f.state === UserValueStates.ACTIVE && f.userId === userId && f.name === name) yield f).firstOption
 
-  def setValue[T](userId: Id[User], name: String, value: T)(implicit session: RWSession): T = {
+  def setValue[T](userId: Id[User], name: UserValueName, value: T)(implicit session: RWSession): T = {
     val stringValue = value.toString
     val updated = (for (v <- rows if v.userId === userId && v.name === name) yield (v.value, v.state, v.updatedAt)).update((stringValue, UserValueStates.ACTIVE, clock.now())) > 0
     if (updated) {
@@ -96,7 +97,7 @@ class UserValueRepoImpl @Inject() (
     }
   }
 
-  def clearValue(userId: Id[User], name: String)(implicit session: RWSession): Boolean = {
+  def clearValue(userId: Id[User], name: UserValueName)(implicit session: RWSession): Boolean = {
     val changed = (for (v <- rows if v.userId === userId && v.name === name && v.state =!= UserValueStates.INACTIVE) yield (v.state, v.updatedAt))
       .update((UserValueStates.INACTIVE, clock.now())) > 0
     if (changed) {

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -683,8 +683,8 @@ POST     /internal/shoebox/database/getProxyP         @com.keepit.controllers.in
 GET      /internal/shoebox/database/isUnscrapable     @com.keepit.controllers.internal.ShoeboxController.isUnscrapable(url: String, destinationUrl: Option[String])
 POST     /internal/shoebox/database/isUnscrapableP    @com.keepit.controllers.internal.ShoeboxController.isUnscrapableP
 GET      /internal/shoebox/database/getFriendRequestBySender @com.keepit.controllers.internal.ShoeboxController.getFriendRequestsBySender(senderId: Id[User])
-GET      /internal/shoebox/database/userValue         @com.keepit.controllers.internal.ShoeboxController.getUserValue(userId: Id[User], key: String)
-POST     /internal/shoebox/database/userValue         @com.keepit.controllers.internal.ShoeboxController.setUserValue(userId: Id[User], key: String)
+GET      /internal/shoebox/database/userValue         @com.keepit.controllers.internal.ShoeboxController.getUserValue(userId: Id[User], key: UserValueName)
+POST     /internal/shoebox/database/userValue         @com.keepit.controllers.internal.ShoeboxController.setUserValue(userId: Id[User], key: UserValueName)
 GET      /internal/shoebox/database/userSegment       @com.keepit.controllers.internal.ShoeboxController.getUserSegment(userId: Id[User])
 GET      /internal/shoebox/database/extensionVersion  @com.keepit.controllers.internal.ShoeboxController.getExtensionVersion(installationId: ExternalId[KifiInstallation])
 POST     /internal/shoebox/database/triggerRawKeepImport @com.keepit.controllers.internal.ShoeboxController.triggerRawKeepImport()

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
@@ -117,7 +117,6 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
 
         val t1 = new DateTime(2013, 2, 14, 21, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val userValueRepo = inject[UserValueRepo]
-        val CollectionOrderingKey = "user_collection_ordering"
 
         val (user, oldOrdering, tagA, tagB, tagC, tagD) = db.readWrite { implicit s =>
           val user1 = userRepo.save(User(firstName = "Mario", lastName = "Luigi", createdAt = t1))
@@ -134,7 +133,7 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
             Nil
           val collectionIds = collections.map(_.externalId).toSeq
 
-          userValueRepo.save(UserValue(userId = user1.id.get, name = CollectionOrderingKey, value = Json.stringify(Json.toJson(collectionIds))))
+          userValueRepo.save(UserValue(userId = user1.id.get, name = UserValueName.USER_COLLECTION_ORDERING, value = Json.stringify(Json.toJson(collectionIds))))
           (user1, collectionIds, tagA, tagB, tagC, tagD)
         }
 
@@ -149,7 +148,7 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
           inject[CollectionCommander].setCollectionIndexOrdering(user.id.get, tagA.externalId, 2)
         }
         db.readOnlyMaster { implicit s =>
-          val ordering = userValueRepo.getUserValue(user.id.get, CollectionOrderingKey).get
+          val ordering = userValueRepo.getUserValue(user.id.get, UserValueName.USER_COLLECTION_ORDERING).get
           val newOrdering = tagB.externalId :: tagC.externalId :: tagA.externalId :: tagD.externalId :: Nil
           ordering.value === Json.stringify(Json.toJson(newOrdering))
         }
@@ -159,7 +158,7 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
           inject[CollectionCommander].setCollectionIndexOrdering(user.id.get, tagA.externalId, 0)
         }
         db.readOnlyMaster { implicit s =>
-          val ordering = userValueRepo.getUserValue(user.id.get, CollectionOrderingKey).get
+          val ordering = userValueRepo.getUserValue(user.id.get, UserValueName.USER_COLLECTION_ORDERING).get
           val newOrdering = tagA.externalId :: tagB.externalId :: tagC.externalId :: tagD.externalId :: Nil
           ordering.value === Json.stringify(Json.toJson(newOrdering))
         }
@@ -169,7 +168,7 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
           inject[CollectionCommander].setCollectionIndexOrdering(user.id.get, tagA.externalId, 3)
         }
         db.readOnlyMaster { implicit s =>
-          val ordering = userValueRepo.getUserValue(user.id.get, CollectionOrderingKey).get
+          val ordering = userValueRepo.getUserValue(user.id.get, UserValueName.USER_COLLECTION_ORDERING).get
           val newOrdering = tagB.externalId :: tagC.externalId :: tagD.externalId :: tagA.externalId :: Nil
           ordering.value === Json.stringify(Json.toJson(newOrdering))
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
@@ -785,7 +785,7 @@ class KeepsControllerTest extends Specification with ApplicationInjector {
             Nil
 
           val collectionIds = collections.map(_.externalId).toSeq
-          inject[UserValueRepo].save(UserValue(userId = user1.id.get, name = "user_collection_ordering", value = Json.stringify(Json.toJson(collectionIds))))
+          inject[UserValueRepo].save(UserValue(userId = user1.id.get, name = UserValueName.USER_COLLECTION_ORDERING, value = Json.stringify(Json.toJson(collectionIds))))
           (user1, collectionIds, tagA, tagB, tagC, tagD)
         }
 

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
@@ -74,6 +74,7 @@ trait FortyTwoGenericTypeMappers { self: { val db: DataBaseComponent } =>
   implicit val libraryAccessTypeMapper = MappedColumnType.base[LibraryAccess, String](_.value, LibraryAccess.apply)
   implicit val usernameTypeMapper = MappedColumnType.base[Username, String](_.value, Username.apply)
   implicit val libraryKindTypeMapper = MappedColumnType.base[LibraryKind, String](_.value, LibraryKind.apply)
+  implicit val userValueNameTypeMapper = MappedColumnType.base[UserValueName, String](_.name, UserValueName.apply)
 
   implicit def experimentTypeProbabilityDensityMapper[T](implicit outcomeFormat: Format[T]) = MappedColumnType.base[ProbabilityDensity[T], String](
     obj => Json.stringify(ProbabilityDensity.format[T].writes(obj)),


### PR DESCRIPTION
@eishay @ymatsuda @andrewconner @stkem
While I was working with user values, I realized that currently the names of our user values are just hardcoded strings duplicated everywhere, which is not great (risk mistyping names, using the same name for two different user values, etc). I refactored the codebase to use the `UserValueName` type to hold user value names, so that they are all gathered in a single place (see UserValue.scala). I think it's a safer pattern. Let me know what you think.
