### PR TITLE
Turning off airbrakes for system libraries, fixing odd empty .next bug

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeFormatter.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeFormatter.scala
@@ -73,7 +73,7 @@ class AirbrakeFormatter(val apiKey: String, val playMode: Mode, service: FortyTw
   }
 
   private def formatStacktrace(error: ErrorWithStack) = {
-    <line method={ error.toString } file={ error.stack.head.getFileName } number={ error.stack.head.getLineNumber.toString }/> ++ {
+    <line method={ error.toString() } file={ error.stack.headOption.map(_.getFileName).getOrElse("unknown") } number={ error.stack.headOption.map(_.getLineNumber).getOrElse(0).toString }/> ++ {
       error.stack.map(e => {
         <line method={ ignoreAnonfun(e.getClassName) + "#" + e.getMethodName } file={ e.getFileName } number={ e.getLineNumber.toString }/>
       })

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -286,14 +286,14 @@ class LibraryCommander @Inject() (
       val mainOpt = if (sysLibs.find(_._2.kind == LibraryKind.SYSTEM_MAIN).isEmpty) {
         val mainLib = libraryRepo.save(Library(name = "Main Library", ownerId = userId, visibility = LibraryVisibility.DISCOVERABLE, slug = LibrarySlug("main"), kind = LibraryKind.SYSTEM_MAIN, memberCount = 1))
         val mainMem = libraryMembershipRepo.save(LibraryMembership(libraryId = mainLib.id.get, userId = userId, access = LibraryAccess.OWNER, showInSearch = true))
-        airbrake.notify("missing main library")
+        //airbrake.notify("missing main library") todo: reactivate, allowing new users to create libraries in peace
         Some(mainLib)
       } else None
 
       val secretOpt = if (sysLibs.find(_._2.kind == LibraryKind.SYSTEM_SECRET).isEmpty) {
         val secretLib = libraryRepo.save(Library(name = "Secret Library", ownerId = userId, visibility = LibraryVisibility.SECRET, slug = LibrarySlug("secret"), kind = LibraryKind.SYSTEM_SECRET, memberCount = 1))
         val secretMem = libraryMembershipRepo.save(LibraryMembership(libraryId = secretLib.id.get, userId = userId, access = LibraryAccess.OWNER, showInSearch = true))
-        airbrake.notify("missing secret library")
+        //airbrake.notify("missing secret library") todo: reactivate, allowing new users to create libraries in peace
         Some(secretLib)
       } else None
 


### PR DESCRIPTION
@ahsu1230 Mind fixing the airbrake in interning libraries?

@eishay Not sure why this is happening just now, but it is causing exceptions, so being safer. Perhaps we'll get insight into why — currently the original exception is blowing away when this happens.
