### PR TITLE
Revert "feed email buttons to have url in body instead of query string"

### DIFF
--- a/kifi-backend/modules/curator/app/views/email/feedRecommendationsInlined.scala.html
+++ b/kifi-backend/modules/curator/app/views/email/feedRecommendationsInlined.scala.html
@@ -12,14 +12,12 @@ Kifi recommends @emailData.recos.size items for you:
             </h3>
             <div style="float:left;clear:both;">
                 <div style="float:right;">
-                    <form method="post" action="https://www.kifi.com/site/recos/vote" style="float:left;">
+                    <form method="post" action="https://www.kifi.com/site/recos/vote?url=@helper.urlEncode(reco.url)" style="float:left;">
                         <input type="hidden" name="vote" value="true"/>
-                        <input type="hidden" name="url" value="@helper.urlEncode(reco.url)"/>
                         <input type="submit" value="Good"/>
                     </form>
-                    <form method="post" action="https://www.kifi.com/site/recos/vote" style="float:left;">
+                    <form method="post" action="https://www.kifi.com/site/recos/vote?url=@helper.urlEncode(reco.url)" style="float:left;">
                         <input type="hidden" name="vote" value="false"/>
-                        <input type="hidden" name="url" value="@helper.urlEncode(reco.url)"/>
                         <input type="submit" value="Bad"/>
                     </form>
                 </div>


### PR DESCRIPTION
This reverts commit 3048ea9dc091d0356698ada8d0f2b0f7b1c9959a.

@lawzlo @stkem 

Doh, didn't realize that the change to the endpoint last week was /feedback instead of /vote, which is what this commit was to address.
