### PR TITLE
token-based endpoints (site)

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OAuth2TokenInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OAuth2TokenInfo.scala
@@ -1,0 +1,15 @@
+package com.keepit.model
+
+import com.kifi.macros.json
+
+// replaces securesocial.core.OAuth2Info
+@json case class OAuth2TokenInfo(
+  accessToken: String,
+  tokenType: Option[String] = None,
+  expiresIn: Option[Int] = None,
+  refreshToken: Option[String] = None)
+
+object OAuth2TokenInfo {
+  implicit def toOAuth2Info(token: OAuth2TokenInfo): securesocial.core.OAuth2Info =
+    securesocial.core.OAuth2Info(token.accessToken, token.tokenType, token.expiresIn, token.refreshToken)
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -81,6 +81,24 @@ class AuthController @Inject() (
     }
   }
 
+  def accessTokenLogin(providerName: String) = Action(parse.tolerantJson) { implicit request =>
+    request.body.asOpt[OAuth2TokenInfo] match {
+      case None =>
+        BadRequest(Json.obj("error" -> "invalid_token"))
+      case Some(oauth2Info) =>
+        authHelper.doAccessTokenLogin(providerName, oauth2Info)
+    }
+  }
+
+  def accessTokenSignup(providerName: String) = Action.async(parse.tolerantJson) { implicit request =>
+    request.body.asOpt[OAuth2TokenInfo] match {
+      case None =>
+        Future.successful(BadRequest(Json.obj("error" -> "invalid_token")))
+      case Some(oauth2Info) =>
+        authHelper.doAccessTokenSignup(providerName, oauth2Info)
+    }
+  }
+
   def afterLogin() = HtmlAction(allowPending = true)(authenticatedAction = { implicit request =>
     if (request.user.state == UserStates.PENDING) {
       Redirect("/")

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileAuthController.scala
@@ -7,7 +7,7 @@ import com.keepit.common.db.{ Id, ExternalId }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
 import com.keepit.common.net.UserAgent
-import com.keepit.social.{ SocialId, UserIdentity }
+import com.keepit.social.{ UserIdentity }
 import com.keepit.controllers.core.{ AuthController, AuthHelper }
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.social.SocialNetworkType
@@ -101,7 +101,7 @@ class MobileAuthController @Inject() (
   }
 
   def accessTokenSignup(providerName: String) = Action.async(parse.tolerantJson) { implicit request =>
-    request.body.asOpt[OAuth2Info] match {
+    request.body.asOpt[OAuth2TokenInfo] match {
       case None =>
         Future.successful(BadRequest(Json.obj("error" -> "invalid_token")))
       case Some(oauth2Info) =>
@@ -110,7 +110,7 @@ class MobileAuthController @Inject() (
   }
 
   def accessTokenLogin(providerName: String) = Action(parse.tolerantJson) { implicit request =>
-    request.body.asOpt[OAuth2Info] match {
+    request.body.asOpt[OAuth2TokenInfo] match {
       case None =>
         BadRequest(Json.obj("error" -> "invalid_token"))
       case Some(oauth2Info) =>

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -20,6 +20,8 @@ GET     /signup                     @com.keepit.controllers.core.AuthController.
 POST    /auth/sign-up               @com.keepit.controllers.core.AuthController.userPasswordSignup()
 POST    /auth/email-finalize        @com.keepit.controllers.core.AuthController.userPassFinalizeAccountAction()
 POST    /auth/social-finalize       @com.keepit.controllers.core.AuthController.socialFinalizeAccountAction()
+POST    /auth/token-login/:provider  @com.keepit.controllers.core.AuthController.accessTokenLogin(provider: String)
+POST    /auth/token-signup/:provider @com.keepit.controllers.core.AuthController.accessTokenSignup(provider: String)
 POST    /auth/upload-binary-image   @com.keepit.controllers.core.AuthController.uploadBinaryPicture()
 POST    /auth/upload-multipart-image @com.keepit.controllers.core.AuthController.uploadFormEncodedPicture()
 POST    /auth/cancel                @com.keepit.controllers.core.AuthController.cancelAuth()


### PR DESCRIPTION
Right now it's the same as mobile counterparts. Would be happy to make any changes required for site.

`OAuth2TokenInfo` replaces use of `securesocial.core.OAuth2Info` in the new endpoints. That further removes dependency on securesocial, and affords additional flexibility (should we choose to add signature fields, etc.)

@andrewconner 
