### PR TITLE
Fix bug where keeping an already kept URL does not close the add-keep modal.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/addKeep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/addKeep.js
@@ -88,6 +88,7 @@ angular.module('kifi')
               if (result.failures && result.failures.length) {
                 $rootScope.$emit('showGlobalModal', 'genericError');
               } else if (result.alreadyKept && result.alreadyKept.length) {
+                scope.resetAndHide();
                 $location.path('/keep/' + result.alreadyKept[0].id);
               } else {
                 return keepActionService.fetchFullKeepInfo(result.keeps[0]).then(function (fullKeep) {
@@ -113,6 +114,7 @@ angular.module('kifi')
               if (result.failures && result.failures.length) {
                 $rootScope.$emit('showGlobalModal', 'genericError');
               } else if (result.alreadyKept.length > 0) {
+                scope.resetAndHide();
                 $location.path('/keep/' + result.alreadyKept[0].id);
               } else {
                 return keepActionService.fetchFullKeepInfo(result.keeps[0]).then(function (fullKeep) {


### PR DESCRIPTION
I found a small bug: when a user adds an already-kept URL in the add keep modal, the modal doesn't automatically close. This pull addresses that.

@andrewconner @ahsu1230 
