### PR TITLE
update unit test

### DIFF
--- a/kifi-backend/modules/curator/test/com/keepit/curator/RecommendationGenerationCommanderTest.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/RecommendationGenerationCommanderTest.scala
@@ -164,7 +164,7 @@ class RecommendationGenerationCommanderTest extends Specification with CuratorTe
         Await.result(futUnit, Duration(10, "seconds"))
         val result = commander.getPublicFeeds(5)
         val feeds = Await.result(result, Duration(10, "seconds"))
-        feeds.size === 5
+        feeds.size === 0
       }
     }
   }


### PR DESCRIPTION
(public feed computation added boostedKeepers so currently the result is 0) @stkem
