### PR TITLE
KeepCommander.allKeeps refactor

### DIFF
--- a/kifi-backend/modules/common/test/com/keepit/scraper/FakeScraperServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/scraper/FakeScraperServiceClientImpl.scala
@@ -38,7 +38,7 @@ class FakeScraperServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, sched
 
   def getEmbedlyInfo(url: String): Future[Option[EmbedlyInfo]] = ???
 
-  def getURISummaryFromEmbedly(uri: NormalizedURI, minSize: ImageSize, descriptionOnly: Boolean): Future[Option[URISummary]] = ???
+  def getURISummaryFromEmbedly(uri: NormalizedURI, minSize: ImageSize, descriptionOnly: Boolean): Future[Option[URISummary]] = Future.successful(None)
 
   def getURIWordCount(uriId: Id[NormalizedURI], url: Option[String]): Future[Int] = ???
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -158,14 +158,7 @@ class KeepsCommander @Inject() (
     libraryRepo: LibraryRepo,
     implicit val publicIdConfig: PublicIdConfiguration) extends Logging {
 
-  private def getKeeps(
-    beforeOpt: Option[ExternalId[Keep]],
-    afterOpt: Option[ExternalId[Keep]],
-    collectionId: Option[ExternalId[Collection]],
-    helprankOpt: Option[String],
-    count: Int,
-    userId: Id[User]): Future[(Seq[Keep], Option[Collection], Map[Id[Keep], Int], Map[Id[Keep], Int])] = {
-
+  private def getHelpRankRelatedKeeps(userId: Id[User], selector: HelpRankSelector, beforeOpt: Option[ExternalId[Keep]], afterOpt: Option[ExternalId[Keep]], count: Int): Future[Seq[(Keep, Option[Int], Option[Int])]] = {
     @inline def filter(counts: Seq[(Id[NormalizedURI], Int)])(implicit r: RSession): Seq[Id[NormalizedURI]] = {
       val uriIds = counts.map(_._1)
       val before = beforeOpt match {
@@ -186,46 +179,91 @@ class KeepsCommander @Inject() (
       if (count > 0) after.take(count) else after
     }
 
-    db.readOnlyReplica { implicit ro =>
-      val collectionOpt = (collectionId map { id => collectionRepo.getByUserAndExternalId(userId, id) }).flatten
-      val keepsF = collectionOpt match {
-        case Some(collection) =>
-          Future.successful(keepRepo.getByUserAndCollection(userId, collection.id.get, beforeOpt, afterOpt, count))
-        case None =>
-          helprankOpt map { selector =>
-            val keepIdsF = selector.trim match {
-              case "rekeep" => heimdalClient.getUriReKeepsWithCountsByKeeper(userId) map { counts => counts.map(c => c.uriId -> c.count) }
-              case _ => heimdalClient.getUriDiscoveriesWithCountsByKeeper(userId) map { counts => counts.map(c => c.uriId -> c.count) }
-            }
-            keepIdsF map { counts =>
-              val keepIds = filter(counts)
-              val km = keepRepo.bulkGetByUserAndUriIds(userId, keepIds.toSet)
-              log.info(s"[getKeeps($beforeOpt,$afterOpt,${helprankOpt.get},$count,$userId)] keeps=$km")
-              km.valuesIterator.toList
-            }
-          } getOrElse Future.successful(keepRepo.getByUser(userId, beforeOpt, afterOpt, count))
+    val keepIdsF = selector match {
+      case HelpRankRekeeps => heimdalClient.getUriReKeepsWithCountsByKeeper(userId) map { counts => counts.map(c => c.uriId -> c.count) }
+      case HelpRankDiscoveries => heimdalClient.getUriDiscoveriesWithCountsByKeeper(userId) map { counts => counts.map(c => c.uriId -> c.count) }
+    }
+    keepIdsF.flatMap { counts =>
+      val keeps = db.readOnlyReplica { implicit session =>
+        val keepUriIds = filter(counts)
+        val km = keepRepo.bulkGetByUserAndUriIds(userId, keepUriIds.toSet)
+        km.valuesIterator.toList.sortBy(_.id).reverse
       }
-      keepsF flatMap { keeps =>
-        val countsF = helprankOpt match {
-          case None =>
-            Future.successful((Map.empty[Id[Keep], Int], Map.empty[Id[Keep], Int]))
-          case Some(_) =>
-            val discCountsF = heimdalClient.getDiscoveryCountsByKeepIds(userId, keeps.map(_.id.get).toSet)
-            val rekeepCountsF = heimdalClient.getReKeepCountsByKeepIds(userId, keeps.map(_.id.get).toSet)
-            for {
-              discCounts <- discCountsF
-              rekeepCounts <- rekeepCountsF
-            } yield {
-              val discMap = discCounts.map { c => c.keepId -> c.count }.toMap
-              val rkMap = rekeepCounts.map { c => c.keepId -> c.count }.toMap
-              (discMap, rkMap)
-            }
-        }
-        countsF map {
-          case (disCount, rkCount) =>
-            (keeps, collectionOpt, disCount, rkCount)
+
+      // Fetch counts
+      val keepIds = keeps.map(_.id.get).toSet
+      val discCountsF = heimdalClient.getDiscoveryCountsByKeepIds(userId, keepIds)
+      val rekeepCountsF = heimdalClient.getReKeepCountsByKeepIds(userId, keepIds)
+      for {
+        discCounts <- discCountsF
+        rekeepCounts <- rekeepCountsF
+      } yield {
+        val discMap = discCounts.map { c => c.keepId -> c.count }.toMap
+        val rkMap = rekeepCounts.map { c => c.keepId -> c.count }.toMap
+        keeps.map { keep =>
+          (keep, discMap.get(keep.id.get), rkMap.get(keep.id.get))
         }
       }
+    }
+  }
+
+  private def getKeepsFromCollection(userId: Id[User], collectionId: ExternalId[Collection], beforeOpt: Option[ExternalId[Keep]], afterOpt: Option[ExternalId[Keep]], count: Int): Seq[Keep] = {
+    db.readOnlyReplica { implicit session =>
+      val collectionOpt = collectionRepo.getByUserAndExternalId(userId, collectionId)
+      val keeps = collectionOpt.map { collection =>
+        keepRepo.getByUserAndCollection(userId, collection.id.get, beforeOpt, afterOpt, count)
+      } getOrElse Seq.empty
+
+      keeps
+    }
+  }
+
+  private def getKeeps(userId: Id[User], beforeOpt: Option[ExternalId[Keep]], afterOpt: Option[ExternalId[Keep]], count: Int): Seq[Keep] = {
+    db.readOnlyReplica { implicit session =>
+      keepRepo.getByUser(userId, beforeOpt, afterOpt, count)
+    }
+  }
+
+  def decorateKeepsIntoKeepInfos(perspectiveUserId: Id[User], keeps: Seq[Keep]): Future[Seq[KeepInfo]] = {
+    val sharingInfosFuture = searchClient.sharingUserInfo(perspectiveUserId, keeps.map(_.uriId))
+    val pageInfosFuture = Future.sequence(keeps.map { keep =>
+      getKeepSummary(keep)
+    })
+
+    val colls = db.readOnlyMaster { implicit s =>
+      keeps.map { keep =>
+        keepToCollectionRepo.getCollectionsForKeep(keep.id.get)
+      }
+    }.map(collectionCommander.getBasicCollections)
+
+    for {
+      sharingInfos <- sharingInfosFuture
+      pageInfos <- pageInfosFuture
+    } yield {
+      val idToBasicUser = db.readOnlyMaster { implicit s =>
+        basicUserRepo.loadAll(sharingInfos.flatMap(_.sharingUserIds).toSet)
+      }
+      val keepsInfo = (keeps zip colls, sharingInfos, pageInfos).zipped.map {
+        case ((keep, collsForKeep), sharingInfoForKeep, pageInfoForKeep) =>
+          val others = sharingInfoForKeep.keepersEdgeSetSize - sharingInfoForKeep.sharingUserIds.size - (if (keep.isPrivate) 0 else 1)
+          KeepInfo(
+            id = Some(keep.externalId),
+            title = keep.title,
+            url = keep.url,
+            isPrivate = keep.isPrivate,
+            createdAt = Some(keep.createdAt),
+            others = Some(others),
+            keepers = Some(sharingInfoForKeep.sharingUserIds.map(idToBasicUser)),
+            collections = Some(collsForKeep.map(_.id.get.id).toSet), // Is this still used?
+            tags = Some(collsForKeep.toSet),
+            uriSummary = Some(pageInfoForKeep),
+            siteName = DomainToNameMapper.getNameFromUrl(keep.url),
+            clickCount = None,
+            rekeepCount = None,
+            libraryId = keep.libraryId.map(l => Library.publicId(l))
+          )
+      }
+      keepsInfo
     }
   }
 
@@ -233,40 +271,36 @@ class KeepsCommander @Inject() (
     uriSummaryCommander.getDefaultURISummary(keep.uriId, waiting)
   }
 
+  // Please do not add to this. It mixes concerns and data sources.
   def allKeeps(
     before: Option[ExternalId[Keep]],
     after: Option[ExternalId[Keep]],
     collectionId: Option[ExternalId[Collection]],
     helprankOpt: Option[String],
     count: Int,
-    userId: Id[User],
-    withPageInfo: Boolean): Future[(Option[BasicCollection], Seq[FullKeepInfo])] = {
-    getKeeps(before, after, collectionId, helprankOpt, count, userId) flatMap {
-      case (keeps, collectionOpt, clkCounts, rkCounts) =>
-        val sharingInfosFuture = searchClient.sharingUserInfo(userId, keeps.map(_.uriId))
-        val pageInfosFuture = Future.sequence(keeps.map { keep =>
-          if (withPageInfo) getKeepSummary(keep).map(Some(_)) else Future.successful(None)
-        })
+    userId: Id[User]): Future[Seq[KeepInfo]] = {
 
-        val colls = db.readOnlyMaster { implicit s =>
-          keeps.map { keep =>
-            keepToCollectionRepo.getCollectionsForKeep(keep.id.get)
-          }
-        }.map(collectionCommander.getBasicCollections)
+    // The Option[Int]s are help rank counts. Only included when looking at help rank info currently.
+    val keepsF: Future[Seq[(Keep, Option[Int], Option[Int])]] = (collectionId, helprankOpt) match {
+      case (Some(c), _) => // collectionId is set
+        val keeps = getKeepsFromCollection(userId, c, before, after, count)
+        Future.successful(keeps.map((_, None, None)))
+      case (_, Some(hr)) => // helprankOpt is set
+        getHelpRankRelatedKeeps(userId, HelpRankSelector(hr), before, after, count)
+      case _ => // neither is set, deliver normal paginated keeps list
+        val keeps = getKeeps(userId, before, after, count)
+        Future.successful(keeps.map((_, None, None)))
+    }
 
-        for {
-          sharingInfos <- sharingInfosFuture
-          pageInfos <- pageInfosFuture
-        } yield {
-          val idToBasicUser = db.readOnlyMaster { implicit s =>
-            basicUserRepo.loadAll(sharingInfos.flatMap(_.sharingUserIds).toSet)
+    keepsF.flatMap {
+      case keepsWithHelpRankCounts =>
+        val (keeps, clickCounts, rkCounts) = keepsWithHelpRankCounts.unzip3
+
+        decorateKeepsIntoKeepInfos(userId, keeps).map { keepInfos =>
+          (keepInfos, clickCounts, rkCounts).zipped.map {
+            case (keepInfo, clickCount, rkCount) =>
+              keepInfo.copy(clickCount = clickCount, rekeepCount = rkCount)
           }
-          val keepsInfo = (keeps zip colls, sharingInfos, pageInfos).zipped.map {
-            case ((keep, colls), sharingInfos, pageInfos) =>
-              val others = sharingInfos.keepersEdgeSetSize - sharingInfos.sharingUserIds.size - (if (keep.isPrivate) 0 else 1)
-              FullKeepInfo(keep, sharingInfos.sharingUserIds map idToBasicUser, colls.map(_.id.get).toSet, colls.toSet, others, DomainToNameMapper.getNameFromUrl(keep.url), pageInfos, clkCounts.get(keep.id.get), rkCounts.get(keep.id.get))
-          }
-          (collectionOpt.map { c => BasicCollection.fromCollection(c.summary) }, keepsInfo)
         }
     }
   }
@@ -683,4 +717,18 @@ class KeepsCommander @Inject() (
     }
   }
 
+}
+
+sealed trait HelpRankSelector { val name: String }
+case object HelpRankRekeeps extends HelpRankSelector { val name = "rekeep" }
+case object HelpRankDiscoveries extends HelpRankSelector { val name = "discovery" }
+object HelpRankSelector {
+  def apply(selector: String) = {
+    selector match {
+      case HelpRankRekeeps.name => HelpRankRekeeps
+      case _ => HelpRankDiscoveries // bad! Need to check all clients to make sure they're sending in the correct string
+    }
+  }
+
+  def unapply(selector: HelpRankSelector) = selector.name
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileBookmarksController.scala
@@ -1,6 +1,7 @@
 package com.keepit.controllers.mobile
 
 import com.keepit.commanders._
+import com.keepit.common.net.URISanitizer
 import com.keepit.heimdal._
 import com.keepit.common.controller.{ ShoeboxServiceController, MobileController, ActionAuthenticator }
 import com.keepit.common.db._
@@ -35,13 +36,21 @@ class MobileBookmarksController @Inject() (
     extends MobileController(actionAuthenticator) with ShoeboxServiceController {
 
   def allKeeps(before: Option[String], after: Option[String], collectionOpt: Option[String], helprankOpt: Option[String], count: Int, withPageInfo: Boolean) = JsonAction.authenticatedAsync { request =>
-    keepsCommander.allKeeps(before map ExternalId[Keep], after map ExternalId[Keep], collectionOpt map ExternalId[Collection], helprankOpt, count, request.userId, withPageInfo) map { res =>
+    keepsCommander.allKeeps(before map ExternalId[Keep], after map ExternalId[Keep], collectionOpt map ExternalId[Collection], helprankOpt, count, request.userId) map { res =>
+      val basicCollection = collectionOpt.flatMap { collStrExtId =>
+        ExternalId.asOpt[Collection](collStrExtId).flatMap { collExtId =>
+          db.readOnlyMaster(collectionRepo.getByUserAndExternalId(request.userId, collExtId)(_)).map { c =>
+            BasicCollection.fromCollection(c.summary)
+          }
+        }
+      }
       val helprank = helprankOpt map (selector => Json.obj("helprank" -> selector)) getOrElse Json.obj()
+      val sanitizedKeeps = res.map(k => k.copy(url = URISanitizer.sanitize(k.url)))
       Ok(Json.obj(
-        "collection" -> res._1,
+        "collection" -> basicCollection,
         "before" -> before,
         "after" -> after,
-        "keeps" -> res._2.map(KeepInfo.fromFullKeepInfo(_, true))
+        "keeps" -> Json.toJson(sanitizedKeeps)
       ) ++ helprank)
     }
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -311,7 +311,9 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
             "keepers":[{"id":"${user2.externalId.toString}","firstName":"Eishay","lastName":"S","pictureName":"0.jpg"}],
             "collections":[],
             "tags":[],
-            "siteName":"Amazon"},
+            "summary":{},
+            "siteName":"Amazon",
+            "libraryId":"lzmfsKLJyou6"},
           {
             "id":"${bookmark1.externalId.toString}",
             "title":"G1",
@@ -322,7 +324,9 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
             "keepers":[],
             "collections":[],
             "tags":[],
-            "siteName":"Google"}
+            "summary":{},
+            "siteName":"Google",
+            "libraryId":"lzmfsKLJyou6"}
         ]}
       """)
       Json.parse(contentAsString(result)) must equalTo(expected)
@@ -378,9 +382,11 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
                       "clickCount":1,
                       "collections":[],
                       "tags":[],
+                      "summary":{},
                       "siteName":"kifi.com",
                       "clickCount":1,
-                      "rekeepCount":1
+                      "rekeepCount":1,
+                      "libraryId":"l7jlKlnA36Su"
                     },
                     {
                       "id":"${keeps1(0).externalId.toString}",
@@ -391,8 +397,10 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
                       "keepers":[],
                       "collections":[],
                       "tags":[],
+                      "summary":{},
                       "siteName":"FortyTwo",
-                      "clickCount":1
+                      "clickCount":1,
+                      "libraryId":"l7jlKlnA36Su"
                     }
                   ],
                   "helprank":"click"
@@ -445,8 +453,10 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
                       "keepers":[{"id":"${u2.externalId.toString}","firstName":"${u2.firstName}","lastName":"${u2.lastName}","pictureName":"0.jpg"}],
                       "collections":[],
                       "tags":[],
+                      "summary":{},
                       "siteName":"FortyTwo",
-                      "clickCount":1
+                      "clickCount":1,
+                      "libraryId":"l7jlKlnA36Su"
                     }
                   ],
                   "helprank":"click"
@@ -532,7 +542,9 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
               "keepers":[],
               "collections":[],
               "tags":[],
-              "siteName":"Amazon"
+              "summary":{},
+              "siteName":"Amazon",
+              "libraryId":"lzmfsKLJyou6"
             }
           ]
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
@@ -147,7 +147,9 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
               "keepers":[{"id":"${user2.externalId.toString}","firstName":"Eishay","lastName":"S","pictureName":"0.jpg"}],
               "collections":[],
               "tags":[],
-              "siteName":"Amazon"},
+              "summary":{},
+              "siteName":"Amazon",
+              "libraryId":"lzmfsKLJyou6"},
             {
               "id":"${bookmark1.externalId.toString}",
               "title":"G1",
@@ -158,7 +160,9 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
               "keepers":[],
               "collections":[],
               "tags":[],
-              "siteName":"Google"}
+              "summary":{},
+              "siteName":"Google",
+              "libraryId":"lzmfsKLJyou6"}
           ]}
         """)
         Json.parse(contentAsString(result)) must equalTo(expected)
@@ -237,7 +241,9 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
                 "keepers":[],
                 "collections":[],
                 "tags":[],
-                "siteName":"Amazon"
+                "summary":{},
+                "siteName":"Amazon",
+                "libraryId":"lzmfsKLJyou6"
               }
             ]
           }
@@ -291,9 +297,11 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
                       "clickCount":1,
                       "collections":[],
                       "tags":[],
+                      "summary":{},
                       "siteName":"kifi.com",
                       "clickCount":1,
-                      "rekeepCount":1
+                      "rekeepCount":1,
+                      "libraryId":"l7jlKlnA36Su"
                     },
                     {
                       "id":"${keeps1(0).externalId.toString}",
@@ -304,8 +312,10 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
                       "keepers":[],
                       "collections":[],
                       "tags":[],
+                      "summary":{},
                       "siteName":"FortyTwo",
-                      "clickCount":1
+                      "clickCount":1,
+                      "libraryId":"l7jlKlnA36Su"
                     }
                   ],
                   "helprank":"click"
@@ -359,8 +369,10 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
                       "keepers":[{"id":"${u2.externalId.toString}","firstName":"${u2.firstName}","lastName":"${u2.lastName}","pictureName":"0.jpg"}],
                       "collections":[],
                       "tags":[],
+                      "summary":{},
                       "siteName":"FortyTwo",
-                      "clickCount":1
+                      "clickCount":1,
+                      "libraryId":"l7jlKlnA36Su"
                     }
                   ],
                   "helprank":"click"


### PR DESCRIPTION
@raymondng 

Re-wrote KeepCommander.allKeeps to make it clearer where data comes from. Not adding help rank attributions to all results right now because UI doesn't show it.

`withPageInfo` removed, it's always included now.
