### PR TITLE
activates reco computation for the remaining users (with enough data)

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/SeedIngestionCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/SeedIngestionCommander.scala
@@ -32,7 +32,7 @@ class SeedIngestionCommander @Inject() (
 
   val MAX_INDIVIDUAL_KEEPERS_TO_CONSIDER = 100
 
-  val MIN_KEEPS_FOR_RECOS = 100 //This will be gradually lowered to 10 or twenty throughout this week
+  val MIN_KEEPS_FOR_RECOS = 20
 
   def usersToIngestGraphDataFor(): Future[Seq[Id[User]]] = experimentCommander.getUsersByExperiment(ExperimentType.RECOS_BETA).map(users => users.map(_.id.get).toSeq)
 


### PR DESCRIPTION
@yingjieMiao 
This is an additional ~700 users (we did very well with a batch of ~600 yesterday, so I don't anticipate any issues)
