### PR TITLE
changing create library route to POST /ext/libraries

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -38,7 +38,7 @@ class ExtLibraryController @Inject() (
     Ok(Json.obj("libraries" -> datas))
   }
 
-  def addLibrary = JsonAction.authenticatedParseJson { request =>
+  def createLibrary = JsonAction.authenticatedParseJson { request =>
     val body = request.body.as[JsObject]
     val name = (body \ "name").as[String]
     val visibility = (body \ "visibility").as[LibraryVisibility]

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -119,7 +119,7 @@ POST    /ext/contacts/hide          @com.keepit.controllers.ext.ExtNonUserSearch
 POST    /ext/invite                 @com.keepit.controllers.ext.ExtInviteController.invite()
 
 GET     /ext/libraries              @com.keepit.controllers.ext.ExtLibraryController.getLibraries()
-POST    /ext/libraries/add          @com.keepit.controllers.ext.ExtLibraryController.addLibrary()
+POST    /ext/libraries              @com.keepit.controllers.ext.ExtLibraryController.createLibrary()
 POST    /ext/libraries/:id/keeps    @com.keepit.controllers.ext.ExtLibraryController.addKeep(id: PublicId[Library])
 GET     /ext/libraries/:id/keeps/:k @com.keepit.controllers.ext.ExtLibraryController.getKeep(id: PublicId[Library], k: ExternalId[Keep])
 DELETE  /ext/libraries/:id/keeps/:k @com.keepit.controllers.ext.ExtLibraryController.removeKeep(id: PublicId[Library], k: ExternalId[Keep])


### PR DESCRIPTION
@ahsu1230 

This is the dominant convention for creating a resource when PUT is not applicable. That is, the resource is not fully defined by the request (e.g. ID will be server generated). To verify this, you can search the web for “REST conventions”, visit any of the top results, and then search the page for “creat”.
