### PR TITLE
shorter event name (for easier mixpanel consumption)

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/heimdal/EventType.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/EventType.scala
@@ -41,7 +41,7 @@ object UserEventTypes {
   val EXT_ERROR = EventType("ext_error")
 
   // recommendaton
-  val RECOMMENDATION_USER_ACTION = EventType("recommendation_user_action")
+  val RECOMMENDATION_USER_ACTION = EventType("reco_action")
 }
 
 object SystemEventTypes {


### PR DESCRIPTION
user events already prepped `user_` to the event name, so we were ending
up with `user_recommendation_user_action` which is too long for some
mixpanel UI elements (and somewhat redundant)
@yingjieMiao 
