### PR TITLE
Actions: identity

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/controller/RemoteUserActionsHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/RemoteUserActionsHelper.scala
@@ -5,7 +5,7 @@ import com.keepit.commanders.RemoteUserExperimentCommander
 import com.keepit.common.controller.FortyTwoCookies.{ ImpersonateCookie, KifiInstallationCookie }
 import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.healthcheck.AirbrakeNotifier
-import com.keepit.model.{ User, ExperimentType }
+import com.keepit.model.{ SocialUserInfo, User, ExperimentType }
 import com.keepit.shoebox.ShoeboxServiceClient
 import play.api.mvc.Request
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -28,4 +28,5 @@ class RemoteUserActionsHelper @Inject() (
 
   def getUserExperiments(userId: Id[User])(implicit request: Request[_]): Future[Set[ExperimentType]] = userExperimentCommander.getExperimentsByUser(userId)
 
+  def getSocialUserInfos(userId: Id[User]): Future[Seq[SocialUserInfo]] = shoebox.getSocialUserInfosByUserId(userId)
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/controller/RemoteUserActionsHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/RemoteUserActionsHelper.scala
@@ -9,6 +9,7 @@ import com.keepit.model.{ SocialUserInfo, User, ExperimentType }
 import com.keepit.shoebox.ShoeboxServiceClient
 import play.api.mvc.Request
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import securesocial.core.Identity
 
 import scala.concurrent.Future
 
@@ -19,6 +20,8 @@ class RemoteUserActionsHelper @Inject() (
     userExperimentCommander: RemoteUserExperimentCommander,
     val impersonateCookie: ImpersonateCookie,
     val kifiInstallationCookie: KifiInstallationCookie) extends UserActionsHelper {
+
+  def buildNonUserRequest[A](implicit request: Request[A]): NonUserRequest[A] = SimpleNonUserRequest(request)
 
   def isAdmin(userId: Id[User])(implicit request: Request[_]): Future[Boolean] = getUserExperiments(userId).map(_.contains(ExperimentType.ADMIN))
 

--- a/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
@@ -6,6 +6,7 @@ import com.keepit.common.logging.Logging
 import com.keepit.common.core._
 import com.keepit.common.net.URI
 import com.keepit.model.{ SocialUserInfo, ExperimentType, KifiInstallation, User }
+import play.api.http.ContentTypes
 import play.api.mvc._
 
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -136,6 +137,12 @@ trait UserActions extends Logging { self: Controller =>
     resF.map(maybeAugmentCORS(_))
   }
 
+  private def pageAction[P[_]] = new ActionFunction[P, P] {
+    def invokeBlock[A](request: P[A], block: (P[A]) => Future[Result]): Future[Result] = {
+      block(request).map(_.withHeaders(CONTENT_TYPE -> HTML))
+    }
+  }
+
   object UserAction extends ActionBuilder[UserRequest] {
     def invokeBlock[A](request: Request[A], block: (UserRequest[A]) => Future[Result]): Future[Result] = {
       implicit val req = request
@@ -145,6 +152,7 @@ trait UserActions extends Logging { self: Controller =>
       }
     }
   }
+  val UserPage = (UserAction andThen pageAction)
 
   object MaybeUserAction extends ActionBuilder[MaybeUserRequest] {
     def invokeBlock[A](request: Request[A], block: (MaybeUserRequest[A]) => Future[Result]): Future[Result] = {
@@ -155,6 +163,7 @@ trait UserActions extends Logging { self: Controller =>
       }
     }
   }
+  val MaybeUserPage = (MaybeUserAction andThen pageAction)
 
   private object AdminCheck extends ActionFilter[UserRequest] {
     protected def filter[A](request: UserRequest[A]): Future[Option[Result]] = {
@@ -167,5 +176,6 @@ trait UserActions extends Logging { self: Controller =>
   }
 
   val AdminUserAction = (UserAction andThen AdminCheck)
+  val AdminUserPage = (AdminUserAction andThen pageAction)
 
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
@@ -141,7 +141,7 @@ trait UserActions extends Logging { self: Controller =>
 
   private def PageAction[P[_]] = new ActionFunction[P, P] {
     def invokeBlock[A](request: P[A], block: (P[A]) => Future[Result]): Future[Result] = {
-      block(request).map(_.withHeaders(CONTENT_TYPE -> HTML)) // todo(ray): handle error with redirects
+      block(request) // todo(ray): handle error with redirects
     }
   }
 

--- a/kifi-backend/modules/common/test/com/keepit/common/controller/FakeUserActionsModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/controller/FakeUserActionsModule.scala
@@ -31,6 +31,7 @@ class FakeUserActionsHelper @Inject() (
   }
 
   override def getUserIdOpt(implicit request: Request[_]): Option[Id[User]] = fixedUser.flatMap(_.id)
+  def buildNonUserRequest[A](implicit request: Request[A]): NonUserRequest[A] = SimpleNonUserRequest(request)
   def isAdmin(userId: Id[User])(implicit request: Request[_]): Future[Boolean] = Future.successful(fixedExperiments.contains(ExperimentType.ADMIN))
   def getUserOpt(userId: Id[User])(implicit request: Request[_]): Future[Option[User]] = Future.successful(fixedUser)
   def getUserByExtIdOpt(extId: ExternalId[User]): Future[Option[User]] = Future.successful(fixedUser)

--- a/kifi-backend/modules/common/test/com/keepit/common/controller/FakeUserActionsModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/controller/FakeUserActionsModule.scala
@@ -4,7 +4,7 @@ import com.google.inject.{ Inject, Singleton }
 import com.keepit.common.controller.FortyTwoCookies.{ KifiInstallationCookie, ImpersonateCookie }
 import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.logging.Logging
-import com.keepit.model.{ User, ExperimentType }
+import com.keepit.model.{ SocialUserInfo, User, ExperimentType }
 import play.api.mvc.Request
 
 import scala.concurrent.Future
@@ -35,5 +35,5 @@ class FakeUserActionsHelper @Inject() (
   def getUserOpt(userId: Id[User])(implicit request: Request[_]): Future[Option[User]] = Future.successful(fixedUser)
   def getUserByExtIdOpt(extId: ExternalId[User]): Future[Option[User]] = Future.successful(fixedUser)
   def getUserExperiments(userId: Id[User])(implicit request: Request[_]): Future[Set[ExperimentType]] = Future.successful(fixedExperiments)
-
+  def getSocialUserInfos(userId: Id[User]): Future[Seq[SocialUserInfo]] = Future.successful(Seq.empty)
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
@@ -2,7 +2,7 @@ package com.keepit.controllers.admin
 
 import com.google.inject.Inject
 import com.keepit.commanders.LibraryCommander
-import com.keepit.common.controller.{ AuthenticatedRequest, ActionAuthenticator, AdminController }
+import com.keepit.common.controller.{ ActionAuthenticator, AdminController }
 import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.DBSession.RWSession

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/TypeaheadAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/TypeaheadAdminController.scala
@@ -23,7 +23,7 @@ class TypeaheadAdminController @Inject() (
 
   implicit val fj = ExecutionContext.fj
 
-  def index = AdminUserAction { request =>
+  def index = AdminUserPage { request =>
     Ok(html.admin.typeahead(request.user))
   }
 
@@ -101,7 +101,7 @@ class TypeaheadAdminController @Inject() (
     }
   }
 
-  def search(userId: Id[User], query: String, limit: Int, pictureUrl: Boolean, dedupEmail: Boolean) = AdminUserAction.async { request =>
+  def search(userId: Id[User], query: String, limit: Int, pictureUrl: Boolean, dedupEmail: Boolean) = AdminUserPage.async { request =>
     typeaheadCommander.searchWithInviteStatus(userId, query, Some(limit), pictureUrl, dedupEmail) map { res => // hack
       Ok(
         "<table border=1><tr><td>label</td><td>networkType</td><td>score</td><td>status</td><td>value</td><td>image</td><td>email</td><td>inviteLastSentAt</td></tr>" +

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/TypeaheadAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/TypeaheadAdminController.scala
@@ -7,6 +7,7 @@ import com.keepit.common.controller.{ UserActions, UserActionsHelper, ShoeboxSer
 import com.keepit.model._
 import com.keepit.common.db.Id
 import com.keepit.typeahead.TypeaheadHit
+import play.twirl.api.Html
 import views.html
 import com.keepit.abook.ABookServiceClient
 import com.keepit.common.concurrent.ExecutionContext
@@ -104,9 +105,9 @@ class TypeaheadAdminController @Inject() (
   def search(userId: Id[User], query: String, limit: Int, pictureUrl: Boolean, dedupEmail: Boolean) = AdminUserPage.async { request =>
     typeaheadCommander.searchWithInviteStatus(userId, query, Some(limit), pictureUrl, dedupEmail) map { res => // hack
       Ok(
-        "<table border=1><tr><td>label</td><td>networkType</td><td>score</td><td>status</td><td>value</td><td>image</td><td>email</td><td>inviteLastSentAt</td></tr>" +
+        Html("<table border=1><tr><td>label</td><td>networkType</td><td>score</td><td>status</td><td>value</td><td>image</td><td>email</td><td>inviteLastSentAt</td></tr>" +
           res.map(c => s"<tr><td>${c.label}</td><td>${c.networkType}</td><td>${c.score}</td><td>${c.status}</td><td>${c.value}</td><td>${c.image.getOrElse("")}</td><td>${c.email}</td><td>${c.inviteLastSentAt}</td></tr>").mkString("") +
-          "</table>"
+          "</table>")
       )
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/controller/ShoeboxUserActionsHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/controller/ShoeboxUserActionsHelper.scala
@@ -7,7 +7,7 @@ import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
-import com.keepit.model._
+import com.keepit.model.{ UserRepo, SocialUserInfoRepo, User, ExperimentType, SocialUserInfo }
 import play.api.mvc.{ Request, Controller }
 
 import scala.concurrent.Future

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/controller/ShoeboxUserActionsHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/controller/ShoeboxUserActionsHelper.scala
@@ -25,7 +25,7 @@ trait ShoeboxSecureSocialHelper {
 }
 
 case class ShoeboxNonUserRequest[T](request: Request[T]) extends WrappedRequest(request) with NonUserRequest[T] with SecureSocialIdentityAccess[T] with ShoeboxSecureSocialHelper {
-  override def identityOptF = () => Future.successful(getSecureSocialUserFromRequest(request))
+  val identityOpt = getSecureSocialUserFromRequest(request)
 }
 
 @Singleton

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/controller/ShoeboxUserActionsHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/controller/ShoeboxUserActionsHelper.scala
@@ -7,7 +7,7 @@ import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
-import com.keepit.model.{ UserRepo, ExperimentType, User }
+import com.keepit.model._
 import play.api.mvc.{ Request, Controller }
 
 import scala.concurrent.Future
@@ -17,6 +17,7 @@ class ShoeboxUserActionsHelper @Inject() (
     db: Database,
     airbrake: AirbrakeNotifier,
     userRepo: UserRepo,
+    suiRepo: SocialUserInfoRepo,
     userExperimentCommander: LocalUserExperimentCommander,
     val impersonateCookie: ImpersonateCookie,
     val kifiInstallationCookie: KifiInstallationCookie) extends Controller with UserActionsHelper with Logging {
@@ -26,7 +27,7 @@ class ShoeboxUserActionsHelper @Inject() (
   }
 
   def getUserOpt(userId: Id[User])(implicit request: Request[_]): Future[Option[User]] = Future.successful {
-    db.readWrite { implicit s => Some(userRepo.get(userId)) }
+    db.readOnlyMaster { implicit s => Some(userRepo.get(userId)) }
   }
 
   def getUserExperiments(userId: Id[User])(implicit request: Request[_]): Future[Set[ExperimentType]] = Future.successful {
@@ -34,6 +35,10 @@ class ShoeboxUserActionsHelper @Inject() (
   }
 
   def getUserByExtIdOpt(extId: ExternalId[User]): Future[Option[User]] = Future.successful {
-    db.readWrite { implicit s => Some(userRepo.get(extId)) }
+    db.readOnlyMaster { implicit s => Some(userRepo.get(extId)) }
+  }
+
+  def getSocialUserInfos(userId: Id[User]): Future[Seq[SocialUserInfo]] = Future.successful {
+    db.readOnlyMaster { implicit s => suiRepo.getByUser(userId) }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/controller/ShoeboxUserActionsHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/controller/ShoeboxUserActionsHelper.scala
@@ -8,9 +8,25 @@ import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.model.{ UserRepo, SocialUserInfoRepo, User, ExperimentType, SocialUserInfo }
-import play.api.mvc.{ Request, Controller }
+import play.api.mvc.{ WrappedRequest, Request, Controller }
+import securesocial.core.{ UserService, SecureSocial, Identity }
 
 import scala.concurrent.Future
+
+trait ShoeboxSecureSocialHelper {
+  def getSecureSocialUserFromRequest[A](implicit request: Request[A]): Option[Identity] = {
+    for (
+      authenticator <- SecureSocial.authenticatorFromRequest;
+      user <- UserService.find(authenticator.identityId)
+    ) yield {
+      user
+    }
+  }
+}
+
+case class ShoeboxNonUserRequest[T](request: Request[T]) extends WrappedRequest(request) with NonUserRequest[T] with SecureSocialIdentityAccess[T] with ShoeboxSecureSocialHelper {
+  override def identityOptF = () => Future.successful(getSecureSocialUserFromRequest(request))
+}
 
 @Singleton
 class ShoeboxUserActionsHelper @Inject() (
@@ -21,6 +37,8 @@ class ShoeboxUserActionsHelper @Inject() (
     userExperimentCommander: LocalUserExperimentCommander,
     val impersonateCookie: ImpersonateCookie,
     val kifiInstallationCookie: KifiInstallationCookie) extends Controller with UserActionsHelper with Logging {
+
+  def buildNonUserRequest[A](implicit request: Request[A]): NonUserRequest[A] = ShoeboxNonUserRequest(request)
 
   def isAdmin(userId: Id[User])(implicit request: Request[_]): Future[Boolean] = Future.successful {
     userExperimentCommander.userHasExperiment(userId, ExperimentType.ADMIN)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/OAuth2Controller.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/OAuth2Controller.scala
@@ -1,7 +1,7 @@
 package com.keepit.controllers.core
 
 import com.google.inject.Inject
-import com.keepit.common.controller.{ ShoeboxServiceController, ActionAuthenticator, WebsiteController, UserActions, UserActionsHelper, UserRequest }
+import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper, UserRequest }
 import com.keepit.common.logging.{ LogPrefix, Logging }
 import java.net.URLEncoder
 import play.api.mvc._
@@ -119,10 +119,9 @@ import OAuth2._
 class OAuth2Controller @Inject() (
     db: Database,
     airbrake: AirbrakeNotifier,
-    actionAuthenticator: ActionAuthenticator,
     abookServiceClient: ABookServiceClient,
     val userActionsHelper: UserActionsHelper,
-    oauth2CommonConfig: OAuth2CommonConfig) extends WebsiteController(actionAuthenticator) with UserActions with ShoeboxServiceController with Logging {
+    oauth2CommonConfig: OAuth2CommonConfig) extends UserActions with ShoeboxServiceController with Logging {
 
   import OAuth2Providers._
   def start(provider: String, stateTokenOpt: Option[String], approvalPromptOpt: Option[String]) = UserAction { implicit request =>
@@ -336,7 +335,7 @@ class OAuth2Controller @Inject() (
     }
   }
 
-  def importContacts(provider: Option[String], approvalPromptOpt: Option[String], redirectUrl: Option[String] = None) = HtmlAction.authenticated { implicit request =>
+  def importContacts(provider: Option[String], approvalPromptOpt: Option[String], redirectUrl: Option[String] = None) = UserPage { implicit request =>
     val stateToken = Json.toJson(StateToken(new BigInteger(130, new SecureRandom()).toString(32), redirectUrl)).toString()
     val route = routes.OAuth2Controller.start(provider.getOrElse("google"), Some(stateToken), approvalPromptOpt)
     log.info(s"[importContacts(${request.userId}, $provider, $approvalPromptOpt)] redirect to $route")


### PR DESCRIPTION
Added support for `SecureSocial`'s `Identity` (for backward compatibility to aid migration to new framework)
`UserRequest`, etc. are now modeled as traits
`buildNonUserRequest` factored out to `UserActionsHelper` to aid injection of different implementations
Added HTML (i.e. `Page`) support
Wired up `OAuth2Controller` (abook import); validated locally

@andrewconner 
