### PR TITLE
Kifi black reset password email

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/mail/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/package.scala
@@ -66,6 +66,7 @@ package object template {
     }
 
     val kifiLogoUrl = htmlUrl(s"$baseUrl/?", "headerLogo")
+    val kifiFooterUrl = htmlUrl(s"$baseUrl/?", "footerKifiLink")
     val privacyUrl = htmlUrl(s"$baseUrl/privacy?", "footerPrivacy")
     val kifiTwitterUrl = htmlUrl("https://twitter.com/kifi?", "footerTwitter")
     val kifiFacebookUrl = htmlUrl("https://www.facebook.com/kifi42?", "footerFacebook")

--- a/kifi-backend/modules/common/app/com/keepit/common/mail/template/EmailToSend.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/template/EmailToSend.scala
@@ -9,7 +9,7 @@ import play.twirl.api.Html
 case class EmailToSend(
   title: String = "Kifi",
   from: EmailAddress,
-  fromName: Option[String] = None,
+  fromName: Option[String] = Some("Kifi"),
   to: Either[Id[User], EmailAddress],
   cc: Seq[EmailAddress] = Seq[EmailAddress](),
   subject: String,

--- a/kifi-backend/modules/common/app/views/email/black/footer.scala.html
+++ b/kifi-backend/modules/common/app/views/email/black/footer.scala.html
@@ -13,7 +13,7 @@
                                     <table width="100%" border="0" cellspacing="0" cellpadding="0">
                                         <tr>
                                             <td align="left" class="center1" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#333333;line-height:22px;">
-                                                <a href="@h.kifiLogoUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Kifi.com</a>
+                                                <a href="@h.kifiFooterUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Kifi.com</a>
                                                 Your recommendations network<br/>Follow us on
                                                 <a href="@h.kifiTwitterUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Twitter</a>
                                                 &nbsp;

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/email/FeedDigestEmailSender.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/email/FeedDigestEmailSender.scala
@@ -4,27 +4,26 @@ import com.google.inject.{ ImplementedBy, Inject }
 import com.keepit.abook.ABookServiceClient
 import com.keepit.commanders.RemoteUserExperimentCommander
 import com.keepit.common.concurrent.FutureHelpers
-import com.keepit.common.db.slick.Database
+import com.keepit.common.concurrent.PimpMyFuture._
 import com.keepit.common.db.Id
+import com.keepit.common.db.slick.Database
 import com.keepit.common.domain.DomainToNameMapper
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
-import com.keepit.common.mail.template.{ EmailToSend, EmailTips }
 import com.keepit.common.mail.SystemEmailAddress
+import com.keepit.common.mail.template.helpers.toHttpsUrl
+import com.keepit.common.mail.template.{ EmailTips, EmailToSend }
 import com.keepit.common.store.S3UserPictureConfig
 import com.keepit.curator.commanders.RecommendationGenerationCommander
-import com.keepit.curator.model.{ UriRecommendationRepo, UriRecommendation }
-import com.keepit.common.mail.template.helpers.toHttpsUrl
+import com.keepit.curator.model.{ UriRecommendation, UriRecommendationRepo }
 import com.keepit.inject.FortyTwoConfig
 import com.keepit.model._
 import com.keepit.shoebox.ShoeboxServiceClient
-import com.keepit.social.{ SocialNetworks, BasicUser }
+import com.keepit.social.{ BasicUser, SocialNetworks }
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import com.keepit.common.time.{ currentDateTime, DEFAULT_DATE_TIME_ZONE }
-import com.keepit.common.concurrent.PimpMyFuture._
 
-import concurrent.Future
-import scala.util.{ Success, Random, Failure }
+import scala.concurrent.Future
+import scala.util.{ Failure, Random, Success }
 
 object DigestEmail {
   val READ_TIMES = (1 to 10) ++ Seq(15, 20, 30, 45, 60)
@@ -110,7 +109,7 @@ class FeedDigestEmailSenderImpl @Inject() (
     protected val config: FortyTwoConfig,
     protected val airbrake: AirbrakeNotifier) extends FeedDigestEmailSender with Logging {
 
-  import DigestEmail._
+  import com.keepit.curator.commanders.email.DigestEmail._
 
   val defaultUriRecommendationScores = UriRecommendationScores()
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
@@ -6,10 +6,9 @@ import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
 import com.keepit.common.mail.EmailAddress
 import com.keepit.inject.FortyTwoConfig
-import com.keepit.common.mail.template.{ TipTemplate, EmailToSend, TagWrapper, Tag, tags, EmailTips }
+import com.keepit.common.mail.template.{ EmailToSend, TagWrapper, tags, EmailTips }
 import com.keepit.common.mail.template.Tag._
 import com.keepit.model.{ UserEmailAddressRepo, UserRepo, User }
-import com.keepit.shoebox.ShoeboxServiceClient
 import com.keepit.social.BasicUser
 import play.api.libs.json.{ Json, JsValue }
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -23,7 +22,6 @@ trait EmailTemplateProcessor {
 }
 
 class EmailTemplateProcessorImpl @Inject() (
-    shoebox: ShoeboxServiceClient,
     db: Database, userRepo: UserRepo,
     userCommander: UserCommander,
     emailAddressRepo: UserEmailAddressRepo,

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ResetPasswordEmailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ResetPasswordEmailSender.scala
@@ -1,0 +1,41 @@
+package com.keepit.commanders.emails
+
+import com.google.inject.Inject
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.logging.Logging
+import com.keepit.common.mail.{ EmailAddress, ElectronicMail, SystemEmailAddress }
+import com.keepit.common.mail.template.EmailToSend
+import com.keepit.controllers.core.routes
+import com.keepit.inject.FortyTwoConfig
+import com.keepit.model.{ PasswordResetRepo, NotificationCategory, User }
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+import scala.concurrent.Future
+
+class ResetPasswordEmailSender @Inject() (
+    db: Database,
+    emailTemplateSender: EmailTemplateSender,
+    passwordResetRepo: PasswordResetRepo,
+    config: FortyTwoConfig,
+    protected val airbrake: AirbrakeNotifier) extends Logging {
+
+  def sendToUser(userId: Id[User], resetEmailAddress: EmailAddress): Future[ElectronicMail] = {
+    val reset = db.readWrite { implicit rw =>
+      passwordResetRepo.createNewResetToken(userId, resetEmailAddress)
+    }
+
+    val resetUrl = config.applicationBaseUrl + routes.AuthController.setPasswordPage(reset.token)
+    val emailToSend = EmailToSend(
+      fromName = Some("Kifi Support"),
+      from = SystemEmailAddress.SUPPORT,
+      subject = "Kifi.com | Password reset requested",
+      to = Right(resetEmailAddress),
+      category = NotificationCategory.User.RESET_PASSWORD,
+      htmlTemplate = views.html.email.resetPasswordBlack(userId, resetUrl),
+      campaign = Some("passwordReset")
+    )
+    emailTemplateSender.send(emailToSend)
+  }
+}

--- a/kifi-backend/modules/shoebox/app/views/email/resetPasswordBlack.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/resetPasswordBlack.scala.html
@@ -1,0 +1,54 @@
+@(userId: com.keepit.common.db.Id[User], resetUrl: String)
+@import com.keepit.common.mail.template.helpers._
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td width="70" class="fix1">&nbsp;</td>
+    <td valign="top">
+      <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td height="46">&nbsp;</td>
+        </tr>
+        <tr>
+          <td align="left" style="font-family:Arial, sans-serif;font-size:16px;color:#333333;line-height:22px;">
+            <span style="font-weight:bold;font-size:22px;line-height:24px;">Hi @firstName(userId),</span>
+            <br/><br/>
+            We received a request to <span style="font-weight:bold;">reset your password</span> on kifi.<br/>
+            To choose a new password, please click the link below:
+          </td>
+        </tr>
+        <tr>
+          <td height="20">&nbsp;</td>
+        </tr>
+        <tr>
+          <td bgcolor="#f3f3f3" height="1" style="line-height:1px;font-size:1px;">&nbsp;</td>
+        </tr>
+        <tr>
+          <td height="20">&nbsp;</td>
+        </tr>
+        <tr>
+          <td align="left" class="text" style="font-family:Arial, sans-serif;font-size:14px;color:#6fa6ef;line-height:20px;">
+            <a href="@resetUrl" target="_blank" style="text-decoration:underline;color:#6fa6ef;">@resetUrl</a></td>
+        </tr>
+        <tr>
+          <td height="25">&nbsp;</td>
+        </tr>
+        <tr>
+          <td bgcolor="#f3f3f3" height="1" style="line-height:1px;font-size:1px;">&nbsp;</td>
+        </tr>
+        <tr>
+          <td height="20">&nbsp;</td>
+        </tr>
+        <tr>
+          <td align="left" style="font-family:Arial, sans-serif;font-size:16px;color:#333333;line-height:22px;">Have a
+            great day,<br/>
+            The Kifi team
+          </td>
+        </tr>
+        <tr>
+          <td height="65">&nbsp;</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -727,6 +727,8 @@ POST     /internal/shoebox/database/triggerSocialGraphFetch @com.keepit.controll
 GET      /internal/shoebox/database/getLapsedUsersForDelighted    @com.keepit.controllers.internal.ShoeboxController.getLapsedUsersForDelighted(maxCount: Int, skipCount: Int, after: DateTime, before: Option[DateTime] ?= None)
 
 GET      /internal/shoebox/emailTest @com.keepit.controllers.internal.EmailTestController.testEmail(name: String)
+GET      /internal/shoebox/emailSenderTest                 @com.keepit.controllers.internal.EmailTestController.testEmailSender(name: String)
+
 POST     /internal/shoebox/database/isSensitiveURI       @com.keepit.controllers.internal.ShoeboxPageController.isSensitiveURI()
 POST     /internal/shoebox/database/updateURIRestriction  @com.keepit.controllers.internal.ShoeboxController.updateURIRestriction()
 GET      /internal/shoebox/database/urlPatternRules         @com.keepit.controllers.internal.ShoeboxScraperController.getAllURLPatternRules()

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/ResetPasswordEmailSenderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/ResetPasswordEmailSenderTest.scala
@@ -1,0 +1,64 @@
+package com.keepit.commanders.emails
+
+import com.keepit.abook.FakeABookServiceClientModule
+import com.keepit.common.cache.FakeCacheModule
+import com.keepit.common.healthcheck.FakeHealthcheckModule
+import com.keepit.common.mail.{ EmailAddress, FakeOutbox }
+import com.keepit.common.net.FakeHttpClientModule
+import com.keepit.common.social.FakeSocialGraphModule
+import com.keepit.cortex.FakeCortexServiceClientModule
+import com.keepit.eliza.FakeElizaServiceClientModule
+import com.keepit.graph.FakeGraphServiceModule
+import com.keepit.heimdal.FakeHeimdalServiceClientModule
+import com.keepit.model.{ User, UserRepo, PasswordResetRepo }
+import com.keepit.scraper.FakeScrapeSchedulerModule
+import com.keepit.search.FakeSearchServiceClientModule
+import com.keepit.test.ShoeboxTestInjector
+import org.specs2.mutable.Specification
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.Await
+
+class ResetPasswordEmailSenderTest extends Specification with ShoeboxTestInjector {
+  val modules = Seq(
+    FakeScrapeSchedulerModule(),
+    FakeHttpClientModule(),
+    FakeSocialGraphModule(),
+    FakeHealthcheckModule(),
+    FakeGraphServiceModule(),
+    FakeCortexServiceClientModule(),
+    FakeHeimdalServiceClientModule(),
+    FakeSearchServiceClientModule(),
+    FakeCacheModule(),
+    FakeElizaServiceClientModule(),
+    FakeABookServiceClientModule())
+
+  "ResetPasswordEmailSender" should {
+
+    "sends reset password email" in {
+      withDb(modules: _*) { implicit injector =>
+        val outbox = inject[FakeOutbox]
+        val passwordResetRepo = inject[PasswordResetRepo]
+        val resetSender = inject[ResetPasswordEmailSender]
+        val user = db.readWrite { implicit rw =>
+          inject[UserRepo].save(User(firstName = "Billy", lastName = "Madison", primaryEmail = Some(EmailAddress("billy@gmail.com"))))
+        }
+        val email = Await.result(resetSender.sendToUser(user.id.get, user.primaryEmail.get), Duration(5, "seconds"))
+        outbox.size === 1
+        outbox(0) === email
+
+        val tokens = db.readOnlyMaster { implicit s => passwordResetRepo.getByUser(user.id.get) }
+        tokens.size === 1
+        val token = tokens(0).token
+        token.size === 8
+
+        val html = email.htmlBody.value
+        html must contain("Hi Billy,")
+        html must contain(s"TEST_MODE/password/$token")
+        html must contain("utm_campaign=passwordReset")
+      }
+    }
+
+  }
+
+}

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/core/AuthControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/core/AuthControllerTest.scala
@@ -1,0 +1,90 @@
+package com.keepit.controllers.core
+
+import com.keepit.abook.FakeABookServiceClientModule
+import com.keepit.common.actor.FakeActorSystemModule
+import com.keepit.common.controller.{ FakeActionAuthenticator, ActionAuthenticator }
+import com.keepit.common.external.FakeExternalServiceModule
+import com.keepit.common.healthcheck.FakeAirbrakeModule
+import com.keepit.common.mail.{ FakeOutbox, EmailAddress, FakeMailModule }
+import com.keepit.common.net.FakeHttpClientModule
+import com.keepit.common.social.FakeSocialGraphModule
+import com.keepit.common.store.FakeShoeboxStoreModule
+import com.keepit.controllers.internal.ShoeboxController
+import com.keepit.cortex.FakeCortexServiceClientModule
+import com.keepit.curator.FakeCuratorServiceClientModule
+import com.keepit.model.{ UserEmailAddress, UserEmailAddressRepo, User, UserRepo }
+import com.keepit.scraper.{ FakeScrapeSchedulerModule, FakeScraperServiceClientModule }
+import com.keepit.search.FakeSearchServiceClientModule
+import com.keepit.shoebox.FakeShoeboxServiceModule
+import com.keepit.test.ShoeboxTestInjector
+import org.specs2.mutable.Specification
+import play.api.libs.json.{ JsArray, Json }
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+class AuthControllerTest extends Specification with ShoeboxTestInjector {
+
+  val modules = Seq(FakeShoeboxServiceModule(),
+    FakeABookServiceClientModule(),
+    FakeSocialGraphModule(),
+    FakeScrapeSchedulerModule(),
+    FakeShoeboxStoreModule(),
+    FakeActorSystemModule(),
+    FakeAirbrakeModule(),
+    FakeHttpClientModule(),
+    FakeMailModule(),
+    FakeSearchServiceClientModule(),
+    FakeExternalServiceModule(),
+    FakeCortexServiceClientModule(),
+    FakeScraperServiceClientModule(),
+    FakeCuratorServiceClientModule())
+
+  "AuthController" should {
+    val call = com.keepit.controllers.core.routes.AuthController.forgotPassword()
+
+    "correct URL and method" in {
+      call.method === "POST"
+      call.url === "/password/forgot"
+    }
+
+    "reset password with valid email" in {
+      withDb(modules: _*) { implicit injector =>
+        val user = db.readWrite { implicit rw =>
+          val user = inject[UserRepo].save(User(firstName = "Elaine", lastName = "Benes"))
+          inject[UserEmailAddressRepo].save(UserEmailAddress(userId = user.id.get,
+            address = EmailAddress("elaine@gmail.com")))
+          inject[UserEmailAddressRepo].save(UserEmailAddress(userId = user.id.get,
+            address = EmailAddress("dancing@gmail.com")))
+          user
+        }
+        inject[ActionAuthenticator].asInstanceOf[FakeActionAuthenticator].setUser(user)
+
+        val outbox = inject[FakeOutbox]
+        val ctrl = inject[AuthController]
+        // test 2 calls for the same user with different valid emails
+        val result1 = ctrl.forgotPassword()(FakeRequest(call).withBody(Json.obj("email" -> "elaine@gmail.com")))
+
+        outbox.size === 1
+        outbox(0).to === Seq(EmailAddress("elaine@gmail.com"))
+        Json.parse(contentAsString(result1)) === Json.obj("addresses" -> Json.toJson(Seq("elaine@gmail.com")))
+        status(result1) === OK
+
+        val result2 = ctrl.forgotPassword()(FakeRequest(call).withBody(Json.obj("email" -> "dancing@gmail.com")))
+
+        outbox.size === 2
+        outbox(1).to === Seq(EmailAddress("dancing@gmail.com"))
+        Json.parse(contentAsString(result2)) === Json.obj("addresses" -> Json.toJson(Seq("dancing@gmail.com")))
+        status(result2) === OK
+      }
+    }
+    "reset password with invalid email" in {
+      withDb(modules: _*) { implicit injector =>
+        val ctrl = inject[AuthController]
+        val body = Json.obj("email" -> "foo@bar.com")
+        val result = ctrl.forgotPassword()(FakeRequest(call).withBody(body))
+        Json.parse(contentAsString(result)) === Json.obj("error" -> "no_account")
+        status(result) === BAD_REQUEST
+      }
+    }
+  }
+}


### PR DESCRIPTION
This does not update the production email.  I will test it with the new emailSenderTest endpoint first, then update the production template in another PR.

I made no changes to AuthController.forgotPassword, but I went ahead and added a unit/regression test for it, which should continue to pass when I change it to use ResetPasswordEmailSender

@stkem 
