### PR TITLE
More library web ui fixes

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -112,16 +112,24 @@ angular.module('kifi')
         }
 
         function keepOne (keep, isPrivate) {
-          keepActionService.keepOne(keep, isPrivate).then(function (keptItem) {
-            keep.buildKeep(keptItem);
-            keep.makeKept();
+          if (scope.librariesEnabled) {
+            keepActionService.keepToLibrary([keep.url], keep.libraryId).then(function (resp) {
+              var keptItem = resp && resp.keeps && resp.keeps[0];
 
-            if (scope.librariesEnabled) {
-              libraryService.addToLibraryCount(keep.libraryId, 1);
-            } else {
+              if (keptItem) {
+                keep.buildKeep(keptItem);
+                keep.makeKept();
+                libraryService.addToLibraryCount(keep.libraryId, 1);
+              }
+            });
+          } else {
+            keepActionService.keepOne(keep, isPrivate).then(function (keptItem) {
+              keep.buildKeep(keptItem);
+              keep.makeKept();
+
               tagService.addToKeepCount(1);
-            }
-           });
+             });
+          }
 
           if (_.isFunction(scope.keepCallback)) {
             scope.keepCallback({ 'keep': keep });

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -113,10 +113,14 @@ angular.module('kifi')
 
         function keepOne (keep, isPrivate) {
           keepActionService.keepOne(keep, isPrivate).then(function (keptItem) {
-             keep.buildKeep(keptItem);
-             keep.makeKept();
-             libraryService.addToLibraryCount(keep.libraryId, 1);
-             tagService.addToKeepCount(1);
+            keep.buildKeep(keptItem);
+            keep.makeKept();
+
+            if (scope.librariesEnabled) {
+              libraryService.addToLibraryCount(keep.libraryId, 1);
+            } else {
+              tagService.addToKeepCount(1);
+            }
            });
 
           if (_.isFunction(scope.keepCallback)) {
@@ -278,8 +282,11 @@ angular.module('kifi')
               keepOne(keep);
             });
 
-            libraryService.addToLibraryCount(keep.libraryId, -1);
-            tagService.addToKeepCount(-1);
+            if (scope.librariesEnabled) {
+              libraryService.addToLibraryCount(keep.libraryId, -1);
+            } else {
+              tagService.addToKeepCount(-1);
+            }
           });
         };
 
@@ -302,7 +309,6 @@ angular.module('kifi')
 
                   libraryService.fetchLibrarySummaries(true);
                   libraryService.addToLibraryCount(libraryId, 1);
-                  tagService.addToKeepCount(1);
                 });
               }
             });

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.tpl.html
@@ -1,5 +1,5 @@
 <div class="kf-main-library-keeps">
-  <div class="kf-library-card-header">
+  <div class="kf-library-card-header" ng-show="!loading">
     <div kf-library-card
       library="library"
       username="username"

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -69,11 +69,6 @@ angular.module('kifi')
             scope.library.owner = profileService.me;
           }
 
-          // TODO(yiping): make sure recommended libraries have visibility.
-          if (!scope.library.visibility && scope.recommendation) {
-            scope.library.visibility = 'published';
-          }
-
           if (scope.library.owner) {
             scope.library.owner.picUrl = friendService.getPictureUrlForUser(scope.library.owner);
           }
@@ -103,8 +98,7 @@ angular.module('kifi')
         };
 
         scope.isUserLibrary = function (library) {
-          // TODO(yiping): get recommendation libraries to have a "kind" property.
-          return library.kind === 'user_created' || scope.recommendation;
+          return library.kind === 'user_created';
         };
 
         scope.isMyLibrary = function (library) {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -41,6 +41,7 @@ angular.module('kifi')
           // 250px needed for other stuff in the parent's width.
           var maxFollowersToShow = Math.floor((parentWidth - 250) / widthPerFollowerPic);
 
+          scope.numAdditionalFollowers = 0;
           if (_.isArray(scope.library.followers)) {
             // If we only have one additional follower that we can't fit in, then we can fit that one
             // in if we don't show the additional-number-of-followers circle.

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -81,7 +81,14 @@ angular.module('kifi')
 
           var maxLength = 150;
           if (scope.library.description && scope.library.description.length > maxLength) {
-            scope.library.shortDescription = scope.library.description.substr(0, maxLength);
+            // Try to chop off at a word boundary, using a simple space as the word boundary delimiter.
+            var clipLastIndex = maxLength;
+            var lastSpaceIndex = scope.library.description.lastIndexOf(' ', maxLength);
+            if (lastSpaceIndex !== -1) {
+              clipLastIndex = lastSpaceIndex + 1;  // Grab the space too.
+            }
+
+            scope.library.shortDescription = scope.library.description.substr(0, clipLastIndex);
             scope.clippedDescription = true;
           }
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
@@ -33,7 +33,7 @@
       <div class="kf-keep-lib-stats-and-followers">
         <div class="kf-keep-lib-keeps-followers-stats">
           <span class="kf-keep-lib-stats-heading">Keeps</span>
-          <span class="kf-keep-lib-stats-number">{{library.keeps.length || library.numKeeps}}</span>
+          <span class="kf-keep-lib-stats-number">{{library.numKeeps}}</span>
         </div>
 
         <div class="kf-keep-lib-keeps-followers-stats">

--- a/kifi-backend/modules/shoebox/angular/src/recos/recoDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recoDecoratorService.js
@@ -7,8 +7,8 @@ angular.module('kifi')
 
     function Recommendation(rawReco, type) {
       this.recoData = {
-        type: type,
-        kind: rawReco.kind,
+        type: type,  // This is either 'recommended' or 'popular'.
+        kind: rawReco.kind,  // This is either 'keep' or 'library'.
         reasons: rawReco.metaData || [],
         explain: rawReco.explain
       };
@@ -23,6 +23,10 @@ angular.module('kifi')
         this.recoKeep = new keepDecoratorService.Keep(rawReco.itemInfo, 'reco');
       } else {
         this.recoLib = rawReco.itemInfo;
+
+        // All recommended libraries are published user-created libraries.
+        this.recoLib.kind = 'user_created';
+        this.recoLib.visibility = 'published';
       }
     }
 


### PR DESCRIPTION
@andrewconner @ahsu1230 

More library bug fixes:
- Don't show additional followers number when re-expanded
  https://app.asana.com/0/15523651812135/17258517427118
- Remove JS error when keeping in non-libraries-enabled mode
  https://app.asana.com/0/15523651812135/17258517427123
- Hardcode metadata about recommended libraries in recoActionService so we can remove checks in the directives.
  https://app.asana.com/0/15523651812135/17179575596242
- Shorten library descriptions on word boundaries
  https://app.asana.com/0/15523651812135/17258517427091
- Use correct keep endpoint when undoing unkeeps
  https://app.asana.com/0/15523651812135/17258517427114
- Don't show library card until library information has been loaded.
  https://app.asana.com/0/15523651812135/17177092390148
- Display correct library count
  https://app.asana.com/0/15523651812135/17247218437956
