### PR TITLE
Fixing multi-word tags, making them real links.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
@@ -128,7 +128,7 @@ angular.module('kifi')
 
     $scope.onFilterChange = _.debounce(function () {
       if ($scope.filter.name === '') {
-        $timeout($scope.clearFilter(), 0);
+        $timeout($scope.clearFilter, 0);
         return $scope.tagList;
       }
       $scope.more = false;
@@ -142,7 +142,9 @@ angular.module('kifi')
         $scope.tagsToShow = sortedTags;
         return sortedTags;
       });
-    }, 200);
+    }, 200, {
+      leading: true
+    });
 
     //
     // Manage Tags
@@ -154,10 +156,6 @@ angular.module('kifi')
         tagService.remove(tag);
         _.remove($scope.tagsToShow, function(t) { return t === tag; });
       }
-    };
-
-    $scope.navigateToTag = function (tagName) {
-      $location.path('/find').search('q', 'tag:' + tagName);
     };
 
   }

--- a/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.tpl.html
@@ -24,7 +24,7 @@
       		<ul class="manage-tag-list">
       			<li class="manage-tag-row" ng-repeat="tag in tagsToShow">
       				<div class="manage-tag-row-name-section">
-                <div class="manage-tag-row-name" title="{{tag.name}}" ng-click="navigateToTag(tag.name)">{{tag.name}}</div>
+                <a class="manage-tag-row-name" title="{{tag.name}}" ng-href="{{tag.href}}">{{tag.name}}</a>
               </div>
               <span class="manage-tag-row-num-keeps-section">
                 <ng-pluralize count="tag.keeps | number:0"


### PR DESCRIPTION
@ahsu1230 When clicking tags with a space, it wasn't properly quoting them. So "Fun plans" was turning into `tag:Fun plans`, which means something else. This should fix it.

While I was at it, I made it a real link (vs a click handler).
