### PR TITLE
fixing GetResult field order

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItem.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItem.scala
@@ -29,7 +29,6 @@ case class RawSeedItem(
   updatedAt: DateTime = currentDateTime,
   seq: SequenceNumber[RawSeedItem] = SequenceNumber.ZERO,
   uriId: Id[NormalizedURI],
-  url: String, //set default url to empty string in db to avoid exceptions.
   userId: Option[Id[User]], //which user is this a seed item for. None means this is for every user.
   firstKept: DateTime, //the first time anyone has kept this uri
   lastKept: DateTime, //the most recent time anyone has kept this uri
@@ -38,7 +37,9 @@ case class RawSeedItem(
   timesKept: Int, //number of times this uri has been kept in total (note that with libraries allowing multiple keep per uri this can exceed the number of users who have kept the uri)
   // attributionInfo: AttributionInfo,
   // libraryInfo: Seq[LibraryInfo]
-  discoverable: Boolean)
+  discoverable: Boolean,
+  url: String //set default url to empty string in db to avoid exceptions.
+  )
     extends Model[RawSeedItem] with ModelWithSeqNumber[RawSeedItem] {
 
   def withId(id: Id[RawSeedItem]): RawSeedItem = this.copy(id = Some(id))

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItemRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItemRepo.scala
@@ -49,7 +49,7 @@ class RawSeedItemRepoImpl @Inject() (
     def priorScore = column[Float]("prior_score", O.Nullable)
     def timesKept = column[Int]("times_kept", O.NotNull)
     def discoverable = column[Boolean]("discoverable", O.NotNull)
-    def * = (id.?, createdAt, updatedAt, seq, uriId, url, userId.?, firstKept, lastKept, lastSeen, priorScore.?, timesKept, discoverable) <> ((RawSeedItem.apply _).tupled, RawSeedItem.unapply _)
+    def * = (id.?, createdAt, updatedAt, seq, uriId, userId.?, firstKept, lastKept, lastSeen, priorScore.?, timesKept, discoverable, url) <> ((RawSeedItem.apply _).tupled, RawSeedItem.unapply _)
   }
 
   def table(tag: Tag) = new RawSeedItemTable(tag)

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItemRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItemRepo.scala
@@ -62,14 +62,14 @@ class RawSeedItemRepoImpl @Inject() (
       updatedAt = r.<<[DateTime],
       seq = r.<<[SequenceNumber[RawSeedItem]],
       uriId = r.<<[Id[NormalizedURI]],
-      url = r.<<[String],
       userId = r.<<[Option[Id[User]]],
       firstKept = r.<<[DateTime],
       lastKept = r.<<[DateTime],
       lastSeen = r.<<[DateTime],
       priorScore = r.<<[Option[Float]],
       timesKept = r.<<[Int],
-      discoverable = r.<<[Boolean]
+      discoverable = r.<<[Boolean],
+      url = r.<<[String]
     )
   }
 


### PR DESCRIPTION
this needs to match the database column order, otherwise very strange exception can result (in this case a NPE in our DateTime TypeMapper)
@lawzlo @yingjieMiao 
