### PR TITLE
new email event that adds detailed tracking properties to emails that ar...

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/mail/template/EmailTrackingParam.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/template/EmailTrackingParam.scala
@@ -10,7 +10,8 @@ import play.api.libs.functional.syntax._
 case class EmailTrackingParam(
     subAction: Option[String] = None,
     variableComponents: Seq[String] = Seq.empty,
-    tips: Seq[EmailTip] = Seq.empty,
+    tip: Option[EmailTip] = None,
+    @deprecated("use `tip` (unless we start supporting multiple tips in 1 email", since = "2014-10-02") tips: Seq[EmailTip] = Seq.empty,
     auxiliaryData: Option[HeimdalContext] = None) {
 
   def encode = EmailTrackingParam.encode(this)
@@ -30,6 +31,7 @@ object EmailTrackingParam extends Logging {
   implicit val format = (
     (__ \ "l").formatNullable[String] and
     (__ \ "c").format[Seq[String]] and
+    (__ \ "t1").formatNullable[EmailTip] and
     (__ \ "t").format[Seq[EmailTip]] and
     (__ \ "a").formatNullable[HeimdalContext]
   )(EmailTrackingParam.apply, unlift(EmailTrackingParam.unapply))

--- a/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalContext.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalContext.scala
@@ -1,19 +1,19 @@
 package com.keepit.heimdal
 
+import com.keepit.common.mail.template.EmailTrackingParam
 import org.joda.time.DateTime
 import play.api.libs.json._
-import com.keepit.common.zookeeper.ServiceDiscovery
 import play.api.mvc.RequestHeader
 import com.keepit.common.controller.AuthenticatedRequest
 import com.keepit.model.{ NotificationCategory, KeepSource, ExperimentType }
 import com.google.inject.{ Inject, Singleton }
-import com.keepit.common.net.{ Host, URI, UserAgent }
+import com.keepit.common.net.{ URI, UserAgent }
 import com.keepit.common.time.DateTimeJsonFormat
 import com.keepit.common.mail.ElectronicMail
 import com.keepit.social.SocialNetworkType
 import scala.util.Try
 import com.keepit.common.service.FortyTwoServices
-import com.keepit.common.amazon.{ MyInstanceInfo, AmazonInstanceInfo }
+import com.keepit.common.amazon.MyInstanceInfo
 import com.keepit.common.time._
 
 sealed trait ContextData
@@ -174,6 +174,16 @@ class HeimdalContextBuilder {
     this.addNotificationCategory(email.category)
     email.inReplyTo.foreach { previousEmailId => this += ("inReplyTo", previousEmailId.id) }
     email.senderUserId.foreach { id => this += ("senderUserId", id.id) }
+  }
+
+  def addDetailedEmailInfo(param: EmailTrackingParam): Unit = {
+    param.subAction.foreach(v => this += ("subaction", v))
+    param.tip.foreach { tip => this += ("emailTip", tip) }
+    if (param.variableComponents.nonEmpty) this += ("emailComponents", param.variableComponents)
+
+    param.auxiliaryData.foreach { ctx =>
+      ctx.data.foreach { case (key, value) => data(key) = value }
+    }
   }
 
   def addNotificationCategory(category: NotificationCategory): Unit = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/SendgridCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/SendgridCommander.scala
@@ -162,14 +162,7 @@ class SendgridCommander @Inject() (
 
       datParamOpt.foreach { encodedEmailTrackingParam =>
         EmailTrackingParam.decode(encodedEmailTrackingParam) match {
-          case Right(param) =>
-            param.subAction.foreach(v => contextBuilder += ("subaction", v))
-            if (param.tips.nonEmpty) contextBuilder += ("emailTips", param.tips)
-            if (param.variableComponents.nonEmpty) contextBuilder += ("emailComponents", param.variableComponents)
-
-            param.auxiliaryData.foreach { ctx =>
-              ctx.data.foreach { case (key, value) => contextBuilder.data(key) = value }
-            }
+          case Right(param) => contextBuilder.addDetailedEmailInfo(param)
           case Left(errors) =>
             val errMsg = errors.mkString("; ")
             airbrake.notify(s"failed to decode EmailTrackingParam: $errMsg")

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
@@ -2,8 +2,7 @@ package com.keepit.commanders.emails
 
 import com.google.inject.{ Provider, ImplementedBy, Inject }
 import com.keepit.commanders.UserCommander
-import com.keepit.commanders.emails.tips.{ EmailTipProvider, ConnectNetworkTip }
-import com.keepit.common.concurrent.FutureHelpers
+import com.keepit.commanders.emails.tips.EmailTipProvider
 import com.keepit.common.db.{ LargeString, Id }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.mail.EmailAddress
@@ -15,7 +14,6 @@ import com.keepit.model.{ NotificationCategory, UserEmailAddressRepo, UserRepo, 
 import com.keepit.social.BasicUser
 import play.api.libs.json.{ Json, JsValue }
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.twirl.api.Html
 
 import scala.concurrent.Future
 
@@ -135,7 +133,7 @@ class EmailTemplateProcessorImpl @Inject() (
           EmailTrackingParam(
             subAction = Json.fromJson[String](tagArgs(0)).asOpt,
             variableComponents = Seq.empty, // todo(josh) this needs to be passed in EmailToSend
-            tips = emailTipOpt.map(Seq(_)) getOrElse Seq.empty,
+            tip = emailTipOpt,
             auxiliaryData = None // todo(josh) this needs to either be set individually for each link in the template or passed in EmailToSend
           ).encode
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateSender.scala
@@ -4,8 +4,9 @@ import com.google.inject.{ ImplementedBy, Inject }
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
-import com.keepit.common.mail.template.{ EmailTip, EmailToSend }
+import com.keepit.common.mail.template.{ EmailTrackingParam, EmailTip, EmailToSend }
 import com.keepit.common.mail.{ ElectronicMail, ElectronicMailRepo, LocalPostOffice }
+import com.keepit.heimdal.{ HeimdalServiceClient, UserEventTypes, UserEvent, HeimdalContextBuilder }
 import com.keepit.inject.FortyTwoConfig
 import com.keepit.model.{ User, UserEmailAddressRepo, UserValueName, UserValueRepo }
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -21,6 +22,7 @@ trait EmailTemplateSender {
 class EmailTemplateSenderImpl @Inject() (
     db: Database,
     htmlPreProcessor: EmailTemplateProcessor,
+    heimdal: HeimdalServiceClient,
     emailRepo: ElectronicMailRepo,
     postOffice: LocalPostOffice,
     emailAddrRepo: UserEmailAddressRepo,
@@ -47,12 +49,27 @@ class EmailTemplateSenderImpl @Inject() (
 
       db.readWrite(attempts = 3) { implicit rw =>
         result.toUser foreach { userId =>
+          trackUserEvent(userId, result, email)
           result.includedTip foreach { tip => recordSentTip(tip, userId) }
         }
 
         postOffice.sendMail(email)
       }
     }
+  }
+
+  private def trackUserEvent(userId: Id[User], processedResult: ProcessedEmailResult, email: ElectronicMail) = {
+    // todo(josh) track the optional variableComponents and auxiliaryData parameters
+    val param = EmailTrackingParam(tip = processedResult.includedTip)
+    val context = {
+      val ctxBuilder = new HeimdalContextBuilder
+      ctxBuilder += ("action", "prepared")
+      ctxBuilder.addEmailInfo(email)
+      ctxBuilder.addDetailedEmailInfo(param)
+      ctxBuilder.build
+    }
+    val event = UserEvent(userId = userId, context = context, eventType = UserEventTypes.WAS_NOTIFIED)
+    heimdal.trackEvent(event)
   }
 
   private def recordSentTip(tip: EmailTip, userId: Id[User]) = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/SendgridMailProvider.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/SendgridMailProvider.scala
@@ -19,7 +19,6 @@ import play.api.Play.current
 import play.api.http.ContentTypes
 import com.keepit.heimdal._
 import play.api.libs.json.JsString
-import scala.Some
 import play.api.libs.json.JsObject
 import com.keepit.common.time._
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/SendgridCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/SendgridCommanderTest.scala
@@ -1,6 +1,6 @@
 package com.keepit.commanders
 
-import com.google.inject.{ Injector }
+import com.google.inject.Injector
 import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.common.db.ExternalId
 import com.keepit.common.db.slick.Database
@@ -84,7 +84,7 @@ class SendgridCommanderTest extends Specification with ShoeboxTestInjector {
           val trackingParam = EmailTrackingParam(
             subAction = Some("kifiLogo"),
             variableComponents = Seq("1Friend"),
-            tips = Seq(EmailTip.FriendRecommendations),
+            tip = Some(EmailTip.FriendRecommendations),
             auxiliaryData = {
               val ctxBuilder = new HeimdalContextBuilder
               ctxBuilder += ("version", 1)
@@ -106,7 +106,7 @@ class SendgridCommanderTest extends Specification with ShoeboxTestInjector {
           actualEvent.eventType === UserEventTypes.WAS_NOTIFIED
           actualEvent.context.get[String]("subaction").get === "kifiLogo"
           actualEvent.context.getSeq[String]("emailComponents").get === Seq("1Friend")
-          actualEvent.context.getSeq[EmailTip]("emailTips").get === Seq(EmailTip.FriendRecommendations)
+          actualEvent.context.get[EmailTip]("emailTip").get === EmailTip.FriendRecommendations
           actualEvent.context.get[Double]("version").get === 1.0
           actualEvent.context.get[String]("tipLocation").get === "top"
           actualEvent.context.get[Boolean]("isAdmin").get === true

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailSenderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailSenderTest.scala
@@ -5,7 +5,6 @@ import com.keepit.abook.{ FakeABookServiceClientImpl, ABookServiceClient, FakeAB
 import com.keepit.common.cache.FakeCacheModule
 import com.keepit.common.healthcheck.FakeHealthcheckModule
 import com.keepit.common.mail.template.{ EmailTip, EmailTrackingParam }
-import com.keepit.common.mail.template.helpers._
 import com.keepit.common.mail.{ EmailAddress, FakeOutbox }
 import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.common.social.FakeSocialGraphModule
@@ -57,7 +56,7 @@ class EmailSenderTest extends Specification with ShoeboxTestInjector {
 
         val trackingCode = EmailTrackingParam(
           subAction = Some("findMoreFriendsBtn"),
-          tips = Seq(EmailTip.ConnectFacebook)).encode
+          tip = Some(EmailTip.ConnectFacebook)).encode
 
         html must contain("utm_source=fromKifi&utm_medium=email&utm_campaign=welcome&utm_content=findMoreFriendsBtn"
           + s"&${EmailTrackingParam.paramName}=$trackingCode")


### PR DESCRIPTION
...e about to be sent

current we create a "sent" event, but it only adds tracking that is based on the ElectronicMail model.
That table doesn't currently persist the new detailed properties (tips, auxiliary data), so this is a workaround w/o modifying the database/repo/model

@stkem 
