### PR TITLE
Changing fonts to always use HTTPS + new filename

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/app.styl
+++ b/kifi-backend/modules/shoebox/angular/src/app.styl
@@ -105,13 +105,13 @@ a[href]
   font-family: 'Merriweather'
   font-style: normal
   font-weight: 400
-  src: local('Merriweather'), url(//djty7jcqog9qu.cloudfront.net/fonts/mw400.woff) format('woff')
+  src: local('Merriweather'), url(https://djty7jcqog9qu.cloudfront.net/fonts/mw400-2.woff) format('woff')
 
 @font-face
   font-family: 'Merriweather'
   font-style: normal
   font-weight: 700
-  src: local('Merriweather Bold'), local('Merriweather-Bold'), url(//djty7jcqog9qu.cloudfront.net/fonts/mw700.woff) format('woff')
+  src: local('Merriweather Bold'), local('Merriweather-Bold'), url(https://djty7jcqog9qu.cloudfront.net/fonts/mw700-2.woff) format('woff')
 
 [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak
   display: none !important


### PR DESCRIPTION
@yipingliao Also re-uploaded them so that CloudFront re-caches everything.

I changed CloudFront to forward the Origin header also.

Headers seem good, but my browser doesn't actually fetch the font anymore since I now have it locally. Let me know if this fixes it.
