### PR TITLE
fix build and email template sender prepend https to image URLs

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
@@ -7,6 +7,7 @@ import com.keepit.common.db.slick.Database
 import com.keepit.common.mail.EmailAddress
 import com.keepit.inject.FortyTwoConfig
 import com.keepit.common.mail.template.{ EmailToSend, TagWrapper, tags, EmailTips }
+import com.keepit.common.mail.template.helpers.toHttpsUrl
 import com.keepit.common.mail.template.Tag._
 import com.keepit.model.{ UserEmailAddressRepo, UserRepo, User }
 import com.keepit.social.BasicUser
@@ -80,7 +81,7 @@ class EmailTemplateProcessorImpl @Inject() (
         case tags.firstName => basicUser.firstName
         case tags.lastName => basicUser.lastName
         case tags.fullName => basicUser.firstName + " " + basicUser.lastName
-        case tags.avatarUrl => input.imageUrls(userId)
+        case tags.avatarUrl => toHttpsUrl(input.imageUrls(userId))
         case tags.unsubscribeUrl =>
           getUnsubUrl(emailToSend.to match {
             case Left(userId) => db.readOnlyReplica { implicit s => emailAddressRepo.getByUser(userId) }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateProcessorImplTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateProcessorImplTest.scala
@@ -73,10 +73,10 @@ class EmailTemplateProcessorImplTest extends Specification with ShoeboxTestInjec
         output must contain("privacy?utm_source=footerPrivacy&utm_medium=email&utm_campaign=tester")
         output must contain("<title>Test Email!!!</title>")
         output must contain("Aaron Paul and Bryan Cranston joined!")
-        output must contain("""<img src="http://cloudfront/users/1/pics/100/0.jpg" alt="Aaron Paul"/>""")
-        output must contain("""<img src="http://cloudfront/users/2/pics/100/0.jpg" alt="Bryan Cranston"/>""")
-        output must contain("""<img src="http://cloudfront/users/3/pics/100/0.jpg" alt="Anna Gunn"/>""")
-        output must contain("""<img src="http://cloudfront/users/4/pics/100/0.jpg" alt="Dean Norris"/>""")
+        output must contain("""<img src="https://cloudfront/users/1/pics/100/0.jpg" alt="Aaron Paul"/>""")
+        output must contain("""<img src="https://cloudfront/users/2/pics/100/0.jpg" alt="Bryan Cranston"/>""")
+        output must contain("""<img src="https://cloudfront/users/3/pics/100/0.jpg" alt="Anna Gunn"/>""")
+        output must contain("""<img src="https://cloudfront/users/4/pics/100/0.jpg" alt="Dean Norris"/>""")
       }
     }
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateSenderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateSenderTest.scala
@@ -97,11 +97,11 @@ class EmailTemplateSenderTest extends Specification with ShoeboxTestInjector {
           val email = inject[ElectronicMailRepo].all().head
           val html = email.htmlBody.value
           html must contain("Find friends on Kifi to benefit from their keeps")
-          html must contain("http://cloudfront/users/1/pics/100/0.jpg")
+          html must contain("https://cloudfront/users/1/pics/100/0.jpg")
           html must contain("alt=\"Aaron\"")
-          html must contain("http://cloudfront/users/2/pics/100/0.jpg")
+          html must contain("https://cloudfront/users/2/pics/100/0.jpg")
           html must contain("alt=\"Bryan\"")
-          html must contain("http://cloudfront/users/4/pics/100/0.jpg")
+          html must contain("https://cloudfront/users/4/pics/100/0.jpg")
           html must contain("alt=\"Dean\"")
         }
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/mail/ElectronicMailTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/mail/ElectronicMailTest.scala
@@ -48,7 +48,7 @@ class ElectronicMailTest extends Specification with ShoeboxTestInjector {
 
       val expectedJson = """
           |{"title":"Kifi","from":"eng@42go.com","to":"josh@kifi.com","cc":[],"subject":"Test",
-          |"htmlTemplate":"this is <b>html</b>","category":"digest",
+          |"htmlTemplate":"this is <b>html</b>","category":"digest","fromName":"Kifi",
           |"campaign":"testing","tips":[]}
         """.stripMargin
       val jsVal = Json.parse(expectedJson)

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/store/FakeS3ImageStore.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/store/FakeS3ImageStore.scala
@@ -8,9 +8,9 @@ import java.io.File
 
 case class FakeS3ImageStore(val config: S3ImageConfig) extends S3ImageStore {
   def getPictureUrl(w: Int, user: User) =
-    promise[String]().success(s"http://cloudfront/${user.id.get}_${w}x${w}").future
+    promise[String]().success(s"//cloudfront/${user.id.get}_${w}x${w}").future
   def getPictureUrl(width: Option[Int], user: User, picVersion: String): Future[String] =
-    promise[String]().success(s"http://cloudfront/users/${user.id.get}/pics/${width.getOrElse(100)}/$picVersion.jpg").future
+    promise[String]().success(s"//cloudfront/users/${user.id.get}/pics/${width.getOrElse(100)}/$picVersion.jpg").future
 
   def uploadPictureFromSocialNetwork(sui: SocialUserInfo, externalId: ExternalId[User], pictureName: String, setDefault: Boolean): Future[Seq[(String, Try[PutObjectResult])]] =
     promise[Seq[(String, Try[PutObjectResult])]]().success(Seq()).future


### PR DESCRIPTION
FakeS3ImageStore updated to return the schema-less URL to be similar to production

@stkem 
