### PR TITLE
removing old filter options

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClient.scala
@@ -92,10 +92,6 @@ trait SearchServiceClient extends ServiceClient {
     filter: Option[String],
     maxHits: Int,
     context: Option[String],
-    start: Option[String],
-    end: Option[String],
-    tz: Option[String],
-    coll: Option[String],
     debug: Option[String]): Seq[Future[JsValue]]
 
   def distLangFreqs(plan: Seq[(ServiceInstance, Set[Shard[NormalizedURI]])], userId: Id[User]): Seq[Future[Map[Lang, Int]]]
@@ -380,10 +376,6 @@ class SearchServiceClientImpl(
     filter: Option[String],
     maxHits: Int,
     context: Option[String],
-    start: Option[String],
-    end: Option[String],
-    tz: Option[String],
-    coll: Option[String],
     debug: Option[String]): Seq[Future[JsValue]] = {
 
     var builder = new SearchRequestBuilder(new ListBuffer)
@@ -395,10 +387,6 @@ class SearchServiceClientImpl(
     if (secondLang.isDefined) builder += ("lang2", secondLang.get.lang)
     if (filter.isDefined) builder += ("filter", filter.get)
     if (context.isDefined) builder += ("context", context.get)
-    if (start.isDefined) builder += ("start", start.get)
-    if (end.isDefined) builder += ("end", end.get)
-    if (tz.isDefined) builder += ("tz", tz.get)
-    if (coll.isDefined) builder += ("coll", coll.get)
     if (debug.isDefined) builder += ("debug", debug.get)
     val request = builder.build
 

--- a/kifi-backend/modules/search/app/com/keepit/controllers/ext/ExtSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/ext/ExtSearchController.scala
@@ -35,7 +35,7 @@ class ExtSearchController @Inject() (
 
     val debugOpt = if (debug.isDefined && request.experiments.contains(ADMIN)) debug else None // debug is only for admin
 
-    val decoratedResult = searchCommander.search(userId, acceptLangs, request.experiments, query, filter, maxHits, lastUUIDStr, context, predefinedConfig = None, start, end, tz, coll, debugOpt, withUriSummary)
+    val decoratedResult = searchCommander.search(userId, acceptLangs, request.experiments, query, filter, maxHits, lastUUIDStr, context, predefinedConfig = None, debugOpt, withUriSummary)
 
     Ok(toKifiSearchResultV1(decoratedResult)).withHeaders("Cache-Control" -> "private, max-age=10")
   }

--- a/kifi-backend/modules/search/app/com/keepit/controllers/mobile/MobileSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/mobile/MobileSearchController.scala
@@ -31,7 +31,7 @@ class MobileSearchController @Inject() (
     val userId = request.userId
     val acceptLangs: Seq[String] = request.request.acceptLanguages.map(_.code)
 
-    val decoratedResult = searchCommander.search(userId, acceptLangs, request.experiments, query, filter, maxHits, lastUUIDStr, context, predefinedConfig = None, start, end, tz, coll, None, withUriSummary)
+    val decoratedResult = searchCommander.search(userId, acceptLangs, request.experiments, query, filter, maxHits, lastUUIDStr, context, predefinedConfig = None, None, withUriSummary)
 
     Ok(toKifiSearchResultV1(decoratedResult)).withHeaders("Cache-Control" -> "private, max-age=10")
   }

--- a/kifi-backend/modules/search/app/com/keepit/controllers/search/SearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/search/SearchController.scala
@@ -42,10 +42,6 @@ class SearchController @Inject() (
     val filter = (searchRequest \ "filter").asOpt[String]
     val maxHits = (searchRequest \ "maxHits").as[Int]
     val context = (searchRequest \ "context").asOpt[String]
-    val start = (searchRequest \ "start").asOpt[String]
-    val end = (searchRequest \ "end").asOpt[String]
-    val tz = (searchRequest \ "tz").asOpt[String]
-    val coll = (searchRequest \ "coll").asOpt[String]
     val debug = (searchRequest \ "debug").asOpt[String]
 
     val id = Id[User](userId)
@@ -62,10 +58,6 @@ class SearchController @Inject() (
       maxHits,
       context,
       None,
-      start,
-      end,
-      tz,
-      coll,
       debug)
 
     Ok(result.json)
@@ -91,7 +83,7 @@ class SearchController @Inject() (
     val query = (js \ "query").as[String]
     val maxHits = (js \ "maxHits").as[Int]
     val predefinedConfig = (js \ "config").as[Map[String, String]]
-    val res = searchCommander.search(userId, acceptLangs = Seq(), experiments = Set.empty, query = query, filter = None, maxHits = maxHits, lastUUIDStr = None, context = None, predefinedConfig = Some(SearchConfig(predefinedConfig)), start = None, end = None, tz = None, coll = None)
+    val res = searchCommander.search(userId, acceptLangs = Seq(), experiments = Set.empty, query = query, filter = None, maxHits = maxHits, lastUUIDStr = None, context = None, predefinedConfig = Some(SearchConfig(predefinedConfig)))
     Ok(JsArray(res.hits.map { x =>
       val id = x.uriId.id
       val title = x.bookmark.title.getOrElse("")

--- a/kifi-backend/modules/search/app/com/keepit/controllers/website/WebsiteSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/website/WebsiteSearchController.scala
@@ -34,7 +34,7 @@ class WebsiteSearchController @Inject() (
 
     val debugOpt = if (debug.isDefined && request.experiments.contains(ADMIN)) debug else None // debug is only for admin
 
-    val decoratedResult = searchCommander.search(userId, acceptLangs, request.experiments, query, filter, maxHits, lastUUIDStr, context, predefinedConfig = None, start, end, tz, coll, debugOpt, withUriSummary)
+    val decoratedResult = searchCommander.search(userId, acceptLangs, request.experiments, query, filter, maxHits, lastUUIDStr, context, predefinedConfig = None, debugOpt, withUriSummary)
 
     Ok(toKifiSearchResultV1(decoratedResult)).withHeaders("Cache-Control" -> "private, max-age=10")
   }

--- a/kifi-backend/modules/search/app/com/keepit/search/MainSearcherFactory.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/MainSearcherFactory.scala
@@ -137,7 +137,7 @@ class MainSearcherFactory @Inject() (
   def getUserSearcher = new UserSearcher(userIndexer.getSearcher)
 
   def getSocialGraphInfo(shard: Shard[NormalizedURI], userId: Id[User], filter: SearchFilter): SocialGraphInfo = {
-    new SocialGraphInfo(userId, getURIGraphSearcher(shard, userId), getCollectionSearcher(shard, userId), filter: SearchFilter, monitoredAwait)
+    new SocialGraphInfo(userId, getURIGraphSearcher(shard, userId), getCollectionSearcher(shard, userId), filter, monitoredAwait)
   }
 
   private[this] def getURIGraphSearcherFuture(shard: Shard[NormalizedURI], userId: Id[User]) = consolidateURIGraphSearcherReq((shard, userId)) {

--- a/kifi-backend/modules/search/app/com/keepit/search/SearchFilter.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/SearchFilter.scala
@@ -9,101 +9,53 @@ import com.keepit.search.util.{ LongArraySet, IdFilterCompressor }
 import scala.concurrent.duration._
 import scala.concurrent.Future
 
-abstract class SearchFilter(
-    context: Option[String],
-    val timeRange: Option[SearchFilter.TimeRange]) {
+abstract class SearchFilter(context: Option[String]) {
 
   lazy val idFilter: LongArraySet = IdFilterCompressor.fromBase64ToSet(context.getOrElse(""))
-  lazy val collections: Option[Seq[Id[Collection]]] = None
 
   def includeMine: Boolean
   def includeShared: Boolean
   def includeFriends: Boolean
   def includeOthers: Boolean
   def isDefault = false
-  def isCustom = false
-  def filterFriends(f: Set[Id[User]]) = f
 }
 
 object SearchFilter {
 
-  case class TimeRange(start: Long, end: Long)
-
-  private def timeRange(startTime: Option[String], endTime: Option[String], tz: Option[String]): Option[TimeRange] = {
-    if (startTime.isDefined || endTime.isDefined) {
-      val startMillis = startTime.map { t => parseStandardTime(t + " 00:00:00.000 " + tz.getOrElse("+0000")).getMillis }.getOrElse(0L)
-      val endMillis = endTime.map { t => parseStandardTime(t + " 23:59:59.999 " + tz.getOrElse("+0000")).getMillis }.getOrElse(Long.MaxValue)
-      Some(TimeRange(startMillis, endMillis))
-    } else {
-      None
-    }
-  }
-
-  def default(context: Option[String] = None) = new SearchFilter(context, None) {
-    def includeMine = true
-    def includeShared = true
-    def includeFriends = true
-    def includeOthers = true
-    override def isDefault = true
-  }
-
-  def all(context: Option[String] = None,
-    startTime: Option[String] = None,
-    endTime: Option[String] = None,
-    tz: Option[String] = None) = {
-    val excludeOthers = (startTime.isDefined || endTime.isDefined)
-    new SearchFilter(context, timeRange(startTime, endTime, tz)) {
+  def default(context: Option[String] = None) = {
+    new SearchFilter(context) {
       def includeMine = true
       def includeShared = true
       def includeFriends = true
-      def includeOthers = !excludeOthers
-      override def isDefault = false
+      def includeOthers = true
+      override def isDefault = true
     }
   }
 
-  def mine(context: Option[String] = None,
-    collectionsFuture: Option[Future[Seq[Id[Collection]]]] = None,
-    startTime: Option[String] = None,
-    endTime: Option[String] = None,
-    tz: Option[String] = None,
-    monitoredAwait: MonitoredAwait) = {
-    new SearchFilter(context, timeRange(startTime, endTime, tz)) {
+  def all(context: Option[String] = None) = {
+    new SearchFilter(context) {
+      def includeMine = true
+      def includeShared = true
+      def includeFriends = true
+      def includeOthers = false
+    }
+  }
 
-      override lazy val collections = collectionsFuture.map { monitoredAwait.result(_, 5 seconds, "getting collections") }
-
+  def mine(context: Option[String] = None) = {
+    new SearchFilter(context) {
       def includeMine = true
       def includeShared = true
       def includeFriends = false
       def includeOthers = false
     }
   }
-  def friends(context: Option[String] = None,
-    startTime: Option[String] = None,
-    endTime: Option[String] = None,
-    tz: Option[String] = None) = {
-    new SearchFilter(context, timeRange(startTime, endTime, tz)) {
+
+  def friends(context: Option[String] = None) = {
+    new SearchFilter(context) {
       def includeMine = false
       def includeShared = false
       def includeFriends = true
       def includeOthers = false
-    }
-  }
-  def custom(context: Option[String] = None,
-    usersFuture: Future[Seq[Id[User]]],
-    startTime: Option[String] = None,
-    endTime: Option[String] = None,
-    tz: Option[String] = None,
-    monitoredAwait: MonitoredAwait) = {
-    new SearchFilter(context, timeRange(startTime, endTime, tz)) {
-
-      private[this] lazy val users = monitoredAwait.result(usersFuture, 5 seconds, "getting users").toSet
-
-      def includeMine = false
-      def includeShared = true
-      def includeFriends = true
-      def includeOthers = false
-      override def isCustom = true
-      override def filterFriends(f: Set[Id[User]]) = (users intersect f)
     }
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/SocialGraphInfo.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/SocialGraphInfo.scala
@@ -21,7 +21,7 @@ class SocialGraphInfo(userId: Id[User], val uriGraphSearcher: URIGraphSearcherWi
   lazy val (myUriEdgeAccessor, mySearchUris: LongArraySet, part1End) = {
     monitoredAwait.result(part1, 5 seconds, s"getting SocialGraphInfo.my* for user Id $userId")
   }
-  lazy val (friendsUriEdgeAccessors, friendSearchUris: LongArraySet, relevantFriendEdgeSet, part2End) = {
+  lazy val (friendsUriEdgeAccessors, friendSearchUris: LongArraySet, friendEdgeSet, part2End) = {
     monitoredAwait.result(part2, 5 seconds, s"getting SocialGraphInfo.friends* for user Id $userId")
   }
 
@@ -31,58 +31,15 @@ class SocialGraphInfo(userId: Id[User], val uriGraphSearcher: URIGraphSearcherWi
 
   private[this] val part1 = SafeFuture {
     val myUriEdges = uriGraphSearcher.myUriEdgeSet
-    val mySearchUris =
-      filter.timeRange match {
-        case Some(timeRange) =>
-          filter.collections match {
-            case Some(collections) =>
-              collections.foldLeft(Set.empty[Long]) { (s, collId) =>
-                s ++ collectionSearcher.getCollectionToUriEdgeSet(collId).accessor.asInstanceOf[BookmarkInfoAccessor[Collection, NormalizedURI]].filterByTimeRange(timeRange.start, timeRange.end).destIdLongSet
-              }
-            case _ => myUriEdges.asInstanceOf[BookmarkInfoAccessor[User, NormalizedURI]].filterByTimeRange(timeRange.start, timeRange.end).destIdLongSet
-          }
-        // no time range
-        case _ =>
-          filter.collections match {
-            case Some(collections) =>
-              collections.foldLeft(Set.empty[Long]) { (s, collId) =>
-                s ++ collectionSearcher.getCollectionToUriEdgeSet(collId).destIdLongSet
-              }
-            case _ => myUriEdges.destIdLongSet
-          }
-      }
+    val mySearchUris = myUriEdges.destIdLongSet
     (myUriEdges.accessor.asInstanceOf[BookmarkInfoAccessor[User, NormalizedURI]], LongArraySet.fromSet(mySearchUris), System.currentTimeMillis)
   }
 
   private[this] val part2 = SafeFuture {
     val friendEdgeSet = uriGraphSearcher.searchFriendEdgeSet
     val friendsUriEdgeSets = uriGraphSearcher.friendsUriEdgeSets
-    val (filteredFriendEdgeSet, relevantFriendEdgeSet) = {
-      if (filter.isCustom) {
-        val fullFriendEdgeSet = uriGraphSearcher.friendEdgeSet
-        val filtered = uriGraphSearcher.getUserToUserEdgeSet(userId, filter.filterFriends(fullFriendEdgeSet.destIdSet)) // a custom filter can have non-search friends
-        val unioned = uriGraphSearcher.getUserToUserEdgeSet(userId, filtered.destIdSet ++ friendEdgeSet.destIdSet)
-        (filtered, unioned)
-      } else {
-        (friendEdgeSet, friendEdgeSet)
-      }
-    }
-    val friendSearchUris = filter.collections match {
-      case Some(colls) =>
-        Set.empty[Long]
-      case _ =>
-        filter.timeRange match {
-          case Some(timeRange) =>
-            filteredFriendEdgeSet.destIdSet.foldLeft(Set.empty[Long]) { (s, f) =>
-              s ++ friendsUriEdgeSets(f.id).accessor.asInstanceOf[BookmarkInfoAccessor[User, NormalizedURI]].filterByTimeRange(timeRange.start, timeRange.end).destIdLongSet
-            }
-          case _ =>
-            filteredFriendEdgeSet.destIdSet.foldLeft(Set.empty[Long]) { (s, f) =>
-              s ++ friendsUriEdgeSets(f.id).destIdLongSet
-            }
-        }
-    }
+    val friendSearchUris = friendEdgeSet.destIdSet.foldLeft(Set.empty[Long]) { (s, f) => s ++ friendsUriEdgeSets(f.id).destIdLongSet }
 
-    (friendsUriEdgeSets.mapValues { _.accessor.asInstanceOf[BookmarkInfoAccessor[User, NormalizedURI]] }, LongArraySet.fromSet(friendSearchUris), relevantFriendEdgeSet, System.currentTimeMillis)
+    (friendsUriEdgeSets.mapValues { _.accessor.asInstanceOf[BookmarkInfoAccessor[User, NormalizedURI]] }, LongArraySet.fromSet(friendSearchUris), friendEdgeSet, System.currentTimeMillis)
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/KifiSearch.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/KifiSearch.scala
@@ -84,12 +84,10 @@ class KifiSearch(
     uriGraphSearcher.intersect(friendEdgeSet, uriGraphSearcher.getUriToUserEdgeSet(Id[NormalizedURI](id)))
   }
 
-  @inline private[this] def sharingScore(sharingUsers: UserToUserEdgeSet): Float = {
-    if (filter.isCustom) filter.filterFriends(sharingUsers.destIdSet).size.toFloat else sharingUsers.size.toFloat
-  }
+  @inline private[this] def sharingScore(sharingUsers: UserToUserEdgeSet): Float = sharingUsers.size.toFloat
 
   @inline private[this] def sharingScore(sharingUsers: UserToUserEdgeSet, normalizedFriendStats: FriendStats): Float = {
-    val users = if (filter.isCustom) filter.filterFriends(sharingUsers.destIdSet) else sharingUsers.destIdSet
+    val users = sharingUsers.destIdSet
     users.foldLeft(sharingUsers.size.toFloat) { (score, id) => score + normalizedFriendStats.score(id) } / 2.0f
   }
 
@@ -124,7 +122,7 @@ class KifiSearch(
 
     val myUriEdgeAccessor = socialGraphInfo.myUriEdgeAccessor
     val friendsUriEdgeAccessors = socialGraphInfo.friendsUriEdgeAccessors
-    val relevantFriendEdgeSet = socialGraphInfo.relevantFriendEdgeSet
+    val friendEdgeSet = socialGraphInfo.friendEdgeSet
 
     val myTotal = myHits.totalHits
     val friendsTotal = friendsHits.totalHits
@@ -142,7 +140,7 @@ class KifiSearch(
     }
 
     val threshold = highScore * tailCutting
-    val friendStats = FriendStats(relevantFriendEdgeSet.destIdLongSet)
+    val friendStats = FriendStats(friendEdgeSet.destIdLongSet)
 
     val usefulPages = monitoredAwait.result(clickHistoryFuture, 40 millisecond, s"getting click history for user $userId", MultiHashFilter.emptyFilter[ClickedURI])
 
@@ -172,7 +170,7 @@ class KifiSearch(
       friendsHits.toRankedIterator.forall {
         case (hit, rank) =>
           val h = hit.hit
-          val sharingUsers = findSharingUsers(h.id, relevantFriendEdgeSet)
+          val sharingUsers = findSharingUsers(h.id, friendEdgeSet)
           val sharingUserSize = sharingUsers.size.toFloat
 
           var recencyScoreVal = 0.0f

--- a/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtSearchControllerTest.scala
@@ -173,10 +173,6 @@ class FixedResultSearchCommander extends SearchCommander {
     lastUUIDStr: Option[String],
     context: Option[String],
     predefinedConfig: Option[SearchConfig] = None,
-    start: Option[String] = None,
-    end: Option[String] = None,
-    tz: Option[String] = None,
-    coll: Option[String] = None,
     debug: Option[String] = None,
     withUriSummary: Boolean = false): DecoratedResult = {
     results(query)
@@ -193,10 +189,6 @@ class FixedResultSearchCommander extends SearchCommander {
     maxHits: Int,
     context: Option[String],
     predefinedConfig: Option[SearchConfig],
-    start: Option[String],
-    end: Option[String],
-    tz: Option[String],
-    coll: Option[String],
     debug: Option[String]): PartialSearchResult = ???
 
   def distLangFreqs(shards: Set[Shard[NormalizedURI]], userId: Id[User]) = ???

--- a/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
@@ -171,10 +171,6 @@ class FixedResultSearchCommander extends SearchCommander {
     lastUUIDStr: Option[String],
     context: Option[String],
     predefinedConfig: Option[SearchConfig] = None,
-    start: Option[String] = None,
-    end: Option[String] = None,
-    tz: Option[String] = None,
-    coll: Option[String] = None,
     debug: Option[String] = None,
     withUriSummary: Boolean = false): DecoratedResult = {
     results(query)
@@ -191,10 +187,6 @@ class FixedResultSearchCommander extends SearchCommander {
     maxHits: Int,
     context: Option[String],
     predefinedConfig: Option[SearchConfig],
-    start: Option[String],
-    end: Option[String],
-    tz: Option[String],
-    coll: Option[String],
     debug: Option[String]): PartialSearchResult = ???
 
   def distLangFreqs(shards: Set[Shard[NormalizedURI]], userId: Id[User]) = ???

--- a/kifi-backend/modules/search/test/com/keepit/search/SearchCommanderTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/SearchCommanderTest.scala
@@ -53,10 +53,6 @@ class SearchCommanderTest extends Specification with SearchTestInjector with Sea
           lastUUIDStr = None,
           context = None,
           predefinedConfig = Some(searchConfig),
-          start = None,
-          end = None,
-          tz = None,
-          coll = None,
           withUriSummary = false)
 
         res.myTotal === 1


### PR DESCRIPTION
Removing old filter options (the time range filter, the custom user filter, and the collection filter)
I don't think these are used any more. And there is no plan to use them again in the future.
If these parameters are specified in the search URLs, the search backend will ignore them silently.

@eishay @2is10 @andrewconner @jaredpetker 
