### PR TITLE
update iPhone redirect page

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
@@ -121,7 +121,7 @@ class HomeController @Inject() (
     context.addRequestInfo(request)
     context += ("type", "landing")
     heimdalServiceClient.trackEvent(AnonymousEvent(context.build, EventType("visitor_viewed_page")))
-    val uriNoProto = request.uri.replaceFirst("^https?://", "")
+    val uriNoProto = request.uri.replaceFirst("^https?:", "")
     Ok(views.html.mobile.iPhoneRedirect(uriNoProto))
   }
 

--- a/kifi-backend/modules/shoebox/app/views/mobile/iPhoneRedirect.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/mobile/iPhoneRedirect.scala.html
@@ -3,23 +3,48 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="viewport" content="width=device-width, user-scalable=no">
 <title>Kifi</title>
+<style type="text/css">
+#app-btn {
+font-family: 'Helvetica Neue', 'Open Sans', Arial, sans-serif;
+background: #93c059;
+text-align: center;
+color: #fff;
+display: inline-block;
+vertical-align: middle;
+padding: 0 1em;
+border: 1px solid #ccc;
+border-radius: 4px;
+font-weight: 400;
+height: 1.9em;
+line-height: 1.9em;
+font-size: 1.5em;
+text-decoration: none;
+outline: none;
+cursor: pointer;
+zoom: 1;
+margin: 0 auto;
+}
+</style>
 </head>
-<body>
-<p style="margin:3em auto;max-width:400px;">
-Loading Kifi app...
-<br/><br/>
-Kifi is the easiest way to organize and share the pages that matter to you online. Find something online that you love?
-Just keep the page, and it's instantly stored and organized in your kifi library where it's accessible from your
-favorite search engine, along with great finds from your friends' libraries, too.
-</p>
+<body style="display:none;text-align:center;padding:3em 0;">
+
+<div><a id="app-btn" href="https://www.kifi.com" onclick="return open();">Loading Kifi App...</a></div>
+
 <!-- source: http://aawaara.com/post/74543339755/smallest-piece-of-code-thats-going-to-change-the-world -->
 <script type="text/javascript">
-var timer, heartbeat, lastInterval;
+var timer,
+	heartbeat,
+	lastInterval,
+	isRunning = false,
+	btn = document.getElementById('app-btn');
 
 function clearTimers() {
     clearTimeout(timer);
     clearTimeout(heartbeat);
+    isRunning = false;
+    btn.innerText = 'Load Kifi App';
 }
 
 window.addEventListener('pageshow', clearTimers, false);
@@ -34,10 +59,19 @@ function intervalHeartbeat() {
     if (diff > 1000) clearTimers();
 }
 
-lastInterval = getTime();
-heartbeat = setInterval(intervalHeartbeat, 200);
-document.location = 'kifi://@url';
-timer = setTimeout(function () { document.location = 'https://itunes.apple.com/app/id740232575'; }, 2000);
+function open() {
+	if (!isRunning) {
+		lastInterval = getTime();
+		heartbeat = setInterval(intervalHeartbeat, 200);
+		document.location = 'kifi:@url';
+		// try to prevent a "flicker" of the body immediately before the redirect
+		setTimeout(function () { document.body.style.display = ''; }, 200);
+		timer = setTimeout(function () { document.location = 'https://itunes.apple.com/app/id740232575'; }, 2000);
+	}
+	return false;
+}
+
+openKifiApp();
 </script>
 </body>
 </html>


### PR DESCRIPTION
@2is10 

the pageshow and pagehide events are useful for safari.  since location.replace() doesn't work in mobile, these are a good way to prevent the auto-redirect when the user navigates back/forward.  The content of the body is now just a button consistent with the Sign Up button.
