### PR TITLE
stop gap to end "user_user_*" events in mix panel

### DIFF
--- a/kifi-backend/modules/heimdal/app/com/keepit/controllers/EventTrackingController.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/controllers/EventTrackingController.scala
@@ -33,7 +33,9 @@ class EventTrackingController @Inject() (
     case nonUserEvent: NonUserEvent => nonUserEventLoggingRepo.persist(nonUserEvent)
   }
 
-  private def handleUserEvent(userEvent: UserEvent) = {
+  private def handleUserEvent(rawUserEvent: UserEvent) = {
+    //Some user events are coming in from clients with the "user_" prefix already present. This is a stop gap to end fragmentation in mixpanel into user_* and user_user_*. Investigating to stop the cause.
+    val userEvent = if (rawUserEvent.eventType.name.startsWith("user_")) rawUserEvent.copy(eventType = EventType(rawUserEvent.eventType.name.substring(5))) else rawUserEvent
     SafeFuture { userEventLoggingRepo.persist(userEvent) }
     userEvent.eventType match {
       case UserEventTypes.RECOMMENDATION_USER_ACTION =>


### PR DESCRIPTION
some client `UserEvent`s are coming in with the "user_" prefix already there, leading to "user_user_*" events in mixpanel.
I think I may have caused this when I switched Kifi.com and the extension to proxy events through our servers instead of sending directly to mixpanel.
This is a hopefully temporary measure until I can patch the clients (it may have to stay for a bit until new versions are distributed)

@leogrim @joshm1 
