### PR TITLE
In not overwriting mode, do not replace inactive KeepImage

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
@@ -180,7 +180,7 @@ class KeepImageCommanderImpl @Inject() (
 
   private def runFetcherAndPersist(keepId: Id[Keep], source: KeepImageSource, overwriteExistingImage: Boolean)(fetcher: => Future[Either[KeepImageStoreFailure, ImageProcessState.ImageLoadedAndHashed]])(implicit requestId: Option[Id[KeepImageRequest]]): Future[ImageProcessDone] = {
     val existingImagesForKeep = db.readOnlyMaster { implicit session =>
-      keepImageRepo.getForKeepId(keepId)
+      keepImageRepo.getAllForKeepId(keepId)
     }
     if (existingImagesForKeep.nonEmpty && !overwriteExistingImage) {
       Future.successful(ImageProcessState.ExistingStoredImagesFound(existingImagesForKeep))


### PR DESCRIPTION
@andrewconner does this make sense?
This way that method is idempotent. This overloads the "inactive" state though, I think a cleaner solution would be to save an active dummy "no image" row in there when users explicitly don't want one. Good enough for now though?
