### PR TITLE
Utility function to show/hide a recommendations score breakdown

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/recos/recoDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recoDecoratorService.js
@@ -9,7 +9,8 @@ angular.module('kifi')
       this.recoData = {
         type: type,
         kind: rawReco.kind,
-        reasons: rawReco.metaData || []
+        reasons: rawReco.metaData || [],
+        explain: rawReco.explain
       };
 
       this.recoData.reasons.forEach(function (reason) {

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.js
@@ -91,6 +91,12 @@ angular.module('kifi')
       $scope.initialCardClosed = true;
     };
 
+
+    /*
+    This is intended be called from the console only, for debugging.
+    Specifically, running `$(".recos-view").scope().toggleExplain(); $(".recos-view").scope().$digest();`
+    in the bowser console while on the recommendations page will toggle between showing the page description and the score breakdown in the card.
+    */
     $scope.toggleExplain = function () {
       $scope.recos.forEach(function (reco) {
         var temp = reco.recoKeep.summary.description;

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.js
@@ -21,7 +21,7 @@ angular.module('kifi')
 
     $scope.getMore = function (opt_recency) {
       $scope.loading = true;
-     
+
       recoStateService.empty();
       recoActionService.getMore(opt_recency).then(function (rawRecos) {
         if (rawRecos.length > 0) {
@@ -42,7 +42,7 @@ angular.module('kifi')
 
     $scope.trash = function (reco) {
       recoActionService.trash(reco.recoKeep);
-      
+
       var trashedRecoIndex = _.findIndex($scope.recos, reco);
       var trashedReco = $scope.recos.splice(trashedRecoIndex, 1)[0];
 
@@ -89,6 +89,14 @@ angular.module('kifi')
 
     $scope.closeInitialCard = function () {
       $scope.initialCardClosed = true;
+    };
+
+    $scope.toggleExplain = function () {
+      $scope.recos.forEach(function (reco) {
+        var temp = reco.recoKeep.summary.description;
+        reco.recoKeep.summary.description = reco.recoData.explain;
+        reco.recoData.explain = temp;
+      });
     };
 
     // Load a new set of recommendations only on page refresh.


### PR DESCRIPTION
to be called from the console only for debugging
(specifically, running `$(".recos-view").scope().toggleExplain(); $(".recos-view").scope().$digest();` in the bowser console while on the recommendations page will toggle between showing the page description and the score breakdown in the card)

@yipingliao @yingjieMiao 
