### PR TITLE
Public ids threadsafe fix

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/crypto/Aes64BitCipher.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/crypto/Aes64BitCipher.scala
@@ -21,7 +21,9 @@ private[crypto] class Aes64BitCipher(key: SecretKey, ivSpec: IvParameterSpec) {
   private def crypt(value: Long, cipher: Cipher): Long = {
     val buffer = ByteBuffer.allocate(8)
     buffer.putLong(0, reverseBytes(value))
-    val bytes: Array[Byte] = cipher.doFinal(buffer.array)
+    val bytes: Array[Byte] = synchronized {
+      cipher.doFinal(buffer.array)
+    }
     buffer.rewind
     buffer.put(bytes)
     buffer.rewind

--- a/kifi-backend/modules/common/app/com/keepit/common/crypto/ModelWithPublicId.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/crypto/ModelWithPublicId.scala
@@ -63,25 +63,13 @@ trait ModelWithPublicIdCompanion[T <: ModelWithPublicId[T]] {
   */
   protected[this] val publicIdIvSpec: IvParameterSpec
 
-  //private val decryptCache: Cache[java.lang.Long, Try[java.lang.Long]] = CacheBuilder.newBuilder().concurrencyLevel(1).initialCapacity(1024).maximumSize(4096).build()
   private def threadSafeDecrypt(id: Long, config: PublicIdConfiguration): Try[Long] = {
-    //    decryptCache.get(id, new Callable[Try[java.lang.Long]] {
-    //      def call() = synchronized {
-    //        Try(config.aes64bit(publicIdIvSpec).decrypt(id))
-    //      }
-    //    }).map(Long2long)
     synchronized {
       Try(config.aes64bit(publicIdIvSpec).decrypt(id))
     }
   }
 
-  //private val encryptCache: Cache[java.lang.Long, java.lang.Long] = CacheBuilder.newBuilder().concurrencyLevel(1).initialCapacity(1024).maximumSize(4096).build()
   private def threadSafeEncrypt(id: Long, config: PublicIdConfiguration): Long = {
-    //    encryptCache.get(id, new Callable[java.lang.Long] {
-    //      def call() = synchronized {
-    //        Long.box(config.aes64bit(publicIdIvSpec).encrypt(id))
-    //      }
-    //    }).toLong
     synchronized {
       config.aes64bit(publicIdIvSpec).encrypt(id)
     }

--- a/kifi-backend/modules/common/app/com/keepit/common/crypto/ModelWithPublicId.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/crypto/ModelWithPublicId.scala
@@ -1,6 +1,5 @@
 package com.keepit.common.crypto
 
-import java.lang.{ Long => JLong }
 import javax.crypto.spec.IvParameterSpec
 
 import com.keepit.common.db.Id

--- a/kifi-backend/modules/common/app/com/keepit/common/crypto/ModelWithPublicId.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/crypto/ModelWithPublicId.scala
@@ -1,17 +1,14 @@
 package com.keepit.common.crypto
 
-import java.util.concurrent.{ Callable, TimeUnit }
+import java.lang.{ Long => JLong }
 import javax.crypto.spec.IvParameterSpec
-import com.google.common.cache.{CacheLoader, CacheBuilder, Cache}
+
 import com.keepit.common.db.Id
-import com.keepit.model.{ User, NormalizedURI }
 import play.api.libs.json._
 import play.api.mvc.{ PathBindable, QueryStringBindable }
-import java.lang.{Long => JLong}
 
-import scala.collection.JavaConverters
 import scala.collection.concurrent.TrieMap
-import scala.util.{ Success, Failure, Try }
+import scala.util.{ Failure, Success, Try }
 
 case class PublicIdConfiguration(key: String) {
   private val cache = TrieMap.empty[IvParameterSpec, Aes64BitCipher]


### PR DESCRIPTION
@2is10 Guava / Scala has this weird bug when storing `java.util.Long`s (Scala tries to optimize it and unbox them, but that blows up the cache at runtime). Without the cache seems fast enough, but I'll keep an eye on it.
