### PR TITLE
Fix bug where the status of a library-share contact is cached even for the next library share.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
@@ -118,7 +118,9 @@ angular.module('kifi')
             var newResults;
 
             if (contacts && contacts.length) {
-              newResults = _.clone(contacts);
+              // Clone deeply; otherwise, the data augmentation we do on individual contacts
+              // will be cached as part of the contacts cached by Clutch.
+              newResults = _.clone(contacts, true);
 
               newResults.forEach(function (result) {
                 if (result.id) {


### PR DESCRIPTION
@andrewconner 
https://app.asana.com/0/15523651812135/18170273343523
