### PR TITLE
remove unnecessary timing in DbRepo

### DIFF
--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DBSession.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DBSession.scala
@@ -36,7 +36,7 @@ object DBSession {
     val sessionId = TrackingId.get
     val isReadOnly = masterSlave != Master
     def runningTime(): Long = System.currentTimeMillis - startTime
-    def timeCheck(): Unit = {
+    private def timeCheck(): Unit = {
       val t = runningTime()
       if (t > 5000) { // tweak
         val msg = s"DBSession($sessionId,$name,$masterSlave) takes too long: $t ms"

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
@@ -86,22 +86,12 @@ trait DbRepo[M <: Model[M]] extends Repo[M] with FortyTwoGenericTypeMappers with
 
   def count(implicit session: RSession): Int = Query(rows.length).first
 
-  private[slick] def checkTiming(time: Long, operation: String, model: M)(implicit session: RSession): Unit = {
-    if (time > 5000) { // tweak
-      val msg = s"DB-$operation (${session.sessionId};${model.getClass.getSimpleName}) takes too long ($time ms); model:${model.toString.abbreviate(200).trimAndRemoveLineBreaks}"
-      log.error(msg, new IllegalStateException(msg))
-    }
-    session.timeCheck()
-  }
-
   protected val getCompiled = Compiled { id: Column[Id[M]] =>
     for (f <- rows if f.id is id) yield f
   }
   def get(id: Id[M])(implicit session: RSession): M = {
     val startTime = System.currentTimeMillis()
     val model = getCompiled(id).firstOption.getOrElse(throw new IllegalArgumentException(s"can't find $id in ${_taggedTable.tableName}"))
-    val time = System.currentTimeMillis - startTime
-    checkTiming(time, "GET", model)
     model
   }
 
@@ -118,9 +108,6 @@ trait DbRepo[M <: Model[M]] extends Repo[M] with FortyTwoGenericTypeMappers with
   private def insert(model: M)(implicit session: RWSession): Id[M] = {
     val startTime = System.currentTimeMillis()
     val inserted = (rows returning rows.map(_.id)) += model
-    val time = System.currentTimeMillis - startTime
-    dbLog.info(s"t:${clock.now}\tsessionId:${session.sessionId}\ttype:INSERT\tduration:$time\tmodel:${inserted.getClass.getSimpleName}\tmodel:${inserted.toString.abbreviate(200).trimAndRemoveLineBreaks}")
-    checkTiming(time, "INSERT", model)
     inserted
   }
 
@@ -128,9 +115,6 @@ trait DbRepo[M <: Model[M]] extends Repo[M] with FortyTwoGenericTypeMappers with
     val startTime = System.currentTimeMillis()
     val target = getCompiled(model.id.get)
     val count = target.update(model)
-    val time = System.currentTimeMillis - startTime
-    dbLog.info(s"t:${clock.now}\tsessionId:${session.sessionId}\ttype:UPDATE\tduration:${time}\tmodel:${model.getClass.getSimpleName()}\tmodel:${model.toString.abbreviate(200).trimAndRemoveLineBreaks}")
-    checkTiming(time, "UPDATE", model)
     if (count != 1) {
       deleteCache(model)
       throw new IllegalStateException(s"Updating $count models of [${model.toString.abbreviate(200).trimAndRemoveLineBreaks}] instead of exactly one. Maybe there is a cache issue. The actual model (from cache) is no longer in db.")
@@ -190,9 +174,6 @@ trait DbRepoWithDelete[M <: Model[M]] extends RepoWithDelete[M] { self: DbRepo[M
     val target = for (t <- rows if t.id === model.id.get) yield t
     val count = target.delete
     deleteCache(model)
-    val time = System.currentTimeMillis - startTime
-    dbLog.info(s"t:${clock.now}\tsessionId:${session.sessionId}\ttype:DELETE\tduration:${time}\ttype:${model.getClass.getSimpleName()}\tmodel:${model.toString.abbreviate(200).trimAndRemoveLineBreaks}")
-    checkTiming(time, "DELETE", model)
     if (changeListener.isDefined) session.onTransactionSuccess {
       changeListener.get(RepoEntryRemoved(model))
     }


### PR DESCRIPTION
@raymondng @ymatsuda @stkem @eishay 

we already track running time when session closes. In addition, within each db session, we are timing every operation (get, insert, delete, update), using _session starting time_. These are redundant. 

Whenever we have a batch operation like

```
bigArray.foreach{ repo.save(_) }
```

once we start timing out at an item, all subsequent items would throw `java.lang.IllegalStateException`.

This 1) could slow down the application 2) sends too much data to the log. 
