### PR TITLE
removing long unused capability to auto-expand the keep button

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1879,19 +1879,9 @@ function kififyWithPageData(tab, d) {
         log('[initTab]', tab.id, 'restricted');
       } else if (ruleSet.rules.shown && d.shown) {
         log('[initTab]', tab.id, 'shown before');
-      } else {
-        var focused = api.tabs.isFocused(tab);
-        if (ruleSet.rules.scroll) {
-          api.tabs.emit(tab, 'scroll_rule', ruleSet.rules.scroll, {queue: 1});
-        }
-        if ((ruleSet.rules.focus || [])[0] != null) {
-          tab.buttonSec = ruleSet.rules.focus[0];
-          if (focused) scheduleAutoEngage(tab, 'button');
-        }
-        if (d.keepers.length) {
-          tab.keepersSec = 20;
-          if (focused) scheduleAutoEngage(tab, 'keepers');
-        }
+      } else if (d.keepers.length) {
+        tab.keepersSec = 20;
+        if (api.tabs.isFocused(tab)) scheduleAutoEngage(tab, 'keepers');
       }
     }
   }
@@ -2050,13 +2040,12 @@ api.tabs.on.focus.add(function(tab) {
   }
   delete tab.focusCallbacks;
   kifify(tab);
-  scheduleAutoEngage(tab, 'button');
   scheduleAutoEngage(tab, 'keepers');
 });
 
 api.tabs.on.blur.add(function(tab) {
   log("#b8a", "[tabs.on.blur] %i %o", tab.id, tab);
-  ['button', 'keepers'].forEach(clearAutoEngageTimer.bind(null, tab));
+  clearAutoEngageTimer(tab, 'keepers');
 });
 
 api.tabs.on.loading.add(function(tab) {
@@ -2095,7 +2084,7 @@ api.tabs.on.unload.add(function(tab, historyApi) {
   if (tabsTagging.length) {
     tabsTagging = tabsTagging.filter(idIsNot(tab.id));
   }
-  ['button', 'keepers'].forEach(clearAutoEngageTimer.bind(null, tab));
+  clearAutoEngageTimer(tab, 'keepers');
   delete tab.nUri;
   delete tab.count;
   delete tab.engaged;

--- a/packrat/scripts/keeper.js
+++ b/packrat/scripts/keeper.js
@@ -88,9 +88,6 @@ var keeper = keeper || function () {  // idempotent for Chrome
 
     // attach event bindings
     $slider
-    .mouseover(function () {
-      idleTimer.kill();
-    })
     .mouseout(function (e) {
       if (e.originalEvent.isTrusted === false) return;
       if (data.dragTimer) {
@@ -139,11 +136,7 @@ var keeper = keeper || function () {  // idempotent for Chrome
         this.classList.add('kifi-hoverless');
       }
     }, 400, true))
-    .on('mouseover', '.kifi-keep-card', function (e) {
-      if ($slider.hasClass('kifi-auto') && e.originalEvent.isTrusted !== false) {
-        growSlider('kifi-auto', 'kifi-wide');
-      }
-    }).on('mouseover', '.kifi-keep-btn>.kifi-tip,.kifi-kept-btn>.kifi-tip', function () {
+    .on('mouseover', '.kifi-keep-btn>.kifi-tip,.kifi-kept-btn>.kifi-tip', function () {
       this.parentNode.classList.add('kifi-hoverless');
     }).hoverfu('.kifi-keep-btn,.kifi-kept-btn', function (configureHover) {
       var btn = this;
@@ -311,7 +304,6 @@ var keeper = keeper || function () {  // idempotent for Chrome
   // trigger is for the event log (e.g. 'key', 'icon')
   function hideSlider(trigger) {
     log('[hideSlider]', trigger);
-    idleTimer.kill();
     $slider.addClass('kifi-hiding')
     .off('transitionend')
     .on('transitionend', function (e) {
@@ -369,20 +361,6 @@ var keeper = keeper || function () {  // idempotent for Chrome
       }
     });
   }
-
-  var idleTimer = {
-    start: function (ms) {
-      log('[idleTimer.start]', ms, 'ms');
-      clearTimeout(this.timeout), this.timeout = setTimeout(hideSlider.bind(null, 'idle'), ms);
-      $slider.on('mouseenter.idle', $.proxy(this, 'kill'));
-    },
-    kill: function () {
-      if (this.timeout) {
-        log('[idleTimer.kill]');
-        clearTimeout(this.timeout), delete this.timeout;
-        $slider && $slider.off('.idle');
-      }
-    }};
 
   function keepPage(how, e, suppressNamePrompt) {
     log('[keepPage]', e, how);
@@ -589,18 +567,12 @@ var keeper = keeper || function () {  // idempotent for Chrome
             setTimeout($.fn.hoverfu.bind($tile, 'hide'), 3000);
           }
         });
-      } else if (type === 'button') {
-        $tile.hoverfu('destroy');
-        showSlider(trigger);
-        growSlider('kifi-tiny', 'kifi-auto');
-        idleTimer.start(5000);
       }
     },
     onPaneChange: function (locator) {
       $slider.find('.kifi-at').removeClass('kifi-at');
       if (locator) {
         $slider.find('.kifi-dock-' + locator.split(/[\/:]/)[1]).addClass('kifi-at');
-        idleTimer.kill();
         $slider.data().stickiness |= 2;
       } else {  // dislodge from pane and prepare for x transition
         $slider.prependTo(tile).layout();

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -7,7 +7,7 @@ var tile = tile || function() {  // idempotent for Chrome
   'use strict';
   log('[keeper_scout]', location.hostname);
 
-  var whenMeKnown = [], tileParent, tileObserver, tileCard, tileCount, onScroll;
+  var whenMeKnown = [], tileParent, tileObserver, tileCard, tileCount;
   while ((tile = document.getElementById('kifi-tile'))) {
     tile.remove();
   }
@@ -91,26 +91,6 @@ var tile = tile || function() {  // idempotent for Chrome
     },
     count: function(n) {
       tile && updateCount(n);
-    },
-    scroll_rule: function(r) {
-      if (!onScroll && !window.keeper) {
-        var lastScrollTime = 0;
-        document.addEventListener('scroll', onScroll = function (e) {
-          var t = e.timeStamp || Date.now();
-          if (t - lastScrollTime > 100) {  // throttling to avoid measuring DOM too freq
-            lastScrollTime = t;
-            var srEl = scrollRoot();
-            var hPage = srEl.scrollHeight;
-            var hViewport = srEl.clientHeight;
-            var hSeen = window.pageYOffset + hViewport;
-            log('[onScroll]', Math.round(hSeen / hPage * 10000) / 100, '>', r[1], '% and', hPage, '>', r[0] * hViewport, '?');
-            if (hPage > r[0] * hViewport && hSeen > (r[1] / 100) * hPage && e.isTrusted !== false) {
-              log('[onScroll] showing');
-              loadAndDo('keeper', 'engage', 'scroll', 'button');
-            }
-          }
-        });
-      }
     },
     reset: cleanUpDom.bind(null, true),
     silence: cleanUpDom.bind(null, true),
@@ -199,10 +179,6 @@ var tile = tile || function() {  // idempotent for Chrome
     } else {
       var args = Array.prototype.slice.call(arguments, 2);
       api.require('scripts/' + name + '.js', function() {
-        if (onScroll && methodName !== 'showKeepers') {
-          document.removeEventListener('scroll', onScroll);
-          onScroll = null;
-        }
         if (window.hideKeeperCallout) {
           hideKeeperCallout();
         }
@@ -273,10 +249,6 @@ var tile = tile || function() {  // idempotent for Chrome
 
   function cleanUpDom(leaveTileInDoc) {
     window.removeEventListener("resize", onResize);
-    if (onScroll) {
-      document.removeEventListener("scroll", onScroll);
-      onScroll = null;
-    }
     if (tile) {
       if (leaveTileInDoc) {
         tile.style.display = 'none';
@@ -292,10 +264,6 @@ var tile = tile || function() {  // idempotent for Chrome
   function paneCall(methodName) {
     var pane = window.pane;
     return pane && pane[methodName]();
-  }
-
-  function scrollRoot() {
-    return document[document.compatMode === 'CSS1Compat' ? 'documentElement' : 'body'];
   }
 
   api.onEnd.push(function() {

--- a/packrat/styles/keeper/keeper.css
+++ b/packrat/styles/keeper/keeper.css
@@ -32,10 +32,6 @@
 .kifi-keeper.kifi-tiny {
   width: 42px;
 }
-.kifi-keeper.kifi-auto {
-  width: 136px;
-  transition: width 200ms ease-out;
-}
 .kifi-keeper.kifi-wide {
   width: 310px;
   transition: width 100ms ease-out;
@@ -48,9 +44,6 @@
   width: 0;
   opacity: 0;
   transition: width 100ms ease-in, opacity 60ms ease-in 40ms;
-}
-.kifi-keeper.kifi-hiding.kifi-auto {
-  transition: width 200ms ease-in, opacity 120ms ease-in 80ms;
 }
 .kifi-keeper-x {
   position: absolute;
@@ -560,9 +553,6 @@ html[kifi-with-pane] .kifi-keep-card {
   font-size: 0;
   line-height: 0;
   text-align: right; /* keeps contents still during transition */
-}
-.kifi-keeper.kifi-auto .kifi-dock {
-  display: none;
 }
 .kifi-dock-btn {
   display: inline-block !important;


### PR DESCRIPTION
(based on time on page or distance scrolled)

I’ll add this back after the keeper redesign is done, if requested.
