### PR TITLE
removed PercentMatchExpr

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/engine/QueryEngine.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/QueryEngine.scala
@@ -3,13 +3,13 @@ package com.keepit.search.engine
 import com.keepit.search.Searcher
 import com.keepit.search.engine.query.KWeight
 import com.keepit.search.engine.result.ResultCollector
-import com.keepit.search.index.{ IdMapper, WrappedSubReader }
+import com.keepit.search.index.WrappedSubReader
 import com.keepit.search.util.join.{ DataBuffer, HashJoin }
 import org.apache.lucene.search.{ Scorer, Query, Weight }
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
 
-class QueryEngine private[engine] (scoreExpr: ScoreExpr, query: Query, scoreArraySize: Int, collector: ResultCollector[ScoreContext]) {
+class QueryEngine private[engine] (scoreExpr: ScoreExpr, query: Query, scoreArraySize: Int) {
 
   private[this] val dataBuffer: DataBuffer = new DataBuffer()
   private[this] var execCount: Int = 0
@@ -65,16 +65,16 @@ class QueryEngine private[engine] (scoreExpr: ScoreExpr, query: Query, scoreArra
     }
   }
 
-  def createScoreContext(): ScoreContext = {
+  def createScoreContext(collector: ResultCollector[ScoreContext]): ScoreContext = {
     new ScoreContext(scoreExpr, scoreArraySize, execCount.toFloat, matchWeight, collector)
   }
 
-  def join(): Unit = {
+  def join(collector: ResultCollector[ScoreContext]): Unit = {
     val size = dataBuffer.size
     if (size > 0) {
       normalizeMatchWeight()
 
-      val hashJoin = new HashJoin(dataBuffer, (size + 10) / 10, createScoreContext())
+      val hashJoin = new HashJoin(dataBuffer, (size + 10) / 10, createScoreContext(collector))
       hashJoin.execute()
     }
   }

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/QueryEngineBuilder.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/QueryEngineBuilder.scala
@@ -7,18 +7,28 @@ import org.apache.lucene.search.BooleanClause.Occur._
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
 
-class QueryEngineBuilder(query: Query, percentMatchThreshold: Float) {
+class QueryEngineBuilder(baseQuery: Query) {
 
-  private[this] var _index: Int = 0
-  private[this] var _query: Query = query
-  private[this] var _expr: ScoreExpr = buildExpr(query)
-  private[this] var _collector: ResultCollector[ScoreContext] = null
+  private[this] var _boosters: List[(Query, Float)] = Nil
+  private[this] var _exprIndex: Int = 0
 
-  def build(): QueryEngine = {
-    new QueryEngine(_expr, _query, _index, _collector)
+  def addBoosterQuery(booster: Query, boostStrength: Float): QueryEngineBuilder = {
+    _boosters = (booster, boostStrength) :: _boosters
+    this
   }
 
-  private[this] def buildExpr(query: Query): ScoreExpr = {
+  def build(): QueryEngine = {
+    _exprIndex = 0
+    val (query, expr) = _boosters.foldLeft(buildExpr(baseQuery)) {
+      case ((query, expr), (booster, boostStrength)) =>
+        val boosterExpr = MaxExpr(_exprIndex)
+        _exprIndex += 1
+        (new KBoostQuery(query, booster, boostStrength), BoostExpr(expr, boosterExpr, boostStrength))
+    }
+    new QueryEngine(expr, query, _exprIndex)
+  }
+
+  private[this] def buildExpr(query: Query): (Query, ScoreExpr) = {
     query match {
       case booleanQuery: KBooleanQuery =>
         val clauses = booleanQuery.clauses
@@ -28,48 +38,32 @@ class QueryEngineBuilder(query: Query, percentMatchThreshold: Float) {
 
         clauses.foreach { clause =>
           clause.getOccur match {
-            case MUST_NOT => filterOut += MaxExpr(_index)
+            case MUST_NOT => filterOut += MaxExpr(_exprIndex)
             case occur =>
               clause.getQuery match {
-                case q: KFilterQuery => required += MaxExpr(_index)
-                case _ => (if (occur == MUST) required else optional) += MaxWithTieBreakerExpr(_index, 0.5f)
+                case q: KFilterQuery => required += MaxExpr(_exprIndex)
+                case _ => (if (occur == MUST) required else optional) += MaxWithTieBreakerExpr(_exprIndex, 0.5f)
               }
           }
-          _index += 1
+          _exprIndex += 1
         }
 
         // put all together and build a score expression
-        FilterOutExpr(
-          expr = PercentMatchExpr(
-            expr = BooleanExpr(
-              optional = DisjunctiveSumExpr(optional),
-              required = ConjunctiveSumExpr(required)
-            ),
-            threshold = percentMatchThreshold
+        val expr = FilterOutExpr(
+          expr = BooleanExpr(
+            optional = DisjunctiveSumExpr(optional),
+            required = ConjunctiveSumExpr(required)
           ),
           filter = ExistsExpr(filterOut)
         )
 
+        (baseQuery, expr)
+
       case textQuery: KTextQuery =>
-        MaxWithTieBreakerExpr(0, 0.5f)
+        (baseQuery, MaxWithTieBreakerExpr(0, 0.5f))
 
       case q =>
-        _query = new KWrapperQuery(q)
-        MaxWithTieBreakerExpr(0, 0.5f)
+        (new KWrapperQuery(q), MaxWithTieBreakerExpr(0, 0.5f))
     }
   }
-
-  def addBooster(booster: Query, boostStrength: Float): QueryEngineBuilder = {
-    _query = new KBoostQuery(_query, booster, boostStrength)
-    val boosterExpr = MaxExpr(_index)
-    _index += 1
-    _expr = BoostExpr(_expr, boosterExpr, boostStrength)
-    this
-  }
-
-  def setResultCollector(collector: ResultCollector[ScoreContext]): QueryEngineBuilder = {
-    _collector = collector
-    this
-  }
 }
-

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/ScoreContext.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/ScoreContext.scala
@@ -18,6 +18,20 @@ class ScoreContext(
 
   def score(): Float = scoreExpr()(this)
 
+  def percentMatch(threshold: Float): Float = {
+    val len = scoreMax.length
+    var pct = 1.0f
+    var i = 0
+    while (i < len) { // using while for performance
+      if (scoreMax(i) <= 0.0f) {
+        pct -= matchWeight(i)
+        if (pct < threshold) return 0.0f
+      }
+      i += 1
+    }
+    pct
+  }
+
   def clear(): Unit = {
     visibility = 0
     Arrays.fill(scoreMax, 0.0f)

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/ScoreExpr.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/ScoreExpr.scala
@@ -217,34 +217,3 @@ object BoostExpr {
     if (expr.isNullExpr) NullExpr else if (booster.isNullExpr || boostStrength <= 0.0f) expr else new BoostExpr(expr, booster, boostStrength)
   }
 }
-
-// Percent Match
-object PercentMatchExpr {
-
-  class PercentMatchExpr(expr: ScoreExpr, threshold: Float) extends ScoreExpr {
-    def apply()(implicit ctx: ScoreContext): Float = {
-      var pct = 1.0f
-      var i = 0
-      val scoreMax = ctx.scoreMax
-      val matchWeight = ctx.matchWeight
-      val len = scoreMax.length
-      while (i < len) { // using while for performance
-        if (scoreMax(i) <= 0.0f) {
-          pct -= matchWeight(i)
-          if (pct < threshold) return 0.0f
-        }
-        i += 1
-      }
-      expr() * pct
-    }
-    override def toString(): String = s"PercentMatch(${expr.toString}, $threshold)"
-  }
-
-  def apply(expr: ScoreExpr, threshold: Float): ScoreExpr = {
-    if (expr.isNullExpr) NullExpr else {
-      // if threshold is non-negative, apply percent match even when threshold is zero because
-      // we still want to apply coord factor. set threshold to negative to disable it.
-      if (threshold < 0.0f || expr.isLeafExpr) expr else new PercentMatchExpr(expr, threshold)
-    }
-  }
-}

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/result/MainResultCollector.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/result/MainResultCollector.scala
@@ -6,7 +6,11 @@ import com.keepit.search.engine.Visibility
 import com.keepit.search.tracker.ResultClickBoosts
 import com.keepit.search.util.LongArraySet
 
-class MainResultCollector(clickBoosts: ResultClickBoosts, friendsUris: LongArraySet, maxHitsPerCategory: Int) extends ResultCollector[ScoreContext] {
+object MainResultCollector {
+  val MIN_PERCENT_MATCH = 0.5f
+}
+
+class MainResultCollector(clickBoosts: ResultClickBoosts, friendsUris: LongArraySet, maxHitsPerCategory: Int, percentMatchThreshold: Float) extends ResultCollector[ScoreContext] {
 
   private[this] val myHits = createQueue(maxHitsPerCategory)
   private[this] val friendsHits = createQueue(maxHitsPerCategory)
@@ -16,15 +20,31 @@ class MainResultCollector(clickBoosts: ResultClickBoosts, friendsUris: LongArray
     val id = ctx.id
     val visibility = ctx.visibility
     if (visibility != Visibility.RESTRICTED) {
-      val score = ctx.score()
-      if (score > 0.0f) {
-        val clickBoost = clickBoosts(id)
-        if ((visibility & Visibility.MEMBER) != 0) {
-          myHits.insert(id, score, clickBoost, true, false)
-        } else if (friendsUris.findIndex(id) >= 0) {
-          friendsHits.insert(id, score, clickBoost, false, false)
+      val percentMatch = ctx.percentMatch(MainResultCollector.MIN_PERCENT_MATCH)
+
+      if (percentMatch > 0.0f) {
+        // compute clickBoost and score
+        var clickBoost = 0.0f
+        var score = 0.0f
+        if (percentMatch < percentMatchThreshold) {
+          clickBoost = clickBoosts(id)
+          // if this is a clicked hit (clickBoost > 0.0f), ignore the threshold
+          if (clickBoost > 0.0f) score = ctx.score() * percentMatch // else score remains 0.0f
         } else {
-          othersHits.insert(id, score, clickBoost, false, false)
+          score = ctx.score() * percentMatch
+          // compute clickBoost only when score > 0.0f (percent match is above the threshold)
+          if (score > 0.0f) clickBoost = clickBoosts(id)
+        }
+
+        if (score > 0.0f) {
+          val clickBoost = clickBoosts(id)
+          if ((visibility & Visibility.MEMBER) != 0) {
+            myHits.insert(id, score, clickBoost, true, false)
+          } else if (friendsUris.findIndex(id) >= 0) {
+            friendsHits.insert(id, score, clickBoost, false, false)
+          } else {
+            othersHits.insert(id, score, clickBoost, false, false)
+          }
         }
       }
     }

--- a/kifi-backend/modules/search/app/com/keepit/search/util/join/HashJoin.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/util/join/HashJoin.scala
@@ -76,8 +76,9 @@ class HashJoin(dataBuffer: DataBuffer, numHashBuckets: Int, createJoiner: => Joi
   }
 }
 
-trait Joiner {
-  var _id: Long = -1
+abstract class Joiner {
+  private[this] var _id: Long = -1
+
   def set(id: Long): Joiner = { _id = id; clear(); this }
   def id = _id
 

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/QueryEngineBuilderTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/QueryEngineBuilderTest.scala
@@ -30,18 +30,15 @@ class QueryEngineBuilderTest extends Specification {
       val query = getParser().parse("information").get
       query must beAnInstanceOf[KBooleanQuery]
 
-      val builder1 = new QueryEngineBuilder(query, -1.0f)
-      builder1.build().getScoreExpr().toString() === "MaxWithTieBreaker(0, 0.5)"
-
-      val builder2 = new QueryEngineBuilder(query, 0.1f)
-      builder2.build().getScoreExpr().toString() === "MaxWithTieBreaker(0, 0.5)"
+      val builder = new QueryEngineBuilder(query)
+      builder.build().getScoreExpr().toString() === "MaxWithTieBreaker(0, 0.5)"
     }
 
     "build an engine from a parsed query with a phrase" in {
       val query = getParser().parse("taming \"information overload\"").get
       query must beAnInstanceOf[KBooleanQuery]
 
-      val builder = new QueryEngineBuilder(query, -1.0f)
+      val builder = new QueryEngineBuilder(query)
       builder.build().getScoreExpr().toString() === "DisjunctiveSum(MaxWithTieBreaker(0, 0.5), MaxWithTieBreaker(1, 0.5))"
     }
 
@@ -49,23 +46,15 @@ class QueryEngineBuilderTest extends Specification {
       val query = getParser().parse("taming information overload").get
       query must beAnInstanceOf[KBooleanQuery]
 
-      val builder = new QueryEngineBuilder(query, -1.0f)
+      val builder = new QueryEngineBuilder(query)
       builder.build().getScoreExpr().toString() === "DisjunctiveSum(MaxWithTieBreaker(0, 0.5), MaxWithTieBreaker(1, 0.5), MaxWithTieBreaker(2, 0.5))"
-    }
-
-    "build an engine from a parsed query with percent match threshold" in {
-      val query = getParser().parse("taming information overload").get
-      query must beAnInstanceOf[KBooleanQuery]
-
-      val builder = new QueryEngineBuilder(query, 0.7f)
-      builder.build().getScoreExpr().toString() === "PercentMatch(DisjunctiveSum(MaxWithTieBreaker(0, 0.5), MaxWithTieBreaker(1, 0.5), MaxWithTieBreaker(2, 0.5)), 0.7)"
     }
 
     "build an engine from a parsed query with optional and required" in {
       val query = getParser().parse("taming +information +overload together").get
       query must beAnInstanceOf[KBooleanQuery]
 
-      val builder = new QueryEngineBuilder(query, -1.0f)
+      val builder = new QueryEngineBuilder(query)
       builder.build().getScoreExpr().toString() ===
         "Boolean(DisjunctiveSum(MaxWithTieBreaker(0, 0.5), MaxWithTieBreaker(3, 0.5)), ConjunctiveSum(MaxWithTieBreaker(1, 0.5), MaxWithTieBreaker(2, 0.5)))"
     }
@@ -74,7 +63,7 @@ class QueryEngineBuilderTest extends Specification {
       val query = getParser().parse("taming +information +overload together -bookmark").get
       query must beAnInstanceOf[KBooleanQuery]
 
-      val builder = new QueryEngineBuilder(query, -1.0f)
+      val builder = new QueryEngineBuilder(query)
       builder.build().getScoreExpr().toString() ===
         "FilterOut(Boolean(DisjunctiveSum(MaxWithTieBreaker(0, 0.5), MaxWithTieBreaker(3, 0.5)), ConjunctiveSum(MaxWithTieBreaker(1, 0.5), MaxWithTieBreaker(2, 0.5))), Max(4))"
     }
@@ -83,7 +72,7 @@ class QueryEngineBuilderTest extends Specification {
       val query = getParser().parse("taming +information +overload together -bookmark -chat").get
       query must beAnInstanceOf[KBooleanQuery]
 
-      val builder = new QueryEngineBuilder(query, -1.0f)
+      val builder = new QueryEngineBuilder(query)
       builder.build().getScoreExpr().toString() ===
         "FilterOut(Boolean(DisjunctiveSum(MaxWithTieBreaker(0, 0.5), MaxWithTieBreaker(3, 0.5)), ConjunctiveSum(MaxWithTieBreaker(1, 0.5), MaxWithTieBreaker(2, 0.5))), Exists(Max(4), Max(5)))"
     }
@@ -91,7 +80,7 @@ class QueryEngineBuilderTest extends Specification {
       val query = getParser().parse("taming +information +overload together -bookmark -chat").get
       query must beAnInstanceOf[KBooleanQuery]
 
-      val builder = new QueryEngineBuilder(query, -1.0f)
+      val builder = new QueryEngineBuilder(query)
       builder.build().getScoreExpr().toString() ===
         "FilterOut(Boolean(DisjunctiveSum(MaxWithTieBreaker(0, 0.5), MaxWithTieBreaker(3, 0.5)), ConjunctiveSum(MaxWithTieBreaker(1, 0.5), MaxWithTieBreaker(2, 0.5))), Exists(Max(4), Max(5)))"
     }
@@ -100,13 +89,12 @@ class QueryEngineBuilderTest extends Specification {
       val query = getParser().parse("information overload").get
       query must beAnInstanceOf[KBooleanQuery]
 
-      val builder = new QueryEngineBuilder(query, -1.0f)
-      builder.addBooster(new TermQuery(new Term("", "important")), 2.0f)
+      val builder = new QueryEngineBuilder(query)
+      builder.addBoosterQuery(new TermQuery(new Term("", "important")), 2.0f)
       val engine = builder.build()
       engine.getScoreExpr().toString() ===
         "Boost(DisjunctiveSum(MaxWithTieBreaker(0, 0.5), MaxWithTieBreaker(1, 0.5)), Max(2), 2.0)"
       engine.getQuery() must beAnInstanceOf[KBoostQuery]
     }
-
   }
 }

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/QueryEngineTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/QueryEngineTest.scala
@@ -48,11 +48,10 @@ class QueryEngineTest extends Specification {
     "find matches with index1" in {
       val query = getParser().parse("abc def").get
       val collector = new TstResultCollector
-      val builder = new QueryEngineBuilder(query, -1.0f).setResultCollector(collector)
-      val engine = builder.build
+      val engine = new QueryEngineBuilder(query).build
 
       engine.execute(searcher1) { (reader, scorers) => new ArticleScoreVectorSource(reader, scorers, LongArraySet.empty) }
-      engine.join()
+      engine.join(collector)
 
       collector.hits === Set(0, 2, 4, 6, 8)
 
@@ -61,11 +60,10 @@ class QueryEngineTest extends Specification {
     "find matches with index2" in {
       val query = getParser().parse("abc def").get
       val collector = new TstResultCollector
-      val builder = new QueryEngineBuilder(query, -1.0f).setResultCollector(collector)
-      val engine = builder.build
+      val engine = new QueryEngineBuilder(query).build
 
       engine.execute(searcher2) { (reader, scorers) => new ArticleScoreVectorSource(reader, scorers, LongArraySet.empty) }
-      engine.join()
+      engine.join(collector)
 
       collector.hits === Set(0, 3, 6, 9)
     }
@@ -73,12 +71,11 @@ class QueryEngineTest extends Specification {
     "find matches with index1 and index2 using Disjunction" in {
       val query = getParser().parse("abc def").get
       val collector = new TstResultCollector
-      val builder = new QueryEngineBuilder(query, -1.0f).setResultCollector(collector)
-      val engine = builder.build
+      val engine = new QueryEngineBuilder(query).build
 
       engine.execute(searcher1) { (reader, scorers) => new ArticleScoreVectorSource(reader, scorers, LongArraySet.empty) }
       engine.execute(searcher2) { (reader, scorers) => new ArticleScoreVectorSource(reader, scorers, LongArraySet.empty) }
-      engine.join()
+      engine.join(collector)
 
       collector.hits === Set(0, 2, 3, 4, 6, 8, 9)
     }
@@ -86,12 +83,11 @@ class QueryEngineTest extends Specification {
     "find matches with index1 and index2 using Conjunction" in {
       val query = getParser().parse("+abc +def").get
       val collector = new TstResultCollector
-      val builder = new QueryEngineBuilder(query, -1.0f).setResultCollector(collector)
-      val engine = builder.build
+      val engine = new QueryEngineBuilder(query).build
 
       engine.execute(searcher1) { (reader, scorers) => new ArticleScoreVectorSource(reader, scorers, LongArraySet.empty) }
       engine.execute(searcher2) { (reader, scorers) => new ArticleScoreVectorSource(reader, scorers, LongArraySet.empty) }
-      engine.join()
+      engine.join(collector)
 
       collector.hits === Set(0, 6)
     }

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/ScoreExprTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/ScoreExprTest.scala
@@ -285,37 +285,5 @@ class ScoreExprTest extends Specification {
       collector.id === -1L
       collector.score === 0.0f
     }
-
-    "compute scores correctly with PercentMatchExpr" in {
-      val numTerms = 16
-      val threshold = 0.3f
-      val allIdx = rnd.shuffle((0 until numTerms).toIndexedSeq)
-      val idx = (0 until 8).map { n => allIdx.take(n) }.toArray
-
-      val weights = new Array[Float](numTerms)
-      allIdx.foreach { i => weights(i) = 1.0f / numTerms.toFloat }
-      val ctx = new ScoreContext(PercentMatchExpr(DisjunctiveSumExpr(allIdx.map(MaxExpr(_))), threshold), numTerms, 1.0f, weights, collector)
-
-      (0 until 8).forall { n =>
-        collector.clear()
-        val id = 1100L + n
-        ctx.set(id)
-        idx(n).foreach { i => ctx.addScore(i, (i + 1).toFloat) }
-        ctx.flush
-
-        if ((n.toFloat / numTerms.toFloat) < threshold) {
-          collector.id === -1
-          collector.score === 0.0f
-        } else {
-          def factor(hits: Int, total: Int): Float = 1.0f - ((total - hits).toFloat / total.toFloat)
-
-          val score = idx(n).map(i => (i + 1).toFloat).sum * factor(n, numTerms)
-
-          collector.id === id
-          (collector.score - score < 0.001f) === true
-        }
-        true
-      } === true
-    }
   }
 }


### PR DESCRIPTION
- removed PercentMatchExpr
- added percent match threshold to MainResultCollector and made it more flexible
- removed ResultCollector from QueryEngine so that a query can be run before constructing the collector

self-merging
FYI: @leogrim 
