### PR TITLE
attempting to allow PathBindable to help with routing

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/db/ExternalId.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/db/ExternalId.scala
@@ -38,8 +38,13 @@ object ExternalId {
   }
 
   implicit def pathBinder[T] = new PathBindable[ExternalId[T]] {
-    override def bind(key: String, value: String): Either[String, ExternalId[T]] =
-      Right(ExternalId(value)) // TODO: handle errors if value is malformed
+    override def bind(key: String, value: String): Either[String, ExternalId[T]] = {
+      if (UUIDPattern.pattern.matcher(value).matches) {
+        Right(ExternalId(value))
+      } else {
+        Left("Not a valid ExternalId")
+      }
+    }
 
     override def unbind(key: String, id: ExternalId[T]): String = id.toString
   }

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -276,7 +276,7 @@ GET     /site/user/import-status    @com.keepit.controllers.website.UserControll
 GET     /site/user/import-check/:network  @com.keepit.controllers.website.UserController.checkIfImporting(network: String, callback: String)
 GET     /site/user/networks         @com.keepit.controllers.website.UserController.socialNetworkInfo()
 GET     /site/user/abooks           @com.keepit.controllers.website.UserController.abookInfo()
-GET     /site/user/$id<[0-9a-f-]{36}> @com.keepit.controllers.website.UserController.basicUserInfo(id: ExternalId[User])
+GET     /site/user/:id              @com.keepit.controllers.website.UserController.basicUserInfo(id: ExternalId[User])
 GET     /site/user/:id/networks     @com.keepit.controllers.website.UserController.friendNetworkInfo(id: ExternalId[User])
 POST    /site/user/:id/unfriend     @com.keepit.controllers.website.UserController.unfriend(id: ExternalId[User])
 POST    /site/user/:id/friend       @com.keepit.controllers.website.UserController.friend(id: ExternalId[User])


### PR DESCRIPTION
@andrewconner @joshm1 

Just for the record, this doesn’t work. Returning a `Left` from a `PathBindable` triggers a `400 Bad Request`, not further route matching.

```
BAD REQUEST: 38ebe7c0-51ba-4ac3-ba3d-4005fbd7924d: [Not a valid ExternalId] on GET:/site/user/friends query: 
```
