### PR TITLE
using the "private" page title in messaging emails

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaEmailCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaEmailCommander.scala
@@ -53,7 +53,7 @@ class ElizaEmailCommander @Inject() (
   def getSummarySmall(thread: MessageThread) = {
     val fut = new SafeFuture(shoebox.getUriSummary(URISummaryRequest(
       url = thread.nUrl.get,
-      imageType = ImageType.ANY,
+      imageType = ImageType.IMAGE,
       minSize = ImageSize(183, 96),
       withDescription = true,
       waiting = true,
@@ -102,7 +102,7 @@ class ElizaEmailCommander @Inject() (
     ThreadEmailInfo(
       pageUrl = thread.nUrl.get,
       pageName = pageName,
-      pageTitle = uriSummary.title.getOrElse(thread.nUrl.get).abbreviate(80),
+      pageTitle = thread.pageTitle.orElse(uriSummary.title).getOrElse(thread.nUrl.get).abbreviate(80),
       isInitialEmail = isInitialEmail,
       heroImageUrl = uriSummary.imageUrl,
       pageDescription = uriSummary.description.map(_.take(190) + "..."),
@@ -186,7 +186,7 @@ class ElizaEmailCommander @Inject() (
       else views.html.discussionEmail(threadInfoSmall, threadItems, false, false, true),
       views.html.discussionEmail(threadInfoSmall, threadItems, false, true, true),
       threadInfoSmall.conversationStarter,
-      uriSummarySmall.title.getOrElse(threadInfoSmall.pageName)
+      threadInfoSmall.pageTitle
     )
   }
 


### PR DESCRIPTION
@andrewconner 
also disallowing screenshots for the image in the small picture version
of the email, which look pretty bad (since they are tiny) and time out 
most of the time anyway.
The email code here is a mess (significant parts of it my fault).
Hopefully we can bring some better structure into this some time soon with @joshm1 new email tools.
