### PR TITLE
new (dry) way to compose where clauses in repos

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
@@ -103,7 +103,7 @@ class RecommendationGenerationCommander @Inject() (
 
   def getTopRecommendationsNotPushed(userId: Id[User], howManyMax: Int, masterScoreThreshold: Float = 0f): Future[Seq[UriRecommendation]] = {
     db.readOnlyReplicaAsync { implicit session =>
-      uriRecRepo.getNotPushedByTopMasterScore(userId, howManyMax, masterScoreThreshold)
+      uriRecRepo.getDigestRecommendableByTopMasterScore(userId, howManyMax, masterScoreThreshold)
     }
   }
 

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendationRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendationRepo.scala
@@ -1,6 +1,7 @@
 package com.keepit.curator.model
 
 import com.google.inject.{ Singleton, Inject, ImplementedBy }
+import com.keepit.common.core._
 import com.keepit.common.db.{ State, Id }
 import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
 import com.keepit.common.db.slick.{ DBSession, DataBaseComponent, DbRepo }
@@ -18,7 +19,7 @@ trait UriRecommendationRepo extends DbRepo[UriRecommendation] {
   def getByUriAndUserId(uriId: Id[NormalizedURI], userId: Id[User], uriRecommendationState: Option[State[UriRecommendation]])(implicit session: RSession): Option[UriRecommendation]
   def getByTopMasterScore(userId: Id[User], maxBatchSize: Int, uriRecommendationState: Option[State[UriRecommendation]] = Some(UriRecommendationStates.ACTIVE))(implicit session: RSession): Seq[UriRecommendation]
   def getRecommendableByTopMasterScore(userId: Id[User], maxBatchSize: Int)(implicit session: RSession): Seq[UriRecommendation]
-  def getNotPushedByTopMasterScore(userId: Id[User], maxBatchSize: Int, masterScoreThreshold: Float = 0f, uriRecommendationState: Option[State[UriRecommendation]] = Some(UriRecommendationStates.ACTIVE))(implicit session: RSession): Seq[UriRecommendation]
+  def getDigestRecommendableByTopMasterScore(userId: Id[User], maxBatchSize: Int, masterScoreThreshold: Float = 0f)(implicit session: RSession): Seq[UriRecommendation]
   def updateUriRecommendationFeedback(userId: Id[User], uriId: Id[NormalizedURI], feedback: UriRecommendationFeedback)(implicit session: RWSession): Boolean
   def incrementDeliveredCount(recoId: Id[UriRecommendation])(implicit session: RWSession): Unit
   def cleanupLowMasterScoreRecos(limitNumRecosForUser: Int, before: DateTime)(implicit session: RWSession): Boolean
@@ -43,6 +44,27 @@ class UriRecommendationRepoImpl @Inject() (
 
   type RepoImpl = UriRecommendationTable
 
+  object QueryBuilder {
+    def recommendable(rows: RepoQuery = rows) =
+      for (row <- active(rows) if row.kept === false && row.trashed === false) yield row
+
+    def byUser(userId: Id[User])(rows: RepoQuery = rows) =
+      for (row <- rows if row.userId === userId) yield row
+
+    def byUri(uriId: Id[NormalizedURI])(rows: RepoQuery = rows) =
+      for (row <- rows if row.uriId === uriId) yield row
+
+    def active(rows: RepoQuery = rows) =
+      for (row <- rows if row.state === UriRecommendationStates.ACTIVE) yield row
+
+    def withThreshold(masterScoreThreshold: Float)(rows: RepoQuery = rows) =
+      for (row <- rows if row.masterScore >= masterScoreThreshold) yield row
+
+    def notPushed(rows: RepoQuery = rows) =
+      for (row <- rows if row.lastPushedAt.isNull) yield row
+  }
+  import QueryBuilder._
+
   class UriRecommendationTable(tag: Tag) extends RepoTable[UriRecommendation](db, tag, "uri_recommendation") {
     def vote = column[Boolean]("vote", O.Nullable)
     def uriId = column[Id[NormalizedURI]]("uri_id", O.NotNull)
@@ -63,22 +85,19 @@ class UriRecommendationRepoImpl @Inject() (
   initTable()
 
   def getByUriAndUserId(uriId: Id[NormalizedURI], userId: Id[User], excludeUriRecommendationState: Option[State[UriRecommendation]])(implicit session: RSession): Option[UriRecommendation] = {
-    (for (row <- rows if row.uriId === uriId && row.userId === userId && row.state =!= excludeUriRecommendationState.orNull) yield row).firstOption
+    (for (row <- byUser(userId)() |> byUri(uriId) if row.state =!= excludeUriRecommendationState.orNull) yield row).firstOption
   }
 
   def getByTopMasterScore(userId: Id[User], maxBatchSize: Int, uriRecommendationState: Option[State[UriRecommendation]] = Some(UriRecommendationStates.ACTIVE))(implicit session: RSession): Seq[UriRecommendation] = {
-    (for (row <- rows if row.userId === userId && row.state === uriRecommendationState) yield row).
-      sortBy(_.masterScore.desc).take(maxBatchSize).list
+    (for (row <- byUser(userId)() if row.state === uriRecommendationState) yield row).sortBy(_.masterScore.desc).take(maxBatchSize).list
   }
 
   def getRecommendableByTopMasterScore(userId: Id[User], maxBatchSize: Int)(implicit session: RSession): Seq[UriRecommendation] = {
-    (for (row <- rows if row.userId === userId && row.state === UriRecommendationStates.ACTIVE && row.kept === false && row.trashed === false) yield row).
-      sortBy(_.masterScore.desc).take(maxBatchSize).list
+    (for (row <- byUser(userId)() |> recommendable) yield row).sortBy(_.masterScore.desc).take(maxBatchSize).list
   }
 
-  def getNotPushedByTopMasterScore(userId: Id[User], maxBatchSize: Int, masterScoreThreshold: Float = 0f, uriRecommendationState: Option[State[UriRecommendation]] = Some(UriRecommendationStates.ACTIVE))(implicit session: RSession): Seq[UriRecommendation] = {
-    (for (row <- rows if row.userId === userId && row.state === uriRecommendationState && row.lastPushedAt.isNull && row.masterScore >= masterScoreThreshold) yield row).
-      sortBy(_.masterScore.desc).take(maxBatchSize).list
+  def getDigestRecommendableByTopMasterScore(userId: Id[User], maxBatchSize: Int, masterScoreThreshold: Float = 0f)(implicit session: RSession): Seq[UriRecommendation] = {
+    (for (row <- byUser(userId)() |> recommendable |> notPushed |> withThreshold(masterScoreThreshold)) yield row).sortBy(_.masterScore.desc).take(maxBatchSize).list
   }
 
   def updateUriRecommendationFeedback(userId: Id[User], uriId: Id[NormalizedURI], feedback: UriRecommendationFeedback)(implicit session: RWSession): Boolean = {
@@ -88,9 +107,9 @@ class UriRecommendationRepoImpl @Inject() (
       sql"UPDATE uri_recommendation SET clicked=clicked+1, updated_at=$currentDateTime WHERE user_id=$userId AND uri_id=$uriId".asUpdate.first > 0
     else true
     val keptResult = if (feedback.kept.isDefined)
-      (for (row <- rows if row.uriId === uriId && row.userId === userId) yield (row.kept, row.updatedAt)).update((feedback.kept.get, currentDateTime)) > 0 else true
+      (for (row <- byUser(userId)() |> byUri(uriId)) yield (row.kept, row.updatedAt)).update((feedback.kept.get, currentDateTime)) > 0 else true
     val trashedResult = if (feedback.trashed.isDefined)
-      (for (row <- rows if row.uriId === uriId && row.userId === userId) yield (row.trashed, row.updatedAt)).update((feedback.trashed.get, currentDateTime)) > 0 else true
+      (for (row <- byUser(userId)() |> byUri(uriId)) yield (row.trashed, row.updatedAt)).update((feedback.trashed.get, currentDateTime)) > 0 else true
 
     clickedResult && keptResult && trashedResult
   }
@@ -115,8 +134,7 @@ class UriRecommendationRepoImpl @Inject() (
               ) AS mScoreTable""".as[Float].first
 
       ((for (
-        row <- rows if row.userId === userId && row.updatedAt < before && row.masterScore < limitScore &&
-          row.state === UriRecommendationStates.ACTIVE
+        row <- byUser(userId)() |> active if row.updatedAt < before && row.masterScore < limitScore
       ) yield (row.state, row.updatedAt)).
         update((UriRecommendationStates.INACTIVE, currentDateTime)) > 0) || updated
     }

--- a/kifi-backend/modules/curator/test/com/keepit/curator/FeedDigestEmailSenderTest.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/FeedDigestEmailSenderTest.scala
@@ -97,7 +97,17 @@ class FeedDigestEmailSenderTest extends Specification with CuratorTestInjector w
             // shouldn't be in reco list b/c it's below threshold (8)
             makeCompleteUriRecommendation(7, 43, 7.99f, "https://www.bing.com"),
             // shouldn't be in reco list b/c image is too tall
-            makeCompleteUriRecommendation(uriId = 8, userId = 43, masterScore = 9, url = "https://www.youtube.com/watch?v=BROWqjuTM0g", summaryImageHeight = Some(1001))
+            makeCompleteUriRecommendation(uriId = 8, userId = 43, masterScore = 9, url = "https://www.youtube.com/watch?v=BROWqjuTM0g", summaryImageHeight = Some(1001)),
+            // shouldn't be in reco list b/c trashed
+            {
+              val tup = makeCompleteUriRecommendation(9, 42, 10f, "http://www.myspace.com")
+              tup.copy(_2 = tup._2.copy(trashed = true))
+            },
+            // shouldn't be in reco list b/c kept
+            {
+              val tup = makeCompleteUriRecommendation(10, 42, 10f, "http://www.apple.com")
+              tup.copy(_2 = tup._2.copy(kept = true))
+            }
           ).map(tuple => saveUriModels(tuple, shoebox))
         }
 
@@ -170,7 +180,7 @@ class FeedDigestEmailSenderTest extends Specification with CuratorTestInjector w
         mail42body must contain("Connect Facebook")
         mail43body must not contain "Connect Facebook"
 
-        val notSentIds = Set(5L, 7F, 8F) // reco Ids in our list that still haven't been sent
+        val notSentIds = Set(5L, 7F, 8F, 9F, 10F) // reco Ids in our list that still haven't been sent
         savedRecoModels.forall { models =>
           val (uri, reco, uriSumm) = models
           db.readOnlyMaster { implicit s =>

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
@@ -47,6 +47,8 @@ trait DbRepo[M <: Model[M]] extends Repo[M] with FortyTwoGenericTypeMappers with
   protected val changeListener: Option[RepoModification.Listener[M]] = None
 
   type RepoImpl <: RepoTable[M]
+  type RepoQuery = scala.slick.lifted.Query[RepoImpl, M]
+
   def table(tag: Tag): RepoImpl
   lazy val _taggedTable = table(new BaseTag { base =>
     def taggedAs(path: List[scala.slick.ast.Symbol]): AbstractTable[_] = base.taggedAs(path)


### PR DESCRIPTION
the motivation is that methods in repos contain a lot of duplicate code.  I'm introducing a syntax that is shorter, (subjectively) as readable , and could eliminate a lot of duplication between methods that have several identical filters.  i tested queries produced by slick and they are the same as before, so no database impact in this case.

the pipe `|>` syntax is a method @andrewconner created that essentially acts like the unix pipe and allows us to compose these `RepoQuery` methods without deeply nesting them like `h(g(f(x)))`

@eishay @stkem @ymatsuda @andrewconner @ahsu1230 @lawzlo @2is10 @raymondng @leogrim 
