### PR TITLE
updating mobile and site end points

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
@@ -36,9 +36,9 @@ class MobileMessagingController @Inject() (
   def getNotifications(howMany: Int, before: Option[String]) = UserAction.async { request =>
     val noticesFuture = before match {
       case Some(before) =>
-        notificationCommander.getSendableNotificationsBefore(request.userId, parseStandardTime(before), howMany.toInt, includeUriSummary = false)
+        notificationCommander.getSendableNotificationsBefore(request.userId, parseStandardTime(before), howMany.toInt, includeUriSummary = true)
       case None =>
-        notificationCommander.getLatestSendableNotifications(request.userId, howMany.toInt, includeUriSummary = false)
+        notificationCommander.getLatestSendableNotifications(request.userId, howMany.toInt, includeUriSummary = true)
     }
     noticesFuture.map { notices =>
       val numUnreadUnmuted = messagingCommander.getUnreadUnmutedThreadCount(request.userId)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
@@ -19,7 +19,7 @@ import com.keepit.commanders.CollectionSaveFail
 import scala.Some
 import com.keepit.normalizer.NormalizedURIInterner
 
-class MobileBookmarksController @Inject() (
+class MobileKeepsController @Inject() (
   db: Database,
   uriSummaryCommander: URISummaryCommander,
   uriRepo: NormalizedURIRepo,
@@ -249,48 +249,6 @@ class MobileBookmarksController @Inject() (
         }
       }
       case None => Future.successful(BadRequest(Json.obj("code" -> "illegal_argument")))
-    }
-  }
-
-  def getImageUrls() = UserAction.async(parse.tolerantJson) { request => // WIP; test-only
-    val urlsOpt = (request.body \ "urls").asOpt[Seq[JsValue]]
-    log.info(s"[getImageUrls] body=${request.body} urls=${urlsOpt}")
-    urlsOpt match {
-      case None => Future.successful(BadRequest(Json.obj("code" -> "illegal_arguments")))
-      case Some(urls) => {
-        val uriOpts = db.readOnlyMaster { implicit ro =>
-          urls flatMap { urlReq =>
-            urlReq match {
-              case JsString(url) => Some((url, normalizedURIInterner.getByUri(url), None))
-              case _ => {
-                val urlOpt = (urlReq \ "url").asOpt[String]
-                urlOpt map { url =>
-                  val minSizeOpt = for {
-                    minWidth <- (urlReq \ "minWidth").asOpt[Int]
-                    minHeight <- (urlReq \ "minHeight").asOpt[Int]
-                  } yield ImageSize(minWidth, minHeight)
-                  (url, normalizedURIInterner.getByUri(url), minSizeOpt)
-                }
-              }
-            }
-          }
-        }
-        val resFutSeq = uriOpts map {
-          case (url, uriOpt, minSizeOpt) =>
-            uriOpt match {
-              case None => Future.successful(Json.obj("url" -> url, "code" -> "uri_not_found"))
-              case Some(uri) => {
-                val screenshotUrlOpt = uriSummaryCommander.getScreenshotURL(uri)
-                uriSummaryCommander.getImageURISummary(uri, minSizeOpt) map { uriSummary =>
-                  toJsObject(url, uri, screenshotUrlOpt, uriSummary.imageUrl, uriSummary.imageWidth, uriSummary.imageHeight)
-                }
-              }
-            }
-        }
-        Future.sequence(resFutSeq) map { res =>
-          Ok(Json.toJson(res))
-        }
-      }
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
@@ -116,28 +116,6 @@ class KeepsController @Inject() (
   }
 
   // todo(martin) - looks like this endpoint is not being used, consider removing
-  def getImageUrl() = UserAction.async(parse.tolerantJson) { request => // WIP; test-only
-    val urlOpt = (request.body \ "url").asOpt[String]
-    log.info(s"[getImageUrl] body=${request.body} url=${urlOpt}")
-    urlOpt match {
-      case None => Future.successful(BadRequest(Json.obj("code" -> "illegal_argument")))
-      case Some(url) => {
-        val (uriOpt, pageInfoOpt) = db.readOnlyReplica { implicit ro =>
-          val uriOpt = normalizedURIInterner.getByUri(url)
-          val pageInfoOpt = uriOpt flatMap { uri => pageInfoRepo.getByUri(uri.id.get) }
-          (uriOpt, pageInfoOpt)
-        }
-        uriOpt match {
-          case None => Future.successful(NotFound(Json.obj("code" -> "uri_not_found")))
-          case Some(uri) => {
-            toJsObject(url, uri, pageInfoOpt) map { js => Ok(js) }
-          }
-        }
-      }
-    }
-  }
-
-  // todo(martin) - looks like this endpoint is not being used, consider removing
   def getImageUrls() = UserAction.async(parse.tolerantJson) { request => // WIP; test-only
     val urlsOpt = (request.body \ "urls").asOpt[Seq[String]]
     log.info(s"[getImageUrls] body=${request.body} urls=${urlsOpt}")

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -159,28 +159,25 @@ POST    /m/1/page/details                   @com.keepit.controllers.mobile.Mobil
 POST    /m/1/page/extensionQuery            @com.keepit.controllers.mobile.MobilePageController.queryExtension(page: Int ?= 0, pageSize: Int ?= 1000)
 
 ## Deprecated
-POST    /m/1/keeps/add                      @com.keepit.controllers.mobile.MobileBookmarksController.keepMultiple()
-POST    /m/2/keeps/add                      @com.keepit.controllers.mobile.MobileBookmarksController.addKeeps()
-POST    /m/1/keeps/addWithTags              @com.keepit.controllers.mobile.MobileBookmarksController.addKeepWithTags()
+POST    /m/1/keeps/add                      @com.keepit.controllers.mobile.MobileKeepsController.keepMultiple()
+POST    /m/2/keeps/add                      @com.keepit.controllers.mobile.MobileKeepsController.addKeeps()
+POST    /m/1/keeps/addWithTags              @com.keepit.controllers.mobile.MobileKeepsController.addKeepWithTags()
 
-POST    /m/1/keeps/remove                   @com.keepit.controllers.mobile.MobileBookmarksController.unkeepMultiple()
-POST    /m/1/keeps/delete                   @com.keepit.controllers.mobile.MobileBookmarksController.unkeepBatch()
-POST    /m/1/keeps/:id/delete               @com.keepit.controllers.mobile.MobileBookmarksController.unkeep(id: ExternalId[Keep])
+POST    /m/1/keeps/remove                   @com.keepit.controllers.mobile.MobileKeepsController.unkeepMultiple()
+POST    /m/1/keeps/delete                   @com.keepit.controllers.mobile.MobileKeepsController.unkeepBatch()
+POST    /m/1/keeps/:id/delete               @com.keepit.controllers.mobile.MobileKeepsController.unkeep(id: ExternalId[Keep])
 
-POST    /m/1/keeps/imageUrl                 @com.keepit.controllers.mobile.MobileBookmarksController.getImageUrl()
-POST    /m/1/keeps/imageUrls                @com.keepit.controllers.mobile.MobileBookmarksController.getImageUrls()
+#Used by both Android and iOS
+POST    /m/1/keeps/imageUrl                 @com.keepit.controllers.mobile.MobileKeepsController.getImageUrl()
 
-POST    /m/1/collections/create             @com.keepit.controllers.mobile.MobileBookmarksController.saveCollection()
-GET     /m/1/collections/all                @com.keepit.controllers.mobile.MobileBookmarksController.allCollections(sort: String ?= "last_kept")
+POST    /m/1/collections/create             @com.keepit.controllers.mobile.MobileKeepsController.saveCollection()
+GET     /m/1/collections/all                @com.keepit.controllers.mobile.MobileKeepsController.allCollections(sort: String ?= "last_kept")
 GET     /m/1/user/me                        @com.keepit.controllers.mobile.MobileUserController.currentUser()
 POST    /m/1/user/me                        @com.keepit.controllers.mobile.MobileUserController.updateCurrentUser()
 GET     /m/1/user/prefs                     @com.keepit.controllers.mobile.MobileUserController.getPrefs()
-GET     /m/1/keeps/all                      @com.keepit.controllers.mobile.MobileBookmarksController.allKeeps(before: Option[String], after: Option[String], collection: Option[String], helprank: Option[String], count: Int ?= Integer.MAX_VALUE, withPageInfo: Boolean ?= false)
-POST    /m/1/tags/:id/addToKeep             @com.keepit.controllers.mobile.MobileBookmarksController.addTag(id: ExternalId[Collection])
-POST    /m/1/tags/:id/removeFromKeep        @com.keepit.controllers.mobile.MobileBookmarksController.removeTag(id: ExternalId[Collection])
-
-POST    /m/1/user/:id/include               @com.keepit.controllers.mobile.MobileUserController.includeFriend(id: ExternalId[User])
-POST    /m/1/user/:id/exclude               @com.keepit.controllers.mobile.MobileUserController.excludeFriend(id: ExternalId[User])
+GET     /m/1/keeps/all                      @com.keepit.controllers.mobile.MobileKeepsController.allKeeps(before: Option[String], after: Option[String], collection: Option[String], helprank: Option[String], count: Int ?= Integer.MAX_VALUE, withPageInfo: Boolean ?= false)
+POST    /m/1/tags/:id/addToKeep             @com.keepit.controllers.mobile.MobileKeepsController.addTag(id: ExternalId[Collection])
+POST    /m/1/tags/:id/removeFromKeep        @com.keepit.controllers.mobile.MobileKeepsController.removeTag(id: ExternalId[Collection])
 
 POST    /m/1/auth/accessTokenLogin/:provider    @com.keepit.controllers.mobile.MobileAuthController.accessTokenLogin(provider)
 POST    /m/1/auth/log-in                        @com.keepit.controllers.mobile.MobileAuthController.loginWithUserPass(link: String ?= "")
@@ -214,6 +211,10 @@ GET     /m/1/user/incomingFriendRequests        @com.keepit.controllers.mobile.M
 POST    /m/1/user/delighted/answer              @com.keepit.controllers.mobile.MobileUserController.postDelightedAnswer()
 POST    /m/1/user/delighted/cancel              @com.keepit.controllers.mobile.MobileUserController.cancelDelightedSurvey()
 GET     /m/1/user/$id<[0-9a-f-]{36}> 			      @com.keepit.controllers.mobile.MobileUserController.basicUserInfo(id: ExternalId[User], friendCount: Boolean ?= false)
+POST    /m/1/user/:id/include                   @com.keepit.controllers.mobile.MobileUserController.includeFriend(id: ExternalId[User])
+POST    /m/1/user/:id/exclude                   @com.keepit.controllers.mobile.MobileUserController.excludeFriend(id: ExternalId[User])
+
+
 
 POST    /m/1/disconnect/:provider               @com.keepit.controllers.mobile.MobileUserController.disconnect(provider)
 
@@ -270,8 +271,9 @@ GET     /site/keeps/export          @com.keepit.controllers.website.KeepsControl
 GET     /site/keeps/:id             @com.keepit.controllers.website.KeepsController.getKeepInfo(id: ExternalId[Keep], withFullInfo: Boolean ?= false)
 POST    /site/keeps/:id/update      @com.keepit.controllers.website.KeepsController.updateKeepInfo(id: ExternalId[Keep])
 POST    /site/keeps/:id/delete      @com.keepit.controllers.website.KeepsController.unkeep(id: ExternalId[Keep])
+#### Deprecated: Used by Android now, should be dropped by Nov 1, 2014
 POST    /site/keeps/screenshot      @com.keepit.controllers.website.KeepsController.getScreenshotUrl()
-POST    /site/keeps/imageUrl        @com.keepit.controllers.website.KeepsController.getImageUrl()
+#### Deprecated: Used by Android and iOS now, should be dropped by Nov 1, 2014 when both will use the new /m/1/eliza/notifications endpoint
 POST    /site/keeps/imageUrls       @com.keepit.controllers.website.KeepsController.getImageUrls()
 
 POST    /site/keeps/unkeep          @com.keepit.controllers.website.KeepsController.unkeepBulk()

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -99,12 +99,12 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
       }
 
       inject[FakeUserActionsHelper].setUser(user)
-      val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.removeTag(collections(0).externalId).url
+      val path = com.keepit.controllers.mobile.routes.MobileKeepsController.removeTag(collections(0).externalId).url
       path === s"/m/1/tags/${collections(0).externalId}/removeFromKeep"
 
       inject[FakeUserActionsHelper].setUser(user)
       val request = FakeRequest("POST", path).withBody(JsObject(Seq("url" -> JsString("http://www.google.com/"))))
-      val result = inject[MobileBookmarksController].removeTag(collections(0).externalId)(request)
+      val result = inject[MobileKeepsController].removeTag(collections(0).externalId)(request)
       status(result) must equalTo(OK)
       contentType(result) must beSome("application/json")
 
@@ -158,12 +158,12 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
         uris.size === 2
       }
 
-      val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.addTag(collections(0).externalId).url
+      val path = com.keepit.controllers.mobile.routes.MobileKeepsController.addTag(collections(0).externalId).url
       path === s"/m/1/tags/${collections(0).externalId}/addToKeep"
 
       inject[FakeUserActionsHelper].setUser(user)
       val request = FakeRequest("POST", path).withBody(JsObject(Seq("url" -> JsString("http://www.google.com/"))))
-      val result = inject[MobileBookmarksController].addTag(collections(0).externalId)(request)
+      val result = inject[MobileKeepsController].addTag(collections(0).externalId)(request)
       status(result) must equalTo(OK);
       contentType(result) must beSome("application/json");
 
@@ -212,12 +212,12 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
         uris.size === 0
       }
 
-      val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.addTag(collections(0).externalId).url
+      val path = com.keepit.controllers.mobile.routes.MobileKeepsController.addTag(collections(0).externalId).url
       path === s"/m/1/tags/${collections(0).externalId}/addToKeep"
 
       inject[FakeUserActionsHelper].setUser(user)
       val request = FakeRequest("POST", path).withBody(JsObject(Seq("url" -> JsString("http://www.google.com/"))))
-      val result = inject[MobileBookmarksController].addTag(collections(0).externalId)(request)
+      val result = inject[MobileKeepsController].addTag(collections(0).externalId)(request)
       status(result) must equalTo(OK)
       contentType(result) must beSome("application/json")
 
@@ -282,7 +282,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
       }
       keeps.size === 2
 
-      val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.allKeeps(before = None, after = None, collection = None, helprank = None).url
+      val path = com.keepit.controllers.mobile.routes.MobileKeepsController.allKeeps(before = None, after = None, collection = None, helprank = None).url
       path === "/m/1/keeps/all"
       inject[FakeSearchServiceClient] === inject[FakeSearchServiceClient]
       val sharingUserInfo = Seq(SharingUserInfo(Set(user2.id.get), 3), SharingUserInfo(Set(), 0))
@@ -290,7 +290,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
 
       inject[FakeUserActionsHelper].setUser(user1)
       val request = FakeRequest("GET", path)
-      val result = inject[MobileBookmarksController].allKeeps(
+      val result = inject[MobileKeepsController].allKeeps(
         before = None,
         after = None,
         collectionOpt = None,
@@ -350,7 +350,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
       }
       keeps.size === keeps1.size
 
-      val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.allKeeps(before = None, after = None, collection = None, helprank = Some("click")).url
+      val path = com.keepit.controllers.mobile.routes.MobileKeepsController.allKeeps(before = None, after = None, collection = None, helprank = Some("click")).url
       path === "/m/1/keeps/all?helprank=click"
       inject[FakeSearchServiceClient] === inject[FakeSearchServiceClient]
       val sharingUserInfo = Seq(SharingUserInfo(Set(u2.id.get), 3), SharingUserInfo(Set(), 0))
@@ -360,7 +360,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
 
       inject[FakeUserActionsHelper].setUser(u1)
       val request = FakeRequest("GET", path)
-      val result = inject[MobileBookmarksController].allKeeps(
+      val result = inject[MobileKeepsController].allKeeps(
         before = None,
         after = None,
         collectionOpt = None,
@@ -424,7 +424,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
 
       val (u1: User, u2: User, keeps1: Seq[Keep]) = helpRankSetup(heimdal, db)
 
-      val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.allKeeps(before = Some(keeps1(1).externalId.toString), after = None, collection = None, helprank = Some("click")).url
+      val path = com.keepit.controllers.mobile.routes.MobileKeepsController.allKeeps(before = Some(keeps1(1).externalId.toString), after = None, collection = None, helprank = Some("click")).url
       path === s"/m/1/keeps/all?before=${keeps1(1).externalId.toString}&helprank=click"
       inject[FakeSearchServiceClient] === inject[FakeSearchServiceClient]
       val sharingUserInfo = Seq(SharingUserInfo(Set(u2.id.get), 3), SharingUserInfo(Set(), 0))
@@ -433,7 +433,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
       Await.result(inject[FakeSearchServiceClient].sharingUserInfo(null, Seq()), Duration(1, SECONDS)) === sharingUserInfo
       inject[FakeUserActionsHelper].setUser(u1)
       val request = FakeRequest("GET", path)
-      val result = inject[MobileBookmarksController].allKeeps(
+      val result = inject[MobileKeepsController].allKeeps(
         before = Some(keeps1(1).externalId.toString),
         after = None,
         collectionOpt = None,
@@ -521,7 +521,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
       inject[FakeSearchServiceClient].sharingUserInfoData(sharingUserInfo)
 
       val request = FakeRequest("GET", s"/m/1/keeps/all?after=${bookmark1.externalId.toString}")
-      val result = inject[MobileBookmarksController].allKeeps(
+      val result = inject[MobileKeepsController].allKeeps(
         before = None,
         after = Some(bookmark1.externalId.toString),
         collectionOpt = None,
@@ -567,13 +567,13 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
 
       inject[LibraryCommander].internSystemGeneratedLibraries(user.id.get)
 
-      val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.saveCollection().url
+      val path = com.keepit.controllers.mobile.routes.MobileKeepsController.saveCollection().url
       path === "/m/1/collections/create"
 
       val json = Json.obj("name" -> JsString("my tag"))
       inject[FakeUserActionsHelper].setUser(user)
       val request = FakeRequest("POST", path).withJsonBody(json)
-      val result = inject[MobileBookmarksController].saveCollection()(request)
+      val result = inject[MobileKeepsController].saveCollection()(request)
       status(result) must equalTo(OK);
       contentType(result) must beSome("application/json");
 
@@ -589,7 +589,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
     }
   }
 
-  "MobileBookmarksController" should {
+  "MobileKeepsController" should {
 
     "allCollections" in {
       withDb(controllerTestModules: _*) { implicit injector =>
@@ -604,12 +604,12 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
           (user, collections)
         }
 
-        val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.allCollections().url
+        val path = com.keepit.controllers.mobile.routes.MobileKeepsController.allCollections().url
         path === "/m/1/collections/all"
 
         inject[FakeUserActionsHelper].setUser(user)
         val request = FakeRequest("GET", path)
-        val result = inject[MobileBookmarksController].allCollections(sort = "last_kept")(request)
+        val result = inject[MobileKeepsController].allCollections(sort = "last_kept")(request)
         status(result) must equalTo(OK);
         contentType(result) must beSome("application/json");
 
@@ -645,7 +645,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
             Nil
         val keepsAndCollections = RawBookmarksWithCollection(Some(Right("myTag")), withCollection)
 
-        val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.keepMultiple().url
+        val path = com.keepit.controllers.mobile.routes.MobileKeepsController.keepMultiple().url
         path === "/m/1/keeps/add"
 
         val json = Json.obj(
@@ -654,7 +654,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
         )
         inject[FakeUserActionsHelper].setUser(user)
         val request = FakeRequest("POST", path).withBody(json)
-        val result = inject[MobileBookmarksController].keepMultiple()(request)
+        val result = inject[MobileKeepsController].keepMultiple()(request)
         status(result) must equalTo(OK);
         contentType(result) must beSome("application/json");
 
@@ -692,7 +692,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
             Nil
         val keepsAndCollections = RawBookmarksWithCollection(Some(Right("myTag")), withCollection)
 
-        val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.addKeeps().url
+        val path = com.keepit.controllers.mobile.routes.MobileKeepsController.addKeeps().url
         path === "/m/2/keeps/add"
 
         val json = Json.obj(
@@ -701,7 +701,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
         )
         inject[FakeUserActionsHelper].setUser(user)
         val request = FakeRequest("POST", path).withBody(json)
-        val result = inject[MobileBookmarksController].addKeeps()(request)
+        val result = inject[MobileKeepsController].addKeeps()(request)
         status(result) must equalTo(OK);
         contentType(result) must beSome("application/json");
 
@@ -737,7 +737,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
             Nil
         val keepsAndCollections = RawBookmarksWithCollection(Some(Right("myTag")), withCollection)
 
-        val addPath = com.keepit.controllers.mobile.routes.MobileBookmarksController.addKeeps().url
+        val addPath = com.keepit.controllers.mobile.routes.MobileKeepsController.addKeeps().url
         addPath === "/m/2/keeps/add"
 
         val addJson = Json.obj(
@@ -745,7 +745,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
           "keeps" -> JsArray(keepsAndCollections.keeps map { k => Json.toJson(k) })
         )
         val addRequest = FakeRequest("POST", addPath).withBody(addJson)
-        val addResult = inject[MobileBookmarksController].addKeeps()(addRequest)
+        val addResult = inject[MobileKeepsController].addKeeps()(addRequest)
         status(addResult) must equalTo(OK);
         contentType(addResult) must beSome("application/json");
 
@@ -755,12 +755,12 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
           keeps.map(_.source) === Seq(KeepSource.mobile, KeepSource.mobile, KeepSource.mobile)
         }
 
-        val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.unkeepMultiple().url
+        val path = com.keepit.controllers.mobile.routes.MobileKeepsController.unkeepMultiple().url
         path === "/m/1/keeps/remove"
 
         val json = JsArray(withCollection.take(2) map { k => Json.toJson(k) })
         val request = FakeRequest("POST", path).withJsonBody(json)
-        val result = inject[MobileBookmarksController].unkeepMultiple()(request)
+        val result = inject[MobileKeepsController].unkeepMultiple()(request)
         status(result) must equalTo(OK);
         contentType(result) must beSome("application/json");
 
@@ -799,8 +799,8 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
           "collectionName" -> JsString(keepsAndCollections.collection.get.right.get),
           "keeps" -> JsArray(keepsAndCollections.keeps map { k => Json.toJson(k) })
         )
-        val keepReq = FakeRequest("POST", com.keepit.controllers.mobile.routes.MobileBookmarksController.keepMultiple().url).withBody(keepJson)
-        val keepRes = inject[MobileBookmarksController].keepMultiple()(keepReq)
+        val keepReq = FakeRequest("POST", com.keepit.controllers.mobile.routes.MobileKeepsController.keepMultiple().url).withBody(keepJson)
+        val keepRes = inject[MobileKeepsController].keepMultiple()(keepReq)
         status(keepRes) must equalTo(OK)
         contentType(keepRes) must beSome("application/json")
 
@@ -814,13 +814,13 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
           keeps.map(_.source) === Seq(KeepSource.mobile, KeepSource.mobile, KeepSource.mobile)
         }
 
-        val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.unkeepBatch().url
+        val path = com.keepit.controllers.mobile.routes.MobileKeepsController.unkeepBatch().url
         path === "/m/1/keeps/delete" // remove already taken
 
         implicit val keepFormat = ExternalId.format[Keep]
         val json = Json.obj("ids" -> JsArray(savedKeeps.take(2) map { k => Json.toJson(k.id.get) }))
         val request = FakeRequest("POST", path).withBody(json)
-        val result = inject[MobileBookmarksController].unkeepBatch()(request)
+        val result = inject[MobileKeepsController].unkeepBatch()(request)
         status(result) must equalTo(OK)
         contentType(result) must beSome("application/json")
 
@@ -859,12 +859,12 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
         val keep2ToCollections = (Json.obj("title" -> "title 11", "url" -> "http://www.hi.com11", "isPrivate" -> false), Seq("tagA", "tagD", "tagE"))
         val keep3ToCollections = (Json.obj("title" -> "title 11", "url" -> "http://www.hi.com11", "isPrivate" -> false), Seq("tagB", "tagD"))
 
-        val path = com.keepit.controllers.mobile.routes.MobileBookmarksController.addKeepWithTags().url
+        val path = com.keepit.controllers.mobile.routes.MobileKeepsController.addKeepWithTags().url
         path === "/m/1/keeps/addWithTags"
 
         inject[FakeUserActionsHelper].setUser(user)
         val request1 = FakeRequest("POST", path).withBody(Json.obj("keep" -> keep1ToCollections._1, "tagNames" -> keep1ToCollections._2))
-        val result1 = inject[MobileBookmarksController].addKeepWithTags()(request1)
+        val result1 = inject[MobileKeepsController].addKeepWithTags()(request1)
         status(result1) must equalTo(OK);
         contentType(result1) must beSome("application/json");
 
@@ -879,7 +879,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
         jsonRes1.contains("tagA") && jsonRes1.contains("tagB") && jsonRes1.contains("tagC") && !jsonRes1.contains("tagD") === true
 
         val request2 = FakeRequest("POST", path).withBody(Json.obj("keep" -> keep2ToCollections._1, "tagNames" -> keep2ToCollections._2))
-        val result2 = inject[MobileBookmarksController].addKeepWithTags()(request2)
+        val result2 = inject[MobileKeepsController].addKeepWithTags()(request2)
         status(result2) must equalTo(OK);
         contentType(result2) must beSome("application/json");
 
@@ -891,7 +891,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
         jsonRes2.contains("tagA") && jsonRes2.contains("tagD") && jsonRes2.contains("tagE") && !jsonRes2.contains("tagB") && !jsonRes2.contains("tagC") === true
 
         val request3 = FakeRequest("POST", path).withBody(Json.obj("keep" -> keep3ToCollections._1, "tagNames" -> keep3ToCollections._2))
-        val result3 = inject[MobileBookmarksController].addKeepWithTags()(request3)
+        val result3 = inject[MobileKeepsController].addKeepWithTags()(request3)
         status(result3) must equalTo(OK);
         contentType(result3) must beSome("application/json");
 


### PR DESCRIPTION
Please review: @andrewconner @2is10 @jaredpetker @thassss 
- rename bookmarks controller to keeps controller
- mark some paths as deprecated
- dropping /site/keeps/imageUrl and /m/1/keeps/imageUrls that are not in use
- Having mobile rest point for messaging include the URI summary for messages which is in the form of:
  imageUrl: Option[String] = None,
  title: Option[String] = None,
  description: Option[String] = None,
  imageWidth: Option[Int] = None,
  imageHeight: Option[Int] = None,
  wordCount: Option[Int] = None
