### PR TITLE
1 retry in the sequence number assigner

### DIFF
--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/DbSequenceAssigner.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/DbSequenceAssigner.scala
@@ -14,7 +14,7 @@ abstract class DbSequenceAssigner[M <: ModelWithSeqNumber[M]](
 
   override def assignSequenceNumbers(): Unit = {
     try {
-      while (db.readWrite { implicit session => repo.assignSequenceNumbers(batchSize) } > 0) {}
+      while (db.readWrite(attempts = 2) { implicit session => repo.assignSequenceNumbers(batchSize) } > 0) {}
     } catch {
       case e: UnsupportedOperationException =>
         reportUnsupported(e)


### PR DESCRIPTION
I think the raw_seed_item table in curator is currently the most
insert/save heavy table in the system. We’ve been seeing the occasional
lock wait timeout exceeded error for the sequence number assigner there
when big batch updates/inserts are going on. I think it’s likely only a
matter of time before this happens elsewhere as well, this I would like
to add one retry to the logic.
Thoughts?

@leogrim @ymatsuda (cc @andrewconner @eishay)
