### PR TITLE
Introduce PersonalTypeahead

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/typeahead/PrefixFilter.scala
+++ b/kifi-backend/modules/common/app/com/keepit/typeahead/PrefixFilter.scala
@@ -77,7 +77,7 @@ object PrefixFilter {
   implicit def binaryFormat[T]: BinaryFormat[PrefixFilter[T]] = ArrayBinaryFormat.longArrayFormat.map(_.data, new PrefixFilter(_))
 }
 
-class PrefixFilter[T](val data: Array[Long]) extends AnyVal {
+class PrefixFilter[T](val data: Array[Long]) {
   def filterBy(query: Array[String]): Seq[Id[T]] = PrefixFilter.eval[T](this, query)
   def isEmpty = (data.length == 1)
   override def toString = s"[PrefixFilter] (len=${data.length - 1}) ${data.drop(1).take(10).grouped(2).map { t => s"${t(0)} -> ${java.lang.Long.toHexString(t(1))}" }.mkString(",")}"

--- a/kifi-backend/modules/common/app/com/keepit/typeahead/Typeahead.scala
+++ b/kifi-backend/modules/common/app/com/keepit/typeahead/Typeahead.scala
@@ -13,46 +13,69 @@ import play.api.libs.json._
 import scala.concurrent._
 import scala.concurrent.duration._
 
+trait PersonalTypeahead[T, E, I] {
+  def ownerId: Id[T]
+  def filter: PrefixFilter[E]
+  def getInfos(infoIds: Seq[Id[E]]): Future[Seq[I]]
+}
+
+object PersonalTypeahead {
+  def apply[T, E, I](id: Id[T], prefixFilter: PrefixFilter[E], infoGetter: Seq[Id[E]] => Future[Seq[I]]) = new PersonalTypeahead[T, E, I] {
+    val ownerId = id
+    val filter = prefixFilter
+    def getInfos(infoIds: Seq[Id[E]]): Future[Seq[I]] = infoGetter(infoIds)
+  }
+}
+
 trait Typeahead[T, E, I] extends Logging {
 
   protected def airbrake: AirbrakeNotifier
 
-  protected def getOrCreatePrefixFilter(ownerId: Id[T]): Future[PrefixFilter[E]]
+  protected def get(ownerId: Id[T]): Future[Option[PersonalTypeahead[T, E, I]]]
 
-  protected def getInfos(ownerId: Id[T], infoIds: Seq[Id[E]]): Future[Seq[I]]
+  protected def create(ownerId: Id[T]): Future[PersonalTypeahead[T, E, I]]
 
-  protected def getAllInfos(ownerId: Id[T]): Future[Seq[(Id[E], I)]]
+  protected def invalidate(typeahead: PersonalTypeahead[T, E, I]): Unit
 
   protected def extractName(info: I): String
+
+  protected def buildFilter(id: Id[T], allInfos: Seq[(Id[E], I)]): PrefixFilter[E] = {
+    timing(s"buildFilter($id)") {
+      val builder = new PrefixFilterBuilder[E]
+      allInfos.foreach { case (infoId, info) => builder.add(infoId, extractName(info)) }
+      val filter = builder.build
+      log.info(s"[buildFilter($id)] allInfos(len=${allInfos.length})(${allInfos.take(10).mkString(",")}) filter.len=${filter.data.length}")
+      filter
+    }
+  }
 
   def topN(ownerId: Id[T], query: String, limit: Option[Int])(implicit ord: Ordering[TypeaheadHit[I]]): Future[Seq[TypeaheadHit[I]]] = {
     if (query.trim.length <= 0) Future.successful(Seq.empty) else {
       implicit val fj = ExecutionContext.fj
-      getPrefixFilter(ownerId) flatMap { prefixFilterOpt =>
-        prefixFilterOpt match {
-          case None =>
-            log.warn(s"[asyncTopN($ownerId,$query)] NO FILTER found")
-            Future.successful(Seq.empty)
-          case Some(filter) =>
-            if (filter.isEmpty) {
-              log.info(s"[asyncTopN($ownerId,$query)] filter is EMPTY")
-              Future.successful(Seq.empty)
-            } else {
-              val queryTerms = PrefixFilter.normalize(query).split("\\s+")
-              getInfos(ownerId, filter.filterBy(queryTerms)).map { infos =>
-                topNWithInfos(infos, queryTerms, limit)
-              }
-            }
+      getOrElseCreate(ownerId) flatMap { typeahead =>
+        if (typeahead.filter.isEmpty) {
+          log.info(s"[asyncTopN($ownerId,$query)] filter is EMPTY")
+          Future.successful(Seq.empty)
+        } else {
+          val queryTerms = PrefixFilter.normalize(query).split("\\s+")
+          typeahead.getInfos(typeahead.filter.filterBy(queryTerms)).map { infos =>
+            topNWithInfos(infos, queryTerms, limit)
+          }
         }
       }
     }
   }
 
-  private[this] val consolidateFetchReq = new RequestConsolidator[Id[T], Option[PrefixFilter[E]]](15 seconds)
+  protected val fetchRequestConsolidationWindow = 15 seconds
+  private[this] val consolidateFetchReq = new RequestConsolidator[Id[T], PersonalTypeahead[T, E, I]](fetchRequestConsolidationWindow)
 
-  private[this] def getPrefixFilter(ownerId: Id[T]): Future[Option[PrefixFilter[E]]] = {
+  private[this] def getOrElseCreate(ownerId: Id[T]): Future[PersonalTypeahead[T, E, I]] = {
+    implicit val fj = ExecutionContext.fj
     consolidateFetchReq(ownerId) { id =>
-      getOrCreatePrefixFilter(id).map(Some(_))(ExecutionContext.fj)
+      get(id).flatMap {
+        case Some(typeahead) => Future.successful(typeahead)
+        case None => refresh(id)
+      }
     }
   }
 
@@ -72,23 +95,18 @@ trait Typeahead[T, E, I] extends Logging {
     }
   }
 
-  private[this] val consolidateBuildReq = new RequestConsolidator[Id[T], PrefixFilter[E]](10 minutes)
+  protected val refreshRequestConsolidationWindow = 10 minutes
+  private[this] val consolidateRefreshReq = new RequestConsolidator[Id[T], PersonalTypeahead[T, E, I]](refreshRequestConsolidationWindow)
 
-  protected def build(id: Id[T]): Future[PrefixFilter[E]] = {
-    consolidateBuildReq(id) { id =>
-      timing(s"buildFilter($id)") {
-        val builder = new PrefixFilterBuilder[E]
-        getAllInfos(id).map { allInfos =>
-          allInfos.foreach { case (infoId, info) => builder.add(infoId, extractName(info)) }
-          val filter = builder.build
-          log.info(s"[buildFilter($id)] allInfos(len=${allInfos.length})(${allInfos.take(10).mkString(",")}) filter.len=${filter.data.length}")
-          filter
-        }(ExecutionContext.fj)
+  def refresh(ownerId: Id[T]): Future[PersonalTypeahead[T, E, I]] = {
+    implicit val fj = ExecutionContext.fj
+    consolidateRefreshReq(ownerId) { id =>
+      create(id).map { typeahead =>
+        invalidate(typeahead)
+        typeahead
       }
     }
   }
-
-  def refresh(id: Id[T]): Future[PrefixFilter[E]] // slow
 
   def refreshByIds(ownerIds: Seq[Id[T]]): Future[Unit] = { // consider using zk and/or sqs to track progress
     implicit val prefix = LogPrefix(s"refreshByIds(#ids=${ownerIds.length})")
@@ -103,9 +121,6 @@ trait Typeahead[T, E, I] extends Logging {
       log.infoP(s"done with re-indexing for ${ownerIds.length} users: ${ownerIds.take(3).toString} ... ${ownerIds.takeRight(3).toString}")
     }
   }
-
-  def refreshAll(): Future[Unit]
-
 }
 
 object TypeaheadHit {

--- a/kifi-backend/modules/shoebox/app/com/keepit/typeahead/SocialUserTypeahead.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/typeahead/SocialUserTypeahead.scala
@@ -31,22 +31,21 @@ class SocialUserTypeahead @Inject() (
 
   implicit val fj = ExecutionContext.fj
 
-  protected def getOrCreatePrefixFilter(userId: Id[User]): Future[PrefixFilter[SocialUserInfo]] = {
-    cache.getOrElseFuture(SocialUserTypeaheadKey(userId)) {
-      val res = store.getWithMetadata(userId)
-      res match {
-        case Some((filter, meta)) =>
+  protected def get(userId: Id[User]) = {
+    val filterOpt = cache.getOrElseOpt(SocialUserTypeaheadKey(userId)) {
+      store.getWithMetadata(userId).map {
+        case (filter, meta) =>
           if (meta.exists(m => m.lastModified.plusMinutes(15).isBefore(currentDateTime))) {
             log.info(s"[asyncGetOrCreatePrefixFilter($userId)] filter EXPIRED (lastModified=${meta.get.lastModified}); (curr=${currentDateTime}); (delta=${Minutes.minutesBetween(meta.get.lastModified, currentDateTime)} minutes) - rebuild")
-            refresh(userId) // async
+            refresh(userId)
           }
-          Future.successful(filter)
-        case None => refresh(userId)
+          filter
       }
     }
+    Future.successful(filterOpt.map(makeTypeahead(userId, _)))
   }
 
-  protected def getInfos(userId: Id[User], ids: Seq[Id[SocialUserInfo]]): Future[Seq[SocialUserBasicInfo]] = {
+  private def getInfos(ids: Seq[Id[SocialUserInfo]]): Future[Seq[SocialUserBasicInfo]] = {
     if (ids.isEmpty) Future.successful(Seq.empty[SocialUserBasicInfo])
     else {
       db.readOnlyMasterAsync { implicit session =>
@@ -55,20 +54,28 @@ class SocialUserTypeahead @Inject() (
     }
   }
 
-  protected def getAllInfos(id: Id[User]): Future[Seq[(Id[SocialUserInfo], SocialUserBasicInfo)]] = SafeFuture {
+  private def makeTypeahead(userId: Id[User], filter: PrefixFilter[SocialUserInfo]) = PersonalTypeahead(userId, filter, getInfos)
+
+  private def getAllInfos(id: Id[User]): Future[Seq[(Id[SocialUserInfo], SocialUserBasicInfo)]] = SafeFuture {
     db.readOnlyMaster { implicit session =>
       socialConnRepo.getSocialConnectionInfosByUser(id).valuesIterator.flatten.toSeq.map(info => info.id -> info)
     }
   }
 
-  override protected def extractName(info: SocialUserBasicInfo): String = info.fullName
+  protected def extractName(info: SocialUserBasicInfo): String = info.fullName
 
-  def refresh(userId: Id[User]): Future[PrefixFilter[SocialUserInfo]] = {
-    build(userId).map { filter =>
-      cache.set(SocialUserTypeaheadKey(userId), filter)
-      store += (userId -> filter)
-      log.info(s"[rebuild($userId)] cache/store updated; filter=$filter")
-      filter
+  protected def invalidate(typeahead: PersonalTypeahead[User, SocialUserInfo, SocialUserBasicInfo]) = {
+    val userId = typeahead.ownerId
+    val filter = typeahead.filter
+    cache.set(SocialUserTypeaheadKey(userId), filter)
+    store += (userId -> filter)
+  }
+
+  protected def create(userId: Id[User]) = {
+    getAllInfos(userId).map { allInfos =>
+      val filter = buildFilter(userId, allInfos)
+      log.info(s"[refresh($userId)] cache/store updated; filter=$filter")
+      makeTypeahead(userId, filter)
     }(ExecutionContext.fj)
   }
 


### PR DESCRIPTION
@andrewconner @stkem @ymatsuda @raymondng 

So the idea is to be able to manipulate a PrefixFilter and the way the infos I that this filter indexes together, so that we can be sure they are in sync (not a problem when these infos are models with long lasting ids, but a potential problem if infos are hashtags for which ids are derived on the fly).

Mostly, the API and consolidators that used to deal with PrefixFilter now deal with PersonalTypeahead. 

I also moved the logic dealing with cache / storage invalidation into the main trait. 
