### PR TITLE
Refresh HashtagTypeahead (maybe)

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/typeahead/Typeahead.scala
+++ b/kifi-backend/modules/common/app/com/keepit/typeahead/Typeahead.scala
@@ -30,6 +30,10 @@ object PersonalTypeahead {
 
 trait Typeahead[T, E, I, P <: PersonalTypeahead[T, E, I]] extends Logging {
 
+  protected val refreshRequestConsolidationWindow = 10 minutes
+
+  protected val fetchRequestConsolidationWindow = 15 seconds
+
   protected def airbrake: AirbrakeNotifier
 
   protected def get(ownerId: Id[T]): Future[Option[P]]
@@ -67,7 +71,6 @@ trait Typeahead[T, E, I, P <: PersonalTypeahead[T, E, I]] extends Logging {
     }
   }
 
-  protected val fetchRequestConsolidationWindow = 15 seconds
   private[this] val consolidateFetchReq = new RequestConsolidator[Id[T], P](fetchRequestConsolidationWindow)
 
   private[this] def getOrElseCreate(ownerId: Id[T]): Future[P] = {
@@ -96,7 +99,6 @@ trait Typeahead[T, E, I, P <: PersonalTypeahead[T, E, I]] extends Logging {
     }
   }
 
-  protected val refreshRequestConsolidationWindow = 10 minutes
   private[this] val consolidateRefreshReq = new RequestConsolidator[Id[T], P](refreshRequestConsolidationWindow)
 
   private def doRefresh(ownerId: Id[T]): Future[P] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/CollectionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/CollectionRepo.scala
@@ -158,6 +158,5 @@ class CollectionRepoImpl @Inject() (
     val query = sql"select DISTINCT c.name from keep_to_collection kc, collection c, bookmark b where b.library_id = ${libraryId} and kc.bookmark_id = b.id and c.id = kc.collection_id and b.state =${KeepStates.ACTIVE} and c.state=${CollectionStates.ACTIVE} and kc.state=${KeepToCollectionStates.ACTIVE}"
     query.as[String].list.map(tag => Hashtag(tag)).toSet
   }
-
 }
 


### PR DESCRIPTION
@andrewconner this is where the decision to stick with user-owned collections are a bit problematic. Since the typeahead is owned by a library, we want to refresh it every time a tag appears for the first time or disappears from a library. But there's no easy way to track this since the Collection object can be shared across libraries (so its lifecycle doesn't align with the required typeahead invalidation). So for now I'm just trying to be aggressive, but that's probably a lot of unnecessary work.
