### PR TITLE
more RESTful route for mobile add participants endpoint

### DIFF
--- a/kifi-backend/modules/eliza/conf/eliza.routes
+++ b/kifi-backend/modules/eliza/conf/eliza.routes
@@ -26,7 +26,7 @@ POST    /m/1/eliza/messages/:parentId     @com.keepit.eliza.controllers.mobile.M
 POST    /m/1/eliza/devices/:deviceType    @com.keepit.eliza.controllers.mobile.MobileDevicesController.registerDevice(deviceType:String)
 GET     /m/1/eliza/thread/:threadId       @com.keepit.eliza.controllers.mobile.MobileMessagingController.getCompactThread(threadId: String)
 GET     /m/2/eliza/thread/:threadId       @com.keepit.eliza.controllers.mobile.MobileMessagingController.getPagedThread(threadId: String, pageSize: Int ?= 1000, fromMessageId: Option[String] ?= None)
-POST    /m/1/eliza/thread/:threadId/addParticipantsToThread  @com.keepit.eliza.controllers.mobile.MobileMessagingController.addParticipantsToThread(threadId: ExternalId[MessageThread], users: String, emailContacts: String)
+POST    /m/1/eliza/thread/:id/participants @com.keepit.eliza.controllers.mobile.MobileMessagingController.addParticipantsToThread(id: ExternalId[MessageThread])
 GET     /m/1/eliza/getThreadsByUrl        @com.keepit.eliza.controllers.mobile.MobileMessagingController.getThreadsByUrl(url: String)
 GET     /m/1/eliza/hasThreadsByUrl        @com.keepit.eliza.controllers.mobile.MobileMessagingController.hasThreadsByUrl(url: String)
 GET     /m/1/eliza/searchMessages         @com.keepit.eliza.controllers.mobile.MobileMessagingController.searchMessages(q: String, p: Int ?= 0, storeInHistory: Boolean ?= true)


### PR DESCRIPTION
@eishay We try to use RESTful public-facing route names. Using the controller method name in the path is a convention for our internal routes only, since those routes are much easier to update.

cc @thassss @jaredpetker @stkem 
Is it too late for this?
