### PR TITLE
tag paginations & unkeep multiple for website

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
@@ -66,6 +66,26 @@ class CollectionCommander @Inject() (
     collections
   }
 
+  def pageCollections(sort: String, offset: Int, pageSize: Int, userId: Id[User]) = {
+    log.info(s"Getting all collections for $userId (sort $sort)")
+    val unsortedCollections = db.readOnlyMaster { implicit s =>
+      val colls = collectionRepo.getUnfortunatelyIncompleteTagSummariesByUser(userId)
+      val bmCounts = collectionRepo.getBookmarkCounts(colls.map(_.id).toSet)
+      colls.map { c => BasicCollection.fromCollection(c, bmCounts.get(c.id).orElse(Some(0))) }
+    }
+    val collections = sort match {
+      case "user" =>
+        userSort(userId, unsortedCollections)
+      case "num_keeps" =>
+        unsortedCollections.sortBy(_.keeps)(Ordering[Option[Int]].reverse)
+      case "name" =>
+        unsortedCollections.sortBy(_.name.toLowerCase)(Ordering[String])
+      case _ => // default is "last_kept"
+        unsortedCollections
+    }
+    collections.drop(offset * pageSize).take(pageSize)
+  }
+
   def updateCollectionOrdering(uid: Id[User])(implicit s: RWSession): Seq[ExternalId[Collection]] = {
     setCollectionOrdering(uid, getCollectionOrdering(uid))
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
@@ -372,6 +372,15 @@ class KeepsController @Inject() (
     }
   }
 
+  def page(sort: String, offset: Int, pageSize: Int) = UserAction.async { request =>
+    val collectionsFuture = SafeFuture { collectionCommander.pageCollections(sort, offset, pageSize, request.userId) }
+    for {
+      collections <- collectionsFuture
+    } yield {
+      Ok(Json.obj("collections" -> collections))
+    }
+  }
+
   def saveCollection() = UserAction { request =>
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
     collectionCommander.saveCollection(request.userId, request.body.asJson.flatMap(Json.fromJson[BasicCollection](_).asOpt)) match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
@@ -372,13 +372,9 @@ class KeepsController @Inject() (
     }
   }
 
-  def page(sort: String, offset: Int, pageSize: Int) = UserAction.async { request =>
-    val collectionsFuture = SafeFuture { collectionCommander.pageCollections(sort, offset, pageSize, request.userId) }
-    for {
-      collections <- collectionsFuture
-    } yield {
-      Ok(Json.obj("collections" -> collections))
-    }
+  def page(sort: String, offset: Int, pageSize: Int) = UserAction { request =>
+    val tags = collectionCommander.pageCollections(sort, offset, pageSize, request.userId)
+    Ok(Json.obj("tags" -> tags))
   }
 
   def saveCollection() = UserAction { request =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -371,6 +371,16 @@ class LibraryController @Inject() (
     }
   }
 
+  def removeKeep(pubId: PublicId[Library], extId: ExternalId[Keep]) = (UserAction andThen LibraryWriteAction(pubId))(parse.tolerantJson) { request =>
+    val libraryId = Library.decodePublicId(pubId).get
+    val source = KeepSource.site
+    implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, source).build
+    keepsCommander.unkeepOneFromLibrary(extId, libraryId, request.userId) match {
+      case Left(failMsg) => BadRequest(Json.obj("error" -> failMsg))
+      case Right(info) => Ok(Json.obj("unkept" -> info))
+    }
+  }
+
   def removeKeeps(pubId: PublicId[Library]) = (UserAction andThen LibraryWriteAction(pubId))(parse.tolerantJson) { request =>
     val libraryId = Library.decodePublicId(pubId).get
     val keepExtIds = (request.body \ "ids").as[Seq[ExternalId[Keep]]]

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -371,6 +371,21 @@ class LibraryController @Inject() (
     }
   }
 
+  def removeKeeps(pubId: PublicId[Library]) = (UserAction andThen LibraryWriteAction(pubId))(parse.tolerantJson) { request =>
+    Library.decodePublicId(pubId) match {
+      case Failure(ex) =>
+        BadRequest(Json.obj("error" -> "invalid_id"))
+      case Success(libId) =>
+        val keepExtIds = (request.body \ "ids").as[Seq[ExternalId[Keep]]]
+        val source = KeepSource.site
+        implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, source).build
+        keepsCommander.unkeepManyFromLibrary(keepExtIds, libId, request.userId) match {
+          case Left(failMsg) => BadRequest(Json.obj("error" -> failMsg))
+          case Right((infos, failures)) => Ok(Json.obj("failures" -> failures, "unkept" -> infos))
+        }
+    }
+  }
+
   def authToLibrary(id: PublicId[Library], authToken: Option[String]) = MaybeUserAction(parse.tolerantJson) { implicit request =>
     val passPhrase = (request.body \ "passPhrase").asOpt[String].map(HashedPassPhrase.generateHashedPhrase)
     val libraryIdTry = Library.decodePublicId(id)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/CollectionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/CollectionRepo.scala
@@ -29,6 +29,9 @@ trait CollectionRepo extends Repo[Collection] with ExternalIdColumnFunction[Coll
   def collectionChanged(collectionId: Id[Collection], isNewKeep: Boolean = false, inactivateIfEmpty: Boolean = false)(implicit session: RWSession): Collection
   def getTagsByKeepId(keepId: Id[Keep])(implicit session: RSession): Set[Hashtag]
   def getTagsByLibrary(libraryId: Id[Library])(implicit session: RSession): Set[Hashtag]
+  def getByUserSortedByName(userId: Id[User], page: Int, size: Int, excludeState: Option[State[Collection]] = Some(CollectionStates.INACTIVE))(implicit session: RSession): Seq[Collection]
+  def getByUserSortedByLastKept(userId: Id[User], page: Int, size: Int, excludeState: Option[State[Collection]] = Some(CollectionStates.INACTIVE))(implicit session: RSession): Seq[Collection]
+  def getByUserSortedByNumKeeps(userId: Id[User], page: Int, size: Int)(implicit session: RSession): Seq[(CollectionSummary, Int)]
 }
 
 @Singleton
@@ -157,6 +160,23 @@ class CollectionRepoImpl @Inject() (
     import StaticQuery.interpolation
     val query = sql"select DISTINCT c.name from keep_to_collection kc, collection c, bookmark b where b.library_id = ${libraryId} and kc.bookmark_id = b.id and c.id = kc.collection_id and b.state =${KeepStates.ACTIVE} and c.state=${CollectionStates.ACTIVE} and kc.state=${KeepToCollectionStates.ACTIVE}"
     query.as[String].list.map(tag => Hashtag(tag)).toSet
+  }
+
+  def getByUserSortedByName(userId: Id[User], page: Int, size: Int, excludeState: Option[State[Collection]] = Some(CollectionStates.INACTIVE))(implicit session: RSession): Seq[Collection] = {
+    (for (c <- rows if c.userId === userId && c.state =!= excludeState) yield c).sortBy(r => (r.name, r.id)).drop(page * size).take(size).list
+  }
+
+  def getByUserSortedByLastKept(userId: Id[User], page: Int, size: Int, excludeState: Option[State[Collection]] = Some(CollectionStates.INACTIVE))(implicit session: RSession): Seq[Collection] = {
+    (for (c <- rows if c.userId === userId && c.state =!= excludeState) yield c).sortBy(r => (r.lastKeptTo.desc, r.id)).drop(page * size).take(size).list
+  }
+
+  def getByUserSortedByNumKeeps(userId: Id[User], page: Int, size: Int)(implicit session: RSession): Seq[(CollectionSummary, Int)] = {
+    import StaticQuery.interpolation
+    import scala.collection.JavaConversions._
+    val query = sql"select c.id, c.external_id, c.name, count(kc.id) as keep_count from collection c, keep_to_collection kc where kc.collection_id = c.id and user_id=${userId} and kc.state = ${KeepToCollectionStates.ACTIVE} and c.state=${CollectionStates.ACTIVE} group by c.id order by keep_count desc limit ${size} offset ${page * size}"
+    query.as[(Id[Collection], ExternalId[Collection], Hashtag, Int)].list.map { row =>
+      (CollectionSummary(row._1, row._2, row._3), row._4)
+    }
   }
 }
 

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -271,6 +271,7 @@ POST    /site/keeps/tag             @com.keepit.controllers.website.KeepsControl
 POST    /site/keeps/untag           @com.keepit.controllers.website.KeepsController.untagKeepBulk()
 
 GET     /site/collections/all       @com.keepit.controllers.website.KeepsController.allCollections(sort: String ?= "last_kept")
+GET     /site/collections/page      @com.keepit.controllers.website.KeepsController.page(sort: String ?= "used", offset : Int ?= 0, pageSize: Int ?= 0)
 POST    /site/collections/ordering  @com.keepit.controllers.website.KeepsController.updateCollectionOrdering()
 POST    /site/collections/reorderTag  @com.keepit.controllers.website.KeepsController.updateCollectionIndexOrdering()
 POST    /site/collections/create    @com.keepit.controllers.website.KeepsController.saveCollection()
@@ -296,6 +297,7 @@ POST    /site/libraries/:id/decline @com.keepit.controllers.website.LibraryContr
 POST    /site/libraries/:id/leave   @com.keepit.controllers.website.LibraryController.leaveLibrary(id: PublicId[Library])
 GET     /site/libraries/:id/keeps   @com.keepit.controllers.website.LibraryController.getKeeps(id: PublicId[Library], count: Int, offset: Int ?= 0, auth:Option[String] ?= None, passCode:Option[HashedPassPhrase] ?= None)
 POST    /site/libraries/:id/keeps   @com.keepit.controllers.website.LibraryController.addKeeps(id: PublicId[Library])
+DELETE  /site/libraries/:id/keeps   @com.keepit.controllers.website.LibraryController.removeKeeps(id: PublicId[Library])
 GET     /site/libraries/:id/collabs @com.keepit.controllers.website.LibraryController.getCollaborators(id: PublicId[Library], count: Int, offset: Int ?= 0, auth: Option[String] ?= None, passCode:Option[HashedPassPhrase] ?= None)
 POST    /site/libraries/:id/importTag @com.keepit.controllers.website.LibraryController.copyKeepsFromCollectionToLibrary(id: PublicId[Library], tag: String)
 POST    /site/libraries/:id/import-file  @com.keepit.controllers.website.BookmarkImporter.importFileToLibrary(id: PublicId[Library])

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -297,7 +297,7 @@ POST    /site/libraries/:id/decline @com.keepit.controllers.website.LibraryContr
 POST    /site/libraries/:id/leave   @com.keepit.controllers.website.LibraryController.leaveLibrary(id: PublicId[Library])
 GET     /site/libraries/:id/keeps   @com.keepit.controllers.website.LibraryController.getKeeps(id: PublicId[Library], count: Int, offset: Int ?= 0, auth:Option[String] ?= None, passCode:Option[HashedPassPhrase] ?= None)
 POST    /site/libraries/:id/keeps   @com.keepit.controllers.website.LibraryController.addKeeps(id: PublicId[Library])
-DELETE  /site/libraries/:id/keeps   @com.keepit.controllers.website.LibraryController.removeKeeps(id: PublicId[Library])
+POST    /site/libraries/:id/keeps/delete   @com.keepit.controllers.website.LibraryController.removeKeeps(id: PublicId[Library])
 GET     /site/libraries/:id/collabs @com.keepit.controllers.website.LibraryController.getCollaborators(id: PublicId[Library], count: Int, offset: Int ?= 0, auth: Option[String] ?= None, passCode:Option[HashedPassPhrase] ?= None)
 POST    /site/libraries/:id/importTag @com.keepit.controllers.website.LibraryController.copyKeepsFromCollectionToLibrary(id: PublicId[Library], tag: String)
 POST    /site/libraries/:id/import-file  @com.keepit.controllers.website.BookmarkImporter.importFileToLibrary(id: PublicId[Library])

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -298,6 +298,7 @@ POST    /site/libraries/:id/leave   @com.keepit.controllers.website.LibraryContr
 GET     /site/libraries/:id/keeps   @com.keepit.controllers.website.LibraryController.getKeeps(id: PublicId[Library], count: Int, offset: Int ?= 0, auth:Option[String] ?= None, passCode:Option[HashedPassPhrase] ?= None)
 POST    /site/libraries/:id/keeps   @com.keepit.controllers.website.LibraryController.addKeeps(id: PublicId[Library])
 POST    /site/libraries/:id/keeps/delete   @com.keepit.controllers.website.LibraryController.removeKeeps(id: PublicId[Library])
+DELETE  /site/libraries/:id/keeps/:keepId   @com.keepit.controllers.website.LibraryController.removeKeep(id: PublicId[Library], keepId: ExternalId[Keep])
 GET     /site/libraries/:id/collabs @com.keepit.controllers.website.LibraryController.getCollaborators(id: PublicId[Library], count: Int, offset: Int ?= 0, auth: Option[String] ?= None, passCode:Option[HashedPassPhrase] ?= None)
 POST    /site/libraries/:id/importTag @com.keepit.controllers.website.LibraryController.copyKeepsFromCollectionToLibrary(id: PublicId[Library], tag: String)
 POST    /site/libraries/:id/import-file  @com.keepit.controllers.website.BookmarkImporter.importFileToLibrary(id: PublicId[Library])

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
@@ -220,8 +220,8 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
 
         collectionCommander.pageCollections("user", 0, 3, user.id.get).map(_.name) === Seq("Mario", "Luigi", "Bowser")
         collectionCommander.pageCollections("name", 0, 3, user.id.get).map(_.name) === Seq("Bowser", "DonkeyKong", "Luigi")
-        collectionCommander.pageCollections("num_keeps", 0, 3, user.id.get).map(_.name) === Seq("Mario", "Bowser", "Luigi")
-        collectionCommander.pageCollections("num_keeps", 1, 3, user.id.get).map(_.name) === Seq("DonkeyKong")
+        collectionCommander.pageCollections("name", 1, 3, user.id.get).map(_.name) === Seq("Mario")
+        collectionCommander.pageCollections("num_keeps", 0, 3, user.id.get).map(_.name) === Seq("Mario", "Bowser") // Luigi & DonkeyKong don't have keeps!
       }
     }
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/CollectionCommanderTest.scala
@@ -176,5 +176,53 @@ class CollectionCommanderTest extends Specification with ShoeboxTestInjector {
         }
       }
     }
+
+    "paging all tags" in {
+      withDb(modules: _*) { implicit injector =>
+        val userValueRepo = inject[UserValueRepo]
+        val t1 = new DateTime(2013, 2, 14, 21, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
+        val keeper = KeepSource.keeper
+        val collectionCommander = inject[CollectionCommander]
+
+        val (user, oldOrdering, tag1, tag2, tag3, tag4) = db.readWrite { implicit s =>
+          val user1 = userRepo.save(User(firstName = "Mario", lastName = "Luigi", createdAt = t1))
+          val lib1 = libraryRepo.save(Library(name = "Lib", ownerId = user1.id.get, visibility = LibraryVisibility.SECRET, slug = LibrarySlug("asdf"), memberCount = 1))
+          libraryMembershipRepo.save(LibraryMembership(libraryId = lib1.id.get, userId = user1.id.get, access = LibraryAccess.OWNER, showInSearch = false))
+
+          val tag1 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("Mario")))
+          val tag2 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("Luigi")))
+          val tag3 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("Bowser")))
+          val tag4 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("DonkeyKong")))
+
+          val uri1 = uriRepo.save(NormalizedURI.withHash(prenormalize("http://www.google.com/"), Some("Google")))
+          val uri2 = uriRepo.save(NormalizedURI.withHash(prenormalize("http://www.amazon.com/"), Some("Amazon")))
+          val url1 = urlRepo.save(URLFactory(url = uri1.url, normalizedUriId = uri1.id.get))
+          val url2 = urlRepo.save(URLFactory(url = uri2.url, normalizedUriId = uri2.id.get))
+
+          val keep1 = keepRepo.save(Keep(title = Some("G1"), userId = user1.id.get, url = url1.url, urlId = url1.id.get,
+            uriId = uri1.id.get, source = keeper, createdAt = t1.plusMinutes(3), state = KeepStates.ACTIVE,
+            visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get), inDisjointLib = lib1.isDisjoint))
+          val keep2 = keepRepo.save(Keep(title = Some("A1"), userId = user1.id.get, url = url2.url, urlId = url2.id.get,
+            uriId = uri2.id.get, source = keeper, createdAt = t1.plusHours(50), state = KeepStates.ACTIVE,
+            visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get), inDisjointLib = lib1.isDisjoint))
+
+          val collectionIds = Seq(tag1.externalId, tag2.externalId, tag3.externalId, tag4.externalId)
+
+          userValueRepo.save(UserValue(userId = user1.id.get, name = UserValueName.USER_COLLECTION_ORDERING, value = Json.stringify(Json.toJson(collectionIds))))
+
+          keepToCollectionRepo.save(KeepToCollection(keepId = keep1.id.get, collectionId = tag1.id.get))
+          keepToCollectionRepo.save(KeepToCollection(keepId = keep2.id.get, collectionId = tag1.id.get))
+
+          keepToCollectionRepo.save(KeepToCollection(keepId = keep1.id.get, collectionId = tag3.id.get))
+
+          (user1, collectionIds, tag1, tag2, tag3, tag4)
+        }
+
+        collectionCommander.pageCollections("user", 0, 3, user.id.get).map(_.name) === Seq("Mario", "Luigi", "Bowser")
+        collectionCommander.pageCollections("name", 0, 3, user.id.get).map(_.name) === Seq("Bowser", "DonkeyKong", "Luigi")
+        collectionCommander.pageCollections("num_keeps", 0, 3, user.id.get).map(_.name) === Seq("Mario", "Bowser", "Luigi")
+        collectionCommander.pageCollections("num_keeps", 1, 3, user.id.get).map(_.name) === Seq("DonkeyKong")
+      }
+    }
   }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -997,10 +997,11 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
           (keeps(0), keeps(1), keeps(2))
         }
 
-        val testPathRemove = com.keepit.controllers.website.routes.LibraryController.removeKeeps(pubId1).url
+        // test bulk unkeeping
+        val testPathRemoveMany = com.keepit.controllers.website.routes.LibraryController.removeKeeps(pubId1).url
         val k4Id: ExternalId[Keep] = ExternalId()
-        val json2 = Json.obj("ids" -> Json.toJson(Seq(k1.externalId, k2.externalId, k3.externalId, k4Id)))
-        val request2 = FakeRequest("POST", testPathRemove).withBody(json2)
+        val json2 = Json.obj("ids" -> Json.toJson(Seq(k1.externalId, k2.externalId, k4Id)))
+        val request2 = FakeRequest("POST", testPathRemoveMany).withBody(json2)
         val result2 = libraryController.removeKeeps(pubId1)(request2)
         status(result2) must equalTo(OK)
         contentType(result2) must beSome("application/json")
@@ -1011,8 +1012,22 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
               "failures":["${k4Id}"],
               "unkept":
               [{"id":"${k1.externalId}","title":"title 11","url":"http://www.hi.com11","isPrivate":false, "libraryId":"${pubId1.id}"},
-              {"id":"${k2.externalId}","title":"title 21","url":"http://www.hi.com21","isPrivate":false, "libraryId":"${pubId1.id}"},
-              {"id":"${k3.externalId}","title":"title 31","url":"http://www.hi.com31","isPrivate":false, "libraryId":"${pubId1.id}"}]
+              {"id":"${k2.externalId}","title":"title 21","url":"http://www.hi.com21","isPrivate":false, "libraryId":"${pubId1.id}"}]
+            }
+          """.stripMargin
+        ))
+
+        // test single unkeeping
+        val testPathRemoveOne = com.keepit.controllers.website.routes.LibraryController.removeKeep(pubId1, k3.externalId).url
+        val request3 = FakeRequest("DELETE", testPathRemoveOne).withBody(Json.obj())
+        val result3: Future[Result] = libraryController.removeKeep(pubId1, k3.externalId)(request3)
+        status(result3) must equalTo(OK)
+        contentType(result3) must beSome("application/json")
+
+        Json.parse(contentAsString(result3)) must equalTo(Json.parse(
+          s"""
+            {
+              "unkept": {"id":"${k3.externalId}","title":"title 31","url":"http://www.hi.com31","isPrivate":false, "libraryId":"${pubId1.id}"}
             }
           """.stripMargin
         ))

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -962,5 +962,66 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
       }
     }
 
+    "remove keeps from library" in {
+      withDb(modules: _*) { implicit injector =>
+        implicit val config = inject[PublicIdConfiguration]
+        val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
+        val libraryController = inject[LibraryController]
+
+        val (user1, lib1) = db.readWrite { implicit s =>
+          val u1 = userRepo.save(User(firstName = "Mario", lastName = "Plumber"))
+          val lib1 = libraryRepo.save(Library(ownerId = u1.id.get, name = "Mario Party", visibility = LibraryVisibility.PUBLISHED, slug = LibrarySlug("marioparty"), memberCount = 1))
+          libraryMembershipRepo.save(LibraryMembership(userId = u1.id.get, libraryId = lib1.id.get, access = LibraryAccess.OWNER, showInSearch = true, createdAt = t1))
+          (u1, lib1)
+        }
+
+        val pubId1 = Library.publicId(lib1.id.get)
+        val testPathAdd = com.keepit.controllers.website.routes.LibraryController.addKeeps(pubId1).url
+
+        val keepsToAdd =
+          RawBookmarkRepresentation(title = Some("title 11"), url = "http://www.hi.com11", isPrivate = None) ::
+            RawBookmarkRepresentation(title = Some("title 21"), url = "http://www.hi.com21", isPrivate = None) ::
+            RawBookmarkRepresentation(title = Some("title 31"), url = "http://www.hi.com31", isPrivate = None) ::
+            Nil
+
+        inject[FakeUserActionsHelper].setUser(user1)
+
+        val json = Json.obj(
+          "keeps" -> JsArray(keepsToAdd map { k => Json.toJson(k) })
+        )
+        val request1 = FakeRequest("POST", testPathAdd).withBody(json)
+        val result1 = libraryController.addKeeps(pubId1)(request1)
+        status(result1) must equalTo(OK)
+
+        val (k1, k2, k3) = db.readOnlyMaster { implicit s =>
+          val keeps = keepRepo.getByLibrary(lib1.id.get, 10, 0).sortBy(_.createdAt)
+          keeps.length === 3
+          (keeps(0), keeps(1), keeps(2))
+        }
+
+        val testPathRemove = com.keepit.controllers.website.routes.LibraryController.removeKeeps(pubId1).url
+        val k4Id: ExternalId[Keep] = ExternalId()
+        val json2 = Json.obj(
+          "ids" -> Json.toJson(Seq(k1.externalId, k2.externalId, k3.externalId, k4Id))
+        )
+        val request2 = FakeRequest("POST", testPathRemove).withBody(json2)
+        val result2 = libraryController.removeKeeps(pubId1)(request2)
+        status(result2) must equalTo(OK)
+        contentType(result2) must beSome("application/json")
+
+        Json.parse(contentAsString(result2)) must equalTo(Json.parse(
+          s"""
+            {
+              "failures":["${k4Id}"],
+              "unkept":
+              [{"id":"${k1.externalId}","title":"title 11","url":"http://www.hi.com11","isPrivate":false, "libraryId":"${pubId1.id}"},
+              {"id":"${k2.externalId}","title":"title 21","url":"http://www.hi.com21","isPrivate":false, "libraryId":"${pubId1.id}"},
+              {"id":"${k3.externalId}","title":"title 31","url":"http://www.hi.com31","isPrivate":false, "libraryId":"${pubId1.id}"}]
+            }
+          """.stripMargin
+        ))
+      }
+    }
+
   }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -986,9 +986,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
         inject[FakeUserActionsHelper].setUser(user1)
 
-        val json = Json.obj(
-          "keeps" -> JsArray(keepsToAdd map { k => Json.toJson(k) })
-        )
+        val json = Json.obj("keeps" -> keepsToAdd)
         val request1 = FakeRequest("POST", testPathAdd).withBody(json)
         val result1 = libraryController.addKeeps(pubId1)(request1)
         status(result1) must equalTo(OK)
@@ -1001,9 +999,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
         val testPathRemove = com.keepit.controllers.website.routes.LibraryController.removeKeeps(pubId1).url
         val k4Id: ExternalId[Keep] = ExternalId()
-        val json2 = Json.obj(
-          "ids" -> Json.toJson(Seq(k1.externalId, k2.externalId, k3.externalId, k4Id))
-        )
+        val json2 = Json.obj("ids" -> Json.toJson(Seq(k1.externalId, k2.externalId, k3.externalId, k4Id)))
         val request2 = FakeRequest("POST", testPathRemove).withBody(json2)
         val result2 = libraryController.removeKeeps(pubId1)(request2)
         status(result2) must equalTo(OK)


### PR DESCRIPTION
tag paginations support sorting (by name, by user's previous ordering, or by num_keeps)
unkeep multiple from a single library endpoint for website

@andrewconner
