### PR TITLE
consolidate queries

### DIFF
--- a/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
@@ -80,9 +80,7 @@ class LDAController @Inject() (
 
     val t1 = System.currentTimeMillis
 
-    val scores1 = lda.batchUserURIsInterests(userId, uriIds)
-    val scores2 = lda.batchGaussianUserURIsInterests(userId, uriIds)
-    val scores = (scores1 zip scores2).map { case (s1, s2) => LDAUserURIInterestScores(s2.global, s1.recency) }
+    val scores = lda.batchUserURIsInterests(userId, uriIds)
 
     val t2 = System.currentTimeMillis
     log.info(s"batch uris scoring for user = ${userId}, num of uris: ${uriIds.size}, took ${t2 - t1} milli seconds")


### PR DESCRIPTION
@stkem 

Removed `batchGaussianUserURIsInterests`. 
Only one primary endpoint: `batchUserURIsInterests`. Renamed some old methods to `computeCosineInterestScore`

This saves duplicated batch lookup for uri features.
