### PR TITLE
Add user status tracking to user_clicked_page

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/mixpanelService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/mixpanelService.js
@@ -50,6 +50,21 @@
       return userStatus;
     }
 
+    function getExperiments() {
+      var experiments = [];
+      if (profileService && profileService.me && profileService.me.experiments) {
+        experiments = profileService.me.experiments || [];
+      }
+
+      // Remove any user status from the list of experiments. Currently user status
+      // is a kind of experiment. TODO: move user status out of experiments.
+      var realExperiments = _.reject(experiments, function (experiment) {
+        return (experiment === 'fake') || (experiment === 'admin') || (experiment === 'standard');
+      });
+
+      return realExperiments;
+    }
+
     function pageTrackForUser(mixpanel, path, origin) {
       if (userId) {
         var oldId = mixpanel.get_distinct_id && mixpanel.get_distinct_id();
@@ -65,7 +80,8 @@
             type: getLocation(path),
             origin: origin,
             siteVersion: 2,
-            userStatus: getUserStatus()
+            userStatus: getUserStatus(),
+            experiments: getExperiments()
           });
 
           mixpanel.track('user_viewed_page', attributes);
@@ -129,6 +145,10 @@
             props.type = getLocation(props.path);
             delete props.path;
           }
+          _.extend(props, {
+            userStatus: getUserStatus(),
+            experiments: getExperiments()
+          });
           $log.log('mixpanelService.eventTrack(' + action + ')', props);
           $window.mixpanel.track(action, props);
         }

--- a/kifi-backend/modules/shoebox/angular/src/common/services/mixpanelService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/mixpanelService.js
@@ -51,18 +51,11 @@
     }
 
     function getExperiments() {
-      var experiments = [];
-      if (profileService && profileService.me && profileService.me.experiments) {
-        experiments = profileService.me.experiments || [];
-      }
+      var experiments = profileService && profileService.me && profileService.me.experiments || [];
 
       // Remove any user status from the list of experiments. Currently user status
       // is a kind of experiment. TODO: move user status out of experiments.
-      var realExperiments = _.reject(experiments, function (experiment) {
-        return (experiment === 'fake') || (experiment === 'admin') || (experiment === 'standard');
-      });
-
-      return realExperiments;
+      return _.without(experiments, 'fake', 'admin', 'standard');
     }
 
     function pageTrackForUser(mixpanel, path, origin) {


### PR DESCRIPTION
Also, add experiment tracking to user_clicked_page and user_viewed_page.

Task: https://app.asana.com/0/15014070792041/11359935698324

@stkem cc @2is10 
