### PR TITLE
Fix UserCred update issue

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/UserCred.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserCred.scala
@@ -18,7 +18,6 @@ case class UserCred(id: Option[Id[UserCred]] = None,
     ) extends ModelWithState[UserCred] {
   def withId(id: Id[UserCred]) = this.copy(id = Some(id))
   def withUpdateTime(now: time.DateTime) = this.copy(updatedAt = now)
-  def withSalt(salt: String) = this.copy(salt = salt)
   def withCredentials(creds: String) = this.copy(credentials = creds)
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/model/UserCred.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserCred.scala
@@ -18,6 +18,8 @@ case class UserCred(id: Option[Id[UserCred]] = None,
     ) extends ModelWithState[UserCred] {
   def withId(id: Id[UserCred]) = this.copy(id = Some(id))
   def withUpdateTime(now: time.DateTime) = this.copy(updatedAt = now)
+  def withSalt(salt: String) = this.copy(salt = salt)
+  def withCredentials(creds: String) = this.copy(credentials = creds)
 }
 
 object UserCredStates extends States[UserCred]

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
@@ -93,6 +93,7 @@ case class BasicUserInfo(basicUser: BasicUser, info: UpdatableUserInfo, notAuthe
 class UserCommander @Inject() (
     db: Database,
     userRepo: UserRepo,
+    userCredRepo: UserCredRepo,
     emailRepo: UserEmailAddressRepo,
     userValueRepo: UserValueRepo,
     userConnectionRepo: UserConnectionRepo,
@@ -378,13 +379,22 @@ class UserCommander @Inject() (
     } map { sui =>
       val hasher = Registry.hashers.currentHasher
       val identity = sui.credentials.get
-      if (!hasher.matches(identity.passwordInfo.get, oldPassword)) throw new IllegalArgumentException("bad_old_password")
-      else {
-        val pInfo = Registry.hashers.currentHasher.hash(newPassword)
-        UserService.save(UserIdentity(
+      if (!hasher.matches(identity.passwordInfo.get, oldPassword)) {
+        log.warn(s"[doChangePassword($userId)] oldPwd=$oldPassword newPwd=$newPassword pwd=${identity.passwordInfo.get}")
+        throw new IllegalArgumentException("bad_old_password")
+      } else {
+        val pwdInfo = Registry.hashers.currentHasher.hash(newPassword)
+        val savedIdentity = UserService.save(UserIdentity(
           userId = sui.userId,
-          socialUser = sui.credentials.get.copy(passwordInfo = Some(pInfo))
+          socialUser = sui.credentials.get.copy(passwordInfo = Some(pwdInfo))
         ))
+        val updatedCred = db.readWrite { implicit session =>
+          userCredRepo.findByUserIdOpt(userId) map { userCred =>
+            userCredRepo.save(userCred).withCredentials(pwdInfo.password)
+          }
+        }
+        log.info(s"[doChangePassword] UserCreds updated=${updatedCred.map(c => s"id=${c.id} userId=${c.userId} login=${c.loginName}")}")
+        savedIdentity
       }
     }
     resOpt getOrElse { throw new IllegalArgumentException("no_user") }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -313,7 +313,7 @@ class AuthHelper @Inject() (
                 )
               ))
               val updated = userCredRepo.findByUserIdOpt(sui.userId.get) map { userCred =>
-                userCredRepo.save(userCred).withSalt(pwdInfo.salt.get).withCredentials(pwdInfo.password)
+                userCredRepo.save(userCred).withCredentials(pwdInfo.password)
               }
               log.info(s"[doSetPassword] UserCreds updated=${updated.map(c => s"id=${c.id} userId=${c.userId} login=${c.loginName}")}")
               authenticateUser(sui.userId.get, onError = { error =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -313,7 +313,7 @@ class AuthHelper @Inject() (
                 )
               ))
               val updated = userCredRepo.findByUserIdOpt(sui.userId.get) map { userCred =>
-                userCredRepo.save(userCred).withCredentials(pwdInfo.password)
+                userCredRepo.save(userCred.withCredentials(pwdInfo.password))
               }
               log.info(s"[doSetPassword] UserCreds updated=${updated.map(c => s"id=${c.id} userId=${c.userId} login=${c.loginName}")}")
               authenticateUser(sui.userId.get, onError = { error =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/PasswordTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/PasswordTest.scala
@@ -1,0 +1,92 @@
+package com.keepit.commanders
+
+import com.keepit.abook.TestABookServiceClientModule
+import com.keepit.common.actor.TestActorSystemModule
+import com.keepit.common.controller.FakeActionAuthenticator
+import com.keepit.common.external.FakeExternalServiceModule
+import com.keepit.common.healthcheck.FakeAirbrakeModule
+import com.keepit.common.mail.{EmailAddress, TestMailModule}
+import com.keepit.common.net.FakeHttpClientModule
+import com.keepit.common.social.{FakeSocialGraphModule, TestShoeboxAppSecureSocialModule}
+import com.keepit.common.store.ShoeboxFakeStoreModule
+import com.keepit.cortex.FakeCortexServiceClientModule
+import com.keepit.heimdal.{HeimdalContext, TestHeimdalServiceClientModule}
+import com.keepit.model._
+import com.keepit.scraper.{FakeScrapeSchedulerModule, TestScraperServiceClientModule}
+import com.keepit.search.TestSearchServiceClientModule
+import com.keepit.shoebox.{FakeShoeboxServiceModule, KeepImportsModule}
+import com.keepit.social.{SocialId, SocialNetworks}
+import com.keepit.test.{ShoeboxApplication, ShoeboxApplicationInjector, ShoeboxInjectionHelpers}
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import play.api.test._
+import securesocial.core._
+
+class PasswordTest extends Specification with ShoeboxApplicationInjector with ShoeboxInjectionHelpers {
+
+  implicit val context = HeimdalContext.empty
+
+  def modules = Seq(
+    FakeShoeboxServiceModule(),
+    TestSearchServiceClientModule(),
+    FakeScrapeSchedulerModule(),
+    ShoeboxFakeStoreModule(),
+    TestActorSystemModule(),
+    FakeAirbrakeModule(),
+    TestABookServiceClientModule(),
+    TestMailModule(),
+    FakeHttpClientModule(),
+    FakeSocialGraphModule(),
+    TestHeimdalServiceClientModule(),
+    TestShoeboxAppSecureSocialModule(),
+    FakeExternalServiceModule(),
+    FakeCortexServiceClientModule(),
+    TestScraperServiceClientModule(),
+    KeepImportsModule()
+  )
+
+  "PasswordHandler" should {
+    "handle change password" in {
+      running(new ShoeboxApplication(modules: _*)) {
+        val oldPwd = "1234567"
+        val newPwd = "7654321"
+        val hasher = Registry.hashers.get("bcrypt").get
+        val pwdInfo = hasher.hash(oldPwd)
+        val user = db.readWrite { implicit session =>
+          val user1 = userRepo.save(User(firstName = "Shanee", lastName = "Smith"))
+          val email1 = emailAddressRepo.save(UserEmailAddress(userId = user1.id.get, address = EmailAddress("username@42go.com")))
+          val uc1 = userCredRepo.save(UserCred(userId = user1.id.get, loginName = email1.address.address, provider = "bcrypt", salt = pwdInfo.salt.getOrElse(""), credentials = pwdInfo.password))
+          val socialUserRepo = inject[SocialUserInfoRepo]
+          val socialUser = SocialUser(
+            identityId = IdentityId(email1.address.address, "userpass"),
+            firstName = user1.firstName,
+            lastName = user1.lastName,
+            fullName = user1.fullName,
+            email = Some(email1.address.address),
+            avatarUrl = None,
+            authMethod = AuthenticationMethod.UserPassword,
+            passwordInfo = Some(pwdInfo)
+          )
+          socialUserRepo.save(SocialUserInfo(userId = user1.id, fullName = user1.fullName, socialId = SocialId(email1.address.address), networkType = SocialNetworks.FORTYTWO, credentials = Some(socialUser)))
+          user1
+        }
+
+        val path = com.keepit.controllers.website.routes.UserController.changePassword().toString()
+        path === "/site/user/password"
+
+        inject[FakeActionAuthenticator].setUser(user)
+        val payload = Json.obj("oldPassword" -> oldPwd, "newPassword" -> newPwd)
+        val request = FakeRequest("POST", path).withJsonBody(payload)
+        val result = route(request).get
+        status(result) must equalTo(OK)
+        contentType(result) must beSome("application/json")
+        contentAsString(result) === Json.obj("success" -> true).toString()
+        db.readOnlyMaster { implicit session =>
+          val uc = userCredRepo.findByUserIdOpt(user.id.get).get
+          hasher.matches(hasher.hash(newPwd), newPwd) === true
+        }
+      }
+    }
+  }
+}

--- a/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxInjectionHelpers.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxInjectionHelpers.scala
@@ -13,6 +13,7 @@ trait ShoeboxInjectionHelpers { self: InjectorProvider =>
 
   def userSessionRepo(implicit injector: Injector) = inject[UserSessionRepo]
   def userRepo(implicit injector: Injector) = inject[UserRepo]
+  def userCredRepo(implicit injector: Injector) = inject[UserCredRepo]
   def rawKeepRepo(implicit injector: Injector) = inject[RawKeepRepo]
   def userPictureRepo(implicit injector: Injector) = inject[UserPictureRepo]
   def basicUserRepo(implicit injector: Injector) = inject[BasicUserRepo]


### PR DESCRIPTION
We currently don't update userCreds when we set/change pwd, this should fix it.

I couldn't find existing test covering either scenario, so added one here as well. Due SecureSocial dependencies (mostly hidden) that took a while.

Added a bit of logging to help diagnose prod-specific issues.

Tested both scenarios locally (thanks to @andrewconner's workaround tip). Plan to push and add more coverage later.

@andrewconner @eishay @leogrim 
