### PR TITLE
new logic to push lda feature to graph

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/cortex/models/lda/LDA.scala
+++ b/kifi-backend/modules/common/app/com/keepit/cortex/models/lda/LDA.scala
@@ -39,7 +39,7 @@ object SparseTopicRepresentation {
   }
 }
 
-case class UriSparseLDAFeatures(uriId: Id[NormalizedURI], uriSeq: SequenceNumber[NormalizedURI], features: SparseTopicRepresentation, isActive: Boolean)
+case class UriSparseLDAFeatures(uriId: Id[NormalizedURI], uriSeq: SequenceNumber[NormalizedURI], features: SparseTopicRepresentation)
 object UriSparseLDAFeatures {
   implicit val format = Json.format[UriSparseLDAFeatures]
 }

--- a/kifi-backend/modules/common/app/com/keepit/cortex/models/lda/LDA.scala
+++ b/kifi-backend/modules/common/app/com/keepit/cortex/models/lda/LDA.scala
@@ -39,7 +39,7 @@ object SparseTopicRepresentation {
   }
 }
 
-case class UriSparseLDAFeatures(uriId: Id[NormalizedURI], uriSeq: SequenceNumber[NormalizedURI], features: SparseTopicRepresentation)
+case class UriSparseLDAFeatures(uriId: Id[NormalizedURI], uriSeq: SequenceNumber[NormalizedURI], features: SparseTopicRepresentation, isActive: Boolean)
 object UriSparseLDAFeatures {
   implicit val format = Json.format[UriSparseLDAFeatures]
 }

--- a/kifi-backend/modules/cortex/app/com/keepit/common/commanders/FeatureRetrievalCommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/commanders/FeatureRetrievalCommander.scala
@@ -11,14 +11,15 @@ import com.keepit.cortex._
 
 @Singleton
 class FeatureRetrievalCommander @Inject() (
-    ldaRetriever: LDADbFeatureRetriever) {
+    ldaRetriever: LDADbFeatureRetriever,
+    ldaCommander: LDACommander) {
 
   def getSparseLDAFeaturesChanged(lowSeq: SequenceNumber[NormalizedURI], fetchSize: Int, version: ModelVersion[DenseLDA], sparsity: Int = PublishedModels.defaultSparsity): Seq[UriSparseLDAFeatures] = {
-
+    val dim = ldaCommander.getLDADimension(version)
     val feats = ldaRetriever.getLDAFeaturesChanged(lowSeq, fetchSize, version)
     feats.map { feat =>
       if (feat.state == URILDATopicStates.ACTIVE) UriSparseLDAFeatures(feat.uriId, feat.uriSeq, generateSparseRepresentation(feat.sparseFeature.get, sparsity), isActive = true)
-      else UriSparseLDAFeatures(feat.uriId, feat.uriSeq, SparseTopicRepresentation(0, Map()), isActive = false)
+      else UriSparseLDAFeatures(feat.uriId, feat.uriSeq, SparseTopicRepresentation(dim, Map()), isActive = false)
     }
   }
 

--- a/kifi-backend/modules/cortex/app/com/keepit/common/commanders/FeatureRetrievalCommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/commanders/FeatureRetrievalCommander.scala
@@ -18,8 +18,8 @@ class FeatureRetrievalCommander @Inject() (
     val dim = ldaCommander.getLDADimension(version)
     val feats = ldaRetriever.getLDAFeaturesChanged(lowSeq, fetchSize, version)
     feats.map { feat =>
-      if (feat.state == URILDATopicStates.ACTIVE) UriSparseLDAFeatures(feat.uriId, feat.uriSeq, generateSparseRepresentation(feat.sparseFeature.get, sparsity), isActive = true)
-      else UriSparseLDAFeatures(feat.uriId, feat.uriSeq, SparseTopicRepresentation(dim, Map()), isActive = false)
+      if (feat.state == URILDATopicStates.ACTIVE) UriSparseLDAFeatures(feat.uriId, feat.uriSeq, generateSparseRepresentation(feat.sparseFeature.get, sparsity))
+      else UriSparseLDAFeatures(feat.uriId, feat.uriSeq, SparseTopicRepresentation(dim, Map()))
     }
   }
 

--- a/kifi-backend/modules/cortex/app/com/keepit/common/commanders/FeatureRetrievalCommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/commanders/FeatureRetrievalCommander.scala
@@ -1,32 +1,30 @@
 package com.keepit.common.commanders
 
 import com.google.inject.{ Inject, Singleton }
+import com.keepit.cortex.dbmodel.{ URILDATopicStates, URILDATopic }
 import com.keepit.cortex.models.lda._
 import com.keepit.cortex.core.ModelVersion
 import com.keepit.common.db.SequenceNumber
 import com.keepit.model.NormalizedURI
 import com.keepit.cortex.core.FeatureRepresentation
 import com.keepit.cortex._
-import com.keepit.cortex.models.lda.DenseLDA
 
 @Singleton
 class FeatureRetrievalCommander @Inject() (
-    ldaURIFeat: LDAURIFeatureRetriever) {
-  def getLDAFeaturesChanged(lowSeq: SequenceNumber[NormalizedURI], fetchSize: Int, version: ModelVersion[DenseLDA]): Seq[(NormalizedURI, FeatureRepresentation[NormalizedURI, DenseLDA])] = {
-    ldaURIFeat.trickyGetSince(lowSeq, fetchSize, version)
-  }
+    ldaRetriever: LDADbFeatureRetriever) {
 
   def getSparseLDAFeaturesChanged(lowSeq: SequenceNumber[NormalizedURI], fetchSize: Int, version: ModelVersion[DenseLDA], sparsity: Int = PublishedModels.defaultSparsity): Seq[UriSparseLDAFeatures] = {
-    val features = getLDAFeaturesChanged(lowSeq, fetchSize, version)
-    features.map {
-      case (uri, feat) =>
-        UriSparseLDAFeatures(uri.id.get, uri.seq, generateSparseRepresentation(feat.vectorize, sparsity))
+
+    val feats = ldaRetriever.getLDAFeaturesChanged(lowSeq, fetchSize, version)
+    feats.map { feat =>
+      if (feat.state == URILDATopicStates.ACTIVE) UriSparseLDAFeatures(feat.uriId, feat.uriSeq, generateSparseRepresentation(feat.sparseFeature.get, sparsity), isActive = true)
+      else UriSparseLDAFeatures(feat.uriId, feat.uriSeq, SparseTopicRepresentation(0, Map()), isActive = false)
     }
   }
 
-  private def generateSparseRepresentation(topicVector: Array[Float], sparsity: Int): SparseTopicRepresentation = {
-    val dim = topicVector.length
-    val topicMap = topicVector.zipWithIndex.sortBy(-1f * _._1).take(sparsity).map { case (score, idx) => (LDATopic(idx), score) }.toMap
+  private def generateSparseRepresentation(feat: SparseTopicRepresentation, sparsity: Int): SparseTopicRepresentation = {
+    val dim = feat.dimension
+    val topicMap = feat.topics.toArray.sortBy(-1f * _._2).take(sparsity).toMap
     SparseTopicRepresentation(dim, topicMap)
   }
 }

--- a/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDACommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDACommander.scala
@@ -30,9 +30,10 @@ class LDACommander @Inject() (
 
   val ldaDimMap = mutable.Map(wordRep.version -> wordRep.lda.dimension)
 
+  // consumers of lda service might query dim of some previous lda model
   def getLDADimension(version: ModelVersion[DenseLDA]): Int = {
     ldaDimMap.getOrElseUpdate(version, {
-      val conf = configStore.get(MiscPrefix.LDA.topicConfigsJsonFile, wordRep.version).get
+      val conf = configStore.get(MiscPrefix.LDA.topicConfigsJsonFile, version).get
       conf.configs.size
     }
     )

--- a/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDACommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDACommander.scala
@@ -2,6 +2,7 @@ package com.keepit.common.commanders
 
 import com.google.inject.{ Inject, Singleton }
 import com.keepit.common.db.slick.Database
+import com.keepit.cortex.core.ModelVersion
 import com.keepit.cortex.dbmodel.{ URILDATopicRepo, UserTopicMean, UserLDAInterestsRepo }
 import com.keepit.cortex.models.lda._
 import com.keepit.cortex.features.Document
@@ -10,6 +11,7 @@ import com.keepit.common.db.Id
 import com.keepit.model.{ User, NormalizedURI }
 import com.keepit.cortex.utils.MatrixUtils.cosineDistance
 import scala.math.exp
+import collection.mutable
 
 @Singleton
 class LDACommander @Inject() (
@@ -25,6 +27,16 @@ class LDACommander @Inject() (
   assume(ldaTopicWords.topicWords.length == wordRep.lda.dimension)
 
   var currentConfig = ldaConfigs
+
+  val ldaDimMap = mutable.Map(wordRep.version -> wordRep.lda.dimension)
+
+  def getLDADimension(version: ModelVersion[DenseLDA]): Int = {
+    ldaDimMap.getOrElseUpdate(version, {
+      val conf = configStore.get(MiscPrefix.LDA.topicConfigsJsonFile, wordRep.version).get
+      conf.configs.size
+    }
+    )
+  }
 
   def numOfTopics: Int = ldaTopicWords.topicWords.length
 

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDADbUpdater.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDADbUpdater.scala
@@ -9,7 +9,7 @@ import com.keepit.common.logging.Logging
 import com.keepit.common.plugin.SchedulingProperties
 import com.keepit.common.time._
 import com.keepit.common.zookeeper.ServiceDiscovery
-import com.keepit.cortex.core.{ FeatureRepresentation, StatModelName }
+import com.keepit.cortex.core.{ ModelVersion, FeatureRepresentation, StatModelName }
 import com.keepit.cortex.dbmodel._
 import com.keepit.cortex.plugins._
 import com.keepit.model.{ NormalizedURI, NormalizedURIStates, UrlHash }
@@ -164,4 +164,14 @@ class LDADbUpdaterImpl @Inject() (
       }
     }
   }
+}
+
+class LDADbFeatureRetriever @Inject() (
+    db: Database,
+    topicRepo: URILDATopicRepo) {
+
+  def getLDAFeaturesChanged(lowSeq: SequenceNumber[NormalizedURI], fetchSize: Int, version: ModelVersion[DenseLDA]): Seq[URILDATopic] = {
+    db.readOnlyReplica { implicit s => topicRepo.getFeaturesSince(lowSeq, version, fetchSize) }
+  }
+
 }

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/dbmodel/URILDARepoTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/dbmodel/URILDARepoTest.scala
@@ -104,6 +104,13 @@ class URILDATopicRepoTest extends Specification with CortexTestInjector {
           uriTopicRepo.getHighestSeqNumber(ModelVersion[DenseLDA](3)).value === 0
         }
 
+        db.readOnlyMaster { implicit s =>
+          uriTopicRepo.getFeaturesSince(SequenceNumber[NormalizedURI](0), ModelVersion[DenseLDA](1), limit = 5).map { _.uriSeq.value } === List(1, 2, 3, 4, 5)
+          uriTopicRepo.getFeaturesSince(SequenceNumber[NormalizedURI](7), ModelVersion[DenseLDA](2), limit = 5).map { _.uriSeq.value } === List(8, 9, 10)
+          uriTopicRepo.getFeaturesSince(SequenceNumber[NormalizedURI](10), ModelVersion[DenseLDA](2), limit = 5).map { _.uriSeq.value } === List()
+          uriTopicRepo.getFeaturesSince(SequenceNumber[NormalizedURI](0), ModelVersion[DenseLDA](3), limit = 5).map { _.uriSeq.value } === List()
+        }
+
       }
     }
   }


### PR DESCRIPTION
@stkem  @leogrim 
1. fetch data from database instead of s3
2. now, we also send 'non-active' features to graph. Graph can remove stale edges if there are any. A non-active feature contains an empty topic map. During the graph update, we first remove all existing topic edges for the URI, then add zero edges. This is equivalent to removing the topic information for that URI. So nothing on the graph side needs to change. 
