### PR TITLE
Change 'trimRight()' to 'trim()' for better browser support.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -128,7 +128,7 @@ angular.module('kifi')
             fileNameIdx += fileNameMatch.index;
             fileName = fileNameMatch[0];
           }
-          fileName = fileName.replace(fileNameToSpaceRe, ' ').trimRight();
+          fileName = fileName.replace(fileNameToSpaceRe, ' ').trim();
 
           for (var i = matches && matches.length; i--;) {
             var match = matches[i];

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keepActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keepActionService.js
@@ -33,7 +33,7 @@ angular.module('kifi')
           };
         })
       };
-      $log.log('keepService.keep()', data);
+      $log.log('keepActionService.keep()', data);
 
       var url = env.xhrBase + '/keeps/add';
       var config = {

--- a/kifi-backend/modules/shoebox/angular/src/recos/recoDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recoDecoratorService.js
@@ -29,7 +29,7 @@ angular.module('kifi')
         fileNameIdx += fileNameMatch.index;
         fileName = fileNameMatch[0];
       }
-      fileName = fileName.replace(fileNameToSpaceRe, ' ').trimRight().trimLeft();
+      fileName = fileName.replace(fileNameToSpaceRe, ' ').trim();
 
       return domain + (fileName ? ' · ' + fileName : '');
     }
@@ -74,7 +74,7 @@ angular.module('kifi')
           fileNameIdx += fileNameMatch.index;
           fileName = fileNameMatch[0];
         }
-        fileName = fileName.replace(fileNameToSpaceRe, ' ').trimRight().trimLeft();
+        fileName = fileName.replace(fileNameToSpaceRe, ' ').trim();
 
         return domain + (fileName ? ' · ' + fileName : '');
       }
@@ -126,7 +126,7 @@ angular.module('kifi')
       };
 
       this.recoData.reasons.forEach(function (reason) {
-        if (!reason.name) {
+        if (!reason.name && reason.url) {
           reason.name = formatTitleFromUrl(reason.url);
         }
       });


### PR DESCRIPTION
Also, call 'formatTitleFromUrl' for recommendation attributions only if there is a url.
https://app.asana.com/0/15589946826415/15785999026810

I found a bug while testing recommendations on IE10 where the browser does not recognize the `trimRight()` method on JavaScript strings. This is also a problem for keeps, but the code path that contains `trimRight()` is accessed more frequently for recommendations. Switching to `trim()`, which is supported by IE9 and up.

@2is10 cc @stkem 
