### PR TITLE
stop immediate indexing of urigraph

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchServiceClient.scala
@@ -91,7 +91,6 @@ class SearchServiceClientImpl(
 
   def updateKeepIndex(): Unit = {
     broadcast(Search.internal.updateKeepIndex())
-    broadcast(Search.internal.updateURIGraph())
   }
 
   def updateLibraryIndex(): Unit = {

--- a/kifi-backend/modules/search/app/com/keepit/controllers/search/IndexController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/search/IndexController.scala
@@ -28,6 +28,7 @@ class IndexController @Inject() (
 
   def updateKeepIndex() = Action { implicit request =>
     keepIndexerPlugin.update()
+    collectionGraphPlugin.update() // still needed for compatibility support
     Ok
   }
 

--- a/kifi-backend/modules/search/app/com/keepit/controllers/search/URIGraphController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/search/URIGraphController.scala
@@ -28,7 +28,6 @@ class URIGraphController @Inject() (
 
   def updateURIGraph() = Action { implicit request =>
     uriGraphPlugin.update()
-    collectionGraphPlugin.update()
     Ok(JsObject(Seq("started" -> JsString("ok"))))
   }
 


### PR DESCRIPTION
- still doing periodical indexing (1 min interval) though
- moved collection index update updateKeepIndex (collection index is still needed for backward compatibility)

@leogrim @eishay 
