### PR TITLE
Feed digest updates

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/concurrent/PimpedFuture.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/concurrent/PimpedFuture.scala
@@ -88,5 +88,22 @@ object FutureHelpers {
     p.future
   }
 
+  private val identityFuture = (x: Any) => Future.successful(x)
+
+  // lazily transform an input Seq and filter by a supplied predicate
+  // useful when a transform op involves an expensive Future and you need to limit the # of futures
+  // that are spawned until you have enough
+  def findMatching[A, B](in: Seq[A], n: Int, predicate: B => Boolean, transform: A => Future[B] = identityFuture,
+    seed: Seq[B] = Seq.empty)(implicit ec: ScalaExecutionContext): Future[Seq[B]] = {
+    if (seed.length >= n) Future.successful(seed)
+    else in.headOption match {
+      case Some(head) =>
+        transform(head).flatMap { s =>
+          findMatching[A, B](in.tail, n, predicate, transform, if (predicate(s)) seed :+ s else seed)
+        }
+      case None => Future.successful(seed)
+    }
+  }
+
 }
 

--- a/kifi-backend/modules/common/app/views/email/black/footer.scala.html
+++ b/kifi-backend/modules/common/app/views/email/black/footer.scala.html
@@ -1,5 +1,5 @@
-@(unsubscribeUrl: String)
-@assetUrlBase = @{ "https://djty7jcqog9qu.cloudfront.net/assets/digest" }
+@(ctx: email.helpers.Context)
+@import email.helpers.{ black, iTunesAppStoreUrl }
 
 <table width="100%" border="0" cellspacing="0" cellpadding="0">
     <tr>
@@ -13,9 +13,13 @@
                                 <td class="aside">
                                     <table width="100%" border="0" cellspacing="0" cellpadding="0">
                                         <tr>
-                                            @{ /* TODO (josh) update link params */ }
-                                            <td align="left" class="center1" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#333333;line-height:22px;"><a href="https://www.kifi.com/?utm_source=headerLogo&amp;utm_medium=email&amp;utm_campaign=emailDigest" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Kifi.com</a> Your recomendations network<br />
-                                                Follow us on <a href="https://twitter.com/kifi?utm_source=footerTwitter&amp;utm_medium=email&amp;utm_campaign=emailDigest" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Twitter</a> &nbsp; <a href="https://www.facebook.com/kifi42?utm_source=footerFacebook&amp;utm_medium=email&amp;utm_campaign=emailDigest" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Facebook</a></td>
+                                            <td align="left" class="center1" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#333333;line-height:22px;">
+                                                <a href="@ctx.kifiLogoUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Kifi.com</a>
+                                                Your recommendations network<br/>Follow us on
+                                                <a href="@ctx.kifiTwitterUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Twitter</a>
+                                                &nbsp;
+                                                <a href="@ctx.kifiFacebookUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Facebook</a>
+                                            </td>
                                         </tr>
                                     </table>
                                 </td>
@@ -26,7 +30,7 @@
                                 <td class="top_space">
                                     <table width="105" border="0" cellspacing="0" cellpadding="0" align="center">
                                         <tr>
-                                            <td><a href="https://itunes.apple.com/us/app/kifi/id740232575" target="_blank"><img src="@assetUrlBase/app_store.png" alt="Available on the App Store" width="105" height="35" style="display:block;" border="0" /></a></td>
+                                            <td><a href="@iTunesAppStoreUrl" target="_blank"><img src="@black.assetUrl("app_store.png")" alt="Available on the App Store" width="105" height="35" style="display:block;" border="0" /></a></td>
                                         </tr>
                                     </table>
                                 </td>
@@ -42,15 +46,15 @@
                         <table width="100%" border="0" cellspacing="0" cellpadding="0">
                             <tr>
                                 <td align="left" class="center" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#333333;line-height:22px;">
-                                    Sent by kifi 883 N Shoreline Blvd, Mountain View, CA 94043, USA<br  />
+                                    Sent by Kifi 883 N Shoreline Blvd, Mountain View, CA 94043, USA<br/>
                                 </td>
                             </tr>
                             <tr>
                                 <td align="left" class="center1" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#333333;line-height:22px;">
-                                    <a href="https://www.kifi.com/privacy?utm_source=footerPrivacy&amp;utm_medium=email&amp;utm_campaign=emailDigest" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#85a4ea;line-height:22px;text-decoration:underline;">privacy policy</a>.
-                                    Click here <a href="@unsubscribeUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#85a4ea;line-height:22px;text-decoration:underline;">unsubscribe</a>
-                                    from update like this.<br class="br" />
-                                    &copy; 2014 FortyTwo, Inc, All rights reserved.
+                                    <a href="@ctx.privacyUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#85a4ea;line-height:22px;text-decoration:underline;">privacy policy</a>.
+                                    Click <a href="@ctx.unsubscribeUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#85a4ea;line-height:22px;text-decoration:underline;">here to unsubscribe</a>
+                                    from updates like this.<br class="br"/>
+                                    &copy; 2014 FortyTwo, Inc. All rights reserved.
                                 </td>
                             </tr>
                         </table>

--- a/kifi-backend/modules/common/app/views/email/black/headCss.scala.html
+++ b/kifi-backend/modules/common/app/views/email/black/headCss.scala.html
@@ -1,0 +1,282 @@
+@()
+<style type="text/css">
+body
+{
+margin-top: 0 !important;
+margin-bottom: 0 !important;
+padding-top: 0 !important;
+padding-bottom: 0 !important;
+width: 100% !important;
+-webkit-text-size-adjust: 100% !important;
+-ms-text-size-adjust: 100% !important;
+-webkit-font-smoothing: antialiased !important;
+}
+
+img
+{
+border: 0 !important;
+outline: none !important;
+display: block !important;
+}
+
+table
+{
+border-collapse: collapse;
+mso-table-lspace: 0px;
+mso-table-rspace: 0px;
+}
+
+td
+{
+border-collapse: collapse;
+mso-line-height-rule: exactly;
+}
+
+a, span
+{
+mso-line-height-rule: exactly;
+}
+
+.ExternalClass *
+{
+line-height: 100%;
+}
+
+.ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass a, .ExternalClass div
+{
+line-height: 100%;
+}
+
+.num a
+{
+color: #9a9a9a;
+text-decoration: none;
+}
+
+.num1 a
+{
+color: #000000;
+text-decoration: none;
+}
+
+.num2 a
+{
+color: #43a0f8;
+text-decoration: none;
+}
+
+.br2
+{
+display: none;
+}
+
+.center a
+{
+text-decoration: none;
+color: #333333;
+}
+
+.center1 a
+{
+text-decoration: underline;
+color: #85a4ea;
+}
+
+.white a
+{
+text-decoration: none;
+color: #fffff;
+}
+
+@@media only screen and (max-width:480px)
+{
+table[class=wrapper]
+{
+width: 100% !important;
+}
+
+table[class=main_table]
+{
+width: 320px !important;
+}
+
+td[class=center]
+{
+text-align: center !important;
+}
+
+img[class=banner]
+{
+width: 100% !important;
+height: auto !important;
+}
+
+td[class=banner]
+{
+width: 100% !important;
+height: auto !important;
+}
+
+td[class=center1]
+{
+text-align: center !important;
+}
+
+td[class=hide]
+{
+display: none !important;
+}
+
+img[class=hide]
+{
+display: none !important;
+}
+
+table[class=hide]
+{
+display: none !important;
+}
+
+td[class=text]
+{
+text-align: center !important;
+}
+
+td[class=top_space]
+{
+padding-top: 20px !important;
+}
+
+td[class=pad_top]
+{
+padding-top: 20px !important;
+}
+
+td[class=pad_bottom]
+{
+padding-bottom: 20px !important;
+}
+
+br[class=break]
+{
+display: none !important;
+}
+
+td[class=cen]
+{
+padding-left: 10px !important;
+padding-right: 10px !important;
+}
+
+br[class=br1]
+{
+display: none !important;
+}
+
+span[class=br2]
+{
+display: block !important;
+}
+
+span[class=hide]
+{
+display: none !important;
+}
+
+td[class=side1]
+{
+width: 15px !important;
+};
+}
+
+@@media only screen and (min-width:480px) and (max-width:599px)
+{
+table[class=wrapper]
+{
+width: 100% !important;
+}
+
+table[class=main_table]
+{
+width: 480px !important;
+}
+
+img[class=hide]
+{
+display: none !important;
+}
+
+img[class=banner]
+{
+width: 100% !important;
+height: auto !important;
+}
+
+td[class=banner]
+{
+width: 100% !important;
+height: auto !important;
+}
+
+td[class=center]
+{
+text-align: center !important;
+}
+
+td[class=center1]
+{
+text-align: center !important;
+}
+
+td[class=top_space]
+{
+padding-top: 20px !important;
+}
+
+td[class=side1]
+{
+width: 15px !important;
+}
+
+span[class=hide]
+{
+display: none !important;
+}
+
+td[class=hide]
+{
+display: none !important;
+}
+
+span[class=br2]
+{
+display: block !important;
+}
+
+table[class=hide]
+{
+display: none !important;
+}
+
+td[class=text]
+{
+text-align: center !important;
+}
+
+td[class=cen]
+{
+padding-left: 10px !important;
+padding-right: 10px !important;
+}
+
+br[class=br1]
+{
+display: none !important;
+}
+
+td[class=pad_bottom]
+{
+padding-bottom: 20px !important;
+};
+}
+</style>

--- a/kifi-backend/modules/common/app/views/email/black/header.scala.html
+++ b/kifi-backend/modules/common/app/views/email/black/header.scala.html
@@ -1,5 +1,5 @@
-@()
-@assetUrlBase = @{ "https://djty7jcqog9qu.cloudfront.net/assets/digest" }
+@(ctx: email.helpers.Context)
+@import email.helpers._
 
 <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center">
     <tr>
@@ -14,8 +14,8 @@
                         <table width="33" border="0" cellspacing="0" cellpadding="0" align="left">
                             <tr>
                                 <td align="left" width="33" height="19">
-                                    <a href="https://kifi.com/?utm_source=headerLogo&utm_medium=email&utm_campaign=emailDigest" target="_blank">
-                                        <img src="@assetUrlBase/kifi-logo.png" width="33" height="19"  style="display:block;" border="0"/>
+                                    <a href="@ctx.kifiLogoUrl" target="_blank">
+                                        <img src="@black.assetUrl("kifi-logo.png")" width="33" height="19"  style="display:block;" border="0"/>
                                     </a>
                                 </td>
                             </tr>

--- a/kifi-backend/modules/common/app/views/email/black/layout.scala.html
+++ b/kifi-backend/modules/common/app/views/email/black/layout.scala.html
@@ -1,307 +1,27 @@
-@(title: String = "Kifi", unsubscribeUrl: String)(content: Html)
-@assetUrlBase = @{ "https://djty7jcqog9qu.cloudfront.net/assets/digest" }
+@(ctx: email.helpers.Context)(content: Html)
+@import email.helpers.black
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>@title</title>
-<style type="text/css">
-body
-{
-margin-top: 0 !important;
-margin-bottom: 0 !important;
-padding-top: 0 !important;
-padding-bottom: 0 !important;
-width: 100% !important;
--webkit-text-size-adjust: 100% !important;
--ms-text-size-adjust: 100% !important;
--webkit-font-smoothing: antialiased !important;
-}
-
-img
-{
-border: 0 !important;
-outline: none !important;
-display: block !important;
-}
-
-table
-{
-border-collapse: collapse;
-mso-table-lspace: 0px;
-mso-table-rspace: 0px;
-}
-
-td
-{
-border-collapse: collapse;
-mso-line-height-rule: exactly;
-}
-
-a, span
-{
-mso-line-height-rule: exactly;
-}
-
-.ExternalClass *
-{
-line-height: 100%;
-}
-
-.ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass a, .ExternalClass div
-{
-line-height: 100%;
-}
-
-.num a
-{
-color: #9a9a9a;
-text-decoration: none;
-}
-
-.num1 a
-{
-color: #000000;
-text-decoration: none;
-}
-
-.num2 a
-{
-color: #43a0f8;
-text-decoration: none;
-}
-
-.br2
-{
-display: none;
-}
-
-.center a
-{
-text-decoration: none;
-color: #333333;
-}
-
-.center1 a
-{
-text-decoration: underline;
-color: #85a4ea;
-}
-
-.white a
-{
-text-decoration: none;
-color: #fffff;
-}
-
-@@media only screen and (max-width:480px)
-{
-table[class=wrapper]
-{
-width: 100% !important;
-}
-
-table[class=main_table]
-{
-width: 320px !important;
-}
-
-td[class=center]
-{
-text-align: center !important;
-}
-
-img[class=banner]
-{
-width: 100% !important;
-height: auto !important;
-}
-
-td[class=banner]
-{
-width: 100% !important;
-height: auto !important;
-}
-
-td[class=center1]
-{
-text-align: center !important;
-}
-
-td[class=hide]
-{
-display: none !important;
-}
-
-img[class=hide]
-{
-display: none !important;
-}
-
-table[class=hide]
-{
-display: none !important;
-}
-
-td[class=text]
-{
-text-align: center !important;
-}
-
-td[class=top_space]
-{
-padding-top: 20px !important;
-}
-
-td[class=pad_top]
-{
-padding-top: 20px !important;
-}
-
-td[class=pad_bottom]
-{
-padding-bottom: 20px !important;
-}
-
-br[class=break]
-{
-display: none !important;
-}
-
-td[class=cen]
-{
-padding-left: 10px !important;
-padding-right: 10px !important;
-}
-
-br[class=br1]
-{
-display: none !important;
-}
-
-span[class=br2]
-{
-display: block !important;
-}
-
-span[class=hide]
-{
-display: none !important;
-}
-
-td[class=side1]
-{
-width: 15px !important;
-};
-}
-
-@@media only screen and (min-width:480px) and (max-width:599px)
-{
-table[class=wrapper]
-{
-width: 100% !important;
-}
-
-table[class=main_table]
-{
-width: 480px !important;
-}
-
-img[class=hide]
-{
-display: none !important;
-}
-
-img[class=banner]
-{
-width: 100% !important;
-height: auto !important;
-}
-
-td[class=banner]
-{
-width: 100% !important;
-height: auto !important;
-}
-
-td[class=center]
-{
-text-align: center !important;
-}
-
-td[class=center1]
-{
-text-align: center !important;
-}
-
-td[class=top_space]
-{
-padding-top: 20px !important;
-}
-
-td[class=side1]
-{
-width: 15px !important;
-}
-
-span[class=hide]
-{
-display: none !important;
-}
-
-td[class=hide]
-{
-display: none !important;
-}
-
-span[class=br2]
-{
-display: block !important;
-}
-
-table[class=hide]
-{
-display: none !important;
-}
-
-td[class=text]
-{
-text-align: center !important;
-}
-
-td[class=cen]
-{
-padding-left: 10px !important;
-padding-right: 10px !important;
-}
-
-br[class=br1]
-{
-display: none !important;
-}
-
-td[class=pad_bottom]
-{
-padding-bottom: 20px !important;
-};
-}
-</style>
+<title>@ctx.title</title>
+@email.black.headCss()
 </head>
-<body marginwidth="0" marginheight="0"  style="margin-top: 0; margin-bottom: 0; padding-top: 0; padding-bottom: 0; width: 100% !important; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; -webkit-font-smoothing: antialiased;" offset="0" topmargin="0" leftmargin="0" bgcolor="#f3f3f3">
+<body marginwidth="0" marginheight="0" style="margin-top: 0; margin-bottom: 0; padding-top: 0; padding-bottom: 0; width: 100% !important; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; -webkit-font-smoothing: antialiased;" offset="0" topmargin="0" leftmargin="0" bgcolor="#f3f3f3">
 <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center" bgcolor="#f3f3f3">
 <tr>
     <td valign="top">
         <table width="625" border="0" cellspacing="0" cellpadding="0" align="center" class="main_table" bgcolor="#f3f3f3">
             <tr>
-                <td class="hide" bgcolor="#ffffff" height="1" style="line-height:0px;font-size:0px;"><img src="@assetUrlBase/spacer.gif" height="1"  width="625" style="display:block; width:625px; min-width:625px;" border="0" /></td>
+                <td class="hide" bgcolor="#ffffff" height="1" style="line-height:0px;font-size:0px;"><img src="@black.assetUrl("spacer.gif")" height="1"  width="625" style="display:block; width:625px; min-width:625px;" border="0" /></td>
             </tr>
             <tr>
                 <td height="30">&nbsp;</td>
             </tr>
             <tr>
                 <td bgcolor="#333333">
-                    @views.html.email.black.header()
+                    @email.black.header(ctx)
                 </td>
             </tr>
             <tr>
@@ -314,7 +34,7 @@ padding-bottom: 20px !important;
             </tr>
             <tr>
                 <td valign="top">
-                    @views.html.email.black.footer(unsubscribeUrl)
+                    @email.black.footer(ctx)
                 </td>
             </tr>
         </table>

--- a/kifi-backend/modules/common/app/views/html/email/helpers.scala
+++ b/kifi-backend/modules/common/app/views/html/email/helpers.scala
@@ -1,0 +1,25 @@
+package views.html.email
+
+object helpers {
+  val cdnBaseUrl = "https://djty7jcqog9qu.cloudfront.net"
+
+  case class Context(campaign: String, unsubscribeUrl: String, title: String = "Kifi") {
+    val privacyUrl = appendUrlUtmCodes("https://www.kifi.com/privacy?", campaign, "footerPrivacy")
+    val kifiTwitterUrl = appendUrlUtmCodes("https://twitter.com/kifi?", campaign, "footerTwitter")
+    val kifiFacebookUrl = appendUrlUtmCodes("https://www.facebook.com/kifi42?", campaign, "footerFacebook")
+    val kifiLogoUrl = appendUrlUtmCodes("https://www.kifi.com/?", campaign, "headerLogo")
+  }
+
+  val iTunesAppStoreUrl = "https://itunes.apple.com/us/app/kifi/id740232575"
+
+  // helpers for the black email theme
+  object black {
+    val assetBaseUrl = cdnBaseUrl + "/assets/black"
+
+    def assetUrl(path: String) = assetBaseUrl + '/' + path
+  }
+
+  // url param must end with a ? or &
+  private def appendUrlUtmCodes(url: String, campaign: String, source: String, medium: String = "email"): String =
+    s"${url}utm_source=${source}&utm_medium=${medium}&utm_campaign=${campaign}"
+}

--- a/kifi-backend/modules/common/test/com/keepit/common/concurrent/FutureHelpersTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/concurrent/FutureHelpersTest.scala
@@ -31,5 +31,21 @@ class FutureHelpersTest extends Specification with Logging {
     }
   }
 
+  "findMatching" should {
+    "return the first N futures that made an async predicate" in {
+      val in = Stream.from(0)
+
+      val predicate = (x: Float) => x % 2 == 0
+      val transform = (x: Int) => Future.successful {
+        if (x > 8) throw new RuntimeException
+        x + 0f
+      }
+
+      val retF = FutureHelpers.findMatching(in, 5, predicate, transform)
+      val ret = Await.result(retF, Duration(5, "seconds"))
+      ret === Seq(0f, 2f, 4f, 6f, 8f)
+    }
+  }
+
 }
 

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/email/FeedDigestEmailSender.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/email/FeedDigestEmailSender.scala
@@ -2,6 +2,7 @@ package com.keepit.curator.commanders.email
 
 import com.google.inject.{ ImplementedBy, Inject }
 import com.keepit.commanders.RemoteUserExperimentCommander
+import com.keepit.common.concurrent.FutureHelpers
 import com.keepit.common.db.slick.Database
 import com.keepit.common.db.{ Id, LargeString }
 import com.keepit.common.domain.DomainToNameMapper
@@ -15,12 +16,25 @@ import com.keepit.shoebox.ShoeboxServiceClient
 import com.keepit.social.BasicUser
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import com.keepit.common.time.{ currentDateTime, DEFAULT_DATE_TIME_ZONE }
+import views.html.email.helpers
+import helpers.Context
+import com.keepit.common.concurrent.PimpMyFuture._
 
 import concurrent.Future
 
 object DigestEmail {
   val READ_TIMES = (1 to 10) ++ Seq(15, 20, 30, 45, 60)
-  val RECOMMENDATION_COUNT = 5
+
+  // recommendations to actual email to the user
+  val RECOMMENDATIONS_TO_DELIVER = 3
+
+  // fetch additional recommendations in case some are filtered out
+  val RECOMMENDATIONS_TO_QUERY = 100
+
+  // exclude recommendations with an image less than this
+  val MIN_IMAGE_WIDTH_PX = 488
+
+  // max # of friend thumbnails to show for each recommendation
   val MAX_FRIENDS_TO_SHOW = 10
 }
 
@@ -103,27 +117,32 @@ class FeedDigestEmailSenderImpl @Inject() (
 
   def sendToUser(user: User): Future[DigestRecoMail] = {
     if (user.primaryEmail.isEmpty) {
-      log.info(s"NOT sending engagement feed email to ${user.id.get}; primaryEmail missing")
+      log.info(s"NOT sending digest email to ${user.id.get}; primaryEmail missing")
       return Future.successful(DigestRecoMail(userId = user.id.get, mailSent = false, Seq.empty))
     }
 
     val userId = user.id.get
     log.info(s"sending engagement feed email to $userId")
 
-    {
-      for {
-        recos <- getDigestRecommendationsForUser(userId)
-        unsubscribeUrl <- shoebox.getUnsubscribeUrlForEmail(user.primaryEmail.get)
-      } yield {
-        composeAndSendEmail(user, recos, unsubscribeUrl)
+    val digestRecoMailF = for {
+      recos <- getDigestRecommendationsForUser(userId)
+      unsubscribeUrl <- shoebox.getUnsubscribeUrlForEmail(user.primaryEmail.get)
+    } yield {
+      if (recos.size > 0) composeAndSendEmail(user, recos, unsubscribeUrl)
+      else {
+        log.info(s"NOT sending digest email to ${user.id.get}; 0 worthy recos")
+        Future.successful(DigestRecoMail(userId, false, Seq.empty))
       }
-    } flatMap (x => x)
+    }
+    digestRecoMailF.flatten
   }
 
-  private def composeAndSendEmail(user: User, digestRecos: Seq[DigestReco], unsubscribeUrl: String): Future[DigestRecoMail] = {
+  private def composeAndSendEmail(user: User, digestRecos: Seq[DigestReco], _unsubscribeUrl: String): Future[DigestRecoMail] = {
     val userId = user.id.get
     val emailData = AllDigestRecos(toUser = user, recos = digestRecos)
-    val htmlBody: LargeString = views.html.email.feedDigest(emailData, unsubscribeUrl).body
+    val ctx = Context(campaign = "emailDigest", unsubscribeUrl = _unsubscribeUrl)
+
+    val htmlBody: LargeString = views.html.email.feedDigest(emailData, ctx).body
 
     // TODO(josh) use the inlined template as soon as the base one is done/approved
     //val htmlBody: LargeString = views.html.email.feedDigestInlined(emailData).body
@@ -131,7 +150,7 @@ class FeedDigestEmailSenderImpl @Inject() (
 
     val email = ElectronicMail(
       category = NotificationCategory.User.DIGEST,
-      subject = "Your Recommended Links from friends on Kifi",
+      subject = s"Kifi Daily Digest: ${digestRecos.head.title}",
       htmlBody = htmlBody,
       textBody = textBody,
       to = Seq(user.primaryEmail.get),
@@ -152,51 +171,48 @@ class FeedDigestEmailSenderImpl @Inject() (
   }
 
   private def getDigestRecommendationsForUser(userId: Id[User]) = {
-    for {
-      recos <- getRecommendationsForUser(userId) if recos.size > 0
-      uriIds = recos.map(_.uriId)
-      summaries <- getRecommendationSummaries(uriIds)
-      uris <- shoebox.getNormalizedURIs(uriIds)
-      recosKeepers <- getRecoKeepers(recos)
-    } yield {
-      val uriMap = uris.map(uri => uri.id.get -> uri).toMap
-      recos.map { reco =>
-        val summary = summaries(reco.uriId)
-        val uri = uriMap(reco.uriId)
-        val recoKeepers = recosKeepers(reco.uriId)
-
-        // ensure a title exists
-        if (summary.title.exists(_.size > 0) || uri.title.exists(_.size > 0)) Some(DigestReco(reco, uri, summary, recoKeepers))
-        else None
-      }.flatten
+    getRecommendationsForUser(userId).flatMap { recos =>
+      FutureHelpers.findMatching(recos, RECOMMENDATIONS_TO_DELIVER, isEmailWorthy, getDigestReco)
     }
   }
 
-  private def getRecommendationsForUser(userId: Id[User]) = {
-    recommendationGenerationCommander.getTopRecommendationsNotPushed(userId, RECOMMENDATION_COUNT)
+  private def isEmailWorthy(reco: DigestReco) = {
+    val summary = reco.uriSummary
+    val uri = reco.uri
+
+    summary.imageWidth.isDefined && summary.imageUrl.isDefined && summary.imageWidth.get >= MIN_IMAGE_WIDTH_PX &&
+      summary.title.exists(_.size > 0) || uri.title.exists(_.size > 0)
   }
 
-  private def getRecommendationSummaries(uriIds: Seq[Id[NormalizedURI]]) = {
+  private def getDigestReco(reco: UriRecommendation) = {
+    val uriId = reco.uriId
+    for {
+      uri <- shoebox.getNormalizedURI(uriId)
+      summaries <- getRecommendationSummaries(uriId)
+      recoKeepers <- getRecoKeepers(reco)
+      if summaries.isDefinedAt(uriId)
+    } yield DigestReco(reco, uri, summaries(uriId), recoKeepers)
+  }
+
+  private def getRecommendationsForUser(userId: Id[User]) = {
+    recommendationGenerationCommander.getTopRecommendationsNotPushed(userId, RECOMMENDATIONS_TO_QUERY)
+  }
+
+  private def getRecommendationSummaries(uriIds: Id[NormalizedURI]*) = {
     shoebox.getUriSummaries(uriIds)
   }
 
-  private def getRecoKeepers(recos: Seq[UriRecommendation]) = {
-    Future.sequence[(Id[NormalizedURI], DigestRecoKeepers), Seq] {
-      recos.map { reco =>
-        reco.attribution.user.collect {
-          case userAttribution if userAttribution.friends.size > 0 =>
-            for {
-              users <- shoebox.getBasicUsers(userAttribution.friends.take(MAX_FRIENDS_TO_SHOW))
-              avatarUrls <- getManyUserImageUrls(users.keys.toSeq: _*)
-            } yield {
-              reco.uriId -> DigestRecoKeepers(friends = userAttribution.friends,
-                others = userAttribution.others, keepers = users, userAvatarUrls = avatarUrls)
-            }
-          case userAttribution =>
-            Future.successful(reco.uriId -> DigestRecoKeepers(others = userAttribution.others))
-        } getOrElse Future.successful(reco.uriId -> DigestRecoKeepers())
-      }
-    }.map(_.toMap)
+  private def getRecoKeepers(reco: UriRecommendation) = {
+    reco.attribution.user match {
+      case Some(userAttribution) if userAttribution.friends.size > 0 =>
+        for {
+          users <- shoebox.getBasicUsers(userAttribution.friends.take(MAX_FRIENDS_TO_SHOW))
+          avatarUrls <- getManyUserImageUrls(users.keys.toSeq: _*)
+        } yield DigestRecoKeepers(friends = userAttribution.friends, others = userAttribution.others,
+          keepers = users, userAvatarUrls = avatarUrls)
+      case Some(userAttribution) => Future.successful(DigestRecoKeepers(others = userAttribution.others))
+      case _ => Future.successful(DigestRecoKeepers())
+    }
   }
 
   private def getManyUserImageUrls(userIds: Id[User]*): Future[Map[Id[User], String]] = {

--- a/kifi-backend/modules/curator/app/views/email/feedDigest.scala.html
+++ b/kifi-backend/modules/curator/app/views/email/feedDigest.scala.html
@@ -1,6 +1,7 @@
-@(allRecos: com.keepit.curator.commanders.email.AllDigestRecos, unsubscribeUrl: String)
-@assetUrlBase = @{ "https://djty7jcqog9qu.cloudfront.net/assets/digest" }
-@views.html.email.black.layout("Kifi", unsubscribeUrl) {
+@(allRecos: com.keepit.curator.commanders.email.AllDigestRecos, ctx: email.helpers.Context)
+@import email.helpers.black.assetUrl
+
+@email.black.layout(ctx) {
 
 <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center">
 <tr>
@@ -68,7 +69,6 @@
                             <td height="17" style="font-size:1px; line-height:1px;">&nbsp;</td>
                         </tr>
 
-                        @reco.imageUrl.map { imageUrl =>
                         <tr>
                             <td>
                                 <table width="625" border="0" cellspacing="0" cellpadding="0" align="center" class="wrapper">
@@ -76,7 +76,7 @@
                                         <td width="72" class="side1">&nbsp;</td>
                                         <td align="center" valign="top" width="488">
                                             <a href="@reco.urls.viewPage" target="_blank">
-                                                <img src="@imageUrl" alt="@reco.title" style="display:block;max-width:488px;" border="0" class="banner" />
+                                                <img src="@reco.imageUrl" alt="@reco.title" style="display:block;max-width:488px;" border="0" class="banner" />
                                             </a>
                                         </td>
                                         <td width="65" class="side1">&nbsp;</td>
@@ -84,7 +84,6 @@
                                 </table>
                             </td>
                         </tr>
-                        }
 
                         <tr>
                             <td height="14" style="font-size:1px;line-height:1px;">&nbsp;</td>
@@ -197,7 +196,7 @@
                 <td align="center">
                     <table width="193" border="0" cellspacing="0" cellpadding="0" align="center">
                         <tr>
-                            <td><a href="https://www.kifi.com/kifeeeed" target="_blank"><img src="@assetUrlBase/viewfulllist_193x47.jpg" alt="View Full list" width="193" height="47"  style="display:block;" border="0" /></a></td>
+                            <td><a href="https://www.kifi.com/kifeeeed" target="_blank"><img src="@assetUrl("digest/viewfulllist.jpg")" alt="View Full list" width="193" height="47"  style="display:block;" border="0" /></a></td>
                         </tr>
                     </table>
                 </td>

--- a/kifi-backend/modules/curator/test/com/keepit/curator/CuratorTestHelpers.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/CuratorTestHelpers.scala
@@ -99,7 +99,7 @@ trait CuratorTestHelpers { this: CuratorTestInjector =>
 
   def makeKeepAttribution() = KeepAttribution(keeps = Seq.empty)
 
-  def makeCompleteUriRecommendation(uriId: Int, userId: Int, masterScore: Float, url: String, wc: Int = 250) = {
+  def makeCompleteUriRecommendation(uriId: Int, userId: Int, masterScore: Float, url: String, wc: Int = 250, summaryImageWidth: Option[Int] = Some(700)) = {
     val normalizedUri = makeNormalizedUri(uriId, url)
     val uriRecommendation = makeUriRecommendation(uriId, userId, masterScore)
     val uriSummary = URISummary(
@@ -110,7 +110,8 @@ trait CuratorTestHelpers { this: CuratorTestInjector =>
         "interdum neque eu vulputate. Nulla fermentum metus felis. In id velit dictum ligula iaculis pulvinar id sit " +
         "amet dolor. Proin eu augue id lectus viverra consectetur at sed orci. Suspendisse potenti."),
       wordCount = Some(wc),
-      imageUrl = Some("https://djty7jcqog9qu.cloudfront.net/screenshot/f5d6aedb-fea9-485f-aead-f2a8d1f31ac5/1000x560.jpg")
+      imageUrl = Some("https://djty7jcqog9qu.cloudfront.net/screenshot/f5d6aedb-fea9-485f-aead-f2a8d1f31ac5/1000x560.jpg"),
+      imageWidth = summaryImageWidth
     )
 
     (normalizedUri, uriRecommendation, uriSummary)


### PR DESCRIPTION
filter digest recos further; lazy load uri summary and attribution details individually instead of loading them in batch

refactor view and introduction of a Context object to encapsulate common dynamic email values ( @2is10 I know you don't like that name and I understand with your reasoning :) may rename in next commit )
