### PR TITLE
include "fullCategory" with global notification json

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
@@ -207,6 +207,7 @@ class NotificationCommander @Inject() (
             "thread" -> message.threadExtId.id,
             "unread" -> true,
             "category" -> categoryString,
+            "fullCategory" -> category.category,
             "title" -> title,
             "bodyHtml" -> body,
             "linkText" -> linkText,


### PR DESCRIPTION
To let the mobile clients distinguish between different kinds of notifs, which the extension doesn't need to since they are all just links to various pages on kifi.com.
@jaredpetker @thassss @andrewconner 
