### PR TITLE
Bootstrap document as the Angular element in dev.html; update  references.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/dev.html
+++ b/kifi-backend/modules/shoebox/angular/dev.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="kifi">
+<html>
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -35,5 +35,6 @@
   </script>
   <script src="/dist/lib.js"></script>
   <script src="/dist/kifi.js"></script>
+  <script>angular.bootstrap(document, ['kifi']);</script>
 </body>
 </html>

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoPics.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoPics.js
@@ -34,7 +34,7 @@ angular.module('kifi.keepWhoPics', ['kifi.keepWhoService'])
           if (!tooltip) {
             // Create tooltip
             tooltip = angular.element($templateCache.get('common/directives/keepWho/friendCard.tpl.html'));
-            $rootElement.append(tooltip);
+            $rootElement.find('html').append(tooltip);
             $compile(tooltip)(scope);
           }
 

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -466,7 +466,7 @@ angular.module('kifi.keep', ['kifi.keepWhoPics', 'kifi.keepWhoText', 'kifi.tagSe
         .on('dragstart', function (e) {
           scope.$apply(function () {
             $rootScope.DRAGGING_KEEP = true;
-            $rootElement.addClass('kf-dragging-keep');
+            $rootElement.find('html').addClass('kf-dragging-keep');
             element.addClass('kf-dragged');
             scope.dragKeeps({keep: scope.keep, event: e, mouseX: 20, mouseY: 50});
             scope.isDragging = true;
@@ -475,7 +475,7 @@ angular.module('kifi.keep', ['kifi.keepWhoPics', 'kifi.keepWhoText', 'kifi.tagSe
         .on('dragend', function () {
           scope.$apply(function () {
             $rootScope.DRAGGING_KEEP = false;
-            $rootElement.removeClass('kf-dragging-keep');
+            $rootElement.find('html').removeClass('kf-dragging-keep');
             element.removeClass('kf-dragged');
             scope.stopDraggingKeeps();
             scope.isDragging = false;

--- a/kifi-backend/modules/shoebox/angular/src/layout/header/HeaderCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/header/HeaderCtrl.js
@@ -7,13 +7,13 @@ angular.module('kifi.layout.header', ['kifi.profileService'])
   function ($scope, $window, $rootElement, $rootScope, $document, profileService, friendService, $location, util, keyIndices) {
 
     $scope.toggleMenu = function () {
-      $rootElement.toggleClass('kf-sidebar-active');
+      $rootElement.find('html').toggleClass('kf-sidebar-active');
     };
 
     $window.addEventListener('message', function (event) {
       if (event.data === 'show_left_column') {  // for guide
         $scope.$apply(function () {
-          $rootElement.addClass('kf-sidebar-active');
+          $rootElement.find('html').addClass('kf-sidebar-active');
         });
       }
     });


### PR DESCRIPTION
Fixes: https://app.asana.com/0/15014070792041/15466640059101

@andrewconner As we discussed, there was a disparity between what `$rootElement` is in dev and in prod, and there are several references to `$rootElement` that was incorrectly assuming that `$rootElement` is `html` (while it's actually `document` in prod). `$rootElement` is now `document` in both dev and prod, and the references are fixed.

What was broken was:
- Upper left hamburger menu (when window is small) didn't work.
- Hovering over friend pic in a keep did not bring up tooltip.
- Dragging keeps to tags didn't show the nice tag highlighting UI effects.

cc @2is10 
