### PR TITLE
Add null check to tags for scope.getCommonTags method.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/tags/tagList.js
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tagList.js
@@ -48,7 +48,7 @@ angular.module('kifi')
         });
 
         scope.getCommonTags = function () {
-          var tagLists = _.pluck(scope.getSelectedKeeps(), 'tagList');
+          var tagLists = _.compact(_.pluck(scope.getSelectedKeeps(), 'tagList'));
           var tagIds = _.map(tagLists, function (tagList) { return _.pluck(tagList, 'id'); });
           var commonTagIds = _.union.apply(this, tagIds);
           var tagMap = _.indexBy(_.flatten(tagLists, true), 'id');


### PR DESCRIPTION
@andrewconner 

This is why the JavaScript code was barfing when you didn't call `buildKeep`. I had this problem earlier too; had forgotten about it but I also used the workaround of forcing a keep's `tagList` to be `[]`.

With this change, a keep's `tagList` can be `undefined` and the code will not generate extraneous errors.
