### PR TITLE
endpoint to recompute user interests

### DIFF
--- a/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
@@ -142,4 +142,9 @@ class LDAController @Inject() (
     Ok(Json.toJson(lda.uriKLDivergence(uri1, uri2)))
   }
 
+  def recomputeUserLDAStat() = Action { request =>
+    lda.recomputeUserLDAStats()
+    Ok
+  }
+
 }

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/UserLDAStatsRepo.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/UserLDAStatsRepo.scala
@@ -16,6 +16,7 @@ import com.keepit.common.db.slick._
 trait UserLDAStatsRepo extends DbRepo[UserLDAStats] {
   def getByUser(userId: Id[User], version: ModelVersion[DenseLDA])(implicit session: RSession): Option[UserLDAStats]
   def getActiveByUser(userId: Id[User], version: ModelVersion[DenseLDA])(implicit session: RSession): Option[UserLDAStats]
+  def getAllUsers(version: ModelVersion[DenseLDA])(implicit session: RSession): Seq[Id[User]]
 }
 
 @Singleton
@@ -49,6 +50,10 @@ class UserLDAStatsRepoImpl @Inject() (
 
   def getActiveByUser(userId: Id[User], version: ModelVersion[DenseLDA])(implicit session: RSession): Option[UserLDAStats] = {
     (for { r <- rows if (r.userId === userId && r.version === version && r.state === UserLDAStatsStates.ACTIVE) } yield r).firstOption
+  }
+
+  def getAllUsers(version: ModelVersion[DenseLDA])(implicit session: RSession): Seq[Id[User]] = {
+    (for { r <- rows } yield r.userId).list
   }
 
 }

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDAUserStatDbUpdater.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDAUserStatDbUpdater.scala
@@ -11,7 +11,7 @@ import com.keepit.common.time._
 import com.keepit.common.zookeeper.ServiceDiscovery
 import com.keepit.cortex.core.{ StatModelName, FeatureRepresentation }
 import com.keepit.cortex.dbmodel._
-import com.keepit.cortex.plugins._
+import com.keepit.cortex.plugins.{ BaseFeatureUpdatePlugin, FeatureUpdatePlugin, FeatureUpdateActor, BaseFeatureUpdater, FeaturePluginMessages }
 import com.keepit.model.User
 import math.abs
 import com.keepit.cortex.utils.MatrixUtils._
@@ -114,6 +114,7 @@ class LDAUserStatDbUpdaterImpl @Inject() (
     def changedMuch(numOfEvidenceBefore: Int, numOfEvidenceNow: Int) = {
       val diff = abs(numOfEvidenceNow - numOfEvidenceBefore)
       if (model.get.state != UserLDAStatsStates.ACTIVE && numOfEvidenceNow >= min_num_evidence) true
+      else if (numOfEvidenceNow < min_num_evidence && model.get.state == UserLDAInterestsStates.ACTIVE) true
       else (diff.toFloat / numOfEvidenceBefore > 0.1f || diff > 100)
     }
 

--- a/kifi-backend/modules/cortex/conf/cortex.routes
+++ b/kifi-backend/modules/cortex/conf/cortex.routes
@@ -34,5 +34,6 @@ GET     /internal/cortex/lda/unamedTopics                                       
 POST    /internal/cortex/lda/getTopicNames                                          @com.keepit.controllers.cortex.LDAController.getTopicNames
 POST    /internal/cortex/lda/explainFeed                                            @com.keepit.controllers.cortex.LDAController.explainFeed
 GET     /internal/cortex/lda/uriKLDivergence                                        @com.keepit.controllers.cortex.LDAController.uriKLDivergence(uri1: Id[NormalizedURI], uri2: Id[NormalizedURI])
+GET     /internal/cortex/lda/recomputeUserLDAStat                                   @com.keepit.controllers.cortex.LDAController.recomputeUserLDAStat
 
 GET     /internal/cortex/data/sparseLDAFeaturesChanged        @com.keepit.controllers.cortex.CortexDataPipeController.getSparseLDAFeaturesChanged(modelVersion: ModelVersion[DenseLDA], seqNum: SequenceNumber[NormalizedURI], fetchSize: Int)


### PR DESCRIPTION
@stkem 

the endpoint will trigger a scan of all users in 'interest profile' repo. However, in the actual update plugin, there is a guard to test if it's necessary to compute the feature. (Mainly used to defend people like Jeff. So for people with few keeps, the guard will let it go). 
