### PR TITLE
+ (internal) getHelpRankInfo endpoint for feed

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -117,6 +117,7 @@ object Shoebox extends Service {
     def getDeepUrl = ServiceRoute(POST, "/internal/shoebox/database/getDeepUrl")
     def getNormalizedUriUpdates(lowSeq: SequenceNumber[ChangedURI], highSeq: SequenceNumber[ChangedURI]) = ServiceRoute(GET, "/internal/shoebox/database/getNormalizedUriUpdates", Param("lowSeq", lowSeq.value), Param("highSeq", highSeq.value))
     def kifiHit() = ServiceRoute(POST, "/internal/shoebox/database/kifiHit")
+    def getHelpRankInfo() = ServiceRoute(POST, "/internal/shoebox/database/getHelpRankInfo")
     def assignScrapeTasks(zkId: Long, max: Int) = ServiceRoute(GET, "/internal/shoebox/database/assignScrapeTasks", Param("zkId", zkId), Param("max", max))
     def getScrapeInfo() = ServiceRoute(POST, "/internal/shoebox/database/getScrapeInfo")
     def saveScrapeInfo() = ServiceRoute(POST, "/internal/shoebox/database/saveScrapeInfo")

--- a/kifi-backend/modules/common/app/com/keepit/model/ReKeep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/ReKeep.scala
@@ -1,5 +1,6 @@
 package com.keepit.model
 
+import com.kifi.macros.json
 import org.joda.time.DateTime
 
 import com.keepit.common.db._
@@ -27,14 +28,4 @@ object ReKeepStates extends States[ReKeep]
 
 case class RichReKeep(id: Option[Id[ReKeep]], createdAt: DateTime, updatedAt: DateTime, state: State[ReKeep], keeper: User, keep: Keep, uri: NormalizedURI, srcUser: User, srcKeep: Keep, attributionFactor: Int)
 
-case class HelpRankInfo(uriId: Id[NormalizedURI], keepDiscoveryCount: Int, rekeepCount: Int)
-
-object HelpRankInfo {
-  import play.api.libs.functional.syntax._
-  import play.api.libs.json._
-  implicit val format = (
-    (__ \ 'uriId).format(Id.format[NormalizedURI]) and
-    (__ \ 'keepDiscoveryCount).format[Int] and
-    (__ \ 'rekeepCount).format[Int]
-  )(HelpRankInfo.apply _, unlift(HelpRankInfo.unapply))
-}
+@json case class HelpRankInfo(uriId: Id[NormalizedURI], keepDiscoveryCount: Int, rekeepCount: Int)

--- a/kifi-backend/modules/common/app/com/keepit/model/ReKeep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/ReKeep.scala
@@ -26,3 +26,15 @@ case class ReKeep(
 object ReKeepStates extends States[ReKeep]
 
 case class RichReKeep(id: Option[Id[ReKeep]], createdAt: DateTime, updatedAt: DateTime, state: State[ReKeep], keeper: User, keep: Keep, uri: NormalizedURI, srcUser: User, srcKeep: Keep, attributionFactor: Int)
+
+case class HelpRankInfo(uriId: Id[NormalizedURI], keepDiscoveryCount: Int, rekeepCount: Int)
+
+object HelpRankInfo {
+  import play.api.libs.functional.syntax._
+  import play.api.libs.json._
+  implicit val format = (
+    (__ \ 'uriId).format(Id.format[NormalizedURI]) and
+    (__ \ 'keepDiscoveryCount).format[Int] and
+    (__ \ 'rekeepCount).format[Int]
+  )(HelpRankInfo.apply _, unlift(HelpRankInfo.unapply))
+}

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -86,7 +86,7 @@ trait ShoeboxServiceClient extends ServiceClient {
   def getDeepUrl(locator: DeepLocator, recipient: Id[User]): Future[String]
   def getNormalizedUriUpdates(lowSeq: SequenceNumber[ChangedURI], highSeq: SequenceNumber[ChangedURI]): Future[Seq[(Id[NormalizedURI], NormalizedURI)]]
   def kifiHit(clicker: Id[User], hit: SanitizedKifiHit): Future[Unit]
-  def getHelpRankStats(uriIds: Seq[Id[NormalizedURI]]): Future[Seq[HelpRankInfo]]
+  def getHelpRankInfos(uriIds: Seq[Id[NormalizedURI]]): Future[Seq[HelpRankInfo]]
   def getScrapeInfo(uri: NormalizedURI): Future[ScrapeInfo]
   def assignScrapeTasks(zkId: Long, max: Int): Future[Seq[ScrapeRequest]]
   def isUnscrapableP(url: String, destinationUrl: Option[String]): Future[Boolean]
@@ -564,7 +564,7 @@ class ShoeboxServiceClientImpl @Inject() (
     call(Shoebox.internal.kifiHit, payload) map { r => Unit }
   }
 
-  def getHelpRankStats(uriIds: Seq[Id[NormalizedURI]]): Future[Seq[HelpRankInfo]] = {
+  def getHelpRankInfos(uriIds: Seq[Id[NormalizedURI]]): Future[Seq[HelpRankInfo]] = {
     val payload = Json.toJson(uriIds)
     call(Shoebox.internal.getHelpRankInfo, payload) map { r =>
       r.json.as[Seq[HelpRankInfo]]

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -86,6 +86,7 @@ trait ShoeboxServiceClient extends ServiceClient {
   def getDeepUrl(locator: DeepLocator, recipient: Id[User]): Future[String]
   def getNormalizedUriUpdates(lowSeq: SequenceNumber[ChangedURI], highSeq: SequenceNumber[ChangedURI]): Future[Seq[(Id[NormalizedURI], NormalizedURI)]]
   def kifiHit(clicker: Id[User], hit: SanitizedKifiHit): Future[Unit]
+  def getHelpRankStats(uriIds: Seq[Id[NormalizedURI]]): Future[Seq[HelpRankInfo]]
   def getScrapeInfo(uri: NormalizedURI): Future[ScrapeInfo]
   def assignScrapeTasks(zkId: Long, max: Int): Future[Seq[ScrapeRequest]]
   def isUnscrapableP(url: String, destinationUrl: Option[String]): Future[Boolean]
@@ -561,6 +562,13 @@ class ShoeboxServiceClientImpl @Inject() (
       "kifiHit" -> hit
     )
     call(Shoebox.internal.kifiHit, payload) map { r => Unit }
+  }
+
+  def getHelpRankStats(uriIds: Seq[Id[NormalizedURI]]): Future[Seq[HelpRankInfo]] = {
+    val payload = Json.toJson(uriIds)
+    call(Shoebox.internal.getHelpRankInfo, payload) map { r =>
+      r.json.as[Seq[HelpRankInfo]]
+    }
   }
 
   def assignScrapeTasks(zkId: Long, max: Int): Future[Seq[ScrapeRequest]] = {

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -499,6 +499,8 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
 
   def kifiHit(clicker: Id[User], hit: SanitizedKifiHit): Future[Unit] = Future.successful()
 
+  def getHelpRankStats(uriIds: Seq[Id[NormalizedURI]]): Future[Seq[HelpRankInfo]] = Future.successful(Seq.empty)
+
   def assignScrapeTasks(zkId: Long, max: Int): Future[Seq[ScrapeRequest]] = {
     Future.successful(Seq.empty[ScrapeRequest])
   }

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -499,7 +499,7 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
 
   def kifiHit(clicker: Id[User], hit: SanitizedKifiHit): Future[Unit] = Future.successful()
 
-  def getHelpRankStats(uriIds: Seq[Id[NormalizedURI]]): Future[Seq[HelpRankInfo]] = Future.successful(Seq.empty)
+  def getHelpRankInfos(uriIds: Seq[Id[NormalizedURI]]): Future[Seq[HelpRankInfo]] = Future.successful(Seq.empty)
 
   def assignScrapeTasks(zkId: Long, max: Int): Future[Seq[ScrapeRequest]] = {
     Future.successful(Seq.empty[ScrapeRequest])

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -630,7 +630,7 @@ class KeepsCommander @Inject() (
       (discMap, rkMap)
     }
     uriIds.toSeq.map { uriId =>
-      HelpRankInfo(uriId, discMap.get(uriId).getOrElse(0), rkMap.get(uriId).getOrElse(0))
+      HelpRankInfo(uriId, discMap.getOrElse(uriId, 0), rkMap.getOrElse(uriId, 0))
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -622,6 +622,18 @@ class KeepsCommander @Inject() (
     }
   }
 
+  def getHelpRankInfo(uriIds: Set[Id[NormalizedURI]]): Seq[HelpRankInfo] = {
+    val (discMap, rkMap) = db.readOnlyMaster { implicit ro =>
+      val discMap = keepDiscoveriesRepo.getDiscoveryCountsByURIs(uriIds)
+      val rkMap = rekeepRepo.getReKeepCountsByURIs(uriIds)
+      log.info(s"getHelpRankInfo discMap=$discMap rkMap=$rkMap")
+      (discMap, rkMap)
+    }
+    uriIds.toSeq.map { uriId =>
+      HelpRankInfo(uriId, discMap.get(uriId).getOrElse(0), rkMap.get(uriId).getOrElse(0))
+    }
+  }
+
   def assembleKeepExport(keepExports: Seq[KeepExport]): String = {
     // HTML format that follows Delicious exports
     val before = """<!DOCTYPE NETSCAPE-Bookmark-file-1>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -580,6 +580,13 @@ class ShoeboxController @Inject() (
     Ok
   }
 
+  def getHelpRankInfo() = SafeAsyncAction(parse.tolerantJson) { request =>
+    val uriIds = Json.fromJson[Seq[Id[NormalizedURI]]](request.body).get
+    val infos = keepsCommander.getHelpRankInfo(uriIds.toSet)
+    log.info(s"[getHelpRankInfo] infos=${infos.mkString(",")}")
+    Ok(Json.toJson(infos))
+  }
+
   def getFriendRequestsBySender(senderId: Id[User]) = Action { request =>
     val requests = db.readOnlyReplica(2) { implicit s =>
       friendRequestRepo.getBySender(senderId)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepDiscoveryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepDiscoveryRepo.scala
@@ -69,7 +69,7 @@ class KeepDiscoveryRepoImpl @Inject() (
   }
 
   def getDiscoveryCountsByURIs(uriIds: Set[Id[NormalizedURI]], since: DateTime)(implicit r: RSession): Map[Id[NormalizedURI], Int] = { // todo(ray): optimize
-    uriIds.map { uriId => uriId -> getDiscoveryCountByURI(uriId) }.toMap
+    uriIds.map { uriId => uriId -> getDiscoveryCountByURI(uriId, since) }.toMap
   }
 
   def getDiscoveryCountsByKeeper(userId: Id[User], since: DateTime)(implicit r: RSession): Map[Id[Keep], Int] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepDiscoveryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepDiscoveryRepo.scala
@@ -14,6 +14,8 @@ trait KeepDiscoveryRepo extends Repo[KeepDiscovery] {
   def getByKeepId(keepId: Id[Keep])(implicit r: RSession): Seq[KeepDiscovery]
   def getDiscoveriesByKeeper(userId: Id[User], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Seq[KeepDiscovery]
   def getDiscoveryCountByKeeper(userId: Id[User], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Int
+  def getDiscoveryCountByURI(uriId: Id[NormalizedURI], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Int
+  def getDiscoveryCountsByURIs(uriIds: Set[Id[NormalizedURI]], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Map[Id[NormalizedURI], Int]
   def getDiscoveryCountsByKeeper(userId: Id[User], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Map[Id[Keep], Int]
   def getUriDiscoveryCountsByKeeper(userId: Id[User], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Map[Id[NormalizedURI], Int]
   def getDiscoveryCountsByKeepIds(userId: Id[User], keepIds: Set[Id[Keep]], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Map[Id[Keep], Int]
@@ -57,6 +59,17 @@ class KeepDiscoveryRepoImpl @Inject() (
 
   def getDiscoveryCountByKeeper(userId: Id[User], since: DateTime)(implicit r: RSession): Int = {
     (for (r <- rows if (r.keeperId === userId && r.state === KeepDiscoveryStates.ACTIVE && r.createdAt >= since)) yield r).length.run
+  }
+
+  def getDiscoveryCountByURI(uriId: Id[NormalizedURI], since: DateTime)(implicit r: RSession): Int = {
+    val q = (for (r <- rows if (r.uriId === uriId && r.state === KeepDiscoveryStates.ACTIVE && r.createdAt >= since)) yield r)
+      .groupBy(_.hitUUID)
+      .map { case (uuid, kc) => (uuid, kc.length) }
+    q.length.run
+  }
+
+  def getDiscoveryCountsByURIs(uriIds: Set[Id[NormalizedURI]], since: DateTime)(implicit r: RSession): Map[Id[NormalizedURI], Int] = { // todo(ray): optimize
+    uriIds.map { uriId => uriId -> getDiscoveryCountByURI(uriId) }.toMap
   }
 
   def getDiscoveryCountsByKeeper(userId: Id[User], since: DateTime)(implicit r: RSession): Map[Id[Keep], Int] = {

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -667,6 +667,7 @@ GET     /internal/shoebox/database/getLibrariesAndMembershipsChanged       @com.
 POST    /internal/shoebox/database/createDeepLink     @com.keepit.controllers.ext.ExtDeepLinkController.createDeepLink()
 POST    /internal/shoebox/database/getDeepUrl         @com.keepit.controllers.ext.ExtDeepLinkController.getDeepUrl()
 POST    /internal/shoebox/database/kifiHit   @com.keepit.controllers.internal.ShoeboxController.kifiHit()
+POST    /internal/shoebox/database/getHelpRankInfo    @com.keepit.controllers.internal.ShoeboxController.getHelpRankInfo()
 
 GET     /internal/shoebox/database/getActiveExperiments @com.keepit.controllers.internal.ShoeboxController.getActiveExperiments
 GET     /internal/shoebox/database/getExperiments     @com.keepit.controllers.internal.ShoeboxController.getExperiments

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
@@ -313,6 +313,35 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
             case (uriId, keep) =>
               keeps2.find(_.uriId == uriId).get == keep
           } === true
+
+          // (global) counts for scoring/recommendation
+
+          keepDiscoveryRepo.getDiscoveryCountByURI(keeps1(0).uriId) === 1
+          keepDiscoveryRepo.getDiscoveryCountByURI(keeps1(1).uriId) === 2
+          val kdcURIs1 = keepDiscoveryRepo.getDiscoveryCountsByURIs(keeps1.map(_.uriId).toSet)
+          keeps1.forall {
+            case k =>
+              kdcURIs1.get(k.uriId).get == keepDiscoveryRepo.getDiscoveryCountByURI(k.uriId)
+          } === true
+          val kdcURIs2 = keepDiscoveryRepo.getDiscoveryCountsByURIs(keeps2.map(_.uriId).toSet)
+          keeps2.forall {
+            case k =>
+              kdcURIs2.get(k.uriId).get == keepDiscoveryRepo.getDiscoveryCountByURI(k.uriId)
+          } === true
+
+          rekeepRepo.getReKeepCountByURI(keeps1(0).uriId) === 0
+          rekeepRepo.getReKeepCountByURI(keeps1(1).uriId) === 2
+          val rkcURIs1 = rekeepRepo.getReKeepCountsByURIs(keeps1.map(_.uriId).toSet)
+          rkcURIs1.get(keeps1(1).uriId).get === 2
+          keeps1.forall {
+            case k =>
+              rkcURIs1.get(k.uriId).get == rekeepRepo.getReKeepCountByURI(k.uriId)
+          } === true
+          val rkcURIs2 = rekeepRepo.getReKeepCountsByURIs(keeps2.map(_.uriId).toSet)
+          keeps2.forall {
+            case k =>
+              rkcURIs2.get(k.uriId).get == rekeepRepo.getReKeepCountByURI(k.uriId)
+          } === true
         }
 
         val attrCmdr = inject[AttributionCommander]


### PR DESCRIPTION
For @stkem (i.e. feed/recommendations) as he needs this "as soon as possible"

Known limitations: counts only (no score) -- not optimized at all; shoebox endpoint needs migration

@yingjieMiao @ymatsuda @eishay 
