### PR TITLE
wire-up connectOptionView

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -371,14 +371,6 @@ class AuthController @Inject() (
   }
 
   private def doSignupPage(implicit request: MaybeUserRequest[_]): Result = {
-    def emailAddressMatchesSomeKifiUser(identity: Identity): Boolean = {
-      identity.email.flatMap { addr =>
-        db.readOnlyMaster { implicit s =>
-          emailAddressRepo.getByAddressOpt(EmailAddress(addr))
-        }
-      }.isDefined
-    }
-
     val agentOpt = request.headers.get("User-Agent").map { agent =>
       UserAgent(agent)
     }
@@ -412,7 +404,7 @@ class AuthController @Inject() (
         case request: NonUserRequest[_] =>
           if (request.identityOpt.isDefined) {
             val identity = request.identityOpt.get
-            if (emailAddressMatchesSomeKifiUser(identity)) {
+            if (authHelper.emailAddressMatchesSomeKifiUser(identity)) {
               // No user exists, but social network identity’s email address matches a Kifi user
               Ok(views.html.auth.connectToAuthenticate(
                 emailAddress = identity.email.get,


### PR DESCRIPTION
2 cases (when email matches some kifi user):
- sui cannot be found 
- sui found but no associated user 

we then present the same page the old endpoint does (`connectOptionView`)

@andrewconner please take a look. don't merge yet.
