### PR TITLE
making dispatch a method on Listeners

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -26,11 +26,6 @@ var api = (function createApi() {
     };
   }
 
-  function dispatch() {
-    var args = arguments;
-    this.forEach(function(f) {f.apply(null, args)});
-  }
-
   // Here's how tabs/pages work in this adapter. This is coming from someone with a strong distaste
   // for comments. It's a good idea to verify these statements to ensure they're still accurate.
   // - A page object is normally created when a page load is committed (all redirects resolved).
@@ -93,7 +88,7 @@ var api = (function createApi() {
 
   chrome.pageAction.onClicked.addListener(errors.wrap(function (tab) {
     log("[pageAction.onClicked]", tab);
-    dispatch.call(api.icon.on.click, pages[tab.id]);
+    api.icon.on.click.dispatch(pages[tab.id]);
   }));
 
   chrome.runtime.onStartup.addListener(errors.wrap(function () {
@@ -128,11 +123,11 @@ var api = (function createApi() {
       selectedTabIds[info.windowId] = info.tabId;
       var prevPage = pages[prevPageId];
       if (prevPage && httpRe.test(prevPage.url)) {
-        dispatch.call(api.tabs.on.blur, prevPage);
+        api.tabs.on.blur.dispatch(prevPage);
       }
       var page = pages[info.tabId];
       if (page && httpRe.test(page.url)) {
-        dispatch.call(api.tabs.on.focus, page);
+        api.tabs.on.focus.dispatch(page);
       }
     }
   }));
@@ -151,7 +146,7 @@ var api = (function createApi() {
         log('[onBeforeNavigate] non-UTF-8 search query:', match[1], e);  // e.g. www.google.co.il/search?hl=iw&q=%EE%E9%E4
       }
       if (query) {
-        dispatch.call(api.on.search, query, ~details.url.indexOf('sourceid=chrome') ? 'o' : 'n');
+        api.on.search.dispatch(query, ~details.url.indexOf('sourceid=chrome') ? 'o' : 'n');
       }
     }
   }));
@@ -173,7 +168,7 @@ var api = (function createApi() {
       }
       var page = createPage(tabId, e.url);
       if (normal && httpRe.test(page.url)) {
-        dispatch.call(api.tabs.on.loading, page);
+        api.tabs.on.loading.dispatch(page);
       }
     }
   }));
@@ -200,9 +195,9 @@ var api = (function createApi() {
     var page = pages[e.tabId];
     if (page && page.url !== e.url) {
       if (httpRe.test(page.url) && page.url.match(stripHashRe)[0] != e.url.match(stripHashRe)[0]) {
-        dispatch.call(api.tabs.on.unload, page, true);
+        api.tabs.on.unload.dispatch(page, true);
         page.url = e.url;
-        dispatch.call(api.tabs.on.loading, page);
+        api.tabs.on.loading.dispatch(page);
       } else {
         page.url = e.url;
       }
@@ -234,7 +229,7 @@ var api = (function createApi() {
         setPageAction(addedTabId, page.icon);
       }
       if (page && httpRe.test(page.url)) {
-        dispatch.call(api.tabs.on.loading, page);
+        api.tabs.on.loading.dispatch(page);
         injectContentScripts(page); // TODO: verify DOM ready first
       }
     }
@@ -253,7 +248,7 @@ var api = (function createApi() {
         delete pages[tabId];
       }
       if (normal && httpRe.test(page.url)) {
-        dispatch.call(api.tabs.on.unload, page);
+        api.tabs.on.unload.dispatch(page);
       }
       if (page._port) {
         log('#0a0', '[onRemoved] %i disconnecting', tabId);
@@ -282,7 +277,7 @@ var api = (function createApi() {
     if (focusedWinId > 0) {
       var page = pages[selectedTabIds[focusedWinId]];
       if (page && httpRe.test(page.url)) {
-        dispatch.call(api.tabs.on.blur, page);
+        api.tabs.on.blur.dispatch(page);
       }
     }
     focusedWinId = winId;
@@ -292,13 +287,13 @@ var api = (function createApi() {
       }
       var page = pages[selectedTabIds[winId]];
       if (page && httpRe.test(page.url)) {
-        dispatch.call(api.tabs.on.focus, page);
+        api.tabs.on.focus.dispatch(page);
       }
     }
   }));
 
   chrome.webRequest.onBeforeRequest.addListener(errors.wrap(function () {
-    dispatch.call(api.on.beforeSearch, 'o');
+    api.on.beforeSearch.dispatch('o');
   }), {
     tabId: -1,
     types: ['main_frame', 'other'],

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -2,11 +2,6 @@
 /*jshint globalstrict:true */
 'use strict';
 
-function dispatch() {
-  var args = arguments;
-  this.forEach(function(f) {f.apply(null, args)});
-}
-
 function merge(o1, o2) {
   for (let k in o2) {
     o1[k] = o2[k];
@@ -84,7 +79,7 @@ exports.icon = {
     }
   }};
 var onIconClick = errors.wrap(function onIconClick(win) {
-  dispatch.call(exports.icon.on.click, pages[win.tabs.activeTab.id]);
+  exports.icon.on.click.dispatch(pages[win.tabs.activeTab.id]);
 });
 
 var addon;
@@ -500,7 +495,7 @@ tabs
         page = createPage(tab);
       }
       if (tab.window === windows.activeWindow && httpRe.test(page.url)) {
-        dispatch.call(exports.tabs.on.focus, page);
+        exports.tabs.on.focus.dispatch(page);
       }
     }
   }
@@ -510,7 +505,7 @@ tabs
   if (tab.window === windows.activeWindow) {
     var page = pages[tab.id];
     if (page && httpRe.test(page.url)) {
-      dispatch.call(exports.tabs.on.blur, page);
+      exports.tabs.on.blur.dispatch(page);
     }
   }
 }))
@@ -537,7 +532,7 @@ windows
     log('[windows:activate]', e);
   }
   if (tabId && (page = pages[tabId]) && httpRe.test(page.url)) {
-    dispatch.call(exports.tabs.on.focus, page);
+    exports.tabs.on.focus.dispatch(page);
   }
 }))
 .on('deactivate', errors.wrap(function onWindowDeactivate(win) {
@@ -549,7 +544,7 @@ windows
     log('[windows:deactivate]', e);
   }
   if (tabId && (page = pages[tabId]) && httpRe.test(page.url)) {
-    dispatch.call(exports.tabs.on.blur, page);
+    exports.tabs.on.blur.dispatch(page);
   }
 }));
 
@@ -573,7 +568,9 @@ errors.wrap(function initTabsAndPages() {
 
 // before search
 
-require('./location').onFocus(errors.wrap(dispatch.bind(exports.on.beforeSearch)));
+require('./location').onFocus(errors.wrap(function (whence) {
+  exports.on.beforeSearch.dispatch(whence);
+}));
 
 // navigation handling
 
@@ -596,19 +593,19 @@ require('./location').onChange(errors.wrap(function onLocationChange(tabId, newP
       }
       if (query) {
         let channel = match[2];
-        dispatch.call(exports.on.search, query, channel === 'fflb' ? 'a' : channel === 'sb' ? 's' : 'n');
+        exports.on.search.dispatch(query, channel === 'fflb' ? 'a' : channel === 'sb' ? 's' : 'n');
       }
     }
     if (httpRe.test(page.url)) {
-      dispatch.call(exports.tabs.on.loading, page);
+      exports.tabs.on.loading.dispatch(page);
     }
   } else {
     let page = pages[tabId];
     if (page && page.url !== tab.url) {
       if (httpRe.test(page.url) && page.url.match(stripHashRe)[0] != tab.url.match(stripHashRe)[0]) {
-        dispatch.call(exports.tabs.on.unload, page, true);
+        exports.tabs.on.unload.dispatch(page, true);
         page.url = tab.url;
-        dispatch.call(exports.tabs.on.loading, page);
+        exports.tabs.on.loading.dispatch(page);
       } else {
         page.url = tab.url;
       }
@@ -637,7 +634,7 @@ function onPageHide(tabId) {
   if (page) {
     delete pages[tabId];
     if (httpRe.test(page.url)) {
-      dispatch.call(exports.tabs.on.unload, page);
+      exports.tabs.on.unload.dispatch(page);
     }
   }
 }

--- a/packrat/adapters/shared/listeners.js
+++ b/packrat/adapters/shared/listeners.js
@@ -1,12 +1,27 @@
-function Listeners() {}
-Listeners.prototype = [];
+function Listeners() {
+  this.arr = [];
+}
 Listeners.prototype.constructor = Listeners;
-Listeners.prototype.add = Listeners.prototype.push;
-Listeners.prototype.remove = function(f) {
-  'use strict';
-  for (var i; ~(i = this.indexOf(f));) {
-    this.splice(i, 1);
+Listeners.prototype.add = function(f) {
+  var i = this.arr.indexOf(f);
+  if (i < 0) {
+    this.arr.push(f);
   }
 };
+Listeners.prototype.remove = function(f) {
+  var i = this.arr.indexOf(f);
+  if (i >= 0) {
+    this.arr.splice(i, 1);
+  }
+};
+Object.defineProperty(Listeners.prototype, 'dispatch', {
+  value: function () {
+    for (var i = 0, n = this.arr.length; i < n; i++) {
+      this.arr[i].apply(null, arguments);
+    }
+  }
+});
 
-this.exports && (this.exports.Listeners = Listeners);
+if (this.exports) {
+  this.exports.Listeners = Listeners;
+}


### PR DESCRIPTION
I think the added clarity is worth the cost (exposing `.dispatch` to client code in main.js). Making the property final and non-enumerable is a small attempt to flag it as private.
