### PR TITLE
login/logout -- add/rm fortytwo_id

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/social/providers/SecureSocialControllers.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/providers/SecureSocialControllers.scala
@@ -1,5 +1,6 @@
 package com.keepit.social.providers
 
+import com.keepit.common.controller.KifiSession
 import play.api.mvc._
 import play.api.i18n.Messages
 import securesocial.core._
@@ -167,7 +168,8 @@ object LoginPage extends Controller {
     }
     val result = Redirect(to).discardingCookies(Authenticator.discardingCookie)
     user match {
-      case Some(u) => result.withSession(Events.fire(new LogoutEvent(u)).getOrElse(request.session))
+      case Some(u) =>
+        result.withSession(Events.fire(new LogoutEvent(u)).getOrElse(request.session) - KifiSession.FORTYTWO_USER_ID)
       case None => result
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
@@ -1,6 +1,7 @@
 package com.keepit.commanders
 
 import com.google.inject.Inject
+import com.keepit.common.controller.KifiSession
 
 import com.keepit.common.core._
 import com.keepit.common.akka.SafeFuture
@@ -320,7 +321,7 @@ class AuthCommander @Inject() (
           error => throw error,
           authenticator =>
             Ok(Json.obj("code" -> "user_logged_in", "sessionId" -> authenticator.id))
-              .withSession(newSession - SecureSocial.OriginalUrlKey - IdentityProvider.SessionId - OAuth1Provider.CacheKey)
+              .withSession(newSession - SecureSocial.OriginalUrlKey - IdentityProvider.SessionId - OAuth1Provider.CacheKey + (KifiSession.FORTYTWO_USER_ID -> userId.toString))
               .withCookies(authenticator.toCookie)
         )
     } getOrElse {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
@@ -150,7 +150,7 @@ class ExtAuthController @Inject() (
     }
     val result = NoContent.discardingCookies(Authenticator.discardingCookie)
     user match {
-      case Some(u) => result.withSession(Events.fire(new LogoutEvent(u)).getOrElse(request.session))
+      case Some(u) => result.withSession(Events.fire(new LogoutEvent(u)).getOrElse(request.session) - KifiSession.FORTYTWO_USER_ID)
       case None => result
     }
   }


### PR DESCRIPTION
Explicitly setting/removing kifi user_id, replacing `SecureSocial`-based mechanism, which does not seem reliable (or is no longer reliable)

We are moving away from `SecureSocial` and in this particular case (kifi user id) we probably shouldn't depend on it in the first place.

Reviewed with @andrewconner 

Thanks @jaredpetker and @2is10 for reporting the problem. Validated locally. Will push to prod to confirm.
