### PR TITLE
reducing the amount of information about library sent to extension with each keep

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeeperInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeeperInfo.scala
@@ -5,7 +5,7 @@ import com.keepit.common.crypto.PublicId
 import com.keepit.common.db.ExternalId
 import com.keepit.common.time.DateTimeJsonFormat
 import com.keepit.model._
-import play.api.libs.json.{ Format, __, JsObject }
+import play.api.libs.json.{ __, JsObject, Writes }
 import play.api.libs.functional.syntax._
 
 case class KeeperInfo(
@@ -21,7 +21,7 @@ case class KeeperInfo(
   keeps: Int)
 
 object KeeperInfo {
-  implicit val writesKeeperInfo = (
+  implicit val writes: Writes[KeeperInfo] = (
     (__ \ 'normalized).write[String] and
     (__ \ 'kept).writeNullable[String] and
     (__ \ 'keepId).writeNullable[ExternalId[Keep]] and
@@ -44,7 +44,7 @@ case class KeeperPageInfo(
   keepers: Seq[BasicUser],
   keeps: Seq[KeepData])
 object KeeperPageInfo {
-  implicit val writesPageInfo = (
+  implicit val writes: Writes[KeeperPageInfo] = (
     (__ \ 'normalized).write[String] and
     (__ \ 'position).writeNullable[JsObject] and
     (__ \ 'neverOnSite).writeNullable[Boolean].contramap[Boolean](Some(_).filter(identity)) and
@@ -59,14 +59,16 @@ case class KeepData(
   id: ExternalId[Keep],
   mine: Boolean,
   removable: Boolean,
-  library: Option[LibraryData] = None)
+  secret: Boolean, // i.e. library.visibility == SECRET
+  libraryId: PublicId[Library])
 object KeepData {
-  implicit val format: Format[KeepData] = (
-    (__ \ 'id).format[ExternalId[Keep]] and
-    (__ \ 'mine).format[Boolean] and
-    (__ \ 'removable).format[Boolean] and
-    (__ \ 'library).formatNullable[LibraryData]
-  )(KeepData.apply, unlift(KeepData.unapply))
+  implicit val writes: Writes[KeepData] = (
+    (__ \ 'id).write[ExternalId[Keep]] and
+    (__ \ 'mine).write[Boolean] and
+    (__ \ 'removable).write[Boolean] and
+    (__ \ 'secret).writeNullable[Boolean].contramap[Boolean](Some(_).filter(identity)) and
+    (__ \ 'libraryId).write[PublicId[Library]]
+  )(unlift(KeepData.unapply))
 }
 
 case class LibraryData(
@@ -75,10 +77,10 @@ case class LibraryData(
   visibility: LibraryVisibility,
   path: String)
 object LibraryData {
-  implicit val format: Format[LibraryData] = (
-    (__ \ 'id).format[PublicId[Library]] and
-    (__ \ 'name).format[String] and
-    (__ \ 'visibility).format[LibraryVisibility] and
-    (__ \ 'path).format[String]
-  )(LibraryData.apply, unlift(LibraryData.unapply))
+  implicit val writes: Writes[LibraryData] = (
+    (__ \ 'id).write[PublicId[Library]] and
+    (__ \ 'name).write[String] and
+    (__ \ 'visibility).write[LibraryVisibility] and
+    (__ \ 'path).write[String]
+  )(unlift(LibraryData.unapply))
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
@@ -129,22 +129,18 @@ class PageCommander @Inject() (
             val (keepId, (keeperId, libId)) = key
 
             // get keeper info (if exists, otherwise just None)
-            val keeperOpt = keeperId.map(basicUserRepo.load(_))
+            val keeperOpt = keeperId.map(basicUserRepo.load)
 
             // get keep info which is based on library info (if exists, otherwise just None)
             val keepDataOpt = libId.map { libId =>
               val lib = libraryRepo.get(libId)
-              val owner = basicUserRepo.load(lib.ownerId)
-              val libData = LibraryData(
-                id = Library.publicId(lib.id.get),
-                name = lib.name,
-                visibility = lib.visibility,
-                path = Library.formatLibraryPath(owner.username, owner.externalId, lib.slug))
               val mine = userId == keeperId.get
-              val removable = (mine || userId == lib.ownerId)
-              // right now assumes keep is "removable" if I own keep or I own library
-              // todo: for collaborators, users may have RW access so they can remove keeps that they don't own
-              KeepData(keepId, mine, removable, Some(libData))
+              KeepData(
+                id = keepId,
+                mine = mine,
+                removable = mine || userId == lib.ownerId, // TODO: also make removable true if user has RW lib access
+                secret = lib.visibility == LibraryVisibility.SECRET,
+                libraryId = Library.publicId(lib.id.get))
             }
             (keeperOpt, keepDataOpt)
           }.toSeq.unzip // separate & flatten to keepers & kept in which libraries

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
@@ -120,7 +120,7 @@ class ExtLibraryControllerTest extends Specification with ShoeboxTestInjector wi
         status(result1) === OK
         contentType(result1) must beSome("application/json")
         val keep1 = db.readOnlyMaster { implicit s => keepRepo.getByLibrary(lib1.id.get, 10, 0).head }
-        contentAsString(result1) === s"""{"id":"${keep1.externalId}","mine":true,"removable":true}"""
+        contentAsString(result1) === s"""{"id":"${keep1.externalId}","mine":true,"removable":true,"libraryId":"${pubId1.id}"}"""
 
         val result2 = addKeep(user1, pubId2, Json.obj(
           "title" -> "IMMA LET YOU FINISH",
@@ -129,7 +129,7 @@ class ExtLibraryControllerTest extends Specification with ShoeboxTestInjector wi
         status(result2) === OK
         contentType(result2) must beSome("application/json")
         val keep2 = db.readOnlyMaster { implicit s => keepRepo.getByLibrary(lib2.id.get, 10, 0).head }
-        contentAsString(result2) === s"""{"id":"${keep2.externalId}","mine":true,"removable":true}"""
+        contentAsString(result2) === s"""{"id":"${keep2.externalId}","mine":true,"removable":true,"secret":true,"libraryId":"${pubId2.id}"}"""
 
         val result3 = addKeep(user1, pubId3, Json.obj(
           "title" -> "IMMA LET YOU FINISH",


### PR DESCRIPTION
The extension really only needs to know the library’s ID and whether it’s secret.
@ahsu1230 
