### PR TITLE
add renormalization code, dealing with empty first/last names and trimmi...

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -901,4 +901,8 @@ class AdminUserController @Inject() (
   def updateUsersWithNoUserName(readOnly: Boolean, max: Int) = Action { implicit request =>
     Ok(userCommander.updateUsersWithNoUserName(readOnly, max).toString)
   }
+
+  def reNormalizedUsername(readOnly: Boolean, max: Int) = Action { implicit request =>
+    Ok(userCommander.reNormalizedUsername(readOnly, max).toString)
+  }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -579,4 +579,5 @@ class UserController @Inject() (
     }
     Status(200).chunked(returnEnumerator.andThen(Enumerator.eof))
   }
+
 }

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -517,6 +517,7 @@ GET     /admin/users/reindex        @com.keepit.controllers.admin.AdminUserIndex
 GET     /admin/users                @com.keepit.controllers.admin.AdminUserController.allUsersView
 POST    /admin/users/autoSetUsernames   @com.keepit.controllers.admin.AdminUserController.autoSetUsernames(startingUserId: Id[User], endingUserId: Id[User], readOnly: Boolean ?= true)
 POST    /admin/users/updateUsersWithNoUserName   @com.keepit.controllers.admin.AdminUserController.updateUsersWithNoUserName(readOnly: Boolean ?= true, max: Int ?= 10)
+POST    /admin/users/reNormalizedUsername        @com.keepit.controllers.admin.AdminUserController.reNormalizedUsername(readOnly: Boolean ?= true, max: Int ?= 10)
 GET     /admin/realUsers            @com.keepit.controllers.admin.AdminUserController.allRegisteredUsersView
 GET     /admin/fakeUsers            @com.keepit.controllers.admin.AdminUserController.allFakeUsersView
 POST    /admin/users/merge          @com.keepit.controllers.admin.AdminUserController.merge

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UserTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UserTest.scala
@@ -20,6 +20,9 @@ class UserTest extends Specification with ShoeboxTestInjector {
     "valid" in {
       UsernameOps.isValid("eishay-kifi") === false
       UsernameOps.isValid("nada-boutros") === false
+      //the following line takes more then a minute to run!
+      //UsernameOps.isValid("eishaytestwithaveryveryveryveryveryveryveryverylongmailgocom-") === false
+      UsernameOps.isValid("eishaytestwitha-") === false
     }
   }
 


### PR DESCRIPTION
...ng very long first/last names as some are killing the validator and just don't make sense.

The max in the db is 64, but 33 chars should do for now :-)
