### PR TITLE
Add ownerId, librarySlug to LibraryRecord

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/index/IndexerVersion.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/IndexerVersion.scala
@@ -27,6 +27,6 @@ object IndexerVersionProviders {
   case object SearchFriend extends IndexerVersionProvider(0, 0)
   case object Message extends IndexerVersionProvider(0, 0)
   case object Phrase extends IndexerVersionProvider(0, 0)
-  case object Library extends IndexerVersionProvider(0, 0)
+  case object Library extends IndexerVersionProvider(0, 1)
   case object Keep extends IndexerVersionProvider(0, 0)
 }


### PR DESCRIPTION
@ymatsuda @yingjieMiao 
Following a design change, this is so that we can include library urls in search results and make the library cartridges clickables. This still requires fetching the owner's basic user to get his / her username. Ideally we could denormalize the owner's username into the library table, but that requires making sure it stays in sync when the user changes it, so we'll get into that later.
