### PR TITLE
keep left library pane consistent at all times

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
@@ -73,7 +73,6 @@ angular.module('kifi')
           return loc === path || util.startsWith(loc, path + '/');
         };
 
-
         //
         // Watches and listeners.
         //
@@ -87,13 +86,7 @@ angular.module('kifi')
         });
 
         $rootScope.$on('librarySummariesChanged', updateNavLibs);
-
-        $rootScope.$on('changedLibrary', function () {
-          if (scope.librariesEnabled) {
-            allUserLibs = _.filter(libraryService.librarySummaries, { 'kind' : 'user_created' });
-            util.replaceArrayInPlace(scope.userLibsToShow, allUserLibs);
-          }
-        });
+        $rootScope.$on('changedLibrary', updateNavLibs);
 
         scope.$watch(function () {
           return friendService.requests.length;


### PR DESCRIPTION
sometimes, the left pane bar doesn't keep its library sorting correctly
and that's because on a certain signal `changedLibrary` it keeps the database sorting.

@yipingliao is going to re-org some of this stuff so will leave this small change here for now. 
@andrewconner 
