### PR TITLE
shoebox newKeepsInLibrary endpoint is GET instead of POST

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -170,7 +170,7 @@ object Shoebox extends Service {
     def getLibrariesChanged(seqNum: SequenceNumber[Library], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getLibrariesChanged", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def getLibraryMembershipsChanged(seqNum: SequenceNumber[LibraryMembership], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getLibraryMembershipsChanged", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def canViewLibrary() = ServiceRoute(POST, "/internal/shoebox/libraries/canView")
-    def newKeepsInLibrary(userId: Id[User], max: Int) = ServiceRoute(POST, "/internal/shoebox/database/newKeepsInLibrary", Param("userId", userId), Param("max", max))
+    def newKeepsInLibrary(userId: Id[User], max: Int) = ServiceRoute(GET, "/internal/shoebox/database/newKeepsInLibrary", Param("userId", userId), Param("max", max))
     def getMutualFriends(user1Id: Id[User], user2Id: Id[User]) = ServiceRoute(GET, "/internal/shoebox/database/getMutualFriends", Param("user1Id", user1Id), Param("user2Id", user2Id))
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -481,7 +481,7 @@ class ShoeboxController @Inject() (
 
   def newKeepsInLibrary(userId: Id[User], max: Int) = Action { request =>
     val keeps = newKeepsInLibraryCommander.getLastViewdKeeps(userId, max)
-    Ok(Json.arr(keeps))
+    Ok(Json.toJson(keeps))
   }
 
   def getMutualFriends(user1Id: Id[User], user2Id: Id[User]) = Action { request =>


### PR DESCRIPTION
- and service client request returned an array of an array of objects instead of array of objects

@eishay 
