### PR TITLE
new Kifi  friend from Facebook gets different email

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/NotificationCategory.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/NotificationCategory.scala
@@ -36,6 +36,7 @@ object NotificationCategory {
 
     val CONTACT_JOINED = NotificationCategory("contact_joined")
     val CONNECTION_MADE = NotificationCategory("connection_made")
+    val SOCIAL_FRIEND_JOINED = NotificationCategory("social_friend_joined")
 
     val LIBRARY_INVITATION = NotificationCategory("library_invitation")
 
@@ -49,10 +50,10 @@ object NotificationCategory {
     val fromKifi = Set(ANNOUNCEMENT, WAITLIST, APPROVED, WELCOME, EMAIL_CONFIRMATION, RESET_PASSWORD, EMAIL_KEEP,
       WHO_KEPT_MY_KEEP)
     val fromFriends = Set(INVITATION, MESSAGE, FRIEND_REQUEST, FRIEND_ACCEPTED)
-    val aboutFriends = Set(CONTACT_JOINED, CONNECTION_MADE)
+    val aboutFriends = Set(CONTACT_JOINED, CONNECTION_MADE, SOCIAL_FRIEND_JOINED)
 
     // Formatting Categories used in the extension
-    val triggered = Set(FRIEND_ACCEPTED, FRIEND_REQUEST, WHO_KEPT_MY_KEEP, CONTACT_JOINED, CONNECTION_MADE)
+    val triggered = Set(FRIEND_ACCEPTED, FRIEND_REQUEST, WHO_KEPT_MY_KEEP, CONTACT_JOINED, CONNECTION_MADE, SOCIAL_FRIEND_JOINED)
     val global = Set(ANNOUNCEMENT)
     val kifiMessageFormattingCategory = Map.empty ++ triggered.map(_ -> "triggered") ++ global.map(_ -> "global")
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/FriendConnectionMadeEmailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/FriendConnectionMadeEmailSender.scala
@@ -4,28 +4,34 @@ import com.google.inject.Inject
 import com.keepit.common.db.Id
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
+import com.keepit.common.mail.SystemEmailAddress
 import com.keepit.common.mail.template.{ EmailTips, EmailToSend }
-import com.keepit.common.mail.template.helpers.fullName
-import com.keepit.common.mail.{ ElectronicMail, SystemEmailAddress }
+import com.keepit.common.mail.template.helpers.{ fullName, firstName }
 import com.keepit.model.{ NotificationCategory, User }
-
-import scala.concurrent.Future
+import com.keepit.social.SocialNetworkType
+import com.keepit.social.SocialNetworks.{ FACEBOOK, LINKEDIN }
 
 class FriendConnectionMadeEmailSender @Inject() (
     emailTemplateSender: EmailTemplateSender,
     protected val airbrake: AirbrakeNotifier) extends Logging {
 
-  def apply(toUserId: Id[User], friendUserId: Id[User], category: NotificationCategory): Future[ElectronicMail] =
-    sendToUser(toUserId, friendUserId, category)
+  def apply(toUserId: Id[User], friendUserId: Id[User], category: NotificationCategory, networkTypeOpt: Option[SocialNetworkType] = None) =
+    sendToUser(toUserId, friendUserId, category, networkTypeOpt)
 
-  def sendToUser(toUserId: Id[User], friendUserId: Id[User], category: NotificationCategory): Future[ElectronicMail] = {
+  def sendToUser(toUserId: Id[User], friendUserId: Id[User], category: NotificationCategory, networkTypeOpt: Option[SocialNetworkType] = None) = {
+    // sanity-check to ensure we don't print other network types to users
+    val networkNameOpt = networkTypeOpt collect { case FACEBOOK | LINKEDIN => networkTypeOpt.get.displayName }
+
     val (subject, campaign) = category match {
-      case NotificationCategory.User.CONNECTION_MADE =>
-        val subject = s"You are now friends with ${fullName(friendUserId)} on Kifi!"
-        (subject, Some("connectionMade"))
       case NotificationCategory.User.FRIEND_ACCEPTED =>
         val subject = s"${fullName(friendUserId)} accepted your Kifi friend request"
         (subject, Some("friendRequestAccepted"))
+      case NotificationCategory.User.SOCIAL_FRIEND_JOINED if networkNameOpt.isDefined =>
+        val subject = s"Your ${networkNameOpt.get} friend ${firstName(friendUserId)} just joined Kifi"
+        (subject, Some("socialFriendJoined"))
+      case _ =>
+        val subject = s"You are now friends with ${fullName(friendUserId)} on Kifi!"
+        (subject, Some("connectionMade"))
     }
 
     val emailToSend = EmailToSend(
@@ -34,8 +40,8 @@ class FriendConnectionMadeEmailSender @Inject() (
       subject = subject,
       to = Left(toUserId),
       category = category,
-      htmlTemplate = views.html.email.black.friendConnectionMade(toUserId, friendUserId, category),
-      textTemplate = Some(views.html.email.black.friendConnectionMadeText(toUserId, friendUserId, category)),
+      htmlTemplate = views.html.email.black.friendConnectionMade(toUserId, friendUserId, category, networkNameOpt),
+      textTemplate = Some(views.html.email.black.friendConnectionMadeText(toUserId, friendUserId, category, networkNameOpt)),
       campaign = campaign,
       tips = Seq(EmailTips.FriendRecommendations)
     )

--- a/kifi-backend/modules/shoebox/app/views/email/black/friendConnectionMade.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/black/friendConnectionMade.scala.html
@@ -1,4 +1,7 @@
-@(toUserId: Id[User], otherUserId: Id[User], category: com.keepit.model.NotificationCategory)
+@(toUserId: Id[User],
+  otherUserId: Id[User],
+  category: com.keepit.model.NotificationCategory,
+  networkNameOpt: Option[String] = None)
 @import com.keepit.common.mail.template.helpers._
 @import com.keepit.model.NotificationCategory.User._
 
@@ -22,11 +25,19 @@
 
         <tr>
           <td align="left" valign="middle" style="font-family:Arial,sans-serif; font-size:16px;color:#333333; line-height:23px;">
-            @if(category == CONNECTION_MADE) {
-            You are now friends with @fullName(otherUserId) on Kifi. Enjoy @firstName(otherUserId)’s
-            keeps in your search results and message @firstName(otherUserId) directly on any page!
-            } else {
-            @firstName(otherUserId) accepted your Kifi friend request.
+            @category match {
+              case SOCIAL_FRIEND_JOINED => {
+                Your @networkNameOpt.getOrElse("") friend @firstName(otherUserId) just joined Kifi
+              }
+
+              case FRIEND_ACCEPTED => {
+                @firstName(otherUserId) accepted your Kifi friend request.
+              }
+
+              case _ => {
+                You are now friends with @fullName(otherUserId) on Kifi. Enjoy @firstName(otherUserId)’s
+                keeps in your search results and message @firstName(otherUserId) directly on any page!
+              }
             }
           </td>
         </tr>

--- a/kifi-backend/modules/shoebox/app/views/email/black/friendConnectionMadeText.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/black/friendConnectionMadeText.scala.html
@@ -1,15 +1,25 @@
-@(toUserId: Id[User], otherUserId: Id[User], category: com.keepit.model.NotificationCategory)
+@(toUserId: Id[User],
+  otherUserId: Id[User],
+  category: com.keepit.model.NotificationCategory,
+  networkNameOpt: Option[String] = None)
 @import com.keepit.common.mail.template.helpers._
 @import com.keepit.model.NotificationCategory.User._
 
 Hey @firstName(toUserId),
-@if(category == CONNECTION_MADE) {
-You are now friends with @fullName(otherUserId) on Kifi. Enjoy @firstName(otherUserId)'s
-keeps in your search results and message @firstName(otherUserId) directly on any page!
-} else {
+@category match {
+case SOCIAL_FRIEND_JOINED => {
+Your @networkNameOpt.getOrElse("") friend @firstName(otherUserId) just joined Kifi
+
+You and @fullName(otherUserId) are now Kifi friends
+}
+case FRIEND_ACCEPTED => {
 @firstName(otherUserId) accepted your Kifi friend request.
 }
-You and @fullName(otherUserId) are now Kifi friends
+case _ => {
+You are now friends with @fullName(otherUserId) on Kifi. Enjoy @firstName(otherUserId)'s
+keeps in your search results and message @firstName(otherUserId) directly on any page!
+}
+}
 
 Have a great day,
 The Kifi team


### PR DESCRIPTION
@stkem 

this changes the "connection made" email if the auto-friended user is < 24 hours old and the connection is made from FB/LinkedIn
