### PR TITLE
smaller batch in recommendation generation...

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/CuratorTasksPlugin.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/CuratorTasksPlugin.scala
@@ -25,7 +25,7 @@ class CuratorTasksPlugin @Inject() (
     scheduleTaskOnLeader(system, 1 minutes, 5 minutes) {
       ingestionCommander.ingestAll()
     }
-    scheduleTaskOnLeader(system, 1 minutes, 5 minutes) {
+    scheduleTaskOnLeader(system, 1 minutes, 2 minutes) {
       generationCommander.precomputeRecommendations()
     }
   }

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
@@ -114,7 +114,7 @@ class RecommendationGenerationCommander @Inject() (
         UserRecommendationGenerationState(userId = userId)
       }
       val seedsFuture = for {
-        seeds <- seedCommander.getBySeqNumAndUser(state.seq, userId, 300)
+        seeds <- seedCommander.getBySeqNumAndUser(state.seq, userId, 200)
         restrictions <- shoebox.getAdultRestrictionOfURIs(seeds.map { _.uriId })
       } yield {
         (seeds zip restrictions) filterNot (_._2) map (_._1)


### PR DESCRIPTION
…to reduce help rank endpoint timeouts.
Also increasing scheduler frequency so we retry quicker when there was
a problem.
