### PR TITLE
Standardizing images in CSS

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/keepWhoService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/keepWhoService.js
@@ -10,7 +10,7 @@ angular.module('kifi.keepWhoService', [])
         if (user && user.id && user.pictureName) {
           return '//djty7jcqog9qu.cloudfront.net/users/' + user.id + '/pics/' + width + '/' + user.pictureName;
         }
-        return '';
+        return '//www.kifi.com/assets/img/ghost.200.png';
       },
 
       getName: function (user) {

--- a/kifi-backend/modules/shoebox/angular/src/friends/noFriendsOrConnectionsView.styl
+++ b/kifi-backend/modules/shoebox/angular/src/friends/noFriendsOrConnectionsView.styl
@@ -16,7 +16,7 @@
     width: 85px
 
   .social-connect-button::before
-    background-image: url(../img/networks2.png)
+    background-image: url(/img/networks2.png)
     background-size: auto 35px;
     background-color: rgba(0, 0, 0, 0.1)
     content: ''

--- a/kifi-backend/modules/shoebox/angular/src/invite/connectionCard.styl
+++ b/kifi-backend/modules/shoebox/angular/src/invite/connectionCard.styl
@@ -1,5 +1,5 @@
 .kf-icon-micro
-  background-image: url('/img/networks2.png')
+  background-image: url(/img/networks2.png)
   background-size: auto 100%
   background-repeat: no-repeat
   border-radius: 1px

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepWho.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepWho.styl
@@ -9,7 +9,7 @@
     vertical-align: middle
 
   .kf-keep-who-others
-    background-image: url(../img/globe.png)
+    background-image: url(/img/globe.png)
 
     .kf-keep.mine &
       display: none

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/main.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/main.styl
@@ -69,7 +69,7 @@
   width: 17px
   height: 17px
   border: 1px solid #e3e6ee
-  background: url(../img/check.png) 99px/12px 8px no-repeat #fff
+  background: url(/img/check.png) 99px/12px 8px no-repeat #fff
   box-sizing: border-box
 
   &.enabled
@@ -82,7 +82,7 @@
     background-position: 2px 4px
 
   &.multi-checked
-    background: url(../img/multi-check.png) 99px/12px 8px no-repeat #fff
+    background: url(/img/multi-check.png) 99px/12px 8px no-repeat #fff
     background-position: 2px 4px
 
 .kf-query-wrap
@@ -200,7 +200,7 @@ input::-ms-clear
 .kf-search-filter + .kf-search-filter
   border-left: defaultBorder
   padding-left: 10px
-  margin-left: 10px 
+  margin-left: 10px
 
 .import-modal
 

--- a/kifi-backend/modules/shoebox/angular/src/profile/profile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profile.styl
@@ -62,7 +62,7 @@ a.profile-logout
       transform: rotateY(180deg)
     .profile-image-change
       transform: rotateY(0deg)
-    
+
 .profile-image
 .profile-image-change
   position: absolute
@@ -628,7 +628,7 @@ a.profile-change-password-save
     position: absolute
     display: block
     content: "."
-    background: url(../img/kifi-k.png) no-repeat
+    background: url(/img/kifi-k.png) no-repeat
     background-size: 100%
     top: -6px
     left: -6px
@@ -697,7 +697,7 @@ a.profile-nw
   top: 0
   left: 0
   content: ' '
-  background-image: url(../img/networks2.png)
+  background-image: url(/img/networks2.png)
   background-size: auto 32px
   width: 32px
   height: 32px
@@ -773,7 +773,7 @@ a.profile-nw
   line-height: 15px
   font-weight: 200
   letter-spacing: .8px
-  background-image: url(../img/check-green.png)
+  background-image: url(/img/check-green.png)
   background-repeat: no-repeat
   background-size: auto 15px
   background-position: 0
@@ -823,7 +823,7 @@ a.profile-export
   font-size: 13px
   letter-spacing: .5px
   border-radius: 2px
-  transition: background 0.2s ease  
+  transition: background 0.2s ease
 
 .profile-close-account-status
 .profile-export-status
@@ -834,7 +834,7 @@ a.profile-export
   line-height: 15px
   font-weight: 200
   letter-spacing: .8px
-  background-image: url(../img/check-green.png)
+  background-image: url(/img/check-green.png)
   background-repeat: no-repeat
   background-size: auto 15px
   background-position: 0
@@ -868,7 +868,7 @@ a.profile-export
 
 td.profile-email-status
   width: 15px
-  background-image: url(../img/check-green.png)
+  background-image: url(/img/check-green.png)
   background-repeat: no-repeat
   background-size: auto 15px
   background-position: 0

--- a/kifi-backend/modules/shoebox/angular/src/profile/profileEmailAddresses.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profileEmailAddresses.tpl.html
@@ -15,7 +15,7 @@
         <span class="profile-email-address-item-pending-primary" ng-if="email.isPendingPrimary && !email.isPrimary && !email.isPlaceholderPrimary">(pending primary)</span>
         <span class="profile-email-address-item-unverified" ng-if="!email.isVerified">(<a class="profile-email-pending-resend" href="javascript:" ng-click="resendVerificationEmail(email.address)">unverified</a>)</span>
         <div class="profile-email-address-item-arrow" href="javascript:" ng-if="!(email.isPrimary || email.isPendingPrimary || email.isPlaceholderPrimary)" ng-click="openDropdownForEmail($event, email.address)">
-          <img class="profile-email-address-item-arrow-image" src="../img/placeholder-icon.png">
+          <img class="profile-email-address-item-arrow-image" src="/img/placeholder-icon.png">
           <ul class="profile-email-address-item-dropdown" ng-show="emailWithActiveDropdown === email.address">
             <li>
               <a class="profile-email-address-item-make-primary" href="javascript:" ng-if="email.isVerified" ng-click="makePrimary(email.address)">Make primary</a>

--- a/kifi-backend/modules/shoebox/angular/src/profileCard/profileCard.styl
+++ b/kifi-backend/modules/shoebox/angular/src/profileCard/profileCard.styl
@@ -69,7 +69,7 @@
   display: inline-block
   width: 15px
   height: 15px
-  background-image: url(../img/gear-white.png)
+  background-image: url(/img/gear-white.png)
   background-repeat: no-repeat
   background-size: 15px 15px
   margin-top: 14px

--- a/kifi-backend/modules/shoebox/angular/src/social/connectNetworks.styl
+++ b/kifi-backend/modules/shoebox/angular/src/social/connectNetworks.styl
@@ -117,7 +117,7 @@
       top: -16px
 
     &.good
-      background: url("/img/checkmark.png") 7px/18px no-repeat #41C381
+      background: url(/img/checkmark.png) 7px/18px no-repeat #41C381
       border: 1px solid #41C381
 
     &.warn

--- a/kifi-backend/modules/shoebox/angular/src/tags/tags.styl
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tags.styl
@@ -27,7 +27,7 @@ highlightColor = #eeeeee
   &.kf-dragged
     .kf-tag-inner-container.hover
       background-color: transparent
-    
+
 
   .kf-dropdown-menu
     right: 0
@@ -235,12 +235,12 @@ input.kf-tag-rename
 
 .kf-tag-dropdown-toggle
   right: 0
-  background: url(../img/arrow-gray-down.png) center/10px no-repeat
+  background: url(/img/arrow-gray-down.png) center/10px no-repeat
 
 .kf-tag-handle
   left: 0
   cursor: move
-  background: url(../img/drag-handle-tag.png) center/10px no-repeat
+  background: url(/img/drag-handle-tag.png) center/10px no-repeat
 
 .kf-fake-tag-item
   .kf-tag-container
@@ -249,4 +249,4 @@ input.kf-tag-rename
 .kf-add-tag-shown
   .kf-fake-tag-item
     display: none
-  
+


### PR DESCRIPTION
@yipingliao @2is10 
- Removing the `../img` to be more consistent
- Removing quotes, because single quotes break `gulp-rev-all`. Will file a bug.
