### PR TITLE
experimental optimization w.r.t. article search

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/engine/DebugOption.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/DebugOption.scala
@@ -18,9 +18,9 @@ object DebugOption {
     def unapply(str: String): Boolean = (str == "library")
   }
 
-  object Timing {
+  object DirectPath {
     val flag = 0x00000004
-    def unapply(str: String): Boolean = (str == "timing")
+    def unapply(str: String): Boolean = (str == "directPath")
   }
 
   object AsNonUser {
@@ -55,8 +55,8 @@ trait DebugOption { self: Logging =>
           flags | Trace.flag
         case Library() =>
           flags | Library.flag
-        case Timing() =>
-          flags | Timing.flag
+        case DirectPath() =>
+          flags | DirectPath.flag
         case AsNonUser() =>
           flags | AsNonUser.flag
         case Log(address, port) =>

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/KifiSearchImpl.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/KifiSearchImpl.scala
@@ -59,6 +59,7 @@ class KifiSearchImpl(
     if (debugFlags != 0) {
       engine.debug(this)
       keepScoreSource.debug(this)
+      articleScoreSource.debug(this)
     }
 
     engine.execute(collector, keepScoreSource, articleScoreSource)

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/ScoreContext.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/ScoreContext.scala
@@ -69,9 +69,11 @@ class ScoreContext(
     if (visibility != Visibility.RESTRICTED) collector.collect(this)
   }
 
-  // for testing only
-  private[engine] def addScore(idx: Int, scr: Float, theVisibility: Int = Visibility.OTHERS) = {
+  private[engine] def addVisibility(theVisibility: Int) = {
     visibility = visibility | theVisibility
+  }
+
+  private[engine] def addScore(idx: Int, scr: Float) = {
     if (scoreMax(idx) < scr) scoreMax(idx) = scr
     scoreSum(idx) += scr
   }

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/ScoreVectorSource.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/ScoreVectorSource.scala
@@ -10,7 +10,7 @@ import com.keepit.search.graph.keep.KeepFields
 import com.keepit.search.index.{ IdMapper, WrappedSubReader }
 import com.keepit.search.query.{ RecencyScorer, RecencyQuery }
 import com.keepit.search.util.LongArraySet
-import com.keepit.search.util.join.{ DataBuffer, DataBufferWriter }
+import com.keepit.search.util.join.{ BloomFilter, DataBuffer, DataBufferWriter }
 import org.apache.lucene.index.{ NumericDocValues, Term, AtomicReaderContext }
 import org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS
 import org.apache.lucene.search.{ MatchAllDocsQuery, Query, Weight, Scorer }
@@ -22,7 +22,7 @@ import scala.concurrent.duration._
 
 trait ScoreVectorSource {
   def createWeights(query: Query): IndexedSeq[(Weight, Float)]
-  def execute(weights: IndexedSeq[(Weight, Float)], coreSize: Int, dataBuffer: DataBuffer): Unit
+  def execute(weights: IndexedSeq[(Weight, Float)], coreSize: Int, dataBuffer: DataBuffer, directScoreContext: ScoreContext): Unit
 }
 
 trait ScoreVectorSourceLike extends ScoreVectorSource with Logging with DebugOption {
@@ -35,7 +35,7 @@ trait ScoreVectorSourceLike extends ScoreVectorSource with Logging with DebugOpt
     weights
   }
 
-  def execute(weights: IndexedSeq[(Weight, Float)], coreSize: Int, dataBuffer: DataBuffer): Unit = {
+  def execute(weights: IndexedSeq[(Weight, Float)], coreSize: Int, dataBuffer: DataBuffer, directScoreContext: ScoreContext): Unit = {
     val scorers = new Array[Scorer](weights.size)
     indexReaderContexts.foreach { readerContext =>
       var i = 0
@@ -43,7 +43,7 @@ trait ScoreVectorSourceLike extends ScoreVectorSource with Logging with DebugOpt
         scorers(i) = weights(i)._1.scorer(readerContext, true, false, readerContext.reader.getLiveDocs)
         i += 1
       }
-      writeScoreVectors(readerContext, scorers, coreSize, dataBuffer)
+      writeScoreVectors(readerContext, scorers, coreSize, dataBuffer, directScoreContext)
     }
   }
 
@@ -51,7 +51,7 @@ trait ScoreVectorSourceLike extends ScoreVectorSource with Logging with DebugOpt
 
   protected def indexReaderContexts: Seq[AtomicReaderContext] = { searcher.indexReader.getContext.leaves }
 
-  protected def writeScoreVectors(readerContext: AtomicReaderContext, scorers: Array[Scorer], coreSize: Int, output: DataBuffer)
+  protected def writeScoreVectors(readerContext: AtomicReaderContext, scorers: Array[Scorer], coreSize: Int, output: DataBuffer, directScoreContext: ScoreContext)
 
   protected def createScorerQueue(scorers: Array[Scorer], coreSize: Int): TaggedScorerQueue = {
     val pq = new TaggedScorerQueue(coreSize)
@@ -184,12 +184,18 @@ trait VisibilityEvaluator { self: ScoreVectorSourceLike =>
 
 class UriFromArticlesScoreVectorSource(protected val searcher: Searcher, filter: SearchFilter) extends ScoreVectorSourceLike {
 
-  protected def writeScoreVectors(readerContext: AtomicReaderContext, scorers: Array[Scorer], coreSize: Int, output: DataBuffer): Unit = {
+  protected def writeScoreVectors(readerContext: AtomicReaderContext, scorers: Array[Scorer], coreSize: Int, output: DataBuffer, directScoreContext: ScoreContext): Unit = {
     val reader = readerContext.reader.asInstanceOf[WrappedSubReader]
     val idFilter = filter.idFilter
 
     val pq = createScorerQueue(scorers, coreSize)
     if (pq.size <= 0) return // no scorer
+
+    val bloomFilter = if ((debugFlags & DebugOption.DirectPath.flag) != 0) {
+      BloomFilter(output) // a bloom filter which test if a uri id is in the buffer
+    } else {
+      BloomFilter.full // this disables the direct path.
+    }
 
     val articleVisibility = ArticleVisibility(reader)
 
@@ -198,6 +204,7 @@ class UriFromArticlesScoreVectorSource(protected val searcher: Searcher, filter:
 
     val taggedScores = pq.createScoreArray // tagged floats
 
+    var directWriteCount = 0
     var docId = pq.top.doc
     while (docId < NO_MORE_DOCS) {
       val uriId = idMapper.getId(docId)
@@ -208,10 +215,25 @@ class UriFromArticlesScoreVectorSource(protected val searcher: Searcher, filter:
           // get all scores
           val size = pq.getTaggedScores(taggedScores)
 
-          // write to the buffer
-          output.alloc(writer, Visibility.OTHERS, 8 + size * 4) // id (8 bytes) and taggedFloats (size * 4 bytes)
-          writer.putLong(uriId).putTaggedFloatBits(taggedScores, size)
-
+          if (bloomFilter(uriId)) {
+            // write to the buffer
+            output.alloc(writer, Visibility.OTHERS, 8 + size * 4) // id (8 bytes) and taggedFloats (size * 4 bytes)
+            writer.putLong(uriId).putTaggedFloatBits(taggedScores, size)
+          } else {
+            // this uriId is not in the buffer
+            // it is safe to bypass the buffering and joining (assuming all score vector sources other than this are executed already)
+            // write directly to the collector through directScoreContext
+            directScoreContext.set(uriId)
+            directScoreContext.addVisibility(Visibility.OTHERS)
+            var i = 0
+            while (i < size) {
+              val bits = taggedScores(i)
+              directScoreContext.addScore(DataBuffer.getTaggedFloatTag(bits), DataBuffer.getTaggedFloatValue(bits))
+              i += 1
+            }
+            directScoreContext.flush()
+            directWriteCount += 1
+          }
           docId = pq.top.doc // next doc
         } else {
           docId = pq.skipCurrentDoc() // skip this doc
@@ -220,6 +242,7 @@ class UriFromArticlesScoreVectorSource(protected val searcher: Searcher, filter:
         docId = pq.skipCurrentDoc() // skip this doc
       }
     }
+    debugLog(s"direct write count=$directWriteCount")
   }
 }
 
@@ -238,7 +261,7 @@ class UriFromKeepsScoreVectorSource(
   private[this] var authorizedLibraryKeepCount = 0
   private[this] var discoverableKeepCount = 0
 
-  protected def writeScoreVectors(readerContext: AtomicReaderContext, scorers: Array[Scorer], coreSize: Int, output: DataBuffer): Unit = {
+  protected def writeScoreVectors(readerContext: AtomicReaderContext, scorers: Array[Scorer], coreSize: Int, output: DataBuffer, directScoreContext: ScoreContext): Unit = {
     val reader = readerContext.reader.asInstanceOf[WrappedSubReader]
     val idFilter = filter.idFilter
 
@@ -373,7 +396,7 @@ class LibraryScoreVectorSource(
     protected val config: SearchConfig,
     protected val monitoredAwait: MonitoredAwait) extends ScoreVectorSourceLike with VisibilityEvaluator {
 
-  protected def writeScoreVectors(readerContext: AtomicReaderContext, scorers: Array[Scorer], coreSize: Int, output: DataBuffer): Unit = {
+  protected def writeScoreVectors(readerContext: AtomicReaderContext, scorers: Array[Scorer], coreSize: Int, output: DataBuffer, directScoreContext: ScoreContext): Unit = {
     val reader = readerContext.reader.asInstanceOf[WrappedSubReader]
     val idFilter = filter.idFilter
 
@@ -423,7 +446,7 @@ class LibraryFromKeepsScoreVectorSource(
     protected val config: SearchConfig,
     protected val monitoredAwait: MonitoredAwait) extends ScoreVectorSourceLike with KeepRecencyEvaluator with VisibilityEvaluator {
 
-  protected def writeScoreVectors(readerContext: AtomicReaderContext, scorers: Array[Scorer], coreSize: Int, output: DataBuffer): Unit = {
+  protected def writeScoreVectors(readerContext: AtomicReaderContext, scorers: Array[Scorer], coreSize: Int, output: DataBuffer, directScoreContext: ScoreContext): Unit = {
     val reader = readerContext.reader.asInstanceOf[WrappedSubReader]
     val idFilter = filter.idFilter
 

--- a/kifi-backend/modules/search/app/com/keepit/search/util/join/BloomFilter.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/util/join/BloomFilter.scala
@@ -1,0 +1,35 @@
+package com.keepit.search.util.join
+
+object BloomFilter {
+  private[this] val ITEMS_PER_ENTRY = 2
+  def apply(dataBuffer: DataBuffer): BloomFilter = {
+    val bitMaps = new Array[Int]((dataBuffer.size + ITEMS_PER_ENTRY - 1) / ITEMS_PER_ENTRY) // 4 items per array entry, each array entry is a bloom filter
+    dataBuffer.scan(new DataBufferReader) { reader =>
+      val id = reader.nextLong()
+      bitMaps((id % bitMaps.length).toInt) |= genBits(id)
+    }
+    new BloomFilter(bitMaps)
+  }
+
+  val full: BloomFilter = new BloomFilter(null) {
+    override def apply(id: Long): Boolean = true
+  }
+
+  private[join] def genBits(id: Long): Int = {
+    // unlike conventional BloomFilter, the number of bits turned on is not fixed
+    // it is expected that the average number of bits on is close to 8 bits (1/4 of 32 bits)
+    // this makes computation very fast
+    // this increases the false positive ratio a little, though
+    val v1 = (id * 0x5DEECE66DL + 0x123456789L)
+    val v2 = (v1 * 0x5DEECE66DL + 0x123456789L)
+
+    ((v1 & v2) >> 16).toInt
+  }
+}
+
+class BloomFilter(bitMaps: Array[Int]) {
+  def apply(id: Long): Boolean = {
+    val bits = BloomFilter.genBits(id)
+    (bits & bitMaps((id % bitMaps.length).toInt)) == bits
+  }
+}

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/DebugOptionTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/DebugOptionTest.scala
@@ -21,9 +21,9 @@ class DebugOptionTest extends Specification {
       ids.get === Set(1L, 100L, 1000L)
     }
 
-    "parse timing" in {
-      val res = "timing" match {
-        case Timing() => true
+    "parse library" in {
+      val res = "library" match {
+        case Library() => true
         case _ => false
       }
 

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/QueryEngineTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/QueryEngineTest.scala
@@ -17,7 +17,7 @@ class QueryEngineTest extends Specification {
 
     protected val searcher: Searcher = indexer.getSearcher
 
-    protected def writeScoreVectors(readerContext: AtomicReaderContext, scorers: Array[Scorer], coreSize: Int, output: DataBuffer): Unit = {
+    protected def writeScoreVectors(readerContext: AtomicReaderContext, scorers: Array[Scorer], coreSize: Int, output: DataBuffer, directScoreContext: ScoreContext): Unit = {
       val reader = readerContext.reader.asInstanceOf[WrappedSubReader]
 
       val pq = createScorerQueue(scorers, coreSize)

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/ScoreExprTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/ScoreExprTest.scala
@@ -43,6 +43,7 @@ class ScoreExprTest extends Specification {
       val idx = rnd.nextInt(size)
       val ctx = mkCtx(NullExpr, idx)
       ctx.set(100L)
+      ctx.addVisibility(Visibility.OWNER)
       for (i <- 0 until size) ctx.addScore(i, 1.0f)
       ctx.flush
       collector.id === -1L
@@ -53,6 +54,7 @@ class ScoreExprTest extends Specification {
       val idx = rnd.nextInt(size)
       val ctx = mkCtx(MaxExpr(idx), idx)
       ctx.set(200L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx, 1.0f)
       ctx.addScore(idx, 2.0f)
       ctx.flush
@@ -64,6 +66,7 @@ class ScoreExprTest extends Specification {
       val idx = rnd.nextInt(size)
       val ctx = mkCtx(SumExpr(idx), idx)
       ctx.set(200L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx, 1.0f)
       ctx.addScore(idx, 2.0f)
       ctx.flush
@@ -75,6 +78,7 @@ class ScoreExprTest extends Specification {
       val idx = rnd.nextInt(size)
       val ctx = mkCtx(MaxWithTieBreakerExpr(idx, 0.2f), idx)
       ctx.set(300L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx, 2.0f)
       ctx.addScore(idx, 3.0f)
       ctx.flush
@@ -84,6 +88,7 @@ class ScoreExprTest extends Specification {
       val referenceScore = collector.score
 
       ctx.set(301L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx, 1.0f)
       ctx.addScore(idx, 2.0f)
       ctx.addScore(idx, 3.0f)
@@ -99,6 +104,7 @@ class ScoreExprTest extends Specification {
 
       val ctx = mkCtx(DisjunctiveSumExpr(Seq(MaxExpr(idx1(0)), MaxExpr(idx1(1)), MaxExpr(idx1(2)))), idx1: _*)
       ctx.set(400L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1(0), 1.0f)
       ctx.addScore(idx1(1), 2.0f)
       ctx.addScore(idx1(2), 3.0f)
@@ -107,6 +113,7 @@ class ScoreExprTest extends Specification {
       collector.score === 6.0f
 
       ctx.set(401L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1(0), 1.0f)
       ctx.addScore(idx1(1), 2.0f)
       ctx.addScore(idx2(0), 3.0f)
@@ -122,6 +129,7 @@ class ScoreExprTest extends Specification {
 
       val ctx = mkCtx(ConjunctiveSumExpr(Seq(MaxExpr(idx1(0)), MaxExpr(idx1(1)), MaxExpr(idx1(2)))), idx1: _*)
       ctx.set(500L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1(0), 1.0f)
       ctx.addScore(idx1(1), 2.0f)
       ctx.addScore(idx1(2), 3.0f)
@@ -131,6 +139,7 @@ class ScoreExprTest extends Specification {
 
       collector.clear()
       ctx.set(501L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1(0), 1.0f)
       ctx.addScore(idx1(1), 2.0f)
       ctx.addScore(idx2(0), 3.0f)
@@ -146,6 +155,7 @@ class ScoreExprTest extends Specification {
 
       val ctx = mkCtx(ExistsExpr(Seq(MaxExpr(idx1(0)), MaxExpr(idx1(1)), MaxExpr(idx1(2)))), idx1: _*)
       ctx.set(600L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1(0), 2.0f)
       ctx.addScore(idx1(1), 3.0f)
       ctx.addScore(idx1(2), 4.0f)
@@ -154,6 +164,7 @@ class ScoreExprTest extends Specification {
       collector.score === 1.0f
 
       ctx.set(601L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1(0), 2.0f)
       ctx.addScore(idx1(1), 3.0f)
       ctx.flush
@@ -161,6 +172,7 @@ class ScoreExprTest extends Specification {
       collector.score === 1.0f
 
       ctx.set(602L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1(0), 2.0f)
       ctx.flush
       collector.id === 602L
@@ -168,6 +180,7 @@ class ScoreExprTest extends Specification {
 
       collector.clear()
       ctx.set(603L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx2(0), 1.0f)
       ctx.addScore(idx2(1), 2.0f)
       ctx.flush
@@ -182,6 +195,7 @@ class ScoreExprTest extends Specification {
 
       val ctx = mkCtx(ForAllExpr(Seq(MaxExpr(idx1(0)), MaxExpr(idx1(1)), MaxExpr(idx1(2)))), idx1: _*)
       ctx.set(700L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1(0), 2.0f)
       ctx.addScore(idx1(1), 3.0f)
       ctx.addScore(idx1(2), 4.0f)
@@ -191,6 +205,7 @@ class ScoreExprTest extends Specification {
 
       collector.clear()
       ctx.set(701L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1(0), 2.0f)
       ctx.addScore(idx1(1), 3.0f)
       ctx.addScore(idx2(0), 5.0f)
@@ -208,6 +223,7 @@ class ScoreExprTest extends Specification {
 
       val ctx = mkCtx(BooleanExpr(optional = MaxExpr(idx1), required = MaxExpr(idx2)), idx1, idx2)
       ctx.set(800L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1, 2.0f)
       ctx.addScore(idx2, 3.0f)
       ctx.addScore(idx3, 4.0f)
@@ -217,6 +233,7 @@ class ScoreExprTest extends Specification {
 
       collector.clear()
       ctx.set(801L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1, 2.0f)
       ctx.addScore(idx3, 4.0f)
       ctx.flush
@@ -225,6 +242,7 @@ class ScoreExprTest extends Specification {
 
       collector.clear()
       ctx.set(802L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx2, 3.0f)
       ctx.addScore(idx3, 4.0f)
       ctx.flush
@@ -240,6 +258,7 @@ class ScoreExprTest extends Specification {
 
       val ctx = mkCtx(FilterExpr(expr = MaxExpr(idx1), filter = MaxExpr(idx2)), idx1)
       ctx.set(900L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1, 2.0f)
       ctx.addScore(idx2, 3.0f)
       ctx.addScore(idx3, 4.0f)
@@ -249,6 +268,7 @@ class ScoreExprTest extends Specification {
 
       collector.clear()
       ctx.set(901L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1, 2.0f)
       ctx.addScore(idx3, 4.0f)
       ctx.flush
@@ -257,6 +277,7 @@ class ScoreExprTest extends Specification {
 
       collector.clear()
       ctx.set(902L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx2, 3.0f)
       ctx.addScore(idx3, 4.0f)
       ctx.flush
@@ -272,6 +293,7 @@ class ScoreExprTest extends Specification {
 
       val ctx = mkCtx(FilterOutExpr(expr = MaxExpr(idx1), filter = MaxExpr(idx2)), idx1)
       ctx.set(1000L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1, 2.0f)
       ctx.addScore(idx2, 3.0f)
       ctx.addScore(idx3, 4.0f)
@@ -281,6 +303,7 @@ class ScoreExprTest extends Specification {
 
       collector.clear()
       ctx.set(1001L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx1, 2.0f)
       ctx.addScore(idx3, 4.0f)
       ctx.flush
@@ -289,6 +312,7 @@ class ScoreExprTest extends Specification {
 
       collector.clear()
       ctx.set(1002L)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(idx2, 3.0f)
       ctx.addScore(idx3, 4.0f)
       ctx.flush

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/result/KifiResultCollectorTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/result/KifiResultCollectorTest.scala
@@ -22,14 +22,14 @@ class KifiResultCollectorTest extends Specification {
       val ctx = new ScoreContext(expr, exprSize, Array(0.3f, 0.3f, 0.4f), collector)
 
       ctx.set(10)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(1, 1.0f)
-      ctx.visibility = Visibility.OWNER
       ctx.flush()
 
       ctx.set(20)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(1, 1.0f)
       ctx.addScore(2, 1.0f)
-      ctx.visibility = Visibility.OWNER
       ctx.flush()
 
       val (mHits, fHits, oHits) = collector.getResults()
@@ -50,24 +50,24 @@ class KifiResultCollectorTest extends Specification {
       val ctx = new ScoreContext(expr, exprSize, Array(0.3f, 0.3f, 0.4f), collector)
 
       ctx.set(10)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(1, 1.0f)
-      ctx.visibility = Visibility.OWNER
       ctx.flush()
       ctx.set(20)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(0, 1.0f)
       ctx.addScore(1, 1.0f)
-      ctx.visibility = Visibility.OWNER
       ctx.flush()
       ctx.set(30)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(1, 1.0f)
       ctx.addScore(2, 1.0f)
-      ctx.visibility = Visibility.OWNER
       ctx.flush()
       ctx.set(40)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(0, 1.0f)
       ctx.addScore(1, 1.0f)
       ctx.addScore(2, 1.0f)
-      ctx.visibility = Visibility.OWNER
       ctx.flush()
 
       val (mHits, fHits, oHits) = collector.getResults()
@@ -86,18 +86,18 @@ class KifiResultCollectorTest extends Specification {
       val ctx = new ScoreContext(expr, exprSize, Array(0.3f, 0.3f, 0.4f), collector)
 
       ctx.set(10)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(1, 1.0f)
-      ctx.visibility = Visibility.OWNER
       ctx.flush()
       ctx.set(20)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(0, 1.0f)
       ctx.addScore(2, 1.0f)
-      ctx.visibility = Visibility.OWNER
       ctx.flush()
       ctx.set(30)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(1, 1.0f)
       ctx.addScore(2, 1.0f)
-      ctx.visibility = Visibility.OWNER
       ctx.flush()
 
       val (mHits, fHits, oHits) = collector.getResults()
@@ -118,24 +118,24 @@ class KifiResultCollectorTest extends Specification {
       val ctx = new ScoreContext(MaxExpr(0), 1, Array(1.0f), collector)
 
       ctx.set(1)
+      ctx.addVisibility(Visibility.RESTRICTED)
       ctx.addScore(0, 1.0f)
-      ctx.visibility = Visibility.RESTRICTED
       ctx.flush()
       ctx.set(10)
+      ctx.addVisibility(Visibility.OTHERS)
       ctx.addScore(0, 1.0f)
-      ctx.visibility = Visibility.OTHERS
       ctx.flush()
       ctx.set(20)
+      ctx.addVisibility(Visibility.NETWORK)
       ctx.addScore(0, 1.0f)
-      ctx.visibility = Visibility.NETWORK
       ctx.flush()
       ctx.set(30)
+      ctx.addVisibility(Visibility.MEMBER)
       ctx.addScore(0, 1.0f)
-      ctx.visibility = Visibility.MEMBER
       ctx.flush()
       ctx.set(40)
+      ctx.addVisibility(Visibility.OWNER)
       ctx.addScore(0, 1.0f)
-      ctx.visibility = Visibility.OWNER
       ctx.flush()
 
       val (mHits, fHits, oHits) = collector.getResults()
@@ -156,16 +156,16 @@ class KifiResultCollectorTest extends Specification {
       val ctx = new ScoreContext(MaxExpr(0), 1, Array(1.0f), collector)
 
       ctx.set(10)
+      ctx.addVisibility(Visibility.RESTRICTED)
       ctx.addScore(0, 1.0f)
-      ctx.visibility = Visibility.RESTRICTED
       ctx.flush()
       ctx.set(20)
+      ctx.addVisibility(Visibility.RESTRICTED)
       ctx.addScore(0, 1.0f)
-      ctx.visibility = Visibility.RESTRICTED
       ctx.flush()
       ctx.set(30)
+      ctx.addVisibility(Visibility.RESTRICTED)
       ctx.addScore(0, 1.0f)
-      ctx.visibility = Visibility.RESTRICTED
       ctx.flush()
 
       val (mHits, fHits, oHits) = collector.getResults()

--- a/kifi-backend/modules/search/test/com/keepit/search/util/join/BloomFilterTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/util/join/BloomFilterTest.scala
@@ -1,0 +1,35 @@
+package com.keepit.search.util.join
+
+import org.specs2.mutable._
+import scala.util.Random
+
+class BloomFilterTest extends Specification {
+  private[this] val rnd = new Random
+  private[this] val positiveIds = (0 until 1000).map { _ => rnd.nextInt(Int.MaxValue).toLong }.toSet
+  private[this] val negativeIds = {
+    var negativeSet = Set.empty[Long]
+    while (negativeSet.size < 1000) {
+      val id = rnd.nextInt(Int.MaxValue).toLong
+      if (!positiveIds.contains(id)) negativeSet += id
+    }
+    negativeSet
+  }
+
+  "BloomFilter" should {
+    "detect existence of ids with no false negative" in {
+      val buf = new DataBuffer()
+      val writer = new DataBufferWriter
+
+      positiveIds.foreach { id => buf.alloc(writer, 1, 8).putLong(id) }
+
+      val bloomFilter = BloomFilter(buf)
+
+      positiveIds.forall(bloomFilter(_)) === true
+
+      val falsePositiveCount = negativeIds.count(bloomFilter(_))
+      println(s"\n\t\t falsePositiveCount = $falsePositiveCount (${falsePositiveCount.toDouble / negativeIds.size.toDouble})\n")
+
+      (falsePositiveCount < negativeIds.size / 10) === true
+    }
+  }
+}


### PR DESCRIPTION
- an article hit is written to the buffer when its uri id is in the buffer already, otherwise the hit is directly passed to the result collector
  - this is determined by a variant of Bloom Filter, thus there are false positives
- the filter is experimental, and it is tuned for speed by sacrificing the precision a little
  - it uses only two hash functions to determine approximately 8 bit positions out of 32 bit position
  - the number of bit turned on varies per item
  - the deviation deteriorates the precision.

This should definitely improve memory usage. If the buffer read/write is a bottleneck, we will see a significant performance improvement, too. 

@leogrim @eishay 
