### PR TITLE
Change explainResult not to use the DistributedSearchRouter in SearchCli...

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -189,7 +189,7 @@ object Search extends Service {
     def searchKeeps(userId: Id[User], query: String) = ServiceRoute(POST, "/internal/search/search/keeps", Param("userId", userId), Param("query", query))
     def searchUsers() = ServiceRoute(POST, "/internal/search/search/users")
     def userTypeahead() = ServiceRoute(POST, "/internal/search/search/userTypeahead")
-    def explain(query: String, userId: Id[User], uriId: Id[NormalizedURI], lang: String) =
+    def explain(query: String, userId: Id[User], uriId: Id[NormalizedURI], lang: Option[String]) =
       ServiceRoute(GET, "/internal/search/search/explainResult", Param("query", query), Param("userId", userId), Param("uriId", uriId), Param("lang", lang))
     def correctSpelling(input: String, enableBoost: Boolean) = ServiceRoute(GET, "/internal/search/spell/suggest", Param("input", input), Param("enableBoost", enableBoost))
     def showUserConfig(id: Id[User]) = ServiceRoute(GET, s"/internal/search/searchConfig/${id.id}")

--- a/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClient.scala
@@ -202,8 +202,7 @@ class SearchServiceClientImpl(
   }
 
   def explainResult(query: String, userId: Id[User], uriId: Id[NormalizedURI], lang: String): Future[Html] = {
-    log.info("running explain in distributed mode")
-    distRouter.call(userId, uriId, Search.internal.explain(query, userId, uriId, lang)).map(r => Html(r.body))
+    call(Search.internal.explain(query, userId, uriId, Some(lang))).map(r => Html(r.body))
   }
 
   def dumpLuceneURIGraph(userId: Id[User]): Future[Html] = {

--- a/kifi-backend/modules/search/app/com/keepit/controllers/search/SearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/search/SearchController.scala
@@ -9,7 +9,7 @@ import com.keepit.search._
 import play.api.mvc.Action
 import views.html
 import com.keepit.model.User
-import scala.concurrent.Await
+import scala.concurrent.{ Future, Await }
 import scala.concurrent.duration._
 import play.api.libs.json._
 import com.keepit.search.sharding.ShardSpecParser
@@ -22,6 +22,8 @@ import com.keepit.search.user.UserSearchRequest
 import com.keepit.commanders.RemoteUserExperimentCommander
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import com.keepit.typeahead.PrefixFilter
+import com.keepit.common.routes.Search
+import play.api.templates.Html
 
 class SearchController @Inject() (
     searcherFactory: MainSearcherFactory,
@@ -30,6 +32,7 @@ class SearchController @Inject() (
     augmentationCommander: AugmentationCommander,
     languageCommander: LanguageCommander,
     librarySearchCommander: LibrarySearchCommander,
+    distributedSearchClient: DistributedSearchServiceClient,
     userExperimentCommander: RemoteUserExperimentCommander) extends SearchServiceController {
 
   def distSearch() = Action(parse.tolerantJson) { request =>
@@ -212,13 +215,11 @@ class SearchController @Inject() (
     Ok(Json.toJson(res))
   }
 
-  def explain(query: String, userId: Id[User], uriId: Id[NormalizedURI], lang: Option[String]) = Action { request =>
+  def explain(query: String, userId: Id[User], uriId: Id[NormalizedURI], lang: Option[String]) = Action.async { request =>
     val userExperiments = Await.result(userExperimentCommander.getExperimentsByUser(userId), 5 seconds)
-    searchCommander.explain(userId, uriId, lang, userExperiments, query) match {
-      case explanation if explanation.isDefined =>
-        Ok(html.admin.explainResult(query, userId, uriId, explanation))
-      case None =>
-        Ok("shard not found")
+    searchCommander.explain(userId, uriId, lang, userExperiments, query) flatMap {
+      case someExplanation if someExplanation.isDefined => Future.successful(Ok(html.admin.explainResult(query, userId, uriId, someExplanation)))
+      case None => distributedSearchClient.call(userId, uriId, Search.internal.explain(query, userId, uriId, lang), JsNull).map(r => Ok(r.body))
     }
   }
 

--- a/kifi-backend/modules/search/app/com/keepit/search/SearchCommander.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/SearchCommander.scala
@@ -83,7 +83,7 @@ trait SearchCommander {
     uriId: Id[NormalizedURI],
     lang: Option[String],
     experiments: Set[ExperimentType],
-    query: String): Option[(Query, Explanation)]
+    query: String): Future[Option[(Query, Explanation)]]
 
   def warmUp(userId: Id[User]): Unit
 }
@@ -421,18 +421,18 @@ class SearchCommanderImpl @Inject() (
     monitoredAwait.result(mainSearcherFactory.distLangFreqsFuture(shards, userId), 10 seconds, "slow getting lang profile")
   }
 
-  def explain(userId: Id[User], uriId: Id[NormalizedURI], lang: Option[String], experiments: Set[ExperimentType], query: String): Option[(Query, Explanation)] = {
-    val configFuture = mainSearcherFactory.getConfigFuture(userId, experiments)
-    val (config, _) = monitoredAwait.result(configFuture, 1 seconds, "getting search config")
+  def explain(userId: Id[User], uriId: Id[NormalizedURI], lang: Option[String], experiments: Set[ExperimentType], query: String): Future[Option[(Query, Explanation)]] = {
+    mainSearcherFactory.getConfigFuture(userId, experiments).map {
+      case (config, _) =>
+        val langs = lang match {
+          case Some(str) => str.split(",").toSeq.map(Lang(_))
+          case None => Seq(DefaultAnalyzer.defaultLang)
+        }
 
-    val langs = lang match {
-      case Some(str) => str.split(",").toSeq.map(Lang(_))
-      case None => Seq(DefaultAnalyzer.defaultLang)
-    }
-
-    shards.find(uriId).flatMap { shard =>
-      val searcher = mainSearcherFactory(shard, userId, query, langs(0), if (langs.size > 1) Some(langs(1)) else None, 0, SearchFilter.default(), config)
-      searcher.explain(uriId)
+        shards.find(uriId).flatMap { shard =>
+          val searcher = mainSearcherFactory(shard, userId, query, langs(0), if (langs.size > 1) Some(langs(1)) else None, 0, SearchFilter.default(), config)
+          searcher.explain(uriId)
+        }
     }
   }
 

--- a/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtSearchControllerTest.scala
@@ -224,6 +224,6 @@ class FixedResultSearchCommander extends SearchCommander {
   def distLangFreqs(shards: Set[Shard[NormalizedURI]], userId: Id[User]) = ???
   def distLangFreqs2(shards: Set[Shard[NormalizedURI]], userId: Id[User], libraryContext: LibraryContext) = ???
 
-  def explain(userId: Id[User], uriId: Id[NormalizedURI], lang: Option[String], experiments: Set[ExperimentType], query: String): Option[(Query, Explanation)] = ???
+  def explain(userId: Id[User], uriId: Id[NormalizedURI], lang: Option[String], experiments: Set[ExperimentType], query: String): Future[Option[(Query, Explanation)]] = ???
   def warmUp(userId: Id[User]): Unit = {}
 }

--- a/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
@@ -222,6 +222,6 @@ class FixedResultSearchCommander extends SearchCommander {
   def distLangFreqs(shards: Set[Shard[NormalizedURI]], userId: Id[User]) = ???
   def distLangFreqs2(shards: Set[Shard[NormalizedURI]], userId: Id[User], libraryContext: LibraryContext) = ???
 
-  def explain(userId: Id[User], uriId: Id[NormalizedURI], lang: Option[String], experiments: Set[ExperimentType], query: String): Option[(Query, Explanation)] = ???
+  def explain(userId: Id[User], uriId: Id[NormalizedURI], lang: Option[String], experiments: Set[ExperimentType], query: String): Future[Option[(Query, Explanation)]] = ???
   def warmUp(userId: Id[User]): Unit = {}
 }


### PR DESCRIPTION
...ent

@ymatsuda I guess in theory, there's a chance of a request bouncing indefinitely if for some reason the Commander keeps returning None (e.g the query cannot be parsed). Given that this method is tied to the old engine, is it worth worrying about this right now?
