### PR TITLE
removing userScoreCache usage from Graph (no cache hits)

### DIFF
--- a/kifi-backend/modules/graph/app/com/keepit/graph/commanders/GraphCommander.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/commanders/GraphCommander.scala
@@ -38,8 +38,6 @@ class GraphCommander @Inject() (
     val urisList = getUriScoreList(startingVertexId, journal, avoidFirstDegreeConnection)
     val usersList = getUsersScoreList(startingVertexId, journal, avoidFirstDegreeConnection)
     uriScoreCache.set(ConnectedUriScoreCacheKey(userId, avoidFirstDegreeConnection), urisList)
-    userScoreCache.set(ConnectedUserScoreCacheKey(userId, avoidFirstDegreeConnection), usersList)
-    log.error(s"Cache Set on UserScoreCache Set ($userId, $avoidFirstDegreeConnection)")
     (urisList, usersList)
   }
 
@@ -57,19 +55,9 @@ class GraphCommander @Inject() (
   }
 
   def getConnectedUserScores(userId: Id[User], avoidFirstDegreeConnections: Boolean): Future[Seq[ConnectedUserScore]] = {
-    val result = userScoreCache.get(ConnectedUserScoreCacheKey(userId, avoidFirstDegreeConnections))
-    result match {
-      case None => {
-        log.error(s"Cache Miss on UserScoreCache miss on ($userId, $avoidFirstDegreeConnections)")
-        val wanderLust = Wanderlust.discovery(userId)
-        wanderingCommander.wander(wanderLust).map { journal =>
-          updateScoreCaches(userId, journal.getStartingVertex, journal, avoidFirstDegreeConnections)._2
-        }
-      }
-      case Some(data) => {
-        log.error(s"Cache Hit on UserScoreCache ($userId, $avoidFirstDegreeConnections)")
-        Future.successful(data)
-      }
+    val wanderLust = Wanderlust.discovery(userId)
+    wanderingCommander.wander(wanderLust).map { journal =>
+      updateScoreCaches(userId, journal.getStartingVertex, journal, avoidFirstDegreeConnections)._2
     }
   }
 

--- a/kifi-backend/modules/graph/app/com/keepit/graph/commanders/GraphCommander.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/commanders/GraphCommander.scala
@@ -38,19 +38,14 @@ class GraphCommander @Inject() (
     val urisList = getUriScoreList(startingVertexId, journal, avoidFirstDegreeConnection)
     val usersList = getUsersScoreList(startingVertexId, journal, avoidFirstDegreeConnection)
     uriScoreCache.set(ConnectedUriScoreCacheKey(userId, avoidFirstDegreeConnection), urisList)
+    userScoreCache.set(ConnectedUserScoreCacheKey(userId, avoidFirstDegreeConnection), usersList)
     (urisList, usersList)
   }
 
   def getConnectedUriScores(userId: Id[User], avoidFirstDegreeConnections: Boolean): Future[Seq[ConnectedUriScore]] = {
-    val result = uriScoreCache.get(ConnectedUriScoreCacheKey(userId, avoidFirstDegreeConnections))
-    result match {
-      case None => {
-        val wanderLust = Wanderlust.discovery(userId)
-        wanderingCommander.wander(wanderLust).map { journal =>
-          updateScoreCaches(userId, journal.getStartingVertex, journal, avoidFirstDegreeConnections)._1
-        }
-      }
-      case Some(data) => Future.successful(data)
+    val wanderLust = Wanderlust.discovery(userId)
+    wanderingCommander.wander(wanderLust).map { journal =>
+      updateScoreCaches(userId, journal.getStartingVertex, journal, avoidFirstDegreeConnections)._1
     }
   }
 


### PR DESCRIPTION
report has been showing up as 100% cache misses on GRAPH for `user_connection_score`.
But really, this is probably a reporting error on GRAPH's side.

@yingjieMiao found that even though there are no cache hits on GRAPH, there are `user_connection_score` usages in CURATOR (which only has a 5% miss). When CURATOR can't find the user score it wants in the cache, it will call a method from GRAPH to retrieve that info.
However, currently in GRAPH, it checks the `user_connection_score` cache (which doesn't have it anyway) and will always cause cache misses and never hits.

So, it might be best to keep the cache reporting on CURATOR (who is really the only one using it anyway) and take the cache gets/sets out of GRAPH.

@yingjieMiao did I miss anything?
@eishay
