### PR TITLE
SocialConnection Cleanup

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminSocialUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminSocialUserController.scala
@@ -32,7 +32,7 @@ class AdminSocialUserController @Inject() (
   def socialUserView(socialUserId: Id[SocialUserInfo]) = AdminHtmlAction.authenticatedAsync { implicit request =>
     for {
       socialUserInfo <- db.readOnlyReplicaAsync { implicit s => socialUserInfoRepo.get(socialUserId) }
-      socialConnections <- db.readOnlyReplicaAsync { implicit s => socialConnectionRepo.getSocialUserConnections(socialUserId).sortWith((a, b) => a.fullName < b.fullName) }
+      socialConnections <- db.readOnlyReplicaAsync { implicit s => socialConnectionRepo.getSocialConnectionInfo(socialUserInfo.id.get).sortWith((a, b) => a.fullName < b.fullName) }
     } yield {
       val rawInfo = socialUserRawInfoStore.get(socialUserInfo.id.get)
       Ok(html.admin.socialUser(socialUserInfo, socialConnections, rawInfo))

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminSocialUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminSocialUserController.scala
@@ -32,7 +32,7 @@ class AdminSocialUserController @Inject() (
   def socialUserView(socialUserId: Id[SocialUserInfo]) = AdminHtmlAction.authenticatedAsync { implicit request =>
     for {
       socialUserInfo <- db.readOnlyReplicaAsync { implicit s => socialUserInfoRepo.get(socialUserId) }
-      socialConnections <- db.readOnlyReplicaAsync { implicit s => socialConnectionRepo.getSocialConnectionInfo(socialUserInfo.id.get).sortWith((a, b) => a.fullName < b.fullName) }
+      socialConnections <- db.readOnlyReplicaAsync { implicit s => socialConnectionRepo.getSocialConnectionInfos(socialUserInfo.id.get).sortWith((a, b) => a.fullName < b.fullName) }
     } yield {
       val rawInfo = socialUserRawInfoStore.get(socialUserInfo.id.get)
       Ok(html.admin.socialUser(socialUserInfo, socialConnections, rawInfo))

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -142,7 +142,7 @@ class AdminUserController @Inject() (
     val contactsF = if (showPrivates) abookClient.getContactsByUser(userId) else Future.successful(Seq.empty[RichContact])
     val (user, socialUserInfos, socialConnections) = db.readOnlyMaster { implicit s =>
       val user = userRepo.get(userId)
-      val socialConnections = socialConnectionRepo.getUserConnections(userId).sortWith((a, b) => a.fullName < b.fullName)
+      val socialConnections = socialConnectionRepo.getSocialConnectionInfosByUser(userId).valuesIterator.flatten.toSeq.sortWith((a, b) => a.fullName < b.fullName)
       val socialUserInfos = socialUserInfoRepo.getByUser(user.id.get)
       (user, socialUserInfos, socialConnections)
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphPluginImpl.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/SocialGraphPluginImpl.scala
@@ -102,7 +102,7 @@ private[social] class SocialGraphActor @Inject() (
           friends.map(_.socialId)
         }.toList.flatten
 
-        val connections = socialUserCreateConnections.createConnections(socialUserInfo, friendsSocialId, graph.networkType)
+        val connections = socialUserCreateConnections.createConnections(socialUserInfo, friendsSocialId)
 
         val updatedSui = rawInfo.jsons.foldLeft(socialUserInfo)(graph.updateSocialUserInfo)
         val latestUserValues = rawInfo.jsons.map(graph.extractUserValues).reduce(_ ++ _)

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/UserConnectionCreator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/UserConnectionCreator.scala
@@ -113,8 +113,8 @@ class UserConnectionCreator @Inject() (
                 None
             }
         }
-      }.toList.flatten
-    }
+      }
+    }.flatten.toSeq
   }
 
   private def disableOldConnections(socialUserInfo: SocialUserInfo, socialIds: Seq[SocialId]): Seq[SocialConnection] = timing(s"disableOldConnections($socialUserInfo): socialIds(${socialIds.length}):${socialIds.mkString(",")}") {

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/UserConnectionCreator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/UserConnectionCreator.scala
@@ -53,7 +53,7 @@ class UserConnectionCreator @Inject() (
   def updateUserConnections(userId: Id[User]) = timing(s"updateUserConnections($userId)") {
     db.readWrite { implicit s =>
       val existingConnections = userConnectionRepo.getConnectedUsers(userId)
-      val socialConnections = socialConnectionRepo.getFortyTwoUserConnections(userId)
+      val socialConnections = socialConnectionRepo.getSociallyConnectedUsers(userId)
       val unfriendedConnections = userConnectionRepo.getUnfriendedUsers(userId)
 
       val newConnections = socialConnections -- existingConnections -- unfriendedConnections

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/SocialConnectionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/SocialConnectionRepo.scala
@@ -16,7 +16,6 @@ import scala.concurrent.duration._
 trait SocialConnectionRepo extends Repo[SocialConnection] with SeqNumberFunction[SocialConnection] {
   def getFortyTwoUserConnections(id: Id[User])(implicit session: RSession): Set[Id[User]]
   def getConnectionOpt(u1: Id[SocialUserInfo], u2: Id[SocialUserInfo])(implicit session: RSession): Option[SocialConnection]
-  def getSocialUserConnections(id: Id[SocialUserInfo])(implicit session: RSession): Seq[SocialUserInfo]
   def getSocialConnectionInfo(id: Id[SocialUserInfo])(implicit session: RSession): Seq[SocialUserBasicInfo]
   def getSocialConnectionInfosByUser(id: Id[User])(implicit session: RSession): Map[SocialNetworkType, Seq[SocialUserBasicInfo]]
   def deactivateAllConnections(id: Id[SocialUserInfo])(implicit session: RWSession): Int
@@ -148,7 +147,7 @@ class SocialConnectionRepoImpl @Inject() (
     Await.result(future, Duration.Inf)
   }
 
-  def getSocialUserConnections(id: Id[SocialUserInfo])(implicit session: RSession): Seq[SocialUserInfo] = {
+  private def getSocialUserConnections(id: Id[SocialUserInfo])(implicit session: RSession): Seq[Id[SocialUserInfo]] = {
     val connections = (for {
       t <- rows if (t.socialUser1 === id || t.socialUser2 === id) && t.state === SocialConnectionStates.ACTIVE
     } yield t).list

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/SocialConnectionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/SocialConnectionRepo.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
 
 @ImplementedBy(classOf[SocialConnectionRepoImpl])
 trait SocialConnectionRepo extends Repo[SocialConnection] with SeqNumberFunction[SocialConnection] {
-  def getFortyTwoUserConnections(id: Id[User])(implicit session: RSession): Set[Id[User]]
+  def getSociallyConnectedUsers(id: Id[User])(implicit session: RSession): Set[Id[User]]
   def getConnectionOpt(u1: Id[SocialUserInfo], u2: Id[SocialUserInfo])(implicit session: RSession): Option[SocialConnection]
   def getSocialConnectionInfos(id: Id[SocialUserInfo])(implicit session: RSession): Seq[SocialUserBasicInfo]
   def getSocialConnectionInfosByUser(id: Id[User])(implicit session: RSession): Map[SocialNetworkType, Seq[SocialUserBasicInfo]]
@@ -72,7 +72,7 @@ class SocialConnectionRepoImpl @Inject() (
     socialUserConnectionsCache.remove(SocialUserConnectionsKey(conn.socialUser2))
   }
 
-  def getFortyTwoUserConnections(id: Id[User])(implicit session: RSession): Set[Id[User]] = {
+  def getSociallyConnectedUsers(id: Id[User])(implicit session: RSession): Set[Id[User]] = {
     val suidSQL = """
         select
              id

--- a/kifi-backend/modules/shoebox/app/com/keepit/typeahead/socialusers/SocialUserTypeahead.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/typeahead/socialusers/SocialUserTypeahead.scala
@@ -59,19 +59,9 @@ class SocialUserTypeahead @Inject() (
   }
 
   protected def getAllInfosForUser(id: Id[User]): Future[Seq[SocialUserBasicInfo]] = SafeFuture {
-    val builder = new mutable.ArrayBuffer[SocialUserBasicInfo]
     db.readOnlyMaster { implicit session =>
-      val infos = socialUserRepo.getSocialUserBasicInfosByUser(id) // todo: filter out fortytwo?
-      log.debug(s"[social.getAllInfosForUser($id)] res(len=${infos.length}):${infos.mkString(",")}")
-      for (info <- infos) {
-        val connInfos = socialConnRepo.getSocialUserConnections(info.id)
-        log.debug(s"[social.getConns($id)] (${info.id},${info.networkType}).conns(len=${connInfos.length}):${connInfos.mkString(",")}")
-        builder ++= connInfos.map { SocialUserBasicInfo.fromSocialUser(_) } // conversion overhead
-      }
+      socialConnRepo.getSocialConnectionInfosByUser(id).valuesIterator.flatten.toSeq
     }
-    val res = builder.result
-    log.debug(s"[social.getAllInfosForUser($id)] res(len=${res.length}): ${res.mkString(",")}")
-    res
   }
 
   override protected def extractId(info: SocialUserBasicInfo): Id[SocialUserInfo] = info.id

--- a/kifi-backend/modules/shoebox/app/views/admin/adminHelper/socialUserDisplay.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/adminHelper/socialUserDisplay.scala.html
@@ -1,4 +1,4 @@
-@(socialUserInfo: SocialUserInfo, socialOnly: Boolean = false)
+@(socialUserInfo: SocialUserBasicInfo, socialOnly: Boolean = false)
 
 @networkLogo = {
   <img src="/assets/securesocial/images/providers/@{socialUserInfo.networkType}.png"
@@ -19,7 +19,7 @@
   </a>
 } else {
   <a data-hover="tooltip" title="@socialUserInfo.fullName"
-     class="name_tooltip_link" href="@com.keepit.controllers.admin.routes.AdminSocialUserController.socialUserView(socialUserInfo.id.get)">
+     class="name_tooltip_link" href="@com.keepit.controllers.admin.routes.AdminSocialUserController.socialUserView(socialUserInfo.id)">
     @avatar @socialUserInfo.fullName @networkLogo
   </a>
 }

--- a/kifi-backend/modules/shoebox/app/views/admin/moreUserInfo.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/moreUserInfo.scala.html
@@ -1,7 +1,7 @@
 @(user: User,
   rawInfos: Seq[SocialUserRawInfo],
-  socialUserInfos: Seq[SocialUserInfo],
-  socialConnections: Seq[SocialUserInfo],
+  socialUserInfos: Seq[SocialUserBasicInfo],
+  socialConnections: Seq[SocialUserBasicInfo],
   abookInfos: Seq[ABookInfo],
   contacts: Seq[com.keepit.abook.model.RichContact]
 )

--- a/kifi-backend/modules/shoebox/app/views/admin/socialUser.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/socialUser.scala.html
@@ -1,4 +1,4 @@
-@(socialUserInfo: SocialUserInfo, socialConnections: Seq[SocialUserInfo], rawInfo: Option[SocialUserRawInfo])
+@(socialUserInfo: SocialUserInfo, socialConnections: Seq[SocialUserBasicInfo], rawInfo: Option[SocialUserRawInfo])
 
 @userWithSocialDisplay = {
   <span style="margin:2px">
@@ -27,7 +27,7 @@
    Last updated: @adminHelper.dateTimeDisplay(socialUserInfo.updatedAt)
 
    @if(socialUserInfo.userId.isDefined) {
-     <h3>Forty Two User: @adminHelper.socialUserDisplay(socialUserInfo)</h3>
+     <h3>Forty Two User: @adminHelper.socialUserDisplay(SocialUserBasicInfo.fromSocialUser(socialUserInfo))</h3>
    }
    <p>
     <button class="btn btn-primary" onclick="refreshSociaUserInfo()">Refresh Social User Info!</button>

--- a/kifi-backend/modules/shoebox/app/views/admin/socialUsers.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/socialUsers.scala.html
@@ -1,6 +1,7 @@
 @(socialUserInfos: Seq[SocialUserInfo], page: Int)
+@import com.keepit.commanders.BasicSocialUser
 
-@pagination(page: Int, pageCount: Int) = {
+    @pagination(page: Int, pageCount: Int) = {
   <div class="pagination pagination-centered pagination-mini">
     <ul>
       <li>
@@ -53,9 +54,9 @@
     <tr>
       <td>@{i+1}</td>
       <td><span class="badge">@socialUserInfo.id.get</span></td>
-      <td>@adminHelper.socialUserDisplay(socialUserInfo, true)</td>
+      <td>@adminHelper.socialUserDisplay(SocialUserBasicInfo.fromSocialUser(socialUserInfo), true)</td>
       <td>@if(socialUserInfo.userId.isDefined) {
-        @adminHelper.socialUserDisplay(socialUserInfo)
+        @adminHelper.socialUserDisplay(SocialUserBasicInfo.fromSocialUser(socialUserInfo))
       }</td>
       <td>@adminHelper.dateDisplay(socialUserInfo.createdAt)</td>
     </tr>

--- a/kifi-backend/modules/shoebox/app/views/admin/user.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/user.scala.html
@@ -1,7 +1,7 @@
 @(user: User,
   totalBookmarks: Int,
   experiments: Set[ExperimentType],
-  socialUsers: Seq[SocialUserInfo],
+  socialUsers: Seq[SocialUserBasicInfo],
   fortyTwoConnections: Seq[User],
   kifiInstallations: Seq[KifiInstallation],
   allowedInvites: Int,

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/SocialConnectionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/SocialConnectionTest.scala
@@ -94,8 +94,8 @@ class SocialConnectionTest extends Specification with ShoeboxTestInjector {
           users
         }
 
-        connections.createConnections(eishaySocialUserInfo, extractFacebookFriendIds(eishayJson), SocialNetworks.FACEBOOK)
-        connections.createConnections(andrewSocialUserInfo, extractFacebookFriendIds(andrewJson), SocialNetworks.FACEBOOK)
+        connections.createConnections(eishaySocialUserInfo, extractFacebookFriendIds(eishayJson))
+        connections.createConnections(andrewSocialUserInfo, extractFacebookFriendIds(andrewJson))
 
         val (eishayFortyTwoConnection, andrewFortyTwoConnection) = inject[Database].readOnlyMaster { implicit s =>
           connectionRepo.count === 18
@@ -169,9 +169,9 @@ class SocialConnectionTest extends Specification with ShoeboxTestInjector {
         }
 
         inject[UserConnectionCreator].createConnections(eishaySocialUserInfo,
-          extractFacebookFriendIds(eishayJson), SocialNetworks.FACEBOOK)
+          extractFacebookFriendIds(eishayJson))
         inject[UserConnectionCreator].createConnections(andrewSocialUserInfo,
-          extractFacebookFriendIds(andrewJson), SocialNetworks.FACEBOOK)
+          extractFacebookFriendIds(andrewJson))
 
         val connectionRepo = inject[SocialConnectionRepo]
 
@@ -246,7 +246,7 @@ class SocialConnectionTest extends Specification with ShoeboxTestInjector {
         }
 
         inject[UserConnectionCreator].createConnections(eishaySocialUserInfo,
-          Seq(eishay1Json, eishay2Json) flatMap extractFacebookFriendIds, SocialNetworks.FACEBOOK)
+          Seq(eishay1Json, eishay2Json) flatMap extractFacebookFriendIds)
 
         val eishayFortyTwoConnection = inject[Database].readOnlyMaster { implicit s =>
           connectionRepo.all.size === 12

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/SocialConnectionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/SocialConnectionTest.scala
@@ -99,8 +99,8 @@ class SocialConnectionTest extends Specification with ShoeboxTestInjector {
 
         val (eishayFortyTwoConnection, andrewFortyTwoConnection) = inject[Database].readOnlyMaster { implicit s =>
           connectionRepo.count === 18
-          (connectionRepo.getFortyTwoUserConnections(eishaySocialUserInfo.userId.get),
-            connectionRepo.getFortyTwoUserConnections(andrewSocialUserInfo.userId.get))
+          (connectionRepo.getSociallyConnectedUsers(eishaySocialUserInfo.userId.get),
+            connectionRepo.getSociallyConnectedUsers(andrewSocialUserInfo.userId.get))
         }
 
         eishayFortyTwoConnection.size === 3
@@ -177,8 +177,8 @@ class SocialConnectionTest extends Specification with ShoeboxTestInjector {
 
         val (eishayFortyTwoConnection, andrewFortyTwoConnection) = inject[Database].readOnlyMaster { implicit s =>
           connectionRepo.all.size === 18
-          (connectionRepo.getFortyTwoUserConnections(eishaySocialUserInfo.userId.get),
-            connectionRepo.getFortyTwoUserConnections(andrewSocialUserInfo.userId.get))
+          (connectionRepo.getSociallyConnectedUsers(eishaySocialUserInfo.userId.get),
+            connectionRepo.getSociallyConnectedUsers(andrewSocialUserInfo.userId.get))
         }
 
         eishayFortyTwoConnection.size === 3
@@ -250,7 +250,7 @@ class SocialConnectionTest extends Specification with ShoeboxTestInjector {
 
         val eishayFortyTwoConnection = inject[Database].readOnlyMaster { implicit s =>
           connectionRepo.all.size === 12
-          connectionRepo.getFortyTwoUserConnections(eishaySocialUserInfo.userId.get)
+          connectionRepo.getSociallyConnectedUsers(eishaySocialUserInfo.userId.get)
         }
 
         eishayFortyTwoConnection.size === 3

--- a/kifi-backend/modules/shoebox/test/com/keepit/social/UserConnectionCreatorTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/social/UserConnectionCreatorTest.scala
@@ -72,7 +72,7 @@ class UserConnectionCreatorTest extends Specification with ShoeboxTestInjector {
         outbox(0).to === Seq(EmailAddress("andrew@gmail.com"))
 
         inject[Database].readOnlyMaster { implicit s =>
-          val fortyTwoConnections = inject[SocialConnectionRepo].getFortyTwoUserConnections(user.id.get)
+          val fortyTwoConnections = inject[SocialConnectionRepo].getSociallyConnectedUsers(user.id.get)
           val userConnections = inject[UserConnectionRepo].getConnectedUsers(user.id.get)
           val connectionCount = inject[UserConnectionRepo].getConnectionCount(user.id.get)
           fortyTwoConnections === userConnections
@@ -135,7 +135,7 @@ class UserConnectionCreatorTest extends Specification with ShoeboxTestInjector {
           .createConnections(socialUserInfo, extractedFriends2.map(_.socialId), SocialNetworks.FACEBOOK)
 
         inject[Database].readOnlyMaster { implicit s =>
-          val fortyTwoConnections = inject[SocialConnectionRepo].getFortyTwoUserConnections(user.id.get)
+          val fortyTwoConnections = inject[SocialConnectionRepo].getSociallyConnectedUsers(user.id.get)
           val userConnections = inject[UserConnectionRepo].getConnectedUsers(user.id.get)
           val connectionCount = inject[UserConnectionRepo].getConnectionCount(user.id.get)
           fortyTwoConnections.size === 1

--- a/kifi-backend/modules/shoebox/test/com/keepit/social/UserConnectionCreatorTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/social/UserConnectionCreatorTest.scala
@@ -62,8 +62,7 @@ class UserConnectionCreatorTest extends Specification with ShoeboxTestInjector {
           (user, socialUserInfo)
         }
 
-        val connections = inject[UserConnectionCreator].createConnections(socialUserInfo,
-          extractedFriends.map(_.socialId), SocialNetworks.FACEBOOK)
+        val connections = inject[UserConnectionCreator].createConnections(socialUserInfo, extractedFriends.map(_.socialId))
 
         connections.size === 12
 
@@ -123,7 +122,7 @@ class UserConnectionCreatorTest extends Specification with ShoeboxTestInjector {
         }
 
         val connections = inject[UserConnectionCreator].createConnections(socialUserInfo,
-          extractedFriends.map(_.socialId), SocialNetworks.FACEBOOK)
+          extractedFriends.map(_.socialId))
 
         connections.size === 12
 
@@ -132,13 +131,13 @@ class UserConnectionCreatorTest extends Specification with ShoeboxTestInjector {
         val extractedFriends2 = inject[FacebookSocialGraph].extractFriends(json2)
 
         val connectionsAfter = inject[UserConnectionCreator]
-          .createConnections(socialUserInfo, extractedFriends2.map(_.socialId), SocialNetworks.FACEBOOK)
+          .createConnections(socialUserInfo, extractedFriends2.map(_.socialId))
 
         inject[Database].readOnlyMaster { implicit s =>
-          val fortyTwoConnections = inject[SocialConnectionRepo].getSociallyConnectedUsers(user.id.get)
+          val sociallyConnectedUsers = inject[SocialConnectionRepo].getSociallyConnectedUsers(user.id.get)
           val userConnections = inject[UserConnectionRepo].getConnectedUsers(user.id.get)
           val connectionCount = inject[UserConnectionRepo].getConnectionCount(user.id.get)
-          fortyTwoConnections.size === 1
+          sociallyConnectedUsers.size === 1
           connectionCount === userConnections.size
           connectionCount === 2
         }


### PR DESCRIPTION
@eishay @raymondng 
Removes duplicate / inefficient pieces of code in a bunch of places (typeahead, connection creator, social connection repo) and overall tries to promote lighter SocialUserBasicInfo over full SocialUserInfo
