### PR TITLE
email placeholders can be applied to the "subject" and "fromName"

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/mail/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/package.scala
@@ -73,6 +73,7 @@ package object template {
 
     def kifiUrl(source: String = "unknown") = htmlUrl(s"$baseUrl/?", source)
 
+    val kifiAddress = "883 N Shoreline Blvd, Mountain View, CA 94043, USA"
     val kifiLogoUrl = kifiUrl("headerLogo")
     val kifiFooterUrl = kifiUrl("footerKifiLink")
     val privacyUrl = htmlUrl(s"$baseUrl/privacy?", "footerPrivacy")

--- a/kifi-backend/modules/common/app/com/keepit/common/mail/template/EmailToSend.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/template/EmailToSend.scala
@@ -9,7 +9,7 @@ import play.twirl.api.Html
 case class EmailToSend(
   title: String = "Kifi",
   from: EmailAddress,
-  fromName: Option[String] = Some("Kifi"),
+  fromName: Option[Either[Id[User], String]] = Some(Right("Kifi")),
   to: Either[Id[User], EmailAddress],
   cc: Seq[EmailAddress] = Seq[EmailAddress](),
   subject: String,
@@ -33,11 +33,12 @@ object EmailToSend {
   }
 
   val toFormat = EitherFormat[Id[User], EmailAddress]
+  val fromNameFormat = EitherFormat[Id[User], String]
 
   implicit val emailToSendFormat: Format[EmailToSend] = (
     (__ \ 'title).format[String] and
     (__ \ 'from).format[EmailAddress] and
-    (__ \ 'fromName).formatNullable[String] and
+    (__ \ 'fromName).formatNullable(fromNameFormat) and
     (__ \ 'to).format(toFormat) and
     (__ \ 'cc).format[Seq[EmailAddress]] and
     (__ \ 'subject).format[String] and

--- a/kifi-backend/modules/common/app/views/email/black/footer.scala.html
+++ b/kifi-backend/modules/common/app/views/email/black/footer.scala.html
@@ -45,7 +45,7 @@
                         <table width="100%" border="0" cellspacing="0" cellpadding="0">
                             <tr>
                                 <td align="left" class="center" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#333333;line-height:22px;">
-                                    Sent by Kifi 883 N Shoreline Blvd, Mountain View, CA 94043, USA<br/>
+                                    Sent by Kifi @h.kifiAddress<br/>
                                 </td>
                             </tr>
                             <tr>

--- a/kifi-backend/modules/common/app/views/email/black/layoutText.scala.html
+++ b/kifi-backend/modules/common/app/views/email/black/layoutText.scala.html
@@ -1,0 +1,9 @@
+@(contents: Seq[Html])
+
+@for(html <- contents) {
+@html
+}
+
+Don't want to receive these messages from Kifi? Unsubscribe here: @h.unsubscribeUrl
+
+Kifi.com | @h.kifiAddress

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/email/FeedDigestEmailSender.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/email/FeedDigestEmailSender.scala
@@ -204,7 +204,7 @@ class FeedDigestEmailSender @Inject() (
       from = SystemEmailAddress.NOTIFICATIONS,
       htmlTemplate = mainTemplate,
       senderUserId = Some(userId),
-      fromName = Some("Kifi"),
+      fromName = Some(Right("Kifi")),
       campaign = Some("digest"),
       tips = Seq(EmailTips.FriendRecommendations)
     )
@@ -256,7 +256,7 @@ class FeedDigestEmailSender @Inject() (
       from = SystemEmailAddress.NOTIFICATIONS,
       htmlTemplate = views.html.email.feedDigest(qaEmailData),
       senderUserId = None,
-      fromName = Some("Kifi"),
+      fromName = Some(Right("Kifi")),
       campaign = Some("digestQA")
     )
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ContactJoinedEmailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ContactJoinedEmailSender.scala
@@ -2,30 +2,28 @@ package com.keepit.commanders.emails
 
 import com.google.inject.Inject
 import com.keepit.common.db.Id
-import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
-import com.keepit.common.mail.{ EmailAddress, SystemEmailAddress, ElectronicMail }
+import com.keepit.common.mail.{ SystemEmailAddress, ElectronicMail }
 import com.keepit.common.mail.template.EmailToSend
+import com.keepit.common.mail.template.helpers.fullName
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.inject.FortyTwoConfig
-import com.keepit.model.{ User, NotificationCategory, PasswordResetRepo }
+import com.keepit.model.{ User, NotificationCategory }
 
 import scala.concurrent.Future
 
 class ContactJoinedEmailSender @Inject() (
-    db: Database,
     basicUserRepo: BasicUserRepo,
     emailTemplateSender: EmailTemplateSender,
     config: FortyTwoConfig,
     protected val airbrake: AirbrakeNotifier) extends Logging {
 
   def sendToUser(toUserId: Id[User], otherUserId: Id[User]): Future[ElectronicMail] = {
-    val otherUser = db.readOnlyReplica { implicit session => basicUserRepo.load(otherUserId) }
     val emailToSend = EmailToSend(
-      fromName = Some(s"${otherUser.firstName} ${otherUser.lastName} (via Kifi)"),
+      fromName = Some(Left(otherUserId)),
       from = SystemEmailAddress.NOTIFICATIONS,
-      subject = s"${otherUser.firstName} ${otherUser.lastName} joined Kifi. Want to connect?",
+      subject = s"${fullName(otherUserId)} joined Kifi. Want to connect?",
       to = Left(toUserId),
       category = NotificationCategory.User.CONTACT_JOINED,
       htmlTemplate = views.html.email.contactJoinedBlack(toUserId, otherUserId),

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateSender.scala
@@ -32,14 +32,15 @@ class EmailTemplateSenderImpl @Inject() (
         case Right(address) => address
       })
 
+      println(mailToSend.fromName, result.fromName)
       val email = ElectronicMail(
         from = mailToSend.from,
         to = toAddresses,
         cc = mailToSend.cc,
-        subject = mailToSend.subject,
+        subject = result.subject,
         htmlBody = result.htmlBody,
         textBody = result.textBody,
-        fromName = mailToSend.fromName,
+        fromName = result.fromName,
         category = mailToSend.category
       )
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/FeatureWaitlistEmailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/FeatureWaitlistEmailSender.scala
@@ -1,7 +1,6 @@
 package com.keepit.commanders.emails
 
 import com.google.inject.Inject
-import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.common.mail.template.EmailToSend
@@ -12,7 +11,6 @@ import com.keepit.model.NotificationCategory
 import scala.concurrent.Future
 
 class FeatureWaitlistEmailSender @Inject() (
-    db: Database,
     emailTemplateSender: EmailTemplateSender,
     config: FortyTwoConfig,
     protected val airbrake: AirbrakeNotifier) extends Logging {
@@ -25,7 +23,7 @@ class FeatureWaitlistEmailSender @Inject() (
     emailTriggers.get(feature).map { template =>
       val emailToSend = EmailToSend(
         title = "kifi — Boom! You're on the wait list",
-        fromName = Some("Kifi"),
+        fromName = Some(Right("Kifi")),
         from = SystemEmailAddress.NOTIFICATIONS,
         to = Right(email),
         subject = "You're on the wait list",

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/FriendRequestEmailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/FriendRequestEmailSender.scala
@@ -24,7 +24,7 @@ class FriendRequestEmailSender @Inject() (
   def sendToUser(toUserId: Id[User], fromUserId: Id[User]): Future[ElectronicMail] = {
     val requestingUser = db.readOnlyReplica { implicit session => basicUserRepo.load(fromUserId) }
     val emailToSend = EmailToSend(
-      fromName = Some(s"${requestingUser.firstName} ${requestingUser.lastName} (via Kifi)"),
+      fromName = Some(Left(fromUserId)),
       from = SystemEmailAddress.NOTIFICATIONS,
       subject = s"${requestingUser.firstName} ${requestingUser.lastName} sent you a friend request.",
       to = Left(toUserId),

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ResetPasswordEmailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ResetPasswordEmailSender.scala
@@ -28,7 +28,7 @@ class ResetPasswordEmailSender @Inject() (
 
     val resetUrl = config.applicationBaseUrl + routes.AuthController.setPasswordPage(reset.token)
     val emailToSend = EmailToSend(
-      fromName = Some("Kifi Support"),
+      fromName = Some(Right("Kifi Support")),
       from = SystemEmailAddress.SUPPORT,
       subject = "Kifi.com | Password reset requested",
       to = Right(resetEmailAddress),

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/WelcomeEmailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/WelcomeEmailSender.scala
@@ -23,7 +23,7 @@ class WelcomeEmailSender @Inject() (
   def sendToUser(userId: Id[User]): Future[ElectronicMail] = {
     val emailToSend = EmailToSend(
       title = "Kifi — Welcome",
-      fromName = Some("Kifi"),
+      fromName = Some(Right("Kifi")),
       from = SystemEmailAddress.NOTIFICATIONS,
       subject = "Let's get started with Kifi",
       to = Left(userId),

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/EmailTestController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/EmailTestController.scala
@@ -1,7 +1,7 @@
 package com.keepit.controllers.internal
 
 import com.google.inject.Inject
-import com.keepit.commanders.emails.{ ContactJoinedEmailSender, FriendRequestEmailSender, WelcomeEmailSender, FriendRequestMadeEmailSender, FeatureWaitlistEmailSender, ResetPasswordEmailSender }
+import com.keepit.commanders.emails.{ ContactJoinedEmailSender, FriendRequestEmailSender, WelcomeEmailSender, FriendConnectionMadeEmailSender, FeatureWaitlistEmailSender, ResetPasswordEmailSender }
 import com.keepit.common.controller.ShoeboxServiceController
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
@@ -20,7 +20,7 @@ class EmailTestController @Inject() (
     waitListSender: FeatureWaitlistEmailSender,
     friendRequestEmailSender: FriendRequestEmailSender,
     contactJoinedEmailSender: ContactJoinedEmailSender,
-    friendRequestAcceptedSender: FriendRequestMadeEmailSender) extends ShoeboxServiceController {
+    friendRequestAcceptedSender: FriendConnectionMadeEmailSender) extends ShoeboxServiceController {
 
   def sendableAction(name: String)(body: => Html) = Action { request =>
     val result = body

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailSenderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailSenderTest.scala
@@ -58,7 +58,7 @@ class EmailSenderTest extends Specification with ShoeboxTestInjector {
   "FriendRequestMadeEmailSender" should {
     def testFriendConnectionMade(toUser: User, category: NotificationCategory)(implicit injector: Injector) = {
       val outbox = inject[FakeOutbox]
-      val sender = inject[FriendRequestMadeEmailSender]
+      val sender = inject[FriendConnectionMadeEmailSender]
       val friendUser = db.readWrite { implicit rw =>
         inject[UserRepo].save(User(firstName = "Billy", lastName = "Madison", primaryEmail = Some(EmailAddress("billy@gmail.com"))))
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateProcessorImplTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateProcessorImplTest.scala
@@ -70,7 +70,7 @@ class EmailTemplateProcessorImplTest extends Specification with ShoeboxTestInjec
           to = Right(SystemEmailAddress.JOSH),
           cc = Seq(SystemEmailAddress.ENG),
           from = SystemEmailAddress.NOTIFICATIONS,
-          fromName = Some("Kifi"),
+          fromName = Some(Right(firstName(id2) + "!!!")),
           subject = "hi " + firstName(id1) + " and " + firstName(id2),
           category = NotificationCategory.System.ADMIN,
           htmlTemplate = html1,
@@ -81,6 +81,7 @@ class EmailTemplateProcessorImplTest extends Specification with ShoeboxTestInjec
         val processed = Await.result(outputF, Duration(5, "seconds"))
 
         processed.subject === "hi Aaron and Bryan"
+        processed.fromName === Some("Bryan!!!")
 
         val output = processed.htmlBody.value
         output must contain("privacy?utm_source=footerPrivacy&utm_medium=email&utm_campaign=tester")
@@ -97,6 +98,8 @@ class EmailTemplateProcessorImplTest extends Specification with ShoeboxTestInjec
         text must contain("unsub1 https://www.kifi.com/unsubscribe/")
         text must contain("unsub2 https://www.kifi.com/unsubscribe/")
         text must contain("unsub3 https://www.kifi.com/unsubscribe/")
+        text must contain("Unsubscribe here: https://www.kifi.com/unsubscribe/")
+        text must contain("Kifi.com | 883 N Shoreline Blvd, Mountain View, CA 94043, USA")
 
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateSenderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateSenderTest.scala
@@ -55,8 +55,8 @@ class EmailTemplateSenderTest extends Specification with ShoeboxTestInjector {
         to = Left(id3),
         cc = Seq(SystemEmailAddress.ENG),
         from = SystemEmailAddress.NOTIFICATIONS,
-        fromName = Some("Kifi"),
-        subject = "hi",
+        fromName = Some(Left(id1)),
+        subject = "hi from " + fullName(id1),
         category = NotificationCategory.System.ADMIN,
         htmlTemplate = html,
         campaign = Some("testing"),
@@ -69,11 +69,11 @@ class EmailTemplateSenderTest extends Specification with ShoeboxTestInjector {
       db.readOnlyMaster { implicit s =>
         val freshEmail = emailRepo.get(email.id.get)
         freshEmail === email
-        email.subject === "hi"
+        email.subject === "hi from Aaron Paul"
         email.to === Seq(EmailAddress("test@gmail.com"))
         email.cc === Seq(SystemEmailAddress.ENG)
-        email.from === emailToSend.from
-        email.fromName === emailToSend.fromName
+        email.from === SystemEmailAddress.NOTIFICATIONS
+        email.fromName === Some("Aaron Paul (via Kifi)")
         email.category === NotificationCategory.toElectronicMailCategory(NotificationCategory.System.ADMIN)
         val html = email.htmlBody.value
         html must contain("<title>Testing!!!</title>")

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/FriendRecommendationsEmailTipTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/FriendRecommendationsEmailTipTest.scala
@@ -66,7 +66,6 @@ class FriendRecommendationsEmailTipTest extends Specification with ShoeboxTestIn
           to = Left(toUserId),
           cc = Seq(SystemEmailAddress.ENG),
           from = SystemEmailAddress.NOTIFICATIONS,
-          fromName = Some("Kifi"),
           subject = "hi",
           category = NotificationCategory.System.ADMIN,
           htmlTemplate = Html("")


### PR DESCRIPTION
@stkem 

It's common that we want an email's fromName to be "first last (via Kifi)".  I created a short method to default to this fromName with only a user id.
- `EmailToSend.fromName` is now `Option[Either[Id[User], String]]`.  instead of `Option[String]`.

If `Left(id)` is used, it will be preprocessed as "<% fullName(id) %> (via Kifi)" and then feed through the template processor

`Left(id)` is just shorthand for `Right(fullName(id) + " (via Kifi)")`

If `Right(str)` is used, it will still go through the template processor and any tags will be replaced

It was also common to put first and last names in the subject line. So I made this work with tags as well.

I was able to drop the database dependency from several email senders using these updates.
