### PR TITLE
Delighting our users

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/UserExperiment.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserExperiment.scala
@@ -45,12 +45,11 @@ object ExperimentType {
   val SHOW_DISCUSSIONS = ExperimentType("show_discussions")
   val MOBILE_REDIRECT = ExperimentType("mobile_redirect")
   val GUIDE = ExperimentType("guide")
-  val DELIGHTED_SURVEY = ExperimentType("delighted_survey")
   val DELIGHTED_SURVEY_PERMANENT = ExperimentType("permanent_delighted_survey")
 
   val _ALL = ADMIN :: AUTO_GEN :: FAKE :: NO_SEARCH_EXPERIMENTS :: NOT_SENSITIVE ::
     CAN_MESSAGE_ALL_USERS :: DEMO :: EXTENSION_LOGGING :: SHOW_HIT_SCORES :: SHOW_DISCUSSIONS ::
-    MOBILE_REDIRECT :: GUIDE :: DELIGHTED_SURVEY :: DELIGHTED_SURVEY_PERMANENT :: Nil
+    MOBILE_REDIRECT :: GUIDE :: DELIGHTED_SURVEY_PERMANENT :: Nil
 
   private val _ALL_MAP: Map[String, ExperimentType] = _ALL map { e => e.value -> e } toMap
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
@@ -720,8 +720,7 @@ class UserCommander @Inject() (
       else if (time.minusDays(DELIGHTED_INITIAL_DELAY) > user.createdAt) {
         heimdalClient.getLastDelightedAnswerDate(userId) map { lastDelightedAnswerDate =>
           val minDate = lastDelightedAnswerDate getOrElse START_OF_TIME
-          (time.minusDays(DELIGHTED_MIN_INTERVAL) > minDate) &&
-            experiments.contains(ExperimentType.DELIGHTED_SURVEY)
+          (time.minusDays(DELIGHTED_MIN_INTERVAL) > minDate)
         }
       } else Future.successful(false)
       shouldShowDelightedQuestionFut map { shouldShowDelightedQuestion =>


### PR DESCRIPTION
@2is10 @andrewconner This will make Delighted surveys visible to anyone on the site (max once every 30 days). I'm keeping the DELIGHTED_SURVEY_PERMANENT experiment for the time being because it will be useful for debugging ( @jaredpetker ).
