### PR TITLE
Fix modal bug so that import can be opened again after an import.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/modal/modal.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/modal/modal.js
@@ -60,8 +60,8 @@ angular.module('kifi')
 
         scope.$watch(function () {
           return scope.forceClose;
-        }, function (newVal) {
-          if (newVal) {
+        }, function (newVal, oldVal) {
+          if (!oldVal && newVal) {
             scope.close();
           }
         });

--- a/kifi-backend/modules/shoebox/angular/src/common/services/modalService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/modalService.js
@@ -28,7 +28,10 @@ angular.module('kifi')
 
     function close () {
       var $modal = modals.pop();
-      $modal.remove();
+
+      if ($modal && $modal.length) {
+        $modal.remove();
+      }
     }
 
     return {

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
@@ -158,6 +158,8 @@ angular.module('kifi')
       // Use $timeout to wait for forceClose to close the currently open modal before opening
       // the next modal.
       $timeout(function () {
+        $scope.forceClose = false;
+
         var kifiVersion = $window.document.documentElement.getAttribute('data-kifi-ext');
 
         if (!kifiVersion) {
@@ -197,6 +199,8 @@ angular.module('kifi')
       // Use $timeout to wait for forceClose to close the currently open modal before opening
       // the next modal.
       $timeout(function () {
+        $scope.forceClose = false;
+
         var kifiVersion = $window.document.documentElement.getAttribute('data-kifi-ext');
 
         if (!kifiVersion) {
@@ -336,6 +340,8 @@ angular.module('kifi')
             // Use $timeout to wait for forceClose to close the currently open modal before
             // opening the next modal.
             $timeout(function () {
+              $scope.forceClose = false;
+
               if (!result.error) { // success!
                 modalService.open({
                   template: 'common/modal/importBookmarkFileInProgressModal.tpl.html'
@@ -389,6 +395,8 @@ angular.module('kifi')
             // Use $timeout to wait for forceClose to close the currently open modal before
             // opening the next modal.
             $timeout(function () {
+              $scope.forceClose = false;
+
               if (!result.error) { // success!
                 modalService.open({
                   template: 'common/modal/importBookmarkFileLibraryInProgressModal.tpl.html'

--- a/kifi-backend/modules/shoebox/angular/src/profile/profileImage.js
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profileImage.js
@@ -229,6 +229,8 @@ angular.module('kifi')
           // Use $timeout to wait for forceClose to close the currently open modal before
           // opening the next modal.
           $timeout(function () {
+            scope.forceClose = false;
+
             modalService.open({
               template: 'profile/imageUploadFailedModal.tpl.html'
             });


### PR DESCRIPTION
@andrewconner 

Another modal fix. Now even after you import, you can import again. The problem was that there was a modal event listener that force closes a modal when a variable has been set to true, so that the modal will not be opened again if it has been forced to close previously. This is only for modals that have two steps.

The fix now looks for a rising edge on the variable. In addition, this variable is reset to false after the modal closes.
