### PR TITLE
Trying to get a handle on uri summary timeouts

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/scraper/ScraperServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/scraper/ScraperServiceClient.scala
@@ -147,6 +147,7 @@ class ScraperServiceClientImpl @Inject() (
     val cacheProvider: ScraperCacheProvider) extends ScraperServiceClient with Logging {
 
   val longTimeout = CallTimeouts(responseTimeout = Some(60000))
+  val superExtraLongTimeoutJustForEmbedly = CallTimeouts(responseTimeout = Some(250000), maxWaitTime = Some(3000), maxJsonParseTime = Some(10000))
   val httpClient = defaultHttpClient.withTimeout(longTimeout)
 
   def getBasicArticle(url: String, proxy: Option[HttpProxy], extractorProviderType: Option[ExtractorProviderType]): Future[Option[BasicArticle]] = {
@@ -213,14 +214,14 @@ class ScraperServiceClientImpl @Inject() (
 
   def getEmbedlyInfo(url: String): Future[Option[EmbedlyInfo]] = {
     val payload = Json.obj("url" -> url)
-    call(Scraper.internal.getEmbedlyInfo, payload).map { r =>
+    call(Scraper.internal.getEmbedlyInfo, payload, callTimeouts = superExtraLongTimeoutJustForEmbedly).map { r =>
       Json.fromJson[Option[EmbedlyInfo]](r.json).get
     }
   }
 
   def getURISummaryFromEmbedly(uri: NormalizedURI, minSize: ImageSize, descriptionOnly: Boolean): Future[Option[URISummary]] = {
     val payload = Json.obj("uri" -> uri, "minSize" -> minSize, "descriptionOnly" -> descriptionOnly)
-    call(Scraper.internal.getURISummaryFromEmbedly, payload).map { r =>
+    call(Scraper.internal.getURISummaryFromEmbedly, payload, callTimeouts = superExtraLongTimeoutJustForEmbedly).map { r =>
       r.json.as[Option[URISummary]]
     }
   }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/embedly/EmbedlyClient.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/embedly/EmbedlyClient.scala
@@ -16,6 +16,7 @@ import play.api.libs.json.Json
 import play.api.libs.ws.{ WSResponse, WS }
 import com.keepit.common.db.Id
 import play.api.Play.current
+import com.keepit.common.healthcheck.AirbrakeNotifier
 
 trait EmbedlyClient {
   def embedlyUrl(url: String): String
@@ -24,7 +25,7 @@ trait EmbedlyClient {
 }
 
 @Singleton
-class EmbedlyClientImpl @Inject() extends EmbedlyClient with Logging {
+class EmbedlyClientImpl @Inject() (airbrake: AirbrakeNotifier) extends EmbedlyClient with Logging {
 
   private val embedlyKey = "e46ecae2611d4cb29342fddb0e666a29"
 
@@ -59,6 +60,7 @@ class EmbedlyClientImpl @Inject() extends EmbedlyClient with Logging {
       } recover {
         case t: Throwable =>
           log.info(s"Caught exception while invoking ($apiUrl): Exception=$t; cause=${t.getCause}")
+          airbrake.notify("Failed getting embedly info", t)
           None
       }
     }


### PR DESCRIPTION
(1) extra long http call time-outs for calls that might go through to
embedly, which could legitimately take a long time to reply if they
have never seen the url before
(2) The actual calls to embedly on scraper will no longer fail silently

@eishay @raymondng @andrewconner 
