### PR TITLE
return marker future when precomputing recos (for testing awaitability)

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
@@ -120,7 +120,7 @@ class RecommendationGenerationCommander @Inject() (
     }
   }
 
-  private def precomputeRecommendationsForUser(userId: Id[User], boostedKeepers: Set[Id[User]]): Unit = recommendationGenerationLock.withLockFuture {
+  private def precomputeRecommendationsForUser(userId: Id[User], boostedKeepers: Set[Id[User]]): Future[Unit] = recommendationGenerationLock.withLockFuture {
     getPerUserGenerationLock(userId).withLockFuture {
       val state = db.readOnlyMaster { implicit session =>
         genStateRepo.getByUserId(userId)
@@ -196,16 +196,18 @@ class RecommendationGenerationCommander @Inject() (
       res.onFailure {
         case t: Throwable => airbrake.notify("Failure during recommendation precomputation", t)
       }
-      res
+      res.map(_ => ())
     }
   }
 
-  def precomputeRecommendations(): Unit = {
-    usersToPrecomputeRecommendationsFor().map { userIds =>
-      specialCurators().map { boostedKeepersSeq =>
+  def precomputeRecommendations(): Future[Unit] = {
+    usersToPrecomputeRecommendationsFor().flatMap { userIds =>
+      specialCurators().flatMap { boostedKeepersSeq =>
         if (recommendationGenerationLock.waiting < userIds.length + 1) {
           val boostedKeepers = boostedKeepersSeq.toSet
-          userIds.foreach(userId => precomputeRecommendationsForUser(userId, boostedKeepers))
+          Future.sequence(userIds.map(userId => precomputeRecommendationsForUser(userId, boostedKeepers))).map(_ => ())
+        } else {
+          Future.successful()
         }
       }
     }


### PR DESCRIPTION
@lawzlo  This is a different solution form what I mentioned earlier. It will only actually indicate the completion of the first batch, but that should be plenty for the tests and I think it's simpler.
In the test simply Await on the future returned by `precomputeRecommendations`. You can either merge this or port it into your PR. Le me know which one you chose.
