### PR TITLE
trying to improve getKeepsAndTagsChanged

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
@@ -156,10 +156,7 @@ class ShoeboxDataPipeController @Inject() (
   def getKeepsAndTagsChanged(seqNum: SequenceNumber[Keep], fetchSize: Int) = Action { request =>
     val keepAndTagsChanged = db.readOnlyReplica(2) { implicit session =>
       val changedKeeps = keepRepo.getBySequenceNumber(seqNum, fetchSize)
-      val collectionIdsByKeepIds = changedKeeps.map { keep => (keep.id.get -> keepToCollectionRepo.getCollectionsForKeep(keep.id.get).toSet) }.toMap
-      val uniqueCollectionIds = collectionIdsByKeepIds.values.flatten.toSet
-      val tagsByCollectionIds = uniqueCollectionIds.map { collectionId => (collectionId -> collectionRepo.get(collectionId).name) }.toMap
-      changedKeeps.map { keep => KeepAndTags(keep, collectionIdsByKeepIds(keep.id.get).map(tagsByCollectionIds(_))) }
+      changedKeeps.map { keep => KeepAndTags(keep, collectionRepo.getTagsByKeepId(keep.id.get)) }
     }
     Ok(Json.toJson(keepAndTagsChanged))
   }


### PR DESCRIPTION
@leogrim 
- There were too many db calls. This change uses joins (collection and keep_to_collection) in db.
- We should bypass caches for indexing.
