### PR TITLE
Hotfix for mobile

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationJsonMaker.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationJsonMaker.scala
@@ -39,7 +39,7 @@ private[commanders] class NotificationJsonMaker @Inject() (
         } yield NotificationJson(
           o ++ unread(o, raw._2)
             ++ Json.obj("author" -> author)
-            ++ Json.obj("participants" -> participants)
+            ++ (if (!participants.isEmpty) Json.obj("participants" -> participants) else Json.obj())
             ++ (if (includeUriSummary) Json.obj("uriSummary" -> uriSummary) else Json.obj())
         )
         Some(jsonFut)


### PR DESCRIPTION
because it seems like an empty participants field (as it happens with
global notification and such) makes an unfortunately already released
to the app store version of the iOS app crash hard.
We previously did not include it when it was empty, so other clients
should not be affected.

@2is10 @andrewconner 
