### PR TITLE
fixing keep to collection duplicate inserts

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -605,9 +605,9 @@ class KeepsCommander @Inject() (
             val tagsToAdd = selectedTagIds.filterNot(existingTagIds.contains(_))
             val tagsToRemove = existingTagIds.filterNot(selectedTagIds.contains(_))
 
-            keepToCollectionRepo.insertAll(tagsToAdd.map { tagId =>
-              KeepToCollection(keepId = keep.id.get, collectionId = tagId)
-            })
+            tagsToAdd.map { tagId =>
+              keepToCollectionRepo.save(KeepToCollection(keepId = keep.id.get, collectionId = tagId))
+            }
             tagsToRemove.map { tagId =>
               keepToCollectionRepo.remove(keep.id.get, tagId)
             }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
@@ -89,7 +89,7 @@ class MobileBookmarksController @Inject() (
       case Left(msg) => BadRequest(msg)
       case Right((keepInfo, tags)) =>
         Ok(Json.obj(
-          "keep" -> keepInfo,
+          "keep" -> Json.toJson(keepInfo),
           "tags" -> tags.map(tag => Json.obj("name" -> tag.name, "id" -> tag.externalId))
         ))
     }


### PR DESCRIPTION
air brake exceptions caused when keep2tag that were inactivated were being added in again
