### PR TITLE
Caching for URISummaries used in notifications

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
@@ -6,6 +6,7 @@ import com.google.inject.{ Provides, Singleton }
 import com.keepit.model._
 import com.keepit.social.BasicUserUserIdCache
 import com.keepit.eliza.model._
+import com.keepit.eliza.commanders.InboxUriSummaryCache
 import com.keepit.search.ActiveExperimentsCache
 import com.keepit.common.usersegment.UserSegmentCache
 
@@ -20,6 +21,11 @@ case class ElizaCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Provides
   def messagesForThreadIdCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new MessagesForThreadIdCache(stats, accessLog, (outerRepo, 30 days))
+
+  @Singleton
+  @Provides
+  def inboxUriSummaryCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new InboxUriSummaryCache(stats, accessLog, (innerRepo, 4 hours), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationJsonMaker.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationJsonMaker.scala
@@ -137,4 +137,3 @@ case class InboxUriSummaryCacheKey(uriId: Id[NormalizedURI]) extends Key[URISumm
 class InboxUriSummaryCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
   extends JsonCacheImpl[InboxUriSummaryCacheKey, URISummary](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
 
-//ZZZ remember cache module

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationJsonMaker.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationJsonMaker.scala
@@ -1,21 +1,33 @@
 package com.keepit.eliza.commanders
 
-import com.google.inject.Inject
+import com.google.inject.{ Inject, Singleton }
 import com.keepit.common.store.ImageSize
 import com.keepit.eliza.model.UserThreadRepo.RawNotification
-import com.keepit.model.{ ImageType, URISummary, URISummaryRequest }
+import com.keepit.model.{ ImageType, URISummary, URISummaryRequest, NormalizedURI }
 import com.keepit.shoebox.ShoeboxServiceClient
 import com.keepit.social.{ BasicUserLikeEntity, BasicUser }
+import com.keepit.common.cache.CacheStatistics
+import com.keepit.common.db.Id
+import com.keepit.common.logging.AccessLog
+import com.keepit.common.cache.{ JsonCacheImpl, FortyTwoCachePlugin, Key }
+import com.keepit.common.concurrent.ReactiveLock
+import com.keepit.common.akka.SafeFuture
+import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 
 import play.api.libs.json.{ JsValue, Json, JsObject }
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 
 private[commanders] case class NotificationJson(obj: JsObject) extends AnyVal
 
 /** Makes `NotificationJson` from `RawNotification` */
+@Singleton
 private[commanders] class NotificationJsonMaker @Inject() (
-    shoebox: ShoeboxServiceClient) {
+    shoebox: ShoeboxServiceClient,
+    summaryCache: InboxUriSummaryCache) {
+
+  private val uriSummaryRequestLimiter = new ReactiveLock(2)
 
   def makeOne(rawNotification: RawNotification, includeUriSummary: Boolean = false): Future[NotificationJson] = {
     makeOpt(rawNotification, includeUriSummary).get
@@ -31,16 +43,15 @@ private[commanders] class NotificationJsonMaker @Inject() (
       case o: JsObject =>
         val authorFut = author(o \ "author")
         val participantsFut = participants(o \ "participants")
-        val uriSummaryFut = if (includeUriSummary) uriSummary(o \ "url") else Future.successful(None)
+        val uriSum = if (includeUriSummary) uriSummary(o \ "url", raw._3) else None
         val jsonFut = for {
           author <- authorFut
           participants <- participantsFut
-          uriSummary <- uriSummaryFut
         } yield NotificationJson(
           o ++ unread(o, raw._2)
             ++ Json.obj("author" -> author)
             ++ (if (!participants.isEmpty) Json.obj("participants" -> participants) else Json.obj())
-            ++ (if (includeUriSummary) Json.obj("uriSummary" -> uriSummary) else Json.obj())
+            ++ (if (includeUriSummary) Json.obj("uriSummary" -> uriSum) else Json.obj())
         )
         Some(jsonFut)
       case _ =>
@@ -82,21 +93,28 @@ private[commanders] class NotificationJsonMaker @Inject() (
     }
   }
 
-  private def uriSummary(value: JsValue): Future[Option[URISummary]] = {
-    value.asOpt[String] map { url =>
-      // TODO: utilize memcache, which will probably require dropping min size requirement here.
-      // We'll also need the Id[NormalizedURI], since arbitrary URLs are too long to be memcache keys.
-      shoebox.getUriSummary(
-        URISummaryRequest(
-          url = url,
-          imageType = ImageType.ANY,
-          minSize = ImageSize(65, 95),
-          withDescription = false,
-          waiting = true,
-          silent = false)) map Some.apply
-    } getOrElse {
-      Future.successful(None)
-    }
+  private def fetchAndCacheUriSummary(uriId: Id[NormalizedURI], url: String): Future[URISummary] = uriSummaryRequestLimiter.withLockFuture {
+    shoebox.getUriSummary(
+      URISummaryRequest(
+        url = url,
+        imageType = ImageType.ANY,
+        minSize = ImageSize(65, 95),
+        withDescription = false,
+        waiting = true,
+        silent = false
+      )
+    ).map { uriSummary =>
+        summaryCache.set(InboxUriSummaryCacheKey(uriId), uriSummary)
+        uriSummary
+      }
+  }
+
+  private def uriSummary(value: JsValue, uriId: Id[NormalizedURI]): Option[URISummary] = {
+    value.asOpt[String].map { url =>
+      val result = summaryCache.get(InboxUriSummaryCacheKey(uriId))
+      if (result.isEmpty) new SafeFuture(fetchAndCacheUriSummary(uriId, url), Some("Fetching URI summary for extension inbox backgrounds"))
+      result
+    }.flatten
   }
 
   private def updateBasicUser(basicUser: BasicUser): Future[BasicUser] = {
@@ -109,3 +127,14 @@ private[commanders] class NotificationJsonMaker @Inject() (
   }
 
 }
+
+case class InboxUriSummaryCacheKey(uriId: Id[NormalizedURI]) extends Key[URISummary] {
+  override val version = 0
+  val namespace = "inbox_uri_summary"
+  def toKey(): String = uriId.id.toString
+}
+
+class InboxUriSummaryCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
+  extends JsonCacheImpl[InboxUriSummaryCacheKey, URISummary](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
+
+//ZZZ remember cache module

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
@@ -17,7 +17,7 @@ import play.api.libs.json.{ JsValue, JsNull }
 import scala.slick.jdbc.StaticQuery
 
 object UserThreadRepo {
-  type RawNotification = (JsValue, Boolean) // lastNotification, unread
+  type RawNotification = (JsValue, Boolean, Id[NormalizedURI]) // lastNotification, unread, uriId
 }
 
 @ImplementedBy(classOf[UserThreadRepoImpl])
@@ -201,7 +201,7 @@ class UserThreadRepoImpl @Inject() (
   }
 
   def getRawNotification(userId: Id[User], threadId: Id[MessageThread])(implicit session: RSession): RawNotification = {
-    (for (row <- rows if row.user === userId && row.threadId === threadId) yield (row.lastNotification, row.unread)).first
+    (for (row <- rows if row.user === userId && row.threadId === threadId) yield (row.lastNotification, row.unread, row.uriId)).first
   }
 
   def getLatestRawNotifications(userId: Id[User], howMany: Int)(implicit session: RSession): List[RawNotification] = {
@@ -211,7 +211,7 @@ class UserThreadRepoImpl @Inject() (
         row.lastNotification.isNotNull
     ) yield row)
       .sortBy(row => (row.notificationUpdatedAt) desc)
-      .take(howMany).map(row => (row.lastNotification, row.unread))
+      .take(howMany).map(row => (row.lastNotification, row.unread, row.uriId))
       .list
   }
 
@@ -223,7 +223,7 @@ class UserThreadRepoImpl @Inject() (
         row.lastNotification.isNotNull
     ) yield row)
       .sortBy(row => (row.notificationUpdatedAt) desc)
-      .take(howMany).map(row => (row.lastNotification, row.unread))
+      .take(howMany).map(row => (row.lastNotification, row.unread, row.uriId))
       .list
   }
 
@@ -235,7 +235,7 @@ class UserThreadRepoImpl @Inject() (
         row.lastNotification.isNotNull
     ) yield row)
       .sortBy(row => (row.notificationUpdatedAt) desc)
-      .take(howMany).map(row => (row.lastNotification, row.unread))
+      .take(howMany).map(row => (row.lastNotification, row.unread, row.uriId))
       .list
   }
 
@@ -248,7 +248,7 @@ class UserThreadRepoImpl @Inject() (
         row.lastNotification.isNotNull
     ) yield row)
       .sortBy(row => (row.notificationUpdatedAt) desc)
-      .take(howMany).map(row => (row.lastNotification, row.unread))
+      .take(howMany).map(row => (row.lastNotification, row.unread, row.uriId))
       .list
   }
 
@@ -260,7 +260,7 @@ class UserThreadRepoImpl @Inject() (
         row.lastNotification.isNotNull
     ) yield row)
       .sortBy(row => (row.notificationUpdatedAt) desc)
-      .take(howMany).map(row => (row.lastNotification, row.unread))
+      .take(howMany).map(row => (row.lastNotification, row.unread, row.uriId))
       .list
   }
 
@@ -273,7 +273,7 @@ class UserThreadRepoImpl @Inject() (
         row.lastNotification.isNotNull
     ) yield row)
       .sortBy(row => (row.notificationUpdatedAt) desc)
-      .take(howMany).map(row => (row.lastNotification, row.unread))
+      .take(howMany).map(row => (row.lastNotification, row.unread, row.uriId))
       .list
   }
 
@@ -285,7 +285,7 @@ class UserThreadRepoImpl @Inject() (
         row.lastNotification.isNotNull
     ) yield row)
       .sortBy(row => (row.notificationUpdatedAt) desc)
-      .take(howMany).map(row => (row.lastNotification, row.unread))
+      .take(howMany).map(row => (row.lastNotification, row.unread, row.uriId))
       .list
   }
 
@@ -298,7 +298,7 @@ class UserThreadRepoImpl @Inject() (
         row.lastNotification.isNotNull
     ) yield row)
       .sortBy(row => (row.notificationUpdatedAt) desc)
-      .take(howMany).map(row => (row.lastNotification, row.unread))
+      .take(howMany).map(row => (row.lastNotification, row.unread, row.uriId))
       .list
   }
 
@@ -409,6 +409,6 @@ class UserThreadRepoImpl @Inject() (
       row <- rows if row.user === userId && row.threadId === threadId &&
         row.lastNotification =!= JsNull.asInstanceOf[JsValue] &&
         row.lastNotification.isNotNull
-    ) yield (row.lastNotification, row.unread)).firstOption
+    ) yield (row.lastNotification, row.unread, row.uriId)).firstOption
   }
 }


### PR DESCRIPTION
This currently errs on the side of speed very aggressively, i.e. if an item is not in the cache proceed immediately and fetch it asynchronously in the background (never waiting for a result).
I chose to keep this cache out of the service client and very Eliza specific for two reasons:
1) All the service client caches we have have "wait for the result if it's not cached" semantics, whereas here we want to proceed immediately if it's not there (and trigger a computation in the background)
2) Virtually all the service client level caches are key-value, whereas here we have a rather complex request object. Caching at the service level would require somehow encoding the request in the key, which is tricky and error prone.
@2is10 
