### PR TITLE
Making multiplier optional since otherwise all current data in the db fails to deserialize

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
@@ -54,7 +54,7 @@ class RecommendationGenerationCommander @Inject() (
       9 * scores.recentInterestScore +
       6 * scores.rekeepScore +
       3 * scores.discoveryScore) *
-      scores.multiplier
+      scores.multiplier.getOrElse(1.0f)
   }
 
   private def computeAdjustedScoreByTester(scoreCoefficients: UriRecommendationScores, scores: UriScores): Float = {
@@ -66,7 +66,7 @@ class RecommendationGenerationCommander @Inject() (
       scoreCoefficients.recentInterestScore.getOrElse(defaultScore) * scores.recentInterestScore +
       scoreCoefficients.rekeepScore.getOrElse(defaultScore) * scores.rekeepScore +
       scoreCoefficients.discoveryScore.getOrElse(defaultScore) * scores.discoveryScore) *
-      scores.multiplier
+      scores.multiplier.getOrElse(1.0f)
   }
 
   def getTopRecommendations(userId: Id[User], howManyMax: Int): Future[Seq[UriRecommendation]] = {

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/UriScoringHelper.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/UriScoringHelper.scala
@@ -120,7 +120,7 @@ class UriScoringHelper @Inject() (
             priorScore = priorScores(i),
             rekeepScore = rekeepScores(i),
             discoveryScore = discoveryScores(i),
-            multiplier = items(i).multiplier
+            multiplier = Some(items(i).multiplier)
           )
           ScoredSeedItem(items(i).userId, items(i).uriId, scores)
         }

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/SeedItem.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/SeedItem.scala
@@ -32,7 +32,7 @@ case class SeedItem(
     priorScore: Float,
     rekeepScore: Float,
     discoveryScore: Float,
-    multiplier: Float) {
+    multiplier: Option[Float]) {
 
   override def toString = s"social:$socialScore --- popularity:$popularityScore --- overallInterest:$overallInterestScore --- recentInterest:$recentInterestScore --- recency:$recencyScore --- prior:$priorScore --- rekeep:$rekeepScore --- discovery:$discoveryScore --- multiplier:$multiplier"
 }

--- a/kifi-backend/modules/curator/test/com/keepit/curator/CuratorTestHelpers.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/CuratorTestHelpers.scala
@@ -71,7 +71,7 @@ trait CuratorTestHelpers { this: CuratorTestInjector =>
         priorScore = 1.0f,
         rekeepScore = 1.0f,
         discoveryScore = 1.0f,
-        multiplier = 1.0f),
+        multiplier = Some(1.0f)),
       seen = false, clicked = false, kept = false, attribution = SeedAttribution.EMPTY)
 
   def makeCompleteUriRecommendation(uriId: Int, userId: Int, masterScore: Float, url: String) = {

--- a/kifi-backend/modules/curator/test/com/keepit/curator/RecommendationGenerationCommanderTest.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/RecommendationGenerationCommanderTest.scala
@@ -36,7 +36,7 @@ class RecommendationGenerationCommanderTest extends Specification with CuratorTe
         priorScore = 1.0f,
         rekeepScore = 1.0f,
         discoveryScore = 1.0f,
-        multiplier = 0.01f),
+        multiplier = Some(0.01f)),
       seen = false, clicked = false, kept = false, attribution = SeedAttribution.EMPTY)
 
     val rec2 = UriRecommendation(uriId = Id[NormalizedURI](2), userId = Id[User](42), masterScore = 0.99f,
@@ -48,7 +48,7 @@ class RecommendationGenerationCommanderTest extends Specification with CuratorTe
         priorScore = 1.0f,
         rekeepScore = 1.0f,
         discoveryScore = 1.0f,
-        multiplier = 1.5f),
+        multiplier = Some(1.5f)),
       seen = false, clicked = false, kept = false, attribution = SeedAttribution.EMPTY)
 
     val rec3 = UriRecommendation(uriId = Id[NormalizedURI](3), userId = Id[User](42), masterScore = 0.5f,
@@ -60,7 +60,7 @@ class RecommendationGenerationCommanderTest extends Specification with CuratorTe
         priorScore = 1.0f,
         rekeepScore = 1.0f,
         discoveryScore = 1.0f,
-        multiplier = 1.0f),
+        multiplier = Some(1.0f)),
       seen = false, clicked = false, kept = false, attribution = SeedAttribution(topic = Some(TopicAttribution("fun"))))
 
     Seq(rec1, rec2, rec3)

--- a/kifi-backend/modules/curator/test/com/keepit/curator/SeedAttributionHelperTest.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/SeedAttributionHelperTest.scala
@@ -45,7 +45,7 @@ class SeedAttributionHelperTest extends Specification {
     priorScore = 0f,
     rekeepScore = 0f,
     discoveryScore = 0f,
-    multiplier = 1.0f)
+    multiplier = Some(1.0f))
 
   val scoredItem1 = ScoredSeedItem(Id[User](1), Id[NormalizedURI](1), emptyScore.copy(socialScore = 0.01f))
   val scoredItem2 = ScoredSeedItem(Id[User](1), Id[NormalizedURI](2), emptyScore.copy(socialScore = 0.9f))


### PR DESCRIPTION
@lawzlo when changing a serialized class always make sure it's compatible with already stored data
