### PR TITLE
Make sure every vertex has an IncomingEdges entry (even if empty)

### DIFF
--- a/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraph.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraph.scala
@@ -13,7 +13,7 @@ case class SimpleGraph(vertices: ConcurrentMap[VertexId, MutableVertex] = TrieMa
 
   private val vertexStatistics = GraphStatistics.newVertexCounter()
   private val edgeStatistics = GraphStatistics.newEdgeCounter()
-  private val incomingEdges = TrieMap[VertexId, MutableIncomingEdges]()
+  private val incomingEdges = TrieMap[VertexId, MutableIncomingEdges]() ++= vertices.mapValues(_ => new MutableIncomingEdges(MutableMap()))
 
   vertices.foreach {
     case (sourceId, mutableVertex) =>
@@ -23,7 +23,6 @@ case class SimpleGraph(vertices: ConcurrentMap[VertexId, MutableVertex] = TrieMa
         case (destinationId, edgeData) =>
           val component = (sourceKind, destinationId.kind, edgeData.kind)
           edgeStatistics(component).incrementAndGet()
-          if (!incomingEdges.contains(destinationId)) { incomingEdges += (destinationId -> new MutableIncomingEdges(MutableMap())) }
           if (!incomingEdges(destinationId).edges.contains(component)) { incomingEdges(destinationId).edges += (component -> MutableSet()) }
           incomingEdges(destinationId).edges(component) += sourceId
       }

--- a/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraphReader.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraphReader.scala
@@ -46,6 +46,7 @@ class SimpleGlobalVertexReader(vertices: Map[VertexId, Vertex], incomingEdges: M
     Vertex.checkIfVertexExists(vertices)(vertex)
     currentVertexId = Some(vertex)
     outgoingEdgeReader.reset()
+    incomingEdgeReader.reset()
   }
   def moveTo[V <: VertexDataReader: VertexKind](vertex: VertexDataId[V]): Unit = { moveTo(VertexId(vertex)) }
 }

--- a/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraphWriter.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraphWriter.scala
@@ -96,6 +96,7 @@ class SimpleGraphWriter(
         false
       case None =>
         bufferedVertices += (vertexId -> new MutableVertex(data, new MutableOutgoingEdges(MutableMap())))
+        getBufferedIncomingEdges(vertexId)
         vertexDeltas(data.kind).incrementAndGet()
         true
     }


### PR DESCRIPTION
@stkem @yingjieMiao 
An alternative would be to stored IncomingEdges together with the Vertex. That may be cleaner but has a couple of caveats:
- Deserialization of MutableVertex is no longer "local" and requires knowledge of the entire graph to be initialized
- Mutating edges would require buffering of both the source and destination vertex, which will generate more garbage. We could make this smarter with nested buffering, in order to avoid buffering an entire MutableVertex when only its data / outgoing edges / incoming edges are touched.
