### PR TITLE
not setting Content-Type header if response status is 204 or 205

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/controller/ActionsBuilder.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/ActionsBuilder.scala
@@ -8,6 +8,7 @@ import play.api.libs.json.{ JsValue, JsNumber }
 import play.api.i18n.Messages
 import securesocial.core.SecuredRequest
 
+import play.api.http.Status.{ NO_CONTENT, RESET_CONTENT }
 import play.api.mvc.SimpleResult
 import com.keepit.common.logging.Logging
 
@@ -64,7 +65,7 @@ class ActionsBuilder0(actionAuthenticator: ActionAuthenticator) extends Controll
     def authenticatedAsync[T](parser: BodyParser[T] = parse.anyContent, apiClient: Boolean = apiClient, allowPending: Boolean = allowPending, authFilter: (AuthenticatedRequest[T] => Boolean) = globalAuthFilter[T] _)(authenticatedAction: AuthenticatedRequest[T] => Future[SimpleResult]): Action[T] = {
       contentTypeOpt match {
         case Some(contentType) =>
-          ActionHandlerAsync(parser, apiClient, allowPending, authFilter)(onAuthenticated = authenticatedAction.andThen(_.map(_.as(contentType))))
+          ActionHandlerAsync(parser, apiClient, allowPending, authFilter)(onAuthenticated = authenticatedAction.andThen(_.map(as(contentType))))
         case None =>
           ActionHandlerAsync(parser, apiClient, allowPending, authFilter)(onAuthenticated = authenticatedAction)
       }
@@ -106,7 +107,7 @@ class ActionsBuilder0(actionAuthenticator: ActionAuthenticator) extends Controll
     def async[T](parser: BodyParser[T] = parse.anyContent, apiClient: Boolean = apiClient, allowPending: Boolean = allowPending, authFilter: AuthenticatedRequest[T] => Boolean = globalAuthFilter[T] _)(authenticatedAction: AuthenticatedRequest[T] => Future[SimpleResult], unauthenticatedAction: Request[T] => Future[SimpleResult]): Action[T] = {
       contentTypeOpt match {
         case Some(contentType) =>
-          ActionHandlerAsync(parser, apiClient, allowPending, authFilter)(onAuthenticated = authenticatedAction.andThen(_.map(_.as(contentType))), onUnauthenticated = unauthenticatedAction.andThen(_.map(_.as(contentType))), onSocialAuthenticated = unauthenticatedAction.andThen(_.map(_.as(contentType))))
+          ActionHandlerAsync(parser, apiClient, allowPending, authFilter)(onAuthenticated = authenticatedAction.andThen(_.map(as(contentType))), onUnauthenticated = unauthenticatedAction.andThen(_.map(as(contentType))), onSocialAuthenticated = unauthenticatedAction.andThen(_.map(as(contentType))))
         case None =>
           ActionHandlerAsync(parser, apiClient, allowPending, authFilter)(onAuthenticated = authenticatedAction, onUnauthenticated = unauthenticatedAction, onSocialAuthenticated = unauthenticatedAction)
       }
@@ -138,6 +139,15 @@ class ActionsBuilder0(actionAuthenticator: ActionAuthenticator) extends Controll
 
     def parseJson(apiClient: Boolean = apiClient, allowPending: Boolean = allowPending)(authenticatedAction: AuthenticatedRequest[JsValue] => SimpleResult, unauthenticatedAction: Request[JsValue] => SimpleResult): Action[JsValue] = {
       apply(parser = parse.tolerantJson, apiClient = apiClient, allowPending = allowPending)(authenticatedAction, unauthenticatedAction)
+    }
+  }
+
+  private def as(contentType: String)(result: SimpleResult): SimpleResult = {
+    result.header.status match {
+      case NO_CONTENT | RESET_CONTENT =>
+        result
+      case _ =>
+        result.as(contentType)
     }
   }
 }


### PR DESCRIPTION
@andrewconner 
cc @joshm1 

A baby step that should help some JS libraries consume our `204` responses better. Would be cool not to set it if the response body is empty, but I think that requires an extra `Iteratee` — not sure of the feasibility or performance implications.
