### PR TITLE
moving code that should not be under /app to /test and small refactoring...

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/PageInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/PageInfo.scala
@@ -46,6 +46,7 @@ case class PageInfo(
   def withId(pageInfoId: Id[PageInfo]) = copy(id = Some(pageInfoId))
   def withUpdateTime(now: DateTime) = copy(updatedAt = now)
   def withImageInfoId(imgInfoId: Id[ImageInfo]) = copy(imageInfoId = Some(imgInfoId))
+  override def toString: String = s"PageInfo[id=$id,uri=$uriId]"
 }
 
 object PageInfo {

--- a/kifi-backend/modules/common/app/com/keepit/scraper/ScraperClientModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/scraper/ScraperClientModule.scala
@@ -31,15 +31,3 @@ case class ProdScraperServiceClientModule() extends ScraperServiceClientModule {
   }
 
 }
-
-case class TestScraperServiceClientModule() extends ScraperServiceClientModule {
-
-  def configure() {}
-
-  @Singleton
-  @Provides
-  def ScraperServiceClient(airbrakeNotifier: AirbrakeNotifier, scheduler: Scheduler): ScraperServiceClient = {
-    new FakeScraperServiceClientImpl(airbrakeNotifier, scheduler)
-  }
-
-}

--- a/kifi-backend/modules/common/test/com/keepit/scraper/FakeScraperServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/scraper/FakeScraperServiceClientImpl.scala
@@ -1,0 +1,46 @@
+package com.keepit.scraper
+
+import akka.actor.Scheduler
+import com.google.inject.util.Providers
+import com.keepit.common.amazon.AmazonInstanceInfo
+import com.keepit.common.db.Id
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.service.ServiceType
+import com.keepit.common.store.ImageSize
+import com.keepit.common.zookeeper.ServiceCluster
+import com.keepit.model._
+import com.keepit.scraper.embedly.EmbedlyInfo
+import com.keepit.scraper.extractor.ExtractorProviderType
+
+import scala.concurrent.Future
+
+class FakeScraperServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, scheduler: Scheduler) extends ScraperServiceClient {
+
+  val serviceCluster: ServiceCluster = new ServiceCluster(ServiceType.TEST_MODE, Providers.of(airbrakeNotifier), scheduler, () => {})
+
+  protected def httpClient: com.keepit.common.net.HttpClient = ???
+
+  override def status(): Seq[Future[(AmazonInstanceInfo, Seq[ScrapeJobStatus])]] = Seq.empty
+
+  def getBasicArticle(url: String, proxy: Option[HttpProxy], extractor: Option[ExtractorProviderType]): Future[Option[BasicArticle]] = ???
+
+  def getSignature(url: String, proxy: Option[HttpProxy], extractor: Option[ExtractorProviderType]): Future[Option[Signature]] = ???
+
+  def getThreadDetails(filterState: Option[String]): Seq[Future[ScraperThreadInstanceInfo]] = ???
+
+  def getPornDetectorModel(): Future[Map[String, Float]] = ???
+
+  def detectPorn(query: String): Future[Map[String, Float]] = ???
+
+  def whitelist(words: String): Future[String] = ???
+
+  def getEmbedlyImageInfos(uriId: Id[NormalizedURI], url: String): Future[Seq[ImageInfo]] = ???
+
+  def getEmbedlyInfo(url: String): Future[Option[EmbedlyInfo]] = ???
+
+  def getURISummaryFromEmbedly(uri: NormalizedURI, minSize: ImageSize, descriptionOnly: Boolean): Future[Option[URISummary]] = ???
+
+  def getURIWordCount(uriId: Id[NormalizedURI], url: Option[String]): Future[Int] = ???
+
+  def getURIWordCountOpt(uriId: Id[NormalizedURI], url: Option[String]): Option[Int] = ???
+}

--- a/kifi-backend/modules/common/test/com/keepit/scraper/TestScraperServiceClientModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/scraper/TestScraperServiceClientModule.scala
@@ -1,0 +1,17 @@
+package com.keepit.scraper
+
+import akka.actor.Scheduler
+import com.google.inject.{ Provides, Singleton }
+import com.keepit.common.healthcheck.AirbrakeNotifier
+
+case class TestScraperServiceClientModule() extends ScraperServiceClientModule {
+
+  def configure() {}
+
+  @Singleton
+  @Provides
+  def ScraperServiceClient(airbrakeNotifier: AirbrakeNotifier, scheduler: Scheduler): ScraperServiceClient = {
+    new FakeScraperServiceClientImpl(airbrakeNotifier, scheduler)
+  }
+
+}


### PR DESCRIPTION
...s to clarify code and reduce heavy logs
@raymondng 
we should not have code that's used only by test available in /app e.g. `TestScraperServiceClientModule` and `FakeScraperServiceClientImpl` so we won't accidentally compile with it and have it running in production
