### PR TITLE
3.2.18: extension support for importing browser bookmarks to a library

### DIFF
--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -130,6 +130,8 @@ GET     /ext/libraries              @com.keepit.controllers.ext.ExtLibraryContro
 POST    /ext/libraries              @com.keepit.controllers.ext.ExtLibraryController.createLibrary()
 GET     /ext/libraries/:id          @com.keepit.controllers.ext.ExtLibraryController.getLibrary(id: PublicId[Library])
 DELETE  /ext/libraries/:id          @com.keepit.controllers.ext.ExtLibraryController.deleteLibrary(id: PublicId[Library])
+# TODO: implement browser bookmarks endpoint below (see ExtBookmarksController.addBookmarks for inspiration)
+#OST    /ext/libraries/:id/bookmarks @com.keepit.controllers.ext.ExtLibraryController.importBrowserBookmarks(id: PublicId[Library])
 POST    /ext/libraries/:id/keeps    @com.keepit.controllers.ext.ExtLibraryController.addKeep(id: PublicId[Library])
 GET     /ext/libraries/:id/keeps/:k @com.keepit.controllers.ext.ExtLibraryController.getKeep(id: PublicId[Library], k: ExternalId[Keep], is: Option[String] = None)
 POST    /ext/libraries/:id/keeps/:k @com.keepit.controllers.ext.ExtLibraryController.updateKeep(id: PublicId[Library], k: ExternalId[Keep])

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.2.17
+version=3.2.18

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1242,13 +1242,9 @@ api.port.on({
       });
     }
   },
-  import_bookmarks: function() {
+  import_bookmarks: function (libraryId) {
     unstore('prompt_to_import_bookmarks');
-    postBookmarks(api.bookmarks.getAll, 'INIT_LOAD');
-  },
-  import_bookmarks_public: function () {
-    unstore('prompt_to_import_bookmarks');
-    postBookmarks(api.bookmarks.getAll, 'INIT_LOAD', true);
+    postBookmarks(api.bookmarks.getAll, 'INIT_LOAD', libraryId);
   },
   import_bookmarks_declined: function() {
     unstore('prompt_to_import_bookmarks')
@@ -1942,21 +1938,19 @@ function updateIconSilence(tab) {
   }
 }
 
-function postBookmarks(supplyBookmarks, bookmarkSource, makePublic) {
+function postBookmarks(supplyBookmarks, bookmarkSource, libraryId) {
   log('[postBookmarks]');
-  supplyBookmarks(function(bookmarks) {
-    if (makePublic) {
+  supplyBookmarks(function (bookmarks) {
+    if (libraryId === 'main') {  // deprecated magic value
       bookmarks.forEach(function (bookmark) {
         bookmark.isPrivate = false;
       });
     }
     log('[postBookmarks] bookmarks:', bookmarks);
-    ajax("POST", "/bookmarks/add", {
-        bookmarks: bookmarks,
-        source: bookmarkSource},
-      function(o) {
-        log('[postBookmarks] resp:', o);
-      });
+    var path = !libraryId || libraryId === 'main' ? '/bookmarks/add' : '/ext/libraries/' + libraryId + '/bookmarks';
+    ajax('POST', path, {bookmarks: bookmarks, source: bookmarkSource}, function (o) {
+      log('[postBookmarks] resp:', o);
+    });
   });
 }
 

--- a/packrat/scripts/installed.js
+++ b/packrat/scripts/installed.js
@@ -39,10 +39,10 @@
         api.port.emit('import_bookmarks_declined');
         break;
       case 'import_bookmarks':
-        api.port.emit('import_bookmarks');
+        api.port.emit('import_bookmarks', data.libraryId);
         break;
-      case 'import_bookmarks_public':
-        api.port.emit('import_bookmarks_public');
+      case 'import_bookmarks_public':  // deprecated
+        api.port.emit('import_bookmarks', 'main');
         break;
       case 'close_tab':
         api.port.emit('close_tab');


### PR DESCRIPTION
@andrewconner 
cc @yipingliao 

The site will need to pass `{type: 'import_bookmarks', libraryId: 'lxxxxxxxxxx'}` to `window.postMessage`.

The changes I’ve made here should be backwards compatible.
