### PR TITLE
action migration: non-sb controllers

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/abook/controllers/ABookController.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/controllers/ABookController.scala
@@ -2,7 +2,7 @@ package com.keepit.abook.controllers
 
 import com.google.inject.Inject
 import com.keepit.common.db.slick.Database
-import com.keepit.common.controller.{ WebsiteController, ABookServiceController, ActionAuthenticator }
+import com.keepit.common.controller.{ WebsiteController, ABookServiceController, UserActions, UserActionsHelper }
 import com.keepit.model._
 import com.keepit.common.db.{ ExternalId, Id }
 import play.api.mvc.Action
@@ -53,7 +53,7 @@ object GmailABookOwnerInfo {
 
 import Logging._
 class ABookController @Inject() (
-    actionAuthenticator: ActionAuthenticator,
+    val userActionsHelper: UserActionsHelper,
     db: Database,
     s3: ABookRawInfoStore,
     abookInfoRepo: ABookInfoRepo,
@@ -62,7 +62,7 @@ class ABookController @Inject() (
     typeahead: EContactTypeahead,
     abookCommander: ABookCommander,
     contactsUpdater: ABookImporterPlugin,
-    richConnectionCommander: LocalRichConnectionCommander) extends WebsiteController(actionAuthenticator) with ABookServiceController {
+    richConnectionCommander: LocalRichConnectionCommander) extends UserActions with ABookServiceController {
 
   // gmail
   def importContacts(userId: Id[User]) = Action.async(parse.json) { request =>

--- a/kifi-backend/modules/abook/test/com/keepit/abook/ABookApplicationInjector.scala
+++ b/kifi-backend/modules/abook/test/com/keepit/abook/ABookApplicationInjector.scala
@@ -8,7 +8,7 @@ import com.keepit.common.healthcheck.{ FakeHealthcheckModule, FakeMemoryUsageMod
 import com.keepit.common.time.FakeClockModule
 import com.keepit.common.zookeeper.FakeDiscoveryModule
 import com.keepit.common.db.{ TestDbInfo, FakeSlickModule }
-import com.keepit.common.controller.FakeActionAuthenticatorModule
+import com.keepit.common.controller.FakeUserActionsModule
 import com.google.inject.util.Modules
 import com.keepit.common.cache.{ HashMapMemoryCacheModule, ABookCacheModule }
 import com.keepit.common.actor.FakeSchedulerModule
@@ -23,7 +23,7 @@ class ABookApplication(overridingModules: Module*)(implicit path: File = new Fil
       FakeFortyTwoModule(),
       FakeDiscoveryModule(),
       FakeSlickModule(TestDbInfo.dbInfo),
-      FakeActionAuthenticatorModule(),
+      FakeUserActionsModule(),
       FakeABookStoreModule(),
       FakeABookImporterPluginModule(),
       FakeAbookRepoChangeListenerModule()

--- a/kifi-backend/modules/abook/test/com/keepit/abook/ABookControllerTest.scala
+++ b/kifi-backend/modules/abook/test/com/keepit/abook/ABookControllerTest.scala
@@ -1,7 +1,8 @@
 package com.keepit.abook
 
-import com.keepit.common.controller.FakeActionAuthenticatorModule
+import com.keepit.common.controller.{ FakeActionAuthenticatorModule, FakeUserActionsModule }
 import com.keepit.common.mail.EmailAddress
+import com.keepit.common.net.FakeHttpClientModule
 import org.specs2.mutable._
 import com.keepit.model._
 import com.keepit.common.db.Id
@@ -25,6 +26,8 @@ class ABookControllerTest extends Specification with ABookTestInjector with ABoo
     FakeSimpleQueueModule(),
     FakeABookImporterPluginModule(),
     FakeABookStoreModule(),
+    FakeUserActionsModule(),
+    FakeHttpClientModule(),
     FakeActionAuthenticatorModule()
   )
 

--- a/kifi-backend/modules/common/test/com/keepit/common/controller/FakeUserActionsModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/controller/FakeUserActionsModule.scala
@@ -14,10 +14,14 @@ case class FakeUserActionsModule() extends UserActionsModule {
   def configure(): Unit = {
     bind[UserActionsHelper].to[FakeUserActionsHelper]
   }
+
+  @Singleton
+  @Provides
+  def userActionsHelper(impCookie: ImpersonateCookie, installCookie: KifiInstallationCookie) = new FakeUserActionsHelper(impCookie, installCookie)
+
 }
 
-@Singleton
-class FakeUserActionsHelper @Inject() (
+class FakeUserActionsHelper(
     val impersonateCookie: ImpersonateCookie,
     val kifiInstallationCookie: KifiInstallationCookie) extends UserActionsHelper with SecureSocialHelper with Logging {
 

--- a/kifi-backend/modules/eliza/app/com/keepit/controllers/site/ChatterController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/controllers/site/ChatterController.scala
@@ -1,6 +1,6 @@
 package com.keepit.controllers.site
 
-import com.keepit.common.controller.{ ElizaServiceController, WebsiteController, ActionAuthenticator }
+import com.keepit.common.controller.{ ElizaServiceController, WebsiteController, UserActions, UserActionsHelper }
 import com.keepit.shoebox.ShoeboxServiceClient
 import com.keepit.common.controller.FortyTwoCookies.ImpersonateCookie
 import com.keepit.common.db.slick.Database
@@ -18,11 +18,11 @@ import com.keepit.eliza.commanders.MessagingCommander
 
 class ChatterController @Inject() (
     messagingCommander: MessagingCommander,
-    actionAuthenticator: ActionAuthenticator,
+    val userActionsHelper: UserActionsHelper,
     threadRepo: MessageThreadRepo,
-    db: Database) extends WebsiteController(actionAuthenticator) with ElizaServiceController {
+    db: Database) extends UserActions with ElizaServiceController {
 
-  def getChatter() = JsonAction.authenticatedParseJsonAsync { request =>
+  def getChatter() = UserAction.async(parse.tolerantJson) { request =>
     val url = (request.body \ "url").as[String]
     messagingCommander.getChatter(request.user.id.get, Seq(url)).map { res =>
       Ok(res.headOption.map {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileDevicesController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileDevicesController.scala
@@ -2,13 +2,13 @@ package com.keepit.eliza.controllers.mobile
 
 import com.google.inject.Inject
 import com.keepit.realtime.{ DeviceType, UrbanAirship }
-import com.keepit.common.controller.{ ActionAuthenticator, ElizaServiceController, WebsiteController }
+import com.keepit.common.controller.{ UserActions, UserActionsHelper, ElizaServiceController, WebsiteController }
 import com.keepit.common.logging.Logging
 import play.api.libs.json._
 
-class MobileDevicesController @Inject() (urbanAirship: UrbanAirship, actionAuthenticator: ActionAuthenticator) extends WebsiteController(actionAuthenticator) with ElizaServiceController with Logging {
+class MobileDevicesController @Inject() (urbanAirship: UrbanAirship, val userActionsHelper: UserActionsHelper) extends UserActions with ElizaServiceController with Logging {
 
-  def registerDevice(deviceType: String) = JsonAction.authenticatedParseJson { implicit request =>
+  def registerDevice(deviceType: String) = UserAction(parse.tolerantJson) { implicit request =>
     (request.body \ "token").asOpt[String] map { token =>
       val isDev: Boolean = (request.body \ "dev").asOpt[Boolean].exists(x => x)
       val device = urbanAirship.registerDevice(request.userId, token, DeviceType(deviceType), isDev)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
@@ -4,7 +4,7 @@ import com.keepit.model.{ User, NormalizedURI }
 import com.keepit.social.BasicUserLikeEntity._
 import com.keepit.eliza.commanders._
 import com.keepit.eliza.model.{ MessageSource, Message, MessageThread }
-import com.keepit.common.controller.{ ElizaServiceController, MobileController, ActionAuthenticator }
+import com.keepit.common.controller.{ ElizaServiceController, MobileController, UserActions, UserActionsHelper }
 import com.keepit.common.time._
 import com.keepit.heimdal._
 import play.api.mvc.Action
@@ -29,11 +29,11 @@ class MobileMessagingController @Inject() (
     messagingCommander: MessagingCommander,
     basicMessageCommander: MessageFetchingCommander,
     notificationCommander: NotificationCommander,
-    actionAuthenticator: ActionAuthenticator,
+    val userActionsHelper: UserActionsHelper,
     heimdalContextBuilder: HeimdalContextBuilderFactory,
-    messageSearchCommander: MessageSearchCommander) extends MobileController(actionAuthenticator) with ElizaServiceController {
+    messageSearchCommander: MessageSearchCommander) extends UserActions with ElizaServiceController {
 
-  def getNotifications(howMany: Int, before: Option[String]) = JsonAction.authenticatedAsync { request =>
+  def getNotifications(howMany: Int, before: Option[String]) = UserAction.async { request =>
     val noticesFuture = before match {
       case Some(before) =>
         notificationCommander.getSendableNotificationsBefore(request.userId, parseStandardTime(before), howMany.toInt, includeUriSummary = false)
@@ -46,7 +46,7 @@ class MobileMessagingController @Inject() (
     }
   }
 
-  def sendMessageAction() = JsonAction.authenticatedParseJsonAsync { request =>
+  def sendMessageAction() = UserAction.async(parse.tolerantJson) { request =>
     val o = request.body
     val (title, text, source) = (
       (o \ "title").asOpt[String],
@@ -78,7 +78,7 @@ class MobileMessagingController @Inject() (
     messageSubmitResponse // todo(JP, Eduardo, Léo): return meaningful error about invalid participants
   }
 
-  def sendMessageReplyAction(threadExtId: ExternalId[MessageThread]) = JsonAction.authenticatedParseJson { request =>
+  def sendMessageReplyAction(threadExtId: ExternalId[MessageThread]) = UserAction(parse.tolerantJson) { request =>
     val tStart = currentDateTime
     val o = request.body
     val (text, source) = (
@@ -94,7 +94,7 @@ class MobileMessagingController @Inject() (
   }
 
   // todo(eishay, léo): the next version of this endpoint should rename the "uri" field to "url"
-  def getPagedThread(threadId: String, pageSize: Int, fromMessageId: Option[String]) = JsonAction.authenticatedAsync { request =>
+  def getPagedThread(threadId: String, pageSize: Int, fromMessageId: Option[String]) = UserAction.async { request =>
     basicMessageCommander.getThreadMessagesWithBasicUser(ExternalId[MessageThread](threadId)) map {
       case (thread, allMsgs) =>
         val url = thread.url.getOrElse("") // needs to change when we have detached threads
@@ -143,7 +143,7 @@ class MobileMessagingController @Inject() (
   }
 
   @deprecated(message = "use getPagedThread", since = "April 23, 2014")
-  def getCompactThread(threadId: String) = JsonAction.authenticatedAsync { request =>
+  def getCompactThread(threadId: String) = UserAction.async { request =>
     basicMessageCommander.getThreadMessagesWithBasicUser(ExternalId[MessageThread](threadId)) map {
       case (thread, msgs) =>
         val url = thread.url.getOrElse("") // needs to change when we have detached threads
@@ -182,39 +182,39 @@ class MobileMessagingController @Inject() (
     }
   }
 
-  def getThreadsByUrl(url: String) = JsonAction.authenticatedAsync { request =>
+  def getThreadsByUrl(url: String) = UserAction.async { request =>
     messagingCommander.getThreadInfos(request.userId, url).map {
       case (_, threadInfos) =>
         Ok(Json.toJson(threadInfos))
     }
   }
 
-  def hasThreadsByUrl(url: String) = JsonAction.authenticatedAsync { request =>
+  def hasThreadsByUrl(url: String) = UserAction.async { request =>
     messagingCommander.hasThreads(request.userId, url).map { yesorno =>
       Ok(Json.toJson(yesorno))
     }
   }
 
-  def searchMessages(query: String, page: Int, storeInHistory: Boolean) = JsonAction.authenticatedAsync { request =>
+  def searchMessages(query: String, page: Int, storeInHistory: Boolean) = UserAction.async { request =>
     messageSearchCommander.searchMessages(request.userId, query, page, storeInHistory).map { notifs =>
       Ok(Json.toJson(notifs.map(_.obj)))
     }
   }
 
-  def getMessageSearchHistory() = JsonAction.authenticated { request =>
+  def getMessageSearchHistory() = UserAction { request =>
     val (queries, emails, optOut) = messageSearchCommander.getHistory(request.userId)
     Ok(Json.obj("qs" -> queries, "es" -> emails, "optOut" -> optOut))
   }
 
-  def getMessageSearchHistoryOptOut() = JsonAction.authenticated { request =>
+  def getMessageSearchHistoryOptOut() = UserAction { request =>
     Ok(Json.obj("didOptOut" -> messageSearchCommander.getHistoryOptOut(request.userId)))
   }
 
-  def setMessageSearchHistoryOptOut() = JsonAction.authenticatedParseJson { request =>
+  def setMessageSearchHistoryOptOut() = UserAction(parse.tolerantJson) { request =>
     Ok(Json.obj("didOptOut" -> messageSearchCommander.setHistoryOptOut(request.userId, (request.body \ "optOut").as[Boolean])))
   }
 
-  def clearMessageSearchHistory() = JsonAction.authenticated { request =>
+  def clearMessageSearchHistory() = UserAction { request =>
     messageSearchCommander.clearHistory(request.userId)
     Ok("")
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
@@ -5,7 +5,7 @@ import com.keepit.eliza.controllers._
 import com.keepit.eliza.commanders.{ MessageFetchingCommander, NotificationCommander, MessagingCommander }
 import com.keepit.common.db.{ ExternalId, State }
 import com.keepit.model.{ User, NotificationCategory, ExperimentType, KifiExtVersion }
-import com.keepit.common.controller.{ BrowserExtensionController, ActionAuthenticator }
+import com.keepit.common.controller.{ BrowserExtensionController, UserActions, UserActionsHelper }
 import com.keepit.shoebox.ShoeboxServiceClient
 import com.keepit.common.controller.FortyTwoCookies.ImpersonateCookie
 import com.keepit.common.time._
@@ -28,7 +28,7 @@ class SharedWsMessagingController @Inject() (
   messagingCommander: MessagingCommander,
   basicMessageCommander: MessageFetchingCommander,
   notificationCommander: NotificationCommander,
-  actionAuthenticator: ActionAuthenticator,
+  val userActionsHelper: UserActionsHelper,
   protected val websocketRouter: WebSocketRouter,
   amazonInstanceInfo: AmazonInstanceInfo,
   threadRepo: MessageThreadRepo,
@@ -43,7 +43,7 @@ class SharedWsMessagingController @Inject() (
   protected val userExperimentCommander: RemoteUserExperimentCommander,
   val accessLog: AccessLog,
   val shoutdownListener: WebsocketsShutdownListener)
-    extends BrowserExtensionController(actionAuthenticator) with AuthenticatedWebSocketsController {
+    extends UserActions with AuthenticatedWebSocketsController {
 
   protected def onConnect(socket: SocketInfo): Unit = {
     websocketRouter.registerUserSocket(socket)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/site/WebsiteMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/site/WebsiteMessagingController.scala
@@ -1,7 +1,7 @@
 package com.keepit.eliza.controllers.site
 
 import com.keepit.eliza.commanders.{ NotificationCommander, MessagingCommander }
-import com.keepit.common.controller.{ WebsiteController, ElizaServiceController, ActionAuthenticator }
+import com.keepit.common.controller.{ WebsiteController, ElizaServiceController, UserActions, UserActionsHelper }
 import com.keepit.common.time._
 import com.keepit.heimdal._
 
@@ -13,10 +13,10 @@ import com.google.inject.Inject
 class WebsiteMessagingController @Inject() (
     messagingCommander: MessagingCommander,
     notificationCommander: NotificationCommander,
-    actionAuthenticator: ActionAuthenticator,
-    heimdalContextBuilder: HeimdalContextBuilderFactory) extends WebsiteController(actionAuthenticator) with ElizaServiceController {
+    val userActionsHelper: UserActionsHelper,
+    heimdalContextBuilder: HeimdalContextBuilderFactory) extends UserActions with ElizaServiceController {
 
-  def getNotifications(howMany: Int, before: Option[String]) = JsonAction.authenticatedAsync { request =>
+  def getNotifications(howMany: Int, before: Option[String]) = UserAction.async { request =>
     val noticesFuture = before match {
       case Some(before) =>
         notificationCommander.getSendableNotificationsBefore(request.userId, parseStandardTime(before), howMany.toInt, includeUriSummary = false)

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/MessagingControllerTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/MessagingControllerTest.scala
@@ -3,7 +3,7 @@ package com.keepit.eliza.controllers
 import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.common.actor.{ FakeActorSystemModule, TestKitSupport }
 import com.keepit.common.cache.ElizaCacheModule
-import com.keepit.common.controller.FakeActionAuthenticatorModule
+import com.keepit.common.controller.FakeUserActionsModule
 import com.keepit.common.crypto.FakeCryptoModule
 import com.keepit.common.db.Id
 import com.keepit.common.net.FakeHttpClientModule
@@ -35,7 +35,7 @@ class MessagingControllerTest extends TestKitSupport with SpecificationLike with
     FakeElizaServiceClientModule(),
     FakeABookServiceClientModule(),
     FakeUrbanAirshipModule(),
-    FakeActionAuthenticatorModule(),
+    FakeUserActionsModule(),
     FakeCryptoModule(),
     FakeScraperServiceClientModule(),
     FakeElizaStoreModule(),

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/ext/ExtMessagingControllerTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/ext/ExtMessagingControllerTest.scala
@@ -3,7 +3,7 @@ package com.keepit.eliza.controllers.ext
 import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.common.actor.{ FakeActorSystemModule, TestKitSupport }
 import com.keepit.common.cache.ElizaCacheModule
-import com.keepit.common.controller.{ FakeActionAuthenticator, FakeActionAuthenticatorModule }
+import com.keepit.common.controller.{ FakeUserActionsHelper, FakeUserActionsModule }
 import com.keepit.common.crypto.FakeCryptoModule
 import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.net.FakeHttpClientModule
@@ -35,7 +35,7 @@ class ExtMessagingControllerTest extends TestKitSupport with SpecificationLike w
     FakeElizaServiceClientModule(),
     FakeABookServiceClientModule(),
     FakeUrbanAirshipModule(),
-    FakeActionAuthenticatorModule(),
+    FakeUserActionsModule(),
     FakeCryptoModule(),
     FakeScraperServiceClientModule(),
     FakeElizaStoreModule(),
@@ -56,7 +56,7 @@ class ExtMessagingControllerTest extends TestKitSupport with SpecificationLike w
         path === "/eliza/messages"
 
         val controller = inject[ExtMessagingController]
-        inject[FakeActionAuthenticator].setUser(shanee)
+        inject[FakeUserActionsHelper].setUser(shanee)
         val input = Json.parse(s"""
           {
             "title": "Search Experiments",
@@ -156,7 +156,7 @@ class ExtMessagingControllerTest extends TestKitSupport with SpecificationLike w
         inject[ShoeboxServiceClient].asInstanceOf[FakeShoeboxServiceClientImpl].saveUsers(shachaf)
 
         val controller = inject[ExtMessagingController]
-        inject[FakeActionAuthenticator].setUser(shanee)
+        inject[FakeUserActionsHelper].setUser(shanee)
         val createThreadJson = Json.parse(s"""
           {
             "title": "Search Experiments",

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/mobile/MobileMessagingControllerTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/mobile/MobileMessagingControllerTest.scala
@@ -1,9 +1,10 @@
 package com.keepit.eliza.controllers.mobile
 
+import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.test.{ ElizaTestInjector }
 import org.specs2.mutable._
 import com.keepit.common.db.slick._
-import com.keepit.common.controller.FakeActionAuthenticator
+import com.keepit.common.controller.{ FakeActionAuthenticatorModule, FakeUserActionsHelper, FakeUserActionsModule }
 import com.keepit.shoebox.{ ShoeboxServiceClient, FakeShoeboxServiceClientImpl }
 import com.keepit.common.time._
 import com.keepit.model.User
@@ -16,7 +17,6 @@ import play.api.libs.json.Json
 import akka.actor.ActorSystem
 import com.keepit.heimdal.FakeHeimdalServiceClientModule
 import com.keepit.common.cache.ElizaCacheModule
-import com.keepit.common.controller.FakeActionAuthenticatorModule
 import play.api.libs.json.JsArray
 import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.eliza.FakeElizaServiceClientModule
@@ -43,6 +43,8 @@ class MobileMessagingControllerTest extends Specification with ElizaTestInjector
       FakeABookServiceClientModule(),
       FakeUrbanAirshipModule(),
       FakeActionAuthenticatorModule(),
+      FakeUserActionsModule(),
+      FakeHttpClientModule(),
       FakeCryptoModule(),
       FakeScraperServiceClientModule(),
       FakeElizaStoreModule()
@@ -62,7 +64,7 @@ class MobileMessagingControllerTest extends Specification with ElizaTestInjector
         val path = com.keepit.eliza.controllers.mobile.routes.MobileMessagingController.sendMessageAction().toString
         path === "/m/1/eliza/messages"
 
-        inject[FakeActionAuthenticator].setUser(shanee)
+        inject[FakeUserActionsHelper].setUser(shanee)
         val input = Json.parse(s"""
           {
             "title": "Search Experiments",
@@ -150,7 +152,7 @@ class MobileMessagingControllerTest extends Specification with ElizaTestInjector
         fakeClient.saveUsers(shanee)
         fakeClient.saveUsers(shachaf)
 
-        inject[FakeActionAuthenticator].setUser(shanee)
+        inject[FakeUserActionsHelper].setUser(shanee)
         val controller = inject[MobileMessagingController]
         val sendMessageAction = controller.sendMessageAction()
         status(sendMessageAction(FakeRequest("POST", "/m/1/eliza/messages").withBody(Json.parse(s"""{
@@ -239,7 +241,7 @@ class MobileMessagingControllerTest extends Specification with ElizaTestInjector
         fakeClient.saveUsers(shanee)
         fakeClient.saveUsers(shachaf)
 
-        inject[FakeActionAuthenticator].setUser(shanee)
+        inject[FakeUserActionsHelper].setUser(shanee)
         val path = com.keepit.eliza.controllers.mobile.routes.MobileMessagingController.sendMessageAction().toString()
         path === "/m/1/eliza/messages"
         status(controller.sendMessageAction()(FakeRequest().withBody(Json.parse(s"""{
@@ -407,7 +409,7 @@ class MobileMessagingControllerTest extends Specification with ElizaTestInjector
         inject[ShoeboxServiceClient].asInstanceOf[FakeShoeboxServiceClientImpl].saveUsers(shanee)
         inject[ShoeboxServiceClient].asInstanceOf[FakeShoeboxServiceClientImpl].saveUsers(shachaf)
 
-        inject[FakeActionAuthenticator].setUser(shanee)
+        inject[FakeUserActionsHelper].setUser(shanee)
         val createThreadJson = Json.parse(s"""
           {
             "title": "Search Experiments",

--- a/kifi-backend/modules/eliza/test/com/keepit/test/ElizaApplication.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/test/ElizaApplication.scala
@@ -1,5 +1,6 @@
 package com.keepit.test
 
+import com.keepit.common.controller.FakeUserActionsModule
 import com.keepit.eliza.{ ElizaServiceTypeModule, FakeElizaServiceClientModule }
 import com.keepit.inject.{ FakeFortyTwoModule, ApplicationInjector }
 import com.keepit.common.db.TestDbInfo
@@ -37,6 +38,8 @@ trait ElizaTestInjector extends TestInjector with DbInjectionHelper with ElizaIn
     ElizaServiceTypeModule(),
     FakeAirbrakeModule(),
     FakeMemoryUsageModule(),
+    FakeUserActionsModule(),
+    FakeHttpClientModule(),
     FakeClockModule(),
     FakeHealthcheckModule(),
     FakeSlickModule(TestDbInfo.dbInfo),

--- a/kifi-backend/modules/heimdal/test/com/keepit/test/HeimdalApplication.scala
+++ b/kifi-backend/modules/heimdal/test/com/keepit/test/HeimdalApplication.scala
@@ -7,7 +7,7 @@ import com.google.inject.util.Modules
 import com.keepit.common.actor.{ FakeActorSystemModule, FakeSchedulerModule }
 import com.keepit.common.aws.AwsModule
 import com.keepit.common.cache.{ HeimdalCacheModule, HashMapMemoryCacheModule }
-import com.keepit.common.controller.FakeActionAuthenticatorModule
+import com.keepit.common.controller.FakeUserActionsModule
 import com.keepit.common.crypto.FakeCryptoModule
 import com.keepit.common.db.{ TestDbInfo, FakeSlickModule }
 import com.keepit.common.healthcheck.{ FakeAirbrakeModule, FakeHealthcheckModule, FakeMemoryUsageModule }
@@ -33,7 +33,7 @@ class HeimdalApplication(overridingModules: Module*)(implicit path: File = new F
     FakeDiscoveryModule(),
     FakeSlickModule(TestDbInfo.dbInfo),
     HeimdalCacheModule(HashMapMemoryCacheModule()),
-    FakeActionAuthenticatorModule(),
+    FakeUserActionsModule(),
     FakeSchedulerModule(),
     FakeSimpleQueueModule(),
     AwsModule(),
@@ -59,6 +59,6 @@ trait HeimdalTestInjector extends TestInjector with DbInjectionHelper with Heimd
     AwsModule(),
     FakeCryptoModule(),
     FakeActorSystemModule(),
-    FakeActionAuthenticatorModule()
+    FakeUserActionsModule()
   )
 }

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperController.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScraperController.scala
@@ -1,7 +1,7 @@
 package com.keepit.scraper
 
 import com.google.inject.Inject
-import com.keepit.common.controller.{ ScraperServiceController, ActionAuthenticator }
+import com.keepit.common.controller.{ ScraperServiceController, UserActions, UserActionsHelper }
 import com.keepit.model._
 import play.api.mvc.Action
 import play.api.libs.json._
@@ -16,7 +16,7 @@ import com.keepit.common.net.URI
 
 class ScraperController @Inject() (
     airbrake: AirbrakeNotifier,
-    actionAuthenticator: ActionAuthenticator,
+    val userActionsHelper: UserActionsHelper,
     scrapeProcessor: ScrapeProcessor) extends ScraperServiceController with Logging {
 
   implicit val fj = ExecutionContext.fj

--- a/kifi-backend/modules/scraper/test/com/keepit/scraper/ScraperControllerTest.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/scraper/ScraperControllerTest.scala
@@ -1,7 +1,8 @@
 package com.keepit.scraper
 
 import com.keepit.common.actor.{ TestKitSupport, FakeActorSystemModule }
-import com.keepit.common.controller.FakeActionAuthenticatorModule
+import com.keepit.common.controller.{ FakeActionAuthenticatorModule, FakeUserActionsModule }
+import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.common.store.ScraperTestStoreModule
 import com.keepit.scraper.embedly.FakeEmbedlyModule
 import com.keepit.scraper.fetcher.FakeHttpFetcherModule
@@ -33,6 +34,8 @@ class ScraperControllerTest extends TestKitSupport with ScraperTestInjector {
       ScraperTestStoreModule(),
       FakeShoeboxServiceModule(),
       FakeActionAuthenticatorModule(),
+      FakeUserActionsModule(),
+      FakeHttpClientModule(),
       FakeActorSystemModule()
     )
   }

--- a/kifi-backend/modules/scraper/test/com/keepit/scraper/actor/FetchAgentTest.scala
+++ b/kifi-backend/modules/scraper/test/com/keepit/scraper/actor/FetchAgentTest.scala
@@ -5,7 +5,8 @@ import akka.testkit.TestActorRef
 import akka.util.Timeout
 import com.keepit.common.actor.{ FakeActorSystemModule, TestKitSupport }
 import com.keepit.common.concurrent.ExecutionContext
-import com.keepit.common.controller.FakeActionAuthenticatorModule
+import com.keepit.common.controller.FakeUserActionsModule
+import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.common.store.ScraperTestStoreModule
 import com.keepit.common.time._
 import com.keepit.scraper._
@@ -40,7 +41,8 @@ class FetchAgentTest extends TestKitSupport with SpecificationLike with ScraperT
       FakeScraperProcessorActorModule(),
       ScraperTestStoreModule(),
       FakeShoeboxServiceModule(),
-      FakeActionAuthenticatorModule(),
+      FakeUserActionsModule(),
+      FakeHttpClientModule(),
       FakeActorSystemModule()
     )
   }

--- a/kifi-backend/modules/search/app/com/keepit/controllers/ext/ExtMessageSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/ext/ExtMessageSearchController.scala
@@ -1,6 +1,6 @@
 package com.keepit.controllers.ext
 
-import com.keepit.common.controller.{ SearchServiceController, BrowserExtensionController, ActionAuthenticator }
+import com.keepit.common.controller.{ SearchServiceController, BrowserExtensionController, UserActions, UserActionsHelper }
 import com.keepit.common.logging.Logging
 import com.keepit.search.message.MessageSearchCommander
 
@@ -12,9 +12,9 @@ import com.keepit.common.core._
 
 class ExtMessageSearchController @Inject() (
     commander: MessageSearchCommander,
-    actionAuthenticator: ActionAuthenticator) extends BrowserExtensionController(actionAuthenticator) with SearchServiceController with Logging {
+    val userActionsHelper: UserActionsHelper) extends UserActions with SearchServiceController with Logging {
 
-  def search(query: String, page: Int) = JsonAction.authenticatedAsync { request =>
+  def search(query: String, page: Int) = UserAction.async { request =>
     if (page < 0) {
       Future.successful(BadRequest("Negative Page Number!"))
     } else {

--- a/kifi-backend/modules/search/app/com/keepit/controllers/ext/ExtSearchEventController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/ext/ExtSearchEventController.scala
@@ -2,7 +2,7 @@ package com.keepit.controllers.ext
 
 import com.keepit.common.http._
 import com.google.inject.Inject
-import com.keepit.common.controller.{ SearchServiceController, BrowserExtensionController, ActionAuthenticator }
+import com.keepit.common.controller.{ SearchServiceController, BrowserExtensionController, UserActions, UserActionsHelper }
 import com.keepit.heimdal._
 import com.keepit.search._
 import com.keepit.common.service.FortyTwoServices
@@ -14,13 +14,13 @@ import play.api.libs.json._
 import com.keepit.common.akka.SafeFuture
 
 class ExtSearchEventController @Inject() (
-  actionAuthenticator: ActionAuthenticator,
+  val userActionsHelper: UserActionsHelper,
   heimdalContextBuilder: HeimdalContextBuilderFactory,
   searchEventCommander: SearchEventCommander)(implicit private val clock: Clock,
     private val fortyTwoServices: FortyTwoServices)
-    extends BrowserExtensionController(actionAuthenticator) with SearchServiceController with Logging {
+    extends UserActions with SearchServiceController with Logging {
 
-  def clickedSearchResult = JsonAction.authenticatedParseJson { request =>
+  def clickedSearchResult = UserAction(parse.tolerantJson) { request =>
     val clickedAt = currentDateTime
     val userId = request.userId
     val json = request.body
@@ -56,7 +56,7 @@ class ExtSearchEventController @Inject() (
     Ok
   }
 
-  def searched = JsonAction.authenticatedParseJson { request =>
+  def searched = UserAction(parse.tolerantJson) { request =>
     val time = clock.now()
     val userId = request.userId
     val json = request.body

--- a/kifi-backend/modules/search/app/com/keepit/controllers/mobile/MobileMessageSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/mobile/MobileMessageSearchController.scala
@@ -1,6 +1,6 @@
 package com.keepit.controllers.mobile
 
-import com.keepit.common.controller.{ SearchServiceController, BrowserExtensionController, ActionAuthenticator }
+import com.keepit.common.controller.{ SearchServiceController, BrowserExtensionController, UserActions, UserActionsHelper }
 import com.keepit.common.logging.Logging
 import com.keepit.search.message.MessageSearchCommander
 
@@ -12,9 +12,9 @@ import com.keepit.common.core._
 
 class MobileMessageSearchController @Inject() (
     commander: MessageSearchCommander,
-    actionAuthenticator: ActionAuthenticator) extends BrowserExtensionController(actionAuthenticator) with SearchServiceController with Logging {
+    val userActionsHelper: UserActionsHelper) extends UserActions with SearchServiceController with Logging {
 
-  def search(query: String, page: Int) = JsonAction.authenticatedAsync { request =>
+  def search(query: String, page: Int) = UserAction.async { request =>
     if (page < 0) {
       Future.successful(BadRequest("Negative Page Number!"))
     } else {

--- a/kifi-backend/modules/search/app/com/keepit/controllers/mobile/MobileSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/mobile/MobileSearchController.scala
@@ -2,7 +2,7 @@ package com.keepit.controllers.mobile
 
 import play.api.libs.json._
 import com.google.inject.Inject
-import com.keepit.common.controller.{ MobileController, SearchServiceController, ActionAuthenticator }
+import com.keepit.common.controller.{ MobileController, SearchServiceController, UserActions, UserActionsHelper }
 import com.keepit.common.logging.Logging
 import com.keepit.model._
 import com.keepit.search.result.DecoratedResult
@@ -12,8 +12,8 @@ import com.keepit.search.util.IdFilterCompressor
 import com.keepit.search.SearchCommander
 
 class MobileSearchController @Inject() (
-    actionAuthenticator: ActionAuthenticator,
-    searchCommander: SearchCommander) extends MobileController(actionAuthenticator) with SearchServiceController with Logging {
+    val userActionsHelper: UserActionsHelper,
+    searchCommander: SearchCommander) extends UserActions with SearchServiceController with Logging {
 
   def searchV1(
     query: String,
@@ -26,7 +26,7 @@ class MobileSearchController @Inject() (
     end: Option[String] = None,
     tz: Option[String] = None,
     coll: Option[String] = None,
-    withUriSummary: Boolean = false) = JsonAction.authenticated { request =>
+    withUriSummary: Boolean = false) = UserAction { request =>
 
     val userId = request.userId
     val acceptLangs: Seq[String] = request.request.acceptLanguages.map(_.code)
@@ -36,7 +36,7 @@ class MobileSearchController @Inject() (
     Ok(toKifiSearchResultV1(decoratedResult)).withHeaders("Cache-Control" -> "private, max-age=10")
   }
 
-  def warmUp() = JsonAction.authenticated { request =>
+  def warmUp() = UserAction { request =>
     searchCommander.warmUp(request.userId)
     Ok
   }

--- a/kifi-backend/modules/search/app/com/keepit/controllers/mobile/MobileSearchEventController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/mobile/MobileSearchEventController.scala
@@ -1,7 +1,7 @@
 package com.keepit.controllers.mobile
 
 import com.google.inject.Inject
-import com.keepit.common.controller.{ MobileController, SearchServiceController, ActionAuthenticator }
+import com.keepit.common.controller.{ MobileController, SearchServiceController, UserActions, UserActionsHelper }
 import com.keepit.heimdal.{ KifiHitContext, SearchEngine, BasicSearchContext, HeimdalContextBuilderFactory }
 import com.keepit.search.SearchEventCommander
 import com.keepit.common.service.FortyTwoServices
@@ -13,13 +13,13 @@ import play.api.libs.json.JsArray
 import play.api.libs.concurrent.Execution.Implicits._
 
 class MobileSearchEventController @Inject() (
-  actionAuthenticator: ActionAuthenticator,
+  val userActionsHelper: UserActionsHelper,
   heimdalContextBuilder: HeimdalContextBuilderFactory,
   searchEventCommander: SearchEventCommander)(implicit private val clock: Clock,
     private val fortyTwoServices: FortyTwoServices)
-    extends MobileController(actionAuthenticator) with SearchServiceController with Logging {
+    extends UserActions with SearchServiceController with Logging {
 
-  def clickedSearchResult = JsonAction.authenticatedParseJson { request =>
+  def clickedSearchResult = UserAction(parse.tolerantJson) { request =>
     val clickedAt = clock.now()
     val userId = request.userId
     val json = request.body
@@ -44,7 +44,7 @@ class MobileSearchEventController @Inject() (
     Ok
   }
 
-  def searched = JsonAction.authenticatedParseJson { request =>
+  def searched = UserAction(parse.tolerantJson) { request =>
     val time = currentDateTime
     val userId = request.userId
     val json = request.body

--- a/kifi-backend/modules/search/app/com/keepit/controllers/mobile/MobileUserSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/mobile/MobileUserSearchController.scala
@@ -1,7 +1,7 @@
 package com.keepit.controllers.mobile
 
 import com.google.inject.Inject
-import com.keepit.common.controller.{ MobileController, ActionAuthenticator, SearchServiceController }
+import com.keepit.common.controller.{ MobileController, UserActions, UserActionsHelper, SearchServiceController }
 import com.keepit.common.db.Id
 import com.keepit.common.logging.Logging
 import com.keepit.model.User
@@ -18,7 +18,7 @@ class MobileUserSearchController @Inject() (
     searcherFactory: MainSearcherFactory,
     filterFactory: UserSearchFilterFactory,
     shoeboxClient: ShoeboxServiceClient,
-    actionAuthenticator: ActionAuthenticator) extends MobileController(actionAuthenticator) with SearchServiceController with Logging {
+    val userActionsHelper: UserActionsHelper) extends UserActions with SearchServiceController with Logging {
 
   val EXCLUDED_EXPERIMENTS = Seq("fake")
 
@@ -30,7 +30,7 @@ class MobileUserSearchController @Inject() (
     }
   }
 
-  def pageV1(queryText: String, filter: Option[String], pageNum: Int, pageSize: Int) = JsonAction.authenticated { request =>
+  def pageV1(queryText: String, filter: Option[String], pageNum: Int, pageSize: Int) = UserAction { request =>
     val userId = request.userId
     val userExps = request.experiments.map { _.value }
     log.info(s"user search: userId = $userId, userExps = ${userExps.mkString(" ")}")
@@ -60,7 +60,7 @@ class MobileUserSearchController @Inject() (
     Ok(JsArray(jsVals))
   }
 
-  def searchV1(queryText: String, filter: Option[String], context: Option[String], maxHits: Int) = JsonAction.authenticated { request =>
+  def searchV1(queryText: String, filter: Option[String], context: Option[String], maxHits: Int) = UserAction { request =>
     val userId = request.userId
     val searchFilter = createFilter(Some(userId), filter, context)
     val searcher = searcherFactory.getUserSearcher

--- a/kifi-backend/modules/search/app/com/keepit/controllers/search/MessageSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/search/MessageSearchController.scala
@@ -1,6 +1,6 @@
 package com.keepit.controllers.search
 
-import com.keepit.common.controller.{ SearchServiceController, ActionAuthenticator }
+import com.keepit.common.controller.{ SearchServiceController, UserActions, UserActionsHelper }
 import com.keepit.search.message.MessageSearchCommander
 import com.keepit.common.db.Id
 import com.keepit.model.User
@@ -16,7 +16,7 @@ import com.keepit.common.core._
 
 class MessageSearchController @Inject() (
     commander: MessageSearchCommander,
-    actionAuthenticator: ActionAuthenticator,
+    val userActionsHelper: UserActionsHelper,
     userExperimentCommander: RemoteUserExperimentCommander) extends SearchServiceController {
 
   def search(userId: Id[User], query: String, page: Int) = Action.async { request =>

--- a/kifi-backend/modules/search/app/com/keepit/controllers/website/WebsiteSearchEventController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/website/WebsiteSearchEventController.scala
@@ -1,7 +1,7 @@
 package com.keepit.controllers.website
 
 import com.google.inject.Inject
-import com.keepit.common.controller.{ WebsiteController, SearchServiceController, ActionAuthenticator }
+import com.keepit.common.controller.{ WebsiteController, SearchServiceController, UserActions, UserActionsHelper }
 import com.keepit.heimdal._
 import com.keepit.search._
 import com.keepit.common.service.FortyTwoServices
@@ -12,13 +12,13 @@ import play.api.libs.concurrent.Execution.Implicits._
 import com.keepit.common.akka.SafeFuture
 
 class WebsiteSearchEventController @Inject() (
-  actionAuthenticator: ActionAuthenticator,
+  val userActionsHelper: UserActionsHelper,
   heimdalContextBuilder: HeimdalContextBuilderFactory,
   searchEventCommander: SearchEventCommander)(implicit private val clock: Clock,
     private val fortyTwoServices: FortyTwoServices)
-    extends WebsiteController(actionAuthenticator) with SearchServiceController with Logging {
+    extends UserActions with SearchServiceController with Logging {
 
-  def clickedKifiResult = JsonAction.authenticatedParseJson { request =>
+  def clickedKifiResult = UserAction(parse.tolerantJson) { request =>
     val clickedAt = currentDateTime
     val userId = request.userId
     val json = request.body
@@ -36,7 +36,7 @@ class WebsiteSearchEventController @Inject() (
     Ok
   }
 
-  def searched = JsonAction.authenticatedParseJson { request =>
+  def searched = UserAction(parse.tolerantJson) { request =>
     val time = clock.now()
     val userId = request.userId
     val json = request.body

--- a/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtSearchControllerTest.scala
@@ -8,7 +8,7 @@ import com.keepit.model._
 import com.keepit.common.db.{ Id, ExternalId }
 import com.keepit.inject._
 import com.keepit.common.actor.FakeActorSystemModule
-import com.keepit.common.controller.{ FakeActionAuthenticator, FakeActionAuthenticatorModule }
+import com.keepit.common.controller.{ FakeActionAuthenticatorModule, FakeUserActionsHelper, FakeUserActionsModule }
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.libs.json._
@@ -30,6 +30,7 @@ class ExtSearchControllerTest extends Specification with SearchTestInjector {
     Seq(
       FakeActorSystemModule(),
       FakeActionAuthenticatorModule(),
+      FakeUserActionsModule(),
       FixedResultIndexModule(),
       PlayAppConfigurationModule(),
       FakeCryptoModule()
@@ -43,7 +44,7 @@ class ExtSearchControllerTest extends Specification with SearchTestInjector {
         path === "/search?q=test&maxHits=7"
 
         val user = User(Some(Id[User](1)), firstName = "prénom", lastName = "nom")
-        inject[FakeActionAuthenticator].setUser(user)
+        inject[FakeUserActionsHelper].setUser(user)
         val request = FakeRequest("GET", path)
         val result = inject[ExtSearchController].search("test", None, 7, None, None, None, None, None, None, None, None)(request)
         status(result) must equalTo(OK)

--- a/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
@@ -1,7 +1,7 @@
 package com.keepit.controllers.mobile
 
 import com.keepit.common.actor.FakeActorSystemModule
-import com.keepit.common.controller.{ FakeActionAuthenticator, FakeActionAuthenticatorModule }
+import com.keepit.common.controller.{ FakeUserActionsHelper, FakeUserActionsModule }
 import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.inject._
@@ -27,7 +27,7 @@ class MobileSearchControllerTest extends SpecificationLike with SearchTestInject
 
   def modules = Seq(
     FakeActorSystemModule(),
-    FakeActionAuthenticatorModule(),
+    FakeUserActionsModule(),
     FixedResultIndexModule(),
     FakeHttpClientModule(),
     PlayAppConfigurationModule()
@@ -41,7 +41,7 @@ class MobileSearchControllerTest extends SpecificationLike with SearchTestInject
         path === "/m/1/search?q=test&maxHits=7"
 
         val user = User(Some(Id[User](1)), firstName = "prénom", lastName = "nom")
-        inject[FakeActionAuthenticator].setUser(user)
+        inject[FakeUserActionsHelper].setUser(user)
         val request = FakeRequest("GET", path)
         val result = mobileSearchController.searchV1("test", None, 7, None, None, None, None, None, None, None)(request)
         status(result) must equalTo(OK)

--- a/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileUserSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileUserSearchControllerTest.scala
@@ -1,11 +1,12 @@
 package com.keepit.controllers.mobile
 
+import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.test.{ SearchApplication, SearchTestInjector }
 import org.specs2.mutable._
 
 import com.keepit.model._
 import com.keepit.common.db.{ Id, ExternalId }
-import com.keepit.common.controller.{ FakeActionAuthenticator, FakeActionAuthenticatorModule }
+import com.keepit.common.controller.{ FakeActionAuthenticatorModule, FakeUserActionsHelper, FakeUserActionsModule }
 import com.keepit.common.actor.FakeActorSystemModule
 
 import play.api.test.FakeRequest
@@ -56,6 +57,8 @@ class MobileUserSearchControllerTest extends Specification with SearchTestInject
   def modules = {
     Seq(
       FakeActorSystemModule(),
+      FakeUserActionsModule(),
+      FakeHttpClientModule(),
       FakeActionAuthenticatorModule(),
       FakeShoeboxServiceModule(),
       PlayAppConfigurationModule()
@@ -73,6 +76,7 @@ class MobileUserSearchControllerTest extends Specification with SearchTestInject
         val path = com.keepit.controllers.mobile.routes.MobileUserSearchController.searchV1("woody", None, None, 3).toString
         path === "/m/1/search/users/search?query=woody&maxHits=3"
 
+        inject[FakeUserActionsHelper].setUser(users.head)
         val request = FakeRequest("GET", path)
 
         val controller = inject[MobileUserSearchController]
@@ -113,8 +117,8 @@ class MobileUserSearchControllerTest extends Specification with SearchTestInject
         val path = com.keepit.controllers.mobile.routes.MobileUserSearchController.pageV1("firstNa", None, 0, 10).toString
         path === "/m/1/search/users/page?query=firstNa&pageNum=0&pageSize=10"
 
+        inject[FakeUserActionsHelper].setUser(users.head)
         val request = FakeRequest("GET", path)
-
         val controller = inject[MobileUserSearchController]
         val result = controller.pageV1("firstNa", None, 0, 10)(request)
         status(result) must equalTo(OK)
@@ -166,6 +170,7 @@ class MobileUserSearchControllerTest extends Specification with SearchTestInject
         val path = com.keepit.controllers.mobile.routes.MobileUserSearchController.pageV1("woody@fox.com", None, 0, 10).toString
         path === "/m/1/search/users/page?query=woody%40fox.com&pageNum=0&pageSize=10"
 
+        inject[FakeUserActionsHelper].setUser(users.head)
         val request = FakeRequest("GET", path)
         val controller = inject[MobileUserSearchController]
         val result = controller.pageV1("woody@fox.com", None, 0, 10)(request)


### PR DESCRIPTION
All non-shoebox Controllers migrated to using new `[User]Actions` framework

(Some Controllers on shoebox are more complex; hence deal with the low hanging fruit first)

95%++ mechanical changes (i.e. search-and-replace)

Tests passed!

@andrewconner 

cc: @42eng 
