### PR TITLE
renaming "url" to "path" in LibraryData and using it in getLibraries

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeeperInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeeperInfo.scala
@@ -73,12 +73,12 @@ case class LibraryData(
   id: PublicId[Library],
   name: String,
   visibility: LibraryVisibility,
-  url: String)
+  path: String)
 object LibraryData {
   implicit val format: Format[LibraryData] = (
     (__ \ 'id).format[PublicId[Library]] and
     (__ \ 'name).format[String] and
     (__ \ 'visibility).format[LibraryVisibility] and
-    (__ \ 'url).format[String]
+    (__ \ 'path).format[String]
   )(LibraryData.apply, unlift(LibraryData.unapply))
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -245,6 +245,12 @@ class LibraryCommander @Inject() (
     }
   }
 
+  def getLibrariesUserCanKeepTo(userId: Id[User]): Seq[Library] = {
+    db.readOnlyMaster { implicit s =>
+      libraryRepo.getByUser(userId, excludeAccess = Some(LibraryAccess.READ_ONLY)).map(_._2)
+    }
+  }
+
   def userAccess(userId: Id[User], libraryId: Id[Library], universalLinkOpt: Option[String]): Option[LibraryAccess] = {
     db.readOnlyMaster { implicit s =>
       libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, userId) match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
@@ -139,7 +139,7 @@ class PageCommander @Inject() (
                 id = Library.publicId(lib.id.get),
                 name = lib.name,
                 visibility = lib.visibility,
-                url = Library.formatLibraryPath(owner.username, owner.externalId, lib.slug))
+                path = Library.formatLibraryPath(owner.username, owner.externalId, lib.slug))
               val mine = userId == keeperId.get
               val removable = (mine || userId == lib.ownerId)
               // right now assumes keep is "removable" if I own keep or I own library

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -8,8 +8,7 @@ import com.keepit.common.db.ExternalId
 import com.keepit.common.db.slick.Database
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.heimdal.HeimdalContextBuilderFactory
-import com.keepit.model.{ LibraryMembershipRepo, Keep, KeepSource, Library, LibraryAccess }
-import com.keepit.social.BasicUser
+import com.keepit.model.{ Keep, KeepSource, Library, LibraryAccess, LibraryMembershipRepo }
 import play.api.libs.json._
 
 import scala.util.{ Success, Failure }
@@ -26,12 +25,8 @@ class ExtLibraryController @Inject() (
     extends BrowserExtensionController(actionAuthenticator) with ShoeboxServiceController {
 
   def getLibraries() = JsonAction.authenticated { request =>
-    val basicSelf = BasicUser.fromUser(request.user)
     val datas = libraryCommander.getLibrariesUserCanKeepTo(request.userId) map { lib =>
-      val owner = if (lib.ownerId == request.userId)
-        basicSelf
-      else
-        db.readOnlyMaster { implicit s => basicUserRepo.load(lib.ownerId) }
+      val owner = db.readOnlyMaster { implicit s => basicUserRepo.load(lib.ownerId) }
       LibraryData(
         id = Library.publicId(lib.id.get),
         name = lib.name,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -1,7 +1,7 @@
 package com.keepit.controllers.ext
 
 import com.google.inject.Inject
-import com.keepit.commanders.{ KeepsCommander, RawBookmarkRepresentation, LibraryCommander }
+import com.keepit.commanders.{ KeepData, KeepsCommander, RawBookmarkRepresentation, LibraryCommander, LibraryData }
 import com.keepit.common.controller.{ ShoeboxServiceController, BrowserExtensionController, ActionAuthenticator }
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.db.ExternalId
@@ -9,6 +9,7 @@ import com.keepit.common.db.slick.Database
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.heimdal.HeimdalContextBuilderFactory
 import com.keepit.model.{ LibraryMembershipRepo, Keep, KeepSource, Library, LibraryAccess }
+import com.keepit.social.BasicUser
 import play.api.libs.json._
 
 import scala.util.{ Success, Failure }
@@ -25,18 +26,19 @@ class ExtLibraryController @Inject() (
     extends BrowserExtensionController(actionAuthenticator) with ShoeboxServiceController {
 
   def getLibraries() = JsonAction.authenticated { request =>
-    val (libraries, _) = libraryCommander.getLibrariesByUser(request.userId)
-    val libsCanKeepTo = libraries.filter(_._1 != LibraryAccess.READ_ONLY)
-    val jsons = libsCanKeepTo.map { a =>
-      val lib = a._2
-      val owner = db.readOnlyMaster { implicit s => basicUserRepo.load(lib.ownerId) }
-      Json.obj(
-        "id" -> Library.publicId(lib.id.get).id,
-        "name" -> lib.name,
-        "path" -> Library.formatLibraryPath(owner.username, owner.externalId, lib.slug),
-        "visibility" -> Json.toJson(lib.visibility))
+    val basicSelf = BasicUser.fromUser(request.user)
+    val datas = libraryCommander.getLibrariesUserCanKeepTo(request.userId) map { lib =>
+      val owner = if (lib.ownerId == request.userId)
+        basicSelf
+      else
+        db.readOnlyMaster { implicit s => basicUserRepo.load(lib.ownerId) }
+      LibraryData(
+        id = Library.publicId(lib.id.get),
+        name = lib.name,
+        visibility = lib.visibility,
+        path = Library.formatLibraryPath(owner.username, owner.externalId, lib.slug))
     }
-    Ok(Json.obj("libraries" -> Json.toJson(jsons)))
+    Ok(Json.obj("libraries" -> datas))
   }
 
   def addKeep(pubId: PublicId[Library]) = JsonAction.authenticatedParseJson { request =>


### PR DESCRIPTION
Also adding a new `LibraryCommander` method `getLibrariesUserCanKeepTo` that does library access level filtering in the database instead of in memory and avoids loading library invitations unnecessarily.

@ahsu1230 
