### PR TITLE
Handle long names in mutual friends modal.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/friends/seeMutualFriends.styl
+++ b/kifi-backend/modules/shoebox/angular/src/friends/seeMutualFriends.styl
@@ -12,7 +12,7 @@
     right: 15px
 
 .kf-mutual-friends-image
-  float: left
+  display: inline-block
   margin-right: 12px
   border-radius: 3px
   width: 60px
@@ -47,6 +47,9 @@ a.kf-mutual-friends-action
   width: 500px
   background-color: #f5f6f7
   font-size: 16px
+
+  .kf-mutual-friends-image
+    float: left
 
 .kf-mutual-friends-pymk-info
   padding: 5px 0
@@ -88,9 +91,13 @@ a.kf-mutual-friends-action
   border: none
 
 .kf-mutual-friend-card-info
-  padding: 10px 0
+  display: inline-block
+  float: right
+  padding-top: 12px
+  width: 143px
   height: 40px
 
 .kf-mutual-friend-card-name
   font-weight: bold
+  line-height: 1.0
 


### PR DESCRIPTION
@2is10 Long names currently look ugly inside the mutual friends modal. :( These are some minor CSS changes to fix that. I'm going to merge and deploy this since this is a small change but fixes bad UI.
