### PR TITLE
Move/Copy keeps to other libraries

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/modal/importBookmarkFileLibraryModal.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/modal/importBookmarkFileLibraryModal.tpl.html
@@ -43,10 +43,10 @@
 
     <div class="import-library-selection">
       <div class="add-keep-to-library-dropdown" ng-if="librariesEnabled" kf-keep-to-library-widget ng-click="showWidget()">
-        <span ng-switch="selection.library.kind" class="keep-to-library-lib-icon-container">
+        <span ng-switch="librarySelection.library.kind" class="keep-to-library-lib-icon-container">
           <span ng-switch-when="system_main" class="keep-to-library-lib-icon svg-main-library-icon"></span>
           <span ng-switch-when="system_secret" class="keep-to-library-lib-icon svg-secret-library-icon"></span>
-          <span ng-switch-default ng-switch="selection.library.visibility">
+          <span ng-switch-default ng-switch="librarySelection.library.visibility">
             <span ng-switch-when="published" class="keep-to-library-lib-icon svg-public-library-icon"></span>
             <span ng-switch-when="secret" class="keep-to-library-lib-icon svg-private-library-icon"></span>
 
@@ -54,13 +54,13 @@
             <span ng-switch-when="discoverable" class="keep-to-library-lib-icon svg-yellow-card-with-globe"></span>
           </span>
         </span>
-        {{selection.library.name}}
+        {{librarySelection.library.name}}
         <span class="add-keep-to-library-dropdown-arrow"></span>
       </div>
     </div>
 
     <div class="dialog-buttons">
-      <button class="import-button" ng-class="{'disabled': disableBookmarkImport || !importFilename}" ng-click="importBookmarkFileToLibrary(selection.library)">Import</button>
+      <button class="import-button" ng-class="{'disabled': disableBookmarkImport || !importFilename}" ng-click="importBookmarkFileToLibrary(librarySelection.library)">Import</button>
     </div>
   </div>
 </div>

--- a/kifi-backend/modules/shoebox/angular/src/common/modal/importBookmarksLibraryModal.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/modal/importBookmarksLibraryModal.tpl.html
@@ -11,23 +11,23 @@
     <div class="import-library-selection">
       Choose a library to import to
       <div class="add-keep-to-library-dropdown" ng-if="librariesEnabled" kf-keep-to-library-widget ng-click="showWidget()">
-        <span ng-switch="selection.library.kind" class="keep-to-library-lib-icon-container">
+        <span ng-switch="librarySelection.library.kind" class="keep-to-library-lib-icon-container">
           <span ng-switch-when="system_main" class="keep-to-library-lib-icon svg-main-library-icon"></span>
           <span ng-switch-when="system_secret" class="keep-to-library-lib-icon svg-secret-library-icon"></span>
-          <span ng-switch-default ng-switch="selection.library.visibility">
+          <span ng-switch-default ng-switch="librarySelection.library.visibility">
             <span ng-switch-when="published" class="keep-to-library-lib-icon svg-public-library-icon"></span>
             <span ng-switch-when="secret" class="keep-to-library-lib-icon svg-private-library-icon"></span>
 
             <span ng-switch-when="discoverable" class="keep-to-library-lib-icon svg-yellow-card-with-globe"></span>
           </span>
         </span>
-        {{selection.library.name}}
+        {{librarySelection.library.name}}
         <span class="add-keep-to-library-dropdown-arrow"></span>
       </div>
     </div>
 
     <div class="dialog-buttons">
-      <button class="import-button" ng-click="importBookmarksToLibrary(selection.library)">Import</button>
+      <button class="import-button" ng-click="importBookmarksToLibrary(librarySelection.library)">Import</button>
     </div>
   </div>
 </div>

--- a/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
@@ -112,6 +112,9 @@ angular.module('kifi')
       addKeepsToLibrary: function (libraryId) {
         return route('/libraries/' + libraryId + '/keeps');
       },
+      copyKeepsToLibrary: function () {
+        return route('/libraries/copy');
+      },
       moveKeepsToLibrary: function () {
         return route('/libraries/move');
       },

--- a/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
@@ -112,6 +112,9 @@ angular.module('kifi')
       addKeepsToLibrary: function (libraryId) {
         return route('/libraries/' + libraryId + '/keeps');
       },
+      moveKeepsToLibrary: function () {
+        return route('/libraries/move');
+      },
       removeKeepFromLibrary: function (libraryId, keepId) {
         return route('/libraries/' + libraryId + '/keeps/' + keepId);
       },

--- a/kifi-backend/modules/shoebox/angular/src/keep/addKeep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/addKeep.js
@@ -110,7 +110,7 @@ angular.module('kifi')
         scope.keepToLibrary = function () {
           var url = (scope.state.input) || '';
           if (url && util.validateUrl(url)) {
-            return keepActionService.keepToLibrary([url], scope.selection.library.id).then(function (result) {
+            return keepActionService.keepToLibrary([url], scope.librarySelection.library.id).then(function (result) {
               if (result.failures && result.failures.length) {
                 scope.resetAndHide();
                 modalService.open({
@@ -126,10 +126,10 @@ angular.module('kifi')
                   keep.makeKept();
 
                   libraryService.fetchLibrarySummaries(true);
-                  libraryService.addToLibraryCount(scope.selection.library.id, 1);
+                  libraryService.addToLibraryCount(scope.librarySelection.library.id, 1);
                   tagService.addToKeepCount(1);
 
-                  scope.$emit('keepAdded', libraryService.getSlugById(scope.selection.library.id), keep);
+                  scope.$emit('keepAdded', libraryService.getSlugById(scope.librarySelection.library.id), keep);
                   scope.resetAndHide();
                 });
               }
@@ -141,11 +141,10 @@ angular.module('kifi')
 
         scope.librariesEnabled = libraryService.isAllowed();
         if (scope.librariesEnabled) {
-          scope.libraries = _.filter(libraryService.librarySummaries, function(lib) {
+          scope.libraries = _.filter(libraryService.librarySummaries, function (lib) {
             return lib.access !== 'read_only';
           });
-          scope.selection = scope.selection || {};
-          scope.selection.library = _.find(scope.libraries, { 'name': 'Main Library' });
+          scope.librarySelection = {};
           scope.libSelectTopOffset = 110;
         }
 

--- a/kifi-backend/modules/shoebox/angular/src/keep/addKeep.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/addKeep.tpl.html
@@ -12,10 +12,10 @@
         <!-- TODO(yiping): Use button instead of div. Styles have been cleaned up but we need a way to not trigger the form submission. -->
         <!-- TODO(yiping): DRY this up. It's being used elsewhere too. -->
         <div class="add-keep-to-library-dropdown" ng-if="librariesEnabled" kf-keep-to-library-widget ng-click="showWidget()">
-          <span ng-switch="selection.library.kind" class="keep-to-library-lib-icon-container">
+          <span ng-switch="librarySelection.library.kind" class="keep-to-library-lib-icon-container">
             <span ng-switch-when="system_main" class="keep-to-library-lib-icon svg-main-library-icon"></span>
             <span ng-switch-when="system_secret" class="keep-to-library-lib-icon svg-secret-library-icon"></span>
-            <span ng-switch-default ng-switch="selection.library.visibility">
+            <span ng-switch-default ng-switch="librarySelection.library.visibility">
               <span ng-switch-when="published" class="keep-to-library-lib-icon svg-public-library-icon"></span>
               <span ng-switch-when="secret" class="keep-to-library-lib-icon svg-private-library-icon"></span>
 
@@ -23,7 +23,7 @@
               <span ng-switch-when="discoverable" class="keep-to-library-lib-icon svg-yellow-card-with-globe"></span>
             </span>
           </span>
-          {{selection.library.name}}
+          {{librarySelection.library.name}}
           <span class="add-keep-to-library-dropdown-arrow"></span>
         </div>
       </div>

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -15,7 +15,8 @@ angular.module('kifi')
        *  librarySelection - an object whose 'library' property will be the selected library.
        *
        *  Optional properties on parent scope:
-       *   clickAction() - a function that can be called once a library is selected
+       *   clickAction() - a function that can be called once a library is selected;
+       *                   called with the element that this widget is on.
        *   libSelectTopOffset - amount to shift up relative to the element that has this directive as an attribute.
        */
       link: function (scope, element/*, attrs*/) {
@@ -78,7 +79,7 @@ angular.module('kifi')
           if (angular.element(event.target).closest('.library-select-option').length) {
             removeTimeout = $timeout(removeWidget, 200);
             if (_.isFunction(scope.clickAction)) {
-              scope.clickAction();
+              scope.clickAction(element);
             }
             return;
           }
@@ -205,7 +206,7 @@ angular.module('kifi')
 
               scope.librarySelection.library = scope.libraries[selectedIndex];
               if (_.isFunction(scope.clickAction)) {
-                scope.clickAction();
+                scope.clickAction(element);
               }
               removeWidget();
               break;
@@ -247,7 +248,7 @@ angular.module('kifi')
               scope.$evalAsync(function () {
                 scope.librarySelection.library = _.find(scope.libraries, { 'name': library.name });
                 if (_.isFunction(scope.clickAction)) {
-                  scope.clickAction();
+                  scope.clickAction(element);
                 }
                 removeWidget();
               });

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -12,13 +12,11 @@ angular.module('kifi')
       /*
        * Relies on parent scope to have:
        *  libraries - an array of library objects to select from.
-       *  selection - an object whose 'library' property will be the selected library.
+       *  librarySelection - an object whose 'library' property will be the selected library.
        *
        *  Optional properties on parent scope:
        *   clickAction() - a function that can be called once a library is selected
        *   libSelectTopOffset - amount to shift up relative to the element that has this directive as an attribute.
-       *
-       *  // todo (yiping): Try to turn this into isolated scope
        */
       link: function (scope, element/*, attrs*/) {
         //
@@ -163,7 +161,7 @@ angular.module('kifi')
           } else {
             clearSelection();
             library.selected = true;
-            scope.selection.library = library;
+            scope.librarySelection.library = library;
             selectedIndex = _.indexOf(scope.libraries, library);
           }
         };
@@ -205,7 +203,7 @@ angular.module('kifi')
               // Prevent any open modals from processing this.
               $event.stopPropagation();
 
-              scope.selection.library = scope.libraries[selectedIndex];
+              scope.librarySelection.library = scope.libraries[selectedIndex];
               if (_.isFunction(scope.clickAction)) {
                 scope.clickAction();
               }
@@ -247,7 +245,7 @@ angular.module('kifi')
               $rootScope.$emit('librarySummariesChanged');
 
               scope.$evalAsync(function () {
-                scope.selection.library = _.find(scope.libraries, { 'name': library.name });
+                scope.librarySelection.library = _.find(scope.libraries, { 'name': library.name });
                 if (_.isFunction(scope.clickAction)) {
                   scope.clickAction();
                 }
@@ -258,6 +256,13 @@ angular.module('kifi')
             submitting = false;
           });
         };
+
+
+        //
+        // On link.
+        //
+        scope.librarySelection.library = _.find(scope.libraries, { 'kind': 'system_main' });
+
 
         //
         // Clean up.

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keepActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keepActionService.js
@@ -173,6 +173,31 @@ angular.module('kifi')
       });
     }
 
+    function moveToLibrary(keepIds, libraryId) {
+      $analytics.eventTrack('user_clicked_page', {
+        // TODO(yiping): should we have a different action
+        // for keeping to library?
+        'action': 'keep',
+        'path': $location.path()
+      });
+
+      var data = {
+        to: libraryId,
+        keeps: keepIds
+      };
+
+      $log.log('keepActionService.moveToLibrary()', data);
+
+      var url = routeService.moveKeepsToLibrary();
+      return $http.post(url, data, {}).then(function (res) {
+        _.uniq(res.data.keeps, function (keep) {
+          return keep.url;
+        });
+
+        return res.data;
+      });
+    }
+
     // When a url is added as a keep, the returned keep does not have the full
     // keep information we need to display it. This function fetches that
     // information.
@@ -253,6 +278,7 @@ angular.module('kifi')
       keepMany: keepMany,
       keepUrl: keepUrl,
       keepToLibrary: keepToLibrary,
+      moveToLibrary: moveToLibrary,
       fetchFullKeepInfo: fetchFullKeepInfo,
       togglePrivateOne: togglePrivateOne,
       togglePrivateMany: togglePrivateMany,

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keepActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keepActionService.js
@@ -173,6 +173,31 @@ angular.module('kifi')
       });
     }
 
+    function copyToLibrary(keepIds, libraryId) {
+      $analytics.eventTrack('user_clicked_page', {
+        // TODO(yiping): should we have a different action
+        // for keeping to library?
+        'action': 'keep',
+        'path': $location.path()
+      });
+
+      var data = {
+        to: libraryId,
+        keeps: keepIds
+      };
+
+      $log.log('keepActionService.copyToLibrary()', data);
+
+      var url = routeService.copyKeepsToLibrary();
+      return $http.post(url, data, {}).then(function (res) {
+        _.uniq(res.data.keeps, function (keep) {
+          return keep.url;
+        });
+
+        return res.data;
+      });
+    }
+
     function moveToLibrary(keepIds, libraryId) {
       $analytics.eventTrack('user_clicked_page', {
         // TODO(yiping): should we have a different action
@@ -278,6 +303,7 @@ angular.module('kifi')
       keepMany: keepMany,
       keepUrl: keepUrl,
       keepToLibrary: keepToLibrary,
+      copyToLibrary: copyToLibrary,
       moveToLibrary: moveToLibrary,
       fetchFullKeepInfo: fetchFullKeepInfo,
       togglePrivateOne: togglePrivateOne,

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
@@ -119,7 +119,7 @@ angular.module('kifi')
           var selectedKeeps = scope.selection.getSelected(scope.keeps);
           var selectedLibrary = scope.librarySelection.library;
 
-          keepActionService.keepToLibrary(_.pluck(selectedKeeps, 'url'), selectedLibrary.id).then(function () {
+          keepActionService.copyToLibrary(_.pluck(selectedKeeps, 'id'), selectedLibrary.id).then(function () {
             // TODO: look at result and flag errors. Right now, even a partial error is flagged so that's
             //       not good.
             libraryService.fetchLibrarySummaries(true).then(function () {

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
@@ -9,12 +9,12 @@
       <div class="kf-keep-selection-options" ng-class="{disabled: editingTags || selection.getSelected(keeps).length === 0}">
         <div ng-if="!librariesEnabled" class="kf-keep-selection-option"><span ng-click="togglePrivate(keeps)">Make {{selectionPrivacyState(keeps)}}</span></div>
 
-        <div ng-if="librariesEnabled" class="kf-keep-selection-option">
-          <span kf-keep-to-library-widget ng-click="showWidget()" libraries="libraries" selection="librarySelection">
-            Copy to library
-          </span>
+        <div ng-if="librariesEnabled" class="kf-keep-selection-option copy-to-library">
+          <span kf-keep-to-library-widget ng-click="showWidget()">Copy to library</span>
         </div>
-        <!-- <div ng-if="librariesEnabled" class="kf-keep-selection-option"><span>Move to library</span></div> -->
+        <div ng-if="librariesEnabled" class="kf-keep-selection-option move-to-library">
+          <span kf-keep-to-library-widget ng-click="showWidget()">Move to library</span>
+        </div>
 
         <div class="kf-keep-selection-option"><span ng-click="unkeep(keeps)">Unkeep</span></div>
         <div class="kf-keep-selection-option" ng-click="enableEditTags()"><span>Edit Tags</span></div>

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
@@ -7,7 +7,15 @@
         <span class="kf-keep-selected-count-text" ng-pluralize count="selection.getSelected(keeps).length" when="{'1': 'keep selected', 'other': 'keeps selected'}"></span>
       </div>
       <div class="kf-keep-selection-options" ng-class="{disabled: editingTags || selection.getSelected(keeps).length === 0}">
-        <div class="kf-keep-selection-option"><span ng-click="togglePrivate(keeps)">Make {{selectionPrivacyState(keeps)}}</span></div>
+        <div ng-if="!librariesEnabled" class="kf-keep-selection-option"><span ng-click="togglePrivate(keeps)">Make {{selectionPrivacyState(keeps)}}</span></div>
+
+        <div ng-if="librariesEnabled" class="kf-keep-selection-option">
+          <span kf-keep-to-library-widget ng-click="showWidget()" libraries="libraries" selection="librarySelection">
+            Copy to library
+          </span>
+        </div>
+        <!-- <div ng-if="librariesEnabled" class="kf-keep-selection-option"><span>Move to library</span></div> -->
+
         <div class="kf-keep-selection-option"><span ng-click="unkeep(keeps)">Unkeep</span></div>
         <div class="kf-keep-selection-option" ng-click="enableEditTags()"><span>Edit Tags</span></div>
         <div class="kf-keep-selection-options-mask"></div>

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
@@ -25,8 +25,7 @@ angular.module('kifi')
         $scope.libraries = _.filter(libraryService.librarySummaries, function(lib) {
           return lib.access !== 'read_only';
         });
-        $scope.selection = $scope.selection || {};
-        $scope.selection.library = _.find($scope.libraries, { 'name': 'Main Library' });
+        $scope.librarySelection = {};
         $scope.libSelectTopOffset = 220;
       });
     }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -155,8 +155,7 @@ angular.module('kifi')
 
     $rootScope.$on('userLoggedInStateChange', init.bind(this, true));
 
-    init();
-
+    init(true);
 
     $scope.submitPassPhrase = function () {
       libraryService.authIntoLibrary($scope.username, $scope.librarySlug, authToken, $scope.passphrase.value.toLowerCase()).then(function () {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.tpl.html
@@ -13,6 +13,7 @@
     </div>
 
     <div kf-keeps
+      library="library"
       keeps="keeps"
       keeps-loading="loading"
       keeps-has-more="hasMore"

--- a/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
@@ -6,6 +6,7 @@ angular.module('kifi')
             'routeService', '$http', '$location', 'modalService', '$timeout', '$rootScope',
   function (tagService, $scope, $window, manageTagService, libraryService,
               routeService, $http, $location, modalService, $timeout, $rootScope) {
+    $scope.librariesEnabled = false;
     $scope.libraries = [];
     $scope.selected = {};
 
@@ -64,10 +65,9 @@ angular.module('kifi')
       });
     }
 
+    //
     // Watchers & Listeners
-    $scope.librariesEnabled = false;
-    $scope.libraries = [];
-
+    //
     $scope.$watch(function () {
       return libraryService.isAllowed();
     }, function (newVal) {
@@ -77,8 +77,7 @@ angular.module('kifi')
           $scope.libraries = _.filter(libraryService.librarySummaries, function (lib) {
             return lib.access !== 'read_only';
           });
-          $scope.selection = $scope.selection || {};
-          $scope.selection.library = _.find($scope.libraries, { 'kind': 'system_main' });
+          $scope.librarySelection = {};
         });
       }
     });
@@ -93,12 +92,12 @@ angular.module('kifi')
 
     $scope.clickAction = function () {
       var tagName = encodeURIComponent($scope.selectedTag.name);
-      libraryService.copyKeepsFromTagToLibrary($scope.selection.library.id, tagName).then(function () {
+      libraryService.copyKeepsFromTagToLibrary($scope.librarySelection.library.id, tagName).then(function () {
         modalService.open({
           template: 'tagManage/tagToLibModal.tpl.html',
-          modalData: { library : $scope.selection.library }
+          modalData: { library : $scope.librarySelection.library }
         });
-        libraryService.addToLibraryCount($scope.selection.library.id, $scope.selectedTag.keeps);
+        libraryService.addToLibraryCount($scope.librarySelection.library.id, $scope.selectedTag.keeps);
       })['catch'](function () {
         modalService.open({
           template: 'common/modal/genericErrorModal.tpl.html'


### PR DESCRIPTION
Closed last pull because of merge conflicts. An update today is that I am now using the 'copy' endpoint. I am also always refetching library info from the network.

Follow-up:
- Do not always flush cache for library info (made Asana task: https://app.asana.com/0/15523651812135/18279074736905)
- Dynamically relocate the widget (to be done soon!)
- Per discussions with @ahsu1230 , there are also a few backend followup items to this feature.

@andrewconner @ahsu1230 
