### PR TITLE
Add restful endpoint to add recipients to a message thread and allow injectable execution context...

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/concurrent/ExecutionContextModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/concurrent/ExecutionContextModule.scala
@@ -1,0 +1,15 @@
+package com.keepit.common.concurrent
+
+import com.google.inject.{ Provides, Singleton }
+import net.codingwell.scalaguice.ScalaModule
+
+import scala.concurrent.ExecutionContext
+
+case class ExecutionContextModule() extends ScalaModule {
+
+  def configure {}
+
+  @Singleton
+  @Provides
+  def executionContext: ExecutionContext = play.api.libs.concurrent.Execution.Implicits.defaultContext
+}

--- a/kifi-backend/modules/common/app/com/keepit/inject/ConfigurationModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/inject/ConfigurationModule.scala
@@ -1,6 +1,7 @@
 package com.keepit.inject
 
 import _root_.net.codingwell.scalaguice.ScalaModule
+import com.keepit.common.concurrent.ExecutionContextModule
 import com.keepit.common.logging.Logging
 import com.keepit.common.crypto.ShoeboxCryptoModule
 import com.keepit.common.actor.{ ActorSystemModule, ProdActorSystemModule, DevActorSystemModule }
@@ -45,6 +46,7 @@ trait CommonServiceModule {
   val serviceTypeModule: ServiceTypeModule
   val discoveryModule: DiscoveryModule
 
+  val executionContextModule = ExecutionContextModule()
   val cryptoModule = ShoeboxCryptoModule()
   val healthCheckModule = ProdHealthCheckModule()
   val httpClientModule = ProdHttpClientModule()

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -1,12 +1,12 @@
 package com.keepit.shoebox
 
+import com.keepit.common.concurrent.ExecutionContext
 import com.keepit.common.mail.template.EmailToSend
 import com.keepit.model.cache.{ UserSessionViewExternalIdKey, UserSessionViewExternalIdCache }
 import com.keepit.shoebox.model.ids.UserSessionExternalId
 import com.keepit.model.view.{ LibraryMembershipView, UserSessionView }
 
-import scala.concurrent.Future
-import scala.concurrent.Promise
+import scala.concurrent.{ ExecutionContext => ScalaExecutionContext, Future, Promise }
 import scala.concurrent.duration._
 import com.google.inject.Inject
 import com.keepit.common.db.{ ExternalId, Id, SequenceNumber }
@@ -20,7 +20,6 @@ import com.keepit.common.zookeeper._
 import com.keepit.search.{ ActiveExperimentsCache, ActiveExperimentsKey, SearchConfigExperiment }
 import com.keepit.social._
 import com.keepit.common.healthcheck.{ StackTrace, AirbrakeNotifier }
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import com.keepit.common.usersegment.UserSegment
 import com.keepit.common.usersegment.UserSegmentFactory
 import com.keepit.common.usersegment.UserSegmentCache
@@ -148,7 +147,8 @@ class ShoeboxServiceClientImpl @Inject() (
   override val serviceCluster: ServiceCluster,
   override val httpClient: HttpClient,
   val airbrakeNotifier: AirbrakeNotifier,
-  cacheProvider: ShoeboxCacheProvider)
+  cacheProvider: ShoeboxCacheProvider,
+  implicit val executionContext: ScalaExecutionContext)
     extends ShoeboxServiceClient with Logging {
 
   val MaxUrlLength = 3000

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClientModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClientModule.scala
@@ -8,6 +8,8 @@ import com.keepit.common.service.ServiceType
 import play.api.Play._
 import net.codingwell.scalaguice.ScalaModule
 
+import scala.concurrent.ExecutionContext
+
 trait ShoeboxServiceClientModule extends ScalaModule
 
 case class ProdShoeboxServiceClientModule() extends ShoeboxServiceClientModule {
@@ -17,13 +19,14 @@ case class ProdShoeboxServiceClientModule() extends ShoeboxServiceClientModule {
   @Singleton
   @Provides
   def shoeboxServiceClient(
+    executionContext: ExecutionContext,
     client: HttpClient,
     cacheProvider: ShoeboxCacheProvider,
     serviceDiscovery: ServiceDiscovery,
     airbrakeNotifier: AirbrakeNotifier): ShoeboxServiceClient = {
     new ShoeboxServiceClientImpl(
       serviceDiscovery.serviceCluster(ServiceType.SHOEBOX),
-      client, airbrakeNotifier, cacheProvider
+      client, airbrakeNotifier, cacheProvider, executionContext
     )
   }
 

--- a/kifi-backend/modules/common/test/com/keepit/common/concurrent/FakeExecutionContextModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/concurrent/FakeExecutionContextModule.scala
@@ -1,0 +1,24 @@
+package com.keepit.common.concurrent
+
+import com.google.inject.{ Provides, Singleton }
+import net.codingwell.scalaguice.ScalaModule
+
+import scala.concurrent.{ ExecutionContext => ScalaExecutionContext }
+
+case class FakeExecutionContextModule() extends ScalaModule {
+
+  def configure {}
+
+  @Singleton
+  @Provides
+  def executionContext(context: WatchableExecutionContext): ScalaExecutionContext = {
+    context
+  }
+
+  @Singleton
+  @Provides
+  def watchableExecutionContext: WatchableExecutionContext = {
+    new WatchableExecutionContext()
+  }
+
+}

--- a/kifi-backend/modules/common/test/com/keepit/common/concurrent/WatchableExecutionContext.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/concurrent/WatchableExecutionContext.scala
@@ -1,0 +1,47 @@
+package com.keepit.common.concurrent
+
+import java.util.concurrent.Executors
+
+import scala.concurrent.{ ExecutionContext => ScalaExecutionContext }
+
+class WatchableExecutionContext extends ScalaExecutionContext {
+  private[this] val internalContext: ScalaExecutionContext = scala.concurrent.ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(2))
+  private[this] val lock = new Object()
+  private[this] var counter: Int = 0
+  private[this] var maxExeutionCount: Int = 0
+
+  override def toString(): String = lock.synchronized { s"WatchableExecutionContext with counter = $counter and maxExeutionCount = $maxExeutionCount" }
+
+  def execute(runnable: Runnable): Unit = lock.synchronized {
+    counter += 1
+    maxExeutionCount += 1
+    val wrapper = new Runnable {
+      override def run(): Unit = {
+        runnable.run()
+        lock.synchronized {
+          counter -= 1
+          if (counter < 0) throw new Exception(s"Counter should never be less then zero")
+          if (counter == 0) lock.notifyAll()
+        }
+      }
+    }
+    internalContext.execute(wrapper)
+  }
+
+  def drain(waitTime: Long = 1000): Int = {
+    lock.synchronized {
+      while (counter > 0) {
+        lock.wait(waitTime)
+      }
+    }
+    maxExeutionCount
+  }
+
+  def reportFailure(t: Throwable): Unit = internalContext.reportFailure(t)
+
+  override def prepare(): ScalaExecutionContext = {
+    internalContext.prepare()
+    this
+  }
+
+}

--- a/kifi-backend/modules/common/test/com/keepit/scraper/FakeScraperServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/scraper/FakeScraperServiceClientImpl.scala
@@ -40,7 +40,7 @@ class FakeScraperServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, sched
 
   def getURISummaryFromEmbedly(uri: NormalizedURI, minSize: ImageSize, descriptionOnly: Boolean): Future[Option[URISummary]] = Future.successful(None)
 
-  def getURIWordCount(uriId: Id[NormalizedURI], url: Option[String]): Future[Int] = ???
+  def getURIWordCount(uriId: Id[NormalizedURI], url: Option[String]): Future[Int] = Future.successful(0)
 
   def getURIWordCountOpt(uriId: Id[NormalizedURI], url: Option[String]): Option[Int] = ???
 }

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -166,7 +166,7 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
   val allSearchFriends = MutableMap[Id[SearchFriend], SearchFriend]()
   val allUserExperiments = MutableMap[Id[User], Set[UserExperiment]]()
   val allProbabilisticExperimentGenerators = MutableMap[Name[ProbabilisticExperimentGenerator], ProbabilisticExperimentGenerator]()
-  val allUserBookmarks = MutableMap[Id[User], Set[Id[Keep]]]()
+  val allUserBookmarks = MutableMap[Id[User], Set[Id[Keep]]]().withDefaultValue(Set.empty)
   val allBookmarks = MutableMap[Id[Keep], Keep]()
   val allNormalizedURIs = MutableMap[Id[NormalizedURI], NormalizedURI]()
   val uriToUrl = MutableMap[Id[NormalizedURI], URL]()

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientModule.scala
@@ -6,6 +6,8 @@ import com.keepit.common.net.HttpClient
 import com.keepit.common.zookeeper.ServiceCluster
 import com.keepit.model.UrlPatternRuleAllCache
 
+import scala.concurrent.ExecutionContext
+
 case class FakeShoeboxServiceClientModule() extends ShoeboxServiceClientModule {
 
   def configure() {}
@@ -16,8 +18,9 @@ case class FakeShoeboxServiceClientModule() extends ShoeboxServiceClientModule {
     shoeboxCacheProvided: ShoeboxCacheProvider,
     httpClient: HttpClient,
     serviceCluster: ServiceCluster,
-    airbrakeNotifier: AirbrakeNotifier): ShoeboxServiceClient =
-    new ShoeboxServiceClientImpl(serviceCluster, httpClient, airbrakeNotifier, shoeboxCacheProvided)
+    airbrakeNotifier: AirbrakeNotifier,
+    executionContext: ExecutionContext): ShoeboxServiceClient =
+    new ShoeboxServiceClientImpl(serviceCluster, httpClient, airbrakeNotifier, shoeboxCacheProvided, executionContext)
 }
 
 case class FakeShoeboxScraperClientModule() extends ShoeboxScraperClientModule {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
@@ -1,29 +1,22 @@
 package com.keepit.eliza.controllers.mobile
 
-import com.keepit.model.{ User, NormalizedURI }
-import com.keepit.social.BasicUserLikeEntity._
-import com.keepit.eliza.commanders._
-import com.keepit.eliza.model.{ MessageSource, Message, MessageThread }
-import com.keepit.common.controller.{ ElizaServiceController, MobileController, UserActions, UserActionsHelper }
-import com.keepit.common.time._
-import com.keepit.heimdal._
-import play.api.mvc.Action
-
-import play.modules.statsd.api.Statsd
-
-import com.keepit.common.db.{ Id, ExternalId }
-
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.api.libs.json._
-
-import scala.concurrent.Future
-
 import com.google.inject.Inject
-import com.keepit.social.{ BasicUserLikeEntity, BasicUser, BasicNonUser }
-import play.api.libs.json.JsArray
-import play.api.libs.json.JsString
-import scala.Some
-import play.api.libs.json.JsObject
+import com.keepit.common.controller.{ ElizaServiceController, UserActions, UserActionsHelper }
+import com.keepit.common.db.ExternalId
+import com.keepit.common.mail.BasicContact
+import com.keepit.common.net.UserAgent
+import com.keepit.common.time._
+import com.keepit.eliza.commanders._
+import com.keepit.eliza.model.{ Message, MessageSource, MessageThread }
+import com.keepit.heimdal._
+import com.keepit.model.User
+import com.keepit.social.BasicUserLikeEntity._
+import com.keepit.social.{ BasicNonUser, BasicUser, BasicUserLikeEntity }
+
+import scala.concurrent.ExecutionContext
+
+//import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.libs.json.{ JsArray, JsObject, JsString, _ }
 
 class MobileMessagingController @Inject() (
     messagingCommander: MessagingCommander,
@@ -31,7 +24,8 @@ class MobileMessagingController @Inject() (
     notificationCommander: NotificationCommander,
     val userActionsHelper: UserActionsHelper,
     heimdalContextBuilder: HeimdalContextBuilderFactory,
-    messageSearchCommander: MessageSearchCommander) extends UserActions with ElizaServiceController {
+    messageSearchCommander: MessageSearchCommander,
+    implicit val executionContext: ExecutionContext) extends UserActions with ElizaServiceController {
 
   def getNotifications(howMany: Int, before: Option[String]) = UserAction.async { request =>
     val noticesFuture = before match {
@@ -216,6 +210,23 @@ class MobileMessagingController @Inject() (
 
   def clearMessageSearchHistory() = UserAction { request =>
     messageSearchCommander.clearHistory(request.userId)
+    Ok("")
+  }
+
+  def addParticipantsToThread(threadId: ExternalId[MessageThread], users: String, emailContacts: String) = UserAction { request =>
+    val source = UserAgent(request) match {
+      case agent if agent.isAndroid => MessageSource.ANDROID
+      case agent if agent.isIphone => MessageSource.IPHONE
+      case agent => throw new IllegalArgumentException(s"user agent not supported: $agent")
+    }
+    if (users.nonEmpty || emailContacts.nonEmpty) {
+      val contextBuilder = heimdalContextBuilder.withRequestInfo(request)
+      contextBuilder += ("source", "mobile")
+      //assuming the client does the proper checks!
+      val validEmails = emailContacts.split(",").map { email => BasicContact.fromString(email.trim) }.map(_.get)
+      val validUserIds = users.split(",").map { id => ExternalId[User](id.trim) }
+      messagingCommander.addParticipantsToThread(request.userId, threadId, validUserIds, validEmails, Some(source))(contextBuilder.build)
+    }
     Ok("")
   }
 }

--- a/kifi-backend/modules/eliza/conf/eliza.routes
+++ b/kifi-backend/modules/eliza/conf/eliza.routes
@@ -25,6 +25,7 @@ POST    /m/1/eliza/messages/:parentId     @com.keepit.eliza.controllers.mobile.M
 POST    /m/1/eliza/devices/:deviceType    @com.keepit.eliza.controllers.mobile.MobileDevicesController.registerDevice(deviceType:String)
 GET     /m/1/eliza/thread/:threadId       @com.keepit.eliza.controllers.mobile.MobileMessagingController.getCompactThread(threadId: String)
 GET     /m/2/eliza/thread/:threadId       @com.keepit.eliza.controllers.mobile.MobileMessagingController.getPagedThread(threadId: String, pageSize: Int ?= 1000, fromMessageId: Option[String] ?= None)
+POST    /m/1/eliza/thread/:threadId/addParticipantsToThread  @com.keepit.eliza.controllers.mobile.MobileMessagingController.addParticipantsToThread(threadId: ExternalId[MessageThread], users: String, emailContacts: String)
 GET     /m/1/eliza/getThreadsByUrl        @com.keepit.eliza.controllers.mobile.MobileMessagingController.getThreadsByUrl(url: String)
 GET     /m/1/eliza/hasThreadsByUrl        @com.keepit.eliza.controllers.mobile.MobileMessagingController.hasThreadsByUrl(url: String)
 GET     /m/1/eliza/searchMessages         @com.keepit.eliza.controllers.mobile.MobileMessagingController.searchMessages(q: String, p: Int ?= 0, storeInHistory: Boolean ?= true)

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
@@ -1,37 +1,28 @@
 package com.keepit.eliza
 
-import org.specs2.mutable._
-import com.keepit.common.db.slick._
-import com.keepit.common.db.Id
-import com.keepit.inject._
-import com.keepit.shoebox.{ ShoeboxServiceClient, FakeShoeboxServiceModule, FakeShoeboxServiceClientImpl }
-import com.keepit.common.cache.ElizaCacheModule
-import com.keepit.common.time._
-import com.keepit.common.actor.FakeActorSystemModule
-import com.keepit.common.db.Id
-import com.keepit.model.User
-import com.keepit.social.BasicUser
-import com.keepit.realtime.{ UrbanAirship, FakeUrbanAirship, FakeUrbanAirshipModule }
-import com.keepit.heimdal.{ HeimdalContext, FakeHeimdalServiceClientModule }
-import com.keepit.common.healthcheck.FakeAirbrakeNotifier
-import com.keepit.abook.{ FakeABookServiceClientImpl, ABookServiceClient, FakeABookServiceClientModule }
-import com.keepit.eliza.controllers.WebSocketRouter
-import com.keepit.eliza.commanders.{ MessagingCommander, MessageFetchingCommander, NotificationCommander }
-import com.keepit.eliza.controllers.internal.MessagingController
-import com.keepit.eliza.model._
-import com.keepit.common.crypto.FakeCryptoModule
 import com.google.inject.Injector
-import play.api.test.Helpers._
-import play.api.libs.json.{ Json, JsObject }
+import com.keepit.abook.FakeABookServiceClientModule
+import com.keepit.common.actor.FakeActorSystemModule
+import com.keepit.common.cache.ElizaCacheModule
+import com.keepit.common.concurrent.{ FakeExecutionContextModule, WatchableExecutionContext }
+import com.keepit.common.crypto.FakeCryptoModule
+import com.keepit.common.db.Id
+import com.keepit.common.store.FakeElizaStoreModule
+import com.keepit.eliza.commanders.{ MessageFetchingCommander, MessagingCommander, NotificationCommander }
+import com.keepit.eliza.controllers.WebSocketRouter
+import com.keepit.eliza.model._
+import com.keepit.heimdal.{ FakeHeimdalServiceClientModule, HeimdalContext }
+import com.keepit.model.User
+import com.keepit.realtime.FakeUrbanAirshipModule
+import com.keepit.scraper.FakeScraperServiceClientModule
+import com.keepit.shoebox.{ FakeShoeboxServiceClientImpl, FakeShoeboxServiceModule, ShoeboxServiceClient }
+import com.keepit.social.BasicUser
+import com.keepit.test.ElizaTestInjector
+import org.specs2.mutable._
+import play.api.libs.json.{ JsObject, Json }
+
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import akka.actor.ActorSystem
-import com.keepit.scraper.FakeScraperServiceClientModule
-import com.keepit.common.store.ElizaDevStoreModule
-import com.keepit.common.aws.AwsModule
-import com.keepit.common.store.FakeStoreModule
-import com.keepit.common.store.FakeElizaStoreModule
-import com.keepit.test.ElizaTestInjector
 
 class MessagingTest extends Specification with ElizaTestInjector {
 
@@ -39,6 +30,7 @@ class MessagingTest extends Specification with ElizaTestInjector {
 
   def modules = {
     Seq(
+      FakeExecutionContextModule(),
       ElizaCacheModule(),
       FakeShoeboxServiceModule(),
       FakeHeimdalServiceClientModule(),
@@ -160,13 +152,13 @@ class MessagingTest extends Specification with ElizaTestInjector {
 
         val (thread, msg) = messagingCommander.sendNewMessage(user1, Seq(user2), Nil, Json.obj("url" -> "http://kifi.com"), Some("title"), "Fortytwo", None)
 
-        Thread.sleep(100) //AHHHHHH. Really need to figure out how to test Async code with multiple execution contexts. (https://app.asana.com/0/5674704693855/9223435240746)
+        inject[WatchableExecutionContext].drain()
         Await.result(notificationCommander.getLatestSendableNotifications(user2, 1, includeUriSummary = false), Duration(4, "seconds")).length === 1
         Await.result(notificationCommander.getLatestSendableNotifications(user3, 1, includeUriSummary = false), Duration(4, "seconds")).length === 0
 
         val user3ExtId = Await.result(shoebox.getUser(user3), Duration(4, "seconds")).get.externalId
         messagingCommander.addParticipantsToThread(user1, thread.externalId, Seq(user3ExtId), Seq.empty, None)
-        Thread.sleep(200) //See comment for same above
+        inject[WatchableExecutionContext].drain()
         Await.result(notificationCommander.getLatestSendableNotifications(user3, 1, includeUriSummary = false), Duration(4, "seconds")).length === 1
       }
     }

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/mobile/MobileMessagingControllerTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/mobile/MobileMessagingControllerTest.scala
@@ -1,33 +1,29 @@
 package com.keepit.eliza.controllers.mobile
 
-import com.keepit.common.concurrent.{ FakeExecutionContextModule, WatchableExecutionContext }
-import com.keepit.common.net.FakeHttpClientModule
-import com.keepit.test.{ ElizaTestInjector }
-import org.specs2.mutable._
-import com.keepit.common.db.slick._
-import com.keepit.common.controller.{ FakeActionAuthenticatorModule, FakeUserActionsHelper, FakeUserActionsModule }
-import com.keepit.shoebox.{ ShoeboxServiceClient, FakeShoeboxServiceClientImpl }
-import com.keepit.common.time._
-import com.keepit.model.User
-import com.keepit.heimdal.HeimdalContext
-import com.keepit.common.db.{ Id, ExternalId }
-import com.keepit.eliza.model._
-import play.api.test.FakeRequest
-import play.api.test.Helpers._
-import play.api.libs.json.Json
-import akka.actor.ActorSystem
-import com.keepit.heimdal.FakeHeimdalServiceClientModule
-import com.keepit.common.cache.ElizaCacheModule
-import play.api.libs.json.JsArray
 import com.keepit.abook.FakeABookServiceClientModule
-import com.keepit.eliza.FakeElizaServiceClientModule
-import com.keepit.shoebox.FakeShoeboxServiceModule
+import com.keepit.common.actor.FakeActorSystemModule
+import com.keepit.common.cache.ElizaCacheModule
+import com.keepit.common.concurrent.{ FakeExecutionContextModule, WatchableExecutionContext }
+import com.keepit.common.controller.{ FakeActionAuthenticatorModule, FakeUserActionsHelper, FakeUserActionsModule }
 import com.keepit.common.crypto.FakeCryptoModule
-import com.keepit.search.FakeSearchServiceClientModule
+import com.keepit.common.db.slick._
+import com.keepit.common.db.{ ExternalId, Id }
+import com.keepit.common.net.FakeHttpClientModule
+import com.keepit.common.store.FakeElizaStoreModule
+import com.keepit.common.time._
+import com.keepit.eliza.FakeElizaServiceClientModule
+import com.keepit.eliza.model._
+import com.keepit.heimdal.{ FakeHeimdalServiceClientModule, HeimdalContext }
+import com.keepit.model.User
 import com.keepit.realtime.FakeUrbanAirshipModule
 import com.keepit.scraper.FakeScraperServiceClientModule
-import com.keepit.common.store.FakeElizaStoreModule
-import com.keepit.common.actor.{ FakeActorSystemModule }
+import com.keepit.search.FakeSearchServiceClientModule
+import com.keepit.shoebox.{ FakeShoeboxServiceClientImpl, FakeShoeboxServiceModule, ShoeboxServiceClient }
+import com.keepit.test.ElizaTestInjector
+import org.specs2.mutable._
+import play.api.libs.json.{ JsArray, Json }
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
 
 class MobileMessagingControllerTest extends Specification with ElizaTestInjector {
 
@@ -94,8 +90,7 @@ class MobileMessagingControllerTest extends Specification with ElizaTestInjector
         status(result) must equalTo(OK)
         contentType(result) must beSome("text/plain")
         val runners = inject[WatchableExecutionContext].drain()
-        //yes! 41 futures where created to get this test to pass! You can remove or edit the next line if it breaks test, just a nice to know
-        runners === 41
+        runners > 2
 
         inject[Database].readOnlyMaster { implicit s =>
           inject[UserThreadRepo].getByThread(thread.id.get).map(_.user).toSet === Set(shanee.id.get, shachaf.id.get, eishay.id.get)


### PR DESCRIPTION
... that we can wait on when testing code that spawns threads/futures
Thanks to @ymatsuda for guideline and help with the execution and @stkem for the idea.

This should mark the end of `Thread.sleep` in test!

@2is10 we may want to use restful endpoint for extension as well.
/cc @leogrim @raymondng @andrewconner @joshm1 @ahsu1230 please check out use of 

``` scala
inject[WatchableExecutionContext].drain()
```
