### PR TITLE
Move back to convenience methods taking librarySearcher as a parameter

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/controllers/util/SearchControllerUtil.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/util/SearchControllerUtil.scala
@@ -20,7 +20,7 @@ import com.keepit.search._
 import com.keepit.common.akka.SafeFuture
 import com.keepit.search.result.DecoratedResult
 import play.api.libs.json.JsObject
-import com.keepit.search.graph.library.{ LibraryIndexer, LibraryRecord, LibraryFields }
+import com.keepit.search.graph.library.{ LibraryIndexable, LibraryIndexer, LibraryRecord, LibraryFields }
 
 import scala.util.{ Failure, Success }
 
@@ -100,10 +100,10 @@ trait SearchControllerUtil {
     augmentationCommander.getAugmentedItems(augmentationRequest).map { augmentedItems => items.map(augmentedItems(_)) }
   }
 
-  def getBasicLibraries(libraryIndexer: LibraryIndexer, libraryIds: Set[Id[Library]]): Map[Id[Library], BasicLibrary] = {
+  def getBasicLibraries(librarySearcher: Searcher, libraryIds: Set[Id[Library]]): Map[Id[Library], BasicLibrary] = {
     libraryIds.map { libId =>
-      val name = libraryIndexer.getRecord(libId).get.name
-      libId -> BasicLibrary(Library.publicId(libId), name, libraryIndexer.isSecret(libId))
+      val name = LibraryIndexable.getRecord(librarySearcher, libId).get.name
+      libId -> BasicLibrary(Library.publicId(libId), name, LibraryIndexable.isSecret(librarySearcher, libId))
     }.toMap
   }
 

--- a/kifi-backend/modules/search/app/com/keepit/search/SearchBackwardCompatibilitySupport.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/SearchBackwardCompatibilitySupport.scala
@@ -6,7 +6,7 @@ import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.model.{ Collection, Library, NormalizedURI, User }
 import com.keepit.search.engine.Visibility
 import com.keepit.search.engine.result.{ KifiShardHit, KifiShardResult }
-import com.keepit.search.graph.library.{ LibraryFields, LibraryIndexer }
+import com.keepit.search.graph.library.{ LibraryIndexable, LibraryFields, LibraryIndexer }
 import com.keepit.search.result._
 import com.keepit.search.sharding.Shard
 import com.google.inject.Inject
@@ -45,7 +45,7 @@ class SearchBackwardCompatibilitySupport @Inject() (
 
         augmentedItem.friends.foreach { friendId => friendStats.add(friendId.id, hit.score) }
 
-        val isPrivate = augmentedItem.isSecret(libraryIndexer.isSecret)
+        val isPrivate = augmentedItem.isSecret(LibraryIndexable.isSecret(libraryIndexer.getSearcher, _))
 
         DetailedSearchHit(
           uriId.id,

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexable.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexable.scala
@@ -4,7 +4,7 @@ import com.keepit.common.db.Id
 import com.keepit.model.view.LibraryMembershipView
 import com.keepit.model.{ LibraryVisibility, User, LibraryMembership, Library }
 import com.keepit.search.index.{ DefaultAnalyzer, Indexable, FieldDecoder }
-import com.keepit.search.LangDetector
+import com.keepit.search.{ Searcher, LangDetector }
 
 object LibraryFields {
   val nameField = "t"
@@ -30,6 +30,16 @@ object LibraryFields {
   }
 
   val decoders: Map[String, FieldDecoder] = Map.empty
+}
+
+object LibraryIndexable {
+  def isSecret(librarySearcher: Searcher, libraryId: Id[Library]): Boolean = {
+    librarySearcher.getLongDocValue(LibraryFields.visibilityField, libraryId.id).exists(_ == LibraryFields.Visibility.SECRET)
+  }
+
+  def getRecord(librarySearcher: Searcher, libraryId: Id[Library]): Option[LibraryRecord] = {
+    librarySearcher.getDecodedDocValue(LibraryFields.recordField, libraryId.id)
+  }
 }
 
 class LibraryIndexable(library: Library, memberships: Seq[LibraryMembershipView]) extends Indexable[Library, Library] {

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexer.scala
@@ -44,14 +44,6 @@ class LibraryIndexer(indexDirectory: IndexDirectory, shoebox: ShoeboxServiceClie
   override def indexInfos(name: String): Seq[IndexInfo] = {
     super.indexInfos(this.name)
   }
-
-  def isSecret(lib: Id[Library]): Boolean = {
-    getSearcher.getLongDocValue(LibraryFields.visibilityField, lib.id).exists(_ == LibraryFields.Visibility.SECRET)
-  }
-
-  def getRecord(libraryId: Id[Library]): Option[LibraryRecord] = {
-    getSearcher.getDecodedDocValue(LibraryFields.recordField, libraryId.id)
-  }
 }
 
 class LibraryIndexerActor @Inject() (


### PR DESCRIPTION
@ymatsuda 
I moved them to LibraryIndexable's companion object, since this is the document they operate on.
