### PR TITLE
more bug fixes in manage tags

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
@@ -55,6 +55,8 @@ angular.module('kifi')
           scope.userLibsToShow = newList[0];
           scope.invitedLibsToShow  = newList[1];
 
+          librarySummarySearch = new Fuse(allUserLibs, fuseOptions);
+          invitedSummarySearch = new Fuse(libraryService.invitedSummaries, fuseOptions);
           scope.$broadcast('refreshScroll');
         }
 
@@ -172,9 +174,6 @@ angular.module('kifi')
 
 
         scope.changeList = function () {
-          librarySummarySearch = new Fuse(allUserLibs, fuseOptions);
-          invitedSummarySearch = new Fuse(libraryService.invitedSummaries, fuseOptions);
-
           var term = scope.filter.name;
           var newLibs = allUserLibs;
           var newInvited = libraryService.invitedSummaries;

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -243,7 +243,9 @@ angular.module('kifi')
       },
 
       copyKeepsFromTagToLibrary: function (libraryId, tagName) {
-        return $http.post(routeService.copyKeepsFromTagToLibrary(libraryId, tagName));
+        return $http.post(routeService.copyKeepsFromTagToLibrary(libraryId, tagName)).then(function(resp) {
+          return resp.data;
+        });
       }
     };
 

--- a/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
@@ -44,7 +44,7 @@ angular.module('kifi')
         manageTagService.reset();
         getPage();
       } else {
-        $scope.tagsToShow = localSortLibs($scope.tagsToShow);
+        $scope.tagsToShow = localSortTags($scope.tagsToShow);
       }
     });
 
@@ -92,11 +92,15 @@ angular.module('kifi')
     $scope.clickAction = function () {
       var tagName = encodeURIComponent($scope.selectedTag.name);
       libraryService.copyKeepsFromTagToLibrary($scope.selection.library.id, tagName).then(function () {
+        modalService.open({
+          template: 'tagManage/tagToLibModal.tpl.html',
+          modalData: { library : $scope.selection.library }
+        });
         libraryService.addToLibraryCount($scope.selection.library.id, $scope.selectedTag.keeps);
-      });
-      modalService.open({
-        template: 'tagManage/tagToLibModal.tpl.html',
-        modalData: { library : $scope.selection.library }
+      })['catch'](function () {
+        modalService.open({
+          template: 'common/modal/genericErrorModal.tpl.html',
+        });
       });
     };
 
@@ -132,18 +136,18 @@ angular.module('kifi')
       }
       $scope.more = false;
       manageTagService.search($scope.filter.name).then(function (tags) {
-        $scope.tagsToShow = localSortLibs(tags);
+        $scope.tagsToShow = localSortTags(tags);
         return $scope.tagsToShow;
       });
     }, 200, {
       leading: true
     });
 
-    function localSortLibs(tags) {
+    function localSortTags(tags) {
       var sortedTags = tags;
       if ($scope.selectedSort === 'name') {
         sortedTags = _.sortBy(sortedTags, function(t) {
-          return t.name;
+          return t.name.toLowerCase();
         }).reverse();
       } else if ($scope.selectedSort === 'num_keeps') {
         sortedTags = _.sortBy(sortedTags, function(t) {

--- a/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
@@ -99,7 +99,7 @@ angular.module('kifi')
         libraryService.addToLibraryCount($scope.selection.library.id, $scope.selectedTag.keeps);
       })['catch'](function () {
         modalService.open({
-          template: 'common/modal/genericErrorModal.tpl.html',
+          template: 'common/modal/genericErrorModal.tpl.html'
         });
       });
     };

--- a/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.styl
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.styl
@@ -126,6 +126,9 @@
   display: inline-block
   width: 50%
 
+.manage-tag-row-name-section a
+  color: #333333
+
 .manage-tag-row-name
   float: left
   max-width: 90%
@@ -135,16 +138,14 @@
   border-radius: 4px
   font-size: 12px
   font-weight: 400
-  color: textDarkGrey
   overflow: hidden
   white-space: nowrap
   text-overflow: ellipsis
   cursor: pointer
 
 .manage-tag-row-name:hover
-  background-color: #c1c1c1
+  background-color: #eeeeee
   border-color: #333333
-  color: #333333
 
 .manage-tag-row-num-keeps-section
   position: relative

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -2,6 +2,7 @@ package com.keepit.controllers.website
 
 import com.google.inject.Inject
 import com.keepit.commanders._
+import com.keepit.common.akka.SafeFuture
 import com.keepit.common.controller._
 import com.keepit.common.crypto.{ PublicIdConfiguration, PublicId }
 import com.keepit.common.db.{ Id, ExternalId }
@@ -77,12 +78,14 @@ class LibraryController @Inject() (
     }
   }
 
-  def copyKeepsFromCollectionToLibrary(libraryId: PublicId[Library], tag: String) = (UserAction andThen LibraryWriteAction(libraryId)) { request =>
+  def copyKeepsFromCollectionToLibrary(libraryId: PublicId[Library], tag: String) = (UserAction andThen LibraryWriteAction(libraryId)).async { request =>
     val hashtag = Hashtag(tag)
     val id = Library.decodePublicId(libraryId).get
-    libraryCommander.copyKeepsFromCollectionToLibrary(id, hashtag) match {
-      case Left(fail) => BadRequest(Json.obj("error" -> fail.message))
-      case Right(success) => Ok(JsString("success"))
+    SafeFuture {
+      libraryCommander.copyKeepsFromCollectionToLibrary(id, hashtag) match {
+        case Left(fail) => BadRequest(Json.obj("error" -> fail.message))
+        case Right(success) => Ok(JsString("success"))
+      }
     }
   }
 


### PR DESCRIPTION
@andrewconner @yipingliao 
- only reset Fuse Search for left pane on library updates
- made copyKeepsFromLibrary async on server-side
- if error, open error modal. Otherwise, open success modal
