### PR TITLE
fixing library attribution all over

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoPics.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoPics.tpl.html
@@ -2,6 +2,7 @@
   <span class="kf-keep-who-pic-box" ng-if="keep.isMyBookmark">
     <span class="kf-keep-who-pic me" title="You! You look great!" ng-attr-style="background-image: url({{getPicUrl(me)}})"></span>
   </span>
+  <span kf-keep-who-lib library="library" ng-repeat="library in keep.libraries| limitTo: 5"></span>
   <span kf-keep-who-pic keeper="keeper" ng-repeat="keeper in keep.keepers | limitTo: 9"></span>
 </div>
 

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
@@ -2,12 +2,52 @@
 
 angular.module('kifi')
 
-.factory('keepDecoratorService', ['tagService', 'util',
-  function (tagService, util) {
+.factory('keepDecoratorService', ['tagService', 'util', 'friendService', 'profileService',
+  function (tagService, util, friendService, profileService) {
+    function processLibraries(item) {
+      if (item.libraries && item.libraries.length>0 && Array.isArray(item.libraries[0])) {
+        var cleanedLibraries = [];
+        var usersWithLibs = {};
+        item.myLibraries = [];
+        item.libraries.forEach( function (lib) {
+          if (lib[1].id!==profileService.me.id) {
+            usersWithLibs[lib[1].id] = true;
+            cleanedLibraries.push({
+              id: lib[0].id,
+              name: lib[0].name,
+              keeperPic: friendService.getPictureUrlForUser(lib[1]),
+              path: lib[0].path
+            });
+          } else {
+            item.myLibraries.push(lib[0]);
+          }
+        });
+
+
+        item.keepers.forEach(function (keeper) {
+          if (usersWithLibs[keeper.id]) {
+            keeper.hidden = true;
+          }
+        });
+
+        item.libraries = cleanedLibraries;
+        item.keepers = [];
+      }
+    }
+
+
     function Keep (item, itemType) {
       if (!item) {
         return {};
       }
+
+      processLibraries(item);
+
+      if (profileService.me && profileService.me.experiments && profileService.me.experiments.indexOf('libraries') < 0){
+        item.libraries = [];
+      }
+
+
 
       _.assign(this, item);
       this.itemType = itemType;

--- a/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
@@ -30,6 +30,7 @@ angular.module('kifi')
 
       var decompressedKeepers = [];
       var decompressedLibraries = [];
+      var myLibraries = [];
       var libUsers = {};
       hit.isMyBookmark = false;
       hit.keepers = hit.keepers || [];
@@ -41,8 +42,9 @@ angular.module('kifi')
         var idxLib = hit.libraries[i];
         var idxUser = hit.libraries[i+1];
         var lib = libraries[idxLib];
+        var user;
         if (idxUser !== -1) {
-          var user = users[idxUser];
+          user = users[idxUser];
           decompressedLibraries.push({
             id: lib.id,
             name: lib.name,
@@ -50,6 +52,14 @@ angular.module('kifi')
             path: lib.path
           });
           libUsers[idxUser] = true;
+        } else {
+          user = profileService.me;
+          lib.keeperPic = friendService.getPictureUrlForUser(user);
+          if (lib.name !== 'Main Library' && lib.name !== 'Secret Library') {
+            decompressedLibraries.push(lib);
+          }
+          myLibraries.push(lib);
+
         }
       }
 
@@ -69,6 +79,7 @@ angular.module('kifi')
 
       hit.keepers = decompressedKeepers;
       hit.libraries = librariesEnabled ? decompressedLibraries : [];
+      hit.myLibraries = myLibraries;
     }
 
     function reportSearchAnalytics(endedWith, numResults) {


### PR DESCRIPTION
this is a bit hacky due to the server endpoint all having _slightly_
different formats. Likely my fault. Will look into cleaning this up,
but this PR should unblock Keep Card work.

(This PR also enables showing your own libs attribution in search
results)

@joshm1 @andrewconner 
