### PR TITLE
less noisy incorrect scheduling alert

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
@@ -21,6 +21,7 @@ import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.commanders.RemoteUserExperimentCommander
 import com.keepit.common.zookeeper.ServiceDiscovery
+import com.keepit.common.service.ServiceStatus
 
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
@@ -241,8 +242,8 @@ class RecommendationGenerationCommander @Inject() (
         }
         res.map(_ => ())
       } else {
-        airbrake.notify("Trying to run reco precomputation on non-leader!")
-        recommendationGenerationLock.clear() //no point in alerting again and again for queued up tasks
+        recommendationGenerationLock.clear()
+        if (serviceDiscovery.myStatus.exists(_ != ServiceStatus.STOPPING)) airbrake.notify("Trying to run reco precomputation on non-leader (and it's not a shut down)!")
         Future.successful()
       }
     }


### PR DESCRIPTION
As it turns out, a service looses leader status _just before_ it shuts down, thus we were getting false alarms here on every deploy (from the shutting down machine).
Now this only alerts when this happens at other times. It's not the cleanest solution, but I would like to get this out to stop the prod exceptions.
@yingjieMiao @joshm1 (cc @andrewconner)
