### PR TITLE
changing extension response for unkeeping from libraries

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -459,25 +459,42 @@ class KeepsCommander @Inject() (
     }
   }
 
-  def unkeepFromLibrary(keeps: Seq[ExternalId[Keep]], libId: Id[Library], userId: Id[User])(implicit context: HeimdalContext): Either[String, (Seq[KeepInfo], Seq[ExternalId[Keep]])] = {
+  private def unkeepFromLibrary(keeps: Seq[ExternalId[Keep]], libId: Id[Library], userId: Id[User])(implicit context: HeimdalContext): (Seq[KeepInfo], Seq[ExternalId[Keep]]) = {
+    val (unkeptKeeps, failedKeepIds) = db.readWrite { implicit s =>
+      val (validKeeps, failures) = keeps.map { kId =>
+        keepRepo.getByExtIdandLibraryId(kId, libId) match {
+          case Some(k) if libId == k.libraryId.get => Left(k)
+          case _ => Right(kId)
+        }
+      }.partition { k => k.isLeft }
+
+      val failedKeepIds = failures.map(f => f.right.get)
+      val unkeptKeeps = validKeeps.map(k => setKeepStateWithSession(k.left.get, KeepStates.INACTIVE, userId))
+      (unkeptKeeps, failedKeepIds)
+    }
+    val validUnkeeps = finalizeUnkeeping(unkeptKeeps, userId)
+    (validUnkeeps, failedKeepIds)
+  }
+  def unkeepOneFromLibrary(keep: ExternalId[Keep], libId: Id[Library], userId: Id[User])(implicit context: HeimdalContext): Either[String, KeepInfo] = {
     db.readOnlyMaster { implicit session =>
       libraryMembershipRepo.getWithLibraryIdAndUserId(libId, userId)
     } match {
       case Some(mem) if mem.hasWriteAccess =>
-        val (unkeptKeeps, failedKeepIds) = db.readWrite { implicit s =>
-          val (validKeeps, failures) = keeps.map { kId =>
-            keepRepo.getByExtIdandLibraryId(kId, libId) match {
-              case Some(k) if libId == k.libraryId.get => Left(k)
-              case _ => Right(kId)
-            }
-          }.partition { k => k.isLeft }
-
-          val failedKeepIds = failures.map(f => f.right.get)
-          val unkeptKeeps = validKeeps.map(k => setKeepStateWithSession(k.left.get, KeepStates.INACTIVE, userId))
-          (unkeptKeeps, failedKeepIds)
-        }
-        val validUnkeeps = finalizeUnkeeping(unkeptKeeps, userId)
-        Right((validUnkeeps, failedKeepIds))
+        val (infos, failures) = unkeepFromLibrary(Seq(keep), libId, userId)
+        if (infos.isEmpty)
+          Left("invalid_keep_id")
+        else
+          Right(infos.head)
+      case _ =>
+        Left("permission_denied")
+    }
+  }
+  def unkeepManyFromLibrary(keeps: Seq[ExternalId[Keep]], libId: Id[Library], userId: Id[User])(implicit context: HeimdalContext): Either[String, (Seq[KeepInfo], Seq[ExternalId[Keep]])] = {
+    db.readOnlyMaster { implicit session =>
+      libraryMembershipRepo.getWithLibraryIdAndUserId(libId, userId)
+    } match {
+      case Some(mem) if mem.hasWriteAccess =>
+        Right(unkeepFromLibrary(keeps, libId, userId))
       case _ =>
         Left("permission_denied")
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -71,9 +71,9 @@ class ExtLibraryController @Inject() (
         BadRequest(Json.obj("error" -> "invalid_library_id"))
       case Success(libraryId) =>
         implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.keeper).build
-        keepsCommander.unkeepFromLibrary(Seq(keepExtId), libraryId, request.userId) match {
+        keepsCommander.unkeepOneFromLibrary(keepExtId, libraryId, request.userId) match {
           case Left(failMsg) => BadRequest(Json.obj("error" -> failMsg))
-          case Right(_) => NoContent
+          case Right(info) => NoContent
         }
     }
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
@@ -196,7 +196,7 @@ class ExtLibraryControllerTest extends Specification with ShoeboxTestInjector wi
         // test incorrect unkeep from own library (keep exists but in wrong library)
         val request2 = FakeRequest("POST", com.keepit.controllers.ext.routes.ExtLibraryController.removeKeep(pubId2, keep2.externalId).url)
         val result2 = extLibraryController.removeKeep(pubId2, keep2.externalId)(request2)
-        status(result2) must equalTo(NO_CONTENT)
+        status(result2) must equalTo(BAD_REQUEST)
         db.readOnlyMaster { implicit s => keepRepo.getByLibrary(lib1.id.get, 10, 0).map(_.title).flatten === Seq("DontChoke", "Throw") }
 
         // test unkeep from someone else's library (have RW access)


### PR DESCRIPTION
@2is10 @andrewconner 
Here's some refactoring we discussed earlier. In the commander there's an `unkeepOne` and `unkeepMany` function which wrap around a common private unkeeping function. With this, it's easy for controllers to call the commander functions and be able to parse out errors, or failed/successful unkeeps

While there are already lots of unkeeping functions in KeepCommander, we'll consolidate them and do some cleanups later so any unkeep APIs are library-aware and like better named lol

Let me know if you have any thoughts
