### PR TITLE
making the extension version an optional parameter again, since it isn't even used

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/controllers/ext/ExtSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/ext/ExtSearchController.scala
@@ -50,12 +50,12 @@ class ExtSearchController @Inject() (
   }
 
   def search2(
-    extVersion: KifiExtVersion,
     query: String,
     maxHits: Int,
     filter: Option[String],
     lastUUIDStr: Option[String],
     context: Option[String],
+    extVersion: Option[KifiExtVersion],
     debug: Option[String] = None) = UserAction { request =>
 
     val libraryContextFuture = getLibraryContextFuture(None, None, request)

--- a/kifi-backend/modules/search/conf/search.routes
+++ b/kifi-backend/modules/search/conf/search.routes
@@ -8,7 +8,7 @@ GET         /admin/search/instance         @com.keepit.controllers.search.Search
 ##########################################
 # Note:     /search will be deprecated when libraries launch
 GET         /search        @com.keepit.controllers.ext.ExtSearchController.search(q: String, f: Option[String], maxHits: Int, lastUUID: Option[String], context: Option[String], kifiVersion: Option[KifiExtVersion] ?= None, start: Option[String], end: Option[String], tz: Option[String], coll: Option[String], debug: Option[String])
-GET         /ext/search                    @com.keepit.controllers.ext.ExtSearchController.search2(v: KifiExtVersion, q: String, n: Int, f: Option[String], u: Option[String], c: Option[String], debug: Option[String])
+GET         /ext/search                    @com.keepit.controllers.ext.ExtSearchController.search2(q: String, n: Int ?= 5, f: Option[String], u: Option[String], c: Option[String], v: Option[KifiExtVersion], debug: Option[String])
 
 # Note:     /search/warmUp is deprecated, was last used in extension 3.2.16
 GET         /search/warmUp        @com.keepit.controllers.ext.ExtSearchController.warmUp()


### PR DESCRIPTION
also defaulting `n` (`maxHits`) to 5 so that a request with just `?q=foo` works (e.g. for manual debugging)
