### PR TITLE
quartz && netty

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/net/ClientResponse.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/ClientResponse.scala
@@ -5,6 +5,7 @@ import com.google.inject.Provider
 import com.keepit.common.controller.CommonHeaders
 import com.keepit.common.logging.Logging
 import com.keepit.common.healthcheck.{ AirbrakeNotifier, AirbrakeError }
+import com.ning.http.client.providers.netty.NettyResponse
 
 import com.ning.http.util.AsyncHttpProviderUtils.parseCharset
 
@@ -16,7 +17,6 @@ import org.apache.commons.io.IOUtils
 
 import play.api.libs.json._
 import play.api.libs.ws._
-import play.api.libs.ws.ning.NingWSResponse
 
 import scala.util.Try
 import scala.xml._
@@ -46,7 +46,7 @@ class ClientResponseImpl(val request: Request, val res: WSResponse, airbrake: Pr
 
   lazy val status: Int = res.status
 
-  lazy val bytes: Array[Byte] = res.underlying[NingWSResponse].ahcResponse.getResponseBodyAsBytes
+  lazy val bytes: Array[Byte] = res.underlying[NettyResponse].getResponseBodyAsBytes
   private var _parsingTime: Option[Long] = None
   override def parsingTime = _parsingTime
 
@@ -55,7 +55,7 @@ class ClientResponseImpl(val request: Request, val res: WSResponse, airbrake: Pr
    */
   def isUp = res.header(CommonHeaders.IsUP).map(_ != "N").getOrElse(true)
 
-  lazy val ahcResponse = res.underlying[NingWSResponse].ahcResponse
+  lazy val ahcResponse = res.underlying[NettyResponse]
 
   // the following is copied from play.api.libs.ws.WS
   // RFC-2616#3.7.1 states that any text/* mime type should default to ISO-8859-1 charset if not

--- a/kifi-backend/project/Global.scala
+++ b/kifi-backend/project/Global.scala
@@ -37,13 +37,13 @@ object Global {
     "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
     // "kevoree Repository" at "http://maven2.kevoree.org/release/",
     "FortyTwo Public Repository" at "http://repo.42go.com:4242/fortytwo/content/groups/public/",
-    "FortyTwo Towel Repository" at "http://repo.42go.com:4242/fortytwo/content/repositories/towel",
+    "FortyTwo Towel Repository" at "http://repo.42go.com:4242/fortytwo/content/repositories/towel"
     //for org.mongodb#casb
     // "snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     // "releases"  at "https://oss.sonatype.org/content/groups/scala-tools",
     // "terracotta" at "http://www.terracotta.org/download/reflector/releases/",
     // "The Buzz Media Maven Repository" at "http://maven.thebuzzmedia.com"
-    "theatr.us" at "http://repo.theatr.us"
+    // "theatr.us" at "http://repo.theatr.us"
   )
 
 

--- a/kifi-backend/project/Global.scala
+++ b/kifi-backend/project/Global.scala
@@ -37,12 +37,13 @@ object Global {
     "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
     // "kevoree Repository" at "http://maven2.kevoree.org/release/",
     "FortyTwo Public Repository" at "http://repo.42go.com:4242/fortytwo/content/groups/public/",
-    "FortyTwo Towel Repository" at "http://repo.42go.com:4242/fortytwo/content/repositories/towel"
+    "FortyTwo Towel Repository" at "http://repo.42go.com:4242/fortytwo/content/repositories/towel",
     //for org.mongodb#casb
     // "snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     // "releases"  at "https://oss.sonatype.org/content/groups/scala-tools",
     // "terracotta" at "http://www.terracotta.org/download/reflector/releases/",
     // "The Buzz Media Maven Repository" at "http://maven.thebuzzmedia.com"
+    "theatr.us" at "http://repo.theatr.us"
   )
 
 
@@ -69,7 +70,7 @@ object Global {
     "com.google.inject.extensions" % "guice-multibindings" % "3.0",
     "net.codingwell" %% "scala-guice" % "3.0.2",
     "org.imgscalr" % "imgscalr-lib" % "4.2",
-    "us.theatr" %% "akka-quartz" % "0.2.0_42.1" exclude("c3p0", "c3p0"),
+    "us.theatr" %% "akka-quartz" % "0.3.0" exclude("c3p0", "c3p0"),
     "org.jsoup" % "jsoup" % "1.7.1",
     "org.bouncycastle" % "bcprov-jdk15on" % "1.50",
     "org.msgpack" %% "msgpack-scala" % "0.6.8",


### PR DESCRIPTION
Found a couple issues via ad hoc testing locally. 

Turns out our quartz dependency does not work with the latest play/akka versions. I upgraded to 0.3.0 but got unresolved dependency error. Adding the quartz repo addressed that, but not sure if that's expected.

Question for @eishay: do/should we need to manually build & add the jar to our nexus repo? I asked because I noticed that our previous quartz version was somewhat "special".

Also removed one cast to `NingWSResponse`.

I'd like to do a bit local testing, and we can try test instance after lunch. 

@andrewconner @eishay 
