### PR TITLE
factor out AdminUserActions

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
@@ -7,11 +7,10 @@ import com.keepit.common.core._
 import com.keepit.common.net.URI
 import com.keepit.model.{ SocialUserInfo, ExperimentType, KifiInstallation, User }
 import play.api.Play
-import play.api.http.ContentTypes
 import play.api.mvc._
 
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import securesocial.core.{ UserService, SecureSocial, Identity }
+import securesocial.core.Identity
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 
@@ -140,7 +139,7 @@ trait UserActions extends Logging { self: Controller =>
     resF.map(maybeAugmentCORS(_))
   }
 
-  private def PageAction[P[_]] = new ActionFunction[P, P] {
+  protected def PageAction[P[_]] = new ActionFunction[P, P] {
     def invokeBlock[A](request: P[A], block: (P[A]) => Future[Result]): Future[Result] = {
       block(request) // todo(ray): handle error with redirects
     }
@@ -167,6 +166,10 @@ trait UserActions extends Logging { self: Controller =>
     }
   }
   val MaybeUserPage = (MaybeUserAction andThen PageAction)
+
+}
+
+trait AdminUserActions extends UserActions with ShoeboxServiceController {
 
   private object AdminCheck extends ActionFilter[UserRequest] {
     protected def filter[A](request: UserRequest[A]): Future[Option[Result]] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminAuthController.scala
@@ -12,13 +12,12 @@ import com.keepit.common.mail.{ SystemEmailAddress, ElectronicMail }
 import com.keepit.common.healthcheck.SystemAdminMailSender
 
 class AdminAuthController @Inject() (
-  actionAuthenticator: ActionAuthenticator,
   val userActionsHelper: UserActionsHelper,
   db: Database,
   userRepo: UserRepo,
   systemAdminMailSender: SystemAdminMailSender,
   impersonateCookie: ImpersonateCookie)
-    extends UserActions with ShoeboxServiceController {
+    extends AdminUserActions {
 
   def unimpersonate = AdminUserAction { request =>
     Ok(Json.obj("userId" -> request.userId.toString)).discardingCookies(impersonateCookie.discard)

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/TypeaheadAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/TypeaheadAdminController.scala
@@ -3,7 +3,7 @@ package com.keepit.controllers.admin
 import com.google.inject.Inject
 import com.keepit.common.db.slick.Database
 import com.keepit.typeahead.socialusers.{ KifiUserTypeahead, SocialUserTypeahead }
-import com.keepit.common.controller.{ UserActions, UserActionsHelper, ShoeboxServiceController }
+import com.keepit.common.controller.{ AdminUserActions, UserActionsHelper }
 import com.keepit.model._
 import com.keepit.common.db.Id
 import com.keepit.typeahead.TypeaheadHit
@@ -20,7 +20,7 @@ class TypeaheadAdminController @Inject() (
     abookServiceClient: ABookServiceClient,
     typeaheadCommander: TypeaheadCommander,
     kifiUserTypeahead: KifiUserTypeahead,
-    socialUserTypeahead: SocialUserTypeahead) extends UserActions with ShoeboxServiceController {
+    socialUserTypeahead: SocialUserTypeahead) extends AdminUserActions {
 
   implicit val fj = ExecutionContext.fj
 


### PR DESCRIPTION
Factored out `AdminUserActions` to make `UserActions` a bit more light weight, and to facilitate migration from old framework

@andrewconner 
