### PR TITLE
Migrate DistributedSearchRouter from SearchServiceClient to DistributedS...

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClient.scala
@@ -11,7 +11,6 @@ import com.keepit.model.{ Collection, NormalizedURI, User }
 import com.keepit.search.user.UserSearchResult
 import com.keepit.search.user.UserSearchRequest
 import com.keepit.search.spellcheck.ScoredSuggest
-import com.keepit.search.sharding.{ DistributedSearchRouter }
 import play.api.libs.json._
 import play.twirl.api.Html
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -76,8 +75,6 @@ trait SearchServiceClient extends ServiceClient {
 
   def augmentation(request: ItemAugmentationRequest): Future[ItemAugmentationResponse]
 
-  //todo(Léo): move to DistributedSearchServiceClient once sharing user info has been migrated to the new augmentation logic
-  def distRouter: DistributedSearchRouter
   def call(instance: ServiceInstance, url: ServiceRoute, body: JsValue): Future[ClientResponse]
 }
 
@@ -89,12 +86,6 @@ class SearchServiceClientImpl(
 
   // request consolidation
   private[this] val consolidateSharingUserInfoReq = new RequestConsolidator[(Id[User], Id[NormalizedURI]), SharingUserInfo](ttl = 3 seconds)
-
-  lazy val distRouter = {
-    val router = new DistributedSearchRouter(this)
-    serviceCluster.setCustomRouter(Some(router))
-    router
-  }
 
   def warmUpUser(userId: Id[User]): Unit = {
     call(Search.internal.warmUpUser(userId))

--- a/kifi-backend/modules/search/app/com/keepit/search/DistributedSearchServiceClient.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/DistributedSearchServiceClient.scala
@@ -66,12 +66,15 @@ trait DistributedSearchServiceClient extends ServiceClient {
 }
 
 class DistributedSearchServiceClientImpl @Inject() (
-    searchClient: SearchServiceClient,
     val serviceCluster: ServiceCluster,
     val httpClient: HttpClient,
     val airbrakeNotifier: AirbrakeNotifier) extends DistributedSearchServiceClient {
 
-  private lazy val distRouter = searchClient.distRouter
+  private lazy val distRouter = {
+    val router = new DistributedSearchRouter(this)
+    serviceCluster.setCustomRouter(Some(router))
+    router
+  }
 
   def distPlan(userId: Id[User], shards: Set[Shard[NormalizedURI]], maxShardsPerInstance: Int = Int.MaxValue): Seq[(ServiceInstance, Set[Shard[NormalizedURI]])] = {
     distRouter.plan(userId, shards, maxShardsPerInstance)

--- a/kifi-backend/modules/search/app/com/keepit/search/DistributedSearchServiceClientModule.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/DistributedSearchServiceClientModule.scala
@@ -15,12 +15,10 @@ case class ProdDistributedSearchServiceClientModule() extends DistributedSearchS
 
   @Provides @Singleton
   def distributedSearchServiceClient(
-    searchClient: SearchServiceClient,
     client: HttpClient,
     serviceDiscovery: ServiceDiscovery,
     airbrakeNotifier: AirbrakeNotifier): DistributedSearchServiceClient = {
     new DistributedSearchServiceClientImpl(
-      searchClient,
       serviceDiscovery.serviceCluster(ServiceType.SEARCH),
       client,
       airbrakeNotifier

--- a/kifi-backend/modules/search/app/com/keepit/search/sharding/DistributedSearchRouter.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/sharding/DistributedSearchRouter.scala
@@ -5,11 +5,11 @@ import com.keepit.common.net.ClientResponse
 import com.keepit.common.routes.ServiceRoute
 import com.keepit.common.zookeeper.{ ServiceInstance, CustomRouter }
 import com.keepit.model.{ User, NormalizedURI }
-import com.keepit.search.SearchServiceClient
+import com.keepit.search.{ DistributedSearchServiceClient }
 import play.api.libs.json.{ JsObject, JsString, JsNull, JsValue }
 import scala.concurrent.Future
 
-class DistributedSearchRouter(client: SearchServiceClient) extends CustomRouter {
+class DistributedSearchRouter(client: DistributedSearchServiceClient) extends CustomRouter {
 
   type T = NormalizedURI
 

--- a/kifi-backend/modules/search/test/com/keepit/search/FakeDistributedSearchServiceClientModule.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/FakeDistributedSearchServiceClientModule.scala
@@ -11,4 +11,4 @@ case class FakeDistributedSearchServiceClientModule() extends DistributedSearchS
 
 }
 
-class FakeDistributedSearchServiceClient() extends DistributedSearchServiceClientImpl(null, null, null, null)
+class FakeDistributedSearchServiceClient() extends DistributedSearchServiceClientImpl(null, null, null)


### PR DESCRIPTION
...earchServiceClient

@ymatsuda as discussed, leaving sharding utilities in Common even though they're only used by Search at the moment :)
