### PR TITLE
and yet more users to compute recos for

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
@@ -50,7 +50,7 @@ class RecommendationGenerationCommander @Inject() (
     serviceDiscovery: ServiceDiscovery) extends Logging {
 
   val defaultScore = 0.0f
-  val recommendationGenerationLock = new ReactiveLock(16)
+  val recommendationGenerationLock = new ReactiveLock(12)
   val perUserRecommendationGenerationLocks = TrieMap[Id[User], ReactiveLock]()
 
   private def usersToPrecomputeRecommendationsFor(): Future[Seq[Id[User]]] = {

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/SeedIngestionCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/SeedIngestionCommander.scala
@@ -32,7 +32,7 @@ class SeedIngestionCommander @Inject() (
 
   val MAX_INDIVIDUAL_KEEPERS_TO_CONSIDER = 100
 
-  val MIN_KEEPS_FOR_RECOS = 400 //This will be gradually lowered to 10 or twenty throughout this week
+  val MIN_KEEPS_FOR_RECOS = 100 //This will be gradually lowered to 10 or twenty throughout this week
 
   def usersToIngestGraphDataFor(): Future[Seq[Id[User]]] = experimentCommander.getUsersByExperiment(ExperimentType.RECOS_BETA).map(users => users.map(_.id.get).toSeq)
 


### PR DESCRIPTION
This change activates the computation for an additional ~500 users,
bringing the total up to about 1200.
(There is a total of about 2200 users with >20 keeps, which is what I
want to get to by friday; so far the system is holding up quite well)
I’ve also reduced the concurrency again by a little bit, since shoebox
has been complaining about too many incoming calls.

@yingjieMiao 
