### PR TITLE
mobile endpoint and tests for PYMK

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobilePeopleRecommendationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobilePeopleRecommendationController.scala
@@ -1,0 +1,34 @@
+package com.keepit.controllers.mobile
+
+import com.keepit.commanders.PeopleRecommendationCommander
+import com.keepit.common.controller.{ ActionAuthenticator, ShoeboxServiceController, WebsiteController }
+import com.google.inject.Inject
+import com.keepit.model.SocialUserInfoRepo
+import play.api.libs.json.{ Json, JsNumber, JsArray }
+import com.keepit.social.BasicUser
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+class MobilePeopleRecommendationController @Inject() (
+    actionAuthenticator: ActionAuthenticator,
+    peopleRecoCommander: PeopleRecommendationCommander,
+    socialUserRepo: SocialUserInfoRepo) extends WebsiteController(actionAuthenticator) with ShoeboxServiceController {
+
+  def getFriendRecommendations(page: Int, pageSize: Int) = JsonAction.authenticatedAsync { request =>
+    peopleRecoCommander.getFriendRecommendations(request.userId, page, pageSize).map { recoData =>
+      val recommendedUsers = recoData.recommendedUsers
+      val basicUsers = recoData.basicUsers
+      val mutualFriends = recoData.mutualFriends
+      val mutualFriendConnectionCounts = recoData.mutualFriendConnectionCounts
+
+      val recommendedUsersArray = JsArray(recommendedUsers.map { recommendedUserId =>
+        val mutualFriendsArray = JsArray(mutualFriends(recommendedUserId).toSeq.map { mutualFriendId =>
+          BasicUser.basicUserFormat.writes(basicUsers(mutualFriendId)) + ("numFriends" -> JsNumber(mutualFriendConnectionCounts(mutualFriendId)))
+        })
+        BasicUser.basicUserFormat.writes(basicUsers(recommendedUserId)) + ("mutualFriends" -> mutualFriendsArray)
+      })
+      val json = Json.obj("users" -> recommendedUsersArray)
+      Ok(json)
+    }
+  }
+}
+

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -114,6 +114,7 @@ GET     /m/1/user/friendsDetails            @com.keepit.controllers.mobile.Mobil
 GET     /m/1/user/networks                  @com.keepit.controllers.mobile.MobileUserController.socialNetworkInfo()
 POST    /m/1/user/:origin/uploadContacts    @com.keepit.controllers.mobile.MobileUserController.uploadContacts(origin:ABookOriginType)
 GET     /m/1/user/abooks                    @com.keepit.controllers.mobile.MobileUserController.abookInfo()
+GET     /m/1/user/friends/recommended       @com.keepit.controllers.mobile.MobilePeopleRecommendationController.getFriendRecommendations(page: Int ?= 0, pageSize: Int ?= 5)
 
 POST    /m/1/page/details                   @com.keepit.controllers.mobile.MobilePageController.getPageDetails()
 POST    /m/1/page/extensionQuery            @com.keepit.controllers.mobile.MobilePageController.queryExtension(page: Int ?= 0, pageSize: Int ?= 1000)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/PeopleRecommendationCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/PeopleRecommendationCommanderTest.scala
@@ -1,7 +1,6 @@
 package com.keepit.commanders
 
 import com.keepit.abook.{ FakeABookServiceClientModule, FakeABookServiceClientImpl, ABookServiceClient }
-import com.keepit.model.{ UserConnection, User, UserRepo, UserConnectionRepo }
 import com.keepit.test.ShoeboxTestInjector
 import org.specs2.mutable.Specification
 
@@ -14,44 +13,28 @@ class PeopleRecommendationCommanderTest extends Specification with ShoeboxTestIn
     FakeABookServiceClientModule()
   )
 
-  "PeopleRecommendationCommanderTest" should {
+  "PeopleRecommendationCommander" should {
     "getFriendRecommendations" should {
       "return users and mutual users friend counts" in {
         withDb(modules: _*) { implicit injector =>
-          val userConnRepo = inject[UserConnectionRepo]
-          val userRepo = inject[UserRepo]
-          val (user1, user2, user3, user4) = db.readWrite { implicit rw =>
-            val user1 = userRepo.save(User(firstName = "Aaron", lastName = "Paul"))
-            val user2 = userRepo.save(User(firstName = "Bryan", lastName = "Cranston"))
-            val user3 = userRepo.save(User(firstName = "Anna", lastName = "Gunn"))
-            val user4 = userRepo.save(User(firstName = "Dean", lastName = "Norris"))
-
-            userConnRepo.save(UserConnection(user1 = user2.id.get, user2 = user3.id.get))
-            userConnRepo.save(UserConnection(user1 = user2.id.get, user2 = user4.id.get))
-            userConnRepo.save(UserConnection(user1 = user3.id.get, user2 = user4.id.get))
-            userConnRepo.save(UserConnection(user1 = user1.id.get, user2 = user2.id.get))
-            userConnRepo.save(UserConnection(user1 = user1.id.get, user2 = user3.id.get))
-
-            (user1, user2, user3, user4)
-          }
-
+          val users = db.readWrite { implicit rw => testFactory.createUsersWithConnections() }
           val abook = inject[ABookServiceClient].asInstanceOf[FakeABookServiceClientImpl]
-          abook.addFriendRecommendationsExpectations(user1.id.get, Seq(user2.id.get, user3.id.get, user4.id.get))
+          abook.addFriendRecommendationsExpectations(users(0).id.get, Seq(users(1).id.get, users(2).id.get, users(3).id.get))
 
-          val friendRecoDataF = inject[PeopleRecommendationCommander].getFriendRecommendations(user1.id.get, 2, 25)
+          val friendRecoDataF = inject[PeopleRecommendationCommander].getFriendRecommendations(users(0).id.get, 2, 25)
           val friendRecoData = Await.result(friendRecoDataF, Duration(5, "seconds"))
 
           friendRecoData.basicUsers === Map(
-            user2.id.get -> com.keepit.social.BasicUser.fromUser(user2),
-            user3.id.get -> com.keepit.social.BasicUser.fromUser(user3),
-            user4.id.get -> com.keepit.social.BasicUser.fromUser(user4)
+            users(1).id.get -> com.keepit.social.BasicUser.fromUser(users(1)),
+            users(2).id.get -> com.keepit.social.BasicUser.fromUser(users(2)),
+            users(3).id.get -> com.keepit.social.BasicUser.fromUser(users(3))
           )
-          friendRecoData.recommendedUsers === Seq(user2.id.get, user3.id.get, user4.id.get)
-          friendRecoData.mutualFriendConnectionCounts === Map(user2.id.get -> 3, user3.id.get -> 3)
+          friendRecoData.recommendedUsers === Seq(users(1).id.get, users(2).id.get, users(3).id.get)
+          friendRecoData.mutualFriendConnectionCounts === Map(users(1).id.get -> 3, users(2).id.get -> 3)
           friendRecoData.mutualFriends === Map(
-            user2.id.get -> Set(user3.id.get),
-            user3.id.get -> Set(user2.id.get),
-            user4.id.get -> Set(user2.id.get, user3.id.get)
+            users(1).id.get -> Set(users(2).id.get),
+            users(2).id.get -> Set(users(1).id.get),
+            users(3).id.get -> Set(users(1).id.get, users(2).id.get)
           )
         }
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobilePeopleRecommendationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobilePeopleRecommendationControllerTest.scala
@@ -1,0 +1,51 @@
+package com.keepit.controllers.mobile
+
+import com.keepit.abook.{ FakeABookServiceClientModule, FakeABookServiceClientImpl, ABookServiceClient }
+import com.keepit.test.{ ShoeboxTestFactory, ShoeboxTestInjector }
+import org.specs2.mutable.Specification
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+class MobilePeopleRecommendationControllerTest extends Specification with ShoeboxTestInjector {
+
+  val modules = Seq(
+    FakeABookServiceClientModule()
+  )
+
+  "MobilePeopleRecommendationController" should {
+
+    "getFriendRecommendations" should {
+
+      "return json for present recommendations" in {
+        withDb(modules: _*) { implicit injector =>
+          val abook = inject[ABookServiceClient].asInstanceOf[FakeABookServiceClientImpl]
+          val users = db.readWrite { implicit rw => testFactory.createUsersWithConnections() }
+          abook.addFriendRecommendationsExpectations(users(0).id.get, Seq(users(1).id.get, users(2).id.get, users(3).id.get))
+
+          val controller = inject[MobilePeopleRecommendationController]
+          val resultF = controller.getFriendRecommendations(1, 25)(FakeRequest())
+
+          status(resultF) === 200
+          contentType(resultF) must beSome("application/json")
+          contentAsString(resultF) === s"""
+               |{"users":[
+               |{"id":"${users(1).externalId}","firstName":"Bryan","lastName":"Cranston","pictureName":"0.jpg",
+               |"mutualFriends":[{"id":"${users(2).externalId}","firstName":"Anna","lastName":"Gunn","pictureName":"0.jpg","numFriends":3}]},
+               |{"id":"${users(2).externalId}","firstName":"Anna","lastName":"Gunn","pictureName":"0.jpg",
+               |"mutualFriends":[{"id":"${users(1).externalId}","firstName":"Bryan","lastName":"Cranston","pictureName":"0.jpg","numFriends":3}]},
+               |{"id":"${users(3).externalId}","firstName":"Dean","lastName":"Norris","pictureName":"0.jpg",
+               |"mutualFriends":[{"id":"${users(1).externalId}","firstName":"Bryan","lastName":"Cranston","pictureName":"0.jpg","numFriends":3},
+               |{"id":"${users(2).externalId}","firstName":"Anna","lastName":"Gunn","pictureName":"0.jpg","numFriends":3}]}
+               |]}
+             """.stripMargin.replaceAll("\n", "").trim
+
+          val call = com.keepit.controllers.mobile.routes.MobilePeopleRecommendationController.getFriendRecommendations()
+          call.toString === "/m/1/user/friends/recommended"
+          call.method === "GET"
+        }
+      }
+
+    }
+
+  }
+}

--- a/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxApplication.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxApplication.scala
@@ -2,7 +2,7 @@ package com.keepit.test
 
 import java.io.File
 
-import com.google.inject.Module
+import com.google.inject.{ Injector, Module }
 import com.google.inject.util.Modules
 import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.common.actor.{ FakeActorSystemModule, FakeSchedulerModule }
@@ -75,4 +75,6 @@ trait ShoeboxTestInjector extends TestInjector with DbInjectionHelper with Shoeb
     FakeActionAuthenticatorModule(),
     FakeKeepImportsModule()
   )
+
+  def testFactory(implicit injector: Injector) = inject[ShoeboxTestFactory]
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxTestFactory.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxTestFactory.scala
@@ -1,0 +1,24 @@
+package com.keepit.test
+
+import com.google.inject.{ Singleton, Inject }
+import com.keepit.common.db.slick.DBSession.RWSession
+import com.keepit.model.{ UserConnection, User, UserRepo, UserConnectionRepo }
+
+@Singleton
+class ShoeboxTestFactory @Inject() (userConnRepo: UserConnectionRepo, userRepo: UserRepo) {
+
+  def createUsersWithConnections()(implicit rw: RWSession): Seq[User] = {
+    val user1 = userRepo.save(User(firstName = "Aaron", lastName = "Paul"))
+    val user2 = userRepo.save(User(firstName = "Bryan", lastName = "Cranston"))
+    val user3 = userRepo.save(User(firstName = "Anna", lastName = "Gunn"))
+    val user4 = userRepo.save(User(firstName = "Dean", lastName = "Norris"))
+
+    userConnRepo.save(UserConnection(user1 = user2.id.get, user2 = user3.id.get))
+    userConnRepo.save(UserConnection(user1 = user2.id.get, user2 = user4.id.get))
+    userConnRepo.save(UserConnection(user1 = user3.id.get, user2 = user4.id.get))
+    userConnRepo.save(UserConnection(user1 = user1.id.get, user2 = user2.id.get))
+    userConnRepo.save(UserConnection(user1 = user1.id.get, user2 = user3.id.get))
+
+    Seq(user1, user2, user3, user4)
+  }
+}


### PR DESCRIPTION
Extracted setup code to ShoeboxTestFactory as a way to make the setup code in our tests more DRY, which I also added as a def in ShoeboxTestInjector.

In many tests, setup code is often duplicated and takes up the much more LOC than the actual test code.  I think we should consider doing this more often, especially for common use cases like creating a users and user connections.

@stkem @andrewconner  @davoda 
