### PR TITLE
library feature updater

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/cortex/core/StatModel.scala
+++ b/kifi-backend/modules/common/app/com/keepit/cortex/core/StatModel.scala
@@ -17,6 +17,7 @@ object StatModelName {
   val LDA = StatModelName("lda")
   val LDA_USER = StatModelName("lda_user")
   val LDA_USER_STATS = StatModelName("lda_user_stats")
+  val LDA_LIBRARY = StatModelName("lda_library")
 }
 
 object ModelVersion {

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/CortexModelModule.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/CortexModelModule.scala
@@ -18,6 +18,7 @@ case class CortexProdModelModule() extends CortexModelModule with Logging {
     bind[LDAUserStatDbUpdatePlugin].to[LDAUserStatDbUpdatePluginImpl].in[AppScoped]
     bind[UserLDAStatisticsPlugin].to[UserLDAStatisticsPluginImpl].in[AppScoped]
     bind[LDAInfoUpdatePlugin].to[LDAInfoUpdatePluginImpl].in[AppScoped]
+    bind[LDALibraryUpdaterPlugin].to[LDALibraryUpdaterPluginImpl].in[AppScoped]
   }
 
   @Singleton
@@ -47,6 +48,7 @@ case class CortexDevModelModule() extends CortexModelModule {
     bind[LDAUserStatDbUpdatePlugin].to[LDAUserStatDbUpdatePluginImpl].in[AppScoped]
     bind[UserLDAStatisticsPlugin].to[UserLDAStatisticsPluginImpl].in[AppScoped]
     bind[LDAInfoUpdatePlugin].to[LDAInfoUpdatePluginImpl].in[AppScoped]
+    bind[LDALibraryUpdaterPlugin].to[LDALibraryUpdaterPluginImpl].in[AppScoped]
   }
 
   @Singleton

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/LibraryLDATopic.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/LibraryLDATopic.scala
@@ -1,0 +1,27 @@
+package com.keepit.cortex.dbmodel
+
+import com.keepit.common.db.{ States, ModelWithState, State, Id }
+import com.keepit.cortex.core.ModelVersion
+import com.keepit.cortex.models.lda.DenseLDA
+import com.keepit.model.Library
+import org.joda.time.DateTime
+import com.keepit.common.time._
+
+case class LibraryTopicMean(value: Array[Float])
+
+case class LibraryLDATopic(
+    id: Option[Id[LibraryLDATopic]] = None,
+    createdAt: DateTime = currentDateTime,
+    updatedAt: DateTime = currentDateTime,
+    libraryId: Id[Library],
+    version: ModelVersion[DenseLDA],
+    numOfEvidence: Int,
+    topic: Option[LibraryTopicMean],
+    state: State[LibraryLDATopic]) extends ModelWithState[LibraryLDATopic] {
+  def withId(id: Id[LibraryLDATopic]): LibraryLDATopic = copy(id = Some(id))
+  def withUpdateTime(time: DateTime): LibraryLDATopic = copy(updatedAt = time)
+}
+
+object LibraryLDATopicStates extends States[LibraryLDATopic] {
+  val NOT_APPLICABLE = State[LibraryLDATopic]("not_applicable")
+}

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/LibraryLDATopicRepo.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/LibraryLDATopicRepo.scala
@@ -1,23 +1,23 @@
 package com.keepit.cortex.dbmodel
 
-import com.google.inject.Inject
+import com.google.inject.{ Inject, ImplementedBy, Singleton }
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.DBSession.RSession
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.time.Clock
 import com.keepit.cortex.core.ModelVersion
-import com.keepit.cortex.models.lda.{ LDATopicFeature, DenseLDA }
+import com.keepit.cortex.models.lda.{ DenseLDA }
 import com.keepit.cortex.sql.CortexTypeMappers
 import com.keepit.model.Library
 import com.keepit.common.db.slick.{ DataBaseComponent, DbRepo }
 
-import scala.slick.jdbc.StaticQuery
-
+@ImplementedBy(classOf[LibraryLDATopicRepoImpl])
 trait LibraryLDATopicRepo extends DbRepo[LibraryLDATopic] {
   def getByLibraryId(libId: Id[Library], version: ModelVersion[DenseLDA])(implicit session: RSession): Option[LibraryLDATopic]
   def getActiveByLibraryId(libId: Id[Library], version: ModelVersion[DenseLDA])(implicit session: RSession): Option[LibraryLDATopic]
 }
 
+@Singleton
 class LibraryLDATopicRepoImpl @Inject() (
     val db: DataBaseComponent,
     val clock: Clock,

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/LibraryLDATopicRepo.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/LibraryLDATopicRepo.scala
@@ -1,0 +1,51 @@
+package com.keepit.cortex.dbmodel
+
+import com.google.inject.Inject
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.DBSession.RSession
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.time.Clock
+import com.keepit.cortex.core.ModelVersion
+import com.keepit.cortex.models.lda.{ LDATopicFeature, DenseLDA }
+import com.keepit.cortex.sql.CortexTypeMappers
+import com.keepit.model.Library
+import com.keepit.common.db.slick.{ DataBaseComponent, DbRepo }
+
+import scala.slick.jdbc.StaticQuery
+
+trait LibraryLDATopicRepo extends DbRepo[LibraryLDATopic] {
+  def getByLibraryId(libId: Id[Library], version: ModelVersion[DenseLDA])(implicit session: RSession): Option[LibraryLDATopic]
+  def getActiveByLibraryId(libId: Id[Library], version: ModelVersion[DenseLDA])(implicit session: RSession): Option[LibraryLDATopic]
+}
+
+class LibraryLDATopicRepoImpl @Inject() (
+    val db: DataBaseComponent,
+    val clock: Clock,
+    airbrake: AirbrakeNotifier) extends DbRepo[LibraryLDATopic] with LibraryLDATopicRepo with CortexTypeMappers {
+
+  import db.Driver.simple._
+
+  type RepoImpl = LibraryLDATopicTable
+
+  class LibraryLDATopicTable(tag: Tag) extends RepoTable[LibraryLDATopic](db, tag, "library_lda_topic") {
+    def libraryId = column[Id[Library]]("library_id")
+    def version = column[ModelVersion[DenseLDA]]("version")
+    def numOfEvidence = column[Int]("num_of_evidence")
+    def topic = column[LibraryTopicMean]("topic", O.Nullable)
+    def * = (id.?, createdAt, updatedAt, libraryId, version, numOfEvidence, topic.?, state) <> ((LibraryLDATopic.apply _).tupled, LibraryLDATopic.unapply _)
+  }
+
+  def table(tag: Tag) = new LibraryLDATopicTable(tag)
+  initTable()
+
+  def deleteCache(model: LibraryLDATopic)(implicit session: RSession): Unit = {}
+  def invalidateCache(model: LibraryLDATopic)(implicit session: RSession): Unit = {}
+
+  def getByLibraryId(libId: Id[Library], version: ModelVersion[DenseLDA])(implicit session: RSession): Option[LibraryLDATopic] = {
+    (for { r <- rows if r.libraryId === libId && r.version === version } yield r).firstOption
+  }
+
+  def getActiveByLibraryId(libId: Id[Library], version: ModelVersion[DenseLDA])(implicit session: RSession): Option[LibraryLDATopic] = {
+    (for { r <- rows if r.libraryId === libId && r.version === version && r.state === LibraryLDATopicStates.ACTIVE } yield r).firstOption
+  }
+}

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDALibraryUpdater.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDALibraryUpdater.scala
@@ -16,19 +16,6 @@ import com.keepit.model.{ LibraryStates, LibraryKind, Library }
 import com.keepit.cortex.utils.MatrixUtils._
 import org.joda.time.DateTime
 
-class LDALibraryUpdaterActor @Inject() (airbrake: AirbrakeNotifier, updater: LDALibraryUpdater) extends FeatureUpdateActor(airbrake, updater)
-
-trait LDALibraryUpdaterPlugin extends FeatureUpdatePlugin[Library, DenseLDA]
-
-@Singleton
-class LDALibraryUpdaterPluginImpl @Inject() (
-  actor: ActorInstance[LDALibraryUpdaterActor],
-  discovery: ServiceDiscovery,
-  val scheduling: SchedulingProperties) extends BaseFeatureUpdatePlugin(actor, discovery) with LDALibraryUpdaterPlugin
-
-@ImplementedBy(classOf[LDALibraryUpdaterImpl])
-trait LDALibraryUpdater extends BaseFeatureUpdater[Id[Library], Library, DenseLDA, FeatureRepresentation[Library, DenseLDA]]
-
 @Singleton
 class LDALibraryUpdaterImpl @Inject() (
     representer: LDAURIRepresenter,
@@ -104,3 +91,16 @@ class LDALibraryUpdaterImpl @Inject() (
     }
   }
 }
+
+class LDALibraryUpdaterActor @Inject() (airbrake: AirbrakeNotifier, updater: LDALibraryUpdater) extends FeatureUpdateActor(airbrake, updater)
+
+trait LDALibraryUpdaterPlugin extends FeatureUpdatePlugin[Library, DenseLDA]
+
+@Singleton
+class LDALibraryUpdaterPluginImpl @Inject() (
+  actor: ActorInstance[LDALibraryUpdaterActor],
+  discovery: ServiceDiscovery,
+  val scheduling: SchedulingProperties) extends BaseFeatureUpdatePlugin(actor, discovery) with LDALibraryUpdaterPlugin
+
+@ImplementedBy(classOf[LDALibraryUpdaterImpl])
+trait LDALibraryUpdater extends BaseFeatureUpdater[Id[Library], Library, DenseLDA, FeatureRepresentation[Library, DenseLDA]]

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDALibraryUpdater.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDALibraryUpdater.scala
@@ -1,0 +1,90 @@
+package com.keepit.cortex.models.lda
+
+import com.google.inject.Inject
+import com.keepit.common.db.{ SequenceNumber, Id }
+import com.keepit.common.db.slick.Database
+import com.keepit.common.logging.Logging
+import com.keepit.common.time._
+import com.keepit.cortex.core.{ StatModelName, FeatureRepresentation }
+import com.keepit.cortex.dbmodel._
+import com.keepit.cortex.plugins.BaseFeatureUpdater
+import com.keepit.model.{ LibraryKind, Library }
+import com.keepit.cortex.utils.MatrixUtils._
+import org.joda.time.DateTime
+
+trait LDALibraryUpdater extends BaseFeatureUpdater[Id[Library], Library, DenseLDA, FeatureRepresentation[Library, DenseLDA]]
+
+class LDALibraryUpdaterImpl @Inject() (
+    representer: LDAURIRepresenter,
+    db: Database,
+    keepRepo: CortexKeepRepo,
+    libRepo: CortexLibraryRepo,
+    libraryLDARepo: LibraryLDATopicRepo,
+    uriTopicRepo: URILDATopicRepo,
+    commitRepo: FeatureCommitInfoRepo) extends LDALibraryUpdater with Logging {
+
+  private val fetchSize = 10000
+  private val modelName = StatModelName.LDA_LIBRARY
+  private val min_num_words = 50
+  protected val min_num_evidence = 1
+
+  def update(): Unit = {
+    val tasks = fetchTasks
+    log.info(s"fetched ${tasks.size} tasks")
+    processTasks(tasks)
+  }
+
+  private def fetchTasks(): Seq[CortexKeep] = {
+    val commitOpt = db.readOnlyReplica { implicit s => commitRepo.getByModelAndVersion(modelName, representer.version.version) }
+    if (commitOpt.isEmpty) db.readWrite { implicit s => commitRepo.save(FeatureCommitInfo(modelName = modelName, modelVersion = representer.version.version, seq = 0L)) }
+
+    val fromSeq = SequenceNumber[CortexKeep](commitOpt.map { _.seq }.getOrElse(0L))
+    log.info(s"fetch tasks from ${fromSeq.value}")
+    db.readOnlyReplica { implicit s => keepRepo.getSince(fromSeq, fetchSize) }
+  }
+
+  private def processTasks(keeps: Seq[CortexKeep]) = {
+    val libs = keeps.flatMap { _.libraryId }.distinct
+    libs.foreach { processLibrary(_) }
+    log.info(s"${libs.size} libs processed")
+    keeps.lastOption.map { keep =>
+      db.readWrite { implicit s =>
+        val commitInfo = commitRepo.getByModelAndVersion(modelName, representer.version.version).get
+        log.info(s"committing with keep seq = ${keep.seq.value}")
+        commitRepo.save(commitInfo.withSeq(keep.seq.value))
+      }
+    }
+
+  }
+
+  private def processLibrary(libId: Id[Library]): Unit = {
+    val model = db.readOnlyReplica { implicit s => libraryLDARepo.getByLibraryId(libId, representer.version) }
+    if (shouldComputeFeature(libId, model)) {
+      val feats = db.readOnlyReplica { implicit s => uriTopicRepo.getLibraryURIFeatures(libId, representer.version, min_num_words) }
+      val mean = getLibraryTopicMean(feats)
+      val state = if (mean.isDefined) LibraryLDATopicStates.ACTIVE else LibraryLDATopicStates.NOT_APPLICABLE
+      val toSave = model match {
+        case Some(m) => m.copy(numOfEvidence = feats.size, topic = mean, state = state)
+        case None => LibraryLDATopic(libraryId = libId, version = representer.version, numOfEvidence = feats.size, topic = mean, state = state)
+      }
+      db.readWrite { implicit s => libraryLDARepo.save(toSave) }
+    }
+  }
+
+  private def shouldComputeFeature(libId: Id[Library], model: Option[LibraryLDATopic]): Boolean = {
+    def isApplicableLibrary(lib: Option[CortexLibrary]): Boolean = lib.exists(x => x.kind != LibraryKind.SYSTEM_MAIN && x.kind != LibraryKind.SYSTEM_SECRET)
+    def isOld(updatedAt: DateTime) = updatedAt.plusMinutes(2).getMillis < currentDateTime.getMillis
+
+    val lib = db.readOnlyReplica { implicit s => libRepo.getByLibraryId(libId) }
+    isApplicableLibrary(lib) && (model.isEmpty || isOld(model.get.updatedAt))
+  }
+
+  private def getLibraryTopicMean(feats: Seq[LDATopicFeature]): Option[LibraryTopicMean] = {
+    if (feats.size < min_num_evidence) None
+    else {
+      val vecs = feats.map { x => toDoubleArray(x.value) }
+      val mean = average(vecs)
+      Some(LibraryTopicMean(mean))
+    }
+  }
+}

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDALibraryUpdater.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDALibraryUpdater.scala
@@ -76,10 +76,9 @@ class LDALibraryUpdaterImpl @Inject() (
 
   private def shouldComputeFeature(libId: Id[Library], model: Option[LibraryLDATopic]): Boolean = {
     def isApplicableLibrary(lib: Option[CortexLibrary]): Boolean = lib.exists(x => x.state.value == LibraryStates.ACTIVE.value && x.kind != LibraryKind.SYSTEM_MAIN && x.kind != LibraryKind.SYSTEM_SECRET)
-    def isOld(updatedAt: DateTime) = updatedAt.plusMinutes(5).getMillis < currentDateTime.getMillis
 
     val lib = db.readOnlyReplica { implicit s => libRepo.getByLibraryId(libId) }
-    isApplicableLibrary(lib) && (model.isEmpty || isOld(model.get.updatedAt))
+    isApplicableLibrary(lib)
   }
 
   private def getLibraryTopicMean(feats: Seq[LDATopicFeature]): Option[LibraryTopicMean] = {

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDALibraryUpdater.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDALibraryUpdater.scala
@@ -76,7 +76,7 @@ class LDALibraryUpdaterImpl @Inject() (
 
   private def shouldComputeFeature(libId: Id[Library], model: Option[LibraryLDATopic]): Boolean = {
     def isApplicableLibrary(lib: Option[CortexLibrary]): Boolean = lib.exists(x => x.state.value == LibraryStates.ACTIVE.value && x.kind != LibraryKind.SYSTEM_MAIN && x.kind != LibraryKind.SYSTEM_SECRET)
-    def isOld(updatedAt: DateTime) = updatedAt.plusMinutes(2).getMillis < currentDateTime.getMillis
+    def isOld(updatedAt: DateTime) = updatedAt.plusMinutes(5).getMillis < currentDateTime.getMillis
 
     val lib = db.readOnlyReplica { implicit s => libRepo.getByLibraryId(libId) }
     isApplicableLibrary(lib) && (model.isEmpty || isOld(model.get.updatedAt))

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDALibraryUpdater.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDALibraryUpdater.scala
@@ -8,7 +8,7 @@ import com.keepit.common.time._
 import com.keepit.cortex.core.{ StatModelName, FeatureRepresentation }
 import com.keepit.cortex.dbmodel._
 import com.keepit.cortex.plugins.BaseFeatureUpdater
-import com.keepit.model.{ LibraryKind, Library }
+import com.keepit.model.{ LibraryStates, LibraryKind, Library }
 import com.keepit.cortex.utils.MatrixUtils._
 import org.joda.time.DateTime
 
@@ -72,7 +72,7 @@ class LDALibraryUpdaterImpl @Inject() (
   }
 
   private def shouldComputeFeature(libId: Id[Library], model: Option[LibraryLDATopic]): Boolean = {
-    def isApplicableLibrary(lib: Option[CortexLibrary]): Boolean = lib.exists(x => x.kind != LibraryKind.SYSTEM_MAIN && x.kind != LibraryKind.SYSTEM_SECRET)
+    def isApplicableLibrary(lib: Option[CortexLibrary]): Boolean = lib.exists(x => x.state.value == LibraryStates.ACTIVE.value && x.kind != LibraryKind.SYSTEM_MAIN && x.kind != LibraryKind.SYSTEM_SECRET)
     def isOld(updatedAt: DateTime) = updatedAt.plusMinutes(2).getMillis < currentDateTime.getMillis
 
     val lib = db.readOnlyReplica { implicit s => libRepo.getByLibraryId(libId) }

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDAUserStatDbUpdater.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDAUserStatDbUpdater.scala
@@ -37,7 +37,6 @@ class LDAUserStatDbUpdatePluginImpl @Inject() (
     actor: ActorInstance[LDAUserStatDbUpdateActor],
     discovery: ServiceDiscovery,
     val scheduling: SchedulingProperties) extends BaseFeatureUpdatePlugin(actor, discovery) with LDAUserStatDbUpdatePlugin {
-  override val updateFrequency: FiniteDuration = 2 minutes
 
   def updateUser(userId: Id[User]): Unit = {
     actor.ref ! LDAUserStatUpdate(userId)

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/sql/CortexTypeMappers.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/sql/CortexTypeMappers.scala
@@ -4,7 +4,7 @@ import com.keepit.common.db.slick.DataBaseComponent
 import com.keepit.cortex.core._
 import java.sql.Blob
 import javax.sql.rowset.serial.SerialBlob
-import com.keepit.cortex.dbmodel.{ UserTopicVar, UserTopicMean }
+import com.keepit.cortex.dbmodel.{ LibraryTopicMean, UserTopicVar, UserTopicMean }
 import com.keepit.cortex.store.StoreUtil.FloatArrayFormmater
 import com.keepit.cortex.models.lda.LDATopic
 import com.keepit.cortex.models.lda.SparseTopicRepresentation
@@ -34,6 +34,11 @@ trait CortexTypeMappers { self: { val db: DataBaseComponent } =>
   implicit def userTopicVarMapper = MappedColumnType.base[UserTopicVar, Blob](
     { topicVar => new SerialBlob(FloatArrayFormmater.toBinary(topicVar.value)) },
     { blob => val len = blob.length().toInt; val arr = FloatArrayFormmater.fromBinary(blob.getBytes(1, len)); UserTopicVar(arr) }
+  )
+
+  implicit def libraryTopicMeanMapper = MappedColumnType.base[LibraryTopicMean, Blob](
+    { topic => new SerialBlob(FloatArrayFormmater.toBinary(topic.value)) },
+    { blob => val len = blob.length().toInt; val arr = FloatArrayFormmater.fromBinary(blob.getBytes(1, len)); LibraryTopicMean(arr) }
   )
 
   implicit def sparseTopicRepresentationMapper = MappedColumnType.base[SparseTopicRepresentation, String](

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDALibraryUpdaterTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDALibraryUpdaterTest.scala
@@ -1,0 +1,47 @@
+package com.keepit.cortex.models.lda
+
+import com.keepit.common.db.{ SequenceNumber, State, Id }
+import com.keepit.common.time._
+import com.keepit.cortex.CortexTestInjector
+import com.keepit.cortex.core.{ StatModelName, ModelVersion }
+import com.keepit.cortex.dbmodel._
+import com.keepit.model._
+import org.joda.time.DateTime
+import org.specs2.mutable.Specification
+
+class LDALibraryUpdaterTest extends Specification with CortexTestInjector with LDADbTestHelper {
+  "lda library updater" should {
+    "work" in {
+      withDb() { implicit injector =>
+        val keepRepo = inject[CortexKeepRepo]
+        val libRepo = inject[CortexLibraryRepo]
+        val commitRepo = inject[FeatureCommitInfoRepo]
+        val uriTopicRepo = inject[URILDATopicRepo]
+        val libLDARepo = inject[LibraryLDATopicRepo]
+        val updater = new LDALibraryUpdaterImpl(uriRep, db, keepRepo, libRepo, libLDARepo, uriTopicRepo, commitRepo)
+
+        val time = new DateTime(2014, 1, 30, 17, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
+
+        db.readWrite { implicit s =>
+          keepRepo.save(CortexKeep(keptAt = time, userId = Id[User](1), keepId = Id[Keep](1), uriId = Id[NormalizedURI](1L), isPrivate = false, state = State[CortexKeep]("active"), seq = SequenceNumber[CortexKeep](1L), source = KeepSource.keeper, libraryId = Some(Id[Library](1))))
+          keepRepo.save(CortexKeep(keptAt = time, userId = Id[User](1), keepId = Id[Keep](2), uriId = Id[NormalizedURI](2L), isPrivate = false, state = State[CortexKeep]("active"), seq = SequenceNumber[CortexKeep](2L), source = KeepSource.keeper, libraryId = Some(Id[Library](1))))
+          keepRepo.save(CortexKeep(keptAt = time, userId = Id[User](1), keepId = Id[Keep](3), uriId = Id[NormalizedURI](3L), isPrivate = false, state = State[CortexKeep]("active"), seq = SequenceNumber[CortexKeep](3L), source = KeepSource.keeper, libraryId = Some(Id[Library](2))))
+          uriTopicRepo.save(URILDATopic(uriId = Id[NormalizedURI](1L), uriSeq = SequenceNumber[NormalizedURI](1L), version = ModelVersion[DenseLDA](1), numOfWords = 200, feature = Some(LDATopicFeature(Array(0f, 1f))), state = URILDATopicStates.ACTIVE))
+          uriTopicRepo.save(URILDATopic(uriId = Id[NormalizedURI](2L), uriSeq = SequenceNumber[NormalizedURI](2L), version = ModelVersion[DenseLDA](1), numOfWords = 200, feature = Some(LDATopicFeature(Array(1f, 0f))), state = URILDATopicStates.ACTIVE))
+          uriTopicRepo.save(URILDATopic(uriId = Id[NormalizedURI](3L), uriSeq = SequenceNumber[NormalizedURI](3L), version = ModelVersion[DenseLDA](1), numOfWords = 200, feature = Some(LDATopicFeature(Array(1f, 0f))), state = URILDATopicStates.ACTIVE))
+          libRepo.save(CortexLibrary(libraryId = Id[Library](1), ownerId = Id[User](1), kind = LibraryKind.USER_CREATED, state = State[CortexLibrary]("active"), seq = SequenceNumber[CortexLibrary](1)))
+          libRepo.save(CortexLibrary(libraryId = Id[Library](1), ownerId = Id[User](1), kind = LibraryKind.SYSTEM_SECRET, state = State[CortexLibrary]("active"), seq = SequenceNumber[CortexLibrary](2)))
+        }
+
+        updater.update()
+
+        db.readOnlyReplica { implicit s =>
+          libLDARepo.all().size === 1
+          libLDARepo.getActiveByLibraryId(Id[Library](1), uriRep.version).get.topic.get.value.toList === List(0.5f, 0.5f)
+          libLDARepo.getActiveByLibraryId(Id[Library](2), uriRep.version) === None
+          commitRepo.getByModelAndVersion(StatModelName.LDA_LIBRARY, uriRep.version.version).get.seq === 3
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
@stkem 
1. the updater listens on keepRepo change
2. currently, when a library is deleted on shoebox, its state becomes inactive. But keep repo doesn't change. Talked to @ahsu1230 (cc: @andrewconner ), was told that library deletion behavior was not fully decided. This means that when library was removed, the updater will not detect this change. We can easily add a reaper to clean active library features for inactive libraries. (alternatively, we can also listen on libraryRepo's seqNum, but that might be more complicated)
