### PR TITLE
Profile bugs fix

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/profile/profile.js
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profile.js
@@ -123,7 +123,7 @@ angular.module('kifi')
         return;
       }
       if (emailInfo.isVerified) {
-        return profileService.setNewPrimaryEmail($scope.me, emailInfo.address);
+        return profileService.setNewPrimaryEmail(emailInfo.address);
       }
       // email is available || (not primary && not pending primary && not verified)
       emailToBeSaved = email;

--- a/kifi-backend/modules/shoebox/angular/src/profile/profileInput.js
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profileInput.js
@@ -45,14 +45,14 @@ angular.module('kifi')
         function onClickOutsideInput(event) {
           if (!angular.element(event.target).is('.profile-email-input, .profile-input-save')) {
             $document.off('mousedown', onClickOutsideInput);
-            scope.$apply(cancel);
+            scope.$evalAsync(cancel);
           }
         }
 
         function onFocusOutsideInput(event) {
           if (!angular.element(event.target).is('.profile-email-input, .profile-input-save')) {
             $window.removeEventListener('focus', onFocusOutsideInput, true);
-            scope.$apply(cancel);
+            scope.$evalAsync(cancel);
           }
         }
 
@@ -92,6 +92,8 @@ angular.module('kifi')
           scope.state.prevValue = scope.state.currentValue;
           updateValue(value);
           scope.state.editing = false;
+          $document.off('mousedown', onClickOutsideInput);
+          $window.removeEventListener('focus', onFocusOutsideInput, true);
 
           if (value === scope.state.prevValue) {
             return;

--- a/kifi-backend/modules/shoebox/angular/src/profile/profileNameInput.js
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profileNameInput.js
@@ -47,14 +47,14 @@ angular.module('kifi')
         function onClickOutsideInput(event) {
           if (!angular.element(event.target).is('.profile-name-input, .profile-input-save')) {
             $document.off('mousedown', onClickOutsideInput);
-            scope.$apply(cancel);
+            scope.$evalAsync(cancel);
           }
         }
 
         function onFocusOutsideInput(event) {
           if (!angular.element(event.target).is('.profile-name-input, .profile-input-save')) {
             $window.removeEventListener('focus', onFocusOutsideInput, true);
-            scope.$apply(cancel);
+            scope.$evalAsync(cancel);
           }
         }
 
@@ -121,6 +121,8 @@ angular.module('kifi')
           }
 
           scope.editing = false;
+          $document.off('mousedown', onClickOutsideInput);
+          $window.removeEventListener('focus', onFocusOutsideInput, true);
 
           // Save name.
           if (sameName(nameToSave, oldName)) {


### PR DESCRIPTION
@andrewconner I found a few bugs in `/profile` while doing modal refresh. They are:
- Cannot change email address from one verified email to another. Based on git blame, this bug seems really old...
- Occasionally, some `scope.$apply` are still giving me `$digest already in progress` errors. I switched to `$evalAsync` for these. That seems to work really well. :)
- There was a bug where re-editing a saved name will re-populate the name with the old name w/o page refresh (though the name was saved correctly to the db).
