### PR TITLE
deal more gracefully with graph call failure

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/TopUriSeedIngestionHelper.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/TopUriSeedIngestionHelper.scala
@@ -25,7 +25,7 @@ class TopUriSeedIngestionHelper @Inject() (
     graph: GraphServiceClient) extends PersonalSeedIngestionHelper with Logging {
 
   //re-ingest top uris for a user should be more than 12 hours later.
-  val uriIngestionFreq = 12
+  val uriIngestionFreq = 4
 
   private def updateUserTrackItem(userTrackItem: LastTopUriIngestion, lastSeen: DateTime)(implicit session: RWSession): Unit = {
     lastTopUriIngestionRepo.save(userTrackItem.copy(
@@ -77,7 +77,11 @@ class TopUriSeedIngestionHelper @Inject() (
     val betweenHours = Hours.hoursBetween(lastIngestionTime, currentDateTime).getHours
 
     if (betweenHours > uriIngestionFreq || firstTimeIngesting) {
-      graph.getConnectedUriScores(userId, avoidFirstDegreeConnections = true).flatMap { uriScores =>
+      graph.getConnectedUriScores(userId, avoidFirstDegreeConnections = true).recover {
+        case ex: Exception =>
+          airbrake.notify("Could not get uris from graph, skipping user $userId", ex)
+          Seq.empty
+      }.flatMap { uriScores =>
         db.readWriteAsync { implicit session =>
           if (firstTimeIngesting) {
             lastTopUriIngestionRepo.save(LastTopUriIngestion(userId = userId, lastIngestionTime = currentDateTime))


### PR DESCRIPTION
also decreases the graph re-ingestion interval for testing purposes. This will go back up later.
@lawzlo 
