### PR TITLE
Modify Typeahead Id generation to allow for non model typeaahead

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/typeahead/Typeahead.scala
+++ b/kifi-backend/modules/common/app/com/keepit/typeahead/Typeahead.scala
@@ -21,9 +21,7 @@ trait Typeahead[T, E, I] extends Logging {
 
   protected def getInfos(ownerId: Id[T], infoIds: Seq[Id[E]]): Future[Seq[I]]
 
-  protected def getAllInfos(ownerId: Id[T]): Future[Seq[I]]
-
-  protected def extractId(info: I): Id[E]
+  protected def getAllInfos(ownerId: Id[T]): Future[Seq[(Id[E], I)]]
 
   protected def extractName(info: I): String
 
@@ -81,7 +79,7 @@ trait Typeahead[T, E, I] extends Logging {
       timing(s"buildFilter($id)") {
         val builder = new PrefixFilterBuilder[E]
         getAllInfos(id).map { allInfos =>
-          allInfos.foreach(info => builder.add(extractId(info), extractName(info)))
+          allInfos.foreach { case (id, info) => builder.add(id, extractName(info)) }
           val filter = builder.build
           log.info(s"[buildFilter($id)] allInfos(len=${allInfos.length})(${allInfos.take(10).mkString(",")}) filter.len=${filter.data.length}")
           filter

--- a/kifi-backend/modules/common/app/com/keepit/typeahead/Typeahead.scala
+++ b/kifi-backend/modules/common/app/com/keepit/typeahead/Typeahead.scala
@@ -79,7 +79,7 @@ trait Typeahead[T, E, I] extends Logging {
       timing(s"buildFilter($id)") {
         val builder = new PrefixFilterBuilder[E]
         getAllInfos(id).map { allInfos =>
-          allInfos.foreach { case (id, info) => builder.add(id, extractName(info)) }
+          allInfos.foreach { case (infoId, info) => builder.add(infoId, extractName(info)) }
           val filter = builder.build
           log.info(s"[buildFilter($id)] allInfos(len=${allInfos.length})(${allInfos.take(10).mkString(",")}) filter.len=${filter.data.length}")
           filter

--- a/kifi-backend/modules/shoebox/app/com/keepit/typeahead/KifiUserTypeahead.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/typeahead/KifiUserTypeahead.scala
@@ -45,14 +45,12 @@ class KifiUserTypeahead @Inject() (
 
   protected def extractName(info: User): String = info.fullName
 
-  protected def extractId(info: User): Id[User] = info.id.get
-
-  protected def getAllInfos(id: Id[User]): Future[Seq[User]] = {
+  protected def getAllInfos(id: Id[User]): Future[Seq[(Id[User], User)]] = {
     db.readOnlyMasterAsync { implicit ro =>
       userConnectionRepo.getConnectedUsers(id)
     } flatMap { ids =>
       log.info(s"[getAllInfosForUser($id)] connectedUsers:(len=${ids.size}):${ids.mkString(",")}")
-      getInfos(id, ids.toSeq)
+      getInfos(id, ids.toSeq).map(_.map(user => user.id.get -> user))
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/typeahead/SocialUserTypeahead.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/typeahead/SocialUserTypeahead.scala
@@ -55,13 +55,11 @@ class SocialUserTypeahead @Inject() (
     }
   }
 
-  protected def getAllInfos(id: Id[User]): Future[Seq[SocialUserBasicInfo]] = SafeFuture {
+  protected def getAllInfos(id: Id[User]): Future[Seq[(Id[SocialUserInfo], SocialUserBasicInfo)]] = SafeFuture {
     db.readOnlyMaster { implicit session =>
-      socialConnRepo.getSocialConnectionInfosByUser(id).valuesIterator.flatten.toSeq
+      socialConnRepo.getSocialConnectionInfosByUser(id).valuesIterator.flatten.toSeq.map(info => info.id -> info)
     }
   }
-
-  override protected def extractId(info: SocialUserBasicInfo): Id[SocialUserInfo] = info.id
 
   override protected def extractName(info: SocialUserBasicInfo): String = info.fullName
 


### PR DESCRIPTION
@raymondng @ymatsuda 
This is a minor change to the API, but hiding the extractId operation within getAllInfos and changing the getInfos API to take the owner id as input make it possible for the info ids not to be model ids (they can be generated from whatever id space that belongs to owner id, e.g. a sequence stored in S3)
