### PR TITLE
All existing libraries do not have this field. Needs to be optional.

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -26,7 +26,7 @@ case class Library(
     state: State[Library] = LibraryStates.ACTIVE,
     seq: SequenceNumber[Library] = SequenceNumber.ZERO,
     kind: LibraryKind = LibraryKind.USER_CREATED,
-    universalLink: Option[String] = None,
+    universalLink: Option[String] = Some(RandomStringUtils.randomAlphanumeric(40)),
     memberCount: Int) extends ModelWithPublicId[Library] with ModelWithState[Library] with ModelWithSeqNumber[Library] {
 
   def withId(id: Id[Library]) = this.copy(id = Some(id))

--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -26,7 +26,7 @@ case class Library(
     state: State[Library] = LibraryStates.ACTIVE,
     seq: SequenceNumber[Library] = SequenceNumber.ZERO,
     kind: LibraryKind = LibraryKind.USER_CREATED,
-    universalLink: String = RandomStringUtils.randomAlphanumeric(40),
+    universalLink: Option[String] = None,
     memberCount: Int) extends ModelWithPublicId[Library] with ModelWithState[Library] with ModelWithSeqNumber[Library] {
 
   def withId(id: Id[Library]) = this.copy(id = Some(id))
@@ -51,7 +51,7 @@ object Library extends ModelWithPublicIdCompanion[Library] {
     (__ \ 'state).format(State.format[Library]) and
     (__ \ 'seq).format(SequenceNumber.format[Library]) and
     (__ \ 'kind).format[LibraryKind] and
-    (__ \ 'universalLink).format[String] and
+    (__ \ 'universalLink).formatNullable[String] and
     (__ \ 'memberCount).format[Int]
   )(Library.apply, unlift(Library.unapply))
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -40,7 +40,7 @@ class LibraryRepoImpl @Inject() (
     def description = column[Option[String]]("description", O.Nullable)
     def slug = column[LibrarySlug]("slug", O.NotNull)
     def kind = column[LibraryKind]("kind", O.NotNull)
-    def universalLink = column[String]("universal_link", O.Nullable)
+    def universalLink = column[Option[String]]("universal_link", O.Nullable)
     def memberCount = column[Int]("member_count", O.NotNull)
 
     def * = (id.?, createdAt, updatedAt, name, ownerId, visibility, description, slug, state, seq, kind, universalLink, memberCount) <> ((Library.apply _).tupled, Library.unapply)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -356,7 +356,7 @@ class LibraryCommanderTest extends Specification with ShoeboxTestInjector {
         libraryCommander.userAccess(userCaptain.id.get, libShwarmas.id.get, None) === Some(LibraryAccess.READ_ONLY) // test no membership (public library)
 
         libraryCommander.userAccess(userCaptain.id.get, libScience.id.get, None) === None // test  library (no membership)
-        libraryCommander.userAccess(userCaptain.id.get, libScience.id.get, Some(libScience.universalLink)) === Some(LibraryAccess.READ_ONLY) // test  library (no membership) but with universalLink
+        libraryCommander.userAccess(userCaptain.id.get, libScience.id.get, libScience.universalLink) === Some(LibraryAccess.READ_ONLY) // test  library (no membership) but with universalLink
       }
     }
 


### PR DESCRIPTION
@ahsu1230 Library endpoints were broken, this should fix it.

When we add new fields, we need to make sure we're backwards compatible with the existing db data.
