### PR TITLE
Quick for for iPhone version parsing failing

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/AuthenticatedWebSocketsController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/AuthenticatedWebSocketsController.scala
@@ -170,7 +170,7 @@ trait AuthenticatedWebSocketsController extends ElizaServiceController {
             implicit val (enumerator, channel) = Concurrent.broadcast[JsArray]
 
             val typedVersionOpt: Option[KifiVersion] = UserAgent.fromString(streamSession.userAgent) match {
-              case ua if ua.isKifiIphoneApp => versionOpt.map { v => KifiIPhoneVersion(v.stripPrefix("m")) }
+              case ua if ua.isKifiIphoneApp || versionOpt.exists(_.startsWith("m")) => versionOpt.map { v => KifiIPhoneVersion(v.stripPrefix("m")) }
               case ua if ua.isKifiAndroidApp => versionOpt.map(KifiAndroidVersion.apply)
               case _ => versionOpt.map(KifiExtVersion.apply)
             }


### PR DESCRIPTION
The server is not detecting correctly that it’t an iOS client and thus
trying to parse it like the Browser Extension. Looks to be a UserAgent
issue.
@thassss can you figure out what UserAgent is being sent wiht the websocket request? (Not urgent, I know you've got a lot going on with the iOS 8 release right now)
cc @2is10 
