### PR TITLE
Introducing Hashtag + tag indexing

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -158,6 +158,7 @@ object Shoebox extends Service {
     def getIndexableSocialUserInfos(seqNum: SequenceNumber[SocialUserInfo], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getIndexableSocialUserInfos", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def getEmailAccountUpdates(seqNum: SequenceNumber[EmailAccountUpdate], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getEmailAccountUpdates", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def getLibrariesAndMembershipsChanged(seqNum: SequenceNumber[Library], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getLibrariesAndMembershipsChanged", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
+    def getKeepsAndTagsChanged(seqNum: SequenceNumber[Keep], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getKeepsAndTagsChanged", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def getLapsedUsersForDelighted(maxCount: Int, skipCount: Int, after: DateTime, before: Option[DateTime]) = ServiceRoute(GET, "/internal/shoebox/database/getLapsedUsersForDelighted", Param("maxCount", maxCount), Param("skipCount", skipCount), Param("after", after), Param("before", before))
     def getAllFakeUsers() = ServiceRoute(GET, "/internal/shoebox/database/getAllFakeUsers")
     def getInvitations(senderId: Id[User]) = ServiceRoute(GET, "/internal/shoebox/database/getInvitations", Param("senderId", senderId))

--- a/kifi-backend/modules/common/app/com/keepit/model/Collection.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Collection.scala
@@ -12,7 +12,7 @@ import com.keepit.common.strings._
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import com.keepit.serializer.BinaryFormat
+import com.keepit.serializer.{ TupleFormat, BinaryFormat }
 import java.io.{ ByteArrayInputStream, DataInputStream, DataOutputStream, ByteArrayOutputStream }
 import scala.collection.mutable.ListBuffer
 import scala.Some
@@ -23,6 +23,13 @@ case class Hashtag(tag: String) extends AnyVal {
 
 object Hashtag {
   implicit val format: Format[Hashtag] = Format(__.read[String].map(Hashtag(_)), new Writes[Hashtag] { def writes(o: Hashtag) = JsString(o.tag) })
+  implicit def hashtagMapFormat[T](implicit tFormat: Format[T]) = {
+    implicit val tupleFormat = TupleFormat.tuple2Format[Hashtag, T]
+    new Format[Map[Hashtag, T]] {
+      def reads(json: JsValue) = json.validate[Seq[(Hashtag, T)]].map(_.toMap)
+      def writes(itemMap: Map[Hashtag, T]) = Json.toJson(itemMap.toSeq)
+    }
+  }
 }
 
 case class Collection(

--- a/kifi-backend/modules/common/app/com/keepit/model/Collection.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Collection.scala
@@ -17,11 +17,19 @@ import java.io.{ ByteArrayInputStream, DataInputStream, DataOutputStream, ByteAr
 import scala.collection.mutable.ListBuffer
 import scala.Some
 
+case class Hashtag(tag: String) extends AnyVal {
+  override def toString = tag
+}
+
+object Hashtag {
+  implicit val format: Format[Hashtag] = Format(__.read[String].map(Hashtag(_)), new Writes[Hashtag] { def writes(o: Hashtag) = JsString(o.tag) })
+}
+
 case class Collection(
     id: Option[Id[Collection]] = None,
     externalId: ExternalId[Collection] = ExternalId(),
     userId: Id[User],
-    name: String,
+    name: Hashtag,
     state: State[Collection] = CollectionStates.ACTIVE,
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime,
@@ -39,7 +47,7 @@ object Collection {
     (__ \ 'id).formatNullable(Id.format[Collection]) and
     (__ \ 'externalId).format(ExternalId.format[Collection]) and
     (__ \ 'userId).format(Id.format[User]) and
-    (__ \ 'name).format[String] and
+    (__ \ 'name).format[Hashtag] and
     (__ \ 'state).format(State.format[Collection]) and
     (__ \ 'createdAt).format(DateTimeJsonFormat) and
     (__ \ 'updatedAt).format(DateTimeJsonFormat) and
@@ -50,7 +58,7 @@ object Collection {
   val MaxNameLength = 64
 }
 
-case class CollectionSummary(id: Id[Collection], externalId: ExternalId[Collection], name: String)
+case class CollectionSummary(id: Id[Collection], externalId: ExternalId[Collection], name: Hashtag)
 
 class CollectionSummariesFormat extends BinaryFormat[Seq[CollectionSummary]] {
 
@@ -65,7 +73,7 @@ class CollectionSummariesFormat extends BinaryFormat[Seq[CollectionSummary]] {
     collections foreach { collection =>
       outStream.writeLong(collection.id.id) //2 bytes
       outStream.writeUTF(collection.externalId.id)
-      outStream.writeUTF(collection.name)
+      outStream.writeUTF(collection.name.tag)
     }
     outStream.writeLong(-1)
     outStream.close()
@@ -80,7 +88,7 @@ class CollectionSummariesFormat extends BinaryFormat[Seq[CollectionSummary]] {
       val externalIdString = inStream.readUTF()
       val nameString = inStream.readUTF()
 
-      collections.append(CollectionSummary(Id[Collection](idLong), ExternalId[Collection](externalIdString), nameString))
+      collections.append(CollectionSummary(Id[Collection](idLong), ExternalId[Collection](externalIdString), Hashtag(nameString)))
 
       idLong = inStream.readLong()
     }
@@ -94,7 +102,7 @@ object CollectionSummary {
 
 case class SendableTag(
   id: ExternalId[Collection],
-  name: String)
+  name: Hashtag)
 
 object SendableTag {
   private implicit val externalIdFormat = ExternalId.format[Collection]

--- a/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
@@ -230,3 +230,9 @@ object KeepSource {
   }
 }
 
+case class KeepAndTags(keep: Keep, tags: Seq[Hashtag])
+
+object KeepAndTags {
+  implicit val format = Json.format[KeepAndTags]
+}
+

--- a/kifi-backend/modules/common/app/com/keepit/search/Item.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/Item.scala
@@ -1,13 +1,11 @@
 package com.keepit.search
 
 import com.keepit.common.db.Id
-import com.keepit.model.{ User, Library, NormalizedURI }
+import com.keepit.model.{ Hashtag, User, Library, NormalizedURI }
 import play.api.libs.json._
-import com.keepit.search.Item.Tag
 import com.keepit.serializer.TupleFormat
 
 object Item {
-  type Tag = String
   implicit val format = Json.format[Item]
   implicit def itemMapFormat[T](implicit tFormat: Format[T]) = {
     implicit val tupleFormat = TupleFormat.tuple2Format[Item, T]
@@ -22,17 +20,17 @@ case class Item(uri: Id[NormalizedURI], keptIn: Option[Id[Library]])
 
 case class AugmentedItem(
   uri: Id[NormalizedURI],
-  kept: Option[(Id[Library], Option[Id[User]], Seq[Tag])],
+  kept: Option[(Id[Library], Option[Id[User]], Seq[Hashtag])],
   moreKeeps: Seq[(Option[Id[Library]], Option[Id[User]])],
-  moreTags: Seq[Tag])
+  moreTags: Seq[Hashtag])
 
-case class RestrictedKeepInfo(keptIn: Option[Id[Library]], keptBy: Option[Id[User]], tags: Seq[Tag])
+case class RestrictedKeepInfo(keptIn: Option[Id[Library]], keptBy: Option[Id[User]], tags: Seq[Hashtag])
 
 object RestrictedKeepInfo {
   implicit val format = new Format[RestrictedKeepInfo] {
     def reads(json: JsValue) = json.validate[Seq[JsValue]].map {
       case Seq(keptIn, keptBy, tags) =>
-        RestrictedKeepInfo(keptIn.as[Option[Id[Library]]], keptBy.as[Option[Id[User]]], tags.as[Seq[Tag]])
+        RestrictedKeepInfo(keptIn.as[Option[Id[Library]]], keptBy.as[Option[Id[User]]], tags.as[Seq[Hashtag]])
     }
     def writes(keep: RestrictedKeepInfo) = Json.arr(keep.keptIn, keep.keptBy, keep.tags)
   }
@@ -46,7 +44,7 @@ object AugmentationInfo {
 case class ContextualAugmentationScores(
     libraryScores: Map[Id[Library], Float],
     userScores: Map[Id[User], Float],
-    tagScores: Map[Tag, Float]) {
+    tagScores: Map[Hashtag, Float]) {
 
   def merge(moreScores: ContextualAugmentationScores): ContextualAugmentationScores = {
     val addedLibraryScores = (libraryScores.keySet ++ moreScores.libraryScores.keySet).map { id =>

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -105,6 +105,7 @@ trait ShoeboxServiceClient extends ServiceClient {
   def getIndexableSocialUserInfos(seqNum: SequenceNumber[SocialUserInfo], fetchSize: Int): Future[Seq[SocialUserInfo]]
   def getEmailAccountUpdates(seqNum: SequenceNumber[EmailAccountUpdate], fetchSize: Int): Future[Seq[EmailAccountUpdate]]
   def getLibrariesAndMembershipsChanged(seqNum: SequenceNumber[Library], fetchSize: Int): Future[Seq[LibraryAndMemberships]]
+  def getKeepsAndTagsChanged(seqNum: SequenceNumber[Keep], fetchSize: Int): Future[Seq[KeepAndTags]]
   def getLapsedUsersForDelighted(maxCount: Int, skipCount: Int, after: DateTime, before: Option[DateTime]): Future[Seq[DelightedUserRegistrationInfo]]
   def getAllFakeUsers(): Future[Set[Id[User]]]
   def getInvitations(senderId: Id[User]): Future[Seq[Invitation]]
@@ -671,6 +672,12 @@ class ShoeboxServiceClientImpl @Inject() (
   def getLibrariesAndMembershipsChanged(seqNum: SequenceNumber[Library], fetchSize: Int): Future[Seq[LibraryAndMemberships]] = {
     call(Shoebox.internal.getLibrariesAndMembershipsChanged(seqNum, fetchSize), callTimeouts = longTimeout).map { r =>
       r.json.as[Seq[LibraryAndMemberships]]
+    }
+  }
+
+  def getKeepsAndTagsChanged(seqNum: SequenceNumber[Keep], fetchSize: Int): Future[Seq[KeepAndTags]] = {
+    call(Shoebox.internal.getKeepsAndTagsChanged(seqNum, fetchSize), callTimeouts = longTimeout).map { r =>
+      r.json.as[Seq[KeepAndTags]]
     }
   }
 

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -632,6 +632,8 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
 
   def getLibrariesAndMembershipsChanged(seqNum: SequenceNumber[Library], fetchSize: Int): Future[Seq[LibraryAndMemberships]] = Future.successful(Seq.empty)
 
+  def getKeepsAndTagsChanged(seqNum: SequenceNumber[Keep], fetchSize: Int): Future[Seq[KeepAndTags]] = Future.successful(Seq.empty)
+
   def getLapsedUsersForDelighted(maxCount: Int, skipCount: Int, after: DateTime, before: Option[DateTime]): Future[Seq[DelightedUserRegistrationInfo]] = Future.successful(Seq.empty)
 
   def getAllFakeUsers(): Future[Set[Id[User]]] = Future.successful(Set.empty)

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -453,11 +453,6 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
     Future.successful(collections)
   }
 
-  def getBookmarksInCollection(collectionId: Id[Collection]): Future[Seq[Keep]] = {
-    val bookmarks = allCollectionBookmarks(collectionId).map(allBookmarks(_)).toSeq
-    Future.successful(bookmarks)
-  }
-
   def getUriIdsInCollection(collectionId: Id[Collection]): Future[Seq[KeepUriAndTime]] = {
     val bookmarks = allCollectionBookmarks(collectionId).map(allBookmarks(_)).toSeq
     Future.successful(bookmarks map { b => KeepUriAndTime(b.uriId, b.createdAt) })
@@ -611,8 +606,6 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
     Future.successful(uri.contains("isSensitive"))
   }
   def updateURIRestriction(id: Id[NormalizedURI], r: Option[Restriction]): Future[Unit] = ???
-
-  def getVerifiedAddressOwners(emailAddresses: Seq[EmailAddress]): Future[Map[EmailAddress, Id[User]]] = Future.successful(Map.empty)
 
   def sendUnreadMessages(threadItems: Seq[ThreadItem], otherParticipants: Set[Id[User]], userId: Id[User], title: String, deepLocator: DeepLocator, notificationUpdatedAt: DateTime): Future[Unit] = Future.successful(Unit)
 

--- a/kifi-backend/modules/search/app/com/keepit/search/AugmentationCommander.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/AugmentationCommander.scala
@@ -1,8 +1,7 @@
 package com.keepit.search
 
-import com.keepit.model.{ Library, NormalizedURI, User }
+import com.keepit.model.{ Hashtag, Library, NormalizedURI, User }
 import com.keepit.common.db.Id
-import com.keepit.search.Item.{ Tag }
 import com.google.inject.{ ImplementedBy, Inject }
 import com.keepit.search.graph.keep.{ ShardedKeepIndexer, KeepFields }
 import org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS
@@ -76,7 +75,7 @@ class AugmentationCommanderImpl @Inject() (
       }
     }
 
-    val (allKeeps, allTags) = info.keeps.foldLeft(Set.empty[(Option[Id[Library]], Option[Id[User]])], Set.empty[Tag]) {
+    val (allKeeps, allTags) = info.keeps.foldLeft(Set.empty[(Option[Id[Library]], Option[Id[User]])], Set.empty[Hashtag]) {
       case ((moreKeeps, moreTags), RestrictedKeepInfo(libraryIdOpt, userIdOpt, tags)) => (moreKeeps + ((libraryIdOpt, userIdOpt)), moreTags ++ tags)
     }
 
@@ -138,7 +137,7 @@ class AugmentationCommanderImpl @Inject() (
         val libraryId = libraryIdDocValues.get(docId)
         val userId = userIdDocValues.get(docId)
         val visibility = visibilityDocValues.get(docId)
-        val tags: Seq[String] = ??? //todo(Léo): implement
+        val tags: Seq[Hashtag] = ??? //todo(Léo): implement
 
         if (libraryIdFilter.findIndex(libraryId) >= 0 || (item.keptIn.isDefined && item.keptIn.get.id == libraryId)) { // kept in my libraries or preferred keep
           val userIdOpt = if (userIdFilter.findIndex(userId) >= 0) Some(Id[User](userId)) else None
@@ -161,7 +160,7 @@ class AugmentationCommanderImpl @Inject() (
   private def computeAugmentationScores(weigthedAugmentationInfos: Iterable[(AugmentationInfo, Float)]): ContextualAugmentationScores = {
     val libraryScores = MutableMap[Id[Library], Float]() withDefaultValue 0f
     val userScores = MutableMap[Id[User], Float]() withDefaultValue 0f
-    val tagScores = MutableMap[Tag, Float]() withDefaultValue 0f
+    val tagScores = MutableMap[Hashtag, Float]() withDefaultValue 0f
 
     weigthedAugmentationInfos.foreach {
       case (info, weight) =>

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/collection/CollectionIdList.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/collection/CollectionIdList.scala
@@ -1,7 +1,7 @@
 package com.keepit.search.graph.collection
 
 import com.keepit.common.db.Id
-import com.keepit.model.Collection
+import com.keepit.model.{ Hashtag, Collection }
 import org.apache.lucene.store.InputStreamDataInput
 import org.apache.lucene.store.OutputStreamDataOutput
 import java.io.ByteArrayInputStream
@@ -15,8 +15,8 @@ trait CollectionIdList {
   def ids: Array[Long]
 }
 
-class SortedCollections(collections: Seq[(Id[Collection], String)]) {
-  def toSeq: Seq[(Id[Collection], String)] = collections
+class SortedCollections(collections: Seq[(Id[Collection], Hashtag)]) {
+  def toSeq: Seq[(Id[Collection], Hashtag)] = collections
 }
 
 object CollectionIdList {
@@ -40,13 +40,13 @@ object CollectionIdList {
     override def ids: Array[Long] = Array.empty[Long]
   }
 
-  def sortCollections(collections: Seq[(Id[Collection], String)]): SortedCollections = new SortedCollections(collections.sortBy(_._1.id))
+  def sortCollections(collections: Seq[(Id[Collection], Hashtag)]): SortedCollections = new SortedCollections(collections.sortBy(_._1.id))
 
-  def toByteArray(collections: Seq[(Id[Collection], String)]): Array[Byte] = toByteArrayFromSorted(collections.sortBy(_._1.id))
+  def toByteArray(collections: Seq[(Id[Collection], Hashtag)]): Array[Byte] = toByteArrayFromSorted(collections.sortBy(_._1.id))
 
   def toByteArray(collections: SortedCollections): Array[Byte] = toByteArrayFromSorted(collections.toSeq)
 
-  private def toByteArrayFromSorted(sortedCollections: Seq[(Id[Collection], String)]): Array[Byte] = {
+  private def toByteArrayFromSorted(sortedCollections: Seq[(Id[Collection], Hashtag)]): Array[Byte] = {
     val size = sortedCollections.size
     val baos = new ByteArrayOutputStream(size * 4)
     val out = new OutputStreamDataOutput(baos)

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/collection/CollectionIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/collection/CollectionIndexer.scala
@@ -147,7 +147,7 @@ object CollectionIndexer {
       val externalId = buildBinaryDocValuesField(externalIdField, collection.externalId.id)
       doc.add(externalId)
 
-      val name = buildBinaryDocValuesField(nameField, collection.name)
+      val name = buildBinaryDocValuesField(nameField, collection.name.tag)
       doc.add(name)
 
       doc

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/collection/CollectionNameIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/collection/CollectionNameIndexer.scala
@@ -58,7 +58,7 @@ class CollectionNameIndexer(
       override val id: Id[User],
       override val sequenceNumber: SequenceNumber[Collection],
       override val isDeleted: Boolean,
-      val collections: Seq[(Id[Collection], String)]) extends Indexable[User, Collection] with LineFieldBuilder {
+      val collections: Seq[(Id[Collection], Hashtag)]) extends Indexable[User, Collection] with LineFieldBuilder {
 
     override def buildDocument = {
       val doc = super.buildDocument
@@ -85,11 +85,11 @@ class CollectionNameIndexer(
       doc
     }
 
-    private def buildNameList(collections: Seq[(Id[Collection], String)], preferedLang: Lang): ArrayBuffer[(Int, String, Lang)] = {
+    private def buildNameList(collections: Seq[(Id[Collection], Hashtag)], preferedLang: Lang): ArrayBuffer[(Int, String, Lang)] = {
       var lineNo = 0
       var names = new ArrayBuffer[(Int, String, Lang)]
       collections.foreach { c =>
-        val name = c._2
+        val name = c._2.tag
         val lang = LangDetector.detect(name, preferedLang)
         names += ((lineNo, name, lang))
         lineNo += 1

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/collection/CollectionSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/collection/CollectionSearcher.scala
@@ -4,7 +4,7 @@ import com.keepit.common.db.ExternalId
 import com.keepit.common.db.Id
 import com.keepit.common.logging.Logging
 import com.keepit.common.strings._
-import com.keepit.model.{ NormalizedURI, User, Collection }
+import com.keepit.model.{ Hashtag, NormalizedURI, User, Collection }
 import com.keepit.search.Searcher
 import com.keepit.search.line.LineIndexReader
 import com.keepit.search.util.LongArraySet
@@ -57,13 +57,13 @@ class CollectionSearcher(searcher: Searcher) extends BaseGraphSearcher(searcher)
     searcher.getDecodedDocValue[String](externalIdField, id)(fromByteArray).map { ExternalId[Collection](_) }
   }
 
-  def getName(id: Id[Collection]): String = getName(id.id)
+  def getName(id: Id[Collection]): Hashtag = Hashtag(getName(id.id))
 
   def getName(id: Long): String = {
     searcher.getDecodedDocValue[String](nameField, id)(fromByteArray).getOrElse("")
   }
 
-  def getCollections(userId: Id[User]): Seq[(Id[Collection], String)] = {
+  def getCollections(userId: Id[User]): Seq[(Id[Collection], Hashtag)] = {
     getUserToCollectionEdgeSet(userId).destIdSet.iterator.map { id => (id, getName(id)) }.toSeq
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/keep/KeepIndexable.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/keep/KeepIndexable.scala
@@ -1,7 +1,7 @@
 package com.keepit.search.graph.keep
 
 import com.keepit.search.index.{ FieldDecoder, DefaultAnalyzer, Indexable }
-import com.keepit.model.{ LibraryVisibility, NormalizedURI, Keep }
+import com.keepit.model.{ Hashtag, LibraryVisibility, NormalizedURI, Keep }
 import com.keepit.search.LangDetector
 import com.keepit.search.sharding.Shard
 import com.keepit.search.graph.library.LibraryFields
@@ -26,7 +26,7 @@ object KeepFields {
   val decoders: Map[String, FieldDecoder] = Map.empty
 }
 
-case class KeepIndexable(keep: Keep, shard: Shard[NormalizedURI]) extends Indexable[Keep, Keep] {
+case class KeepIndexable(keep: Keep, tags: Seq[Hashtag], shard: Shard[NormalizedURI]) extends Indexable[Keep, Keep] {
   val id = keep.id.get
   val sequenceNumber = keep.seq
   val isDeleted = !keep.isActive || !shard.contains(keep.uriId)

--- a/kifi-backend/modules/search/test/com/keepit/search/MainSearcherTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/MainSearcherTest.scala
@@ -432,8 +432,8 @@ class MainSearcherTest extends Specification with SearchTestInjector with Search
         val (coll1set, _) = bookmarks.partition { b => b.userId == user1.id.get && b.uriId.id % 3 == 0 }
         val (coll2set, _) = bookmarks.partition { b => b.userId == user1.id.get && b.uriId.id % 3 == 1 }
         val Seq(coll1, coll2) = saveCollections(
-          Collection(userId = user1.id.get, name = "mycoll"),
-          Collection(userId = user1.id.get, name = "different mycoll")
+          Collection(userId = user1.id.get, name = Hashtag("mycoll")),
+          Collection(userId = user1.id.get, name = Hashtag("different mycoll"))
         )
         saveBookmarksToCollection(coll1.id.get, coll1set: _*)
         saveBookmarksToCollection(coll2.id.get, coll2set: _*)

--- a/kifi-backend/modules/search/test/com/keepit/search/graph/GraphTestHelper.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/graph/GraphTestHelper.scala
@@ -117,7 +117,7 @@ trait GraphTestHelper extends SearchTestInjector {
 
   def saveCollection(user: User, name: String)(implicit injector: Injector): Collection = {
     val fakeShoeboxServiceClient = inject[ShoeboxServiceClient].asInstanceOf[FakeShoeboxServiceClientImpl]
-    val Seq(collection) = fakeShoeboxServiceClient.saveCollections(Collection(userId = user.id.get, name = name))
+    val Seq(collection) = fakeShoeboxServiceClient.saveCollections(Collection(userId = user.id.get, name = Hashtag(name)))
     collection
   }
 

--- a/kifi-backend/modules/search/test/com/keepit/search/graph/collection/CollectionIndexerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/graph/collection/CollectionIndexerTest.scala
@@ -211,7 +211,7 @@ class CollectionIndexerTest extends Specification with SearchTestInjector with G
         val searcher = new CollectionSearcherWithUser(collectionIndexSearcher, collectionNameIndexSearcher, user.id.get)
 
         def getCollectionId(name: String): Long = {
-          collections.find(_.name == name).get.id.get.id
+          collections.find(_.name.tag == name).get.id.get.id
         }
         def detect(text: String) = {
           val it = new TermIterator("", text, DefaultAnalyzer.getAnalyzerWithStemmer(DefaultAnalyzer.defaultLang))

--- a/kifi-backend/modules/search/test/com/keepit/search/sharding/IndexShardingTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/sharding/IndexShardingTest.scala
@@ -33,7 +33,7 @@ class IndexShardingTest extends Specification with SearchTestInjector with Searc
         )
         val collections = collKeeps.zipWithIndex.map {
           case (s, i) =>
-            val Seq(collection) = saveCollections(Collection(userId = users(i).id.get, name = s"coll $i"))
+            val Seq(collection) = saveCollections(Collection(userId = users(i).id.get, name = Hashtag(s"coll $i")))
             saveBookmarksToCollection(collection.id.get, s: _*)
             collection
         }
@@ -110,7 +110,7 @@ class IndexShardingTest extends Specification with SearchTestInjector with Searc
         val expectedUriToUserEdges = uris.take(5).map(_ -> Seq(user))
         val bookmarks = saveBookmarksByURI(expectedUriToUserEdges)
         val collection = {
-          val Seq(collection) = saveCollections(Collection(userId = userId, name = "mutating collection"))
+          val Seq(collection) = saveCollections(Collection(userId = userId, name = Hashtag("mutating collection")))
           saveBookmarksToCollection(collection.id.get, bookmarks: _*)
           collection
         }

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -159,7 +159,7 @@ class AdminUserController @Inject() (
 
   def updateCollectionsForBookmark(id: Id[Keep]) = AdminHtmlAction.authenticated { implicit request =>
     request.request.body.asFormUrlEncoded.map { _.map(r => (r._1 -> r._2.head)) }.map { map =>
-      val collectionNames = map.get("collections").getOrElse("").split(",").map(_.trim).filterNot(_.isEmpty)
+      val collectionNames = map.get("collections").getOrElse("").split(",").map(_.trim).filterNot(_.isEmpty).map(Hashtag.apply)
       val collections = db.readWrite { implicit s =>
         val bookmark = keepRepo.get(id)
         val userId = bookmark.userId

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
@@ -22,7 +22,7 @@ object BasicCollection {
   implicit val externalIdFormat = ExternalId.format[Collection]
   implicit val format = Json.format[BasicCollection]
   def fromCollection(c: CollectionSummary, keeps: Option[Int] = None): BasicCollection =
-    BasicCollection(Some(c.externalId), c.name, keeps)
+    BasicCollection(Some(c.externalId), c.name.tag, keeps)
 }
 
 case class BasicCollectionByIdKey(id: Id[Collection]) extends Key[BasicCollection] {
@@ -143,8 +143,8 @@ class CollectionCommander @Inject() (
 
   def saveCollection(userId: Id[User], collectionOpt: Option[BasicCollection])(implicit context: HeimdalContext): Either[BasicCollection, CollectionSaveFail] = {
     val saved: Option[Either[BasicCollection, CollectionSaveFail]] = collectionOpt map { basicCollection =>
-      val name = basicCollection.name.trim.replaceAll("""\s+""", " ")
-      if (name.length <= Collection.MaxNameLength) {
+      val name = Hashtag(basicCollection.name.trim.replaceAll("""\s+""", " "))
+      if (name.tag.length <= Collection.MaxNameLength) {
         db.readWrite { implicit s =>
           val existingCollection = collectionRepo.getByUserAndName(userId, name, None)
           val existingExternalId = existingCollection collect { case c if c.isActive => c.externalId }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
@@ -41,7 +41,6 @@ class CollectionCommander @Inject() (
     collectionRepo: CollectionRepo,
     userValueRepo: UserValueRepo,
     searchClient: SearchServiceClient,
-    keepToCollectionRepo: KeepToCollectionRepo,
     keptAnalytics: KeepingAnalytics,
     basicCollectionCache: BasicCollectionByIdCache,
     clock: Clock) extends Logging {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepingAnalytics.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepingAnalytics.scala
@@ -22,8 +22,8 @@ class KeepingAnalytics @Inject() (heimdal: HeimdalServiceClient) {
 
       // Anonymized event with tag information
       anonymise(contextBuilder)
-      contextBuilder += ("oldTagName", oldTag.name)
-      contextBuilder += ("tagName", newTag.name)
+      contextBuilder += ("oldTagName", oldTag.name.tag)
+      contextBuilder += ("tagName", newTag.name.tag)
       heimdal.trackEvent(AnonymousEvent(contextBuilder.build, AnonymousEventTypes.KEPT, renamedAt))
     }
   }
@@ -41,7 +41,7 @@ class KeepingAnalytics @Inject() (heimdal: HeimdalServiceClient) {
 
       // Anonymized event with tag information
       anonymise(contextBuilder)
-      contextBuilder += ("tagName", newTag.name)
+      contextBuilder += ("tagName", newTag.name.tag)
       heimdal.trackEvent(AnonymousEvent(contextBuilder.build, AnonymousEventTypes.KEPT, createdAt))
     }
   }
@@ -206,7 +206,7 @@ class KeepingAnalytics @Inject() (heimdal: HeimdalServiceClient) {
     if (action == "taggedPage") {
       anonymise(contextBuilder)
       contextBuilder.addUrlInfo(keep.url)
-      contextBuilder += ("tagName", tag.name)
+      contextBuilder += ("tagName", tag.name.tag)
       heimdal.trackEvent(AnonymousEvent(contextBuilder.build, AnonymousEventTypes.KEPT, changedAt))
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -517,7 +517,10 @@ class KeepsCommander @Inject() (
       }
       val tagged = (activated ++ newK2C).toSet
       val taggingAt = currentDateTime
-      tagged.foreach(ktc => keptAnalytics.taggedPage(collection, keepsById(ktc.keepId), context, taggingAt))
+      tagged.foreach { ktc =>
+        keepRepo.save(keepsById(ktc.keepId)) // notify keep index
+        keptAnalytics.taggedPage(collection, keepsById(ktc.keepId), context, taggingAt)
+      }
       tagged
     }
     if (updateUriGraph) {
@@ -533,11 +536,13 @@ class KeepsCommander @Inject() (
         case ktc if ktc.state != KeepToCollectionStates.INACTIVE && keepsById.contains(ktc.keepId) =>
           keepToCollectionRepo.save(ktc.copy(state = KeepToCollectionStates.INACTIVE))
       }
-
       collectionRepo.collectionChanged(collection.id.get)
 
       val removedAt = currentDateTime
-      removed.foreach(ktc => keptAnalytics.untaggedPage(collection, keepsById(ktc.keepId), context, removedAt))
+      removed.foreach { ktc =>
+        keepRepo.save(keepsById(ktc.keepId)) // notify keep index
+        keptAnalytics.untaggedPage(collection, keepsById(ktc.keepId), context, removedAt)
+      }
       removed.toSet
     } tap { _ => searchClient.updateURIGraph() }
   }
@@ -571,12 +576,14 @@ class KeepsCommander @Inject() (
       } {
         keepToCollectionRepo.remove(keepId = keep.id.get, collectionId = collection.id.get)
         collectionRepo.collectionChanged(collection.id.get)
+        keepRepo.save(keep) // notify keep index
         keptAnalytics.untaggedPage(collection, keep, context)
       }
     }
     searchClient.updateURIGraph()
   }
 
+  //todo(hopefully not Léo): this method does not report to analytics, let's fix this after we get rid of Collection
   def clearTags(url: String, userId: Id[User]): Unit = {
     db.readWrite { implicit s =>
       for {
@@ -585,6 +592,7 @@ class KeepsCommander @Inject() (
         ktc <- keepToCollectionRepo.getByKeep(keep.id.get)
       } {
         keepToCollectionRepo.save(ktc.copy(state = KeepToCollectionStates.INACTIVE))
+        keepRepo.save(keep) // notify keep index
         collectionRepo.collectionChanged(ktc.collectionId)
       }
     }
@@ -603,6 +611,7 @@ class KeepsCommander @Inject() (
     }
   }
 
+  //todo(hopefully not Léo): this method does not report to analytics, let's fix this after we get rid of Collection
   def keepWithSelectedTags(userId: Id[User], rawBookmark: RawBookmarkRepresentation, libraryId: Id[Library], source: KeepSource, selectedTagNames: Seq[String])(implicit context: HeimdalContext): Either[String, (KeepInfo, Seq[Collection])] = {
 
     val library = db.readOnlyReplica { implicit session =>
@@ -622,10 +631,13 @@ class KeepsCommander @Inject() (
               case None => keepToCollectionRepo.save(KeepToCollection(keepId = keep.id.get, collectionId = tagId))
               case Some(k2c) => keepToCollectionRepo.save(k2c.copy(state = KeepToCollectionStates.ACTIVE))
             }
+            collectionRepo.collectionChanged(tagId, true)
           }
           tagsToRemove.map { tagId =>
             keepToCollectionRepo.remove(keep.id.get, tagId)
+            collectionRepo.collectionChanged(tagId, false)
           }
+          keepRepo.save(keep) // notify keep index
           keepToCollectionRepo.getCollectionsForKeep(keep.id.get).map { id => collectionRepo.get(id) }
         }
         Right((KeepInfo.fromKeep(keep), tags))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -632,16 +632,6 @@ class KeepsCommander @Inject() (
     }
   }
 
-  def setFirstKeeps(userId: Id[User], keeps: Seq[Keep]): Unit = {
-    db.readWrite { implicit session =>
-      val origin = keepRepo.oldestKeep(userId).map(_.createdAt) getOrElse currentDateTime
-      keeps.zipWithIndex.foreach {
-        case (keep, i) =>
-          keepRepo.save(keep.copy(createdAt = origin.minusSeconds(i + 1)))
-      }
-    }
-  }
-
   def assembleKeepExport(keepExports: Seq[KeepExport]): String = {
     // HTML format that follows Delicious exports
     val before = """<!DOCTYPE NETSCAPE-Bookmark-file-1>

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -556,7 +556,7 @@ class KeepsCommander @Inject() (
   }
 
   def getOrCreateTag(userId: Id[User], name: String)(implicit context: HeimdalContext): Collection = {
-    val normalizedName = name.trim.replaceAll("""\s+""", " ").take(Collection.MaxNameLength)
+    val normalizedName = Hashtag(name.trim.replaceAll("""\s+""", " ").take(Collection.MaxNameLength))
     val collection = db.readOnlyReplica { implicit s =>
       collectionRepo.getByUserAndName(userId, normalizedName, excludeState = None)
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -175,7 +175,7 @@ class LibraryCommander @Inject() (
     }
   }
 
-  def copyKeepsFromCollectionToLibrary(libraryId: Id[Library], tagName: String): Either[LibraryFail, Seq[(Keep, LibraryError)]] = {
+  def copyKeepsFromCollectionToLibrary(libraryId: Id[Library], tagName: Hashtag): Either[LibraryFail, Seq[(Keep, LibraryError)]] = {
     val (library, ownerId, memTo, tagOpt, keeps) = db.readOnlyMaster { implicit s =>
       val library = libraryRepo.get(libraryId)
       val ownerId = library.ownerId

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
@@ -19,6 +19,7 @@ class ShoeboxDataPipeController @Inject() (
     userRepo: UserRepo,
     normUriRepo: NormalizedURIRepo,
     collectionRepo: CollectionRepo,
+    keepToCollectionRepo: KeepToCollectionRepo,
     keepRepo: KeepRepo,
     changedUriRepo: ChangedURIRepo,
     phraseRepo: PhraseRepo,
@@ -150,5 +151,16 @@ class ShoeboxDataPipeController @Inject() (
       }
     }
     Ok(Json.toJson(librariesWithMembersChanged))
+  }
+
+  def getKeepsAndTagsChanged(seqNum: SequenceNumber[Keep], fetchSize: Int) = Action { request =>
+    val keepAndTagsChanged = db.readOnlyReplica(2) { implicit session =>
+      val changedKeeps = keepRepo.getBySequenceNumber(seqNum, fetchSize)
+      val collectionIdsByKeepIds = changedKeeps.map { keep => (keep.id.get -> keepToCollectionRepo.getCollectionsForKeep(keep.id.get)) }.toMap
+      val uniqueCollectionIds = collectionIdsByKeepIds.values.flatten.toSet
+      val tagsByCollectionIds = uniqueCollectionIds.map { collectionId => (collectionId -> collectionRepo.get(collectionId).name) }.toMap
+      changedKeeps.map { keep => KeepAndTags(keep, collectionIdsByKeepIds(keep.id.get).map(tagsByCollectionIds(_))) }
+    }
+    Ok(Json.toJson(keepAndTagsChanged))
   }
 }

--- a/kifi-backend/modules/shoebox/app/views/admin/libraryKeeps.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/libraryKeeps.scala.html
@@ -1,7 +1,7 @@
 @(library: Library,
   owner: User,
   totalKeepCount: Int,
-  keepInfos: Seq[(Keep, NormalizedURI, User, Seq[String])],
+  keepInfos: Seq[(Keep, NormalizedURI, User, Seq[Hashtag])],
   page: Int,
   pageSize: Int
 )

--- a/kifi-backend/modules/shoebox/app/views/admin/userKeeps.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/userKeeps.scala.html
@@ -1,6 +1,6 @@
 @(user: User,
   totalBookmarks: Int,
-  bookmarks: Seq[(Keep, NormalizedURI, Seq[String])],
+  bookmarks: Seq[(Keep, NormalizedURI, Seq[Hashtag])],
   bookmarkSearch: Option[String],
   collections: Seq[Collection],
   collectionFilter: Option[Id[Collection]]

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -679,6 +679,7 @@ GET     /internal/shoebox/database/getIndexableSocialConnections   @com.keepit.c
 GET     /internal/shoebox/database/getIndexableSocialUserInfos   @com.keepit.controllers.internal.ShoeboxDataPipeController.getIndexableSocialUserInfos(seqNum: SequenceNumber[SocialUserInfo], fetchSize: Int)
 GET     /internal/shoebox/database/getEmailAccountUpdates       @com.keepit.controllers.internal.ShoeboxDataPipeController.getEmailAccountUpdates(seqNum: SequenceNumber[EmailAccountUpdate], fetchSize: Int)
 GET     /internal/shoebox/database/getLibrariesAndMembershipsChanged       @com.keepit.controllers.internal.ShoeboxDataPipeController.getLibrariesAndMembershipsChanged(seqNum: SequenceNumber[Library], fetchSize: Int)
+GET     /internal/shoebox/database/getKeepsAndTagsChanged                  @com.keepit.controllers.internal.ShoeboxDataPipeController.getKeepsAndTagsChanged(seqNum: SequenceNumber[Keep], fetchSize: Int)
 
 POST    /internal/shoebox/database/createDeepLink     @com.keepit.controllers.ext.ExtDeepLinkController.createDeepLink()
 POST    /internal/shoebox/database/getDeepUrl         @com.keepit.controllers.ext.ExtDeepLinkController.getDeepUrl()

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
@@ -49,9 +49,9 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
             visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get)))
 
           val collectionRepo = inject[CollectionRepo]
-          val collections = collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction1")) ::
-            collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction2")) ::
-            collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction3")) ::
+          val collections = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction1"))) ::
+            collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction2"))) ::
+            collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction3"))) ::
             Nil
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark1.id.get, collectionId = collections(0).id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark2.id.get, collectionId = collections(0).id.get))
@@ -123,10 +123,10 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
         val (user, oldOrdering, tagA, tagB, tagC, tagD) = db.readWrite { implicit s =>
           val user1 = userRepo.save(User(firstName = "Mario", lastName = "Luigi", createdAt = t1))
 
-          val tagA = Collection(userId = user1.id.get, name = "tagA")
-          val tagB = Collection(userId = user1.id.get, name = "tagB")
-          val tagC = Collection(userId = user1.id.get, name = "tagC")
-          val tagD = Collection(userId = user1.id.get, name = "tagD")
+          val tagA = Collection(userId = user1.id.get, name = Hashtag("tagA"))
+          val tagB = Collection(userId = user1.id.get, name = Hashtag("tagB"))
+          val tagC = Collection(userId = user1.id.get, name = Hashtag("tagC"))
+          val tagD = Collection(userId = user1.id.get, name = Hashtag("tagD"))
 
           val collections = collectionRepo.save(tagA) ::
             collectionRepo.save(tagB) ::

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepsCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepsCommanderTest.scala
@@ -73,7 +73,7 @@ class KeepsCommanderTest extends Specification with ShoeboxTestInjector {
             uriId = uri3.id.get, source = KeepSource.keeper, createdAt = t1.plusMinutes(6),
             visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get)))
 
-          val col1 = collectionRepo.save(Collection(userId = user1.id.get, name = "t1"))
+          val col1 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("t1")))
           keepToCollectionRepo.save(KeepToCollection(keepId = keep1.id.get, collectionId = col1.id.get))
         }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -151,8 +151,8 @@ class LibraryCommanderTest extends Specification with ShoeboxTestInjector {
         uriId = uri3.id.get, source = KeepSource.keeper, createdAt = t1.plusMinutes(3),
         visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(libMurica.id.get)))
 
-      val tag1 = collectionRepo.save(Collection(userId = userCaptain.id.get, name = "USA"))
-      val tag2 = collectionRepo.save(Collection(userId = userCaptain.id.get, name = "food"))
+      val tag1 = collectionRepo.save(Collection(userId = userCaptain.id.get, name = Hashtag("USA")))
+      val tag2 = collectionRepo.save(Collection(userId = userCaptain.id.get, name = Hashtag("food")))
 
       keepToCollectionRepo.save(KeepToCollection(keepId = keep1.id.get, collectionId = tag1.id.get))
       keepToCollectionRepo.save(KeepToCollection(keepId = keep2.id.get, collectionId = tag1.id.get))
@@ -704,12 +704,12 @@ class LibraryCommanderTest extends Specification with ShoeboxTestInjector {
             uriId = uri3.id.get, source = KeepSource.keeper, createdAt = t1.plusMinutes(3),
             visibility = LibraryVisibility.DISCOVERABLE, libraryId = None))
 
-          val tag1 = collectionRepo.save(Collection(userId = userCaptain.id.get, name = "USA"))
+          val tag1 = collectionRepo.save(Collection(userId = userCaptain.id.get, name = Hashtag("USA")))
           keepToCollectionRepo.save(KeepToCollection(keepId = keep1.id.get, collectionId = tag1.id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = keep2.id.get, collectionId = tag1.id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = keep3.id.get, collectionId = tag1.id.get))
 
-          val tag2 = collectionRepo.save(Collection(userId = userCaptain.id.get, name = "Murica"))
+          val tag2 = collectionRepo.save(Collection(userId = userCaptain.id.get, name = Hashtag("Murica")))
           keepToCollectionRepo.save(KeepToCollection(keepId = keep1.id.get, collectionId = tag2.id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = keep2.id.get, collectionId = tag2.id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = keep3.id.get, collectionId = tag2.id.get))
@@ -724,8 +724,8 @@ class LibraryCommanderTest extends Specification with ShoeboxTestInjector {
         }
 
         val libraryCommander = inject[LibraryCommander]
-        libraryCommander.copyKeepsFromCollectionToLibrary(libUSA.id.get, "Canada").isLeft === true
-        val res1 = libraryCommander.copyKeepsFromCollectionToLibrary(libUSA.id.get, "USA") //move keeps with "USA" to library "USA"
+        libraryCommander.copyKeepsFromCollectionToLibrary(libUSA.id.get, Hashtag("Canada")).isLeft === true
+        val res1 = libraryCommander.copyKeepsFromCollectionToLibrary(libUSA.id.get, Hashtag("USA")) //move keeps with "USA" to library "USA"
         res1.isRight === true
         res1.right.get.length === 0
         db.readOnlyMaster { implicit s =>
@@ -733,7 +733,7 @@ class LibraryCommanderTest extends Specification with ShoeboxTestInjector {
           keepToCollectionRepo.count === 9
         }
 
-        val res2 = libraryCommander.copyKeepsFromCollectionToLibrary(libMurica.id.get, "Murica") //move keeps with "Murica" to library "Murica"
+        val res2 = libraryCommander.copyKeepsFromCollectionToLibrary(libMurica.id.get, Hashtag("Murica")) //move keeps with "Murica" to library "Murica"
         res2.isRight === true
         res2.right.get.unzip._1.map(_.title.get).sorted === Seq("Freedom", "Reddit")
         db.readOnlyMaster { implicit s =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtKeepsControllerTest.scala
@@ -83,9 +83,9 @@ class ExtKeepsControllerTest extends Specification with ShoeboxTestInjector with
             visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get)))
 
           val collectionRepo = inject[CollectionRepo]
-          val collections = collectionRepo.save(Collection(userId = user1.id.get, name = "myCollection1")) ::
-            collectionRepo.save(Collection(userId = user1.id.get, name = "myCollection2")) ::
-            collectionRepo.save(Collection(userId = user1.id.get, name = "myCollection3")) ::
+          val collections = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollection1"))) ::
+            collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollection2"))) ::
+            collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollection3"))) ::
             Nil
           keepToCollectionRepo.save(KeepToCollection(keepId = k1.id.get, collectionId = collections(0).id.get))
           collectionRepo.collectionChanged(collections(0).id.get, true)
@@ -157,9 +157,9 @@ class ExtKeepsControllerTest extends Specification with ShoeboxTestInjector with
             visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get)))
 
           val collectionRepo = inject[CollectionRepo]
-          val collections = collectionRepo.save(Collection(userId = user1.id.get, name = "myCollection1")) ::
-            collectionRepo.save(Collection(userId = user1.id.get, name = "myCollection2")) ::
-            collectionRepo.save(Collection(userId = user1.id.get, name = "myCollection3")) ::
+          val collections = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollection1"))) ::
+            collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollection2"))) ::
+            collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollection3"))) ::
             Nil
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark1.id.get, collectionId = collections(0).id.get))
           collectionRepo.collectionChanged(collections(0).id.get, true)
@@ -232,9 +232,9 @@ class ExtKeepsControllerTest extends Specification with ShoeboxTestInjector with
             visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get)))
 
           val collectionRepo = inject[CollectionRepo]
-          val collections = collectionRepo.save(Collection(userId = user1.id.get, name = "myCollection1")) ::
-            collectionRepo.save(Collection(userId = user1.id.get, name = "myCollection2")) ::
-            collectionRepo.save(Collection(userId = user1.id.get, name = "myCollection3")) ::
+          val collections = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollection1"))) ::
+            collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollection2"))) ::
+            collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollection3"))) ::
             Nil
 
           (user1, bookmark1, bookmark2, collections)
@@ -292,9 +292,9 @@ class ExtKeepsControllerTest extends Specification with ShoeboxTestInjector with
           uriRepo.count === 0
 
           val collectionRepo = inject[CollectionRepo]
-          val collections = collectionRepo.save(Collection(userId = user1.id.get, name = "myCollection1")) ::
-            collectionRepo.save(Collection(userId = user1.id.get, name = "myCollection2")) ::
-            collectionRepo.save(Collection(userId = user1.id.get, name = "myCollection3")) ::
+          val collections = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollection1"))) ::
+            collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollection2"))) ::
+            collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollection3"))) ::
             Nil
 
           (user1, collections)

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -72,9 +72,9 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
           visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get)))
 
         val collectionRepo = inject[CollectionRepo]
-        val collections = collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction1")) ::
-          collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction2")) ::
-          collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction3")) ::
+        val collections = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction1"))) ::
+          collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction2"))) ::
+          collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction3"))) ::
           Nil
         keepToCollectionRepo.save(KeepToCollection(keepId = bookmark1.id.get, collectionId = collections(0).id.get))
         collectionRepo.collectionChanged(collections(0).id.get, true)
@@ -138,9 +138,9 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
           uriId = uri2.id.get, source = keeper, createdAt = t1.plusHours(50), state = KeepStates.ACTIVE, visibility = Keep.isPrivateToVisibility(false), libraryId = Some(lib1.id.get)))
 
         val collectionRepo = inject[CollectionRepo]
-        val collections = collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction1")) ::
-          collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction2")) ::
-          collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction3")) ::
+        val collections = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction1"))) ::
+          collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction2"))) ::
+          collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction3"))) ::
           Nil
 
         (user1, bookmark1, bookmark2, collections)
@@ -193,9 +193,9 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
         libCommander.internSystemGeneratedLibraries(user1.id.get)
         uriRepo.count === 0
 
-        val collections = collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction1")) ::
-          collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction2")) ::
-          collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction3")) ::
+        val collections = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction1"))) ::
+          collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction2"))) ::
+          collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction3"))) ::
           Nil
 
         (user1, collections)
@@ -564,7 +564,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
         collections.size === 1
         collections.head
       }
-      collection.name === "my tag"
+      collection.name.tag === "my tag"
 
       val expected = Json.parse(s"""{"id":"${collection.externalId}","name":"my tag"}""")
       Json.parse(contentAsString(result)) must equalTo(expected)
@@ -579,9 +579,9 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
           val user = userRepo.save(User(firstName = "Eishay", lastName = "Smith"))
           inject[LibraryCommander].internSystemGeneratedLibraries(user.id.get)
           val collectionRepo = inject[CollectionRepo]
-          val collections = collectionRepo.save(Collection(userId = user.id.get, name = "myCollaction1")) ::
-            collectionRepo.save(Collection(userId = user.id.get, name = "myCollaction2")) ::
-            collectionRepo.save(Collection(userId = user.id.get, name = "myCollaction3")) ::
+          val collections = collectionRepo.save(Collection(userId = user.id.get, name = Hashtag("myCollaction1"))) ::
+            collectionRepo.save(Collection(userId = user.id.get, name = Hashtag("myCollaction2"))) ::
+            collectionRepo.save(Collection(userId = user.id.get, name = Hashtag("myCollaction3"))) ::
             Nil
           (user, collections)
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobilePageControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobilePageControllerTest.scala
@@ -82,8 +82,8 @@ class MobilePageControllerTest extends TestKit(ActorSystem()) with Specification
             visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get),
             externalId = ExternalId("dddddddd-286e-4386-8336-da255120b273")))
 
-          val coll1 = collectionRepo.save(Collection(userId = user1.id.get, name = "Cooking", createdAt = t1, externalId = ExternalId("eeeeeeee-51ad-4c7d-a88e-d4e6e3c9a672")))
-          val coll2 = collectionRepo.save(Collection(userId = user1.id.get, name = "Baking", createdAt = t2, externalId = ExternalId("ffffffff-51ad-4c7d-a88e-d4e6e3c9a673")))
+          val coll1 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("Cooking"), createdAt = t1, externalId = ExternalId("eeeeeeee-51ad-4c7d-a88e-d4e6e3c9a672")))
+          val coll2 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("Baking"), createdAt = t2, externalId = ExternalId("ffffffff-51ad-4c7d-a88e-d4e6e3c9a673")))
 
           keepToCollectionRepo.save(KeepToCollection(keepId = keep1.id.get, collectionId = coll1.id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = keep1.id.get, collectionId = coll2.id.get))
@@ -150,8 +150,8 @@ class MobilePageControllerTest extends TestKit(ActorSystem()) with Specification
             visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get),
             externalId = ExternalId("dddddddd-286e-4386-8336-da255120b273")))
 
-          val coll1 = collectionRepo.save(Collection(userId = user1.id.get, name = "Cooking", createdAt = t1, externalId = ExternalId("eeeeeeee-51ad-4c7d-a88e-d4e6e3c9a672")))
-          val coll2 = collectionRepo.save(Collection(userId = user1.id.get, name = "Baking", createdAt = t2, externalId = ExternalId("ffffffff-51ad-4c7d-a88e-d4e6e3c9a673")))
+          val coll1 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("Cooking"), createdAt = t1, externalId = ExternalId("eeeeeeee-51ad-4c7d-a88e-d4e6e3c9a672")))
+          val coll2 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("Baking"), createdAt = t2, externalId = ExternalId("ffffffff-51ad-4c7d-a88e-d4e6e3c9a673")))
 
           keepToCollectionRepo.save(KeepToCollection(keepId = keep1.id.get, collectionId = coll1.id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = keep1.id.get, collectionId = coll2.id.get))

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
@@ -61,7 +61,7 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
 
   def forCollection(userId: Id[User], name: String)(implicit injector: Injector): Collection = {
     inject[Database].readWrite { implicit session =>
-      val collections = inject[CollectionRepo].getByUserAndName(userId, name)
+      val collections = inject[CollectionRepo].getByUserAndName(userId, Hashtag(name))
       collections.size === 1
       collections.head
     }
@@ -374,9 +374,9 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
       withDb(controllerTestModules: _*) { implicit injector =>
         val (user, collections) = inject[Database].readWrite { implicit session =>
           val user = inject[UserRepo].save(User(firstName = "Eishay", lastName = "Smith"))
-          val collections = inject[CollectionRepo].save(Collection(userId = user.id.get, name = "myCollaction1")) ::
-            inject[CollectionRepo].save(Collection(userId = user.id.get, name = "myCollaction2")) ::
-            inject[CollectionRepo].save(Collection(userId = user.id.get, name = "myCollaction3")) ::
+          val collections = inject[CollectionRepo].save(Collection(userId = user.id.get, name = Hashtag("myCollaction1"))) ::
+            inject[CollectionRepo].save(Collection(userId = user.id.get, name = Hashtag("myCollaction2"))) ::
+            inject[CollectionRepo].save(Collection(userId = user.id.get, name = Hashtag("myCollaction3"))) ::
             Nil
           (user, collections)
         }
@@ -475,7 +475,7 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
           collections.size === 1
           collections.head
         }
-        collection.name === "my tag"
+        collection.name.tag === "my tag"
 
         val expected = Json.parse(s"""
           {"id":"${collection.externalId}","name":"my tag"}
@@ -623,10 +623,10 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
           val user1 = inject[UserRepo].save(User(firstName = "Tony", lastName = "Stark"))
           inject[LibraryCommander].internSystemGeneratedLibraries(user1.id.get)
 
-          val tagA = Collection(userId = user1.id.get, name = "tagA")
-          val tagB = Collection(userId = user1.id.get, name = "tagB")
-          val tagC = Collection(userId = user1.id.get, name = "tagC")
-          val tagD = Collection(userId = user1.id.get, name = "tagD")
+          val tagA = Collection(userId = user1.id.get, name = Hashtag("tagA"))
+          val tagB = Collection(userId = user1.id.get, name = Hashtag("tagB"))
+          val tagC = Collection(userId = user1.id.get, name = Hashtag("tagC"))
+          val tagD = Collection(userId = user1.id.get, name = Hashtag("tagD"))
 
           val collectionRepo = inject[CollectionRepo]
           val collections = collectionRepo.save(tagA) ::

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
@@ -410,10 +410,10 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
         val (user) = db.readWrite { implicit session =>
           val user1 = userRepo.save(User(firstName = "Mega", lastName = "Tron"))
           inject[LibraryCommander].internSystemGeneratedLibraries(user1.id.get)
-          val tagA = collectionRepo.save(Collection(userId = user1.id.get, name = "tagA", createdAt = t1))
-          val tagB = collectionRepo.save(Collection(userId = user1.id.get, name = "tagB", createdAt = t1))
-          val tagC = collectionRepo.save(Collection(userId = user1.id.get, name = "tagC", createdAt = t1.plusMinutes(1)))
-          val tagD = collectionRepo.save(Collection(userId = user1.id.get, name = "tagD", createdAt = t1.plusMinutes(2)))
+          val tagA = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("tagA"), createdAt = t1))
+          val tagB = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("tagB"), createdAt = t1))
+          val tagC = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("tagC"), createdAt = t1.plusMinutes(1)))
+          val tagD = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("tagD"), createdAt = t1.plusMinutes(2)))
 
           uriRepo.count === 0
           val uri1 = uriRepo.save(NormalizedURI.withHash("http://www.google.com/", Some("Google")))

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
@@ -168,8 +168,8 @@ class UriIntegrityPluginTest extends TestKitSupport with SpecificationLike with 
             val bm2better = bmRepo.save(Keep(title = Some("google"), userId = user.id.get, url = url2.url, urlId = url2.id.get, uriId = uri2better.id.get, source = hover,
               visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get)))
 
-            val c0 = collectionRepo.save(Collection(userId = user.id.get, name = "google"))
-            val c1 = collectionRepo.save(Collection(userId = user.id.get, name = "googleBetter"))
+            val c0 = collectionRepo.save(Collection(userId = user.id.get, name = Hashtag("google")))
+            val c1 = collectionRepo.save(Collection(userId = user.id.get, name = Hashtag("googleBetter")))
 
             keepToCollectionRepo.save(KeepToCollection(keepId = bm0.id.get, collectionId = c0.id.get))
             keepToCollectionRepo.save(KeepToCollection(keepId = bm0better.id.get, collectionId = c0.id.get))

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/CollectionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/CollectionTest.scala
@@ -43,10 +43,10 @@ class CollectionTest extends Specification with CommonTestInjector with DbInject
         urlId = url2.id.get, uriId = uri2.id.get, source = hover, createdAt = t1.plusHours(50),
         visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get)))
 
-      val coll1 = collectionRepo.save(Collection(userId = user1.id.get, name = "Cooking", createdAt = t1))
-      val coll2 = collectionRepo.save(Collection(userId = user1.id.get, name = "Apparel", createdAt = t1))
-      val coll3 = collectionRepo.save(Collection(userId = user1.id.get, name = "Scala", createdAt = t2))
-      val coll4 = collectionRepo.save(Collection(userId = user2.id.get, name = "Scala", createdAt = t2))
+      val coll1 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("Cooking"), createdAt = t1))
+      val coll2 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("Apparel"), createdAt = t1))
+      val coll3 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("Scala"), createdAt = t2))
+      val coll4 = collectionRepo.save(Collection(userId = user2.id.get, name = Hashtag("Scala"), createdAt = t2))
 
       (user1, user2, bookmark1, bookmark2, coll1, coll2, coll3, coll4)
     }
@@ -54,10 +54,10 @@ class CollectionTest extends Specification with CommonTestInjector with DbInject
 
   "collections" should {
     "binary serialization" in {
-      val coll1 = Collection(id = Some(Id[Collection](1)), userId = Id[User](1), name = "Cooking")
-      val coll2 = Collection(id = Some(Id[Collection](2)), userId = Id[User](1), name = "Apparel")
-      val coll3 = Collection(id = Some(Id[Collection](3)), userId = Id[User](1), name = "Scala")
-      val coll4 = Collection(id = Some(Id[Collection](4)), userId = Id[User](1), name = "Java")
+      val coll1 = Collection(id = Some(Id[Collection](1)), userId = Id[User](1), name = Hashtag("Cooking"))
+      val coll2 = Collection(id = Some(Id[Collection](2)), userId = Id[User](1), name = Hashtag("Apparel"))
+      val coll3 = Collection(id = Some(Id[Collection](3)), userId = Id[User](1), name = Hashtag("Scala"))
+      val coll4 = Collection(id = Some(Id[Collection](4)), userId = Id[User](1), name = Hashtag("Java"))
       val collectionSummaries = Seq(coll1.summary, coll2.summary, coll3.summary, coll4.summary)
       val formatter = new CollectionSummariesFormat()
       val binary = formatter.writes(Some(collectionSummaries))
@@ -72,15 +72,15 @@ class CollectionTest extends Specification with CommonTestInjector with DbInject
       withDb(modules: _*) { implicit injector =>
         val (user1, user2, bookmark1, bookmark2, coll1, coll2, coll3, coll4) = setup()
         db.readWrite { implicit s =>
-          collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name).toSet === Set("Cooking", "Apparel", "Scala")
-          collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name).toSet === Set("Cooking", "Apparel", "Scala")
+          collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name.tag).toSet === Set("Cooking", "Apparel", "Scala")
+          collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name.tag).toSet === Set("Cooking", "Apparel", "Scala")
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark1.id.get, collectionId = coll1.id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark2.id.get, collectionId = coll1.id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark2.id.get, collectionId = coll2.id.get))
         }
         db.readOnlyMaster { implicit s =>
-          collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name).toSet === Set("Apparel", "Cooking", "Scala")
-          collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name).toSet === Set("Apparel", "Cooking", "Scala")
+          collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name.tag).toSet === Set("Apparel", "Cooking", "Scala")
+          collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name.tag).toSet === Set("Apparel", "Cooking", "Scala")
           keepRepo.getByUserAndCollection(user1.id.get, coll1.id.get, None, None, 5) must haveLength(2)
           keepRepo.getByUser(user1.id.get, None, None, 5) must haveLength(2)
           keepRepo.getByUserAndCollection(user1.id.get, coll2.id.get, None, None, 5) must haveLength(1)
@@ -92,8 +92,8 @@ class CollectionTest extends Specification with CommonTestInjector with DbInject
       withDb(modules: _*) { implicit injector =>
         val (user1, user2, bookmark1, bookmark2, coll1, coll2, coll3, coll4) = setup()
         db.readWrite { implicit s =>
-          collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name).toSet === Set("Cooking", "Apparel", "Scala")
-          collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name).toSet === Set("Cooking", "Apparel", "Scala")
+          collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name.tag).toSet === Set("Cooking", "Apparel", "Scala")
+          collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name.tag).toSet === Set("Cooking", "Apparel", "Scala")
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark1.id.get, collectionId = coll1.id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark2.id.get, collectionId = coll3.id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark2.id.get, collectionId = coll1.id.get))
@@ -104,8 +104,8 @@ class CollectionTest extends Specification with CommonTestInjector with DbInject
         db.readOnlyMaster { implicit s =>
           keepToCollectionRepo.getKeepsInCollection(coll1.id.get).toSet === Set(bookmark1.id.get, bookmark2.id.get)
           keepToCollectionRepo.getUriIdsInCollection(coll1.id.get).toSet === Set(KeepUriAndTime(bookmark1.uriId, bookmark1.createdAt), KeepUriAndTime(bookmark2.uriId, bookmark2.createdAt))
-          collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name).toSet === Set("Cooking", "Scala", "Apparel")
-          collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name).toSet === Set("Cooking", "Scala", "Apparel")
+          collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name.tag).toSet === Set("Cooking", "Scala", "Apparel")
+          collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name.tag).toSet === Set("Cooking", "Scala", "Apparel")
           keepToCollectionRepo.count(coll1.id.get) === 2
         }
         db.readWrite { implicit s =>
@@ -123,8 +123,8 @@ class CollectionTest extends Specification with CommonTestInjector with DbInject
         }
         sessionProvider.doWithoutCreatingSessions {
           db.readOnlyMaster { implicit s =>
-            collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name).toSet === Set("Cooking", "Apparel", "Scala")
-            collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name).toSet === Set("Cooking", "Apparel", "Scala")
+            collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name.tag).toSet === Set("Cooking", "Apparel", "Scala")
+            collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name.tag).toSet === Set("Cooking", "Apparel", "Scala")
           }
         }
       }
@@ -134,8 +134,8 @@ class CollectionTest extends Specification with CommonTestInjector with DbInject
         val (user1, user2, bookmark1, bookmark2, coll1, coll2, coll3, coll4) = setup()
         db.readWrite { implicit s =>
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark1.id.get, collectionId = coll3.id.get))
-          collectionRepo.getByUserAndName(user1.id.get, "Scala").get.id.get === coll3.id.get
-          collectionRepo.getByUserAndName(user2.id.get, "Scala").get.id.get === coll4.id.get
+          collectionRepo.getByUserAndName(user1.id.get, Hashtag("Scala")).get.id.get === coll3.id.get
+          collectionRepo.getByUserAndName(user2.id.get, Hashtag("Scala")).get.id.get === coll4.id.get
           keepToCollectionRepo.getKeepsInCollection(coll3.id.get).length === 1
           keepToCollectionRepo.getUriIdsInCollection(coll3.id.get).length === 1
           keepToCollectionRepo.getKeepsInCollection(coll4.id.get).length === 0
@@ -143,7 +143,7 @@ class CollectionTest extends Specification with CommonTestInjector with DbInject
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark2.id.get, collectionId = coll4.id.get))
           keepToCollectionRepo.getKeepsInCollection(coll4.id.get).length === 1
           keepToCollectionRepo.getUriIdsInCollection(coll4.id.get).length === 1
-          collectionRepo.getByUserAndName(user2.id.get, "Cooking") must beNone
+          collectionRepo.getByUserAndName(user2.id.get, Hashtag("Cooking")) must beNone
         }
       }
     }
@@ -151,8 +151,8 @@ class CollectionTest extends Specification with CommonTestInjector with DbInject
       withDb(modules: _*) { implicit injector =>
         val (user1, user2, bookmark1, bookmark2, coll1, coll2, coll3, coll4) = setup()
         db.readWrite { implicit s =>
-          collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name).toSet === Set("Cooking", "Apparel", "Scala")
-          collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name).toSet === Set("Cooking", "Apparel", "Scala")
+          collectionRepo.getUnfortunatelyIncompleteTagsByUser(user1.id.get).map(_.name.tag).toSet === Set("Cooking", "Apparel", "Scala")
+          collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(user1.id.get).map(_.name.tag).toSet === Set("Cooking", "Apparel", "Scala")
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark1.id.get, collectionId = coll1.id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark2.id.get, collectionId = coll1.id.get))
           keepToCollectionRepo.getKeepsInCollection(coll1.id.get).toSet === Set(bookmark1.id.get, bookmark2.id.get)
@@ -226,7 +226,7 @@ class CollectionTest extends Specification with CommonTestInjector with DbInject
       withDb(modules: _*) { implicit injector =>
         val (user1, _, _, _, _, _, _, _) = setup()
         db.readOnlyMaster { implicit s =>
-          collectionRepo.getByUserAndName(user1.id.get, "scala") === collectionRepo.getByUserAndName(user1.id.get, "Scala")
+          collectionRepo.getByUserAndName(user1.id.get, Hashtag("scala")) === collectionRepo.getByUserAndName(user1.id.get, Hashtag("Scala"))
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepToCollectionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepToCollectionTest.scala
@@ -42,9 +42,9 @@ class KeepToCollectionTest extends Specification with ShoeboxTestInjector {
             uriId = uri4.id.get, source = KeepSource.keeper, state = KeepStates.ACTIVE, visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get)))
 
           val collectionRepo = inject[CollectionRepo]
-          val collections = collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction1")) ::
-            collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction2")) ::
-            collectionRepo.save(Collection(userId = user1.id.get, name = "myCollaction3")) ::
+          val collections = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction1"))) ::
+            collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction2"))) ::
+            collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction3"))) ::
             Nil
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark1.id.get, collectionId = collections(0).id.get))
           keepToCollectionRepo.save(KeepToCollection(keepId = bookmark2.id.get, collectionId = collections(0).id.get))

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
@@ -75,6 +75,7 @@ trait FortyTwoGenericTypeMappers { self: { val db: DataBaseComponent } =>
   implicit val usernameTypeMapper = MappedColumnType.base[Username, String](_.value, Username.apply)
   implicit val libraryKindTypeMapper = MappedColumnType.base[LibraryKind, String](_.value, LibraryKind.apply)
   implicit val userValueNameTypeMapper = MappedColumnType.base[UserValueName, String](_.name, UserValueName.apply)
+  implicit val hashtagTypeMapper = MappedColumnType.base[Hashtag, String](_.tag, Hashtag.apply)
 
   implicit def experimentTypeProbabilityDensityMapper[T](implicit outcomeFormat: Format[T]) = MappedColumnType.base[ProbabilityDensity[T], String](
     obj => Json.stringify(ProbabilityDensity.format[T].writes(obj)),
@@ -146,6 +147,7 @@ trait FortyTwoGenericTypeMappers { self: { val db: DataBaseComponent } =>
   implicit def setStateParameter[M <: Model[M]] = setParameterFromMapper[State[M]]
   implicit val setSocialNetworkTypeParameter = setParameterFromMapper[SocialNetworkType]
   implicit val setEmailAddressParameter = setParameterFromMapper[EmailAddress]
+  implicit val setHashtagParameter = setParameterFromMapper[Hashtag]
 
   // GetResult mappers to be used for interpolated query results
 
@@ -163,4 +165,5 @@ trait FortyTwoGenericTypeMappers { self: { val db: DataBaseComponent } =>
   implicit val getEmailAddressResult = getResultFromMapper[EmailAddress]
   implicit val getLibraryVisiblityResult = getResultFromMapper[LibraryVisibility]
   implicit val getOptLibraryVisiblityResult = getResultOptionFromMapper[LibraryVisibility]
+  implicit val getHashtagResult = getResultFromMapper[Hashtag]
 }


### PR DESCRIPTION
@eishay @andrewconner I have typed the name of a Collection with the value class Hashtag. So that we can get into the habit of passing tags around as typed strings. See also my comments in KeepCommander. 

@ymatsuda tags are available in KeepIndexable, but I haven't spelled out the actual index fields yet (will do next as soon as we merge this). See also my comments in KeepCommander, I'm afraid they were some bugs in the current code for tag search.

I decided not to refactor the current code to inactivate tags together with inactivated keeps (we should) because the "undo" function of the website relies on them. I think we should wait until we get rid of the Collection model to clean this up. 

Thanks @andrewconner for your awesome job on KeepCommander, I agree with you that there's still some work left there :)
