### PR TITLE
play templates -> twirl (merge update)

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/mail/ElectronicMail.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/ElectronicMail.scala
@@ -11,7 +11,7 @@ import com.keepit.serializer.EitherFormat
 import org.joda.time.DateTime
 
 import play.api.mvc.PathBindable
-import play.api.templates.Html
+import play.twirl.api.Html
 
 case class ElectronicMailMessageId(id: String) {
   def toEmailHeader = s"<$id>"

--- a/kifi-backend/modules/common/app/com/keepit/model/Email.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Email.scala
@@ -3,7 +3,7 @@ package com.keepit.model
 import com.keepit.common.db.Id
 import com.keepit.common.mail.EmailAddress
 import play.api.libs.json._
-import play.api.templates.Html
+import play.twirl.api.Html
 
 import scala.util.matching.Regex
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
@@ -11,8 +11,8 @@ import com.keepit.model.{ UserEmailAddressRepo, UserRepo, User }
 import com.keepit.shoebox.ShoeboxServiceClient
 import com.keepit.social.BasicUser
 import play.api.libs.json.{ Json, JsValue }
-import play.api.templates.Html
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.twirl.api.Html
 
 import scala.concurrent.Future
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateProcessorImplTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateProcessorImplTest.scala
@@ -13,7 +13,7 @@ import com.keepit.search.FakeSearchServiceClientModule
 import com.keepit.shoebox.ProdShoeboxServiceClientModule
 import com.keepit.test.{ ShoeboxTestFactory, ShoeboxTestInjector }
 import org.specs2.mutable.Specification
-import play.api.templates.Html
+import play.twirl.api.Html
 import com.keepit.model.Email.placeholders._
 
 import scala.concurrent.Await

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateSenderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateSenderTest.scala
@@ -14,7 +14,7 @@ import com.keepit.search.FakeSearchServiceClientModule
 import com.keepit.shoebox.ProdShoeboxServiceClientModule
 import com.keepit.test.{ ShoeboxTestFactory, ShoeboxTestInjector }
 import org.specs2.mutable.Specification
-import play.api.templates.Html
+import play.twirl.api.Html
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/mail/ElectronicMailTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/mail/ElectronicMailTest.scala
@@ -4,7 +4,7 @@ import com.keepit.test._
 import org.specs2.mutable.Specification
 import com.keepit.model.NotificationCategory
 import play.api.libs.json.{ JsSuccess, Json }
-import play.api.templates.Html
+import play.twirl.api.Html
 
 class ElectronicMailTest extends Specification with ShoeboxTestInjector {
 


### PR DESCRIPTION
this should take care of all (currently known) references to `play.api.templates.Html`

@andrewconner @joshm1 
