### PR TITLE
inserting mac.css on Macs without any message passing when keeper_scout is injected

### DIFF
--- a/packrat/adapters/chrome/scripts/api.js
+++ b/packrat/adapters/chrome/scripts/api.js
@@ -151,5 +151,3 @@ var log = log || function () {
   log.buffer = [];
   return log;
 }();
-
-/^Mac/.test(navigator.platform) && api.require('styles/mac.css', api.noop);

--- a/packrat/adapters/firefox/data/scripts/api.js
+++ b/packrat/adapters/firefox/data/scripts/api.js
@@ -103,5 +103,3 @@ function log() {
   args.unshift("'" + ds.substr(0,2) + ds.substr(15,9) + "." + String(+d).substr(10) + "'");
   console.log.apply(console, args);
 }
-
-/^Mac/.test(navigator.platform) && api.require('styles/mac.css', api.noop);

--- a/packrat/gulpfile.js
+++ b/packrat/gulpfile.js
@@ -276,9 +276,8 @@ gulp.task('meta', function () {
         }
       }
     }
-    var contentScriptsString = ' [\n  ' + contentScriptItems.join(',\n  ') + ']';
     return JSON.stringify([
-      contentScriptsString,
+      ' [\n  ' + contentScriptItems.join(',\n  ') + ']',
       JSON.stringify(styleDeps, undefined, 2),
       JSON.stringify(scriptDeps, undefined, 2)
     ]);
@@ -297,7 +296,7 @@ gulp.task('meta', function () {
       return 'meta = {\n  contentScripts:' + data[0] +
         ',\n  styleDeps: ' + data[1] +
         ',\n  scriptDeps: ' + data[2] +
-        '};';
+        "};\nif (/^Mac/.test(navigator.platform)) {\n  meta.styleDeps['scripts/keeper_scout.js'] = ['styles/mac.css'];\n}\n";
     }))
     .pipe(gulp.dest(outDir + '/chrome'));
 
@@ -307,7 +306,7 @@ gulp.task('meta', function () {
       return 'exports.contentScripts =' + data[0] +
         ';\nexports.styleDeps = ' + data[1] +
         ';\nexports.scriptDeps = ' + data[2] +
-        ';';
+        ";\nconst {Ci, Cc} = require('chrome');\nif (/^Mac/.test(Cc['@mozilla.org/network/protocol;1?name=http'].getService(Ci.nsIHttpProtocolHandler).platform)) {\n  exports.styleDeps['scripts/keeper_scout.js'] = ['styles/mac.css'];\n}\n";
     }))
     .pipe(gulp.dest(outDir + '/firefox/lib'));
 

--- a/packrat/meta.js
+++ b/packrat/meta.js
@@ -1,0 +1,8 @@
+!function (exports) {
+  'use strict';
+  // generated exports.contentScripts, exports.styleDeps, exports.scriptDeps go here
+
+  if (/^Mac/.test(navigator.platform)) {
+    meta.styleDeps['scripts/keeper_scout.js'].unshift('styles/mac.css');
+  }
+}(this.exports || (this.meta = {}));


### PR DESCRIPTION
I’m sure there’s a way to do this more cleanly. Open to suggestions.
