### PR TITLE
3.1.10: updating the cached total keep count of a page when user keeps/unkeeps

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.1.9
+version=3.1.10


### PR DESCRIPTION
@joshm1 This fixes the incorrect “others” keep count after you’ve kept a page.
https://app.asana.com/0/2456298849186/15297801118444
