### PR TITLE
fix a scraper error

### DIFF
--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/DefaultExtractor.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/extractor/DefaultExtractor.scala
@@ -120,11 +120,12 @@ class DefaultContentHandler(maxContentChars: Int, handler: ContentHandler, metad
   }
 
   // link tag
-  private def startLink(uri: String, localName: String, qName: String, atts: Attributes) = {
+  private def startLink(uri: String, localName: String, qName: String, atts: Attributes): Unit = {
     super.startElement(uri, localName, qName, atts)
     val rel = atts.getValue("rel")
     val href = atts.getValue("href")
-    links.addBinding(rel, href)
+
+    if (rel != null && href != null) links.addBinding(rel, href)
   }
 
   // option tag


### PR DESCRIPTION
I noticed there are many exceptions like this in a scraper's app.log.

17:21:36.684 [ForkJoinPool-4-worker-165] ERROR c.k.s.e.LinkProcessingExtractor - extraction failed: 
java.lang.IllegalArgumentException: Flat hash tables cannot contain null elements.
...
com.keepit.scraper.extractor.DefaultContentHandler.com$keepit$scraper$extractor$DefaultContentHandler$$startLink(DefaultExtractor.scala:127)
...

@leogrim @raymondng 
