### PR TITLE
preventing library collaborators from tagging for the time being

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
@@ -27,9 +27,8 @@ case class LibraryMembership(
 
   override def toString: String = s"LibraryMembership[id=$id,libraryId=$libraryId,userId=$userId,access=$access,state=$state]"
 
-  def hasWriteAccess: Boolean = {
-    return access == LibraryAccess.READ_WRITE || access == LibraryAccess.OWNER
-  }
+  def hasWriteAccess: Boolean = access == LibraryAccess.READ_WRITE || access == LibraryAccess.OWNER
+  def isOwner: Boolean = access == LibraryAccess.OWNER
 }
 
 object LibraryMembership {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -164,11 +164,11 @@ class ExtLibraryController @Inject() (
       db.readOnlyMaster { implicit session =>
         libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, request.userId)
       } match {
-        case Some(mem) if mem.hasWriteAccess =>
+        case Some(mem) if mem.isOwner => // TODO: change to .hasWriteAccess
           keepsCommander.getKeep(libraryId, keepExtId, request.userId) match {
             case Right(keep) =>
               implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.keeper).build
-              val coll = keepsCommander.getOrCreateTag(request.userId, tag)
+              val coll = keepsCommander.getOrCreateTag(request.userId, tag) // TODO: library ID, not user ID
               keepsCommander.addToCollection(coll.id.get, Seq(keep))
               Ok(Json.obj("tag" -> coll.name))
             case Left((status, code)) =>
@@ -185,11 +185,11 @@ class ExtLibraryController @Inject() (
       db.readOnlyMaster { implicit session =>
         libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, request.userId)
       } match {
-        case Some(mem) if mem.hasWriteAccess =>
+        case Some(mem) if mem.isOwner => // TODO: change to .hasWriteAccess
           keepsCommander.getKeep(libraryId, keepExtId, request.userId) match {
             case Right(keep) =>
               db.readOnlyReplica { implicit s =>
-                collectionRepo.getByUserAndName(request.userId, Hashtag(tag))
+                collectionRepo.getByUserAndName(request.userId, Hashtag(tag)) // TODO: library ID, not user ID
               } foreach { coll =>
                 implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.keeper).build
                 keepsCommander.removeFromCollection(coll, Seq(keep))


### PR DESCRIPTION
The previous code could have potentially let collaborators create their own personal tags on someone else’s keeps in someone else’s library. I’m disabling that to keep our current schema consistent until we properly support library-specific tags.

@andrewconner 
cc @leogrim 
