### PR TITLE
Implement invite header for library card.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
@@ -162,6 +162,9 @@ angular.module('kifi')
       leaveLibrary: function (libraryId) {
         return route('/libraries/' + libraryId + '/leave');
       },
+      declineToJoinLibrary: function (libraryId) {
+        return route('/libraries/' + libraryId + '/decline');
+      },
       deleteLibrary: function (libraryId) {
         return route('/libraries/' + libraryId + '/delete');
       },

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
@@ -1,4 +1,8 @@
 // TODO(yiping): move library card styles to its own .styl file
+
+// Library card colors
+invite-header-orange = #ff7c3c
+
 .kf-library-card-header
   padding: 0 25px 0 30px
   margin-bottom: 10px
@@ -32,6 +36,31 @@
 
 
 .library-card
+  .library-card-invite-header
+    padding: 10px 32px
+    background-color: invite-header-orange
+
+  .library-card-invite-header-info
+    font-size: 13px
+    color: #fff
+    line-height: 25px
+
+  .library-card-invite-header-button
+    float: right
+    margin-left: 10px
+    border: 1px solid #fff
+    border-radius: 5px
+    padding: 5px 15px
+    font-size: 11px
+
+    &.library-card-invite-header-accept
+      background: #fff
+      color: invite-header-orange
+
+    &.library-card-invite-header-ignore
+      background: invite-header-orange
+      color: #fff
+
   .kf-keep-lib-header
     padding-top: 20px
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -3,9 +3,9 @@
 angular.module('kifi')
 
 .directive('kfLibraryCard', [
-  '$FB', '$location', '$rootScope', '$window', 'env', 'friendService', 'libraryService', 'modalService',
+  '$FB', '$location', '$q', '$rootScope', '$window', 'env', 'friendService', 'libraryService', 'modalService',
   'profileService', 'platformService', 'signupService', '$twitter',
-  function ($FB, $location, $rootScope, $window, env, friendService, libraryService, modalService,
+  function ($FB, $location, $q, $rootScope, $window, env, friendService, libraryService, modalService,
     profileService, platformService, signupService, $twitter) {
     return {
       restrict: 'A',
@@ -99,6 +99,26 @@ angular.module('kifi')
 
           scope.library.shareUrl = env.origin + scope.library.url;
           scope.library.shareText = 'Check out this Kifi library about ' + scope.library.name + '!';
+
+          // Figure out whether this library is a library that the user has been invited to.
+          // If so, display an invite header.
+          var promise = null;
+          if (libraryService.invitedSummaries) {
+            promise = $q.when(libraryService.invitedSummaries);
+          } else {
+            promise = libraryService.fetchLibrarySummaries(true).then(function () {
+              return libraryService.invitedSummaries;
+            });
+          }
+
+          promise.then(function (invitedSummaries) {
+            if (_.find(invitedSummaries, { 'id' : scope.library.id })) {
+              scope.library.invite = {
+                inviterName: scope.library.owner.firstName + ' ' + scope.library.owner.lastName,
+                actedOn: false
+              };
+            }
+          });
         }
 
         function preloadSocial () {
@@ -115,6 +135,20 @@ angular.module('kifi')
         //
         // Scope methods.
         //
+        scope.acceptInvitation = function (library) {
+          if (library.invite) {
+            library.invite.actedOn = true;
+            scope.followLibrary(library);
+          }
+        };
+
+        scope.ignoreInvitation = function (library) {
+          if (library.invite) {
+            library.invite.actedOn = true;
+            libraryService.declineToJoinLibrary(library.id);
+          }
+        };
+
         scope.showLongDescription = function () {
           scope.clippedDescription = false;
         };

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
@@ -1,4 +1,9 @@
 <div class="kf-keep library-card" ng-class="{ 'loggedOutUser': isUserLoggedOut }">
+  <div ng-show="library.invite && !library.invite.actedOn" class="library-card-invite-header">
+    <button class="library-card-invite-header-button library-card-invite-header-accept" ng-click="acceptInvitation(library)">Accept</button>
+    <button class="library-card-invite-header-button library-card-invite-header-ignore" ng-click="ignoreInvitation(library)">Ignore</button>
+    <span class="library-card-invite-header-info">{{library.invite.inviterName}} has invited you to follow this library</span>
+  </div>
   <div class="kf-keep-body">
     <div class="kf-keep-lib-header">
       <div ng-if="!isUserLoggedOut" ng-switch="library.kind" class="kf-keep-lib-icon-container">

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -255,6 +255,13 @@ angular.module('kifi')
         });
       },
 
+      declineToJoinLibrary: function (libraryId) {
+        return $http.post(routeService.declineToJoinLibrary(libraryId)).then(function () {
+          _.remove(invitedSummaries, { id: libraryId });
+          $rootScope.$emit('librarySummariesChanged');
+        });
+      },
+
       deleteLibrary: function (libraryId) {
         return $http.post(routeService.deleteLibrary(libraryId)).then(function () {
           _.remove(librarySummaries, function (library) {


### PR DESCRIPTION
https://app.asana.com/0/15523651812135/18412051444297

@andrewconner @ahsu1230 

Note that although calls to the "decline" endpoint succeed (200, with "success" in the response), when I reload the page the declined library still appears in my list of invited libraries. Not sure if this is intended behavior.
