### PR TITLE
Stop swallowing sequencing plugin task exceptions.

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/abook/model/EContactRepo.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/model/EContactRepo.scala
@@ -162,7 +162,7 @@ class EContactSequencingPluginImpl @Inject() (
 }
 
 @Singleton
-class EContactSequenceNumberAssigner @Inject() (db: Database, repo: EContactRepo, airbrake: AirbrakeNotifier)
+class EContactSequenceNumberAssigner @Inject() (db: Database, repo: EContactRepo, val airbrake: AirbrakeNotifier)
   extends DbSequenceAssigner[EContact](db, repo, airbrake)
 
 class EContactSequencingActor @Inject() (

--- a/kifi-backend/modules/abook/app/com/keepit/abook/model/EmailAccountRepo.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/model/EmailAccountRepo.scala
@@ -101,7 +101,7 @@ class EmailAccountSequencingPluginImpl @Inject() (
 }
 
 @Singleton
-class EmailAccountSequenceNumberAssigner @Inject() (db: Database, repo: EmailAccountRepo, airbrake: AirbrakeNotifier)
+class EmailAccountSequenceNumberAssigner @Inject() (db: Database, repo: EmailAccountRepo, val airbrake: AirbrakeNotifier)
   extends DbSequenceAssigner[EmailAccount](db, repo, airbrake)
 
 class EmailAccountSequencingActor @Inject() (

--- a/kifi-backend/modules/common/app/com/keepit/common/plugin/SequencingPlugin.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/plugin/SequencingPlugin.scala
@@ -34,10 +34,14 @@ trait SequencingPlugin extends SchedulerPlugin {
 
 trait SequenceAssigner extends RecurringTaskManager {
 
+  val airbrake: AirbrakeNotifier
   def assignSequenceNumbers(): Unit
   def sanityCheck(): Unit
 
   override def doTask(): Unit = assignSequenceNumbers()
+  override def onError(e: Throwable): Unit = {
+    airbrake.notify("Error during SequenceAssigner task", e)
+  }
 }
 
 class SequenceNumberAssignmentStalling(seq: Long) extends Exception(s"sequence number assignment may be stalling: $seq")

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItemRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItemRepo.scala
@@ -99,7 +99,7 @@ class RawSeedItemSequencingPluginImpl @Inject() (
 }
 
 @Singleton
-class RawSeedItemSequenceNumberAssigner @Inject() (db: Database, repo: RawSeedItemRepo, airbrake: AirbrakeNotifier)
+class RawSeedItemSequenceNumberAssigner @Inject() (db: Database, repo: RawSeedItemRepo, val airbrake: AirbrakeNotifier)
   extends DbSequenceAssigner[RawSeedItem](db, repo, airbrake)
 
 class RawSeedItemSequencingActor @Inject() (

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryMembershipRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryMembershipRepo.scala
@@ -107,7 +107,7 @@ class LibraryMembershipSequencingPluginImpl @Inject() (
 }
 
 @Singleton
-class LibraryMembershipSequenceNumberAssigner @Inject() (db: Database, repo: LibraryMembershipRepo, airbrake: AirbrakeNotifier)
+class LibraryMembershipSequenceNumberAssigner @Inject() (db: Database, repo: LibraryMembershipRepo, val airbrake: AirbrakeNotifier)
   extends DbSequenceAssigner[LibraryMembership](db, repo, airbrake)
 
 class LibraryMembershipSequencingActor @Inject() (

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -115,7 +115,7 @@ class LibrarySequencingPluginImpl @Inject() (
 }
 
 @Singleton
-class LibrarySequenceNumberAssigner @Inject() (db: Database, repo: LibraryRepo, airbrake: AirbrakeNotifier)
+class LibrarySequenceNumberAssigner @Inject() (db: Database, repo: LibraryRepo, val airbrake: AirbrakeNotifier)
   extends DbSequenceAssigner[Library](db, repo, airbrake)
 
 class LibrarySequencingActor @Inject() (

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ImageInfoSequencingPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ImageInfoSequencingPlugin.scala
@@ -21,7 +21,7 @@ class ImageInfoSequencingPluginImpl @Inject() (
 }
 
 @Singleton
-class ImageInfoSequenceNumberAssigner @Inject() (db: Database, repo: ImageInfoRepo, airbrake: AirbrakeNotifier)
+class ImageInfoSequenceNumberAssigner @Inject() (db: Database, repo: ImageInfoRepo, val airbrake: AirbrakeNotifier)
   extends DbSequenceAssigner[ImageInfo](db, repo, airbrake)
 
 class ImageInfoSequencingActor @Inject() (

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/NormalizedURISequencingPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/NormalizedURISequencingPlugin.scala
@@ -15,7 +15,7 @@ class NormalizedURISequencingPluginImpl @Inject() (
   override val scheduling: SchedulingProperties) extends NormalizedURISequencingPlugin
 
 @Singleton
-class NormalizedURISequenceNumberAssigner @Inject() (db: Database, repo: NormalizedURIRepo, airbrake: AirbrakeNotifier)
+class NormalizedURISequenceNumberAssigner @Inject() (db: Database, repo: NormalizedURIRepo, val airbrake: AirbrakeNotifier)
   extends DbSequenceAssigner[NormalizedURI](db, repo, airbrake)
 
 class NormalizedURISequencingActor @Inject() (

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/UserConnectionSequencingPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/UserConnectionSequencingPlugin.scala
@@ -19,7 +19,7 @@ class UserConnectionSequencingPluginImpl @Inject() (
 }
 
 @Singleton
-class UserConnectionSequenceNumberAssigner @Inject() (db: Database, repo: UserConnectionRepo, airbrake: AirbrakeNotifier)
+class UserConnectionSequenceNumberAssigner @Inject() (db: Database, repo: UserConnectionRepo, val airbrake: AirbrakeNotifier)
   extends DbSequenceAssigner[UserConnection](db, repo, airbrake)
 
 class UserConnectionSequencingActor @Inject() (


### PR DESCRIPTION
@ymatsuda @leogrim @raymondng Discovered that Library and LibraryMembership had no sequence number table. When digging into why we didn't get alerted, I found that `onError` isn't being called for the sequence number assigner.

Merge after lunch, just in case any of them are regularly blowing up.
