### PR TITLE
play23: mongo

### DIFF
--- a/kifi-backend/project/Build.scala
+++ b/kifi-backend/project/Build.scala
@@ -44,8 +44,8 @@ object ApplicationBuild extends Build {
   )
 
   lazy val heimdalDependencies = Seq(
-    "org.reactivemongo" %% "reactivemongo" % "0.10.0",
-    "org.reactivemongo" %% "play2-reactivemongo" % "0.10.2",
+    "org.reactivemongo" %% "reactivemongo" % "0.10.5.akka23-SNAPSHOT",
+    "org.reactivemongo" %% "play2-reactivemongo" % "0.10.5.akka23-SNAPSHOT",
     "com.maxmind.geoip2" % "geoip2" % "0.5.0",
     "com.mixpanel" % "mixpanel-java" % "1.2.1"
   ) map (_.excludeAll(


### PR DESCRIPTION
Unfortunately, it appears that we'll have to go with SNAPSHOT (it's officially published, still) for play23/akka23. heimdal-d1 is deployed with this config.

akka23 has been more problematic than I'd anticipated -- it's quite a glaring omission that it didn't get highlighted (actually, no mention at all) in the play 23 migration guide https://www.playframework.com/documentation/2.3.x/Migration23

@andrewconner 
