### PR TITLE
Add spacing between delighted survey and library header card.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/delighted/delighted.js
+++ b/kifi-backend/modules/shoebox/angular/src/delighted/delighted.js
@@ -7,11 +7,12 @@ angular.module('kifi')
   function ($timeout, $analytics, profileService) {
     return {
       restrict: 'A',
-      scope: {},
+      scope: {
+        showSurvey: '='
+      },
       templateUrl: 'delighted/delightedSurvey.tpl.html',
       link: function (scope, element) {
         scope.delighted = {};
-        scope.showSurvey = true;
 
         var answerId = null;
 
@@ -67,7 +68,7 @@ angular.module('kifi')
         };
 
         function hideSurvey() {
-          element.find('.kf-delighted-wrap').addClass('hide');
+          scope.showSurvey = false;
         }
 
         function submitAnswer() {

--- a/kifi-backend/modules/shoebox/angular/src/delighted/delighted.styl
+++ b/kifi-backend/modules/shoebox/angular/src/delighted/delighted.styl
@@ -1,12 +1,15 @@
-.kf-delighted-wrap
-  overflow: hidden
-  padding: 0 25px 0 30px
-  max-height 200px
-  
-  &.hide
+.delighted-survey
+  max-height: 200px
+  opacity: 1
+
+  &.ng-hide
     transition: opacity .4s, max-height .4s .4s
     max-height: 0
     opacity: 0
+
+.kf-delighted-wrap
+  overflow: hidden
+  padding: 0 25px 0 30px
 
 .kf-delighted-title
   padding: 8px 28px // make sure the title doesn't underlap the cancel button
@@ -21,7 +24,7 @@
   border: 1px solid #dadae2
   text-align: center
   position: relative
-  
+
   button
     background-color: #4372b1
     color: #fff

--- a/kifi-backend/modules/shoebox/angular/src/delighted/delightedSurvey.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/delighted/delightedSurvey.tpl.html
@@ -1,4 +1,4 @@
-<div class="kf-delighted-wrap" ng-show="showSurvey">
+<div class="kf-delighted-wrap">
   <div class="kf-delighted-body">
     <div ng-switch="surveyStage">
       <div class="kf-delighted-score-chooser" ng-switch-when="score">

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
@@ -426,9 +426,7 @@ angular.module('kifi')
       $rootElement.find('body').addClass('mac');
     }
 
-    $scope.showDelightedSurvey = function () {
-      return profileService.prefs && profileService.prefs.show_delighted_question;
-    };
+    $scope.showDelightedSurvey = profileService.prefs && profileService.prefs.show_delighted_question;
 
     /**
      * Make the page "extension-friendly"

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/main.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/main.tpl.html
@@ -1,6 +1,6 @@
 <div class="kf-col-inner" ng-controller="MainCtrl">
   <div ng-show="searchEnabled" ng-include="'search/mainSearchBar.tpl.html'"></div>
-  <div kf-delighted-survey ng-show="showDelightedSurvey()"></div>
+  <div kf-delighted-survey ng-show="showDelightedSurvey" class="delighted-survey" ng-class="{ 'delighted-visible': showDelightedSurvey }" show-survey="showDelightedSurvey"></div>
   <div ng-view></div>
   <div class="kf-small-tooltip" ng-if="undo.isSet() || tooltipMessage">
     <span class="kf-small-tooltip-box">

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
@@ -3,6 +3,9 @@
   padding: 0 25px 0 30px
   margin-bottom: 10px
 
+.delighted-visible ~ div .kf-library-card-header
+  margin-top: 10px
+
 .library-card
   .kf-keep-lib-header
     padding-top: 20px


### PR DESCRIPTION
Asana: https://app.asana.com/0/15523651812135/17379239993717

If the Delighted survey is visible, there needs to be a margin between it and the library header card. If not, there is no margin.

There was a bit of clean-up here in the code; that's why it looks like so many lines.

Thanks!
@andrewconner 
