### PR TITLE
Do not reload raw recommendations unless there is a page refresh.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/recos/recoStateService.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recoStateService.js
@@ -1,0 +1,23 @@
+'use strict';
+
+angular.module('kifi')
+
+.factory('recoStateService', [
+  function () {
+    var savedRecos = [];
+
+    var api = {
+      recosList: savedRecos,
+
+      populate: function (recos) {
+        savedRecos.push.apply(savedRecos, recos);
+      },
+
+      empty: function () {
+        savedRecos.length = 0;
+      }
+    };
+
+    return api;
+  }
+]);

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.js
@@ -9,25 +9,27 @@ angular.module('kifi')
   '$window',
   'recoActionService',
   'recoDecoratorService',
+  'recoStateService',
   'undoService',
   function ($scope, $rootScope, $analytics, $window,
-    recoActionService, recoDecoratorService, undoService) {
+    recoActionService, recoDecoratorService, recoStateService, undoService) {
     $window.document.title = 'Kifi • Your Recommendation List';
 
-    $scope.recos = [];
-    $scope.loading = true;
+    $scope.recos = recoStateService.recosList;
     $scope.recosState = 'hasRecos';
     $scope.initialCardClosed = false;
 
     $scope.getMore = function (opt_recency) {
-      $scope.recos = [];
       $scope.loading = true;
      
+      recoStateService.empty();
       recoActionService.getMore(opt_recency).then(function (rawRecos) {
         if (rawRecos.length > 0) {
+          var recos = [];
           rawRecos.forEach(function (rawReco) {
-            $scope.recos.push(recoDecoratorService.newUserRecommendation(rawReco));
+            recos.push(recoDecoratorService.newUserRecommendation(rawReco));
           });
+          recoStateService.populate(recos);
 
           $scope.recosState = 'hasRecos';
         } else {
@@ -58,13 +60,16 @@ angular.module('kifi')
     $scope.showPopular = function () {
       $scope.loading = true;
 
+      recoStateService.empty();
       recoActionService.getPopular().then(function (rawRecos) {
+        var recos = [];
         rawRecos.forEach(function (rawReco) {
-          $scope.recos.push(recoDecoratorService.newPopularRecommendation(rawReco));
+          recos.push(recoDecoratorService.newPopularRecommendation(rawReco));
         });
+        recoStateService.populate(recos);
 
-        $scope.loading = false;
         $scope.recosState = 'hasPopularRecos';
+        $scope.loading = false;
       });
     };
 
@@ -86,29 +91,35 @@ angular.module('kifi')
       $scope.initialCardClosed = true;
     };
 
-    recoActionService.get().then(function (rawRecos) {
-      if (rawRecos.length > 0) {
-        rawRecos.forEach(function (rawReco) {
-          $scope.recos.push(recoDecoratorService.newUserRecommendation(rawReco));
-        });
+    // Load a new set of recommendations only on page refresh.
+    // Otherwise, load the recommendations we have previously shown.
+    if (recoStateService.recosList.length === 0) {
+      $scope.loading = true;
 
-        $scope.loading = false;
-        $scope.recosState = 'hasRecos';
-      } else {
-        $scope.recosState = 'noRecos';
+      recoStateService.empty();
+      recoActionService.get().then(function (rawRecos) {
+        var recos = [];
 
-        // If the user has no recommendations, show some popular
-        // keeps/libraries as recommendations.
-        recoActionService.getPopular().then(function (rawRecos) {
+        if (rawRecos.length > 0) {
           rawRecos.forEach(function (rawReco) {
-            $scope.recos.push(recoDecoratorService.newPopularRecommendation(rawReco));
+            recos.push(recoDecoratorService.newUserRecommendation(rawReco));
           });
+          $scope.recosState = 'hasRecos';
+        } else {
+          // If the user has no recommendations, show some popular
+          // keeps/libraries as recommendations.
+          recoActionService.getPopular().then(function (rawRecos) {
+            rawRecos.forEach(function (rawReco) {
+              recos.push(recoDecoratorService.newPopularRecommendation(rawReco));
+            });
+          });
+          $scope.recosState = 'noRecos';
+        }
 
-          $scope.loading = false;
-        });
-      }
-
-    });
+        recoStateService.populate(recos);
+        $scope.loading = false;
+      });
+    }
   }
 ])
 


### PR DESCRIPTION
@stkem Currently there is a bug with recommendations front end where an Angular re-route back to /recommendations reloads the raw recommendations we have previously received from the server. While there is no extra call to the server, what this means is that user changes on the client side to the recommendations (trashing, keeping) are not preserved.

I made a new service called `recoStateService` to store state about the client side recommendations, so that routing within the Angular app will maintain those changes.

Thanks to @ahsu1230 @jaredpetker and @andrewconner  for looking at that subtle JS bug with me. :)
