### PR TITLE
privatize FORTYTWO_USER_ID

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/social/SecureSocialUserService.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/SecureSocialUserService.scala
@@ -11,6 +11,7 @@ import play.api.mvc.{ Session, RequestHeader }
 import securesocial.core._
 import securesocial.core.providers.Token
 import net.codingwell.scalaguice.ScalaModule
+import KifiSession._
 
 class SecureSocialIdGenerator(app: Application) extends IdGenerator(app) {
   def generate: String = ExternalId[String]().toString
@@ -38,7 +39,7 @@ private class SecureSocialEventListener extends securesocial.core.EventListener 
   def onEvent(event: Event, request: RequestHeader, session: Session): Option[Session] = event match {
     case LogoutEvent(identity) =>
       // Remove our user ID info when the user logs out
-      Some(session - KifiSession.FORTYTWO_USER_ID)
+      Some(session.deleteUserId)
     case _ =>
       None
   }

--- a/kifi-backend/modules/common/app/com/keepit/social/UserIdentityProvider.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/UserIdentityProvider.scala
@@ -21,6 +21,7 @@ import play.api.libs.json.JsNumber
 import play.api.mvc.Call
 import securesocial.core.OAuth2Info
 import securesocial.core.AuthenticationException
+import KifiSession._
 
 /**
  * An identity provider which returns UserIdentity instances. This allows us to know the currently logged in user when
@@ -33,7 +34,7 @@ trait UserIdentityProvider extends IdentityProvider with Logging {
   abstract override def authenticate[A]()(implicit request: Request[A]): Either[Result, Identity] = {
     log.info(s"UserIdentityProvider got request: $request")
     log.info(s"session data: ${request.session.data}")
-    val userIdOpt = request.session.get(KifiSession.FORTYTWO_USER_ID).map { id => Id[User](id.toLong) }
+    val userIdOpt = request.session.getUserId
     doAuth()(request) match {
       case Right(socialUser) =>
         val filledSocialUser = fillProfile(socialUser)

--- a/kifi-backend/modules/common/app/com/keepit/social/providers/SecureSocialControllers.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/providers/SecureSocialControllers.scala
@@ -117,6 +117,7 @@ import securesocial.core._
 import play.api.Play
 import Play.current
 import providers.utils.RoutesHelper
+import KifiSession._
 
 /**
  * The Login page controller
@@ -171,9 +172,9 @@ object LoginPage extends Controller with Logging {
     log.info(s"[logout] user.email=${user.map(_.email)} user.class=${user.getClass}")
     user match {
       case Some(u) =>
-        result.withSession(Events.fire(new LogoutEvent(u)).getOrElse(request.session) - KifiSession.FORTYTWO_USER_ID)
+        result.withSession(Events.fire(new LogoutEvent(u)).getOrElse(request.session).deleteUserId())
       case None =>
-        result.withSession(request.session - KifiSession.FORTYTWO_USER_ID)
+        result.withSession(request.session.deleteUserId())
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
@@ -36,6 +36,7 @@ import securesocial.core._
 import securesocial.core.providers.utils.GravatarHelper
 
 import scala.util.{ Failure, Success, Try }
+import KifiSession._
 
 case class EmailPassword(email: EmailAddress, password: Array[Char])
 object EmailPassword {
@@ -321,7 +322,7 @@ class AuthCommander @Inject() (
           error => throw error,
           authenticator =>
             Ok(Json.obj("code" -> "user_logged_in", "sessionId" -> authenticator.id))
-              .withSession(newSession - SecureSocial.OriginalUrlKey - IdentityProvider.SessionId - OAuth1Provider.CacheKey + (KifiSession.FORTYTWO_USER_ID -> userIdOpt.get.toString))
+              .withSession((newSession - SecureSocial.OriginalUrlKey - IdentityProvider.SessionId - OAuth1Provider.CacheKey).setUserId(userIdOpt.get))
               .withCookies(authenticator.toCookie)
         )
     } getOrElse {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -2,7 +2,6 @@ package com.keepit.controllers.core
 
 import com.google.inject.Inject
 import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper, UserRequest, MaybeUserRequest, NonUserRequest, SecureSocialHelper }
-import com.keepit.common.controller.KifiSession.FORTYTWO_USER_ID
 import com.keepit.common.crypto.PublicId
 import com.keepit.common.db.ExternalId
 import com.keepit.common.db.slick.Database
@@ -13,6 +12,7 @@ import com.keepit.inject.FortyTwoConfig
 import com.keepit.model._
 import com.keepit.social.{ SecureSocialClientIds, SocialNetworkType }
 import com.kifi.macros.json
+import com.keepit.common.controller.KifiSession._
 
 import play.api.Play._
 import play.api.libs.json.{ JsValue, JsNumber, Json }
@@ -189,7 +189,7 @@ class AuthController @Inject() (
                   authenticator =>
                     Future.successful(
                       Ok(Json.obj("uri" -> session.get(SecureSocial.OriginalUrlKey).getOrElse(home.url).asInstanceOf[String]))
-                        .withSession(session - SecureSocial.OriginalUrlKey + (FORTYTWO_USER_ID -> sui.userId.get.toString))
+                        .withSession((session - SecureSocial.OriginalUrlKey).setUserId(sui.userId.get))
                         .withCookies(authenticator.toCookie)
                     )
                 )
@@ -251,7 +251,7 @@ class AuthController @Inject() (
     authRes(request).map { result =>
       authHelper.authHandler(request, result) { (_, sess: Session) =>
         // TODO: set FORTYTWO_USER_ID instead of clearing it and then setting it on the next request?
-        result.withSession(sess - FORTYTWO_USER_ID + (SecureSocial.OriginalUrlKey -> routes.AuthController.signupPage().url))
+        result.withSession((sess + (SecureSocial.OriginalUrlKey -> routes.AuthController.signupPage().url)).deleteUserId)
       }
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -109,11 +109,11 @@ class AuthHelper @Inject() (
               }
               if (finalized) {
                 Ok(Json.obj("uri" -> session.get(SecureSocial.OriginalUrlKey).getOrElse(home.url).asInstanceOf[String])) // todo(ray): uri not relevant for mobile
-                  .withSession(session - SecureSocial.OriginalUrlKey + (FORTYTWO_USER_ID -> sui.userId.get.toString))
+                  .withSession((session - SecureSocial.OriginalUrlKey).setUserId(sui.userId.get))
                   .withCookies(authenticator.toCookie)
               } else {
                 Ok(Json.obj("success" -> true))
-                  .withSession(session + (FORTYTWO_USER_ID -> sui.userId.get.toString))
+                  .withSession(session.setUserId(sui.userId.get))
                   .withCookies(authenticator.toCookie)
               }
             }
@@ -130,7 +130,7 @@ class AuthHelper @Inject() (
         error => Status(INTERNAL_SERVER_ERROR)("0"),
         authenticator =>
           Ok(Json.obj("success" -> true))
-            .withSession(session + (FORTYTWO_USER_ID -> userId.toString))
+            .withSession(session.setUserId(userId))
             .withCookies(authenticator.toCookie)
       )
     }
@@ -197,7 +197,7 @@ class AuthHelper @Inject() (
       error => Status(INTERNAL_SERVER_ERROR)("0"),
       authenticator => Ok(Json.obj("uri" -> uri))
         .withCookies(authenticator.toCookie).discardingCookies(DiscardingCookie("inv"))
-        .withSession(request.session + (KifiSession.FORTYTWO_USER_ID -> user.id.get.toString))
+        .withSession(request.session.setUserId(user.id.get))
     )
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
@@ -22,6 +22,7 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 
 import securesocial.core.{ Authenticator, Events, LogoutEvent, OAuth2Provider, Registry, SecureSocial, UserService }
+import KifiSession._
 
 class ExtAuthController @Inject() (
   val userActionsHelper: UserActionsHelper,
@@ -150,7 +151,7 @@ class ExtAuthController @Inject() (
     }
     val result = NoContent.discardingCookies(Authenticator.discardingCookie)
     user match {
-      case Some(u) => result.withSession(Events.fire(new LogoutEvent(u)).getOrElse(request.session) - KifiSession.FORTYTWO_USER_ID)
+      case Some(u) => result.withSession(Events.fire(new LogoutEvent(u)).getOrElse(request.session).deleteUserId)
       case None => result
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
@@ -22,6 +22,7 @@ import com.keepit.commanders.ConnectionInfo
 import scala.util.Success
 import play.api.libs.json.JsObject
 import com.keepit.common.http._
+import KifiSession._
 
 class MobileUserController @Inject() (
   val userActionsHelper: UserActionsHelper,
@@ -208,7 +209,7 @@ class MobileUserController @Inject() (
           error => Status(INTERNAL_SERVER_ERROR)(Json.obj("code" -> "internal_server_error")),
           authenticator => {
             Ok(Json.obj("code" -> code))
-              .withSession(request.session - SecureSocial.OriginalUrlKey + (KifiSession.FORTYTWO_USER_ID -> newLoginUser.userId.get.toString)) // note: newLoginuser.userId
+              .withSession((request.session - SecureSocial.OriginalUrlKey).setUserId(newLoginUser.userId.get))
               .withCookies(authenticator.toCookie)
           }
         )

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
@@ -24,6 +24,7 @@ import play.twirl.api.Html
 import securesocial.core.{ Authenticator, SecureSocial }
 
 import scala.concurrent.Future
+import KifiSession._
 
 class HomeController @Inject() (
   db: Database,
@@ -282,7 +283,7 @@ class HomeController @Inject() (
           error => Status(INTERNAL_SERVER_ERROR)("0"),
           authenticator => {
             Redirect("/profile") // hard coded because reverse router doesn't let us go there. todo: fix
-              .withSession(request.session - SecureSocial.OriginalUrlKey + (KifiSession.FORTYTWO_USER_ID -> newLoginUser.userId.get.toString)) // note: newLoginuser.userId
+              .withSession((request.session - SecureSocial.OriginalUrlKey).setUserId(newLoginUser.userId.get))
               .withCookies(authenticator.toCookie)
           }
         )

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/PasswordTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/PasswordTest.scala
@@ -31,6 +31,7 @@ import play.api.test._
 import securesocial.core._
 
 import scala.concurrent.Future
+import KifiSession._
 
 // todo(ray): figure out how to deal with SecureSocial's dependency on application
 class PasswordTest extends Specification with ShoeboxApplicationInjector {
@@ -102,7 +103,7 @@ class PasswordTest extends Specification with ShoeboxApplicationInjector {
       status(result) === OK
       val sess = session(result)
       userIdOpt foreach { userId =>
-        sess(KifiSession.FORTYTWO_USER_ID).toLong === userId.id
+        sess.getUserId.get === userId.id
       }
       contentAsString(result) === Json.obj("uri" -> "/login/after").toString()
     } else {


### PR DESCRIPTION
Made `FORTYTWO_USER_ID` private
Added implicit class with type-safe operations on `userId`
DRY-er code

Relying on `toString` is unsafe/dangerous ... this should help prevent/eliminate this type of errors.

@andrewconner @eishay @2is10 
