### PR TITLE
logging to figure out cache misses on user_connection_scores

### DIFF
--- a/kifi-backend/modules/graph/app/com/keepit/graph/commanders/GraphCommander.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/commanders/GraphCommander.scala
@@ -39,6 +39,7 @@ class GraphCommander @Inject() (
     val usersList = getUsersScoreList(startingVertexId, journal, avoidFirstDegreeConnection)
     uriScoreCache.set(ConnectedUriScoreCacheKey(userId, avoidFirstDegreeConnection), urisList)
     userScoreCache.set(ConnectedUserScoreCacheKey(userId, avoidFirstDegreeConnection), usersList)
+    log.error(s"Cache Set on UserScoreCache Set ($userId, $avoidFirstDegreeConnection)")
     (urisList, usersList)
   }
 
@@ -59,12 +60,16 @@ class GraphCommander @Inject() (
     val result = userScoreCache.get(ConnectedUserScoreCacheKey(userId, avoidFirstDegreeConnections))
     result match {
       case None => {
+        log.error(s"Cache Miss on UserScoreCache miss on ($userId, $avoidFirstDegreeConnections)")
         val wanderLust = Wanderlust.discovery(userId)
         wanderingCommander.wander(wanderLust).map { journal =>
           updateScoreCaches(userId, journal.getStartingVertex, journal, avoidFirstDegreeConnections)._2
         }
       }
-      case Some(data) => Future.successful(data)
+      case Some(data) => {
+        log.error(s"Cache Hit on UserScoreCache ($userId, $avoidFirstDegreeConnections)")
+        Future.successful(data)
+      }
     }
   }
 


### PR DESCRIPTION
Some info:

"user_connection_score" (ConnectedUserScoreCache) is reporting 100% cache miss (no hits, all misses & sets) starting on September 13th. This code was made by Tan in July, but the cache misses started happening recently.

It appears in GraphServiceClient & GraphCommander, but it's not clear (to me or @yingjieMiao) what is causing some cache misses. So will add logging to see what keys are being requested & what is being set (maybe they're not being set correctly as the intended value)
Will remove the loggings once this is figured out.

Open to any suggestions
@eishay @leogrim @andrewconner 
