### PR TITLE
Fixing build

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/engine/result/KifiShardResultMerger.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/result/KifiShardResultMerger.scala
@@ -2,7 +2,7 @@ package com.keepit.search.engine.result
 
 import com.keepit.search.SearchConfig
 import com.keepit.search.engine.Visibility
-import com.keepit.search.util.HitQueue
+import com.keepit.search.util.{ HitQueue => UtilHitQueue }
 import play.api.libs.json.JsResultException
 import scala.math._
 
@@ -106,7 +106,7 @@ class KifiShardResultMerger(enableTailCutting: Boolean, config: SearchConfig) {
     }
   }
 
-  @inline private[this] def createQueue(maxHits: Int) = new HitQueue[KifiShardHit](maxHits)
+  @inline private[this] def createQueue(maxHits: Int) = new UtilHitQueue[KifiShardHit](maxHits)
   @inline private[this] def dampFunc(rank: Int, halfDecay: Double) = (1.0d / (1.0d + pow(rank.toDouble / halfDecay, 3.0d))).toFloat
 
   private def mergeTotals(results: Seq[KifiShardResult]): (Int, Int, Int) = {


### PR DESCRIPTION
@ymatsuda The build didn't previously break because the reason for the break is:

```
[warn] /var/lib/jenkins/jobs/all-quick-s3/workspace/kifi-backend/modules/search/app/com/keepit/search/engine/result/KifiShardResultMerger.scala:5: imported `HitQueue' is permanently hidden by definition of class HitQueue in package result
[warn] import com.keepit.search.util.HitQueue
[warn]                               ^
[error] /var/lib/jenkins/jobs/all-quick-s3/workspace/kifi-backend/modules/search/app/com/keepit/search/engine/result/KifiShardResultMerger.scala:109: com.keepit.search.engine.result.HitQueue does not take type parameters
[error]   @inline private[this] def createQueue(maxHits: Int) = new HitQueue[KifiShardHit](maxHits)
[error]   
```

So basically, `HitQueue` was added to result, and since the entirety of result wasn't recompiled, it didn't catch that the import changed.

This passes tests. If this is not what is intended please feel free to fix. /cc @eishay
