### PR TITLE
Streamline Actor Test setup (cont'd)

### DIFF
--- a/kifi-backend/modules/common/test/com/keepit/common/actor/ActorInstanceTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/actor/ActorInstanceTest.scala
@@ -17,11 +17,9 @@ class MyTestActorB extends Actor {
 }
 
 class ActorInstanceTest extends Specification with CommonTestInjector {
-  implicit val system = ActorSystem("test")
-
   "ActorInstance" should {
     "provide singletons" in {
-      withInjector(StandaloneTestActorSystemModule()) { implicit injector =>
+      withInjector(FakeActorSystemModule()) { implicit injector =>
         val actorA = inject[ActorInstance[MyTestActorA]].ref
         val actorB = inject[ActorInstance[MyTestActorB]].ref
         //checking we're not getting the same reference fo rdiferant actor types

--- a/kifi-backend/modules/common/test/com/keepit/common/actor/FakeActorSystemModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/actor/FakeActorSystemModule.scala
@@ -10,7 +10,7 @@ import com.keepit.common.healthcheck.FakeAirbrakeModule
 import com.keepit.common.zookeeper.ServiceDiscovery
 import net.codingwell.scalaguice.ScalaModule
 
-case class FakeActorSystemModule(implicit val system: ActorSystem = ActorTestSupport.getActorSystem()) extends ActorSystemModule {
+case class FakeActorSystemModule(implicit system: ActorSystem = ActorTestSupport.getActorSystem()) extends ActorSystemModule {
 
   def configure() {
     install(FakeAirbrakeModule())
@@ -18,16 +18,6 @@ case class FakeActorSystemModule(implicit val system: ActorSystem = ActorTestSup
     bind[ActorBuilder].to[TestActorBuilderImpl]
     bind[Scheduler].to[FakeScheduler]
     bind[ActorSystem].toInstance(system)
-  }
-
-}
-
-case class StandaloneTestActorSystemModule(implicit system: ActorSystem) extends ActorSystemModule {
-
-  def configure() {
-    bind[ActorBuilder].to[TestActorBuilderImpl]
-    bind[ActorSystem].toInstance(system)
-    install(FakeSchedulerModule())
   }
 
 }

--- a/kifi-backend/modules/common/test/com/keepit/common/healthcheck/AirbrakeTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/healthcheck/AirbrakeTest.scala
@@ -14,7 +14,6 @@ import javax.xml.validation.{ Validator => JValidator }
 import java.io.StringReader
 
 import scala.xml._
-import akka.actor.ActorSystem
 import com.keepit.model.User
 
 class AirbrakeTest extends Specification with CommonTestInjector {
@@ -77,7 +76,6 @@ class AirbrakeTest extends Specification with CommonTestInjector {
     }
 
     "format with url and no params" in {
-      implicit val system = ActorSystem("test")
       withInjector(FakeFortyTwoModule(), FakeDiscoveryModule(), FakeActorSystemModule()) { implicit injector =>
         val formatter = inject[AirbrakeFormatter]
         val error = AirbrakeError(
@@ -100,7 +98,6 @@ class AirbrakeTest extends Specification with CommonTestInjector {
     }
 
     "format with user info" in {
-      implicit val system = ActorSystem("test")
       withInjector(FakeFortyTwoModule(), FakeDiscoveryModule(), FakeActorSystemModule()) { implicit injector =>
         val formatter = inject[AirbrakeFormatter]
         val error = AirbrakeError(

--- a/kifi-backend/modules/common/test/com/keepit/common/healthcheck/AirbrakeTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/healthcheck/AirbrakeTest.scala
@@ -78,7 +78,7 @@ class AirbrakeTest extends Specification with CommonTestInjector {
 
     "format with url and no params" in {
       implicit val system = ActorSystem("test")
-      withInjector(FakeFortyTwoModule(), FakeDiscoveryModule(), StandaloneTestActorSystemModule()) { implicit injector =>
+      withInjector(FakeFortyTwoModule(), FakeDiscoveryModule(), FakeActorSystemModule()) { implicit injector =>
         val formatter = inject[AirbrakeFormatter]
         val error = AirbrakeError(
           exception = new IllegalArgumentException("hi there"),
@@ -101,7 +101,7 @@ class AirbrakeTest extends Specification with CommonTestInjector {
 
     "format with user info" in {
       implicit val system = ActorSystem("test")
-      withInjector(FakeFortyTwoModule(), FakeDiscoveryModule(), StandaloneTestActorSystemModule()) { implicit injector =>
+      withInjector(FakeFortyTwoModule(), FakeDiscoveryModule(), FakeActorSystemModule()) { implicit injector =>
         val formatter = inject[AirbrakeFormatter]
         val error = AirbrakeError(
           exception = new IllegalArgumentException("hi there"),

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
@@ -7,7 +7,7 @@ import com.keepit.inject._
 import com.keepit.shoebox.{ ShoeboxServiceClient, FakeShoeboxServiceModule, FakeShoeboxServiceClientImpl }
 import com.keepit.common.cache.ElizaCacheModule
 import com.keepit.common.time._
-import com.keepit.common.actor.StandaloneTestActorSystemModule
+import com.keepit.common.actor.FakeActorSystemModule
 import com.keepit.common.db.Id
 import com.keepit.model.User
 import com.keepit.social.BasicUser
@@ -38,13 +38,12 @@ class MessagingTest extends Specification with ElizaTestInjector {
   implicit val context = HeimdalContext.empty
 
   def modules = {
-    implicit val system = ActorSystem("test")
     Seq(
       ElizaCacheModule(),
       FakeShoeboxServiceModule(),
       FakeHeimdalServiceClientModule(),
       FakeElizaServiceClientModule(),
-      StandaloneTestActorSystemModule(),
+      FakeActorSystemModule(),
       FakeABookServiceClientModule(),
       FakeUrbanAirshipModule(),
       FakeCryptoModule(),

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/ext/ExtMessagingControllerTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/ext/ExtMessagingControllerTest.scala
@@ -11,7 +11,7 @@ import com.keepit.inject._
 import com.keepit.shoebox.{ ShoeboxServiceClient, FakeShoeboxServiceModule, FakeShoeboxServiceClientImpl }
 import com.keepit.common.cache.ElizaCacheModule
 import com.keepit.common.time._
-import com.keepit.common.actor.{ TestKitSupport, FakeActorSystemModule, StandaloneTestActorSystemModule }
+import com.keepit.common.actor.{ TestKitSupport, FakeActorSystemModule }
 import com.keepit.common.db.{ Id, ExternalId }
 import com.keepit.model.User
 import com.keepit.realtime.{ FakeUrbanAirshipModule }

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/mobile/MobileMessagingControllerTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/mobile/MobileMessagingControllerTest.scala
@@ -26,21 +26,20 @@ import com.keepit.search.FakeSearchServiceClientModule
 import com.keepit.realtime.FakeUrbanAirshipModule
 import com.keepit.scraper.FakeScraperServiceClientModule
 import com.keepit.common.store.FakeElizaStoreModule
-import com.keepit.common.actor.{ StandaloneTestActorSystemModule, FakeActorSystemModule }
+import com.keepit.common.actor.{ FakeActorSystemModule }
 
 class MobileMessagingControllerTest extends Specification with ElizaTestInjector {
 
   implicit val context = HeimdalContext.empty
 
   def modules = {
-    implicit val system = ActorSystem("test")
     Seq(
       FakeSearchServiceClientModule(),
       ElizaCacheModule(),
       FakeShoeboxServiceModule(),
       FakeHeimdalServiceClientModule(),
       FakeElizaServiceClientModule(),
-      StandaloneTestActorSystemModule(),
+      FakeActorSystemModule(),
       FakeABookServiceClientModule(),
       FakeUrbanAirshipModule(),
       FakeActionAuthenticatorModule(),

--- a/kifi-backend/modules/heimdal/test/com/keepit/controllers/EventTrackingTest.scala
+++ b/kifi-backend/modules/heimdal/test/com/keepit/controllers/EventTrackingTest.scala
@@ -9,7 +9,7 @@ import com.keepit.test.CommonTestInjector
 import com.google.inject.Injector
 import com.keepit.common.cache.HeimdalCacheModule
 import com.keepit.common.time._
-import com.keepit.common.actor.StandaloneTestActorSystemModule
+import com.keepit.common.actor.FakeActorSystemModule
 import com.keepit.heimdal._
 
 import play.api.test.Helpers._
@@ -21,8 +21,7 @@ import com.keepit.social.NonUserKinds
 class EventTrackingTest extends Specification with CommonTestInjector {
 
   def modules = {
-    implicit val system = ActorSystem("test")
-    Seq(FakeMongoModule(), StandaloneTestActorSystemModule(), HeimdalQueueDevModule(), HeimdalServiceTypeModule())
+    Seq(FakeMongoModule(), FakeActorSystemModule(), HeimdalQueueDevModule(), HeimdalServiceTypeModule())
   }
 
   def setup()(implicit injector: Injector) = {

--- a/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtSearchControllerTest.scala
@@ -5,7 +5,7 @@ import org.specs2.mutable._
 import com.keepit.model._
 import com.keepit.common.db.{ Id, ExternalId }
 import com.keepit.inject._
-import com.keepit.common.actor.StandaloneTestActorSystemModule
+import com.keepit.common.actor.FakeActorSystemModule
 import com.keepit.common.controller.{ FakeActionAuthenticator, FakeActionAuthenticatorModule }
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -25,9 +25,8 @@ import com.keepit.common.util.PlayAppConfigurationModule
 class ExtSearchControllerTest extends Specification with SearchTestInjector {
 
   def modules = {
-    implicit val system = ActorSystem("test")
     Seq(
-      StandaloneTestActorSystemModule(),
+      FakeActorSystemModule(),
       FakeActionAuthenticatorModule(),
       FixedResultIndexModule(),
       PlayAppConfigurationModule()

--- a/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtUserSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtUserSearchControllerTest.scala
@@ -7,7 +7,7 @@ import org.specs2.mutable._
 import com.keepit.model._
 import com.keepit.common.db.{ Id, ExternalId }
 import com.keepit.common.controller.{ FakeActionAuthenticator, FakeActionAuthenticatorModule }
-import com.keepit.common.actor.StandaloneTestActorSystemModule
+import com.keepit.common.actor.FakeActorSystemModule
 
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -51,9 +51,8 @@ class ExtUserSearchControllerTest extends Specification with SearchTestInjector 
   }
 
   def modules = {
-    implicit val system = ActorSystem("test")
     Seq(
-      StandaloneTestActorSystemModule(),
+      FakeActorSystemModule(),
       FakeActionAuthenticatorModule(),
       FakeShoeboxServiceModule(),
       PlayAppConfigurationModule(),

--- a/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
@@ -1,6 +1,6 @@
 package com.keepit.controllers.mobile
 
-import com.keepit.common.actor.StandaloneTestActorSystemModule
+import com.keepit.common.actor.FakeActorSystemModule
 import com.keepit.common.controller.{ FakeActionAuthenticator, FakeActionAuthenticatorModule }
 import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.net.FakeHttpClientModule
@@ -23,7 +23,7 @@ import play.api.test.Helpers._
 class MobileSearchControllerTest extends SpecificationLike with SearchTestInjector {
 
   def modules = Seq(
-    StandaloneTestActorSystemModule(),
+    FakeActorSystemModule(),
     FakeActionAuthenticatorModule(),
     FixedResultIndexModule(),
     FakeHttpClientModule(),

--- a/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileUserSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileUserSearchControllerTest.scala
@@ -6,7 +6,7 @@ import org.specs2.mutable._
 import com.keepit.model._
 import com.keepit.common.db.{ Id, ExternalId }
 import com.keepit.common.controller.{ FakeActionAuthenticator, FakeActionAuthenticatorModule }
-import com.keepit.common.actor.StandaloneTestActorSystemModule
+import com.keepit.common.actor.FakeActorSystemModule
 
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -54,9 +54,8 @@ class MobileUserSearchControllerTest extends Specification with SearchTestInject
   def filterFactory(implicit injector: Injector) = inject[UserSearchFilterFactory]
 
   def modules = {
-    implicit val system = ActorSystem("test")
     Seq(
-      StandaloneTestActorSystemModule(),
+      FakeActorSystemModule(),
       FakeActionAuthenticatorModule(),
       FakeShoeboxServiceModule(),
       PlayAppConfigurationModule()

--- a/kifi-backend/modules/search/test/com/keepit/search/SearchTestHelper.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/SearchTestHelper.scala
@@ -1,6 +1,6 @@
 package com.keepit.search
 
-import com.keepit.common.actor.StandaloneTestActorSystemModule
+import com.keepit.common.actor.FakeActorSystemModule
 import com.keepit.common.akka.MonitoredAwait
 import com.keepit.common.db._
 import com.keepit.common.healthcheck.AirbrakeNotifier
@@ -183,6 +183,6 @@ trait SearchTestHelper { self: SearchTestInjector =>
   val allHitsConfig = defaultConfig.overrideWith("tailCutting" -> "0")
 
   // implicit val system = ActorSystem("test")
-  val helperModules = Seq(StandaloneTestActorSystemModule(), FakeShoeboxServiceModule(), new AwsModule(), FakeHttpClientModule(), PlayAppConfigurationModule())
+  val helperModules = Seq(FakeActorSystemModule(), FakeShoeboxServiceModule(), new AwsModule(), FakeHttpClientModule(), PlayAppConfigurationModule())
 
 }

--- a/kifi-backend/modules/search/test/com/keepit/search/feed/FeedMetaInfoProviderTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/feed/FeedMetaInfoProviderTest.scala
@@ -11,7 +11,7 @@ import com.keepit.shoebox.FakeShoeboxServiceClientImpl
 import com.keepit.model.NormalizedURI
 import com.keepit.model.NormalizedURIStates._
 import akka.actor.ActorSystem
-import com.keepit.common.actor.StandaloneTestActorSystemModule
+import com.keepit.common.actor.FakeActorSystemModule
 import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.common.util.PlayAppConfigurationModule
 
@@ -19,7 +19,7 @@ class FeedMetaInfoProviderTest extends Specification with SearchTestInjector {
   "FeedMetaInfoProvider" should {
     "work" in {
       implicit val system = ActorSystem("test")
-      withInjector(FakeShoeboxServiceModule(), StandaloneTestActorSystemModule(), FakeHttpClientModule(), PlayAppConfigurationModule()) { implicit injector =>
+      withInjector(FakeShoeboxServiceModule(), FakeActorSystemModule(), FakeHttpClientModule(), PlayAppConfigurationModule()) { implicit injector =>
         val client = inject[ShoeboxServiceClient].asInstanceOf[FakeShoeboxServiceClientImpl]
         val uris = client.saveURIs(
           NormalizedURI.withHash(title = Some("1"), normalizedUrl = "http://www.keepit.com/login", state = UNSCRAPABLE),

--- a/kifi-backend/modules/search/test/com/keepit/test/SearchApplication.scala
+++ b/kifi-backend/modules/search/test/com/keepit/test/SearchApplication.scala
@@ -1,7 +1,7 @@
 package com.keepit.test
 
 import akka.actor.ActorSystem
-import com.keepit.common.actor.StandaloneTestActorSystemModule
+import com.keepit.common.actor.FakeActorSystemModule
 import com.keepit.search.spellcheck.FakeSpellCorrectorModule
 import com.keepit.inject.{ FakeFortyTwoModule, ApplicationInjector }
 import java.io.File
@@ -50,7 +50,7 @@ trait SearchTestInjector extends TestInjector with SearchInjectionHelpers {
   implicit val system = ActorSystem("test")
 
   val module = Modules.combine(
-    StandaloneTestActorSystemModule(),
+    FakeActorSystemModule(),
     FakeHttpClientModule(),
     FakeHeimdalServiceClientModule(),
     SearchServiceTypeModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
@@ -11,7 +11,7 @@ import com.keepit.common.healthcheck._
 import com.keepit.scraper.FakeScrapeSchedulerModule
 import com.keepit.heimdal.{ KifiHitContext, SanitizedKifiHit, HeimdalContext }
 import com.keepit.shoebox.{ FakeKeepImportsModule, KeepImportsModule }
-import com.keepit.common.actor.{ StandaloneTestActorSystemModule, FakeActorSystemModule }
+import com.keepit.common.actor.{ FakeActorSystemModule }
 import akka.actor.ActorSystem
 import com.keepit.search.ArticleSearchResult
 import com.keepit.common.db.{ Id, ExternalId }
@@ -26,7 +26,6 @@ import scala.concurrent.Await
 class KeepInternerTest extends Specification with ShoeboxTestInjector {
 
   implicit val context = HeimdalContext.empty
-  implicit val system = ActorSystem("test")
   implicit val execCtx = fj
 
   def modules: Seq[ScalaModule] = Seq(FakeKeepImportsModule(), FakeScrapeSchedulerModule())

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/RawKeepImporterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/RawKeepImporterTest.scala
@@ -2,7 +2,7 @@ package com.keepit.commanders
 
 import java.io.File
 
-import com.keepit.common.actor.{ StandaloneTestActorSystemModule, FakeActorSystemModule, TestKitSupport }
+import com.keepit.common.actor.{ FakeActorSystemModule, TestKitSupport }
 import com.keepit.common.cache.{ HashMapMemoryCacheModule, ShoeboxCacheModule }
 import com.keepit.common.db.{ FakeSlickModule, TestDbInfo }
 import com.keepit.common.external.FakeExternalServiceModule
@@ -35,7 +35,7 @@ class RawKeepImporterTest extends TestKitSupport with SpecificationLike with Sho
     FakeNormalizationUpdateJobQueueModule(),
     ShoeboxCacheModule(HashMapMemoryCacheModule()),
     KeepImportsModule(),
-    StandaloneTestActorSystemModule(),
+    FakeActorSystemModule(),
     FakeSearchServiceClientModule(),
     FakeShoeboxServiceClientModule(),
     FakeHttpClientModule(),

--- a/kifi-backend/modules/shoebox/test/com/keepit/normalizer/NormalizationServiceTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/normalizer/NormalizationServiceTest.scala
@@ -1,7 +1,7 @@
 package com.keepit.normalizer
 
 import com.google.inject.Injector
-import com.keepit.common.actor.{ TestKitSupport, StandaloneTestActorSystemModule }
+import com.keepit.common.actor.{ TestKitSupport, FakeActorSystemModule }
 import com.keepit.common.healthcheck.FakeAirbrakeModule
 import com.keepit.common.zookeeper.FakeDiscoveryModule
 import com.keepit.eliza.FakeElizaServiceClientModule
@@ -47,7 +47,7 @@ class NormalizationServiceTest extends TestKitSupport with SpecificationLike wit
     FakeDiscoveryModule(),
     FakeScrapeSchedulerModule(Some(fakeArticles)),
     FakeAirbrakeModule(),
-    StandaloneTestActorSystemModule(),
+    FakeActorSystemModule(),
     FakeElizaServiceClientModule(),
     FakeKeepImportsModule(),
     new ScalaModule {


### PR DESCRIPTION
... the second half of the pull request. This one replaces StandaloneTestActorSystem[M] with FakeActorSystem[M]

Also, the requirement to define an implicit for ActorSystem is now gone.

@leogrim @andrewconner @eishay 
