### PR TITLE
prevent recommendation generation from stalling...

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
@@ -38,7 +38,7 @@ class RecommendationGenerationCommander @Inject() (
 
   val defaultScore = 0.0f
 
-  val recommendationGenerationLock = new ReactiveLock(10)
+  val recommendationGenerationLock = new ReactiveLock(15)
   val perUserRecommendationGenerationLocks = TrieMap[Id[User], ReactiveLock]()
 
   private def usersToPrecomputeRecommendationsFor(): Future[Seq[Id[User]]] = experimentCommander.getUsersByExperiment(ExperimentType.RECOS_BETA).map(users => users.map(_.id.get).toSeq)
@@ -132,6 +132,7 @@ class RecommendationGenerationCommander @Inject() (
             db.readWrite { implicit session =>
               genStateRepo.save(newState)
             }
+            if (state.seq < newSeqNum) { precomputeRecommendationsForUser(userId) }
             Future.successful(false)
           } else {
             val cleanedItems = seedItems.filter { seedItem => //discard super popular items and the users own keeps
@@ -174,11 +175,9 @@ class RecommendationGenerationCommander @Inject() (
                 genStateRepo.save(newState)
               }
 
-              if (!cleanedItems.isEmpty) {
-                precomputeRecommendationsForUser(userId)
-                true
-              } else false
+              precomputeRecommendationsForUser(userId)
 
+              !seedItems.isEmpty
             }
           }
       }


### PR DESCRIPTION
…if a batch is empty after filtering. Also increases maximum concurrency.
@yingjieMiao @lawzlo 
