### PR TITLE
Rotate empty state connection badge.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/friends/noFriendsOrConnectionsView.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/friends/noFriendsOrConnectionsView.tpl.html
@@ -1,7 +1,7 @@
 <div>
   <h2 class="kf-rightcol-header">Find friends on Kifi</h2>
-  <div class="kf-friends-content">Connect your Facebook account to find friends already on Kifi!</div>
-  <a class="social-connect-button facebook" href="javascript:" ng-click="connectFacebook()">Connect</a>
+  <div class="kf-friends-content">Connect your {{network}} account to find friends already on Kifi!</div>
+  <div kf-rotating-connect network="network"></div>
   <div class="kf-friends-content"><a href="/invite">Connect with a different service</a></div>
 </div>
 

--- a/kifi-backend/modules/shoebox/angular/src/friends/rightColConnectView.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/friends/rightColConnectView.tpl.html
@@ -1,7 +1,5 @@
-<div class="kf-rightcol-friends-connect" ng-if="network">
+<div class="kf-rightcol-friends-connect" ng-show="connectSocial">
   <div class="kf-friends-content kf-friends-content-bigger">Find friends already on Kifi</div>
-  <a ng-show="network === 'facebook'" href="javascript:" kf-facebook-connect-button class="social-connect-button facebook" ng-click="connectFacebook()">Connect</a>
-  <a ng-show="network === 'linkedin'" href="javascript:" kf-linkedin-connect-button class="social-connect-button linkedin" ng-click="connectLinkedIn()">Connect</a>
-  <a ng-show="network === 'gmail'" href="javascript:" class="social-connect-button gmail" ng-click="importGmail()">Connect</a>
+  <div kf-rotating-connect network="network"></div>
   <div class="kf-friends-content"><a href="/invite">See more connection options &#0187;</a></div>
 </div>

--- a/kifi-backend/modules/shoebox/angular/src/friends/rightColFriendsView.js
+++ b/kifi-backend/modules/shoebox/angular/src/friends/rightColFriendsView.js
@@ -57,8 +57,6 @@ angular.module('kifi.friends.rightColFriendsView', [
     restrict: 'A',
     templateUrl: 'friends/rightColConnectView.tpl.html',
     link: function (scope/*, element, attrs*/) {
-      scope.connectSocial = false;
-
       socialService.refresh();
       scope.$watch(function () {
         return (friendService.totalFriends() < 20) && scope.network;

--- a/kifi-backend/modules/shoebox/angular/src/friends/rightColFriendsView.js
+++ b/kifi-backend/modules/shoebox/angular/src/friends/rightColFriendsView.js
@@ -57,28 +57,14 @@ angular.module('kifi.friends.rightColFriendsView', [
     restrict: 'A',
     templateUrl: 'friends/rightColConnectView.tpl.html',
     link: function (scope/*, element, attrs*/) {
-      function getEligibleNetworksCsv() {
-        if (friendService.totalFriends() < 20) {
-          return _.compact([
-            socialService.facebook && socialService.facebook.profileUrl ? null : 'facebook',
-            socialService.linkedin && socialService.linkedin.profileUrl ? null : 'linkedin',
-            socialService.gmail && socialService.gmail.length ? null : 'gmail'
-          ]).join(',');
-        } else {
-          return '';
-        }
-      }
-
-      function chooseNetwork(csv) {
-        scope.network = csv ? _.sample(csv.split(',')) : null;
-      }
-
-      scope.connectFacebook = socialService.connectFacebook;
-      scope.connectLinkedIn = socialService.connectLinkedIn;
-      scope.importGmail = socialService.importGmail;
+      scope.connectSocial = false;
 
       socialService.refresh();
-      scope.$watch(getEligibleNetworksCsv, chooseNetwork);
+      scope.$watch(function () {
+        return (friendService.totalFriends() < 20) && scope.network;
+      }, function (newVal) {
+        scope.connectSocial = newVal;
+      });
     }
   };
 }])
@@ -202,13 +188,41 @@ angular.module('kifi.friends.rightColFriendsView', [
   };
 }])
 
-.directive('kfNoFriendsOrConnectionsView', ['socialService', function (socialService) {
+.directive('kfNoFriendsOrConnectionsView', [function () {
   return {
     replace: true,
     restrict: 'A',
-    templateUrl: 'friends/noFriendsOrConnectionsView.tpl.html',
-    link: function (scope) {
+    templateUrl: 'friends/noFriendsOrConnectionsView.tpl.html'
+  };
+}])
+
+.directive('kfRotatingConnect', ['socialService', function (socialService) {
+  return {
+    replace: true,
+    restrict: 'A',
+    scope: {
+      network: '='
+    },
+    templateUrl: 'friends/rotatingConnect.tpl.html',
+    link:  function (scope/*, element, attrs*/) {
+      function getEligibleNetworksCsv() {
+        return _.compact([
+          socialService.facebook && socialService.facebook.profileUrl ? null : 'Facebook',
+          socialService.linkedin && socialService.linkedin.profileUrl ? null : 'LinkedIn',
+          socialService.gmail && socialService.gmail.length ? null : 'Gmail'
+        ]).join(',');
+      }
+
+      function chooseNetwork(csv) {
+        scope.network = csv ? _.sample(csv.split(',')) : null;
+      }
+
       scope.connectFacebook = socialService.connectFacebook;
+      scope.connectLinkedIn = socialService.connectLinkedIn;
+      scope.importGmail = socialService.importGmail;
+
+      socialService.refresh();
+      scope.$watch(getEligibleNetworksCsv, chooseNetwork);
     }
   };
 }]);

--- a/kifi-backend/modules/shoebox/angular/src/friends/rotatingConnect.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/friends/rotatingConnect.tpl.html
@@ -1,0 +1,5 @@
+<div>
+  <a ng-show="network === 'Facebook'" href="javascript:" class="social-connect-button facebook" ng-click="connectFacebook()">Connect</a>
+  <a ng-show="network === 'LinkedIn'" href="javascript:" class="social-connect-button linkedin" ng-click="connectLinkedIn()">Connect</a>
+  <a ng-show="network === 'Gmail'" href="javascript:" class="social-connect-button gmail" ng-click="importGmail()">Connect</a>
+</div>


### PR DESCRIPTION
Rotate the connection badge on empty state (0 friends, 0 connections). Currently it's a static FB connection badge.

Also refactored out the rotating badge as its own directive so both empty state and non-empty state use it.

Fixes: https://app.asana.com/0/15014070792041/15493074535350
Screenshot of the two different badges at: https://app.asana.com/0/15014070792041/15493074535345

@2is10 
