### PR TITLE
move links in facebook/linkedin email tips

### DIFF
--- a/kifi-backend/modules/shoebox/app/views/email/tips/connectFacebook.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/tips/connectFacebook.scala.html
@@ -13,19 +13,23 @@
   @email.tags.trSpacer(29)
   <tr>
     <td align="center">
-      <a href="@baseUrl/link/facebook" target="_blank" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;line-height:22px;color:#fff;text-decoration:none;">
-        @email.tags.roundedContainer(260, 60, 10, "506DA5") {
-        <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center">
-          <tr>
-            <td width="50" height="40" align="center" valign="middle"><img src='@assetUrl("fb-letter.png")' width="9" height="20" border="0"/></td>
-            <td bgcolor="#738BB7" width="2"></td>
-            <td align="center" valign="middle" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;line-height:22px;color:#fff;text-decoration:none;border-collapse:collapse;mso-line-height-rule:exactly;">
+      @email.tags.roundedContainer(260, 60, 10, "506DA5") {
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center">
+        <tr>
+          <td width="50" height="40" align="center" valign="middle">
+            <a href="@baseUrl/link/facebook" target="_blank" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;line-height:22px;color:#fff;text-decoration:none;">
+              <img src='@assetUrl("fb-letter.png")' width="9" height="20" border="0"/>
+            </a>
+          </td>
+          <td bgcolor="#738BB7" width="2"></td>
+          <td align="center" valign="middle" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;line-height:22px;color:#fff;text-decoration:none;border-collapse:collapse;mso-line-height-rule:exactly;">
+            <a href="@baseUrl/link/facebook" target="_blank" style="display:block;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;line-height:22px;color:#fff;text-decoration:none;">
               Connect to Facebook
-            </td>
-          </tr>
-        </table>
-        }
-      </a>
+            </a>
+          </td>
+        </tr>
+      </table>
+      }
     </td>
   </tr>
   @email.tags.trSpacer(44)

--- a/kifi-backend/modules/shoebox/app/views/email/tips/connectLinkedIn.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/tips/connectLinkedIn.scala.html
@@ -13,18 +13,22 @@
   @email.tags.trSpacer(29)
   <tr>
     <td align="center">
-      <a href="@baseUrl/link/linkedin" target="_blank" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;line-height:22px;color:#fff;text-decoration:none;">
-        @email.tags.roundedContainer(260, 60, 10, "1B6E9B") {
-        <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center">
-          <tr>
-            <td width="50" height="40" align="center" valign="middle" style="border-right:2px solid 2px solid #468BAE;"><img src='@assetUrl("lin-letter.png")' width="22" height="21" border="0"/></td>
-            <td align="center" valign="middle" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;line-height:22px;color:#fff;text-decoration:none;border-collapse:collapse;mso-line-height-rule:exactly;">
+      @email.tags.roundedContainer(260, 60, 10, "1B6E9B") {
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center">
+        <tr>
+          <td width="50" height="40" align="center" valign="middle" style="border-right:2px solid 2px solid #468BAE;">
+            <a href="@baseUrl/link/linkedin" target="_blank" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;line-height:22px;color:#fff;text-decoration:none;">
+              <img src='@assetUrl("lin-letter.png")' width="22" height="21" border="0"/>
+            </a>
+          </td>
+          <td align="center" valign="middle" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;line-height:22px;color:#fff;text-decoration:none;border-collapse:collapse;mso-line-height-rule:exactly;">
+            <a href="@baseUrl/link/linkedin" target="_blank" style="display:block;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;line-height:22px;color:#fff;text-decoration:none;">
               Connect with LinkedIn
-            </td>
-          </tr>
-        </table>
-        }
-      </a>
+            </a>
+          </td>
+        </tr>
+      </table>
+      }
     </td>
   </tr>
   @email.tags.trSpacer(44)


### PR DESCRIPTION
@stkem 

some email clients don't like links that wrap <tables>.  moved the links directly wrap the text and image
