### PR TITLE
trimming down a query to available fields

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/article/ArticleIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/article/ArticleIndexer.scala
@@ -28,6 +28,8 @@ object ArticleFields {
   val homePageField = "home_page"
   val mediaField = "media"
   val recordField = "rec"
+
+  val textSearchFields = Set(titleField, titleStemmedField, contentField, contentStemmedField, siteField, homePageField, mediaField)
 }
 
 class ArticleIndexer(

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/parser/KQueryExpansion.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/parser/KQueryExpansion.scala
@@ -76,7 +76,7 @@ trait KQueryExpansion extends QueryParser {
     }
 
     def addSiteQuery(baseQuery: KTextQuery, queryText: String) {
-      if (Domain.isValid(queryText)) baseQuery.addQuery(KSiteQuery(queryText), siteBoost)
+      if (Domain.isValid(queryText)) baseQuery.addQuery(new TermQuery(new Term("site", queryText)), siteBoost)
     }
 
     def isNumericTermQuery(query: Query): Boolean = query match {

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/query/KBoostQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/query/KBoostQuery.scala
@@ -7,11 +7,13 @@ import org.apache.lucene.search._
 import org.apache.lucene.util.Bits
 import scala.collection.mutable.ArrayBuffer
 
-class KBoostQuery(override val textQuery: Query, override val boosterQuery: Query, val boosterStrength: Float) extends BoostQuery {
+class KBoostQuery(override val textQuery: Query, override val boosterQuery: Query, val boosterStrength: Float) extends BoostQuery with ProjectableQuery {
 
   override def createWeight(searcher: IndexSearcher): Weight = new KBoostWeight(this, searcher)
 
   override protected val name = "KBoost"
+
+  def project(fields: Set[String]): Query = new KBoostQuery(project(textQuery, fields), boosterQuery, boosterStrength)
 
   override def recreate(rewrittenTextQuery: Query, rewrittenBoosterQuery: Query): Query = {
     new KBoostQuery(rewrittenTextQuery, rewrittenBoosterQuery, boosterStrength)

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/query/KFilterQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/query/KFilterQuery.scala
@@ -6,13 +6,15 @@ import org.apache.lucene.util.{ Bits, ToStringUtils }
 
 import scala.collection.mutable.ArrayBuffer
 
-abstract class KFilterQuery extends Query {
+abstract class KFilterQuery extends Query with ProjectableQuery {
 
   def label: String
 
   protected def label(operator: String, operand: String) = """%s:"%s"""".format(operator, operand)
 
   val subQuery: Query
+
+  def project(fields: Set[String]): Query = this
 
   override def createWeight(searcher: IndexSearcher): Weight = {
     val underlying = subQuery.createWeight(searcher)

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/query/KTextQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/query/KTextQuery.scala
@@ -13,7 +13,7 @@ object KTextQuery {
   val tieBreakerMultiplier = 0.5f
 }
 
-class KTextQuery(val label: String) extends Query with Logging {
+class KTextQuery(val label: String) extends Query with ProjectableQuery with Logging {
 
   private var subQuery: Query = new DisjunctionMaxQuery(KTextQuery.tieBreakerMultiplier)
 
@@ -39,6 +39,12 @@ class KTextQuery(val label: String) extends Query with Logging {
         disjunct.add(query)
         disjunct
     }
+  }
+
+  def project(fields: Set[String]) = {
+    val projectedQuery = this.clone().asInstanceOf[KTextQuery]
+    projectedQuery.subQuery = QueryProjector.project(subQuery, fields)
+    projectedQuery
   }
 
   override def createWeight(searcher: IndexSearcher): Weight = {

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/query/ProjectableQuery.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/query/ProjectableQuery.scala
@@ -1,0 +1,62 @@
+package com.keepit.search.engine.query
+
+import org.apache.lucene.search._
+import scala.collection.JavaConversions._
+
+trait ProjectableQuery {
+  def project(fields: Set[String]): Query
+  def project(query: Query, fields: Set[String]): Query = QueryProjector.project(query, fields)
+}
+
+object QueryProjector {
+
+  def projectTermQuery(query: TermQuery, fields: Set[String]): Query = {
+    if (query == null) null
+    else if (fields.contains(query.getTerm.field)) query
+    else null
+  }
+
+  def projectPhraseQuery(query: PhraseQuery, fields: Set[String]): Query = {
+    if (query == null) null
+    else if (query.getTerms().forall(term => fields.contains(term.field))) query
+    else null
+  }
+
+  def projectBooleanQuery(query: BooleanQuery, fields: Set[String]): Query = {
+    val projectedQuery = new BooleanQuery()
+    query.getClauses.foreach { c =>
+      val q = c.getQuery match {
+        case projectable: ProjectableQuery => projectable.project(fields)
+        case nonProjectable: Query => project(nonProjectable, fields)
+      }
+      if (q != null) projectedQuery.add(q, c.getOccur)
+    }
+    projectedQuery.setBoost(query.getBoost())
+    projectedQuery
+  }
+
+  def projectDisjunctionMaxQuery(query: DisjunctionMaxQuery, fields: Set[String]): Query = {
+    val projectedQuery = new DisjunctionMaxQuery(query.getTieBreakerMultiplier)
+    query.getDisjuncts.foreach { subq =>
+      val q = subq match {
+        case projectable: ProjectableQuery => projectable.project(fields)
+        case nonProjectable: Query => project(nonProjectable, fields)
+      }
+      if (q != null) projectedQuery.add(q)
+    }
+    projectedQuery.setBoost(query.getBoost())
+    projectedQuery
+  }
+
+  def project(query: Query, fields: Set[String]): Query = {
+    query match {
+      case null => null
+      case q: ProjectableQuery => q.project(fields) // KTextQuery, KBooleanQuery, KFilterQuery, KBoostQuery
+      case q: TermQuery => projectTermQuery(q, fields)
+      case q: PhraseQuery => projectPhraseQuery(q, fields)
+      case q: BooleanQuery => projectBooleanQuery(q, fields)
+      case q: DisjunctionMaxQuery => projectDisjunctionMaxQuery(q, fields)
+      case q => throw new Exception(s"failed to project query: ${q.toString}")
+    }
+  }
+}

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/keep/KeepIndexable.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/keep/KeepIndexable.scala
@@ -29,6 +29,8 @@ object KeepFields {
   val tagsKeywordField = "tag"
   val recordField = "rec"
 
+  val textSearchFields = Set(titleField, titleStemmedField, siteField, homePageField, tagsField, tagsStemmedField, tagsKeywordField)
+
   val decoders: Map[String, FieldDecoder] = Map.empty
 }
 

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexable.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexable.scala
@@ -17,6 +17,8 @@ object LibraryFields {
   val allUsersField = "a"
   val recordField = "rec"
 
+  val textSearchFields = Set(nameField, nameStemmedField, descriptionField, descriptionStemmedField)
+
   object Visibility {
     val SECRET = 0
     val DISCOVERABLE = 1

--- a/kifi-backend/modules/search/app/com/keepit/search/query/QueryUtil.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/query/QueryUtil.scala
@@ -5,23 +5,12 @@ import org.apache.lucene.index.AtomicReaderContext
 import org.apache.lucene.index.DocsEnum
 import org.apache.lucene.index.DocsAndPositionsEnum
 import org.apache.lucene.index.Term
-import org.apache.lucene.search.BooleanQuery
-import org.apache.lucene.search.DocIdSet
-import org.apache.lucene.search.DocIdSetIterator
+import org.apache.lucene.search._
 import org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS
-import org.apache.lucene.search.PhraseQuery
-import org.apache.lucene.search.Query
-import org.apache.lucene.search.Scorer
-import org.apache.lucene.search.TermQuery
-import org.apache.lucene.search.Weight
 import org.apache.lucene.util.Bits
 import org.apache.lucene.util.BytesRef
 import java.util.{ HashSet => JHashSet }
 import scala.collection.JavaConversions._
-import org.apache.lucene.analysis.Analyzer
-import java.io.StringReader
-import org.apache.lucene.analysis.tokenattributes.OffsetAttribute
-import scala.collection.mutable.ListBuffer
 
 object QueryUtil extends Logging {
 

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/parser/KQueryExpansionTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/parser/KQueryExpansionTest.scala
@@ -100,7 +100,7 @@ class KQueryExpansionTest extends Specification {
 
     "expand a query with site" in new QueryParserScope(concatBoostValue = 0.0f) {
       parser.parse("www.yahoo.com").get.toString ===
-        s"""KTextQuery((t:"www yahoo com"$b | c:"www yahoo com" | h:"www yahoo com" | site(site:www.yahoo.com) | ts:"www yahoo com"$b | cs:"www yahoo com" | hs:"www yahoo com")~$tb)"""
+        s"""KTextQuery((t:"www yahoo com"$b | c:"www yahoo com" | h:"www yahoo com" | site:www.yahoo.com | ts:"www yahoo com"$b | cs:"www yahoo com" | hs:"www yahoo com")~$tb)"""
     }
   }
 }

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/query/QueryProjectorTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/query/QueryProjectorTest.scala
@@ -1,0 +1,217 @@
+package com.keepit.search.engine.query
+
+import com.keepit.search.query.HomePageQuery
+import org.apache.lucene.index.Term
+import org.apache.lucene.search.BooleanClause.Occur
+import org.apache.lucene.search.{ DisjunctionMaxQuery, PhraseQuery, BooleanQuery, TermQuery }
+import org.specs2.mutable.Specification
+
+class QueryProjectorTest extends Specification {
+
+  import QueryProjector._
+
+  private[this] val t1 = new TermQuery(new Term("a", "t"))
+  private[this] val t2 = new TermQuery(new Term("b", "t"))
+  private[this] val t3 = new TermQuery(new Term("c", "t"))
+  private[this] val t4 = new TermQuery(new Term("d", "t"))
+
+  val pq = new PhraseQuery()
+  pq.add(new Term("a", "t1"), 1)
+  pq.add(new Term("a", "t2"), 3)
+  pq.setBoost(3.14f)
+
+  private[this] val b1 = new BooleanQuery()
+  b1.add(t1, Occur.MUST)
+  b1.add(t2, Occur.SHOULD)
+  b1.add(t3, Occur.MUST_NOT)
+  b1.setBoost(3.14f)
+
+  private[this] val b2 = new BooleanQuery()
+  b2.add(b1, Occur.SHOULD)
+  b2.add(t4, Occur.SHOULD)
+  b2.setBoost(2.71828f)
+
+  private[this] val d1 = new DisjunctionMaxQuery(1.5f)
+  d1.add(t1)
+  d1.add(t2)
+  d1.add(t3)
+  d1.setBoost(3.14f)
+
+  private[this] val d2 = new DisjunctionMaxQuery(2.5f)
+  d2.add(b1)
+  d2.add(t4)
+  d2.setBoost(2.71828f)
+
+  private[this] val siteQuery = new TermQuery(new Term("site", "t"))
+
+  private[this] val textQuery = new KTextQuery("t")
+  textQuery.addQuery(t1, 2.0f)
+  textQuery.addQuery(t2)
+  textQuery.addQuery(t3)
+  textQuery.addQuery(siteQuery, 0.5f)
+  textQuery.setBoost(3.14f)
+
+  private[this] val kBoolean = new KBooleanQuery()
+  kBoolean.add(b1, Occur.MUST)
+  kBoolean.add(textQuery, Occur.SHOULD)
+  kBoolean.setBoost(2.71828f)
+
+  "QueryProjectorTest" should {
+
+    "project TermQuery" in {
+      project(t1, Set("a")) === t1
+      project(t1, Set("b")) === null
+    }
+
+    "project PhraseQuery" in {
+      project(pq, Set("a")) === pq
+      project(pq, Set("b")) === null
+    }
+
+    "project BooleanQuery" in {
+      project(b1, Set("a")) === {
+        val expected = new BooleanQuery()
+        expected.add(t1, Occur.MUST)
+        expected.setBoost(3.14f)
+        expected
+      }
+      project(b1, Set("b")) === {
+        val expected = new BooleanQuery()
+        expected.add(t2, Occur.SHOULD)
+        expected.setBoost(3.14f)
+        expected
+      }
+      project(b1, Set("c")) === {
+        val expected = new BooleanQuery()
+        expected.add(t3, Occur.MUST_NOT)
+        expected.setBoost(3.14f)
+        expected
+      }
+      project(b1, Set("a", "c")) === {
+        val expected = new BooleanQuery()
+        expected.add(t1, Occur.MUST)
+        expected.add(t3, Occur.MUST_NOT)
+        expected.setBoost(3.14f)
+        expected
+      }
+      project(b1, Set("z")) === {
+        val expected = new BooleanQuery()
+        expected.setBoost(3.14f)
+        expected
+      }
+      project(b1, Set("a", "b", "c")) === {
+        b1
+      }
+      project(b2, Set("a", "c")) === {
+        val expected = new BooleanQuery()
+        expected.add(project(b1, Set("a", "c")), Occur.SHOULD)
+        expected.setBoost(2.71828f)
+        expected
+      }
+      project(b2, Set("d")) === {
+        val expected = new BooleanQuery()
+        expected.add(project(b1, Set("d")), Occur.SHOULD)
+        expected.add(t4, Occur.SHOULD)
+        expected.setBoost(2.71828f)
+        expected
+      }
+    }
+
+    "project DisjunctionMaxQuery" in {
+      project(d1, Set("a")) === {
+        val expected = new DisjunctionMaxQuery(1.5f)
+        expected.add(t1)
+        expected.setBoost(3.14f)
+        expected
+      }
+      project(d1, Set("b")) === {
+        val expected = new DisjunctionMaxQuery(1.5f)
+        expected.add(t2)
+        expected.setBoost(3.14f)
+        expected
+      }
+      project(d1, Set("c")) === {
+        val expected = new DisjunctionMaxQuery(1.5f)
+        expected.add(t3)
+        expected.setBoost(3.14f)
+        expected
+      }
+      project(d1, Set("a", "c")) === {
+        val expected = new DisjunctionMaxQuery(1.5f)
+        expected.add(t1)
+        expected.add(t3)
+        expected.setBoost(3.14f)
+        expected
+      }
+      project(d1, Set("a", "b", "c")) === {
+        d1
+      }
+      project(d2, Set("a", "c")) === {
+        val expected = new DisjunctionMaxQuery(2.5f)
+        expected.add(project(b1, Set("a", "c")))
+        expected.setBoost(2.71828f)
+        expected
+      }
+      project(d2, Set("d")) === {
+        val expected = new DisjunctionMaxQuery(2.5f)
+        expected.add(project(b1, Set("d")))
+        expected.add(t4)
+        expected.setBoost(2.71828f)
+        expected
+      }
+    }
+
+    "do nothing for KFilterQuery" in {
+      val siteQ = KSiteQuery("com")
+      project(siteQ, Set("a")) === siteQ
+
+      val mediaQ = KMediaQuery("pdf")
+      project(mediaQ, Set("a")) === mediaQ
+
+      val tagQ = KTagQuery("amazing")
+      project(tagQ, Set("a")) === tagQ
+    }
+
+    "project textQuery part and do nothing for the booster part of KBoostQuery" in {
+      val booster = new HomePageQuery(Seq(new Term("site", "kifi")))
+      val boostQ = new KBoostQuery(b1, booster, 0.9f)
+      project(boostQ, Set("a")) === {
+        new KBoostQuery(project(b1, Set("a")), booster, 0.9f)
+      }
+    }
+
+    "project KTextQuery" in {
+      project(textQuery, Set("a", "b")) === {
+        val expected = new KTextQuery("t")
+        expected.addQuery(t1, 2.0f)
+        expected.addQuery(t2)
+        expected.setBoost(3.14f)
+        expected
+      }
+      project(textQuery, Set("b", "c")) === {
+        val expected = new KTextQuery("t")
+        expected.addQuery(t2)
+        expected.addQuery(t3)
+        expected.setBoost(3.14f)
+        expected
+      }
+      project(textQuery, Set("b", "site")) === {
+        val expected = new KTextQuery("t")
+        expected.addQuery(t2)
+        expected.addQuery(siteQuery)
+        expected.setBoost(3.14f)
+        expected
+      }
+    }
+
+    "project KBooleanQuery" in {
+      project(kBoolean, Set("a", "b")) === {
+        val expected = new KBooleanQuery()
+        expected.add(project(b1, Set("a", "b")), Occur.MUST)
+        expected.add(project(textQuery, Set("a", "b")), Occur.SHOULD)
+        expected.setBoost(2.71828f)
+        expected
+      }
+    }
+  }
+}


### PR DESCRIPTION
FYI @leogrim @yingjieMiao 

Before executing a query for an index, it is trimmed down only to available fields. I hope this will improve performance of computing a Lucene's Weight tree, which is surprisingly expensive, by eliminating unnecessary probing of term statistics. This framework also allows us to customize a query by limiting to arbitrary fields (if desired).
