### PR TITLE
adding authentication token as optional parameter to viewing libraries (...

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -4,7 +4,7 @@ import com.google.inject.Inject
 import com.keepit.commanders._
 import com.keepit.common.controller.{ ShoeboxServiceController, WebsiteController, ActionAuthenticator }
 import com.keepit.common.crypto.{ PublicIdConfiguration, PublicId }
-import com.keepit.common.db.ExternalId
+import com.keepit.common.db.{ Id, ExternalId }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.mail.EmailAddress
 import com.keepit.common.time.Clock
@@ -16,6 +16,7 @@ import scala.util.{ Success, Failure }
 class LibraryController @Inject() (
   db: Database,
   libraryRepo: LibraryRepo,
+  libraryMembershipRepo: LibraryMembershipRepo,
   userRepo: UserRepo,
   keepRepo: KeepRepo,
   libraryCommander: LibraryCommander,
@@ -70,18 +71,28 @@ class LibraryController @Inject() (
     }
   }
 
-  def getLibraryById(pubId: PublicId[Library]) = JsonAction.authenticated { request =>
+  private def canView(userId: Id[User], lib: Library, authToken: Option[String]): Boolean = {
+    db.readOnlyMaster { implicit s =>
+      libraryMembershipRepo.getOpt(userId = userId, libraryId = lib.id.get).nonEmpty ||
+        (lib.universalLink.nonEmpty && authToken.nonEmpty && lib.universalLink.get == authToken.get)
+    }
+  }
+
+  def getLibraryById(pubId: PublicId[Library], authToken: Option[String] = None) = JsonAction.authenticated { request =>
     val idTry = Library.decodePublicId(pubId)
     idTry match {
       case Failure(ex) =>
         BadRequest(Json.obj("error" -> "invalid id"))
       case Success(id) =>
         val lib = db.readOnlyMaster { implicit s => libraryRepo.get(id) }
-        Ok(Json.obj("library" -> Json.toJson(libraryCommander.createFullLibraryInfo(lib))))
+        if (canView(request.userId, lib, authToken))
+          Ok(Json.obj("library" -> Json.toJson(libraryCommander.createFullLibraryInfo(lib))))
+        else
+          BadRequest(Json.obj("error" -> "invalid access"))
     }
   }
 
-  def getLibraryByPath(userStr: String, slugStr: String) = JsonAction.authenticated { request =>
+  def getLibraryByPath(userStr: String, slugStr: String, authToken: Option[String] = None) = JsonAction.authenticated { request =>
     // check if str is either a username or externalId
     val ownerOpt = db.readOnlyMaster { implicit s =>
       ExternalId.asOpt[User](userStr) match {
@@ -92,9 +103,16 @@ class LibraryController @Inject() (
     ownerOpt match {
       case None => BadRequest(Json.obj("error" -> "invalid username"))
       case Some(owner) =>
-        db.readOnlyMaster { implicit s => libraryRepo.getBySlugAndUserId(userId = owner.id.get, slug = LibrarySlug(slugStr)) } match {
-          case None => BadRequest(Json.obj("error" -> "no library found"))
-          case Some(lib) => Ok(Json.obj("library" -> Json.toJson(libraryCommander.createFullLibraryInfo(lib))))
+
+        db.readOnlyMaster { implicit s =>
+          libraryRepo.getBySlugAndUserId(userId = owner.id.get, slug = LibrarySlug(slugStr)) match {
+            case None => BadRequest(Json.obj("error" -> "no library found"))
+            case Some(lib) =>
+              if (canView(request.userId, lib, authToken))
+                Ok(Json.obj("library" -> Json.toJson(libraryCommander.createFullLibraryInfo(lib))))
+              else
+                BadRequest(Json.obj("error" -> "invalid access"))
+          }
         }
     }
   }
@@ -199,20 +217,22 @@ class LibraryController @Inject() (
     }
   }
 
-  def getKeeps(pubId: PublicId[Library], count: Int, offset: Int) = JsonAction.authenticated { request =>
+  def getKeeps(pubId: PublicId[Library], count: Int, offset: Int, authToken: Option[String] = None) = JsonAction.authenticated { request =>
     val idTry = Library.decodePublicId(pubId)
     idTry match {
       case Failure(ex) =>
         BadRequest(Json.obj("error" -> "invalid id"))
       case Success(libraryId) =>
-        val take = Math.min(count, 100)
-        val (keeps, numKeeps) = db.readOnlyReplica { implicit session =>
-          val k = keepRepo.getByLibrary(libraryId, take, offset)
-          val numK = keepRepo.getCountByLibrary(libraryId)
-          (k, numK)
+
+        db.readOnlyReplica { implicit session =>
+          if (canView(request.userId, libraryRepo.get(libraryId), authToken)) {
+            val take = Math.min(count, 100)
+            val numKeeps = keepRepo.getCountByLibrary(libraryId)
+            val keepInfos = keepRepo.getByLibrary(libraryId, take, offset).map(KeepInfo.fromKeep)
+            Ok(Json.obj("keeps" -> Json.toJson(keepInfos), "count" -> Math.min(take, keepInfos.length), "offset" -> offset, "numKeeps" -> numKeeps))
+          } else
+            BadRequest(Json.obj("error" -> "invalid access"))
         }
-        val keepInfos = keeps.map(KeepInfo.fromKeep)
-        Ok(Json.obj("keeps" -> Json.toJson(keepInfos), "count" -> Math.min(take, keeps.length), "offset" -> offset, "numKeeps" -> numKeeps))
     }
   }
 

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -246,19 +246,22 @@ POST    /site/collections/:id/undelete @com.keepit.controllers.website.KeepsCont
 POST    /site/collections/:id/removeKeeps @com.keepit.controllers.website.KeepsController.removeKeepsFromCollection(id: ExternalId[Collection])
 POST    /site/collections/:id/addKeeps @com.keepit.controllers.website.KeepsController.keepToCollection(id: ExternalId[Collection])
 
+
+GET     /site/users/:userStr/libraries/:slug    @com.keepit.controllers.website.LibraryController.getLibraryByPath(userStr:String, slug:String, auth:Option[String] ?= None)
+
+GET     /site/libraries             @com.keepit.controllers.website.LibraryController.getLibrarySummariesByUser()
 POST    /site/libraries/add         @com.keepit.controllers.website.LibraryController.addLibrary()
+POST    /site/libraries/copy        @com.keepit.controllers.website.LibraryController.copyKeeps()
+POST    /site/libraries/move        @com.keepit.controllers.website.LibraryController.moveKeeps()
+
+GET     /site/libraries/:id         @com.keepit.controllers.website.LibraryController.getLibraryById(id: PublicId[Library], auth:Option[String] ?= None)
 POST    /site/libraries/:id/modify  @com.keepit.controllers.website.LibraryController.modifyLibrary(id: PublicId[Library])
 POST    /site/libraries/:id/delete  @com.keepit.controllers.website.LibraryController.removeLibrary(id: PublicId[Library])
-GET     /site/libraries/:id         @com.keepit.controllers.website.LibraryController.getLibraryById(id: PublicId[Library])
-GET     /site/users/:userStr/libraries/:slug    @com.keepit.controllers.website.LibraryController.getLibraryByPath(userStr:String, slug:String)
-GET     /site/libraries             @com.keepit.controllers.website.LibraryController.getLibrarySummariesByUser()
 POST    /site/libraries/:id/invite  @com.keepit.controllers.website.LibraryController.inviteUsersToLibrary(id: PublicId[Library])
 POST    /site/libraries/:id/join    @com.keepit.controllers.website.LibraryController.joinLibrary(id: PublicId[Library])
 POST    /site/libraries/:id/decline @com.keepit.controllers.website.LibraryController.declineLibrary(id: PublicId[Library])
 POST    /site/libraries/:id/leave   @com.keepit.controllers.website.LibraryController.leaveLibrary(id: PublicId[Library])
-GET     /site/libraries/:id/keeps   @com.keepit.controllers.website.LibraryController.getKeeps(id: PublicId[Library], count: Int, offset: Int ?= 0)
-POST    /site/libraries/copy        @com.keepit.controllers.website.LibraryController.copyKeeps()
-POST    /site/libraries/move        @com.keepit.controllers.website.LibraryController.moveKeeps()
+GET     /site/libraries/:id/keeps   @com.keepit.controllers.website.LibraryController.getKeeps(id: PublicId[Library], count: Int, offset: Int ?= 0, auth:Option[String] ?= None)
 
 POST    /site/recos/adHoc           @com.keepit.controllers.website.RecommendationsController.adHocRecos(n: Int)
 GET     /site/recos/top             @com.keepit.controllers.website.RecommendationsController.topRecos(more: Boolean, recency: Float)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -228,6 +228,18 @@ class LibraryCommanderTest extends Specification with ShoeboxTestInjector {
             (userIron.id.get, userHulk.id.get) ::
             Nil
         }
+
+        // test re-activating inactive library
+        val libScience = add3.right.get
+        db.readWrite { implicit s =>
+          libraryRepo.save(libScience.copy(state = LibraryStates.INACTIVE))
+        }
+        libraryCommander.addLibrary(lib3Request, userIron.id.get).isRight === true
+        db.readOnlyMaster { implicit s =>
+          val allLibs = libraryRepo.all
+          allLibs.length === 3
+          allLibs.map(_.slug.value) === Seq("avengers", "murica", "science")
+        }
       }
 
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -194,10 +194,13 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
 
-        val (user1, lib1) = db.readWrite { implicit s =>
-          val user = userRepo.save(User(firstName = "Aaron", lastName = "Hsu", createdAt = t1, username = Some(Username("ahsu"))))
-          val library = libraryRepo.save(Library(name = "Library1", ownerId = user.id.get, slug = LibrarySlug("lib1"), memberCount = 1, visibility = LibraryVisibility.SECRET))
-          (user, library)
+        val (user1, user2, lib1) = db.readWrite { implicit s =>
+          val user1 = userRepo.save(User(firstName = "Aaron", lastName = "Hsu", createdAt = t1, username = Some(Username("ahsu"))))
+          val user2 = userRepo.save(User(firstName = "AyAy", lastName = "Ron", createdAt = t1, username = Some(Username("ayayron"))))
+
+          val library = libraryRepo.save(Library(name = "Library1", ownerId = user1.id.get, slug = LibrarySlug("lib1"), memberCount = 1, visibility = LibraryVisibility.SECRET))
+          libraryMembershipRepo.save(LibraryMembership(userId = user1.id.get, libraryId = library.id.get, access = LibraryAccess.OWNER, showInSearch = true))
+          (user1, user2, library)
         }
 
         val pubId1 = Library.publicId(lib1.id.get)
@@ -227,6 +230,16 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
              |}}
            """.stripMargin)
         Json.parse(contentAsString(result1)) must equalTo(expected)
+
+        // test authentication token
+        inject[FakeActionAuthenticator].setUser(user2)
+        val request2 = FakeRequest("GET", com.keepit.controllers.website.routes.LibraryController.getLibraryById(pubId1).url)
+        val result2: Future[SimpleResult] = libraryController.getLibraryById(pubId1)(request2)
+        status(result2) must equalTo(BAD_REQUEST)
+        val request3 = FakeRequest("GET", com.keepit.controllers.website.routes.LibraryController.getLibraryById(pubId1, lib1.universalLink).url)
+        val result3: Future[SimpleResult] = libraryController.getLibraryById(pubId1, lib1.universalLink)(request3)
+        status(result3) must equalTo(OK)
+        Json.parse(contentAsString(result3)) must equalTo(expected)
       }
     }
     "get library by path" in {
@@ -235,10 +248,12 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
 
-        val (user1, lib1) = db.readWrite { implicit s =>
-          val user = userRepo.save(User(firstName = "Aaron", lastName = "Hsu", createdAt = t1, username = Some(Username("ahsu"))))
-          val library = libraryRepo.save(Library(name = "Library1", ownerId = user.id.get, slug = LibrarySlug("lib1"), memberCount = 1, visibility = LibraryVisibility.SECRET))
-          (user, library)
+        val (user1, user2, lib1) = db.readWrite { implicit s =>
+          val user1 = userRepo.save(User(firstName = "Aaron", lastName = "Hsu", createdAt = t1, username = Some(Username("ahsu"))))
+          val user2 = userRepo.save(User(firstName = "AyAy", lastName = "Ron", createdAt = t1, username = Some(Username("ayayron"))))
+          val library = libraryRepo.save(Library(name = "Library1", ownerId = user1.id.get, slug = LibrarySlug("lib1"), memberCount = 1, visibility = LibraryVisibility.SECRET))
+          libraryMembershipRepo.save(LibraryMembership(userId = user1.id.get, libraryId = library.id.get, access = LibraryAccess.OWNER, showInSearch = true))
+          (user1, user2, library)
         }
 
         val unInput = "ahsu"
@@ -283,6 +298,16 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
            """.stripMargin)
         Json.parse(contentAsString(result1)) must equalTo(expected)
         Json.parse(contentAsString(result2)) must equalTo(expected)
+
+        // test authentication token
+        inject[FakeActionAuthenticator].setUser(user2)
+        val request3 = FakeRequest("GET", com.keepit.controllers.website.routes.LibraryController.getLibraryByPath(extInput, slugInput).url)
+        val result3: Future[SimpleResult] = libraryController.getLibraryByPath(extInput, slugInput)(request3)
+        status(result3) must equalTo(BAD_REQUEST)
+        val request4 = FakeRequest("GET", com.keepit.controllers.website.routes.LibraryController.getLibraryByPath(extInput, slugInput, lib1.universalLink).url)
+        val result4: Future[SimpleResult] = libraryController.getLibraryByPath(extInput, slugInput, lib1.universalLink)(request4)
+        status(result4) must equalTo(OK)
+        Json.parse(contentAsString(result4)) must equalTo(expected)
       }
     }
 
@@ -481,8 +506,9 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
         val site1 = "http://www.google.com/"
         val site2 = "http://www.amazon.com/"
-        val (user1, lib1, keep1, keep2) = db.readWrite { implicit s =>
+        val (user1, user2, lib1, keep1, keep2) = db.readWrite { implicit s =>
           val userA = userRepo.save(User(firstName = "Aaron", lastName = "Hsu", createdAt = t1))
+          val userB = userRepo.save(User(firstName = "AyAyRon", lastName = "Hsu", createdAt = t1))
 
           val library1 = libraryRepo.save(Library(name = "Library1", ownerId = userA.id.get, slug = LibrarySlug("lib1"), visibility = LibraryVisibility.DISCOVERABLE, memberCount = 1))
           libraryMembershipRepo.save(LibraryMembership(libraryId = library1.id.get, userId = userA.id.get, access = LibraryAccess.OWNER, showInSearch = true))
@@ -500,7 +526,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
             uriId = uri2.id.get, source = KeepSource.keeper, createdAt = t1.plusMinutes(3),
             visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(library1.id.get)))
 
-          (userA, library1, keep1, keep2)
+          (userA, userB, library1, keep1, keep2)
         }
 
         val pubId1 = Library.publicId(lib1.id.get)
@@ -536,6 +562,16 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
              |}
            """.stripMargin)
         Json.parse(contentAsString(result1)) must equalTo(expected1)
+
+        // test authentication token
+        inject[FakeActionAuthenticator].setUser(user2)
+        val request2 = FakeRequest("GET", com.keepit.controllers.website.routes.LibraryController.getKeeps(pubId1, 10, 0).url)
+        val result2: Future[SimpleResult] = libraryController.getKeeps(pubId1, 10, 0)(request2)
+        status(result2) must equalTo(BAD_REQUEST)
+        val request3 = FakeRequest("GET", com.keepit.controllers.website.routes.LibraryController.getKeeps(pubId1, 10, 0, lib1.universalLink).url)
+        val result3: Future[SimpleResult] = libraryController.getKeeps(pubId1, 10, 0, lib1.universalLink)(request3)
+        status(result3) must equalTo(OK)
+        Json.parse(contentAsString(result3)) must equalTo(expected1)
       }
     }
 


### PR DESCRIPTION
...GET actions)

following GET actions have auth tokens now
- /site/users/:userStr/libraries/:slug?auth=
- /site/libraries/:id?auth=
- /site/libraries/:id/keeps?count=0&offset=0&auth=

& some other stuff
- users cannot be invited / join a system-generated library
- commander -> add libraries changed so it can reactivate "deleted" libraries of same name/slug
- tests

@andrewconner 
