### PR TITLE
userHasVisibility & createLibraryFromTag

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
@@ -165,6 +165,7 @@ object KeepSource {
   val kippt = KeepSource("Kippt")
   val pocket = KeepSource("Pocket")
   val instapaper = KeepSource("Instapaper")
+  val tagImport = KeepSource("tagImport")
 
   val valid = Set(keeper, bookmarkImport, site, mobile, email, default, bookmarkFileImport, kippt, pocket, instapaper)
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -76,7 +76,7 @@ class LibraryController @Inject() (
       case Failure(ex) =>
         BadRequest(Json.obj("error" -> "invalid id"))
       case Success(id) =>
-        val lib = libraryCommander.getLibraryById(id)
+        val lib = db.readOnlyMaster { implicit s => libraryRepo.get(id) }
         Ok(Json.obj("library" -> Json.toJson(libraryCommander.createFullLibraryInfo(lib))))
     }
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -726,7 +726,8 @@ class LibraryCommanderTest extends Specification with ShoeboxTestInjector {
         }
         val res2 = libraryCommander.createLibraryFromCollection(userCaptain.id.get, tag2) // try to create library Murica
         res2._2.length === 2 // two bad keeps already in Murica
-        res2._2.map(_._1.title.get).toSeq === Seq("Reddit", "Freedom")
+        res2._2.map(_._1.title.get).contains("Reddit") === true
+        res2._2.map(_._1.title.get).contains("Freedom") === true
         db.readOnlyMaster { implicit s =>
           keepRepo.getByLibrary(libMurica.id.get).map(_.title.get) === Seq("Reddit", "Freedom", "McDonalds")
           keepRepo.count === 7


### PR DESCRIPTION
commander functions & tests
for (1) check to see if user has visibility to a library
for (2) create a library from a tag (follows the same structure as copy/move keeps to a library)
if a library of same tag name exists, any URIs that already exist in the library will have an error
these new keeps in the destination library will also retain the tag

@andrewconner 

controller API still in the works...
