### PR TITLE
library invite email

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/mail/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/package.scala
@@ -20,6 +20,7 @@ package object template {
     val title = TagLabel("title")
     val baseUrl = TagLabel("baseUrl")
     val trackingParam = TagLabel("trackingParam")
+    val footerHtml = TagLabel("footer")
   }
 
   // val/def that use tags need to return the Html type so certain characters aren't escaped as HTML entities
@@ -30,6 +31,8 @@ package object template {
     val iTunesAppStoreUrl = "https://itunes.apple.com/us/app/kifi/id740232575"
     private val cdnBaseUrl = "https://djty7jcqog9qu.cloudfront.net"
     private val assetBaseUrl = cdnBaseUrl + "/assets/black"
+
+    val footerHtml = Tag0(tags.footerHtml).toHtml
 
     def assetUrl(path: String) = assetBaseUrl + '/' + path
 

--- a/kifi-backend/modules/common/app/com/keepit/common/mail/template/EmailToSend.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/template/EmailToSend.scala
@@ -1,10 +1,42 @@
 package com.keepit.common.mail.template
 
-import com.keepit.common.db.{ LargeString, Id }
+import com.keepit.common.db.Id
 import com.keepit.common.mail.{ ElectronicMailCategory, EmailAddress }
+import com.keepit.heimdal.{ ContextStringData, ContextData }
 import com.keepit.model.User
 import com.keepit.serializer.EitherFormat
 import play.twirl.api.Html
+
+sealed trait EmailLayout { val name: String }
+
+object EmailLayout {
+  private[EmailLayout] sealed case class EmailLayoutImpl(name: String) extends EmailLayout
+
+  object DefaultLayout extends EmailLayoutImpl("default")
+  object CustomLayout extends EmailLayoutImpl("custom")
+
+  val ALL = CustomLayout :: DefaultLayout :: Nil
+
+  def apply(name: String) =
+    ALL.find(_.name == name).getOrElse(throw new IllegalArgumentException(s"$name is not a recognized EmailLayout"))
+
+  implicit def toContextData(v: EmailLayout): ContextData = ContextStringData(v)
+
+  private val fromContextDataPf: PartialFunction[ContextData, EmailLayout] = {
+    case ContextStringData(value) => EmailLayoutImpl(value)
+  }
+
+  implicit def fromContextData(v: ContextData): Option[EmailLayout] = Some(v) collect fromContextDataPf
+  implicit def fromContextData(v: Option[ContextData]): Option[EmailLayout] = v collect fromContextDataPf
+
+  implicit def toString(v: EmailLayout): String = v.name
+  implicit def fromString(v: String): EmailLayout = EmailLayoutImpl(v)
+}
+
+object TemplateOptions {
+  val CustomLayout: (String, ContextData) = ("layout", EmailLayout.CustomLayout)
+  val DefaultLayout: (String, ContextData) = ("layout", EmailLayout.DefaultLayout)
+}
 
 case class EmailToSend(
   title: String = "Kifi",
@@ -20,6 +52,7 @@ case class EmailToSend(
   senderUserId: Option[Id[User]] = None,
   tips: Seq[EmailTip] = Seq.empty,
   closingLines: Seq[String] = Seq.empty,
+  templateOptions: Map[String, ContextData] = Map.empty,
   extraHeaders: Option[Map[String, String]] = None)
 
 object EmailToSend {
@@ -50,6 +83,7 @@ object EmailToSend {
     (__ \ 'senderUserId).formatNullable[Id[User]] and
     (__ \ 'tips).format[Seq[EmailTip]] and
     (__ \ 'closingLines).format[Seq[String]] and
+    (__ \ 'templateOptions).format[Map[String, ContextData]] and
     (__ \ 'extraHeaders).formatNullable[Map[String, String]]
   )(EmailToSend.apply, unlift(EmailToSend.unapply))
 }

--- a/kifi-backend/modules/common/app/views/html/email/package.scala
+++ b/kifi-backend/modules/common/app/views/html/email/package.scala
@@ -1,5 +1,0 @@
-package views.html.email
-
-package object black {
-  val h = com.keepit.common.mail.template.helpers
-}

--- a/kifi-backend/modules/common/app/views/html/package.scala
+++ b/kifi-backend/modules/common/app/views/html/package.scala
@@ -1,5 +1,0 @@
-package views
-
-package object html {
-  val h = com.keepit.common.mail.template.helpers
-}

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -340,16 +340,11 @@ class LibraryCommander @Inject() (
           )
 
           // send emails to both users & non-users
-          key._2.map { invite =>
-            val recipient = invite.userId match {
-              case Some(id) => Left(id)
-              case _ => Right(invite.emailAddress.get)
-            }
-            libraryInviteSender.get.inviteUserToLibrary(recipient, inviterId, invite.libraryId, invite.message)
-          }
+          key._2.map(libraryInviteSender.get.inviteUserToLibrary)
         }.toSeq.flatten
     }
-    Future.sequence(emailFutures)
+    val emailsF = Future.sequence(emailFutures)
+    emailsF map (_.filter(_.isDefined).map(_.get))
   }
 
   def internSystemGeneratedLibraries(userId: Id[User], generateNew: Boolean = true): (Library, Library) = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/LibraryInviteEmailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/LibraryInviteEmailSender.scala
@@ -1,12 +1,15 @@
 package com.keepit.commanders.emails
 
 import com.google.inject.Inject
+import com.keepit.commanders.LibraryInfo
+import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.common.mail.{ EmailAddress, SystemEmailAddress, ElectronicMail }
 import com.keepit.common.mail.template.EmailToSend
+import com.keepit.common.mail.template.TemplateOptions._
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.model._
 import com.keepit.common.mail.template.helpers.fullName
@@ -17,24 +20,28 @@ class LibraryInviteEmailSender @Inject() (
     db: Database,
     emailTemplateSender: EmailTemplateSender,
     basicUserRepo: BasicUserRepo,
+    keepRepo: KeepRepo,
     libraryRepo: LibraryRepo,
     protected val airbrake: AirbrakeNotifier) extends Logging {
 
-  def inviteUserToLibrary(toUserRecipient: Either[Id[User], EmailAddress], fromUserId: Id[User], libraryId: Id[Library], inviteMsg: Option[String] = None): Future[ElectronicMail] = {
-    val (library, libraryOwner) = db.readOnlyReplica { implicit session =>
+  def inviteUserToLibrary(toUserRecipient: Either[Id[User], EmailAddress], fromUserId: Id[User], libraryId: Id[Library], inviteMsg: Option[String] = None)(implicit publicIdConfig: PublicIdConfiguration): Future[ElectronicMail] = {
+    val (library, libraryInfo, libraryOwner) = db.readWrite { implicit session =>
       val library = libraryRepo.get(libraryId)
       val libOwner = basicUserRepo.load(library.ownerId)
-      (library, libOwner)
+      val numKeeps = keepRepo.getCountByLibrary(library.id.get)
+      val libraryInfo = LibraryInfo.fromLibraryAndOwner(library, libOwner, numKeeps)
+      (library, libraryInfo, libOwner)
     }
-    val libLink = s"""https://www.kifi.com${Library.formatLibraryPath(libraryOwner.username, libraryOwner.externalId, library.slug)}"""
+
     val emailToSend = EmailToSend(
       fromName = Some(Left(fromUserId)),
       from = SystemEmailAddress.NOTIFICATIONS,
       subject = s"${fullName(fromUserId)} invited you to follow ${library.name}!",
       to = toUserRecipient,
       category = NotificationCategory.User.LIBRARY_INVITATION,
-      htmlTemplate = views.html.email.libraryInvitation(toUserRecipient.left.toOption, fromUserId, inviteMsg, library.name, library.description, libLink),
-      campaign = Some("libraryInvite")
+      htmlTemplate = views.html.email.libraryInvitation(toUserRecipient.left.toOption, fromUserId, inviteMsg, libraryInfo),
+      textTemplate = Some(views.html.email.libraryInvitationText(toUserRecipient.left.toOption, fromUserId, inviteMsg, libraryInfo)),
+      templateOptions = Seq(CustomLayout).toMap
     )
     emailTemplateSender.send(emailToSend)
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/LibraryInviteEmailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/LibraryInviteEmailSender.scala
@@ -11,9 +11,10 @@ import com.keepit.common.mail.{ EmailAddress, SystemEmailAddress, ElectronicMail
 import com.keepit.common.mail.template.EmailToSend
 import com.keepit.common.mail.template.TemplateOptions._
 import com.keepit.common.social.BasicUserRepo
-import com.keepit.model._
 import com.keepit.common.mail.template.helpers.fullName
+import com.keepit.model.{ NotificationCategory, User, LibraryInvite, LibraryRepo, KeepRepo }
 
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 
 class LibraryInviteEmailSender @Inject() (
@@ -24,25 +25,37 @@ class LibraryInviteEmailSender @Inject() (
     libraryRepo: LibraryRepo,
     protected val airbrake: AirbrakeNotifier) extends Logging {
 
-  def inviteUserToLibrary(toUserRecipient: Either[Id[User], EmailAddress], fromUserId: Id[User], libraryId: Id[Library], inviteMsg: Option[String] = None)(implicit publicIdConfig: PublicIdConfiguration): Future[ElectronicMail] = {
-    val (library, libraryInfo, libraryOwner) = db.readWrite { implicit session =>
-      val library = libraryRepo.get(libraryId)
-      val libOwner = basicUserRepo.load(library.ownerId)
-      val numKeeps = keepRepo.getCountByLibrary(library.id.get)
-      val libraryInfo = LibraryInfo.fromLibraryAndOwner(library, libOwner, numKeeps)
-      (library, libraryInfo, libOwner)
-    }
+  def inviteUserToLibrary(invite: LibraryInvite)(implicit publicIdConfig: PublicIdConfiguration): Future[Option[ElectronicMail]] = {
+    val toUserRecipientOpt: Option[Either[Id[User], EmailAddress]] =
+      if (invite.userId.isDefined) Some(Left(invite.userId.get))
+      else if (invite.emailAddress.isDefined) Some(Right(invite.emailAddress.get))
+      else None
 
-    val emailToSend = EmailToSend(
-      fromName = Some(Left(fromUserId)),
-      from = SystemEmailAddress.NOTIFICATIONS,
-      subject = s"${fullName(fromUserId)} invited you to follow ${library.name}!",
-      to = toUserRecipient,
-      category = NotificationCategory.User.LIBRARY_INVITATION,
-      htmlTemplate = views.html.email.libraryInvitation(toUserRecipient.left.toOption, fromUserId, inviteMsg, libraryInfo),
-      textTemplate = Some(views.html.email.libraryInvitationText(toUserRecipient.left.toOption, fromUserId, inviteMsg, libraryInfo)),
-      templateOptions = Seq(CustomLayout).toMap
-    )
-    emailTemplateSender.send(emailToSend)
+    toUserRecipientOpt map { toUserRecipient =>
+      val (library, libraryInfo) = db.readWrite { implicit session =>
+        val library = libraryRepo.get(invite.libraryId)
+        val libOwner = basicUserRepo.load(library.ownerId)
+        val numKeeps = keepRepo.getCountByLibrary(library.id.get)
+        val libraryInfo = LibraryInfo.fromLibraryAndOwner(library, libOwner, numKeeps)
+        (library, libraryInfo)
+      }
+
+      val trimmedInviteMsg = invite.message map (_.trim) filter (_.nonEmpty)
+      val fromUserId = invite.ownerId
+      val emailToSend = EmailToSend(
+        fromName = Some(Left(invite.ownerId)),
+        from = SystemEmailAddress.NOTIFICATIONS,
+        subject = s"${fullName(fromUserId)} invited you to follow ${library.name}!",
+        to = toUserRecipient,
+        category = NotificationCategory.User.LIBRARY_INVITATION,
+        htmlTemplate = views.html.email.libraryInvitation(toUserRecipient.left.toOption, fromUserId, trimmedInviteMsg, libraryInfo, invite.passPhrase),
+        textTemplate = Some(views.html.email.libraryInvitationText(toUserRecipient.left.toOption, fromUserId, trimmedInviteMsg, libraryInfo, invite.passPhrase)),
+        templateOptions = Seq(CustomLayout).toMap
+      )
+      emailTemplateSender.send(emailToSend) map (Some(_))
+    } getOrElse {
+      airbrake.notify(s"LibraryInvite does not have a recipient: $invite")
+      Future.successful(None)
+    }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/EmailTestController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/EmailTestController.scala
@@ -3,6 +3,7 @@ package com.keepit.controllers.internal
 import com.google.inject.Inject
 import com.keepit.commanders.emails._
 import com.keepit.common.controller.ShoeboxServiceController
+import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.db.Id
 import com.keepit.common.time._
 import com.keepit.common.db.slick.Database
@@ -82,8 +83,14 @@ class EmailTestController @Inject() (
       case "connectionMade" => connectionMadeSender.sendToUser(userId, friendId, NotificationCategory.User.CONNECTION_MADE, Some(FACEBOOK))
       case "socialFriendJoined" => connectionMadeSender.sendToUser(userId, friendId, NotificationCategory.User.SOCIAL_FRIEND_JOINED, Some(FACEBOOK))
       case "contactJoined" => contactJoinedEmailSender.sendToUser(userId, friendId)
-      case "libraryInviteUser" => libraryInviteEmailSender.inviteUserToLibrary(Left(userId), friendId, libraryId)
-      case "libraryInviteNonUser" => libraryInviteEmailSender.inviteUserToLibrary(Right(sendTo), friendId, libraryId)
+      case "libraryInviteUser" => {
+        implicit val config = PublicIdConfiguration("secret key")
+        libraryInviteEmailSender.inviteUserToLibrary(Left(userId), friendId, libraryId)
+      }
+      case "libraryInviteNonUser" => {
+        implicit val config = PublicIdConfiguration("secret key")
+        libraryInviteEmailSender.inviteUserToLibrary(Right(sendTo), friendId, libraryId)
+      }
       case "confirm" => emailConfirmationSender.sendToUser(UserEmailAddress(userId = userId, address = sendTo).withVerificationCode(currentDateTime))
     }
 

--- a/kifi-backend/modules/shoebox/app/views/email/layouts/custom.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/layouts/custom.scala.html
@@ -1,0 +1,3 @@
+@(html: Html, emailToSend: com.keepit.common.mail.template.EmailToSend)
+@import com.keepit.common.mail.template.helpers._
+@html

--- a/kifi-backend/modules/shoebox/app/views/email/layouts/customText.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/layouts/customText.scala.html
@@ -1,0 +1,2 @@
+@(html: Html, emailToSend: com.keepit.common.mail.template.EmailToSend)
+@html

--- a/kifi-backend/modules/shoebox/app/views/email/layouts/default.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/layouts/default.scala.html
@@ -1,10 +1,11 @@
 @(contents: Seq[Html], emailToSend: com.keepit.common.mail.template.EmailToSend)
+@import com.keepit.common.mail.template.helpers._
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>@h.title</title>
+<title>@title</title>
 @headCss()
 </head>
 <body marginwidth="0" marginheight="0" style="margin-top: 0; margin-bottom: 0; padding-top: 0; padding-bottom: 0; width: 100% !important; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; -webkit-font-smoothing: antialiased;" offset="0" topmargin="0" leftmargin="0" bgcolor="#f3f3f3">
@@ -25,7 +26,7 @@
       @email.tags.trSpacer(49)
       <tr>
           <td valign="top">
-              @footer()
+              @email.layouts.footer()
           </td>
       </tr>
     </table>

--- a/kifi-backend/modules/shoebox/app/views/email/layouts/defaultText.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/layouts/defaultText.scala.html
@@ -1,9 +1,10 @@
 @(contents: Seq[Html])
+@import com.keepit.common.mail.template.helpers._
 
 @for(html <- contents) {
 @html
 }
 
-Don't want to receive these messages from Kifi? Unsubscribe here: @h.unsubscribeUrl
+Don't want to receive these messages from Kifi? Unsubscribe here: @unsubscribeUrl
 
-Kifi.com | @h.kifiAddress
+Kifi.com | @kifiAddress

--- a/kifi-backend/modules/shoebox/app/views/email/layouts/footer.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/layouts/footer.scala.html
@@ -1,4 +1,5 @@
 @()
+@import com.keepit.common.mail.template.helpers._
 
 <table width="100%" border="0" cellspacing="0" cellpadding="0">
     <tr>
@@ -13,11 +14,11 @@
                                     <table width="100%" border="0" cellspacing="0" cellpadding="0">
                                         <tr>
                                             <td align="left" class="center1" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#333333;line-height:22px;">
-                                                <a href="@h.kifiFooterUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Kifi.com</a>
+                                                <a href="@kifiFooterUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Kifi.com</a>
                                                 Your recommendations network<br/>Follow us on
-                                                <a href="@h.kifiTwitterUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Twitter</a>
+                                                <a href="@kifiTwitterUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Twitter</a>
                                                 &nbsp;
-                                                <a href="@h.kifiFacebookUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Facebook</a>
+                                                <a href="@kifiFacebookUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Facebook</a>
                                             </td>
                                         </tr>
                                     </table>
@@ -29,7 +30,7 @@
                                 <td class="top_space">
                                     <table width="105" border="0" cellspacing="0" cellpadding="0" align="center">
                                         <tr>
-                                            <td><a href="@h.iTunesAppStoreUrl" target="_blank"><img src="@h.assetUrl("app_store.png")" alt="Available on the App Store" width="105" height="35" style="display:block;" border="0" /></a></td>
+                                            <td><a href="@iTunesAppStoreUrl" target="_blank"><img src="@assetUrl("app_store.png")" alt="Available on the App Store" width="105" height="35" style="display:block;" border="0" /></a></td>
                                         </tr>
                                     </table>
                                 </td>
@@ -45,13 +46,13 @@
                         <table width="100%" border="0" cellspacing="0" cellpadding="0">
                             <tr>
                                 <td align="left" class="center1" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#333333;line-height:22px;">
-                                    Sent by Kifi @h.kifiAddress<br/>
+                                    Sent by Kifi @kifiAddress<br/>
                                 </td>
                             </tr>
                             <tr>
                                 <td align="left" class="center1" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#333333;line-height:22px;">
-                                    View our <a href="@h.privacyUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#85a4ea;line-height:22px;text-decoration:underline;">privacy policy</a>.
-                                    <a href="@h.unsubscribeUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#85a4ea;line-height:22px;text-decoration:underline;">Click to unsubscribe</a>
+                                    View our <a href="@privacyUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#85a4ea;line-height:22px;text-decoration:underline;">privacy policy</a>.
+                                    <a href="@unsubscribeUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#85a4ea;line-height:22px;text-decoration:underline;">Click to unsubscribe</a>
                                     from updates like this.<br class="br"/>
                                     &copy; 2014 FortyTwo, Inc. All rights reserved.
                                 </td>

--- a/kifi-backend/modules/shoebox/app/views/email/layouts/header.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/layouts/header.scala.html
@@ -1,5 +1,5 @@
 @()
-
+@import com.keepit.common.mail.template.helpers._
 <table class="wrapper" width="100%" border="0" cellspacing="0" cellpadding="0" align="center">
     <tr><td height="14" style="font-size:1px;line-height:1px;">&nbsp;</td></tr>
     <tr>
@@ -11,8 +11,8 @@
                         <table width="33" border="0" cellspacing="0" cellpadding="0" align="left">
                             <tr>
                                 <td align="left" width="33" height="19">
-                                    <a href="@h.kifiLogoUrl" target="_blank">
-                                        <img src="@h.assetUrl("kifi-logo.png")" alt="Kifi" width="33" height="19" style="display:block;" border="0"/>
+                                    <a href="@kifiLogoUrl" target="_blank">
+                                        <img src="@assetUrl("kifi-logo.png")" alt="Kifi" width="33" height="19" style="display:block;" border="0"/>
                                     </a>
                                 </td>
                             </tr>

--- a/kifi-backend/modules/shoebox/app/views/email/libraryInvitation.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/libraryInvitation.scala.html
@@ -1,10 +1,12 @@
 @(inviteeId: Option[Id[User]],
   inviterId: Id[User],
   inviteMsg: Option[String],
-  libraryInfo: com.keepit.commanders.LibraryInfo)
+  libraryInfo: com.keepit.commanders.LibraryInfo,
+  passPhrase: String)
 @import com.keepit.common.mail.template.helpers._
 @libraryAssetUrl(path: String) = @{assetUrl("library/" + path)}
 @libraryUrl = {@{baseUrl}@libraryInfo.url}
+@invitedHeader = {@firstName(inviterId) invited you to follow a library on kifi}
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -219,50 +221,67 @@
 <!-- //Header -->
 <!-- Content -->
 <tr>
-  <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
-    <tr>
-      <td width="1" bgcolor="#dedddd"></td>
-      <td bgcolor="#FFFFFF"><table width="100%" border="0" cellspacing="0" cellpadding="0">
-        <tr>
-          <td height="30">&nbsp;</td>
-        </tr>
-        <tr>
-          <td class="aside"><table width="100%" border="0" cellspacing="0" cellpadding="0">
+  <td>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0">
+      <tr>
+        <td width="1" bgcolor="#dedddd"></td>
+        <td bgcolor="#FFFFFF">
+          <table width="100%" border="0" cellspacing="0" cellpadding="0">
+            @inviteMsg.map { _ =>
             <tr>
-              <td width="60" class="hide">&nbsp;</td>
-              <td class="grey_link" style="font-family:'HelveticaNeueLT Std Roman', Helvetica, Arial, sans-serif;font-size:18px;color:#333333;line-height:20px;">
-                <a href="@libraryUrl" target="_blank" style="text-decoration:none;color:#333333;">@firstName(inviterId) invited you to follow a library on kifi</a>
+              <td height="30">&nbsp;</td>
+            </tr>
+            <tr>
+              <td class="aside">
+                <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                  <tr>
+                    <td width="60" class="hide">&nbsp;</td>
+                    <td class="grey_link" style="font-family:'HelveticaNeueLT Std Roman',Helvetica,Arial,sans-serif;font-size:18px;color:#333333;line-height:20px;">
+                      <a href="@libraryUrl" target="_blank" style="text-decoration:none;color:#333333;">
+                        @invitedHeader
+                      </a>
+                    </td>
+                  </tr>
+                </table>
               </td>
             </tr>
-          </table></td>
-        </tr>
-        <tr>
-          <td height="26">&nbsp;</td>
-        </tr>
-        <tr>
-          <td class="aside"><table width="100%" border="0" cellspacing="0" cellpadding="0">
+            }
             <tr>
-              <td width="40" class="hide">&nbsp;</td>
-              <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
-                <tr>
-                  <td width="54" valign="top"><img src='@avatarUrl(inviterId)' alt="@firstName(inviterId)" width="54" height="55" style="display:block;" border="0" /></td>
-                  <td width="20">&nbsp;</td>
-                  <td valign="top" style="font-family:Arial, sans-serif;font-size:17px;color:#667a90;line-height:21px;">
-                    @inviteMsg.map { msg =>
-                    “@msg”
-                    }
-                  </td>
-                  <td width="10"></td>
-                </tr>
-              </table></td>
+              <td height="26">&nbsp;</td>
             </tr>
-          </table></td>
-        </tr>
-        <tr>
-          <td height="40">&nbsp;</td>
-        </tr>
-      </table></td>
-      <td width="1" bgcolor="#dedddd"></td>
+            <tr>
+              <td class="aside">
+                <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                  <tr>
+                    <td width="40" class="hide">&nbsp;</td>
+                    <td>
+                      <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                        <tr>
+                          <td width="54" valign="top"><img src='@avatarUrl(inviterId)' alt="@firstName(inviterId)" width="54" height="55" style="display:block;" border="0" /></td>
+                          <td width="20">&nbsp;</td>
+                          @inviteMsg.map { msg =>
+                          <td valign="top" style="font-family:Arial,sans-serif;font-size:17px;color:#667a90;line-height:21px;">
+                            “@msg”
+                          </td>
+                          }.getOrElse {
+                          <td valign="middel" style="font-family:Arial,sans-serif;font-size:17px;color:#333333;line-height:21px;">
+                            @invitedHeader
+                          </td>
+                          }
+                          <td width="10"></td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td height="40">&nbsp;</td>
+            </tr>
+          </table>
+        </td>
+        <td width="1" bgcolor="#dedddd"></td>
     </tr>
   </table></td>
 </tr>
@@ -311,6 +330,8 @@
                         <tr>
                           <td style="font-family:'HelveticaNeueLT Std Roman', Helvetica, Arial, sans-serif;font-size:16px;color:#333333;line-height:20px;">
                             @libraryInfo.shortDescription.getOrElse("")
+                            <br/><br/>
+                            You may need to enter the following passphrase to view library: @passPhrase
                           </td>
                         </tr>
                         <tr>

--- a/kifi-backend/modules/shoebox/app/views/email/libraryInvitation.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/libraryInvitation.scala.html
@@ -1,54 +1,422 @@
 @(inviteeId: Option[Id[User]],
   inviterId: Id[User],
   inviteMsg: Option[String],
-  libraryName: String,
-  libraryDescription: Option[String],
-  libraryLink: String)
+  libraryInfo: com.keepit.commanders.LibraryInfo)
 @import com.keepit.common.mail.template.helpers._
+@libraryAssetUrl(path: String) = @{assetUrl("library/" + path)}
+@libraryUrl = {@{baseUrl}@libraryInfo.url}
 
-<!-- title = "Kifi - @firstName(inviterId) invited you to join @libraryName" -->
-<table class="row">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="format-detection" content="telephone=no" />
+  <!--[if !mso]><!-->
+  <link href='http://fonts.googleapis.com/css?family=Merriweather' rel='stylesheet' type='text/css'>
+  <!--<![endif]-->
+  <title>Kifi - Our Social Library</title>
+  <style type="text/css">
+    table {
+    border-collapse: collapse !important;
+    padding: 0px !important;
+    border: none !important;
+    border-bottom-width: 0px !important;
+    mso-table-lspace: 0pt;
+    mso-table-rspace: 0pt;
+    }
+    table td {
+    border-collapse: collapse;
+    }
+    body {
+    margin: 0px;
+    padding: 0px;
+    }
+    td {
+    border-collapse: collapse;
+    mso-line-height-rule: exactly;
+    }
+    .ExternalClass * {
+    line-height: 100%;
+    }
+    .grey_link a {
+    text-decoration: none;
+    color: #333333;
+    }
+    .grey_link1 a {
+    text-decoration: none;
+    color: #999999;
+    }
+    .blue_link a {
+    text-decoration: underline;
+    color: #6fa6ef;
+    }
+    .blue_link1 a {
+    text-decoration: underline;
+    color: #6fa6ef;
+    }
+    .footer a {
+    text-decoration: none;
+    color: #333333;
+    }
+    .txt_1 a {
+    text-decoration: none;
+    color: #68757d;
+    }
+    .txt_2 a {
+    text-decoration: none;
+    color: #2a2f32;
+    }
+    @@media only screen and (max-width:480px) {
+    table[class=wrapper] {
+    width: 100% !important;
+    }
+    table[class=main_table] {
+    width: 320px !important;
+    }
+    table[class=hide] {
+    display: none !important;
+    }
+    td[class=hide] {
+    display: none !important;
+    }
+    span[class=hide] {
+    display: none !important;
+    }
+    br[class=br] {
+    display: none !important;
+    }
+    td[class=aside] {
+    padding-left: 14px !important;
+    padding-right: 14px !important;
+    }
+    td[class=center] {
+    text-align: center !important;
+    }
+    td[class=top_space] {
+    padding-top: 16px !important;
+    }
+    td[class=width] {
+    width: 125px !important;
+    }
+    img[class=width] {
+    width: 125px !important;
+    height: auto !important;
+    }
+    td[class=width1] {
+    width: 60px !important;
+    }
+    td[class=txt_1] {
+    font-size: 13px !important;
+    line-height: 15px !important;
+    }
+    td[class=txt_2] {
+    font-size: 18px !important;
+    line-height: 20px !important;
+    }
+    td[class=blue_link1] {
+    text-align: center !important;
+    }
+    td[class=footer] {
+    text-align: center !important;
+    }
+    }
+    @@media only screen and (min-width:480px) and (max-width:579px) {
+    table[class=wrapper] {
+    width: 100% !important;
+    }
+    table[class=main_table] {
+    width: 480px !important;
+    }
+    table[class=hide] {
+    display: none !important;
+    }
+    td[class=hide] {
+    display: none !important;
+    }
+    span[class=hide] {
+    display: none !important;
+    }
+    br[class=br] {
+    display: none !important;
+    }
+    td[class=aside] {
+    padding-left: 14px !important;
+    padding-right: 14px !important;
+    }
+    td[class=center] {
+    text-align: center !important;
+    }
+    td[class=top_space] {
+    padding-top: 16px !important;
+    }
+    td[class=width] {
+    width: 125px !important;
+    }
+    img[class=width] {
+    width: 125px !important;
+    height: auto !important;
+    }
+    td[class=width1] {
+    width: 60px !important;
+    }
+    td[class=txt_1] {
+    font-size: 13px !important;
+    line-height: 15px !important;
+    }
+    td[class=txt_2] {
+    font-size: 18px !important;
+    line-height: 20px !important;
+    }
+    td[class=blue_link1] {
+    text-align: center !important;
+    }
+    td[class=footer] {
+    text-align: center !important;
+    }
+    }
+  </style>
+</head>
+<body marginwidth="0" marginheight="0"  style="margin-top: 0; margin-bottom: 0; padding-top: 0; padding-bottom: 0; width: 100% !important; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; -webkit-font-smoothing: antialiased;background-color:#f3f3f3;" offset="0" topmargin="0" leftmargin="0" bgcolor="#f3f3f3">
+<!-- 100% Table -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#f3f3f3">
+<tr>
+<td><table width="533" border="0" cellspacing="0" cellpadding="0" align="center" class="main_table">
+<tr>
+<td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+<!-- Header -->
+<tr>
+  <td bgcolor="#333333"><table width="100%" border="0" cellspacing="0" cellpadding="0">
     <tr>
-        <td class="wrapper">
-            <table class="two columns">
-                <tr>
-                    <td>
-                        <img height="80" width="80" src="@avatarUrl(inviterId)">
-                    </td>
-                    <td class="expander"></td>
-                </tr>
-            </table>
-        </td>
-
-        <td class="wrapper last">
-            <table class="ten columns">
-                <tr>
-                    <td>
-                        @inviteeId match {
-                            case Some(id) => {Hey @firstName(id),}
-                            case None => {"Hello!"}
-                        } <br><br>
-                        @fullName(inviterId) would like to share @libraryName with you <br><br>
-
-                        @inviteMsg match {
-                            case Some(msg) if msg != "" => {@firstName(inviterId) sent you a message: @msg <br><br>}
-                            case _ => {}
-                        }
-
-                        <font color="#A3C879">Come check it out here!</font><br>
-                        <a href="@libraryLink"><u>@libraryName</u></a><br>
-                        @libraryDescription match {
-                            case Some(descr) if descr != "" => {Library Description: @descr}
-                            case _ => {}
-                        }
-                        <br><br>
-
-                        Cheers! <br>
-                        The Kifi Team
-                    </td>
-                    <td class="expander"></td>
-                </tr>
-            </table>
-        </td>
+      <td class="hide" style="line-height:1px;min-width:533px;" height="1"><img src='@libraryAssetUrl("spacer.gif")' height="1"  width="533" style="max-height:1px; min-height:1px; display:block; width:533px;min-width:533px;" border="0" /></td>
     </tr>
+    @email.tags.trSpacer(13)
+    <tr>
+      <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td width="44">&nbsp;</td>
+          <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+            <tr>
+              <td width="42" valign="top"><a href="@kifiLogoUrl" target="_blank"><img src='@libraryAssetUrl("kifi.png")' width="34" height="21" alt="kifi" style="display:block;" border="0" /></a></td>
+              <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td height="6" style="line-height:1px;font-size:1px;">&nbsp;</td>
+                </tr>
+                <tr>
+                  <td style="font-family:Arial, sans-serif;font-size:14px;color:#ffffff;line-height:16px;">Our social library</td>
+                </tr>
+              </table></td>
+            </tr>
+          </table></td>
+        </tr>
+      </table></td>
+    </tr>
+    <tr>
+      <td height="14" style="line-height:1px;font-size:1px;">&nbsp;</td>
+    </tr>
+  </table></td>
+</tr>
+<!-- //Header -->
+<!-- Content -->
+<tr>
+  <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+    <tr>
+      <td width="1" bgcolor="#dedddd"></td>
+      <td bgcolor="#FFFFFF"><table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td height="30">&nbsp;</td>
+        </tr>
+        <tr>
+          <td class="aside"><table width="100%" border="0" cellspacing="0" cellpadding="0">
+            <tr>
+              <td width="60" class="hide">&nbsp;</td>
+              <td class="grey_link" style="font-family:'HelveticaNeueLT Std Roman', Helvetica, Arial, sans-serif;font-size:18px;color:#333333;line-height:20px;">
+                <a href="@libraryUrl" target="_blank" style="text-decoration:none;color:#333333;">@firstName(inviterId) invited you to follow a library on kifi</a>
+              </td>
+            </tr>
+          </table></td>
+        </tr>
+        <tr>
+          <td height="26">&nbsp;</td>
+        </tr>
+        <tr>
+          <td class="aside"><table width="100%" border="0" cellspacing="0" cellpadding="0">
+            <tr>
+              <td width="40" class="hide">&nbsp;</td>
+              <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td width="54" valign="top"><img src='@avatarUrl(inviterId)' alt="@firstName(inviterId)" width="54" height="55" style="display:block;" border="0" /></td>
+                  <td width="20">&nbsp;</td>
+                  <td valign="top" style="font-family:Arial, sans-serif;font-size:17px;color:#667a90;line-height:21px;">
+                    @inviteMsg.map { msg =>
+                    “@msg”
+                    }
+                  </td>
+                  <td width="10"></td>
+                </tr>
+              </table></td>
+            </tr>
+          </table></td>
+        </tr>
+        <tr>
+          <td height="40">&nbsp;</td>
+        </tr>
+      </table></td>
+      <td width="1" bgcolor="#dedddd"></td>
+    </tr>
+  </table></td>
+</tr>
+<tr>
+  <td height="1" bgcolor="#dedddd" style="line-height:0px;font-size:0px;"><img src='@libraryAssetUrl("spacer.gif")' width="1" height="1" style="display:block;" border="0" /></td>
+</tr>
+<tr>
+  <td height="20" style="line-height:1px;font-size:1px;">&nbsp;</td>
+</tr>
+<tr>
+  <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+    <tr
+      <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td style="line-height:0px;font-size:0px;"><img src='@libraryAssetUrl("top_img.png")' width="100%"  style="display:block;" border="0" /></td>
+        </tr>
+        <tr>
+          <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+            <tr>
+              <td width="1" bgcolor="#dedddd"></td>
+              <td bgcolor="#FFFFFF"><table width="100%" border="0" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td height="20" style="line-height:1px;font-size:1px;">&nbsp;</td>
+                </tr>
+                <tr>
+                  <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+                    <tr>
+                      <td width="54" class="hide">&nbsp;</td>
+                      <td class="aside"><table width="100%" border="0" cellspacing="0" cellpadding="0">
+                        <tr>
+                          <td>
+                            <a href="@libraryUrl" style="display:block;font-family:'Merriweather',Georgia,'Times New Roman',Times,serif;font-size:28px;color:#333333;line-height:36px;font-weight:bold;text-decoration:none;">@libraryInfo.name</a>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td height="18" style="line-height:1px;font-size:1px;">&nbsp;</td>
+                        </tr>
+                        <tr>
+                          <td class="grey_link1" style="font-family:'HelveticaNeueLT Std Roman', Helvetica, Arial, sans-serif;font-size:16px;color:#333333;line-height:20px;">Curator: <br />
+                            <span style="color:#999999">@fullName(inviterId)</span>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td height="18" style="line-height:1px;font-size:1px;">&nbsp;</td>
+                        </tr>
+                        <tr>
+                          <td style="font-family:'HelveticaNeueLT Std Roman', Helvetica, Arial, sans-serif;font-size:16px;color:#333333;line-height:20px;">
+                            @libraryInfo.shortDescription.getOrElse("")
+                          </td>
+                        </tr>
+                        <tr>
+                          <td height="18" style="line-height:1px;font-size:1px;">&nbsp;</td>
+                        </tr>
+                        <tr>
+                          <td height="1" bgcolor="#e7e7e7" style="line-height:0px;font-size:0px;"><img src='@libraryAssetUrl("spacer.gif")' width="1" height="1" style="display:block;" border="0" /></td>
+                        </tr>
+                        <tr>
+                          <td height="18" style="line-height:1px;font-size:1px;">&nbsp;</td>
+                        </tr>
+                        <tr>
+                          <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+                            <tr>
+                              <td width="80" valign="middle" class="width1"><table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                <tr>
+                                  <td class="txt_1" style="font-family:Arial, sans-serif;font-size:14px;color:#68757d;line-height:16px;">
+                                    <span style="text-decoration:none;color:#68757d;">KEEPS</span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td height="6" style="line-height:1px;font-size:1px;">&nbsp;</td>
+                                </tr>
+                                <tr>
+                                  <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                    <tr>
+                                      <td width="10">&nbsp;</td>
+                                      <td class="txt_2" style="font-family:Arial, sans-serif;font-size:20px;color:#2a2f32;line-height:22px;font-weight:bold;">@libraryInfo.numKeeps</td>
+                                    </tr>
+                                  </table></td>
+                                </tr>
+                              </table></td>
+                              <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                <tr>
+                                  <td class="txt_1" style="font-family:Arial, sans-serif;font-size:14px;color:#68757d;line-height:16px;">
+                                    <span style="text-decoration:none;color:#68757d;">FOLLOWERS</span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td height="6" style="line-height:1px;font-size:1px;">&nbsp;</td>
+                                </tr>
+                                <tr>
+                                  <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                    <tr>
+                                      <td width="18">&nbsp;</td>
+                                      <td class="txt_2" style="font-family:Arial, sans-serif;font-size:20px;color:#2a2f32;line-height:22px;font-weight:bold;">@libraryInfo.numFollowers</td>
+                                    </tr>
+                                  </table></td>
+                                </tr>
+                              </table></td>
+                              <td>&nbsp;</td>
+                              <td width="145" class="width">
+                                <a href="@libraryUrl" target="_blank" style="display:block;">
+                                  <img class="width" src='@libraryAssetUrl("follow_library_btn.png")' alt="Follow Library" width="145" height="49" style="display:block;" border="0" />
+                                </a>
+                              </td>
+                            </tr>
+                          </table></td>
+                        </tr>
+                        <tr>
+                          <td height="10" style="line-height:1px;font-size:1px;">&nbsp;</td>
+                        </tr>
+                      </table></td>
+                      <td width="54" class="hide">&nbsp;</td>
+                    </tr>
+                  </table></td>
+                </tr>
+              </table></td>
+              <td width="1" bgcolor="#dedddd"></td>
+            </tr>
+          </table></td>
+        </tr>
+        <tr>
+          <td><a href="@libraryUrl" target="_blank"><img src='@libraryAssetUrl("banner.png")' alt="" width="100%" style="display:block;" border="0"/></a></td>
+        </tr>
+      </table></td>
+    </tr>
+  </table></td>
+</tr>
+<!-- //Content -->
+<tr>
+  <td height="50"></td>
+</tr>
+<!-- Footer -->
+<tr>
+  <td>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0">
+      <tr>
+        <td width="20" class="hide">&nbsp;</td>
+        <td class="aside">
+          <table width="100%" border="0" cellspacing="0" cellpadding="0">
+            @footerHtml
+          </table>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+
+<!-- //Footer -->
+</table></td>
+</tr>
+</table></td>
+</tr>
 </table>
+
+<!-- //100% Table -->
+</body>
+</html>

--- a/kifi-backend/modules/shoebox/app/views/email/libraryInvitationText.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/libraryInvitationText.scala.html
@@ -1,0 +1,20 @@
+@(inviteeId: Option[Id[User]],
+inviterId: Id[User],
+inviteMsg: Option[String],
+libraryInfo: com.keepit.commanders.LibraryInfo)
+@import com.keepit.common.mail.template.helpers._
+@libraryAssetUrl(path: String) = @{assetUrl("library/" + path)}
+@libraryUrl = {@{baseUrl}@libraryInfo.url}
+
+@fullName(inviterId) invited you to follow a library on kifi
+@inviteMsg.map { msg =>
+  "@msg"
+}
+@libraryInfo.name
+
+@libraryInfo.shortDescription.getOrElse("")
+
+@libraryUrl
+
+Cheers!
+The Kifi team

--- a/kifi-backend/modules/shoebox/app/views/email/libraryInvitationText.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/libraryInvitationText.scala.html
@@ -1,7 +1,8 @@
 @(inviteeId: Option[Id[User]],
 inviterId: Id[User],
 inviteMsg: Option[String],
-libraryInfo: com.keepit.commanders.LibraryInfo)
+libraryInfo: com.keepit.commanders.LibraryInfo,
+passPhrase: String)
 @import com.keepit.common.mail.template.helpers._
 @libraryAssetUrl(path: String) = @{assetUrl("library/" + path)}
 @libraryUrl = {@{baseUrl}@libraryInfo.url}
@@ -15,6 +16,7 @@ libraryInfo: com.keepit.commanders.LibraryInfo)
 @libraryInfo.shortDescription.getOrElse("")
 
 @libraryUrl
+Passphrase: @passPhrase
 
 Cheers!
 The Kifi team

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailSenderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailSenderTest.scala
@@ -3,6 +3,7 @@ package com.keepit.commanders.emails
 import com.google.inject.Injector
 import com.keepit.abook.{ FakeABookServiceClientImpl, ABookServiceClient, FakeABookServiceClientModule }
 import com.keepit.common.cache.FakeCacheModule
+import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.healthcheck.FakeHealthcheckModule
 import com.keepit.common.mail.template.{ EmailTip, EmailTrackingParam }
 import com.keepit.common.mail.{ EmailAddress, FakeOutbox }
@@ -294,49 +295,69 @@ class EmailSenderTest extends Specification with ShoeboxTestInjector {
   }
 
   "LibraryInviteEmailSender" should {
+    implicit val config = PublicIdConfiguration("secret key")
+
+    def setup()(implicit injector: Injector) = {
+      val keepRepo = inject[KeepRepo]
+      val urlRepo = inject[URLRepo]
+      val uriRepo = inject[NormalizedURIRepo]
+
+      db.readWrite { implicit rw =>
+        val user1 = userRepo.save(User(firstName = "Tom", lastName = "Brady", username = Some(Username("tom")), primaryEmail = Some(EmailAddress("tombrady@gmail.com"))))
+        val user2 = userRepo.save(User(firstName = "Aaron", lastName = "Rodgers", username = Some(Username("aaron")), primaryEmail = Some(EmailAddress("aaronrodgers@gmail.com"))))
+        val lib1 = libraryRepo.save(Library(name = "Football", ownerId = user1.id.get, slug = LibrarySlug("football"),
+          visibility = LibraryVisibility.PUBLISHED, memberCount = 1, description = Some("Lorem ipsum")))
+
+        val uri = uriRepo.save(NormalizedURI(url = "http://www.kifi.com", urlHash = UrlHash("abc")))
+        // todo(andrew) jared compiler bug if url_ var is named url
+        val url_ = urlRepo.save(URL(url = "http://www.kifi.com", domain = None, normalizedUriId = uri.id.get))
+        val keep = keepRepo.save(Keep(urlId = url_.id.get, url = url_.url, libraryId = lib1.id, uriId = uri.id.get, visibility = LibraryVisibility.SECRET, userId = user1.id.get, source = KeepSource.keeper, inDisjointLib = false))
+
+        libraryMembershipRepo.save(LibraryMembership(libraryId = lib1.id.get, userId = user1.id.get, access = LibraryAccess.OWNER, showInSearch = true))
+
+        (user1, user2, lib1)
+      }
+    }
+
     "sends invite to user (userId)" in {
       withDb(modules: _*) { implicit injector =>
+        val (user1, user2, lib1) = setup()
         val outbox = inject[FakeOutbox]
         val inviteSender = inject[LibraryInviteEmailSender]
-        val (user1, user2, lib1) = db.readWrite { implicit rw =>
-          val user1 = userRepo.save(User(firstName = "Tom", lastName = "Brady", username = Some(Username("tom")), primaryEmail = Some(EmailAddress("tombrady@gmail.com"))))
-          val lib1 = libraryRepo.save(Library(name = "Football", ownerId = user1.id.get, slug = LibrarySlug("football"), visibility = LibraryVisibility.PUBLISHED, memberCount = 1))
-          libraryMembershipRepo.save(LibraryMembership(libraryId = lib1.id.get, userId = user1.id.get, access = LibraryAccess.OWNER, showInSearch = true))
-
-          val user2 = userRepo.save(User(firstName = "Aaron", lastName = "Rodgers", username = Some(Username("aaron")), primaryEmail = Some(EmailAddress("aaronrodgers@gmail.com"))))
-          (user1, user2, lib1)
-        }
         val email = Await.result(inviteSender.inviteUserToLibrary(Left(user2.id.get), user1.id.get, lib1.id.get), Duration(5, "seconds"))
+
         outbox.size === 1
         outbox(0) === email
 
         email.subject === "Tom Brady invited you to follow Football!"
+        email.to(0) === EmailAddress("aaronrodgers@gmail.com")
         val html = email.htmlBody.value
-        html must contain("Hey Aaron,")
-        html must contain("Tom Brady would like to share Football with you")
-        html must contain(s"""<a href="https://www.kifi.com/tom/football"><u>Football</u></a>""")
+        html must contain("Football")
+        html must contain("Tom invited you to")
+        html must contain("Tom Brady")
+        html must contain("Lorem ipsum")
+        html must contain("TEST_MODE/tom/football")
       }
     }
 
     "send invite to non-user (email)" in {
       withDb(modules: _*) { implicit injector =>
+        val (user1, user2, lib1) = setup()
         val outbox = inject[FakeOutbox]
         val inviteSender = inject[LibraryInviteEmailSender]
-        val (user1, lib1) = db.readWrite { implicit rw =>
-          val user1 = userRepo.save(User(firstName = "Tom", lastName = "Brady", username = Some(Username("tom")), primaryEmail = Some(EmailAddress("tombrady@gmail.com"))))
-          val lib1 = libraryRepo.save(Library(name = "Football", ownerId = user1.id.get, slug = LibrarySlug("football"), visibility = LibraryVisibility.PUBLISHED, memberCount = 1))
-          libraryMembershipRepo.save(LibraryMembership(libraryId = lib1.id.get, userId = user1.id.get, access = LibraryAccess.OWNER, showInSearch = true))
-          (user1, lib1)
-        }
         val email = Await.result(inviteSender.inviteUserToLibrary(Right(EmailAddress("aaronrodgers@gmail.com")), user1.id.get, lib1.id.get), Duration(5, "seconds"))
+
         outbox.size === 1
         outbox(0) === email
 
         email.subject === "Tom Brady invited you to follow Football!"
+        email.to(0) === EmailAddress("aaronrodgers@gmail.com")
         val html = email.htmlBody.value
-        html must contain("Hello!")
-        html must contain("Tom Brady would like to share Football with you")
-        html must contain(s"""<a href="https://www.kifi.com/tom/football"><u>Football</u></a>""")
+        html must contain("Football")
+        html must contain("Tom invited you to")
+        html must contain("Tom Brady")
+        html must contain("Lorem ipsum")
+        html must contain("TEST_MODE/tom/football")
       }
     }
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/mail/ElectronicMailTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/mail/ElectronicMailTest.scala
@@ -1,10 +1,11 @@
 package com.keepit.common.mail
 
-import com.keepit.common.mail.template.EmailToSend
+import com.keepit.common.mail.template.{ TemplateOptions, EmailLayout, EmailToSend }
+import com.keepit.heimdal.ContextData
 import com.keepit.test._
 import org.specs2.mutable.Specification
 import com.keepit.model.NotificationCategory
-import play.api.libs.json.{ JsSuccess, Json }
+import play.api.libs.json.{ JsValue, JsSuccess, Json }
 import play.twirl.api.Html
 
 class ElectronicMailTest extends Specification with ShoeboxTestInjector {
@@ -47,23 +48,12 @@ class ElectronicMailTest extends Specification with ShoeboxTestInjector {
         closingLines = Seq("Happy Keeping!", "The Kifi team")
       )
 
-      val expectedJson = """
-          |{"title":"Kifi","from":"eng@42go.com","to":"josh@kifi.com","cc":[],"subject":"Test",
-          |"htmlTemplate":"this is <b>html</b>","category":"digest","fromName":"Kifi",
-          |"campaign":"testing","tips":[],
-          |"closingLines":["Happy Keeping!","The Kifi team"]
-          |}
-        """.stripMargin
-      val jsVal = Json.parse(expectedJson)
-      Json.toJson(em) === jsVal
+      val otherEm = Json.fromJson[EmailToSend](Json.toJson[EmailToSend](em)).get
 
-      val result = jsVal.as[EmailToSend]
-      result.from === em.from
-      result.to === em.to
-      result.subject === em.subject
-      result.campaign === em.campaign
-      result.category === em.category
-      result.htmlTemplate.body === em.htmlTemplate.body
+      // Html objects don't have a good equals method when we just care about the Html.body
+      val blankHtml = Html("")
+      otherEm.copy(htmlTemplate = blankHtml) === em.copy(htmlTemplate = blankHtml)
+      otherEm.htmlTemplate.body === em.htmlTemplate.body
     }
   }
 }


### PR DESCRIPTION
this is not complete (ready for production) - it is a wired-up version of the design/HTML
there are still edge cases we still need to account for:
- improve design when empty message from inviter
- the "Follow Library" button is a full image, and it's not possible to actually follow the library from email, so maybe it should be renamed
- non users need the passphrase
- the image is a static placeholder

@stkem 
cc @ahsu1230 
