### PR TITLE
more flexible cortex model version control

### DIFF
--- a/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDACommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDACommander.scala
@@ -6,9 +6,9 @@ import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
 import com.keepit.cortex.core.ModelVersion
 import com.keepit.cortex.dbmodel._
-import com.keepit.cortex.features.Document
 import com.keepit.cortex.models.lda._
 import com.keepit.cortex.utils.MatrixUtils._
+import com.keepit.cortex.PublishingVersions
 import com.keepit.model.{ Library, Keep, NormalizedURI, User }
 import play.api.libs.json._
 import scala.math.exp
@@ -19,50 +19,39 @@ class LDACommander @Inject() (
     db: Database,
     userTopicRepo: UserLDAInterestsRepo,
     uriTopicRepo: URILDATopicRepo,
-    wordRep: LDAWordRepresenter,
-    docRep: LDADocRepresenter,
     userLDAStatsRetriever: UserLDAStatisticsRetriever,
     topicInfoRepo: LDAInfoRepo,
     userLDAStatRepo: UserLDAStatsRepo,
     libTopicRepo: LibraryLDATopicRepo,
     userStatUpdatePlugin: LDAUserStatDbUpdatePlugin) extends Logging {
 
-  val numOfTopics: Int = wordRep.lda.dimension
+  val ldaVersion = PublishingVersions.denseLDAVersion // all methods in this commander should query against this version
+  assume(ldaVersion == infoCommander.ldaVersion)
+
+  val numOfTopics: Int = infoCommander.getLDADimension()
 
   def activeTopics = infoCommander.activeTopics
-
-  def getLDADimension(version: ModelVersion[DenseLDA]): Int = {
-    infoCommander.getLDADimension(version)
-  }
 
   private def projectToActive(arr: Array[Float]): Array[Float] = {
     assume(arr.size == numOfTopics)
     activeTopics.map { i => arr(i) }.toArray
   }
 
-  def wordTopic(word: String): Option[Array[Float]] = {
-    wordRep(word).map { _.vectorize }
-  }
-
-  def docTopic(doc: Document): Option[Array[Float]] = {
-    docRep(doc).map { _.vectorize }
-  }
-
   def userTopicMean(userId: Id[User]): Option[UserLDAInterests] = {
     db.readOnlyReplica { implicit s =>
-      userTopicRepo.getByUser(userId, wordRep.version)
+      userTopicRepo.getByUser(userId, ldaVersion)
     }
   }
 
   def libraryTopic(libId: Id[Library]): Option[LibraryLDATopic] = {
-    db.readOnlyReplica { implicit s => libTopicRepo.getActiveByLibraryId(libId, wordRep.version) }
+    db.readOnlyReplica { implicit s => libTopicRepo.getActiveByLibraryId(libId, ldaVersion) }
   }
 
   // for admin
   def userUriInterest(userId: Id[User], uriId: Id[NormalizedURI]): LDAUserURIInterestScores = {
     db.readOnlyReplica { implicit s =>
-      val uriTopicOpt = uriTopicRepo.getActiveByURI(uriId, wordRep.version)
-      val userInterestOpt = userTopicRepo.getByUser(userId, wordRep.version)
+      val uriTopicOpt = uriTopicRepo.getActiveByURI(uriId, ldaVersion)
+      val userInterestOpt = userTopicRepo.getByUser(userId, ldaVersion)
       computeCosineInterestScore(uriTopicOpt, userInterestOpt)
     }
   }
@@ -70,8 +59,8 @@ class LDACommander @Inject() (
   // for admin
   def gaussianUserUriInterest(userId: Id[User], uriId: Id[NormalizedURI]): LDAUserURIInterestScores = {
     db.readOnlyReplica { implicit s =>
-      val uriTopicOpt = uriTopicRepo.getActiveByURI(uriId, wordRep.version)
-      val userInterestStatOpt = userLDAStatRepo.getByUser(userId, wordRep.version)
+      val uriTopicOpt = uriTopicRepo.getActiveByURI(uriId, ldaVersion)
+      val userInterestStatOpt = userLDAStatRepo.getByUser(userId, ldaVersion)
       computeGaussianInterestScore(uriTopicOpt, userInterestStatOpt)
     }
   }
@@ -82,10 +71,10 @@ class LDACommander @Inject() (
 
     val junkTopics = infoCommander.inactiveTopics
     db.readOnlyReplica { implicit s =>
-      val userInterestOpt = userTopicRepo.getByUser(userId, wordRep.version)
-      val userInterestStatOpt = userLDAStatRepo.getActiveByUser(userId, wordRep.version)
-      val libFeats = db.readOnlyReplica { implicit s => libTopicRepo.getUserFollowedLibraryFeatures(userId, wordRep.version) }
-      val uriTopicOpts = uriTopicRepo.getActiveByURIs(uriIds, wordRep.version)
+      val userInterestOpt = userTopicRepo.getByUser(userId, ldaVersion)
+      val userInterestStatOpt = userLDAStatRepo.getActiveByUser(userId, ldaVersion)
+      val libFeats = db.readOnlyReplica { implicit s => libTopicRepo.getUserFollowedLibraryFeatures(userId, ldaVersion) }
+      val uriTopicOpts = uriTopicRepo.getActiveByURIs(uriIds, ldaVersion)
       uriTopicOpts.map { uriTopicOpt =>
         if (!isInJunkTopic(uriTopicOpt, junkTopics)) {
           val s1 = computeCosineInterestScore(uriTopicOpt, userInterestOpt)
@@ -102,8 +91,8 @@ class LDACommander @Inject() (
 
   // admin
   def libraryInducedUserURIInterest(userId: Id[User], uriId: Id[NormalizedURI]): Option[LDAUserURIInterestScore] = {
-    val libFeats = db.readOnlyReplica { implicit s => libTopicRepo.getUserFollowedLibraryFeatures(userId, wordRep.version) }
-    val uriFeatOpt = db.readOnlyReplica { implicit s => uriTopicRepo.getActiveByURI(uriId, wordRep.version) }
+    val libFeats = db.readOnlyReplica { implicit s => libTopicRepo.getUserFollowedLibraryFeatures(userId, ldaVersion) }
+    val uriFeatOpt = db.readOnlyReplica { implicit s => uriTopicRepo.getActiveByURI(uriId, ldaVersion) }
     libraryInducedUserURIInterestScore(libFeats, uriFeatOpt)
   }
 
@@ -157,7 +146,7 @@ class LDACommander @Inject() (
   private def computeCosineInterestScore(numOfEvidenceForUser: Int, userFeatOpt: Option[UserTopicMean], uriFeat: URILDATopic, isRecent: Boolean): Option[LDAUserURIInterestScore] = {
     (userFeatOpt, uriFeat.feature) match {
       case (Some(userFeat), Some(uriFeatVec)) =>
-        val userVec = getUserLDAStats(wordRep.version) match {
+        val userVec = getUserLDAStats(ldaVersion) match {
           case None => userFeat.mean
           case Some(stat) => scale(userFeat.mean, stat.mean, stat.std)
         }
@@ -181,7 +170,7 @@ class LDACommander @Inject() (
   def sampleURIs(topicId: Int): Seq[(Id[NormalizedURI], Float)] = {
     val SAMPLE_SIZE = 20
     val uris = db.readOnlyReplica { implicit s =>
-      uriTopicRepo.getLatestURIsInTopic(LDATopic(topicId), wordRep.version, limit = 100)
+      uriTopicRepo.getLatestURIsInTopic(LDATopic(topicId), ldaVersion, limit = 100)
     }
     scala.util.Random.shuffle(uris).take(SAMPLE_SIZE).sortBy(-1f * _._2)
   }
@@ -205,12 +194,12 @@ class LDACommander @Inject() (
   }
 
   def getSimilarUsers(userId: Id[User], topK: Int): (Seq[Id[User]], Seq[Float]) = {
-    val target = db.readOnlyReplica { implicit s => userTopicRepo.getTopicMeanByUser(userId, wordRep.version) }
+    val target = db.readOnlyReplica { implicit s => userTopicRepo.getTopicMeanByUser(userId, ldaVersion) }
     if (target.isEmpty) return (Seq(), Seq())
-    val statOpt = getUserLDAStats(wordRep.version)
+    val statOpt = getUserLDAStats(ldaVersion)
     val targetScaled = scale(target.get.mean, statOpt)
 
-    val (users, vecs) = db.readOnlyReplica { implicit s => userTopicRepo.getAllUserTopicMean(wordRep.version, minEvidence = 100) }
+    val (users, vecs) = db.readOnlyReplica { implicit s => userTopicRepo.getAllUserTopicMean(ldaVersion, minEvidence = 100) }
     val idsAndScores = (users zip vecs).map {
       case (userId, vec) =>
         val (u, v) = (targetScaled, scale(vec.mean, statOpt))
@@ -222,9 +211,9 @@ class LDACommander @Inject() (
   }
 
   def userSimilairty(userId1: Id[User], userId2: Id[User]): Option[Float] = {
-    val vecOpt1 = db.readOnlyReplica { implicit s => userTopicRepo.getTopicMeanByUser(userId1, wordRep.version) }
-    val vecOpt2 = db.readOnlyReplica { implicit s => userTopicRepo.getTopicMeanByUser(userId2, wordRep.version) }
-    val statOpt = getUserLDAStats(wordRep.version)
+    val vecOpt1 = db.readOnlyReplica { implicit s => userTopicRepo.getTopicMeanByUser(userId1, ldaVersion) }
+    val vecOpt2 = db.readOnlyReplica { implicit s => userTopicRepo.getTopicMeanByUser(userId2, ldaVersion) }
+    val statOpt = getUserLDAStats(ldaVersion)
 
     (vecOpt1, vecOpt2) match {
       case (Some(v1), Some(v2)) => Some(cosineDistance(scale(v1.mean, statOpt), scale(v2.mean, statOpt)))
@@ -237,7 +226,7 @@ class LDACommander @Inject() (
     val cutoff = (1.0f / numOfTopics) * 50
     val topicIdOpts = db.readOnlyReplica { implicit s =>
       uris.map { uri =>
-        uriTopicRepo.getFirstTopicAndScore(uri, wordRep.version) match {
+        uriTopicRepo.getFirstTopicAndScore(uri, ldaVersion) match {
           case Some((topic, score)) =>
             if (score > cutoff) Some(topic.index) else None
           case None => None
@@ -267,8 +256,8 @@ class LDACommander @Inject() (
       scored.filter { _._2 < MAX_KL_DIST }.sortBy(_._2).take(topK).map { _._1 }
     }
 
-    val userFeats = db.readOnlyReplica { implicit s => uriTopicRepo.getUserRecentURIFeatures(userId, wordRep.version, min_num_words = 50, limit = 200) }
-    val uriFeats = db.readOnlyReplica { implicit s => uriTopicRepo.getActiveByURIs(uris, wordRep.version) }
+    val userFeats = db.readOnlyReplica { implicit s => uriTopicRepo.getUserRecentURIFeatures(userId, ldaVersion, min_num_words = 50, limit = 200) }
+    val uriFeats = db.readOnlyReplica { implicit s => uriTopicRepo.getActiveByURIs(uris, ldaVersion) }
     uriFeats.map { uriFeatOpt =>
       uriFeatOpt match {
         case Some(uriFeat) if uriFeat.numOfWords > 50 => bestMatch(userFeats, uriFeat)
@@ -278,8 +267,8 @@ class LDACommander @Inject() (
   }
 
   def uriKLDivergence(uriId1: Id[NormalizedURI], uriId2: Id[NormalizedURI]): Option[Float] = {
-    val feat1 = db.readOnlyReplica { implicit s => uriTopicRepo.getActiveByURI(uriId1, wordRep.version) }
-    val feat2 = db.readOnlyReplica { implicit s => uriTopicRepo.getActiveByURI(uriId2, wordRep.version) }
+    val feat1 = db.readOnlyReplica { implicit s => uriTopicRepo.getActiveByURI(uriId1, ldaVersion) }
+    val feat2 = db.readOnlyReplica { implicit s => uriTopicRepo.getActiveByURI(uriId2, ldaVersion) }
     (feat1, feat2) match {
       case (Some(f1), Some(f2)) if (f1.numOfWords > 50 && f2.numOfWords > 50) => Some(KL_divergence(f1.feature.get.value, f2.feature.get.value))
       case _ => None
@@ -287,7 +276,7 @@ class LDACommander @Inject() (
   }
 
   def recomputeUserLDAStats(): Unit = {
-    val users = db.readOnlyReplica { implicit s => userLDAStatRepo.getAllUsers(wordRep.version) }
+    val users = db.readOnlyReplica { implicit s => userLDAStatRepo.getAllUsers(ldaVersion) }
     log.info(s"recomputing user LDA Stats for ${users.size} users")
     var n = 0
     users.foreach { user =>
@@ -299,7 +288,7 @@ class LDACommander @Inject() (
 
   // just for examine data
   def dumpFeature(dataType: String, id: Long): JsValue = {
-    val version = wordRep.version
+    val version = ldaVersion
     dataType match {
       case "user" => db.readOnlyReplica { implicit s =>
         val uid = Id[User](id)

--- a/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDARepresenterCommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDARepresenterCommander.scala
@@ -1,0 +1,20 @@
+package com.keepit.common.commanders
+
+import com.google.inject.{ Inject, Singleton }
+import com.keepit.cortex.features.Document
+import com.keepit.cortex.models.lda.{ LDADocRepresenter, LDAWordRepresenter }
+
+@Singleton
+class LDARepresenterCommander @Inject() (
+    wordRep: LDAWordRepresenter,
+    docRep: LDADocRepresenter) {
+
+  def wordTopic(word: String): Option[Array[Float]] = {
+    wordRep(word).map { _.vectorize }
+  }
+
+  def docTopic(doc: Document): Option[Array[Float]] = {
+    docRep(doc).map { _.vectorize }
+  }
+
+}

--- a/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/CortexDataPipeController.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/CortexDataPipeController.scala
@@ -7,7 +7,7 @@ import com.keepit.model.NormalizedURI
 import com.keepit.common.commanders.FeatureRetrievalCommander
 import com.keepit.common.db.SequenceNumber
 import com.keepit.cortex.models.lda.DenseLDA
-import com.keepit.cortex.PublishedModels
+import com.keepit.cortex.PublishingVersions
 import play.api.mvc.Action
 import com.keepit.cortex.core.ModelVersion
 
@@ -16,7 +16,7 @@ class CortexDataPipeController @Inject() (
 
   def getSparseLDAFeaturesChanged(modelVersion: ModelVersion[DenseLDA], seqNum: SequenceNumber[NormalizedURI], fetchSize: Int) = Action { request =>
 
-    val publishedLDAVersion = PublishedModels.denseLDAVersion
+    val publishedLDAVersion = PublishingVersions.denseLDAVersion
     require(modelVersion <= publishedLDAVersion, s"Version $modelVersion of LDA has not been published yet.")
     val lowUriSeq = if (modelVersion < publishedLDAVersion) SequenceNumber.ZERO[NormalizedURI] else seqNum
 

--- a/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
@@ -5,7 +5,7 @@ import com.keepit.common.logging.Logging
 import play.api.mvc.Action
 import play.api.libs.json._
 import com.keepit.common.controller.CortexServiceController
-import com.keepit.common.commanders.{ LDAInfoCommander, LDACommander }
+import com.keepit.common.commanders.{ LDARepresenterCommander, LDAInfoCommander, LDACommander }
 import com.keepit.cortex.features.Document
 import com.keepit.cortex.utils.TextUtils
 import com.keepit.cortex.models.lda.{ LDAUserURIInterestScores, LDATopicConfiguration, LDATopicInfo }
@@ -14,6 +14,7 @@ import com.keepit.common.db.Id
 
 class LDAController @Inject() (
   lda: LDACommander,
+  representer: LDARepresenterCommander,
   infoCommander: LDAInfoCommander)
     extends CortexServiceController with Logging {
 
@@ -33,7 +34,7 @@ class LDAController @Inject() (
   }
 
   def wordTopic(word: String) = Action { request =>
-    val res = lda.wordTopic(word)
+    val res = representer.wordTopic(word)
     Ok(Json.toJson(res))
   }
 
@@ -41,7 +42,7 @@ class LDAController @Inject() (
     val js = request.body
     val doc = (js \ "doc").as[String]
     val wrappedDoc = Document(TextUtils.TextTokenizer.LowerCaseTokenizer.tokenize(doc))
-    val res = lda.docTopic(wrappedDoc)
+    val res = representer.docTopic(wrappedDoc)
     Ok(Json.toJson(res))
   }
 

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/package.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/package.scala
@@ -8,9 +8,15 @@ package object cortex {
 
   val S3_CORTEX_BUCKET = "amazon.s3.cortex.bucket"
 
+  // version of feature representers/updaters
   object ModelVersions {
     val denseLDAVersion = ModelVersion[DenseLDA](2)
     val word2vecVersion = ModelVersion[Word2Vec](2)
+  }
+
+  // version available for consumer/admin, i.e. services outside cortex
+  object PublishingVersions {
+    val denseLDAVersion = ModelVersion[DenseLDA](2)
   }
 
   object ModelStorePrefix {
@@ -49,11 +55,6 @@ package object cortex {
       val stopwordsFoler = "misc/stopwords/"
       val stopwordsJsonFile = "stopwords"
     }
-  }
-
-  object PublishedModels {
-    val denseLDAVersion = ModelVersion[DenseLDA](2) // doesn't have to sync with cortex lda version
-    val defaultSparsity = 2
   }
 
 }


### PR DESCRIPTION
@stkem 

I initially wanted to have a more flexible control, e.g. view topic words of different versions. Turns out it's far more complicated than I thought. For example, in the admin LDA page, we can query word's topic and doc topic, but this can only be done for "the active" model. (unless we load several possible models together into memory). Things like user/uri interest score, lda configurations, etc, also significantly adds complexity. 

What's in this PR:
- In `LDACommander` and `LDAInfoCommander`, the ldaVersion is not from injected `wordRepresenter`. It's 'hard coded' to the PublishingLDAVersion. (Decouple of the retrieval version and updating version)
- take `wordRep` and `docRep` out of LDACommander, mainly because they could have different underlying versions than other components in the `LDACommander`. Put them in the same context can be confusing. They now form a `RepresenterCommander`, used for admin only. 
- some clean up/ code reordering. No actual logic change. 
