### PR TITLE
using URIs

### DIFF
--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeWorker.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeWorker.scala
@@ -296,7 +296,7 @@ class ScrapeWorkerImpl @Inject() (
   }
 
   private def fetch(normalizedUri: NormalizedURI, httpFetcher: HttpFetcher, info: ScrapeInfo, proxyOpt: Option[HttpProxy]): Future[ScraperResult] = {
-    val url = normalizedUri.url
+    val url = URI.parse(normalizedUri.url).get
     val extractor = extractorFactory(url)
     log.debug(s"[fetchArticle] url=${normalizedUri.url} ${extractor.getClass}")
     val ifModifiedSince = getIfModifiedSince(normalizedUri, info)
@@ -386,7 +386,7 @@ class ScrapeWorkerImpl @Inject() (
     lazy val isFishy = syncHelper.syncGetLatestKeep(movedUri.url).filter(_.createdAt.isAfter(currentDateTime.minusHours(1))) match {
       case Some(recentKeep) if recentKeep.source != KeepSource.bookmarkImport => true
       case Some(importedBookmark) =>
-        val parsedBookmarkUrl = URI.parse(importedBookmark.url).get.toString()
+        val parsedBookmarkUrl = URI.parse(importedBookmark.url).get
         (parsedBookmarkUrl != movedUri.url) && (httpFetcher.fetch(parsedBookmarkUrl)(httpFetcher.NO_OP).statusCode != HttpStatus.SC_MOVED_PERMANENTLY)
       case None => false
     }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ShoeboxDbCallbacks.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ShoeboxDbCallbacks.scala
@@ -87,7 +87,7 @@ class ShoeboxDbCallbackHelper @Inject() (
   def getLatestKeep(url: String): Future[Option[Keep]] = shoeboxScraperClient.getLatestKeep(url)
   def saveBookmark(bookmark: Keep): Future[Keep] = shoeboxScraperClient.saveBookmark(bookmark)
   def recordPermanentRedirect(uri: NormalizedURI, redirect: HttpRedirect): Future[NormalizedURI] = shoeboxScraperClient.recordPermanentRedirect(uri, redirect)
-  def isUnscrapableP(url: String, destinationUrl: Option[String]) = shoeboxScraperClient.isUnscrapableP(url, destinationUrl)
+  def isUnscrapableP(url: URI, destinationUrl: Option[String]) = shoeboxScraperClient.isUnscrapableP(url.toString(), destinationUrl)
   def recordScrapedNormalization(uriId: Id[NormalizedURI], uriSignature: Signature, candidateUrl: String, candidateNormalization: Normalization, alternateUrls: Set[String]): Future[Unit] = {
     shoeboxScraperClient.recordScrapedNormalization(uriId, uriSignature, candidateUrl, candidateNormalization, alternateUrls)
   }
@@ -98,7 +98,7 @@ class ShoeboxDbCallbackHelper @Inject() (
 
 trait SyncShoeboxDbCallbacks {
   def syncAssignTasks(zkId: Long, max: Int): Seq[ScrapeRequest]
-  def syncIsUnscrapableP(url: String, destinationUrl: Option[String]): Boolean
+  def syncIsUnscrapableP(url: URI, destinationUrl: Option[String]): Boolean
   def syncGetNormalizedUri(uri: NormalizedURI): Option[NormalizedURI]
   def syncSaveNormalizedUri(uri: NormalizedURI): NormalizedURI
   def syncUpdateNormalizedURIState(uriId: Id[NormalizedURI], state: State[NormalizedURI]): Unit

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ShoeboxDbCallbacks.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ShoeboxDbCallbacks.scala
@@ -1,6 +1,7 @@
 package com.keepit.scraper
 
 import com.google.inject.{ Inject, Singleton }
+import com.keepit.common.net.URI
 import com.keepit.shoebox.{ ShoeboxScraperClient, ShoeboxServiceClient }
 import scala.concurrent.{ Future, Await, Awaitable }
 import com.keepit.model._
@@ -26,7 +27,7 @@ class ShoeboxDbCallbackHelper @Inject() (
   private def await[T](awaitable: Awaitable[T]) = Await.result(awaitable, config.syncAwaitTimeout seconds)
 
   def syncAssignTasks(zkId: Long, max: Int): Seq[ScrapeRequest] = await(assignTasks(zkId, max))
-  def syncIsUnscrapableP(url: String, destinationUrl: Option[String]) = await(isUnscrapableP(url, destinationUrl))
+  def syncIsUnscrapableP(url: URI, destinationUrl: Option[String]) = await(isUnscrapableP(url, destinationUrl))
   def syncGetNormalizedUri(uri: NormalizedURI): Option[NormalizedURI] = await(getNormalizedUri(uri))
   def syncSaveNormalizedUri(uri: NormalizedURI): NormalizedURI = {
     try {
@@ -124,6 +125,6 @@ trait ShoeboxDbCallbacks {
   def getLatestKeep(url: String): Future[Option[Keep]]
   def saveBookmark(bookmark: Keep): Future[Keep]
   def recordPermanentRedirect(uri: NormalizedURI, redirect: HttpRedirect): Future[NormalizedURI]
-  def isUnscrapableP(url: String, destinationUrl: Option[String]): Future[Boolean]
+  def isUnscrapableP(url: URI, destinationUrl: Option[String]): Future[Boolean]
   def recordScrapedNormalization(uriId: Id[NormalizedURI], uriSignature: Signature, candidateUrl: String, candidateNormalization: Normalization, alternateUrls: Set[String]): Future[Unit]
 }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/DefaultExtractor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/DefaultExtractor.scala
@@ -16,9 +16,8 @@ import scala.collection.mutable
 
 object DefaultExtractorProvider extends ExtractorProvider {
   def isDefinedAt(uri: URI) = true
-  def apply(uri: URI) = apply(uri.toString)
-  def apply(url: String) = new DefaultExtractor(url, ScraperConfig.maxContentChars, htmlMapper)
-  def apply(uri: URI, maxContentChars: Int) = new DefaultExtractor(uri.toString, maxContentChars, htmlMapper)
+  def apply(uri: URI) = new DefaultExtractor(uri, ScraperConfig.maxContentChars, htmlMapper)
+  def apply(uri: URI, maxContentChars: Int) = new DefaultExtractor(uri, maxContentChars, htmlMapper)
 
   val htmlMapper = Some(new DefaultHtmlMapper {
     override def mapSafeElement(name: String) = {
@@ -35,7 +34,7 @@ object DefaultExtractor {
   val spaceRegex = """\s+""".r
 }
 
-class DefaultExtractor(url: String, maxContentChars: Int, htmlMapper: Option[HtmlMapper]) extends TikaBasedExtractor(url, maxContentChars, htmlMapper) {
+class DefaultExtractor(url: URI, maxContentChars: Int, htmlMapper: Option[HtmlMapper]) extends TikaBasedExtractor(url, maxContentChars, htmlMapper) {
   private[this] val handler: DefaultContentHandler = new DefaultContentHandler(maxContentChars, output, metadata, url)
 
   protected def getContentHandler: ContentHandler = handler
@@ -79,7 +78,7 @@ class DefaultExtractor(url: String, maxContentChars: Int, htmlMapper: Option[Htm
   }
 }
 
-class DefaultContentHandler(maxContentChars: Int, handler: ContentHandler, metadata: Metadata, uri: String) extends ContentHandlerDecorator(handler) with Logging {
+class DefaultContentHandler(maxContentChars: Int, handler: ContentHandler, metadata: Metadata, uri: URI) extends ContentHandlerDecorator(handler) with Logging {
 
   var charsCount = 0
   var maxContentCharsLimitReached = false

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/Extractor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/Extractor.scala
@@ -57,6 +57,6 @@ trait Extractor {
     )
 }
 
-trait ExtractorFactory extends Function[String, Extractor]
+trait ExtractorFactory extends Function[URI, Extractor]
 
 abstract class ExtractorProvider extends PartialFunction[URI, Extractor]

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/ExtractorFactoryImpl.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/ExtractorFactoryImpl.scala
@@ -19,21 +19,15 @@ class ExtractorFactoryImpl @Inject() (
     linkProcessingExtractorProvider
   )
 
-  def apply(url: String): Extractor = {
+  def apply(uri: URI): Extractor = {
     try {
-      URI.parse(url) match {
-        case Success(uri) =>
-          all.find(_.isDefinedAt(uri)).map { f =>
-            f.apply(uri)
-          }.getOrElse(throw new Exception("failed to find an extractor factory"))
-        case Failure(_) =>
-          log.warn(s"uri parsing failed: [$url]")
-          DefaultExtractorProvider(url)
-      }
+      all.find(_.isDefinedAt(uri)).map { f =>
+        f.apply(uri)
+      }.getOrElse(throw new Exception("failed to find an extractor factory"))
     } catch {
       case e: Throwable =>
-        log.warn(s"uri parsing failed: [$url][$e]")
-        DefaultExtractorProvider(url)
+        log.warn(s"uri parsing failed: [$uri][$e]")
+        DefaultExtractorProvider(uri)
     }
   }
 }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/GithubExtractor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/GithubExtractor.scala
@@ -17,14 +17,15 @@ object GithubExtractorProvider extends ExtractorProvider {
       case _ => false
     }
   }
-  def apply(uri: URI) = new GithubExtractor(uri.toString, ScraperConfig.maxContentChars)
+  def apply(uri: URI) = new GithubExtractor(uri, ScraperConfig.maxContentChars)
 }
 
-class GithubExtractor(url: String, maxContentChars: Int) extends JsoupBasedExtractor(url, maxContentChars) with Logging {
+class GithubExtractor(uri: URI, maxContentChars: Int) extends JsoupBasedExtractor(uri, maxContentChars) with Logging {
 
   override def getCanonicalUrl(): Option[String] = None //we don't trust github's canonical urls
 
   def parse(doc: Document) = {
+    val url = uri.toString()
     // Determine which kind of page we're on
     val selectors =
       if (url.matches(".*/issues/.*")) {

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/JsoupBasedExtractor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/JsoupBasedExtractor.scala
@@ -1,5 +1,7 @@
 package com.keepit.scraper.extractor
 
+import com.keepit.common.net.URI
+
 import scala.collection.JavaConversions._
 
 import com.keepit.common.logging.Logging
@@ -9,14 +11,14 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import java.util.regex.Pattern
 
-abstract class JsoupBasedExtractor(url: String, maxContentChars: Int) extends Extractor with Logging {
+abstract class JsoupBasedExtractor(url: URI, maxContentChars: Int) extends Extractor with Logging {
   protected var doc: Document = null
 
   def parse(doc: Document): String
 
   def process(input: HttpInputStream) {
     try {
-      doc = Jsoup.parse(input, null, url) // null charset autodetects based on `http-equiv` meta tag and default to UTF-8, Parser defaults to HTML
+      doc = Jsoup.parse(input, null, url.toString()) // null charset autodetects based on `http-equiv` meta tag and default to UTF-8, Parser defaults to HTML
     } catch {
       case e: Throwable => log.error("Jsoup extraction failed: ", e)
     }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/LinkProcessingExtractor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/LinkProcessingExtractor.scala
@@ -1,7 +1,7 @@
 package com.keepit.scraper.extractor
 
 import com.google.inject.{ Inject, Singleton }
-import com.keepit.common.net.URI
+import com.keepit.common.net.{ URIParser, URI }
 import com.keepit.model.HttpProxy
 import com.keepit.scraper.ScraperConfig
 import com.keepit.scraper.fetcher.HttpFetcher
@@ -39,7 +39,7 @@ class LinkProcessingExtractor(
         log.info(s"Scraping additional content from link ${linkUrl} for url ${url}")
         val extractor = new DefaultExtractor(linkUrl, maxContentChars, htmlMapper)
         val proxy = syncGetProxyP(url)
-        httpFetcher.fetch(linkUrl, proxy = proxy)(extractor.process)
+        httpFetcher.fetch(URI.parse(linkUrl).get, proxy = proxy)(extractor.process)
         val content = extractor.getContent
         val keywords = extractor.getKeywords
         log.info(s"Scraped additional content from link ${linkUrl} for url ${url}: time-lapsed:${System.currentTimeMillis - ts} content.len=${content.length} keywords=$keywords")

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/LinkedInExtractor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/LinkedInExtractor.scala
@@ -8,10 +8,10 @@ import com.keepit.common.net.URI
 
 object LinkedInExtractorProvider extends ExtractorProvider {
   def isDefinedAt(uri: URI) = false //LinkedInNormalizer.linkedInCanonicalPublicProfile.findFirstIn(uri.toString).isDefined // TODO
-  def apply(uri: URI) = new LinkedInExtractor(uri.toString, ScraperConfig.maxContentChars)
+  def apply(uri: URI) = new LinkedInExtractor(uri, ScraperConfig.maxContentChars)
 }
 
-class LinkedInExtractor(publicProfileUrl: String, maxContentChars: Int) extends JsoupBasedExtractor(publicProfileUrl, maxContentChars) with Logging {
+class LinkedInExtractor(publicProfileUrl: URI, maxContentChars: Int) extends JsoupBasedExtractor(publicProfileUrl, maxContentChars) with Logging {
   val idExtractor = new LinkedInIdExtractor(publicProfileUrl, maxContentChars)
 
   def parse(doc: Document) = {
@@ -24,7 +24,7 @@ class LinkedInExtractor(publicProfileUrl: String, maxContentChars: Int) extends 
   }
 }
 
-class LinkedInIdExtractor(publicProfileUrl: String, maxContentChars: Int) extends JsoupBasedExtractor(publicProfileUrl, maxContentChars) with Logging {
+class LinkedInIdExtractor(publicProfileUrl: URI, maxContentChars: Int) extends JsoupBasedExtractor(publicProfileUrl, maxContentChars) with Logging {
 
   def parse(doc: Document): String = {
     val idPattern = """newTrkInfo = '([0-9]{1,20}),' \+ document.referrer.substr\(0\,128\)""".r

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/SimpleJsoupBasedExtractor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/SimpleJsoupBasedExtractor.scala
@@ -1,13 +1,15 @@
 package com.keepit.scraper.extractor
 
+import java.util.concurrent.atomic.AtomicLong
+
+import com.google.inject.{ Inject, Singleton }
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
-import com.keepit.common.net.{ Host, URI }
+import com.keepit.common.net.URI
 import com.keepit.scraper.ScraperConfig
 import org.jsoup.nodes.Document
-import com.google.inject.{ Inject, Singleton }
+
 import scala.util.matching.Regex
-import java.util.concurrent.atomic.AtomicLong
 
 @Singleton
 class SimpleJsoupBasedExtractorProvider @Inject() (airbrake: AirbrakeNotifier) extends ExtractorProvider with Logging {
@@ -46,13 +48,13 @@ class SimpleJsoupBasedExtractorProvider @Inject() (airbrake: AirbrakeNotifier) e
 
   def apply(uri: URI) = {
     findRule(uri) match {
-      case Some(rule) => new SimpleJsoupBasedExtractor(uri.toString(), ScraperConfig.maxContentChars, rule.selectors, this)
+      case Some(rule) => new SimpleJsoupBasedExtractor(uri, ScraperConfig.maxContentChars, rule.selectors, this)
       case None => throw new IllegalArgumentException(s"no matching uri=${uri.toString}")
     }
   }
 }
 
-class SimpleJsoupBasedExtractor(url: String, maxContentChars: Int, selectors: Seq[(String, Boolean)], provider: SimpleJsoupBasedExtractorProvider) extends JsoupBasedExtractor(url, maxContentChars) with Logging {
+class SimpleJsoupBasedExtractor(url: URI, maxContentChars: Int, selectors: Seq[(String, Boolean)], provider: SimpleJsoupBasedExtractorProvider) extends JsoupBasedExtractor(url, maxContentChars) with Logging {
   def parse(doc: Document): String = {
     val content = selectors.map {
       case (selector, required) =>

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/TikaBasedExtractor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/TikaBasedExtractor.scala
@@ -1,6 +1,7 @@
 package com.keepit.scraper.extractor
 
 import com.keepit.common.logging.Logging
+import com.keepit.common.net.URI
 import com.keepit.scraper.HttpInputStream
 import org.apache.tika.detect.DefaultDetector
 import org.apache.tika.metadata.Metadata
@@ -15,7 +16,7 @@ import org.xml.sax.ContentHandler
 import play.api.http.MimeTypes
 import org.apache.tika.io.{ TikaInputStream, TemporaryResources }
 
-abstract class TikaBasedExtractor(url: String, maxContentChars: Int, htmlMapper: Option[HtmlMapper]) extends Extractor with Logging {
+abstract class TikaBasedExtractor(url: URI, maxContentChars: Int, htmlMapper: Option[HtmlMapper]) extends Extractor with Logging {
 
   protected val output = new WriteOutContentHandler(maxContentChars)
 

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/URITokenizer.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/URITokenizer.scala
@@ -7,13 +7,9 @@ object URITokenizer {
 
   private[this] val specialCharRegex = """[/\.:#&+~_-]+""".r
 
-  def getTokens(uriString: String): Seq[String] = {
-    URI.parse(uriString) match {
-      case Success(uri) =>
-        uri.path match {
-          case Some(path) => specialCharRegex.split(path).filter { _.length > 0 }
-          case _ => Seq()
-        }
+  def getTokens(uri: URI): Seq[String] = {
+    uri.path match {
+      case Some(path) => specialCharRegex.split(path).filter { _.length > 0 }
       case _ => Seq()
     }
   }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/fetcher/HttpFetcher.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/fetcher/HttpFetcher.scala
@@ -1,5 +1,6 @@
 package com.keepit.scraper.fetcher
 
+import com.keepit.common.net.URI
 import com.keepit.model.HttpProxy
 import com.keepit.scraper.{ HttpFetchStatus, HttpInputStream }
 import org.joda.time.DateTime
@@ -9,7 +10,7 @@ import scala.concurrent.Future
 trait HttpFetcher {
   val NO_OP = { is: HttpInputStream => }
   // deprecated
-  def fetch(url: String, ifModifiedSince: Option[DateTime] = None, proxy: Option[HttpProxy] = None)(f: HttpInputStream => Unit): HttpFetchStatus
-  def get(url: String, ifModifiedSince: Option[DateTime] = None, proxy: Option[HttpProxy] = None)(f: HttpInputStream => Unit): Future[HttpFetchStatus]
+  def fetch(url: URI, ifModifiedSince: Option[DateTime] = None, proxy: Option[HttpProxy] = None)(f: HttpInputStream => Unit): HttpFetchStatus
+  def get(url: URI, ifModifiedSince: Option[DateTime] = None, proxy: Option[HttpProxy] = None)(f: HttpInputStream => Unit): Future[HttpFetchStatus]
 }
 

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/fetcher/apache/ApacheHttpFetcher.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/fetcher/apache/ApacheHttpFetcher.scala
@@ -331,7 +331,7 @@ class ApacheHttpFetcher(val airbrake: AirbrakeNotifier, userAgent: String, conne
     }
   }
 
-  def get(url: String, ifModifiedSince: Option[DateTime], proxy: Option[HttpProxy])(f: (HttpInputStream) => Unit): Future[HttpFetchStatus] = SafeFuture {
+  def get(url: URI, ifModifiedSince: Option[DateTime], proxy: Option[HttpProxy])(f: (HttpInputStream) => Unit): Future[HttpFetchStatus] = SafeFuture {
     fetch(url, ifModifiedSince, proxy)(f)
   }(ExecutionContext.fj)
 }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/fetcher/apache/ApacheHttpFetcher.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/fetcher/apache/ApacheHttpFetcher.scala
@@ -219,8 +219,9 @@ class ApacheHttpFetcher(val airbrake: AirbrakeNotifier, userAgent: String, conne
       HttpFetchHandlerResult(responseOpt, fetchInfo, httpGet, httpContext)
   }
 
-  private def fetchHandler(url: String, ifModifiedSince: Option[DateTime] = None, proxy: Option[HttpProxy] = None, disableGzip: Boolean = false): HttpFetchHandlerResult = {
-    if (URI.parse(url).get.host.isEmpty) throw new IllegalArgumentException(s"url $url has no host!")
+  private def fetchHandler(uri: URI, ifModifiedSince: Option[DateTime] = None, proxy: Option[HttpProxy] = None, disableGzip: Boolean = false): HttpFetchHandlerResult = {
+    if (uri.host.isEmpty) throw new IllegalArgumentException(s"url $uri has no host!")
+    val url = uri.toString()
     implicit val httpGet = new HttpGet(url)
     implicit val httpContext = new BasicHttpContext()
 
@@ -253,7 +254,7 @@ class ApacheHttpFetcher(val airbrake: AirbrakeNotifier, userAgent: String, conne
       Some(response)
     } catch {
       case e: ZipException => if (disableGzip) logAndSet(fetchInfo, None)(e, "fetch", url, true)
-      else fetchHandler(url, ifModifiedSince, proxy, true) // Retry with gzip compression disabled
+      else fetchHandler(uri, ifModifiedSince, proxy, true) // Retry with gzip compression disabled
       case e: ConnectException => logAndSet(fetchInfo, None)(e, "fetch", url)
       case e: ValidatorException => logAndSet(fetchInfo, None)(e, "fetch", url)
       case e: CertPathBuilderException => logAndSet(fetchInfo, None)(e, "fetch", url)
@@ -271,7 +272,7 @@ class ApacheHttpFetcher(val airbrake: AirbrakeNotifier, userAgent: String, conne
       case t: Throwable => logAndSet(fetchInfo, None)(t, "fetch", url, true)
     }
   }
-  def fetch(url: String, ifModifiedSince: Option[DateTime] = None, proxy: Option[HttpProxy] = None)(f: HttpInputStream => Unit): HttpFetchStatus = timing(s"HttpFetcher.fetch($url) ${proxy.map { p => s" via ${p.alias}" }.getOrElse("")}") {
+  def fetch(url: URI, ifModifiedSince: Option[DateTime] = None, proxy: Option[HttpProxy] = None)(f: HttpInputStream => Unit): HttpFetchStatus = timing(s"HttpFetcher.fetch($url) ${proxy.map { p => s" via ${p.alias}" }.getOrElse("")}") {
     val HttpFetchHandlerResult(responseOpt, fetchInfo, httpGet, httpContext) = fetchHandler(url, ifModifiedSince, proxy)
     responseOpt match {
       case None =>

--- a/kifi-backend/modules/scraper/test/com/keepit/scraper/extractor/URITokenizerTest.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/scraper/extractor/URITokenizerTest.scala
@@ -1,15 +1,16 @@
 package com.keepit.scraper.extractor
 
+import com.keepit.common.net.URI
 import org.specs2.mutable._
 
 class URITokenizerTest extends Specification {
   "URITokenizerTest" should {
     "extract keywords from URI" in {
       // extracts keywords from th epath part only for now
-      URITokenizer.getTokens("http://kifi.com/documents/User_Guide.pdf") === Seq("documents", "User", "Guide", "pdf")
-      URITokenizer.getTokens("http://kifi.com/documents/User_Guide") === Seq("documents", "User", "Guide")
-      URITokenizer.getTokens("http://kifi.com/documents/User_Guide/") === Seq("documents", "User", "Guide")
-      URITokenizer.getTokens("http://code.google.com/p/language-detection/") === Seq("p", "language", "detection")
+      URITokenizer.getTokens(URI.parse("http://kifi.com/documents/User_Guide.pdf").get) === Seq("documents", "User", "Guide", "pdf")
+      URITokenizer.getTokens(URI.parse("http://kifi.com/documents/User_Guide").get) === Seq("documents", "User", "Guide")
+      URITokenizer.getTokens(URI.parse("http://kifi.com/documents/User_Guide/").get) === Seq("documents", "User", "Guide")
+      URITokenizer.getTokens(URI.parse("http://code.google.com/p/language-detection/").get) === Seq("p", "language", "detection")
     }
   }
 }

--- a/kifi-backend/modules/scraper/test/com/keepit/scraper/fetcher/FakeHttpFetcher.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/scraper/fetcher/FakeHttpFetcher.scala
@@ -1,6 +1,7 @@
 package com.keepit.scraper.fetcher
 
 import com.keepit.common.akka.SafeFuture
+import com.keepit.common.net.URI
 import com.keepit.model.HttpProxy
 import com.keepit.scraper.{ HttpRedirect, FetcherHttpContext, HttpFetchStatus, HttpInputStream }
 import org.joda.time.DateTime
@@ -9,7 +10,8 @@ import play.api.http.Status
 import scala.concurrent.Future
 
 class FakeHttpFetcher(urlToResponse: Option[PartialFunction[String, HttpFetchStatus]] = None) extends HttpFetcher {
-  def fetch(url: String, ifModifiedSince: Option[DateTime], proxy: Option[HttpProxy])(f: (HttpInputStream) => Unit): HttpFetchStatus = {
+  def fetch(uri: URI, ifModifiedSince: Option[DateTime], proxy: Option[HttpProxy])(f: (HttpInputStream) => Unit): HttpFetchStatus = {
+    val url = uri.toString()
     if (urlToResponse.exists(_.isDefinedAt(url))) {
       urlToResponse.get(url)
     } else HttpFetchStatus(Status.OK, None, new FetcherHttpContext {
@@ -19,7 +21,7 @@ class FakeHttpFetcher(urlToResponse: Option[PartialFunction[String, HttpFetchSta
   }
 
   implicit val fj = com.keepit.common.concurrent.ExecutionContext.fj
-  def get(url: String, ifModifiedSince: Option[DateTime], proxy: Option[HttpProxy])(f: (HttpInputStream) => Unit): Future[HttpFetchStatus] = SafeFuture {
+  def get(url: URI, ifModifiedSince: Option[DateTime], proxy: Option[HttpProxy])(f: (HttpInputStream) => Unit): Future[HttpFetchStatus] = SafeFuture {
     fetch(url, ifModifiedSince, proxy)(f)
   }
 }


### PR DESCRIPTION
There are many exceptions in the code that comes from bad url format. Since we use futures in may cases its very hard to trace the source of the bad urls.
This commit adds more usage of URI which is processed by our parser and is properly escaped. By using it early on, before passing it to the http client, we can trace sources of miss-formatted URLs earlier and can deal with them at the source.
@raymondng @ymatsuda @2is10 
