### PR TITLE
never filter out uris that were previously recommended to a user

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendationRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendationRepo.scala
@@ -23,6 +23,7 @@ trait UriRecommendationRepo extends DbRepo[UriRecommendation] {
   def updateUriRecommendationFeedback(userId: Id[User], uriId: Id[NormalizedURI], feedback: UriRecommendationFeedback)(implicit session: RWSession): Boolean
   def incrementDeliveredCount(recoId: Id[UriRecommendation], withLastPushedAt: Boolean = false)(implicit session: RWSession): Unit
   def cleanupLowMasterScoreRecos(limitNumRecosForUser: Int, before: DateTime)(implicit session: RWSession): Boolean
+  def getUriIdsForUser(userId: Id[User])(implicit session: RSession): Set[Id[NormalizedURI]]
 }
 
 @Singleton
@@ -148,7 +149,10 @@ class UriRecommendationRepoImpl @Inject() (
       ) yield (row.state, row.updatedAt)).
         update((UriRecommendationStates.INACTIVE, currentDateTime)) > 0) || updated
     }
+  }
 
+  def getUriIdsForUser(userId: Id[User])(implicit session: RSession): Set[Id[NormalizedURI]] = {
+    (for (row <- byUser(userId)(rows)) yield row.uriId).list.toSet
   }
 
   def deleteCache(model: UriRecommendation)(implicit session: RSession): Unit = {}


### PR DESCRIPTION
otherwise recommendations with incorrectly high scores will never get
corrected if even if we fix the algorithm if the new score is below the
threshold for inclusion

also refactored the code a bit to make it clearer

@yingjieMiao 
