### PR TITLE
helprank: reverse chronological order

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -190,12 +190,12 @@ class KeepsCommander @Inject() (
               val keepIds = selector.trim match {
                 case "rekeep" => {
                   val rekeepsWithCounts = rekeepRepo.getUriReKeepsWithCountsByKeeper(userId)
-                  val rekeepCounts = rekeepsWithCounts map { case (uriId, _, createdAt, count) => uriId -> count }
+                  val rekeepCounts = rekeepsWithCounts map { case (uriId, _, _, count) => uriId -> count }
                   filter(rekeepCounts)
                 }
                 case _ => {
                   val discoveriesWithCounts = keepDiscoveriesRepo.getUriDiscoveriesWithCountsByKeeper(userId)
-                  val discoveryCounts = discoveriesWithCounts map { case (uriId, _, createdAt, count) => uriId -> count }
+                  val discoveryCounts = discoveriesWithCounts map { case (uriId, _, _, count) => uriId -> count }
                   filter(discoveryCounts)
                 } // click
               }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -189,14 +189,10 @@ class KeepsCommander @Inject() (
             case Some(selector) =>
               val keepIds = selector.trim match {
                 case "rekeep" => {
-                  val rekeepsWithCounts = rekeepRepo.getUriReKeepsWithCountsByKeeper(userId)
-                  val rekeepCounts = rekeepsWithCounts map { case (uriId, _, _, count) => uriId -> count }
-                  filter(rekeepCounts)
+                  filter(rekeepRepo.getUriReKeepsWithCountsByKeeper(userId) map { case (uriId, _, _, count) => uriId -> count })
                 }
                 case _ => {
-                  val discoveriesWithCounts = keepDiscoveriesRepo.getUriDiscoveriesWithCountsByKeeper(userId)
-                  val discoveryCounts = discoveriesWithCounts map { case (uriId, _, _, count) => uriId -> count }
-                  filter(discoveryCounts)
+                  filter(keepDiscoveriesRepo.getUriDiscoveriesWithCountsByKeeper(userId) map { case (uriId, _, _, count) => uriId -> count })
                 } // click
               }
               val km = keepRepo.bulkGetByUserAndUriIds(userId, keepIds.toSet)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepDiscoveryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepDiscoveryRepo.scala
@@ -83,7 +83,7 @@ class KeepDiscoveryRepoImpl @Inject() (
   }
 
   def getUriDiscoveriesWithCountsByKeeper(userId: Id[User], since: DateTime)(implicit r: RSession): Seq[(Id[NormalizedURI], Id[Keep], Id[User], Int)] = {
-    sql"select uri_id, keep_id, keeper_id, count(*) c from keep_click where created_at >= $since and keeper_id=$userId group by uri_id, keeper_id order by keep_id desc".as[(Id[NormalizedURI], Id[Keep], Id[User], Int)].list()
+    sql"select uri_id, keep_id, keeper_id, count(*) c from keep_click where created_at >= $since and keeper_id=$userId group by uri_id order by keep_id desc".as[(Id[NormalizedURI], Id[Keep], Id[User], Int)].list()
   }
 
   def getUriDiscoveryCountsByKeeper(userId: Id[User], since: DateTime)(implicit r: RSession): Map[Id[NormalizedURI], Int] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepDiscoveryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepDiscoveryRepo.scala
@@ -19,7 +19,7 @@ trait KeepDiscoveryRepo extends Repo[KeepDiscovery] {
   def getDiscoveryCountByURI(uriId: Id[NormalizedURI], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Int
   def getDiscoveryCountsByURIs(uriIds: Set[Id[NormalizedURI]], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Map[Id[NormalizedURI], Int]
   def getDiscoveryCountsByKeeper(userId: Id[User], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Map[Id[Keep], Int]
-  def getUriDiscoveriesWithCountsByKeeper(userId: Id[User], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Seq[(Id[NormalizedURI], Id[User], DateTime, Int)]
+  def getUriDiscoveriesWithCountsByKeeper(userId: Id[User], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Seq[(Id[NormalizedURI], Id[Keep], Id[User], Int)]
   def getUriDiscoveryCountsByKeeper(userId: Id[User], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Map[Id[NormalizedURI], Int]
   def getDiscoveryCountsByKeepIds(userId: Id[User], keepIds: Set[Id[Keep]], since: DateTime = currentDateTime.minusMonths(1))(implicit r: RSession): Map[Id[Keep], Int]
 }
@@ -82,8 +82,8 @@ class KeepDiscoveryRepoImpl @Inject() (
     q.toMap()
   }
 
-  def getUriDiscoveriesWithCountsByKeeper(userId: Id[User], since: DateTime)(implicit r: RSession): Seq[(Id[NormalizedURI], Id[User], DateTime, Int)] = {
-    sql"select uri_id, keeper_id, created_at, count(*) c from keep_click group by uri_id, keeper_id having keeper_id=$userId order by created_at desc".as[(Id[NormalizedURI], Id[User], DateTime, Int)].list()
+  def getUriDiscoveriesWithCountsByKeeper(userId: Id[User], since: DateTime)(implicit r: RSession): Seq[(Id[NormalizedURI], Id[Keep], Id[User], Int)] = {
+    sql"select uri_id, keep_id, keeper_id, count(*) c from keep_click group by uri_id, keeper_id having keeper_id=$userId order by keep_id desc".as[(Id[NormalizedURI], Id[Keep], Id[User], Int)].list()
   }
 
   def getUriDiscoveryCountsByKeeper(userId: Id[User], since: DateTime)(implicit r: RSession): Map[Id[NormalizedURI], Int] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepDiscoveryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepDiscoveryRepo.scala
@@ -83,7 +83,7 @@ class KeepDiscoveryRepoImpl @Inject() (
   }
 
   def getUriDiscoveriesWithCountsByKeeper(userId: Id[User], since: DateTime)(implicit r: RSession): Seq[(Id[NormalizedURI], Id[Keep], Id[User], Int)] = {
-    sql"select uri_id, keep_id, keeper_id, count(*) c from keep_click group by uri_id, keeper_id having keeper_id=$userId order by keep_id desc".as[(Id[NormalizedURI], Id[Keep], Id[User], Int)].list()
+    sql"select uri_id, keep_id, keeper_id, count(*) c from keep_click where created_at >= $since and keeper_id=$userId group by uri_id, keeper_id order by keep_id desc".as[(Id[NormalizedURI], Id[Keep], Id[User], Int)].list()
   }
 
   def getUriDiscoveryCountsByKeeper(userId: Id[User], since: DateTime)(implicit r: RSession): Map[Id[NormalizedURI], Int] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/ReKeepRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/ReKeepRepo.scala
@@ -91,7 +91,7 @@ class ReKeepRepoImpl @Inject() (val db: DataBaseComponent, val clock: Clock) ext
   }
 
   def getUriReKeepsWithCountsByKeeper(userId: Id[User])(implicit r: RSession): Seq[(Id[NormalizedURI], Id[Keep], Id[User], Int)] = {
-    sql"select uri_id, keep_id, keeper_id, count(*) c from rekeep group by uri_id, keeper_id having keeper_id=$userId order by keep_id desc".as[(Id[NormalizedURI], Id[Keep], Id[User], Int)].list()
+    sql"select uri_id, keep_id, keeper_id, count(*) c from rekeep where keeper_id=$userId group by uri_id order by keep_id desc".as[(Id[NormalizedURI], Id[Keep], Id[User], Int)].list()
   }
 
   def getUriReKeepCountsByKeeper(userId: Id[User])(implicit r: RSession): Map[Id[NormalizedURI], Int] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/ReKeepRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/ReKeepRepo.scala
@@ -21,7 +21,7 @@ trait ReKeepRepo extends Repo[ReKeep] {
   def getReKeepCountsByKeepIds(userId: Id[User], keepIds: Set[Id[Keep]])(implicit r: RSession): Map[Id[Keep], Int]
   def getReKeepCountByURI(uriId: Id[NormalizedURI])(implicit r: RSession): Int
   def getReKeepCountsByURIs(uriIds: Set[Id[NormalizedURI]])(implicit r: RSession): Map[Id[NormalizedURI], Int]
-  def getUriReKeepsWithCountsByKeeper(userId: Id[User])(implicit r: RSession): Seq[(Id[NormalizedURI], Id[User], DateTime, Int)]
+  def getUriReKeepsWithCountsByKeeper(userId: Id[User])(implicit r: RSession): Seq[(Id[NormalizedURI], Id[Keep], Id[User], Int)]
   def getUriReKeepCountsByKeeper(userId: Id[User])(implicit r: RSession): Map[Id[NormalizedURI], Int]
   def getReKeeps(keepIds: Set[Id[Keep]])(implicit r: RSession): Map[Id[Keep], Seq[ReKeep]]
   def getAllReKeepCountsByUser()(implicit r: RSession): Map[Id[User], Int]
@@ -90,8 +90,8 @@ class ReKeepRepoImpl @Inject() (val db: DataBaseComponent, val clock: Clock) ext
     q.toMap()
   }
 
-  def getUriReKeepsWithCountsByKeeper(userId: Id[User])(implicit r: RSession): Seq[(Id[NormalizedURI], Id[User], DateTime, Int)] = {
-    sql"select uri_id, keeper_id, created_at, count(*) c from rekeep group by uri_id, keeper_id having keeper_id=$userId order by created_at desc".as[(Id[NormalizedURI], Id[User], DateTime, Int)].list()
+  def getUriReKeepsWithCountsByKeeper(userId: Id[User])(implicit r: RSession): Seq[(Id[NormalizedURI], Id[Keep], Id[User], Int)] = {
+    sql"select uri_id, keep_id, keeper_id, count(*) c from rekeep group by uri_id, keeper_id having keeper_id=$userId order by keep_id desc".as[(Id[NormalizedURI], Id[Keep], Id[User], Int)].list()
   }
 
   def getUriReKeepCountsByKeeper(userId: Id[User])(implicit r: RSession): Map[Id[NormalizedURI], Int] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/ReKeepRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/ReKeepRepo.scala
@@ -21,6 +21,7 @@ trait ReKeepRepo extends Repo[ReKeep] {
   def getReKeepCountsByKeepIds(userId: Id[User], keepIds: Set[Id[Keep]])(implicit r: RSession): Map[Id[Keep], Int]
   def getReKeepCountByURI(uriId: Id[NormalizedURI])(implicit r: RSession): Int
   def getReKeepCountsByURIs(uriIds: Set[Id[NormalizedURI]])(implicit r: RSession): Map[Id[NormalizedURI], Int]
+  def getUriReKeepsWithCountsByKeeper(userId: Id[User])(implicit r: RSession): Seq[(Id[NormalizedURI], Id[User], DateTime, Int)]
   def getUriReKeepCountsByKeeper(userId: Id[User])(implicit r: RSession): Map[Id[NormalizedURI], Int]
   def getReKeeps(keepIds: Set[Id[Keep]])(implicit r: RSession): Map[Id[Keep], Seq[ReKeep]]
   def getAllReKeepCountsByUser()(implicit r: RSession): Map[Id[User], Int]
@@ -87,6 +88,10 @@ class ReKeepRepoImpl @Inject() (val db: DataBaseComponent, val clock: Clock) ext
       .groupBy(_.keepId)
       .map { case (kId, rk) => (kId, rk.length) }
     q.toMap()
+  }
+
+  def getUriReKeepsWithCountsByKeeper(userId: Id[User])(implicit r: RSession): Seq[(Id[NormalizedURI], Id[User], DateTime, Int)] = {
+    sql"select uri_id, keeper_id, created_at, count(*) c from rekeep group by uri_id, keeper_id having keeper_id=$userId order by created_at desc".as[(Id[NormalizedURI], Id[User], DateTime, Int)].list()
   }
 
   def getUriReKeepCountsByKeeper(userId: Id[User])(implicit r: RSession): Map[Id[NormalizedURI], Int] = {

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
@@ -359,7 +359,7 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
           discoveriesWithCounts1(0)._1 === keeps1(1).uriId // reverse chronological
           discoveriesWithCounts1(1)._1 === keeps1(0).uriId
           discoveriesWithCounts1.forall {
-            case (uriId, userId, createdAt, count) =>
+            case (uriId, _, _, count) =>
               counts1.get(keeps1.find(_.uriId == uriId).get.id.get).get == count
           } === true
           val discoveriesWithCounts2 = keepDiscoveryRepo.getUriDiscoveriesWithCountsByKeeper(u2.id.get)
@@ -371,13 +371,13 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
           val rekeepsWithCounts1 = rekeepRepo.getUriReKeepsWithCountsByKeeper(u1.id.get)
           rekeepsWithCounts1.length === 1
           rekeepsWithCounts1.forall {
-            case (uriId, userId, createdAt, count) =>
+            case (uriId, _, _, count) =>
               rkc1.get(keeps1.find(_.uriId == uriId).get.id.get).get == count
           } === true
           val rekeepsWithCounts2 = rekeepRepo.getUriReKeepsWithCountsByKeeper(u2.id.get)
           rekeepsWithCounts2.length === 2
           rekeepsWithCounts2.forall {
-            case (uriId, userId, createdAt, count) =>
+            case (uriId, _, _, count) =>
               rkc2.get(keeps2.find(_.uriId == uriId).get.id.get).get == count
           } === true
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
@@ -112,7 +112,7 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
         val bookmarkInterner = inject[KeepInterner]
         val raw1 = inject[RawBookmarkFactory].toRawBookmarks(Json.arr(keep42, keepKifi))
         val raw2 = inject[RawBookmarkFactory].toRawBookmarks(Json.arr(keepKifi, keepGoog, keepBing))
-        val raw3 = inject[RawBookmarkFactory].toRawBookmarks(Json.arr(keepKifi, keepStanford))
+        val raw3 = inject[RawBookmarkFactory].toRawBookmarks(Json.arr(keepKifi, keepStanford, keepBing))
         val raw4 = inject[RawBookmarkFactory].toRawBookmarks(Json.arr(keepKifi, keepGoog, keepApple))
 
         val deduped = bookmarkInterner.deDuplicate(raw1)
@@ -125,7 +125,7 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
         keeps2.size === 3
         keeps1(1).uriId === keeps2(0).uriId
 
-        val (kc0, kc1, kc2) = db.readWrite { implicit rw =>
+        val (kc0, kc1, kc2, kc3) = db.readWrite { implicit rw =>
           val kifiHitCache = inject[KifiHitCache]
           val origin = "https://www.google.com"
           val kc0 = keepDiscoveryRepo.save(KeepDiscovery(createdAt = currentDateTime, hitUUID = ExternalId[ArticleSearchResult](), numKeepers = 1, keeperId = u1.id.get, keepId = keeps1(0).id.get, uriId = keeps1(0).uriId))
@@ -139,32 +139,37 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
           // u3 -> kifi (u1, u2) [rekeep]
           kifiHitCache.set(KifiHitKey(u3.id.get, keeps1(1).uriId), SanitizedKifiHit(kc1.hitUUID, origin, raw1(1).url, kc1.uriId, KifiHitContext(false, false, 0, Seq(u1.externalId, u2.externalId), Seq.empty, None, 0, 0)))
 
-          (kc0, kc1, kc2)
+          // u3 -> bing (u2) [rekeep]
+          val ts3 = currentDateTime
+          val uuid3 = ExternalId[ArticleSearchResult]()
+          val kc3 = keepDiscoveryRepo.save(KeepDiscovery(createdAt = ts3, hitUUID = uuid3, numKeepers = 1, keeperId = u2.id.get, keepId = keeps2(2).id.get, uriId = keeps2(2).uriId))
+          kifiHitCache.set(KifiHitKey(u3.id.get, keeps2(2).uriId), SanitizedKifiHit(kc3.hitUUID, origin, raw2(2).url, kc3.uriId, KifiHitContext(false, false, 0, Seq(u2.externalId), Seq.empty, None, 0, 0)))
+          (kc0, kc1, kc2, kc3)
         }
 
         val (keeps3, _) = bookmarkInterner.internRawBookmarks(raw3, u3.id.get, KeepSource.default, true)
 
-        val kc3 = db.readWrite { implicit rw =>
+        val kc4 = db.readWrite { implicit rw =>
           val kifiHitCache = inject[KifiHitCache]
           val origin = "https://www.google.com"
-          val kc3 = keepDiscoveryRepo.save(KeepDiscovery(createdAt = currentDateTime, hitUUID = ExternalId[ArticleSearchResult](), numKeepers = 1, keeperId = u3.id.get, keepId = keeps3(0).id.get, uriId = keeps3(0).uriId))
+          val kc4 = keepDiscoveryRepo.save(KeepDiscovery(createdAt = currentDateTime, hitUUID = ExternalId[ArticleSearchResult](), numKeepers = 1, keeperId = u3.id.get, keepId = keeps3(0).id.get, uriId = keeps3(0).uriId))
           // u4 -> kifi (u3) [rekeep]
-          kifiHitCache.set(KifiHitKey(u4.id.get, keeps3(0).uriId), SanitizedKifiHit(kc3.hitUUID, origin, raw3(0).url, kc3.uriId, KifiHitContext(false, false, 0, Seq(u3.externalId), Seq.empty, None, 0, 0)))
-          kc3
+          kifiHitCache.set(KifiHitKey(u4.id.get, keeps3(0).uriId), SanitizedKifiHit(kc4.hitUUID, origin, raw3(0).url, kc4.uriId, KifiHitContext(false, false, 0, Seq(u3.externalId), Seq.empty, None, 0, 0)))
+          kc4
         }
 
         val (keeps4, _) = bookmarkInterner.internRawBookmarks(raw4, u4.id.get, KeepSource.default, true)
 
         db.readWrite { implicit session =>
           userRepo.get(u1.id.get) === u1
-          keeps1.size === 2
-          keepRepo.all.size === 10
-          keeps2.size === 3
-          keeps3.size === 2
-          keeps4.size === 3
+          keeps1.size === raw1.size
+          keeps2.size === raw2.size
+          keeps3.size === raw3.size
+          keeps4.size === raw4.size
+          keepRepo.all.size === (raw1.size + raw2.size + raw3.size + raw4.size)
 
           val allDiscoveries = keepDiscoveryRepo.all()
-          allDiscoveries.size === 4
+          allDiscoveries.size === 5
 
           val cu0 = keepDiscoveryRepo.getDiscoveriesByUUID(kc0.hitUUID)
           cu0.size === 1
@@ -194,7 +199,7 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
           ck1.size === 2
 
           val ck2 = keepDiscoveryRepo.getDiscoveriesByKeeper(u2.id.get)
-          ck2.size === 1
+          ck2.size === 2
 
           val counts1 = keepDiscoveryRepo.getDiscoveryCountsByKeeper(u1.id.get)
           counts1.keySet.size === 2
@@ -210,10 +215,10 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
           } === true
 
           val counts2 = keepDiscoveryRepo.getDiscoveryCountsByKeeper(u2.id.get)
-          counts2.keySet.size === 1
+          counts2.keySet.size === 2
           counts2.get(keeps2(0).id.get) === Some(1)
           counts2.get(keeps2(1).id.get) === None
-          counts2.get(keeps2(2).id.get) === None
+          counts2.get(keeps2(2).id.get) === Some(1)
 
           keepDiscoveryRepo.getDiscoveryCountByKeeper(u1.id.get) === ck1.size
           keepDiscoveryRepo.getDiscoveryCountByKeeper(u2.id.get) === ck2.size
@@ -227,7 +232,7 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
           val cm2 = keepDiscoveryRepo.getDiscoveryCountsByKeepIds(u2.id.get, keeps2.map(_.id.get).toSet)
 
           val rekeeps = rekeepRepo.all
-          rekeeps.size === 3
+          rekeeps.size === 4
 
           val rk1 = rekeeps.find(_.keeperId == u1.id.get).get
           rk1.keeperId === u1.id.get
@@ -248,12 +253,17 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
           rkseq1(0).srcUserId === u3.id.get
           rkseq1(0).srcKeepId === keeps3(0).id.get
 
-          val rkmap2 = rekeepRepo.getReKeeps(Set(keeps2(0).id.get))
-          val rkseq2 = rkmap2(keeps2(0).id.get)
-          rkseq2.length === 1
-          rkseq2(0).keepId === keeps2(0).id.get
-          rkseq2(0).srcUserId === u3.id.get
-          rkseq2(0).srcKeepId === keeps3(0).id.get
+          val rkmap2 = rekeepRepo.getReKeeps(Set(keeps2(0).id.get, keeps2(2).id.get))
+          val rkseq2a = rkmap2(keeps2(0).id.get)
+          rkseq2a.length === 1
+          rkseq2a(0).keepId === keeps2(0).id.get
+          rkseq2a(0).srcUserId === u3.id.get
+          rkseq2a(0).srcKeepId === keeps3(0).id.get
+          val rkseq2b = rkmap2(keeps2(2).id.get)
+          rkseq2b.length === 1
+          rkseq2b(0).keepId === keeps2(2).id.get
+          rkseq2b(0).srcUserId === u3.id.get
+          rkseq2b(0).srcKeepId === keeps3(2).id.get
 
           val rkmap3 = rekeepRepo.getReKeeps(Set(keeps3(0).id.get))
           val rkseq3 = rkmap3(keeps3(0).id.get)
@@ -264,12 +274,12 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
 
           val rkbk1 = rekeepRepo.getReKeepsByKeeper(u1.id.get)
           rkbk1.head === rk1
-          rekeepRepo.getAllReKeepsByKeeper(u1.id.get) === rkbk1
+          rekeepRepo.getAllReKeepsByKeeper(u1.id.get).sortBy(_.createdAt) === rkbk1.sortBy(_.createdAt)
 
           val rkbk2 = rekeepRepo.getReKeepsByKeeper(u2.id.get)
           rkbk2.head === rk2
-          rekeepRepo.getReKeepsByReKeeper(u3.id.get).length === 2
-          rekeepRepo.getAllReKeepsByKeeper(u2.id.get) === rkbk2
+          rekeepRepo.getReKeepsByReKeeper(u3.id.get).length === 3
+          rekeepRepo.getAllReKeepsByKeeper(u2.id.get).sortBy(_.createdAt) === rkbk2.sortBy(_.createdAt)
 
           val rkc1 = rekeepRepo.getReKeepCountsByKeeper(u1.id.get)
           rkc1.get(keeps1(0).id.get) === None
@@ -296,7 +306,7 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
           val rkc2 = rekeepRepo.getReKeepCountsByKeeper(u2.id.get)
           rkc2.get(keeps2(0).id.get) === Some(1)
           rkc2.get(keeps2(1).id.get) === None
-          rkc2.get(keeps2(2).id.get) === None
+          rkc2.get(keeps2(2).id.get) === Some(1)
 
           rekeepRepo.getReKeepCountByKeeper(u1.id.get) === rkc1.valuesIterator.foldLeft(0) { (a, c) => a + c }
           rekeepRepo.getReKeepCountByKeeper(u2.id.get) === rkc2.valuesIterator.foldLeft(0) { (a, c) => a + c }
@@ -342,6 +352,35 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
             case k =>
               rkcURIs2.get(k.uriId).get == rekeepRepo.getReKeepCountByURI(k.uriId)
           } === true
+
+          // rows + counts
+          val discoveriesWithCounts1 = keepDiscoveryRepo.getUriDiscoveriesWithCountsByKeeper(u1.id.get)
+          discoveriesWithCounts1.length === 2
+          discoveriesWithCounts1(0)._1 === keeps1(1).uriId // reverse chronological
+          discoveriesWithCounts1(1)._1 === keeps1(0).uriId
+          discoveriesWithCounts1.forall {
+            case (uriId, userId, createdAt, count) =>
+              counts1.get(keeps1.find(_.uriId == uriId).get.id.get).get == count
+          } === true
+          val discoveriesWithCounts2 = keepDiscoveryRepo.getUriDiscoveriesWithCountsByKeeper(u2.id.get)
+          discoveriesWithCounts2.length !== keeps2.length // not all have been discovered
+          discoveriesWithCounts2.length === 2
+          discoveriesWithCounts2(0)._1 === keeps2(2).uriId // reverse chronological
+          discoveriesWithCounts2(1)._1 === keeps2(0).uriId
+
+          val rekeepsWithCounts1 = rekeepRepo.getUriReKeepsWithCountsByKeeper(u1.id.get)
+          rekeepsWithCounts1.length === 1
+          rekeepsWithCounts1.forall {
+            case (uriId, userId, createdAt, count) =>
+              rkc1.get(keeps1.find(_.uriId == uriId).get.id.get).get == count
+          } === true
+          val rekeepsWithCounts2 = rekeepRepo.getUriReKeepsWithCountsByKeeper(u2.id.get)
+          rekeepsWithCounts2.length === 2
+          rekeepsWithCounts2.forall {
+            case (uriId, userId, createdAt, count) =>
+              rkc2.get(keeps2.find(_.uriId == uriId).get.id.get).get == count
+          } === true
+
         }
 
         val attrCmdr = inject[AttributionCommander]

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -505,30 +505,30 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
                    "after":null,
                    "keeps":[
                     {
-                      "id":"${keeps1(0).externalId.toString}",
-                      "url":"${keeps1(0).url}",
-                      "isPrivate":${keeps1(0).isPrivate},
-                      "createdAt":"${keeps1(0).createdAt.toStandardTimeString}",
-                      "others":1,
-                      "keepers":[{"id":"${u2.externalId.toString}","firstName":"${u2.firstName}","lastName":"${u2.lastName}","pictureName":"0.jpg"}],
-                      "collections":[],
-                      "tags":[],
-                      "siteName":"FortyTwo",
-                      "clickCount":1
-                    },
-                    {
                       "id":"${keeps1(1).externalId.toString}",
                       "url":"${keeps1(1).url}",
                       "isPrivate":${keeps1(1).isPrivate},
                       "createdAt":"${keeps1(1).createdAt.toStandardTimeString}",
-                      "others":-1,
-                      "keepers":[],
+                      "others":1,
+                      "keepers":[{"id":"${u2.externalId.toString}","firstName":"${u2.firstName}","lastName":"${u2.lastName}","pictureName":"0.jpg"}],
                       "clickCount":1,
                       "collections":[],
                       "tags":[],
                       "siteName":"kifi.com",
                       "clickCount":1,
                       "rekeepCount":1
+                    },
+                    {
+                      "id":"${keeps1(0).externalId.toString}",
+                      "url":"${keeps1(0).url}",
+                      "isPrivate":${keeps1(0).isPrivate},
+                      "createdAt":"${keeps1(0).createdAt.toStandardTimeString}",
+                      "others":-1,
+                      "keepers":[],
+                      "collections":[],
+                      "tags":[],
+                      "siteName":"FortyTwo",
+                      "clickCount":1
                     }
                   ],
                   "helprank":"click"
@@ -625,8 +625,8 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
       clicks.keySet.size === 2
       rekeeps.keySet.size === 1
 
-      val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.allKeeps(before = Some(keeps1(0).externalId.toString), after = None, collection = None, helprank = Some("click")).toString
-      path === s"/m/1/keeps/all?before=${keeps1(0).externalId.toString}&helprank=click"
+      val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.allKeeps(before = Some(keeps1(1).externalId.toString), after = None, collection = None, helprank = Some("click")).toString
+      path === s"/m/1/keeps/all?before=${keeps1(1).externalId.toString}&helprank=click"
       inject[FakeSearchServiceClient] === inject[FakeSearchServiceClient]
       val sharingUserInfo = Seq(SharingUserInfo(Set(u2.id.get), 3), SharingUserInfo(Set(), 0))
       inject[FakeSearchServiceClient].sharingUserInfoData(sharingUserInfo)
@@ -645,27 +645,26 @@ class MobileKeepsControllerTest extends Specification with ApplicationInjector {
 
       val expected = Json.parse(s"""
                   {"collection":null,
-                   "before":"${keeps1(0).externalId.toString}",
+                   "before":"${keeps1(1).externalId.toString}",
                    "after":null,
                    "keeps":[
                     {
-                      "id":"${keeps1(1).externalId.toString}",
-                      "url":"${keeps1(1).url}",
-                      "isPrivate":${keeps1(1).isPrivate},
-                      "createdAt":"${keeps1(1).createdAt.toStandardTimeString}",
+                      "id":"${keeps1(0).externalId.toString}",
+                      "url":"${keeps1(0).url}",
+                      "isPrivate":${keeps1(0).isPrivate},
+                      "createdAt":"${keeps1(0).createdAt.toStandardTimeString}",
                       "others":1,
                       "keepers":[{"id":"${u2.externalId.toString}","firstName":"${u2.firstName}","lastName":"${u2.lastName}","pictureName":"0.jpg"}],
-                      "clickCount":1,
                       "collections":[],
                       "tags":[],
-                      "siteName":"kifi.com",
-                      "clickCount":1,
-                      "rekeepCount":1
+                      "siteName":"FortyTwo",
+                      "clickCount":1
                     }
                   ],
                   "helprank":"click"
                   }
                 """)
+
       Json.parse(contentAsString(result)) must equalTo(expected)
     }
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
@@ -361,30 +361,30 @@ class KeepsControllerTest extends Specification with ApplicationInjector {
                    "after":null,
                    "keeps":[
                     {
-                      "id":"${keeps1(0).externalId.toString}",
-                      "url":"${keeps1(0).url}",
-                      "isPrivate":${keeps1(0).isPrivate},
-                      "createdAt":"${keeps1(0).createdAt.toStandardTimeString}",
-                      "others":1,
-                      "keepers":[{"id":"${u2.externalId.toString}","firstName":"${u2.firstName}","lastName":"${u2.lastName}","pictureName":"0.jpg"}],
-                      "collections":[],
-                      "tags":[],
-                      "siteName":"FortyTwo",
-                      "clickCount":1
-                    },
-                    {
                       "id":"${keeps1(1).externalId.toString}",
                       "url":"${keeps1(1).url}",
                       "isPrivate":${keeps1(1).isPrivate},
                       "createdAt":"${keeps1(1).createdAt.toStandardTimeString}",
-                      "others":-1,
-                      "keepers":[],
+                      "others":1,
+                      "keepers":[{"id":"${u2.externalId.toString}","firstName":"${u2.firstName}","lastName":"${u2.lastName}","pictureName":"0.jpg"}],
                       "clickCount":1,
                       "collections":[],
                       "tags":[],
                       "siteName":"kifi.com",
                       "clickCount":1,
                       "rekeepCount":1
+                    },
+                    {
+                      "id":"${keeps1(0).externalId.toString}",
+                      "url":"${keeps1(0).url}",
+                      "isPrivate":${keeps1(0).isPrivate},
+                      "createdAt":"${keeps1(0).createdAt.toStandardTimeString}",
+                      "others":-1,
+                      "keepers":[],
+                      "collections":[],
+                      "tags":[],
+                      "siteName":"FortyTwo",
+                      "clickCount":1
                     }
                   ],
                   "helprank":"click"
@@ -481,8 +481,8 @@ class KeepsControllerTest extends Specification with ApplicationInjector {
         clicks.keySet.size === 2
         rekeeps.keySet.size === 1
 
-        val path = com.keepit.controllers.website.routes.KeepsController.allKeeps(before = Some(keeps1(0).externalId.toString), after = None, collection = None, helprank = Some("click")).toString
-        path === s"/site/keeps/all?before=${keeps1(0).externalId.toString}&helprank=click"
+        val path = com.keepit.controllers.website.routes.KeepsController.allKeeps(before = Some(keeps1(1).externalId.toString), after = None, collection = None, helprank = Some("click")).toString
+        path === s"/site/keeps/all?before=${keeps1(1).externalId.toString}&helprank=click"
         inject[FakeSearchServiceClient] === inject[FakeSearchServiceClient]
         val sharingUserInfo = Seq(SharingUserInfo(Set(u2.id.get), 3), SharingUserInfo(Set(), 0))
         inject[FakeSearchServiceClient].sharingUserInfoData(sharingUserInfo)
@@ -501,22 +501,20 @@ class KeepsControllerTest extends Specification with ApplicationInjector {
 
         val expected = Json.parse(s"""
                   {"collection":null,
-                   "before":"${keeps1(0).externalId.toString}",
+                   "before":"${keeps1(1).externalId.toString}",
                    "after":null,
                    "keeps":[
                     {
-                      "id":"${keeps1(1).externalId.toString}",
-                      "url":"${keeps1(1).url}",
-                      "isPrivate":${keeps1(1).isPrivate},
-                      "createdAt":"${keeps1(1).createdAt.toStandardTimeString}",
+                      "id":"${keeps1(0).externalId.toString}",
+                      "url":"${keeps1(0).url}",
+                      "isPrivate":${keeps1(0).isPrivate},
+                      "createdAt":"${keeps1(0).createdAt.toStandardTimeString}",
                       "others":1,
                       "keepers":[{"id":"${u2.externalId.toString}","firstName":"${u2.firstName}","lastName":"${u2.lastName}","pictureName":"0.jpg"}],
-                      "clickCount":1,
                       "collections":[],
                       "tags":[],
-                      "siteName":"kifi.com",
-                      "clickCount":1,
-                      "rekeepCount":1
+                      "siteName":"FortyTwo",
+                      "clickCount":1
                     }
                   ],
                   "helprank":"click"


### PR DESCRIPTION
Using counts to sort the results runs the risk of the results looking "stale" (if say one keep has many clicks & rekeeps it'll stay on top for a long time)

Based on input from @eishay , we will now use "reverse chronological" order (approximately, based on keep_id) so results will appear more "fresh" 

The trade-off is that your most "helpful" keep is no longer at the top. Ultimately we may want to let user decide how to view the results.

@yingjieMiao @stkem @eishay @JRuff42 
