### PR TITLE
Fixing FB invites when the script was blocked from the page

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/angular-facebook-api.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/angular-facebook-api.js
@@ -106,6 +106,7 @@ angular.module('jun.facebook', [])
 	this.loading = false;
 	this.loaded = false;
 	this.FB = null;
+	this.failedToLoad = false;
 
 	this.load = function () {
 		if (!FBPromise) {
@@ -123,6 +124,18 @@ angular.module('jun.facebook', [])
 				});
 			};
 
+			var failedToLoadHander = function () {
+				if (!that.FB && that.loading && !that.loaded) {
+					that.loading = false;
+					that.failedToLoad = true;
+					document.getElementById('facebook-jssdk').remove();
+					deferred.reject({'error': 'no_FB_on_page'});
+					FBPromise = null;
+				}
+			}
+
+			$timeout(failedToLoadHander, 5000);
+
 			(function (d, s, id) {
 				var js, fjs = d.getElementsByTagName(s)[0];
 				if (d.getElementById(id)) {
@@ -131,6 +144,7 @@ angular.module('jun.facebook', [])
 				js = d.createElement(s);
 				js.id = id;
 				js.src = '//connect.facebook.net/en_US/all.js';
+				js.addEventListener('error', failedToLoadHander);
 				fjs.parentNode.insertBefore(js, fjs);
 			}(window.document, 'script', 'facebook-jssdk'));
 
@@ -144,9 +158,7 @@ angular.module('jun.facebook', [])
 	this.initialized = false;
 
 	this.init = function (params) {
-		if (window.FB && that.loading) {
-			return $q.reject({'error': 'no_FB_on_page'});
-		} else if (!initPromise) {
+		if (!initPromise || (!that.loading && !that.loaded)) {
 			initPromise = that.load().then(function (FB) {
 				params = angular.extend({
 					appId: options.appId,

--- a/kifi-backend/modules/shoebox/angular/src/invite/invite.js
+++ b/kifi-backend/modules/shoebox/angular/src/invite/invite.js
@@ -86,8 +86,8 @@ angular.module('kifi')
 ])
 
 .directive('kfSocialInviteAction', [
-  '$log', 'inviteService', '$timeout',
-  function ($log, inviteService, $timeout) {
+  '$log', 'inviteService', '$timeout', '$FB',
+  function ($log, inviteService, $timeout, $FB) {
     return {
       restrict: 'A',
       scope: {
@@ -107,6 +107,8 @@ angular.module('kifi')
         link.click(function (elem, $event) {
           scope.invite(scope.result, $event);
         });
+
+        $FB.init();
 
         scope.invite = function (result, $event) {
           result = result || scope.result;

--- a/kifi-backend/modules/shoebox/angular/src/invite/inviteService.js
+++ b/kifi-backend/modules/shoebox/angular/src/invite/inviteService.js
@@ -148,7 +148,7 @@ angular.module('kifi')
         }
 
         //login if needed
-        if (platform === 'facebook') {
+        if (platform === 'facebook' && $FB.FB) {
           if ($FB.FB.getAuthResponse()) {
             doInvite();
           } else {


### PR DESCRIPTION
@yipingliao Old bug — if facebook's script was blocked from loading, we ended up in a weird state where users wouldn't get good error messages. This should fix it.
