### PR TITLE
removing library query parameter from new extension search endpoint, new route

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/controllers/ext/ExtSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/ext/ExtSearchController.scala
@@ -55,7 +55,6 @@ class ExtSearchController @Inject() (
   def search2(
     query: String,
     filter: Option[String],
-    library: Option[String],
     maxHits: Int,
     lastUUIDStr: Option[String],
     context: Option[String],
@@ -63,7 +62,7 @@ class ExtSearchController @Inject() (
     debug: Option[String] = None,
     withUriSummary: Boolean = false) = MaybeUserAction { request =>
 
-    val libraryContextFuture = getLibraryContextFuture(library, None, request)
+    val libraryContextFuture = getLibraryContextFuture(None, None, request)
     val acceptLangs = getAcceptLangs(request)
     val (userId, experiments) = getUserAndExperiments(request)
 

--- a/kifi-backend/modules/search/conf/search.routes
+++ b/kifi-backend/modules/search/conf/search.routes
@@ -2,7 +2,7 @@
 # Search Extension API
 ##########################################
 GET         /search        @com.keepit.controllers.ext.ExtSearchController.search(q: String, f: Option[String], maxHits: Int, lastUUID: Option[String], context: Option[String], kifiVersion: Option[KifiExtVersion] ?= None, start: Option[String], end: Option[String], tz: Option[String], coll: Option[String], debug: Option[String])
-GET         /search2       @com.keepit.controllers.ext.ExtSearchController.search2(q: String, f: Option[String], l: Option[String], maxHits: Int, lastUUID: Option[String], context: Option[String], kifiVersion: Option[KifiExtVersion] ?= None, debug: Option[String])
+GET         /ext/search           @com.keepit.controllers.ext.ExtSearchController.search2(q: String, f: Option[String], maxHits: Int, lastUUID: Option[String], context: Option[String], kifiVersion: Option[KifiExtVersion] ?= None, debug: Option[String])
 GET         /search/warmUp        @com.keepit.controllers.ext.ExtSearchController.warmUp()
 GET         /search/instance      @com.keepit.controllers.ext.ExtSearchController.instance()
 GET         /search/message        @com.keepit.controllers.ext.ExtMessageSearchController.search(q: String, page: Int ?= 0)


### PR DESCRIPTION
@leogrim 

(I think we should migrate the other extension routes to `/ext/...` too.)
