### PR TITLE
fix tag scrolling not working

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/tags/tags.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tags.tpl.html
@@ -1,4 +1,4 @@
-<div class="kf-tags" ng-if="!librariesEnabled">
+<div class="kf-tags" ng-show="!librariesEnabled">
   <div class="kf-nav-group-name">TAGS</div>
   <div class="kf-tag-input-box" ng-class="{'focused': isFilterFocused}">
     <a class="kf-tag-input-clear" href="javascript:" ng-click="clearFilter(true)" ng-show="filter.name">&times;</a>


### PR DESCRIPTION
tag list scrolling doesn't work for non-library experimenters
swap out ng-show for ng-if
For some reason

@yipingliao @andrewconner 
