### PR TITLE
scalability enhancements to feed digest sender

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -78,6 +78,7 @@ object Shoebox extends Service {
     def getBasicUsers() = ServiceRoute(POST, "/internal/shoebox/database/getBasicUsers")
     def getBasicUsersNoCache() = ServiceRoute(POST, "/internal/shoebox/database/getBasicUsersNoCache")
     def getEmailAddressesForUsers() = ServiceRoute(POST, "/internal/shoebox/database/getEmailAddressesForUsers")
+    def getPrimaryEmailAddressForUsers() = ServiceRoute(POST, "/internal/shoebox/database/getPrimaryEmailAddressForUsers")
     def getCollectionIdsByExternalIds(ids: String) = ServiceRoute(GET, "/internal/shoebox/database/collectionIdsByExternalIds", Param("ids", ids))
     def getUserOpt(id: ExternalId[User]) = ServiceRoute(GET, "/internal/shoebox/database/getUserOpt", Param("id", id))
     def getUserExperiments(id: Id[User]) = ServiceRoute(GET, "/internal/shoebox/database/getUserExperiments", Param("id", id))

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -47,6 +47,7 @@ trait ShoeboxServiceClient extends ServiceClient {
   def getBasicUsers(users: Seq[Id[User]]): Future[Map[Id[User], BasicUser]]
   def getBasicUsersNoCache(users: Seq[Id[User]]): Future[Map[Id[User], BasicUser]]
   def getEmailAddressesForUsers(userIds: Seq[Id[User]]): Future[Map[Id[User], Seq[EmailAddress]]]
+  def getPrimaryEmailAddressForUsers(userIds: Seq[Id[User]]): Future[Map[Id[User], Option[EmailAddress]]]
   def getNormalizedURI(uriId: Id[NormalizedURI]): Future[NormalizedURI]
   def getNormalizedURIs(uriIds: Seq[Id[NormalizedURI]]): Future[Seq[NormalizedURI]]
   def getNormalizedURIByURL(url: String): Future[Option[NormalizedURI]]
@@ -299,6 +300,12 @@ class ShoeboxServiceClientImpl @Inject() (
       log.debug(s"[res.request.trackingId] getEmailAddressesForUsers for users $userIds returns json ${res.json}")
       res.json.as[Map[String, Seq[EmailAddress]]].map { case (id, emails) => Id[User](id.toLong) -> emails }.toMap
     }
+  }
+
+  def getPrimaryEmailAddressForUsers(userIds: Seq[Id[User]]): Future[Map[Id[User], Option[EmailAddress]]] = {
+    redundantDBConnectionCheck(userIds)
+    val payload = Json.toJson(userIds)
+    call(Shoebox.internal.getPrimaryEmailAddressForUsers(), payload) map { _.json.as[Map[Id[User], Option[EmailAddress]]] }
   }
 
   def getSearchFriends(userId: Id[User]): Future[Set[Id[User]]] = consolidateSearchFriendsReq(SearchFriendsKey(userId)) { key =>

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -475,6 +475,13 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
     Future.successful(m)
   }
 
+  def getPrimaryEmailAddressForUsers(userIds: Seq[Id[User]]): Future[Map[Id[User], Option[EmailAddress]]] = {
+    val m = allUserEmails collect {
+      case (id, emails) if userIds.contains(id) => (id, emails.headOption)
+    }
+    Future.successful(m.toMap)
+  }
+
   def sendMail(email: ElectronicMail): Future[Boolean] = synchronized {
     sentMail += email
     Future.successful(true)

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/email/FeedDigestEmailSender.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/email/FeedDigestEmailSender.scala
@@ -1,8 +1,9 @@
 package com.keepit.curator.commanders.email
 
-import com.google.inject.Inject
+import com.google.inject.{ Singleton, Inject }
 import com.keepit.abook.ABookServiceClient
 import com.keepit.commanders.RemoteUserExperimentCommander
+import com.keepit.common.concurrent.ReactiveLock
 import com.keepit.common.concurrent.FutureHelpers
 import com.keepit.common.concurrent.PimpMyFuture._
 import com.keepit.common.db.Id
@@ -124,16 +125,15 @@ sealed case class DigestRecoKeepers(friends: Seq[Id[User]] = Seq.empty, others: 
 
 sealed case class DigestRecoMail(userId: Id[User], mailSent: Boolean, feed: Seq[DigestReco])
 
+@Singleton
 class FeedDigestEmailSender @Inject() (
     recommendationGenerationCommander: RecommendationGenerationCommander,
     uriRecommendationRepo: UriRecommendationRepo,
     seedCommander: SeedIngestionCommander,
     shoebox: ShoeboxServiceClient,
-    abook: ABookServiceClient,
     db: Database,
     serviceDiscovery: ServiceDiscovery,
     queue: SQSQueue[SendFeedDigestToUserMessage],
-    userExperimentCommander: RemoteUserExperimentCommander,
     protected val config: FortyTwoConfig,
     protected val airbrake: AirbrakeNotifier) extends Logging {
 
@@ -141,22 +141,20 @@ class FeedDigestEmailSender @Inject() (
 
   val defaultUriRecommendationScores = UriRecommendationScores()
 
-  def addToQueue(additionalUsers: Seq[Id[User]] = Seq.empty): Future[Set[Id[User]]] = {
+  private val queueLock = new ReactiveLock(10)
+
+  def addToQueue(additionalUsers: Seq[Id[User]] = Seq.empty): Future[Unit] = {
     if (serviceDiscovery.isLeader()) {
-      shoebox.getUsers(seedCommander.getUsersWithSufficientData().toSeq ++ additionalUsers).map { userSet =>
-        userSet.map { user =>
-          if (user.primaryEmail.isDefined) {
-            queue.send(SendFeedDigestToUserMessage(user.id.get))
-            user.id
-          } else {
-            log.info(s"NOT sending digest email to ${user.id.get}; primaryEmail missing")
-            None
-          }
-        }.flatten.toSet
+      val usersIdsToSendTo = seedCommander.getUsersWithSufficientData().toSeq ++ additionalUsers
+
+      val seqF = usersIdsToSendTo.map { userId =>
+        queueLock.withLockFuture { queue.send(SendFeedDigestToUserMessage(userId)) }
       }
+
+      Future.sequence(seqF) map (_ -> ())
     } else {
       airbrake.notify("FeedDigestEmailSender.send() should not be called by non-leader!")
-      Future.successful(Set.empty)
+      Future.successful(())
     }
   }
 

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -684,6 +684,7 @@ GET     /internal/shoebox/database/userIdsByExternalIds                @com.keep
 POST    /internal/shoebox/database/getBasicUsers                       @com.keepit.controllers.internal.ShoeboxController.getBasicUsers()
 POST    /internal/shoebox/database/getBasicUsersNoCache                @com.keepit.controllers.internal.ShoeboxController.getBasicUsersNoCache()
 POST    /internal/shoebox/database/getEmailAddressesForUsers           @com.keepit.controllers.internal.ShoeboxController.getEmailAddressesForUsers()
+POST    /internal/shoebox/database/getPrimaryEmailAddressForUsers      @com.keepit.controllers.internal.ShoeboxController.getPrimaryEmailAddressForUsers()
 GET     /internal/shoebox/database/collectionIdsByExternalIds          @com.keepit.controllers.internal.ShoeboxController.getCollectionIdsByExternalIds(ids: String)
 GET     /internal/shoebox/database/getUserOpt                          @com.keepit.controllers.internal.ShoeboxController.getUserOpt(id: ExternalId[User])
 GET     /internal/shoebox/database/getUserExperiments                  @com.keepit.controllers.internal.ShoeboxController.getUserExperiments(id: Id[User])


### PR DESCRIPTION
- does not rely on a calls to shoebox to determine if a user has a primaryEmail (the sender handles this)
- uses reactive lock to ensure a a limited # of threads are consumed when queuing messages

I created an endpoint getPrimaryEmailAddressForUsers that I was originally using (before I realized I didn't need it).  Leaving it in it could be useful somewhere else.

@stkem 
