### PR TITLE
increasing cache TTL for uri_summary_by_id. we have too many misses, its...

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/common/cache/ABookCacheModule.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/common/cache/ABookCacheModule.scala
@@ -46,7 +46,7 @@ case class ABookCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Singleton
   @Provides
   def uriSummaryCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
+    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/common/test/com/keepit/common/cache/FakeCacheModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/cache/FakeCacheModule.scala
@@ -54,7 +54,7 @@ case class FakeCacheModule() extends CacheModule(HashMapMemoryCacheModule()) {
   @Singleton
   @Provides
   def uriSummaryCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
+    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/cortex/app/com/keepit/common/cache/CortexCacheModule.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/cache/CortexCacheModule.scala
@@ -45,7 +45,7 @@ case class CortexCacheModule(cachePluginModules: CachePluginModule*) extends Cac
   @Singleton
   @Provides
   def uriSummaryCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
+    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/curator/app/com/keepit/common/cache/CuratorCacheModule.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/common/cache/CuratorCacheModule.scala
@@ -46,7 +46,7 @@ case class CuratorCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Singleton
   @Provides
   def uriSummaryCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
+    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
@@ -65,7 +65,7 @@ case class ElizaCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Singleton
   @Provides
   def uriSummaryCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
+    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/graph/app/com/keepit/graph/common/cache/GraphCacheModule.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/common/cache/GraphCacheModule.scala
@@ -51,7 +51,7 @@ case class GraphCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Singleton
   @Provides
   def uriSummaryCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
+    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/heimdal/app/com/keepit/common/cache/HeimdalCacheModule.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/common/cache/HeimdalCacheModule.scala
@@ -47,7 +47,7 @@ case class HeimdalCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Singleton
   @Provides
   def uriSummaryCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
+    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/scraper/app/com/keepit/common/cache/ScraperCacheModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/common/cache/ScraperCacheModule.scala
@@ -43,7 +43,7 @@ case class ScraperCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Singleton
   @Provides
   def uriSummaryCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
+    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/search/app/com/keepit/common/cache/SearchCacheModule.scala
+++ b/kifi-backend/modules/search/app/com/keepit/common/cache/SearchCacheModule.scala
@@ -57,7 +57,7 @@ case class SearchCacheModule(cachePluginModules: CachePluginModule*) extends Cac
   @Singleton
   @Provides
   def uriSummaryCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
+    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -83,7 +83,7 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Singleton
   @Provides
   def uriSummaryCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 7 days))
+    new URISummaryCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides


### PR DESCRIPTION
... probably due to the nature of this cache. this increase should reduce the misses with scrapes that have more then one week re-scraping intervals.
@raymondng 
