### PR TITLE
Correctly deal with merged uriId

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/AllKeepsSeedIngestionHelper.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/AllKeepsSeedIngestionHelper.scala
@@ -28,14 +28,59 @@ class AllKeepSeedIngestionHelper @Inject() (
 
   private val SEQ_NUM_NAME: Name[SequenceNumber[Keep]] = Name("all_keeps_seq_num")
 
+  private def dateMin(d0: DateTime, ds: DateTime*): DateTime = {
+    var min = d0
+    ds.foreach { d =>
+      if (d.isBefore(min)) min = d
+    }
+    min
+  }
+
+  private def dateMax(d0: DateTime, ds: DateTime*): DateTime = {
+    var max = d0
+    ds.foreach { d =>
+      if (d.isAfter(max)) max = d
+    }
+    max
+  }
+
   private def updateRawSeedItem(seedItem: RawSeedItem, uriId: Id[NormalizedURI], newDateCandidate: DateTime, countChange: Int)(implicit session: RWSession): Unit = {
-    rawSeedsRepo.save(seedItem.copy(
-      uriId = uriId, //implicit renormalize :-)
-      firstKept = if (newDateCandidate.isBefore(seedItem.firstKept)) newDateCandidate else seedItem.firstKept,
-      lastKept = if (newDateCandidate.isAfter(seedItem.lastKept)) newDateCandidate else seedItem.lastKept,
-      lastSeen = if (newDateCandidate.isAfter(seedItem.lastSeen)) newDateCandidate else seedItem.lastSeen,
-      timesKept = seedItem.timesKept + countChange
-    ))
+    if (seedItem.uriId != uriId) {
+      //there was a renormalization of this item, thus we need to check if there should be a merge
+      val existingItemOpt = rawSeedsRepo.getByUriIdAndUserId(uriId, seedItem.userId)
+      existingItemOpt.map { existingItem =>
+        //there is an item for this uriId (and possibly userId) already. Need to merge.
+        val mergedFirstKept = dateMin(seedItem.firstKept, newDateCandidate, existingItem.firstKept)
+        val mergedLastKept = dateMax(seedItem.firstKept, newDateCandidate, existingItem.firstKept)
+        val mergedLastSeen = dateMax(seedItem.lastSeen, newDateCandidate, existingItem.lastSeen)
+        val mergedTimesKept = seedItem.timesKept + countChange + existingItem.timesKept
+
+        rawSeedsRepo.save(existingItem.copy(
+          firstKept = mergedFirstKept,
+          lastKept = mergedLastKept,
+          lastSeen = mergedLastSeen,
+          priorScore = if (seedItem.updatedAt.isAfter(existingItem.updatedAt)) seedItem.priorScore else existingItem.priorScore,
+          timesKept = mergedTimesKept
+        ))
+        rawSeedsRepo.delete(seedItem)
+      } getOrElse {
+        //no exisitng item for this uriId (and possibly userId). Good to just move over.
+        rawSeedsRepo.save(seedItem.copy(
+          uriId = uriId,
+          firstKept = if (newDateCandidate.isBefore(seedItem.firstKept)) newDateCandidate else seedItem.firstKept,
+          lastKept = if (newDateCandidate.isAfter(seedItem.lastKept)) newDateCandidate else seedItem.lastKept,
+          lastSeen = if (newDateCandidate.isAfter(seedItem.lastSeen)) newDateCandidate else seedItem.lastSeen,
+          timesKept = seedItem.timesKept + countChange
+        ))
+      }
+    } else {
+      rawSeedsRepo.save(seedItem.copy(
+        firstKept = if (newDateCandidate.isBefore(seedItem.firstKept)) newDateCandidate else seedItem.firstKept,
+        lastKept = if (newDateCandidate.isAfter(seedItem.lastKept)) newDateCandidate else seedItem.lastKept,
+        lastSeen = if (newDateCandidate.isAfter(seedItem.lastSeen)) newDateCandidate else seedItem.lastSeen,
+        timesKept = seedItem.timesKept + countChange
+      ))
+    }
   }
 
   private def processKeep(keep: Keep)(implicit session: RWSession): Unit = {

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/TopUriSeedIngestionHelper.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/TopUriSeedIngestionHelper.scala
@@ -33,7 +33,7 @@ class TopUriSeedIngestionHelper @Inject() (
   }
 
   def processUriScores(uriScore: ConnectedUriScore, userId: Id[User])(implicit session: RWSession): Unit = {
-    rawSeedsRepo.getByUriIdAndUserId(uriScore.uriId, userId) match {
+    rawSeedsRepo.getByUriIdAndUserId(uriScore.uriId, Some(userId)) match {
       case Some(seedItem) => {
         rawSeedsRepo.save(seedItem.copy(
           priorScore = Some(uriScore.score.toFloat),

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItem.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItem.scala
@@ -26,7 +26,7 @@ case class AttributionInfo(
 case class RawSeedItem(
   id: Option[Id[RawSeedItem]] = None,
   createdAt: DateTime = currentDateTime,
-  updateAt: DateTime = currentDateTime,
+  updatedAt: DateTime = currentDateTime,
   seq: SequenceNumber[RawSeedItem] = SequenceNumber.ZERO,
   uriId: Id[NormalizedURI],
   userId: Option[Id[User]], //which user is this a seed item for. None means this is for every user.
@@ -41,5 +41,5 @@ case class RawSeedItem(
     extends Model[RawSeedItem] with ModelWithSeqNumber[RawSeedItem] {
 
   def withId(id: Id[RawSeedItem]): RawSeedItem = this.copy(id = Some(id))
-  def withUpdateTime(updateTime: DateTime): RawSeedItem = this.copy(updateAt = updateTime)
+  def withUpdateTime(updateTime: DateTime): RawSeedItem = this.copy(updatedAt = updateTime)
 }

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItemRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItemRepo.scala
@@ -1,6 +1,7 @@
 package com.keepit.curator.model
 
 import com.keepit.common.db.slick.{ DbRepo, SeqNumberFunction, SeqNumberDbFunction, DataBaseComponent, Database }
+import com.keepit.common.db.slick.{ RepoWithDelete, DbRepoWithDelete }
 import com.keepit.common.db.{ Id, DbSequenceAssigner, SequenceNumber }
 import com.keepit.model.{ User, NormalizedURI }
 import com.keepit.common.time.Clock
@@ -17,9 +18,9 @@ import com.google.inject.{ ImplementedBy, Singleton, Inject }
 import org.joda.time.DateTime
 
 @ImplementedBy(classOf[RawSeedItemRepoImpl])
-trait RawSeedItemRepo extends DbRepo[RawSeedItem] with SeqNumberFunction[RawSeedItem] {
+trait RawSeedItemRepo extends DbRepo[RawSeedItem] with SeqNumberFunction[RawSeedItem] with RepoWithDelete[RawSeedItem] {
   def getByUriId(uriId: Id[NormalizedURI])(implicit session: RSession): Seq[RawSeedItem]
-  def getByUriIdAndUserId(uriId: Id[NormalizedURI], userId: Id[User])(implicit session: RSession): Option[RawSeedItem]
+  def getByUriIdAndUserId(uriId: Id[NormalizedURI], userIdOpt: Option[Id[User]])(implicit session: RSession): Option[RawSeedItem]
   def getBySeqNumAndUser(start: SequenceNumber[RawSeedItem], userId: Id[User], maxBatchSize: Int)(implicit session: RSession): Seq[RawSeedItem]
   def getRecent(userId: Id[User], maxBatchSize: Int)(implicit session: RSession): Seq[RawSeedItem]
   def getRecentGeneric(maxBatchSize: Int)(implicit session: RSession): Seq[RawSeedItem]
@@ -31,7 +32,7 @@ trait RawSeedItemRepo extends DbRepo[RawSeedItem] with SeqNumberFunction[RawSeed
 class RawSeedItemRepoImpl @Inject() (
   val db: DataBaseComponent,
   val clock: Clock)
-    extends DbRepo[RawSeedItem] with RawSeedItemRepo with SeqNumberDbFunction[RawSeedItem] {
+    extends DbRepo[RawSeedItem] with RawSeedItemRepo with SeqNumberDbFunction[RawSeedItem] with DbRepoWithDelete[RawSeedItem] {
 
   import db.Driver.simple._
 
@@ -68,8 +69,12 @@ class RawSeedItemRepoImpl @Inject() (
     (for (row <- rows if row.uriId === uriId && row.userId.isNull) yield row).firstOption
   }
 
-  def getByUriIdAndUserId(uriId: Id[NormalizedURI], userId: Id[User])(implicit session: RSession): Option[RawSeedItem] = {
-    (for (row <- rows if row.uriId === uriId && row.userId === userId) yield row).firstOption
+  def getByUriIdAndUserId(uriId: Id[NormalizedURI], userIdOpt: Option[Id[User]])(implicit session: RSession): Option[RawSeedItem] = {
+    userIdOpt.map { userId =>
+      (for (row <- rows if row.uriId === uriId && row.userId === userId) yield row).firstOption
+    } getOrElse {
+      (for (row <- rows if row.uriId === uriId && row.userId.isNull) yield row).firstOption
+    }
   }
 
   def getBySeqNumAndUser(start: SequenceNumber[RawSeedItem], userId: Id[User], maxBatchSize: Int)(implicit session: RSession): Seq[RawSeedItem] = {


### PR DESCRIPTION
This fixes an issue where duplicate raw seed items were being created
whenever two uriIds where being merged in a migration. In the case of
items associated with a user this was causing a constraint violation in
the database (the other case should have caused one too, but
unfortunately MySQL has some limitations with constraints on nullable
columns)

Data will need to be reingested from scratch after this is merged
(takes about 90 minutes)

@lawzlo @yingjieMiao 
