### PR TITLE
preRestart handling

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/akka/FortyTwoActor.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/akka/FortyTwoActor.scala
@@ -14,7 +14,7 @@ trait AlertingActor extends Actor {
 
   override def preRestart(reason: Throwable, message: Option[Any]) {
     alert(reason, message)
-    postStop()
+    super.preRestart(reason, message)
   }
 }
 

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeProcessorModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeProcessorModule.scala
@@ -1,6 +1,7 @@
 package com.keepit.scraper
 
 import com.keepit.inject.AppScoped
+import com.keepit.scraper.actor.ScrapeProcessorActorImpl
 import com.keepit.scraper.extractor.{ ExtractorFactory, ExtractorFactoryImpl }
 import net.codingwell.scalaguice.ScalaModule
 
@@ -13,7 +14,7 @@ case class ProdScraperProcessorModule() extends ScrapeProcessorModule {
     bind[ShoeboxDbCallbacks].to[ShoeboxDbCallbackHelper].in[AppScoped]
     bind[SyncShoeboxDbCallbacks].to[ShoeboxDbCallbackHelper].in[AppScoped]
     bind[PullerPlugin].to[PullerPluginImpl].in[AppScoped]
-    bind[ScrapeProcessor].to[QueuedScrapeProcessor]
+    bind[ScrapeProcessor].to[ScrapeProcessorActorImpl]
     install(ProdScraperConfigModule())
     install(ProdScrapeSchedulerConfigModule())
   }


### PR DESCRIPTION
This appears to be a long standing issue but didn't show up until now.

In short, in Akka lifecycle preRestart() typically stops the children -- that's the default behavior. However we have overridden preRestart in AlertingActor but we do not call super.preRestart(), so that behavior is lost.

Unless we want to limit AlertingActor to be used for single-level (no children) actors, then we need to either [1] call super.preRestart() or [2] add the code to stop & unwatch children here.

IMO [1] is simpler and safer -- this would ensure that we don't break any assumptions as the platform (Akka) moves forward.

@eishay @ymatsuda @yingjieMiao @andrewconner
