### PR TITLE
Reco frontend fixes

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -620,7 +620,7 @@ angular.module('kifi')
 
         scope.clickKeep = function (keep) {
           if (keep.keepType === 'reco') {
-            recoActionService.click(keep);
+            recoActionService.trackClick(keep);
           }
         };
 

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -497,7 +497,8 @@ angular.module('kifi')
       restrict: 'A',
       scope: {
         keep: '=',
-        keepPublic: '&'
+        keepPublic: '&',
+        keepPrivate: '&'
       },
       replace: true,
       templateUrl: 'keep/keepContent.tpl.html',
@@ -607,10 +608,6 @@ angular.module('kifi')
 
         scope.unkeep = function () {
           keepService.unkeep([scope.keep]);
-        };
-
-        scope.keepPrivate = function () {
-          keepService.keep([scope.keep], true);
         };
 
         scope.getSingleSelectedKeep = function () {

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keepActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keepActionService.js
@@ -45,14 +45,14 @@ angular.module('kifi')
       });
     }
 
-    function keepPublic (keep) {
-      return keepMany([keep], false).then(function (keeps) {
+    function keepOne (keep, isPrivate) {
+      return keepMany([keep], isPrivate).then(function (keeps) {
         return keeps[0];
       });
     }
 
     var api = {
-      keepPublic: keepPublic
+      keepOne: keepOne
     };
 
     return api;

--- a/kifi-backend/modules/shoebox/angular/src/recos/recoActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recoActionService.js
@@ -69,11 +69,11 @@ angular.module('kifi')
         $http.post(routeService.recoFeedback(keep.urlId), { vote: vote });
       },
 
-      keep: function (keep) {
+      trackKeep: function (keep) {
         $http.post(routeService.recoFeedback(keep.urlId), { kept: true });
       },
 
-      click: function (keep) {
+      trackClick: function (keep) {
         $http.post(routeService.recoFeedback(keep.urlId), { clicked: true });
       },
 

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.js
@@ -102,10 +102,6 @@ angular.module('kifi')
       $scope.initialCardClosed = true;
     };
 
-    $scope.$watch(tagService.getTotalKeepCount, function (val) {
-      $scope.numKeptItems = val;
-    });
-
     recoActionService.get().then(function (rawRecos) {
       if (rawRecos.length > 0) {
         rawRecos.forEach(function (rawReco) {

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.js
@@ -36,10 +36,10 @@ angular.module('kifi')
       _.pull($scope.recos, reco);
     };
 
-    $scope.keepReco = function (reco) {
+    $scope.keepReco = function (reco, isPrivate) {
       recoActionService.keep(reco.recoKeep);
-
-      keepActionService.keepPublic(reco.recoKeep).then(function (keptKeep) {
+      
+      keepActionService.keepOne(reco.recoKeep, isPrivate).then(function (keptKeep) {
         reco.recoKeep.id = keptKeep.id;
         reco.recoKeep.isPrivate = keptKeep.isPrivate;
 

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.js
@@ -3,8 +3,19 @@
 angular.module('kifi')
 
 .controller('RecosCtrl', [
-  '$scope', '$rootScope', '$analytics', '$timeout', '$window', 'keepActionService', 'keepService', 'recoActionService', 'recoDecoratorService', 'tagService',
-  function ($scope, $rootScope, $analytics, $timeout, $window, keepActionService, keepService, recoActionService, recoDecoratorService, tagService) {
+  '$scope',
+  '$rootScope',
+  '$analytics',
+  '$timeout',
+  '$window',
+  'keepActionService',
+  'keepService',
+  'recoActionService',
+  'recoDecoratorService',
+  'tagService',
+  'undoService',
+  function ($scope, $rootScope, $analytics, $timeout, $window, keepActionService, keepService,
+    recoActionService, recoDecoratorService, tagService, undoService) {
     $window.document.title = 'Kifi • Your Recommendation List';
 
     $scope.recos = [];
@@ -33,10 +44,21 @@ angular.module('kifi')
 
     $scope.trash = function (reco) {
       recoActionService.trash(reco.recoKeep);
-      _.pull($scope.recos, reco);
+      
+      var trashedRecoIndex = _.findIndex($scope.recos, reco);
+      var trashedReco = $scope.recos.splice(trashedRecoIndex, 1)[0];
 
+      // If the user has trashed all the recommendations, reload a new set of
+      // recommendations.
       if ($scope.recos.length === 0) {
         $scope.getMore();
+      } 
+      // If the user has recommendations remaining on the page, present her
+      // with the option to undo the trashing of the recommendation.
+      else {
+        undoService.add('Recommendation removed.', function () {
+          $scope.recos.splice(trashedRecoIndex, 0, trashedReco);
+        });
       }
     };
 

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.js
@@ -37,8 +37,8 @@ angular.module('kifi')
     };
 
     $scope.keepReco = function (reco, isPrivate) {
-      recoActionService.keep(reco.recoKeep);
-      
+      recoActionService.trackKeep(reco.recoKeep);
+
       keepActionService.keepOne(reco.recoKeep, isPrivate).then(function (keptKeep) {
         reco.recoKeep.id = keptKeep.id;
         reco.recoKeep.isPrivate = keptKeep.isPrivate;

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.js
@@ -52,14 +52,11 @@ angular.module('kifi')
       // recommendations.
       if ($scope.recos.length === 0) {
         $scope.getMore();
-      } 
-      // If the user has recommendations remaining on the page, present her
-      // with the option to undo the trashing of the recommendation.
-      else {
-        undoService.add('Recommendation removed.', function () {
-          $scope.recos.splice(trashedRecoIndex, 0, trashedReco);
-        });
       }
+
+      undoService.add('Recommendation removed.', function () {
+        $scope.recos.splice(trashedRecoIndex, 0, trashedReco);
+      });
     };
 
     $scope.keepReco = function (reco, isPrivate) {

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.js
@@ -12,11 +12,11 @@ angular.module('kifi')
     $scope.recosState = 'hasRecos';
     $scope.initialCardClosed = false;
 
-    $scope.getMore = function (recency) {
+    $scope.getMore = function (opt_recency) {
       $scope.recos = [];
       $scope.loading = true;
      
-      recoActionService.getMore(recency).then(function (rawRecos) {
+      recoActionService.getMore(opt_recency).then(function (rawRecos) {
         if (rawRecos.length > 0) {
           rawRecos.forEach(function (rawReco) {
             $scope.recos.push(recoDecoratorService.newUserRecommendation(rawReco));
@@ -34,6 +34,10 @@ angular.module('kifi')
     $scope.trash = function (reco) {
       recoActionService.trash(reco.recoKeep);
       _.pull($scope.recos, reco);
+
+      if ($scope.recos.length === 0) {
+        $scope.getMore();
+      }
     };
 
     $scope.keepReco = function (reco, isPrivate) {

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.js
@@ -170,8 +170,8 @@ angular.module('kifi')
   }
 ])
 
-.directive('kfRecoDropdownMenu', ['recoActionService',
-  function (recoActionService) {
+.directive('kfRecoDropdownMenu', ['$document', 'keyIndices', 'recoActionService',
+  function ($document, keyIndices, recoActionService) {
     return {
       restrict: 'A',
       replace: true,
@@ -181,25 +181,50 @@ angular.module('kifi')
       },
       templateUrl: 'recos/recoDropdownMenu.tpl.html',
       link: function (scope, element/*, attrs*/) {
-        var dropdownArrow= element.find('.kf-reco-dropdown-menu-down');
+        var dropdownArrow = element.find('.kf-reco-dropdown-menu-down');
         var dropdownMenu = element.find('.kf-dropdown-menu');
+        var show = false;
+
+        // Clicking outside the dropdown menu will close the menu.
+        function onMouseDown(event) {
+          if ((dropdownMenu.find(event.target).length === 0) &&
+              (!event.target.classList.contains('kf-reco-dropdown-menu-down'))) {
+            hideMenu();
+          }
+        }
+
+        function showMenu() {
+          show = true;
+          dropdownMenu.show();
+          $document.on('mousedown', onMouseDown);
+        }
+
+        function hideMenu() {
+          show = false;
+          dropdownMenu.hide();
+          $document.off('mousedown', onMouseDown);
+        }
 
         dropdownArrow.on('click', function () {
-          dropdownMenu.toggle();
+          if (show) {
+            hideMenu();
+          } else {
+            showMenu();
+          }
         });
 
         scope.upVote = function (reco) {
-          dropdownMenu.hide();
+          hideMenu();
           recoActionService.vote(reco.recoKeep, true);
         };
 
         scope.downVote = function (reco) {
-          dropdownMenu.hide();
+          hideMenu();
           recoActionService.vote(reco.recoKeep, false);
         };
 
         scope.showModal = function () {
-          dropdownMenu.hide();
+          hideMenu();
           scope.showImprovementModal();
         };
       }

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.styl
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.styl
@@ -85,6 +85,13 @@
 .kf-reco.ng-leave.ng-leave-active
   opacity: 0
 
+.kf-reco.ng-enter
+  opacity: 0
+  transition: 0.5s ease all
+
+.kf-reco.ng-enter.ng-enter-active
+  opacity: 1
+
 .kf-reco-info
   margin: 0 25px 20px 30px
   border: defaultBorder

--- a/kifi-backend/modules/shoebox/angular/src/recos/recosView.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recosView.tpl.html
@@ -48,7 +48,7 @@
             <time am-time-ago="reason.when"></time>
           </div>
           <div ng-if="reason.kind === 'topic'">
-            <div>Because it's trending in a topic you're interested in:
+            <div>Because it's about a topic you're interested in:
             <span class="kf-reco-reason-topic">{{reason.name}}</span></div>
           </div>
           <div ng-if="reason.kind === 'users'">

--- a/kifi-backend/modules/shoebox/angular/src/recos/recosView.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recosView.tpl.html
@@ -29,7 +29,7 @@
     <div class="kf-reco" ng-repeat="reco in recos" reco="reco" ng-controller="RecoCtrl">
       <header class="kf-reco-top">
         <span class="kf-reco-icon kf-reco-close-x" ng-click="trash(reco)"></span>
-        <div kf-reco-dropdown-menu reco="reco" show-improvement-modal="showImprovementModal()"></div>
+        <div ng-if="reco.recoData.type === 'recommended'" kf-reco-dropdown-menu reco="reco" show-improvement-modal="showImprovementModal()"></div>
         <span>{{reco.recoData.type | titlecase}} {{reco.recoData.kind | titlecase}}</span>
       </header>
 

--- a/kifi-backend/modules/shoebox/angular/src/recos/recosView.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recosView.tpl.html
@@ -34,7 +34,7 @@
       </header>
 
       <div class="kf-keep">
-        <div kf-keep-content keep="reco.recoKeep" keep-public="keepReco(reco)"></div>
+        <div kf-keep-content keep="reco.recoKeep" keep-public="keepReco(reco, false)" keep-private="keepReco(reco, true)"></div>
       </div>
 
       <footer class="kf-reco-bottom" ng-if="hasReason()" ng-class="{ 'kf-reco-multiple-reasons': hasTwoOrMoreReasons() }">

--- a/kifi-backend/modules/shoebox/angular/src/recos/recosView.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recosView.tpl.html
@@ -11,8 +11,8 @@
   <div class="kf-reco kf-reco-info" ng-if="recosState === 'noRecos'" ng-hide="initialCardClosed">
     <span class="kf-reco-icon kf-reco-close-x" ng-click="closeInitialCard()"></span>
     <h4>Turn on Kifi Recommendations</h4>
-    <p>Kifi works by recommending things based on what you've kept. We'll cater to your interests over time but we need at least 5 items to get started (you've kept {{numKeptItems}} so far). It's quick to get started if you <a href="javascript:" ng-click="importBookmarks()">import bookmarks</a>, and even better if you <a href="/invite">connect with friends</a>.
-    <p>In the meantime, enjoy popular things being kept on Kifi.</p>
+    <p>Kifi works by recommending things based on what you've kept. We'll cater to your interests over time but we need at least a dozen good articles kept to get started. It's quick to get started if you <a href="javascript:" ng-click="importBookmarks()">import bookmarks</a>, and even better if you <a href="/invite">connect with friends</a>.
+    <p>In the meantime, enjoy popular things being kept on Kifi. If you keep some of the ones you like it will help us give you personalized recommendations faster.</p>
     <a href="http://support.kifi.com">Learn more</a>
   </div>
 


### PR DESCRIPTION
A few more frontend fixes for recommendations:
- Get untag to work for private keeps (forgot to fix this path when I fixed the public keeps)
- Renamed the tracking actions for recommendations so that it's clear that they are only for tracking
- When a user removes all the recommendations, reload a new set of recommendations
- Allow users to undo the removal of a recommendation

@stkem cc @2is10 
