### PR TITLE
mapKeys for Map and convert for Format[T]

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/collection/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/collection/package.scala
@@ -2,13 +2,15 @@ package com.keepit.common
 
 package object collection {
 
-  implicit class PimpedMap[A, B](x: Map[A, B]) {
+  implicit class PimpedMap[A, B](val m: Map[A, B]) {
     /**
      * Adds given (key, value) pairs to the map, where each value is wrapped in an Option.
      * For each value, if the Option is None, the pair is dropped.
      */
     def withOpt(optElems: (A, Option[B])*) = {
-      this.x ++ optElems.collect { case (a, b) if b.nonEmpty => (a, b.get) }.toMap
+      m ++ optElems.collect { case (a, b) if b.nonEmpty => (a, b.get) }.toMap
     }
+
+    def mapKeys[C](f: A => C) = m.map { case (k, v) => (f(k), v) }
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/collection/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/collection/package.scala
@@ -2,7 +2,7 @@ package com.keepit.common
 
 package object collection {
 
-  implicit class PimpedMap[A, B](val m: Map[A, B]) {
+  implicit class PimpedMap[A, B](m: Map[A, B]) {
     /**
      * Adds given (key, value) pairs to the map, where each value is wrapped in an Option.
      * For each value, if the Option is None, the pair is dropped.

--- a/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
@@ -24,6 +24,7 @@ package object json {
 
   implicit class PimpedFormat[A](format: Format[A]) {
     private implicit val implicitFormat: Format[A] = format
+
     def convert[B](atob: A => B, btoa: B => A): Format[B] = Format(
       Reads(Json.fromJson[A](_).map(atob)),
       Writes(obj => Json.toJson(btoa(obj)))

--- a/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
@@ -1,9 +1,9 @@
-package com.keepit.common.json
+package com.keepit.common
 
 import play.api.libs.json._
 import play.api.data.validation.ValidationError
 
-object JsonFormatters {
+package object json {
 
   /* Inspired from https://coderwall.com/p/orci8g */
   implicit def tuple2Reads[A, B](implicit aReads: Reads[A], bReads: Reads[B]): Reads[Tuple2[A, B]] = Reads[Tuple2[A, B]] {
@@ -21,4 +21,13 @@ object JsonFormatters {
   implicit def tuple2Format[A, B](implicit reads: Reads[(A, B)], writes: Writes[(A, B)]) = {
     Format(reads, writes)
   }
+
+  implicit class PimpedFormat[A](format: Format[A]) {
+    private implicit val implicitFormat: Format[A] = format
+    def convert[B](atob: A => B, btoa: B => A): Format[B] = Format(
+      Reads(Json.fromJson[A](_).map(atob)),
+      Writes(obj => Json.toJson(btoa(obj)))
+    )
+  }
+
 }

--- a/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
@@ -22,7 +22,7 @@ import com.google.inject.util.Providers
 import com.keepit.eliza.model.{ MessageHandle, UserThreadStatsForUserIdKey, UserThreadStatsForUserIdCache, UserThreadStats }
 
 import akka.actor.Scheduler
-import com.keepit.common.json.JsonFormatters._
+import com.keepit.common.json._
 
 trait ElizaServiceClient extends ServiceClient {
   final val serviceType = ServiceType.ELIZA

--- a/kifi-backend/modules/common/app/com/keepit/model/PageInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/PageInfo.scala
@@ -8,7 +8,7 @@ import play.api.libs.functional.syntax._
 import com.keepit.common.db._
 import org.joda.time.DateTime
 import com.keepit.common.time._
-import com.keepit.common.json.JsonFormatters._
+import com.keepit.common.json._
 import org.apache.commons.lang3.RandomStringUtils
 import com.keepit.common.store.ImageSize
 import com.keepit.scraper.embedly.EmbedlyKeyword

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/MessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/MessagingController.scala
@@ -40,7 +40,7 @@ import scala.util.{ Failure, Success, Try }
 import play.api.libs.json.JsArray
 import com.keepit.eliza.model.UserThread
 import play.api.libs.json.JsObject
-import com.keepit.common.json.JsonFormatters._
+import com.keepit.common.json._
 
 //For migration only
 import play.api.mvc.Action

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -8,7 +8,7 @@ import com.keepit.common.db.ExternalId
 import com.keepit.common.db.slick.Database
 import com.keepit.common.time.Clock
 import com.keepit.model._
-import com.keepit.common.json.JsonFormatters._
+import com.keepit.common.json._
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{ JsString, Json }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.Json
 import play.api.mvc.SimpleResult
 import play.api.test.Helpers._
 import play.api.test._
-import com.keepit.common.json.JsonFormatters._
+import com.keepit.common.json._
 
 import scala.concurrent.Future
 


### PR DESCRIPTION
@stkem @leogrim @andrewconner Suggesting two super-simple convenience methods that I've always been missing: `mapKeys` for Map (same as `mapValues` but for keys) and `convert` for Format (to transform a Format[A] into a Format[B])

@lawzlo I think this should allow you to simplify your MapFormatUtil object quite a bit:

```
import com.keepit.common.collection._
import com.keepit.common.json._

object MapFormatUtil {
  implicit def scoreTypeMapFormat(implicit f: Format[Map[String, Float]]): Format[Map[ScoreType, Float]] =
    f.convert(_.mapKeys(ScoreType.withName _), _.mapKeys(_.toString))
}
```
