### PR TITLE
searching in library

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
@@ -5,14 +5,13 @@ import com.keepit.common.db.Id
 import com.keepit.common.akka.MonitoredAwait
 import com.keepit.common.akka.SafeFuture
 import com.keepit.common.service.RequestConsolidator
-import com.keepit.model.{ ExperimentType, UserExperimentGenerator, User }
+import com.keepit.model.{ ExperimentType, User }
 import com.keepit.shoebox.ShoeboxServiceClient
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import com.keepit.common.logging.Logging
 import com.keepit.common.usersegment.UserSegment
-import com.keepit.commanders.RemoteUserExperimentCommander
 
 object SearchConfig {
   private[search] val defaultParams =
@@ -21,7 +20,6 @@ object SearchConfig {
       "siteBoost" -> "1.0",
       "concatBoost" -> "0.8",
       "homePageBoost" -> "0.2",
-      "similarity" -> "default",
       "maxResultClickBoost" -> "20.0",
       "minMyBookmarks" -> "2",
       "myBookmarkBoost" -> "1.5",
@@ -54,7 +52,6 @@ object SearchConfig {
       "siteBoost" -> "boost value for matching website names and domains",
       "concatBoost" -> "boost value for concatenated terms",
       "homePageBoost" -> "boost value for home page [0f,1f]",
-      "similarity" -> "similarity characteristics",
       "maxResultClickBoost" -> "boosting by recent result clicks",
       "minMyBookmarks" -> "the minimum number of my bookmarks in a search result",
       "myBookmarkBoost" -> "importance of my bookmark",

--- a/kifi-backend/modules/search/app/com/keepit/search/MainSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/MainSearcher.scala
@@ -59,7 +59,6 @@ class MainSearcher(
   private[this] val dampingHalfDecayMine = config.asFloat("dampingHalfDecayMine")
   private[this] val dampingHalfDecayFriends = config.asFloat("dampingHalfDecayFriends")
   private[this] val dampingHalfDecayOthers = config.asFloat("dampingHalfDecayOthers")
-  private[this] val similarity = Similarity(config.asString("similarity"))
   private[this] val minMyBookmarks = config.asInt("minMyBookmarks")
   private[this] val myBookmarkBoost = config.asFloat("myBookmarkBoost")
   private[this] val usefulPageBoost = config.asFloat("usefulPageBoost")
@@ -118,7 +117,6 @@ class MainSearcher(
 
       val tPersonalSearcher = currentDateTime.getMillis()
       val personalizedSearcher = getPersonalizedSearcher(articleQuery)
-      personalizedSearcher.setSimilarity(similarity)
       timeLogs.personalizedSearcher = currentDateTime.getMillis() - tPersonalSearcher
 
       val weight = personalizedSearcher.createWeight(articleQuery)
@@ -402,7 +400,6 @@ class MainSearcher(
   def explain(uriId: Id[NormalizedURI]): Option[(Query, Explanation)] = {
     parser.parsedQuery.map { query =>
       var personalizedSearcher = getPersonalizedSearcher(query)
-      personalizedSearcher.setSimilarity(similarity)
 
       (query, personalizedSearcher.explain(query, uriId.id))
     }

--- a/kifi-backend/modules/search/app/com/keepit/search/SearchFilter.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/SearchFilter.scala
@@ -1,17 +1,14 @@
 package com.keepit.search
 
 import com.keepit.common.db.Id
-import com.keepit.common.time._
-import com.keepit.model.User
-import com.keepit.model.Collection
-import com.keepit.common.akka.MonitoredAwait
+import com.keepit.model.Library
 import com.keepit.search.util.{ LongArraySet, IdFilterCompressor }
-import scala.concurrent.duration._
-import scala.concurrent.Future
 
 abstract class SearchFilter(context: Option[String]) {
 
   lazy val idFilter: LongArraySet = IdFilterCompressor.fromBase64ToSet(context.getOrElse(""))
+
+  val libraryId: Option[Id[Library]] = None
 
   def includeMine: Boolean
   def includeShared: Boolean
@@ -56,6 +53,18 @@ object SearchFilter {
       def includeShared = false
       def includeFriends = true
       def includeOthers = false
+    }
+  }
+
+  def library(libId: Id[Library], context: Option[String] = None) = {
+    new SearchFilter(context) {
+
+      override val libraryId: Option[Id[Library]] = Some(libId)
+
+      def includeMine = true
+      def includeShared = true
+      def includeFriends = true
+      def includeOthers = true
     }
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/Similarity.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/Similarity.scala
@@ -38,6 +38,8 @@ object Similarity extends Logging {
     ("noTF" -> new DefaultSimilarity with DocCountBasedIDF with NoTF with NoCoord)
   )
 
+  def apply() = similarities("default")
+
   def apply(name: String) = {
     def fallback = {
       log.warn("Similarity(%s) not found".format(name))

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/KifiSearch.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/KifiSearch.scala
@@ -30,7 +30,7 @@ class KifiSearch(
     articleSearcher: Searcher,
     keepSearcher: Searcher,
     friendIdsFuture: Future[Set[Long]],
-    libraryIdsFuture: Future[(Set[Long], Set[Long])],
+    libraryIdsFuture: Future[(Set[Long], Set[Long], Set[Long])],
     clickBoostsFuture: Future[ResultClickBoosts],
     clickHistoryFuture: Future[MultiHashFilter[ClickedURI]],
     monitoredAwait: MonitoredAwait,
@@ -44,7 +44,6 @@ class KifiSearch(
   private[this] val dampingHalfDecayMine = config.asFloat("dampingHalfDecayMine")
   private[this] val dampingHalfDecayFriends = config.asFloat("dampingHalfDecayFriends")
   private[this] val dampingHalfDecayOthers = config.asFloat("dampingHalfDecayOthers")
-  private[this] val similarity = Similarity(config.asString("similarity"))
   private[this] val minMyBookmarks = config.asInt("minMyBookmarks")
   private[this] val myBookmarkBoost = config.asFloat("myBookmarkBoost")
   private[this] val usefulPageBoost = config.asFloat("usefulPageBoost")
@@ -53,12 +52,10 @@ class KifiSearch(
 
   def searchText(maxTextHitsPerCategory: Int, promise: Option[Promise[_]] = None): (HitQueue, HitQueue, HitQueue) = {
 
-    keepSearcher.setSimilarity(similarity)
-    val keepScoreSource = new UriFromKeepsScoreVectorSource(keepSearcher, userId.id, friendIdsFuture, libraryIdsFuture, filter.idFilter, config, monitoredAwait)
+    val keepScoreSource = new UriFromKeepsScoreVectorSource(keepSearcher, userId.id, friendIdsFuture, libraryIdsFuture, filter, config, monitoredAwait)
     engine.execute(keepScoreSource)
 
-    articleSearcher.setSimilarity(similarity)
-    val articleScoreSource = new UriFromArticlesScoreVectorSource(articleSearcher, filter.idFilter)
+    val articleScoreSource = new UriFromArticlesScoreVectorSource(articleSearcher, filter)
     engine.execute(articleScoreSource)
 
     val tClickBoosts = currentDateTime.getMillis()

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/QueryEngineBuilder.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/QueryEngineBuilder.scala
@@ -1,7 +1,7 @@
 package com.keepit.search.engine
 
 import com.keepit.search.engine.query._
-import com.keepit.search.engine.result.ResultCollector
+import com.keepit.search.query.FixedScoreQuery
 import org.apache.lucene.search.Query
 import org.apache.lucene.search.BooleanClause.Occur._
 import scala.collection.JavaConversions._
@@ -21,6 +21,10 @@ class QueryEngineBuilder(baseQuery: Query) {
   def addBoosterQuery(booster: Query, boostStrength: Float): QueryEngineBuilder = {
     _boosters = (booster, boostStrength) :: _boosters
     this
+  }
+
+  def addFilterQuery(filter: Query): QueryEngineBuilder = {
+    addBoosterQuery(new FixedScoreQuery(filter), 1.0f)
   }
 
   def build(): QueryEngine = {

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/ScoreContext.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/ScoreContext.scala
@@ -47,8 +47,7 @@ class ScoreContext(
     val thisVisibility = reader.recordType
     visibility = visibility | thisVisibility
 
-    if ((thisVisibility & Visibility.SEARCHABLE_KEEP) != 0) {
-      // a searchable keep has a library id as a secondary id
+    if ((thisVisibility & Visibility.HAS_SECONDARY_ID) != 0) {
       val id2 = reader.nextLong()
       var scr2 = 0.0f // use a simple sum of scores to compare secondary ids
 

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/Visibility.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/Visibility.scala
@@ -3,10 +3,12 @@ package com.keepit.search.engine
 object Visibility { // use value class?
   // NOTE: only 7 bits for record type.
   val RESTRICTED = 0x00
-  val SEARCHABLE_KEEP = 0x10
 
   val OTHERS = 0x01
   val NETWORK = 0x02
   val MEMBER = 0x04
   val OWNER = 0x08
+  //  unused = 0x10
+  //  unused = 0x20
+  val HAS_SECONDARY_ID = 0x40
 }


### PR DESCRIPTION
searching keeps in a specified library
- added SearchFilter.library(Id[Library])
- added an ability to search keep metadata in public library when the search is in a library context
- added a filter to restrict the search scope to a library
  cleanup
- removed "similarity" search config option

FYI @leogrim 
