### PR TITLE
removing Google I/O choice from the guide b/c it breaks the guide now

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/layout/rightCol/RightColCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/rightCol/RightColCtrl.js
@@ -109,17 +109,6 @@ angular.module('kifi')
           matches: {title: [[0,5],[35,3]], url: [[39,5],[72,3]]},
           track: 'leatherTote'
         }, {
-          url: 'http://www.theverge.com/2014/6/26/5845996/watch-google-io-2014-keynote-on-demand',
-          name: ['Google I/O','2014','Keynote'],
-          site: 'theverge.com',
-          thumb: '/img/guide/google_io.jpg',
-          noun: 'article',
-          tag: 'Watch Later',
-          query: 'google+io',
-          title: 'You can now watch Google’s entire two-and-a-half-hour I/O keynote',
-          matches: {title: [[18,6],[54,3]], url: [[48,6],[55,2]]},
-          track: 'googleIoKeynote'
-        }, {
           url: 'http://www.ted.com/talks/steve_jobs_how_to_live_before_you_die',
           name: ['Steve Jobs:','How to Live','Before You Die'],
           site: 'ted.com',


### PR DESCRIPTION
@ahsu1230 

This will reduce the number of page choices from 4 to 3, for now. (Product has been considering dropping it to 2.)
