### PR TITLE
Prevent body from scrolling when modal is open.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/dev.html
+++ b/kifi-backend/modules/shoebox/angular/dev.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/dist/lib.css">
   <link rel="stylesheet" type="text/css" href="/dist/kifi.css">
 </head>
-<body>
+<body ng-class="{'modal-open': modalOpen}">
   <div class="kf-cols" ng-controller="AppCtrl">
     <header class="kf-header" ng-include="'layout/header/header.tpl.html'"></header>
     <div class="kf-col-island">

--- a/kifi-backend/modules/shoebox/angular/index.html
+++ b/kifi-backend/modules/shoebox/angular/index.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" type="text/css" href="/dist/lib.min.css">
   <link rel="stylesheet" type="text/css" href="/dist/kifi.min.css">
 </head>
-<body>
+<body ng-class="{'modal-open': modalOpen}">
   <div class="kf-cols" ng-controller="AppCtrl">
     <header class="kf-header" ng-include="'layout/header/header.tpl.html'"></header>
     <div class="kf-col-island">

--- a/kifi-backend/modules/shoebox/angular/src/app.styl
+++ b/kifi-backend/modules/shoebox/angular/src/app.styl
@@ -14,6 +14,9 @@ body
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif
   min-width: 800px
 
+  &.modal-open
+    overflow: hidden
+
 *, :after, :before
   box-sizing: content-box
 

--- a/kifi-backend/modules/shoebox/angular/src/common/modal/modal.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/modal/modal.js
@@ -13,7 +13,7 @@ angular.module('kifi.modal', [])
       },
       templateUrl: 'common/modal/modal.tpl.html',
       transclude: true,
-      controller: ['$scope', function ($scope) {
+      controller: ['$scope', '$rootScope', function ($scope, $rootScope) {
         var defaultHideAction = null;
 
         this.setDefaultHideAction = function (action) {
@@ -57,7 +57,15 @@ angular.module('kifi.modal', [])
 
         $scope.$on('$destroy', function () {
           $document.off('keydown', exitModal);
+          $rootScope.modalOpen = false;
         });
+
+        $scope.$watch(function () {
+          return $('.modal-backdrop:visible').length > 0;
+        }, function (newVal) {
+          $rootScope.modalOpen = newVal;
+        });
+
       }],
       link: function (scope, element, attrs) {
         scope.dialogStyle = {};


### PR DESCRIPTION
@2is10 Currently, when you scroll in a modal the body content underneath scrolls. This change prevents the body from scrolling. The solution is hacky. CC'ing @andrewconner because he authored modal.js.

P.S. I struggled for a few hours with getting antiscroll to work in a modal and have not gotten very far. It seems like the scroll event does not trigger when antiscroll is used in a modal. Will try to make progress on other things before circling back to this.
