### PR TITLE
Google OAuth2 update

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/OAuth2Controller.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/OAuth2Controller.scala
@@ -40,7 +40,7 @@ object OAuth2Providers { // TODO: wire-in (securesocial) config
     accessTokenUrl = "https://accounts.google.com/o/oauth2/token",
     clientId = "572465886361.apps.googleusercontent.com", // "991651710157.apps.googleusercontent.com",
     clientSecret = "heYhp5R2Q0lH26VkrJ1NAMZr", // "vt9BrxsxM6iIG4EQNkm18L-m",
-    scope = "https://www.googleapis.com/auth/email https://www.google.com/m8/feeds" // "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/plus.me"
+    scope = "email https://www.google.com/m8/feeds" // "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/plus.me"
   )
   val FACEBOOK = OAuth2Config(
     provider = "facebook",

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/OAuth2Controller.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/OAuth2Controller.scala
@@ -38,9 +38,9 @@ object OAuth2Providers { // TODO: wire-in (securesocial) config
     provider = "google",
     authUrl = "https://accounts.google.com/o/oauth2/auth",
     accessTokenUrl = "https://accounts.google.com/o/oauth2/token",
-    clientId = "572465886361.apps.googleusercontent.com", // "991651710157.apps.googleusercontent.com",
-    clientSecret = "heYhp5R2Q0lH26VkrJ1NAMZr", // "vt9BrxsxM6iIG4EQNkm18L-m",
-    scope = "email https://www.google.com/m8/feeds" // "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/plus.me"
+    clientId = "572465886361.apps.googleusercontent.com",
+    clientSecret = "heYhp5R2Q0lH26VkrJ1NAMZr",
+    scope = "email https://www.googleapis.com/auth/contacts.readonly"
   )
   val FACEBOOK = OAuth2Config(
     provider = "facebook",

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/OAuth2Controller.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/OAuth2Controller.scala
@@ -40,7 +40,7 @@ object OAuth2Providers { // TODO: wire-in (securesocial) config
     accessTokenUrl = "https://accounts.google.com/o/oauth2/token",
     clientId = "572465886361.apps.googleusercontent.com", // "991651710157.apps.googleusercontent.com",
     clientSecret = "heYhp5R2Q0lH26VkrJ1NAMZr", // "vt9BrxsxM6iIG4EQNkm18L-m",
-    scope = "https://www.googleapis.com/auth/userinfo.email https://www.google.com/m8/feeds" // "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/plus.me"
+    scope = "https://www.googleapis.com/auth/email https://www.google.com/m8/feeds" // "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/plus.me"
   )
   val FACEBOOK = OAuth2Config(
     provider = "facebook",


### PR DESCRIPTION
Updating scopes only. Thanks @andrewconner for the tip about deprecation of `userinfo.email`

This takes care of the easy part, the other part about getting profile info is on the TODO list.

As a bonus, found that Google Contacts recently (finally!) added a readonly scope -- adopted as well.

Tested locally (with real google accounts)

@andrewconner @eishay 
