### PR TITLE
using user image url cache only in shoebox, making the ttl to be 30 days...

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/common/cache/ABookCacheModule.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/common/cache/ABookCacheModule.scala
@@ -79,11 +79,6 @@ case class ABookCacheModule(cachePluginModules: CachePluginModule*) extends Cach
 
   @Singleton
   @Provides
-  def userImageUrlCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new UserImageUrlCache(stats, accessLog, (innerRepo, 1 minute), (outerRepo, 10 minute))
-
-  @Singleton
-  @Provides
   def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new UserExperimentCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
 

--- a/kifi-backend/modules/common/app/com/keepit/model/User.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/User.scala
@@ -92,10 +92,10 @@ case class ExternalUserIdKey(id: ExternalId[User]) extends Key[Id[User]] {
 class ExternalUserIdCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
   extends JsonCacheImpl[ExternalUserIdKey, Id[User]](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)(Id.format[User])
 
-case class UserImageUrlCacheKey(userId: Id[User], width: Int) extends Key[String] {
+case class UserImageUrlCacheKey(userId: Id[User], width: Int, imageName: String) extends Key[String] {
   override val version = 1
   val namespace = "user_image_by_width"
-  def toKey(): String = s"$userId#$width"
+  def toKey(): String = s"$userId#$width#$imageName"
 }
 
 class UserImageUrlCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -150,8 +150,7 @@ case class ShoeboxCacheProvider @Inject() (
   userBookmarkCountCache: KeepCountCache,
   userSegmentCache: UserSegmentCache,
   extensionVersionCache: ExtensionVersionInstallationIdCache,
-  urlPatternRuleAllCache: UrlPatternRuleAllCache,
-  userImageUrlCache: UserImageUrlCache)
+  urlPatternRuleAllCache: UrlPatternRuleAllCache)
 
 class ShoeboxServiceClientImpl @Inject() (
   override val serviceCluster: ServiceCluster,
@@ -821,10 +820,8 @@ class ShoeboxServiceClientImpl @Inject() (
   }
 
   def getUserImageUrl(userId: Id[User], width: Int): Future[String] = {
-    cacheProvider.userImageUrlCache.getOrElseFuture(UserImageUrlCacheKey(userId, width)) {
-      call(Shoebox.internal.getUserImageUrl(userId.id, width)).map { r =>
-        r.json.as[String]
-      }
+    call(Shoebox.internal.getUserImageUrl(userId.id, width)).map { r =>
+      r.json.as[String]
     }
   }
 

--- a/kifi-backend/modules/cortex/app/com/keepit/common/cache/CortexCacheModule.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/cache/CortexCacheModule.scala
@@ -77,11 +77,6 @@ case class CortexCacheModule(cachePluginModules: CachePluginModule*) extends Cac
 
   @Singleton
   @Provides
-  def userImageUrlCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new UserImageUrlCache(stats, accessLog, (innerRepo, 1 minute), (outerRepo, 10 minute))
-
-  @Singleton
-  @Provides
   def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new UserExperimentCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
 

--- a/kifi-backend/modules/curator/app/com/keepit/common/cache/CuratorCacheModule.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/common/cache/CuratorCacheModule.scala
@@ -79,11 +79,6 @@ case class CuratorCacheModule(cachePluginModules: CachePluginModule*) extends Ca
 
   @Singleton
   @Provides
-  def userImageUrlCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new UserImageUrlCache(stats, accessLog, (innerRepo, 1 minute), (outerRepo, 10 minute))
-
-  @Singleton
-  @Provides
   def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new UserExperimentCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
 

--- a/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
@@ -93,11 +93,6 @@ case class ElizaCacheModule(cachePluginModules: CachePluginModule*) extends Cach
 
   @Singleton
   @Provides
-  def userImageUrlCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new UserImageUrlCache(stats, accessLog, (innerRepo, 1 minute), (outerRepo, 10 minute))
-
-  @Singleton
-  @Provides
   def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new UserExperimentCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
 

--- a/kifi-backend/modules/graph/app/com/keepit/graph/common/cache/GraphCacheModule.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/common/cache/GraphCacheModule.scala
@@ -75,11 +75,6 @@ case class GraphCacheModule(cachePluginModules: CachePluginModule*) extends Cach
 
   @Singleton
   @Provides
-  def userImageUrlCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new UserImageUrlCache(stats, accessLog, (innerRepo, 1 minute), (outerRepo, 10 minute))
-
-  @Singleton
-  @Provides
   def userSessionExternalIdCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new UserSessionExternalIdCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 24 hours))
 

--- a/kifi-backend/modules/heimdal/app/com/keepit/common/cache/HeimdalCacheModule.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/common/cache/HeimdalCacheModule.scala
@@ -79,11 +79,6 @@ case class HeimdalCacheModule(cachePluginModules: CachePluginModule*) extends Ca
 
   @Singleton
   @Provides
-  def userImageUrlCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new UserImageUrlCache(stats, accessLog, (innerRepo, 1 minute), (outerRepo, 10 minute))
-
-  @Singleton
-  @Provides
   def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new UserExperimentCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
 

--- a/kifi-backend/modules/scraper/app/com/keepit/common/cache/ScraperCacheModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/common/cache/ScraperCacheModule.scala
@@ -77,11 +77,6 @@ case class ScraperCacheModule(cachePluginModules: CachePluginModule*) extends Ca
 
   @Singleton
   @Provides
-  def userImageUrlCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new UserImageUrlCache(stats, accessLog, (innerRepo, 1 minute), (outerRepo, 10 minute))
-
-  @Singleton
-  @Provides
   def userExperimentCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new UserExperimentCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
 

--- a/kifi-backend/modules/search/app/com/keepit/common/cache/SearchCacheModule.scala
+++ b/kifi-backend/modules/search/app/com/keepit/common/cache/SearchCacheModule.scala
@@ -81,11 +81,6 @@ case class SearchCacheModule(cachePluginModules: CachePluginModule*) extends Cac
 
   @Singleton
   @Provides
-  def userImageUrlCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new UserImageUrlCache(stats, accessLog, (innerRepo, 1 minute), (outerRepo, 10 minute))
-
-  @Singleton
-  @Provides
   def userSessionExternalIdCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new UserSessionExternalIdCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 24 hours))
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
@@ -710,9 +710,10 @@ class UserCommander @Inject() (
 
   def getUserImageUrl(userId: Id[User], width: Int): Future[String] = {
     val user = db.readOnlyMaster { implicit session => userRepo.get(userId) }
+    val imageName = user.pictureName.getOrElse("0")
     implicit val txn = TransactionalCaching.Implicits.directCacheAccess
-    userImageUrlCache.getOrElseFuture(UserImageUrlCacheKey(userId, width)) {
-      s3ImageStore.getPictureUrl(Some(width), user, user.pictureName.getOrElse("0"))
+    userImageUrlCache.getOrElseFuture(UserImageUrlCacheKey(userId, width, imageName)) {
+      s3ImageStore.getPictureUrl(Some(width), user, imageName)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -138,7 +138,7 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Singleton
   @Provides
   def userImageUrlCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new UserImageUrlCache(stats, accessLog, (innerRepo, 1 minute), (outerRepo, 10 minutes))
+    new UserImageUrlCache(stats, accessLog, (innerRepo, 10 minute), (outerRepo, 30 days))
 
   @Singleton
   @Provides


### PR DESCRIPTION
..., adding to the key the image name to make sure we don't have stale data and higher hit rate
@stkem 
