### PR TITLE
Cookie check

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
@@ -191,16 +191,18 @@ trait UserActions extends Logging { self: Controller =>
   }
 
   private def maybeSetUserIdInSession[A](userId: Id[User], res: Result)(implicit request: Request[A]): Result = {
-    userActionsHelper.getUserIdFromSession match {
-      case Success(userIdOpt) =>
-        userIdOpt match {
-          case Some(id) if id == userId => res
-          case _ => res.withSession(request.session + (KifiSession.FORTYTWO_USER_ID -> userId.toString))
-        }
-      case Failure(t) =>
-        log.error(s"[maybeSetUserIdInSession($userId)] Caught exception while retrieving userId from kifi cookie", t)
-        res.withSession(request.session + (KifiSession.FORTYTWO_USER_ID -> userId.toString))
-    }
+    Play.maybeApplication.map { app =>
+      userActionsHelper.getUserIdFromSession match {
+        case Success(userIdOpt) =>
+          userIdOpt match {
+            case Some(id) if id == userId => res
+            case _ => res.withSession(request.session + (KifiSession.FORTYTWO_USER_ID -> userId.toString))
+          }
+        case Failure(t) =>
+          log.error(s"[maybeSetUserIdInSession($userId)] Caught exception while retrieving userId from kifi cookie", t)
+          res.withSession(request.session + (KifiSession.FORTYTWO_USER_ID -> userId.toString))
+      }
+    } getOrElse res
   }
 
   private def impersonate[A](adminUserId: Id[User], impersonateExtId: ExternalId[User])(implicit request: Request[A]): Future[UserRequest[A]] = {

--- a/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
@@ -118,7 +118,9 @@ trait SecureSocialHelper extends Logging {
 trait UserActionsHelper extends UserActionsRequirements with Logging {
 
   def getUserIdFromSession(implicit request: Request[_]): Try[Option[Id[User]]] =
-    Try(request.session.get(KifiSession.FORTYTWO_USER_ID).map(id => Id[User](id.toLong)))
+    Try {
+      Play.maybeApplication.flatMap { _ => request.session.get(KifiSession.FORTYTWO_USER_ID).map(id => Id[User](id.toLong)) }
+    }
 
   def getUserIdOptWithFallback(implicit request: Request[_]): Future[Option[Id[User]]] = {
     val kifiIdOpt = getUserIdFromSession recover {

--- a/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
@@ -14,6 +14,7 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import securesocial.core.{ UserService, SecureSocial, Identity }
 import scala.concurrent.duration._
 import scala.concurrent.{ Promise, Await, Future }
+import scala.util.{ Failure, Success, Try }
 
 sealed trait MaybeUserRequest[T] extends Request[T] {
   // for backward compatibility only; use UserRequest/NonUserRequest where possible
@@ -116,14 +117,16 @@ trait SecureSocialHelper extends Logging {
 
 trait UserActionsHelper extends UserActionsRequirements with Logging {
 
-  def getUserIdOpt(implicit request: Request[_]): Future[Option[Id[User]]] = {
-    val kifiIdOpt = try {
-      request.session.get(KifiSession.FORTYTWO_USER_ID).map(id => Id[User](id.toLong))
-    } catch {
+  def getUserIdFromSession(implicit request: Request[_]): Try[Option[Id[User]]] =
+    Try(request.session.get(KifiSession.FORTYTWO_USER_ID).map(id => Id[User](id.toLong)))
+
+  def getUserIdOptWithFallback(implicit request: Request[_]): Future[Option[Id[User]]] = {
+    val kifiIdOpt = getUserIdFromSession recover {
       case t: Throwable =>
         airbrake.notify(s"[getUserIdOpt] Caught exception $t while retrieving userId from request; cause=${t.getCause}", t)
         None
-    }
+    } get
+
     kifiIdOpt match {
       case Some(userId) =>
         Future.successful(Some(userId))
@@ -185,12 +188,16 @@ trait UserActions extends Logging { self: Controller =>
     } getOrElse res
   }
 
-  private def maybeSetUserIdInSession[A](userId: Id[User], res: Result)(implicit request: Request[A]): Future[Result] = {
-    userActionsHelper.getUserIdOpt map { userIdOpt =>
-      userIdOpt match {
-        case Some(id) if id == userId => res
-        case _ => res.withSession(request.session + (KifiSession.FORTYTWO_USER_ID -> userId.toString))
-      }
+  private def maybeSetUserIdInSession[A](userId: Id[User], res: Result)(implicit request: Request[A]): Result = {
+    userActionsHelper.getUserIdFromSession match {
+      case Success(userIdOpt) =>
+        userIdOpt match {
+          case Some(id) if id == userId => res
+          case _ => res.withSession(request.session + (KifiSession.FORTYTWO_USER_ID -> userId.toString))
+        }
+      case Failure(t) =>
+        log.error(s"[maybeSetUserIdInSession($userId)] Caught exception while retrieving userId from kifi cookie", t)
+        res.withSession(request.session + (KifiSession.FORTYTWO_USER_ID -> userId.toString))
     }
   }
 
@@ -209,10 +216,10 @@ trait UserActions extends Logging { self: Controller =>
     userActionsHelper.getImpersonatedUserIdOpt match {
       case Some(impExtId) =>
         impersonate(userId, impExtId).flatMap { userRequest =>
-          block(userRequest).flatMap(maybeSetUserIdInSession(userId, _))
+          block(userRequest).map(maybeSetUserIdInSession(userId, _))
         }
       case None =>
-        block(buildUserRequest(userId)).flatMap(maybeSetUserIdInSession(userId, _))
+        block(buildUserRequest(userId)).map(maybeSetUserIdInSession(userId, _))
     }
   }
 
@@ -225,7 +232,7 @@ trait UserActions extends Logging { self: Controller =>
   object UserAction extends ActionBuilder[UserRequest] {
     def invokeBlock[A](request: Request[A], block: (UserRequest[A]) => Future[Result]): Future[Result] = {
       implicit val req = request
-      val result = userActionsHelper.getUserIdOpt flatMap { userIdOpt =>
+      val result = userActionsHelper.getUserIdOptWithFallback flatMap { userIdOpt =>
         userIdOpt match {
           case Some(userId) => buildUserAction(userId, block)
           case None => Future.successful(Forbidden) tap { _ => log.warn(s"[UserAction] Failed to retrieve userId for request=$request; headers=${request.headers.toMap}") }
@@ -239,7 +246,7 @@ trait UserActions extends Logging { self: Controller =>
   object MaybeUserAction extends ActionBuilder[MaybeUserRequest] {
     def invokeBlock[A](request: Request[A], block: (MaybeUserRequest[A]) => Future[Result]): Future[Result] = {
       implicit val req = request
-      val result = userActionsHelper.getUserIdOpt flatMap { userIdOpt =>
+      val result = userActionsHelper.getUserIdOptWithFallback flatMap { userIdOpt =>
         userIdOpt match {
           case Some(userId) => buildUserAction(userId, block)
           case None => block(userActionsHelper.buildNonUserRequest).map(maybeAugmentKcid(_))

--- a/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
@@ -193,11 +193,8 @@ trait UserActions extends Logging { self: Controller =>
   private def maybeSetUserIdInSession[A](userId: Id[User], res: Result)(implicit request: Request[A]): Result = {
     Play.maybeApplication.map { app =>
       userActionsHelper.getUserIdFromSession match {
-        case Success(userIdOpt) =>
-          userIdOpt match {
-            case Some(id) if id == userId => res
-            case _ => res.withSession(request.session + (KifiSession.FORTYTWO_USER_ID -> userId.toString))
-          }
+        case Success(Some(id)) if id == userId => res
+        case Success(_) => res.withSession(request.session + (KifiSession.FORTYTWO_USER_ID -> userId.toString))
         case Failure(t) =>
           log.error(s"[maybeSetUserIdInSession($userId)] Caught exception while retrieving userId from kifi cookie", t)
           res.withSession(request.session + (KifiSession.FORTYTWO_USER_ID -> userId.toString))

--- a/kifi-backend/modules/common/test/com/keepit/common/controller/FakeUserActionsModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/controller/FakeUserActionsModule.scala
@@ -37,7 +37,7 @@ class FakeUserActionsHelper(
     this
   }
 
-  override def getUserIdOpt(implicit request: Request[_]): Future[Option[Id[User]]] = Future.successful(fixedUser.flatMap(_.id))
+  override def getUserIdOptWithFallback(implicit request: Request[_]): Future[Option[Id[User]]] = Future.successful(fixedUser.flatMap(_.id))
   def isAdmin(userId: Id[User])(implicit request: Request[_]): Future[Boolean] = Future.successful(fixedExperiments.contains(ExperimentType.ADMIN))
   def getUserOpt(userId: Id[User])(implicit request: Request[_]): Future[Option[User]] = Future.successful(fixedUser)
   def getUserByExtIdOpt(extId: ExternalId[User]): Future[Option[User]] = Future.successful(fixedUser)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -131,8 +131,10 @@ class AuthController @Inject() (
   // Note: some of the below code is taken from ProviderController in SecureSocial
   // Logout is still handled by SecureSocial directly.
 
-  def loginSocial(provider: String) = ProviderController.authenticate(provider)
-  def logInWithUserPass(link: String) = Action.async(parse.anyContent) { implicit request =>
+  def loginSocial(provider: String) = MaybeUserAction.async { implicit request =>
+    ProviderController.authenticate(provider)(request)
+  }
+  def logInWithUserPass(link: String) = MaybeUserAction.async { implicit request =>
     val authRes = timing(s"[logInWithUserPass] authenticate") { ProviderController.authenticate("userpass")(request) }
     authRes.map {
       case res: Result if res.header.status == 303 =>


### PR DESCRIPTION
Migrated 2 old endpoints to new actions
Decoupling fallback logic while setting userId
Very simple cookie sanity check in unit test (`PasswordTest` as it does explicit u/p authentication)
Obvious gap is testing with `SecureSocial` and FB/LNKD ... need to look into it a bit more

@andrewconner @eishay @2is10 
