### PR TITLE
+ simple status reporting

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -277,6 +277,7 @@ object ABook extends Service {
 
 object Scraper extends Service {
   object internal {
+    def status() = ServiceRoute(GET, s"/internal/scraper/status")
     def getBasicArticle() = ServiceRoute(POST, s"/internal/scraper/getBasicArticle")
     def getSignature() = ServiceRoute(POST, s"/internal/scraper/getSignature")
     def getPornDetectorModel() = ServiceRoute(GET, s"/internal/scraper/getPornDetectorModel")

--- a/kifi-backend/modules/common/app/com/keepit/model/ScrapeJobStatus.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/ScrapeJobStatus.scala
@@ -1,0 +1,17 @@
+package com.keepit.model
+
+import org.joda.time.DateTime
+
+case class ScrapeJobStatus(worker: String, submit: DateTime, uri: NormalizedURI, info: ScrapeInfo)
+
+object ScrapeJobStatus {
+  import play.api.libs.functional.syntax._
+  import play.api.libs.json._
+
+  implicit val format = (
+    (__ \ 'worker).format[String] and
+    (__ \ 'submitTS).format[DateTime] and
+    (__ \ 'uri).format[NormalizedURI] and
+    (__ \ 'scrape).format[ScrapeInfo]
+  )(ScrapeJobStatus.apply _, unlift(ScrapeJobStatus.unapply))
+}

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/QueuedScrapeProcessor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/QueuedScrapeProcessor.scala
@@ -106,8 +106,6 @@ class QueuedScrapeProcessor @Inject() (
 
   log.info(s"[QScraper.ctr] pool=$fjPool")
 
-  def status: Future[Seq[ScrapeJobStatus]] = Future.successful(Seq.empty)
-
   private def removeRef(iter: java.util.Iterator[_], msgOpt: Option[String] = None) {
     try {
       msgOpt.foreach { log.info(_) }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/QueuedScrapeProcessor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/QueuedScrapeProcessor.scala
@@ -106,6 +106,8 @@ class QueuedScrapeProcessor @Inject() (
 
   log.info(s"[QScraper.ctr] pool=$fjPool")
 
+  def status: Future[Seq[ScrapeJobStatus]] = Future.successful(Seq.empty)
+
   private def removeRef(iter: java.util.Iterator[_], msgOpt: Option[String] = None) {
     try {
       msgOpt.foreach { log.info(_) }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeProcessor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeProcessor.scala
@@ -2,11 +2,27 @@ package com.keepit.scraper
 
 import com.keepit.model.{ PageInfo, ScrapeInfo, NormalizedURI, HttpProxy }
 import com.keepit.scraper.extractor.ExtractorProviderType
+import org.joda.time.DateTime
 
 import scala.concurrent.Future
 
 trait ScrapeProcessor {
   def fetchBasicArticle(url: String, proxyOpt: Option[HttpProxy], extractorProviderTypeOpt: Option[ExtractorProviderType]): Future[Option[BasicArticle]]
   def asyncScrape(uri: NormalizedURI, info: ScrapeInfo, pageInfo: Option[PageInfo], proxyOpt: Option[HttpProxy]): Unit
+  def status: Future[Seq[ScrapeJobStatus]]
   def pull: Unit = {}
+}
+
+case class ScrapeJobStatus(worker: String, submit: DateTime, uri: NormalizedURI, info: ScrapeInfo)
+
+object ScrapeJobStatus {
+  import play.api.libs.functional.syntax._
+  import play.api.libs.json._
+
+  implicit val format = (
+    (__ \ 'worker).format[String] and
+    (__ \ 'submitTS).format[DateTime] and
+    (__ \ 'uri).format[NormalizedURI] and
+    (__ \ 'scrape).format[ScrapeInfo]
+  )(ScrapeJobStatus.apply _, unlift(ScrapeJobStatus.unapply))
 }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeProcessor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeProcessor.scala
@@ -1,8 +1,7 @@
 package com.keepit.scraper
 
-import com.keepit.model.{ PageInfo, ScrapeInfo, NormalizedURI, HttpProxy }
+import com.keepit.model._
 import com.keepit.scraper.extractor.ExtractorProviderType
-import org.joda.time.DateTime
 
 import scala.concurrent.Future
 
@@ -13,16 +12,3 @@ trait ScrapeProcessor {
   def pull(): Unit = {}
 }
 
-case class ScrapeJobStatus(worker: String, submit: DateTime, uri: NormalizedURI, info: ScrapeInfo)
-
-object ScrapeJobStatus {
-  import play.api.libs.functional.syntax._
-  import play.api.libs.json._
-
-  implicit val format = (
-    (__ \ 'worker).format[String] and
-    (__ \ 'submitTS).format[DateTime] and
-    (__ \ 'uri).format[NormalizedURI] and
-    (__ \ 'scrape).format[ScrapeInfo]
-  )(ScrapeJobStatus.apply _, unlift(ScrapeJobStatus.unapply))
-}

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeProcessor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeProcessor.scala
@@ -9,8 +9,8 @@ import scala.concurrent.Future
 trait ScrapeProcessor {
   def fetchBasicArticle(url: String, proxyOpt: Option[HttpProxy], extractorProviderTypeOpt: Option[ExtractorProviderType]): Future[Option[BasicArticle]]
   def asyncScrape(uri: NormalizedURI, info: ScrapeInfo, pageInfo: Option[PageInfo], proxyOpt: Option[HttpProxy]): Unit
-  def status: Future[Seq[ScrapeJobStatus]]
-  def pull: Unit = {}
+  def status(): Future[Seq[ScrapeJobStatus]] = Future.successful(Seq.empty)
+  def pull(): Unit = {}
 }
 
 case class ScrapeJobStatus(worker: String, submit: DateTime, uri: NormalizedURI, info: ScrapeInfo)

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperController.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperController.scala
@@ -19,6 +19,8 @@ class ScraperController @Inject() (
     actionAuthenticator: ActionAuthenticator,
     scrapeProcessor: ScrapeProcessor) extends ScraperServiceController with Logging {
 
+  implicit val fj = ExecutionContext.fj
+
   def getBasicArticle() = Action.async(parse.json) { request =>
     log.info(s"getBasicArticle body=${request.body}")
     processBasicArticleRequest(request.body).map { articleOption =>
@@ -26,7 +28,7 @@ class ScraperController @Inject() (
       val url = (request.body \ "url").as[String]
       log.info(s"[getBasicArticle($url})] result: $json")
       Ok(json)
-    }(ExecutionContext.fj)
+    }
   }
 
   def getSignature() = Action.async(parse.json) { request =>
@@ -37,7 +39,15 @@ class ScraperController @Inject() (
       val json = Json.toJson(signatureOption.map(_.toBase64()))
       log.info(s"[getSignature($url)] result: $json")
       Ok(json)
-    }(ExecutionContext.fj)
+    }
+  }
+
+  def status() = Action.async { request =>
+    scrapeProcessor.status.map { res =>
+      val json = Json.toJson(res)
+      log.info(s"[getStatus] result: $json")
+      Ok(json)
+    }
   }
 
   private def processBasicArticleRequest(parameters: JsValue): Future[Option[BasicArticle]] = {

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/actor/ScrapeAgentSupervisor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/actor/ScrapeAgentSupervisor.scala
@@ -10,7 +10,8 @@ import com.keepit.common.concurrent.ExecutionContext
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.common.time._
-import com.keepit.scraper.{ ScrapeJobStatus, ScraperConfig }
+import com.keepit.model.ScrapeJobStatus
+import com.keepit.scraper.ScraperConfig
 import com.keepit.search.Article
 import org.joda.time.DateTime
 

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/actor/ScrapeProcessorActorImpl.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/actor/ScrapeProcessorActorImpl.scala
@@ -8,10 +8,9 @@ import com.keepit.common.concurrent.ExecutionContext
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.common.zookeeper.ServiceDiscovery
-import com.keepit.model.{ HttpProxy, NormalizedURI, PageInfo, ScrapeInfo }
+import com.keepit.model._
 import com.keepit.scraper._
 import com.keepit.scraper.extractor._
-import org.joda.time.DateTime
 
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/kifi-backend/modules/scraper/conf/scraper.routes
+++ b/kifi-backend/modules/scraper/conf/scraper.routes
@@ -2,6 +2,7 @@
 #INTERNAL ROUTES/Scraper
 ##########################################
 
+GET     /internal/scraper/status                        @com.keepit.scraper.ScraperController.status
 POST    /internal/scraper/getBasicArticle               @com.keepit.scraper.ScraperController.getBasicArticle
 POST    /internal/scraper/getSignature                  @com.keepit.scraper.ScraperController.getSignature
 GET     /internal/scraper/getPornDetectorModel          @com.keepit.controllers.scraper.PornDetectorController.getModel

--- a/kifi-backend/modules/scraper/test/com/keepit/commander/WordCountCommanderTest.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/commander/WordCountCommanderTest.scala
@@ -1,27 +1,20 @@
 package com.keepit.commander
 
-import org.specs2.mutable.Specification
-import com.keepit.common.actor.StandaloneTestActorSystemModule
-import com.keepit.common.controller.FakeActionAuthenticatorModule
-import com.keepit.common.db.Id
-import com.keepit.common.time.{ DEFAULT_DATE_TIME_ZONE, currentDateTime }
-import com.keepit.inject.ApplicationInjector
-import com.keepit.model._
-import com.keepit.model.NormalizedURIStates._
-import com.keepit.scraper.{ TestScraperServiceClientModule, ScraperServiceClient }
-import com.keepit.search.{ Article, ArticleStore, Lang }
-import akka.actor.ActorSystem
-import play.api.test.Helpers.running
-import scala.concurrent.Await
-import scala.concurrent.duration._
-import com.keepit.scraper.TestScraperServiceModule
-import com.keepit.scraper.extractor._
-import scala.concurrent.Future
-import com.keepit.scraper.BasicArticle
 import com.keepit.commanders.WordCountCommanderImpl
-import com.keepit.scraper.ScrapeProcessor
+import com.keepit.common.db.Id
+import com.keepit.common.time.{DEFAULT_DATE_TIME_ZONE, currentDateTime}
+import com.keepit.inject.ApplicationInjector
+import com.keepit.model.NormalizedURIStates._
+import com.keepit.model._
+import com.keepit.scraper.{BasicArticle, ScrapeProcessor, Signature, TestScraperServiceModule}
+import com.keepit.scraper.extractor._
+import com.keepit.search.{Article, ArticleStore, Lang}
 import com.keepit.test.TestApplication
-import com.keepit.scraper.Signature
+import org.specs2.mutable.Specification
+import play.api.test.Helpers.running
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
 
 class WordCountCommanderTest extends Specification with ApplicationInjector {
 

--- a/kifi-backend/modules/scraper/test/com/keepit/commander/WordCountCommanderTest.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/commander/WordCountCommanderTest.scala
@@ -52,6 +52,7 @@ class WordCountCommanderTest extends Specification with ApplicationInjector {
       Future.successful(Some(BasicArticle(title = "not important", content = content, signature = Signature("fixedSignature"), destinationUrl = url)))
     }
     def asyncScrape(uri: NormalizedURI, info: ScrapeInfo, pageInfo: Option[PageInfo], proxyOpt: Option[HttpProxy]): Unit = {}
+    def status: Future[Seq[ScrapeJobStatus]] = Future.successful(Seq.empty)
   }
 
   "WordCountCommander" should {

--- a/kifi-backend/modules/scraper/test/com/keepit/commander/WordCountCommanderTest.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/commander/WordCountCommanderTest.scala
@@ -52,7 +52,6 @@ class WordCountCommanderTest extends Specification with ApplicationInjector {
       Future.successful(Some(BasicArticle(title = "not important", content = content, signature = Signature("fixedSignature"), destinationUrl = url)))
     }
     def asyncScrape(uri: NormalizedURI, info: ScrapeInfo, pageInfo: Option[PageInfo], proxyOpt: Option[HttpProxy]): Unit = {}
-    def status: Future[Seq[ScrapeJobStatus]] = Future.successful(Seq.empty)
   }
 
   "WordCountCommander" should {

--- a/kifi-backend/modules/scraper/test/com/keepit/scraper/TestScraperProcessorModule.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/scraper/TestScraperProcessorModule.scala
@@ -1,14 +1,9 @@
 package com.keepit.scraper
 
-import com.keepit.model.{ HttpProxy, PageInfo, ScrapeInfo, NormalizedURI }
-import com.keepit.scraper.actor.ScrapeProcessorActorImpl
-import com.keepit.scraper.extractor.{ ExtractorProviderType, ExtractorFactoryImpl, ExtractorFactory }
+import com.google.inject.{Provides, Singleton}
 import com.keepit.inject.AppScoped
-import com.google.inject.{ Provides, Singleton }
-import com.keepit.common.healthcheck.AirbrakeNotifier
-import com.keepit.common.plugin.SchedulingProperties
-import com.keepit.scraper.fetcher.HttpFetcher
-import com.keepit.scraper.fetcher.apache.ApacheHttpFetcher
+import com.keepit.model.{HttpProxy, NormalizedURI, PageInfo, ScrapeInfo}
+import com.keepit.scraper.extractor.{ExtractorFactory, ExtractorFactoryImpl, ExtractorProviderType}
 
 import scala.concurrent.Future
 

--- a/kifi-backend/modules/scraper/test/com/keepit/scraper/TestScraperProcessorModule.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/scraper/TestScraperProcessorModule.scala
@@ -28,7 +28,6 @@ case class TestScraperProcessorModule() extends ScrapeProcessorModule {
   def scrapeProcessor: ScrapeProcessor = new ScrapeProcessor {
     def fetchBasicArticle(url: String, proxyOpt: Option[HttpProxy], extractorProviderTypeOpt: Option[ExtractorProviderType]): Future[Option[BasicArticle]] = Future.successful(None)
     def asyncScrape(uri: NormalizedURI, info: ScrapeInfo, pageInfo: Option[PageInfo], proxyOpt: Option[HttpProxy]): Unit = ()
-    def status: Future[Seq[ScrapeJobStatus]] = Future.successful(Seq.empty)
   }
 
 }

--- a/kifi-backend/modules/scraper/test/com/keepit/scraper/TestScraperProcessorModule.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/scraper/TestScraperProcessorModule.scala
@@ -28,6 +28,7 @@ case class TestScraperProcessorModule() extends ScrapeProcessorModule {
   def scrapeProcessor: ScrapeProcessor = new ScrapeProcessor {
     def fetchBasicArticle(url: String, proxyOpt: Option[HttpProxy], extractorProviderTypeOpt: Option[ExtractorProviderType]): Future[Option[BasicArticle]] = Future.successful(None)
     def asyncScrape(uri: NormalizedURI, info: ScrapeInfo, pageInfo: Option[PageInfo], proxyOpt: Option[HttpProxy]): Unit = ()
+    def status: Future[Seq[ScrapeJobStatus]] = Future.successful(Seq.empty)
   }
 
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/ScraperAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/ScraperAdminController.scala
@@ -30,6 +30,12 @@ class ScraperAdminController @Inject() (
 
   val MAX_COUNT_DISPLAY = 25
 
+  def status = AdminJsonAction.authenticatedAsync { implicit request =>
+    Future.sequence(scraperServiceClient.status()).map { res =>
+      Ok(Json.toJson(res.map { case (_, jobs) => jobs }.flatten))
+    }
+  }
+
   def searchScraper = AdminHtmlAction.authenticated { implicit request => Ok(html.admin.searchScraper()) }
 
   def scraperRequests(stateFilter: Option[String] = None) = AdminHtmlAction.authenticatedAsync { implicit request =>

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -395,6 +395,7 @@ GET     /admin/data/patterns      @com.keepit.controllers.admin.UrlController.ge
 POST    /admin/data/patterns      @com.keepit.controllers.admin.UrlController.savePatterns
 GET     /admin/data/proxies      @com.keepit.controllers.admin.ScraperAdminController.getProxies
 POST    /admin/data/proxies      @com.keepit.controllers.admin.ScraperAdminController.saveProxies
+GET     /admin/data/scraper/status      @com.keepit.controllers.admin.ScraperAdminController.status
 GET     /admin/data/scrape              @com.keepit.controllers.admin.ScraperAdminController.searchScraper
 GET     /admin/data/scrapeArticle       @com.keepit.controllers.admin.ScraperAdminController.scrapeArticle(url:String ?= "")
 GET     /admin/data/scraperRequests     @com.keepit.controllers.admin.ScraperAdminController.scraperRequests(stateFilter: Option[String] ?= None)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/URISummaryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/URISummaryCommanderTest.scala
@@ -1,5 +1,6 @@
 package com.keepit.commanders
 
+import com.keepit.common.amazon.AmazonInstanceInfo
 import com.keepit.test.ShoeboxTestInjector
 import com.keepit.model._
 import scala.concurrent._


### PR DESCRIPTION
very simple impl -- mostly boilerplate code in the pull request

up next: admin page wire-in

with this, we can move away from thread-id based reporting which places unnecessary constraints on how scraper is implemented internally

@yingjieMiao @martinraison @ymatsuda @leogrim @eishay 
