### PR TITLE
minor readability improvements

### DIFF
--- a/kifi-backend/modules/shoebox/angular/test/unit/friends/rightColFriends.spec.js
+++ b/kifi-backend/modules/shoebox/angular/test/unit/friends/rightColFriends.spec.js
@@ -2,47 +2,32 @@
 
 describe('kifi.friends.rightColFriendsView', function () {
 
-  var $injector,
-      $compile,
-      $rootScope,
-      elem,
-      scope,
-      friendService;
-
-  function compile(tpl) {
-    elem = angular.element(tpl);
-    scope = $rootScope.$new();
-    $compile(elem)(scope);
-  }
-
-  function mockPromise() {
-    return $injector.get('$q').defer().promise;
-  }
-
   beforeEach(module('kifi.friends.rightColFriendsView'));
 
-  beforeEach(inject(function (_$injector_) {
-    $injector = _$injector_;
-    $rootScope = $injector.get('$rootScope');
-    $compile = $injector.get('$compile');
+  var $q,
+      $compile,
+      $rootScope,
+      friendService;
 
+  beforeEach(inject(function ($injector) {
+    $q = $injector.get('$q');
+    $compile = $injector.get('$compile');
+    $rootScope = $injector.get('$rootScope');
     friendService = $injector.get('friendService');
   }));
 
   describe('kfCompactFriendsView', function () {
-    var tpl = '<div kf-compact-friends-view></div>';
+    var scope,
+        elem;
 
     beforeEach(function () {
-      compile(tpl);
+      scope = $rootScope.$new();
+      elem = $compile('<div kf-compact-friends-view></div>')(scope);
     });
 
     it('should have the correct friend count text', function () {
       spyOn(friendService, 'totalFriends').andReturn(2);
-      spyOn(friendService, 'getKifiFriends').andReturn(mockPromise());
-
-      // Hardcode this to be a positive number so ng-if will be true
-      // for this test.
-      scope.friends = [1, 2];
+      spyOn(friendService, 'getKifiFriends').andReturn(promise([{}, {}]));
 
       scope.$digest();
 
@@ -57,5 +42,10 @@ describe('kifi.friends.rightColFriendsView', function () {
     });
   });
 
-});
+  function promise(val) {
+    var deferred = $q.defer();
+    deferred.resolve(val);
+    return deferred.promise;
+  }
 
+});


### PR DESCRIPTION
@yipingliao 

I began playing with this new spec primarily as a learning exercise for myself, and indeed, by playing with it, I learned a few things about angular. I made a pull request with a few of my edits. I don’t feel strongly about them. I’m interested in your opinions and will happily back out any changes you don’t like, since this is a spec you just authored, after all!  :)  To be clear, please don’t interpret this pull request as criticism of how you originally wrote the spec. You wrote it very nicely, very clearly. These are minor, minor edits.
- moving `beforeEach(module('kifi.friends.rightColFriendsView'))` up so that the repetition of `'kifi.friends.rightColFriendsView'` is more apparent
- initializing variables immediately after they’re declared (no code in between) for continuity, and in the same order they’re declared, making it easier to verify that they’re all initialized
- narrowing the scope of `elem` and `scope` to the specific test case, since their values are test-case specific
- initializing `elem` using the return value of `$compile(...)(...)` for brevity
- injecting `$q` just once, no longer keeping a reference to `$injector`
- updating `mockPromise` to take the promised value, which makes the spec simpler and which results in more of the directive code under test actually executing
- using empty objects as fake friends instead of arbitrarily chosen numbers
- moving helper functions to the bottom, so the reader can get to the actual test cases (the meat) faster; reading helper functions isn’t very fun until it’s properly motivated by encountering them used in a test case
