### PR TITLE
optimize

### DIFF
--- a/kifi-backend/modules/heimdal/app/com/keepit/controllers/HelpRankController.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/controllers/HelpRankController.scala
@@ -34,12 +34,13 @@ class HelpRankController @Inject() (
     }
   }
 
-  def getHelpRankInfo() = SafeAsyncAction(parse.tolerantJson) { request =>
+  def getHelpRankInfo() = Action.async(parse.tolerantJson) { request =>
     val uriIds = Json.fromJson[Seq[Id[NormalizedURI]]](request.body).get
-    val infos = helprankCommander.getHelpRankInfo(uriIds)
-    if (uriIds.length != infos.length) // debug
-      log.warn(s"[getHelpRankInfo] (mismatch) uriIds(len=${uriIds.length}):${uriIds.mkString(",")} res(len=${infos.length}):${infos.mkString(",")}")
-    Ok(Json.toJson(infos))
+    helprankCommander.getHelpRankInfo(uriIds) map { infos =>
+      if (uriIds.length != infos.length) // debug
+        log.warn(s"[getHelpRankInfo] (mismatch) uriIds(len=${uriIds.length}):${uriIds.mkString(",")} res(len=${infos.length}):${infos.mkString(",")}")
+      Ok(Json.toJson(infos))
+    }
   }
 
   def getKeepAttributionInfo(userId: Id[User]) = Action { request =>

--- a/kifi-backend/modules/heimdal/app/com/keepit/model/helprank/KeepDiscoveryRepo.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/model/helprank/KeepDiscoveryRepo.scala
@@ -76,7 +76,7 @@ class KeepDiscoveryRepoImpl @Inject() (
     sql"select count(distinct (hit_uuid)) from keep_click where uri_id=$uriId and created_at >= $since".as[Int].first
   }
 
-  def getDiscoveryCountsByURIs(uriIds: Set[Id[NormalizedURI]], since: DateTime)(implicit session: RSession): Map[Id[NormalizedURI], Int] = timing(s"getDiscoveryCountsByURIs(${uriIds.size})") {
+  def getDiscoveryCountsByURIs(uriIds: Set[Id[NormalizedURI]], since: DateTime)(implicit session: RSession): Map[Id[NormalizedURI], Int] = timing(s"getDiscoveryCountsByURIs(sz=${uriIds.size})") {
     if (uriIds.isEmpty) Map.empty
     else {
       val valueMap = uriDiscoveryCountCache.bulkGetOrElse(uriIds.map(UriDiscoveryCountKey(_)).toSet) { keys =>
@@ -89,7 +89,7 @@ class KeepDiscoveryRepoImpl @Inject() (
             case (uriId, idx) =>
               stmt.setLong(idx + 1, uriId.id)
           }
-          val res = stmt.execute()
+          val res = timing(s"getDiscoveryCountsByURIs(sz=${ids.size};ids=$ids)") { stmt.execute() }
           if (!res) throw new SQLException(s"[getDiscoveryCountsByURIs] ($stmt) failed to execute")
           val rs = stmt.getResultSet()
           while (rs.next()) {


### PR DESCRIPTION
A follow-up. Bring `getReKeepCountsByURIs` up to par with `getDiscoveryCountsByURIs` based on prod results -- currently the latter beat the former by a wide margin in terms of performance. 

Now both utilizes the same approach (and almost same code except SQL) -- there might be room for a utility function here. Will look into it some more.

Also made `getHelpRankInfo` async -- issue both queries in parallel to further improve performance.

@ymatsuda @yingjieMiao @stkem @andrewconner 
