### PR TITLE
Fix issues with mini hover cards and refactor fetch and follow/unfollow events

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
@@ -1,13 +1,9 @@
 <span>
   <a class="kf-keep-who-pic-box" ng-href="{{library.path}}">
-    <span class="kf-keep-who-pic"
-     ng-attr-style="background-image: url({{library.keeperPic}})">
-    </span>
+    <span class="kf-keep-who-pic" ng-attr-style="background-image: url({{library.keeperPic}})"></span>
     <span class="kf-keep-who-lib">{{library.name}}</span>
     <span kf-tooltip position="top" padding="10">
-      <span kf-library-mini-card
-        library-id="library.id"
-      ></span>
+      <span kf-library-mini-card library="library"></span>
     </span>
   </a>
 </span>

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/tooltip/tooltip.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/tooltip/tooltip.js
@@ -50,7 +50,7 @@ angular.module('kifi')
               setCssPos(parentPos.top - 0.5*el.outerHeight() + 0.5*container.outerHeight(), parentPos.left - el.outerWidth());
               break;
             case 'right':
-              setCssPos(parentPos.top - 0.5*el.outerHeight() + 0.5*container.outerHeight(), parentPos.left + container.outerWidth());
+              setCssPos(parentPos.top - 0.5*el.outerHeight() + 0.5*container.outerHeight(), parentPos.left + 0.5*container.outerWidth());
               break;
           }
         }

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/tooltip/tooltip.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/tooltip/tooltip.tpl.html
@@ -1,5 +1,5 @@
 <div class="kf-tooltip">
-  <div ng-show="showing()">
+  <div ng-if="showing()">
     <div class="kf-tooltip-bg"></div>
     <div class="kf-tooltip-body" ng-transclude></div>
   </div>

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -261,8 +261,6 @@ angular.module('kifi')
 
           libraryService.createLibrary(library).then(function () {
             libraryService.fetchLibrarySummaries(true).then(function () {
-              $rootScope.$emit('librarySummariesChanged');
-
               scope.$evalAsync(function () {
                 scope.librarySelection.library = _.find(scope.libraries, { 'name': library.name });
                 if (_.isFunction(scope.clickAction)) {

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
@@ -122,9 +122,7 @@ angular.module('kifi')
           keepActionService.copyToLibrary(_.pluck(selectedKeeps, 'id'), selectedLibrary.id).then(function () {
             // TODO: look at result and flag errors. Right now, even a partial error is flagged so that's
             //       not good.
-            libraryService.fetchLibrarySummaries(true).then(function () {
-              $rootScope.$emit('librarySummariesChanged');
-            });
+            libraryService.fetchLibrarySummaries(true);
           });
         }
 
@@ -140,9 +138,7 @@ angular.module('kifi')
               selectedKeep.makeUnkept();
             });
 
-            libraryService.fetchLibrarySummaries(true).then(function () {
-              $rootScope.$emit('librarySummariesChanged');
-            });
+            libraryService.fetchLibrarySummaries(true);
           });
         }
 

--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.tpl.html
@@ -120,11 +120,10 @@
                                      'other':' {} followers'}"></ng-pluralize>
               </div>
             </div>
-            <div kf-tooltip position="right" padding="3">
-              <div kf-library-mini-card library-id="library.id"></div>
-            </div>
           </a>
-
+          <div kf-tooltip position="top" padding="3">
+            <div kf-library-mini-card library="library"></div>
+          </div>
         </li>
         <li ng-repeat="library in invitedLibsToShow" class="kf-nav-lib-item" ng-class="{ active: isActive(library.url) }">
           <a class="kf-nav-link" ng-href="{{library.url}}">
@@ -137,10 +136,10 @@
               <div class="kf-nav-lib-name">{{library.secondLine}}</div>
               <div class="kf-nav-lib-text">invitation pending</div>
             </div>
-            <div kf-tooltip position="right" padding="3">
-              <div kf-library-mini-card library-id="library.id"></div>
-            </div>
           </a>
+          <div kf-tooltip position="top" padding="3">
+            <div kf-library-mini-card library="library" invite="true"></div>
+          </div>
         </li>
       </ul>
     </div>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -126,8 +126,6 @@ angular.module('kifi')
 
 
     var init = function (invalidateCache) {
-      debugger;
-
       // Request for library object also retrieves an initial set of keeps in the library.
       libraryService.getLibraryByUserSlug($scope.username, $scope.librarySlug, authToken, invalidateCache || false).then(function (library) {
         // If library information has already been prepopulated, extend the library object.

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -126,6 +126,8 @@ angular.module('kifi')
 
 
     var init = function (invalidateCache) {
+      debugger;
+
       // Request for library object also retrieves an initial set of keeps in the library.
       libraryService.getLibraryByUserSlug($scope.username, $scope.librarySlug, authToken, invalidateCache || false).then(function (library) {
         // If library information has already been prepopulated, extend the library object.

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -239,23 +239,13 @@ angular.module('kifi')
               pictureName: profileService.me.pictureName
             });
 
-            libraryService.fetchLibrarySummaries(true).then(function () {
-              $rootScope.$emit('librarySummariesChanged');
-              augmentData();
-              adjustFollowerPicsSize();
-            });
+            augmentData();
+            adjustFollowerPicsSize();
           });
         };
 
         scope.unfollowLibrary = function (library) {
-          libraryService.leaveLibrary(library.id).then(function () {
-            libraryService.fetchLibrarySummaries(true).then(function () {
-              $rootScope.$emit('librarySummariesChanged');
-
-              // Note: no need to augmentData for unfollowed library.
-              adjustFollowerPicsSize();
-            });
-          });
+          libraryService.leaveLibrary(library.id);
         };
 
         scope.manageLibrary = function () {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.tpl.html
@@ -1,6 +1,6 @@
 <div class="kf-library-mini-card">
 
-  <div ng-switch="visibility()">
+  <div ng-switch="library.visibility">
     <div ng-switch-when="published" class="kf-library-mini-card-visbility svg-public-library-icon"></div>
     <div ng-switch-when="secret" class="kf-library-mini-card-visbility svg-private-library-icon"></div>
     <div ng-switch-when="discoverable" class="kf-library-mini-card-visbility svg-yellow-card-with-globe"></div>
@@ -8,35 +8,28 @@
 
   <div class="kf-library-mini-card-header">
     <div class="kf-library-mini-card-curator">
-      <img class="kf-library-mini-card-curator-img" ng-src="{{curatorImage() || 'https://www.kifi.com/assets/img/ghost.200.png'}}">
+      <img class="kf-library-mini-card-curator-img" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}">
       <span class="kf-library-mini-card-curator-info">
         <div class="kf-library-mini-card-curator-heading">Library Curator:</div>
-        <div class="kf-library-mini-card-curator-name">{{curatorName()}}</div>
+        <div class="kf-library-mini-card-curator-name">{{library.owner.firstName}} {{library.owner.lastName}}</div>
       </span>
     </div>
   </div>
 
   <div class="kf-library-mini-card-body">
-    <div class="kf-library-mini-card-name" ng-click="view()">{{libraryName()}}</div>
+    <div class="kf-library-mini-card-name" ng-click="view()">{{library.name}}</div>
 
     <div class="kf-library-mini-card-stats-container">
       <span class="kf-library-mini-card-stat">
         <div class="kf-library-mini-card-stat-title">Keeps</div>
-        <div class="kf-library-mini-card-stat-num">{{numKeeps() || 0}}</div>
+        <div class="kf-library-mini-card-stat-num">{{library.numKeeps || 0}}</div>
       </span>
 
       <span class="kf-library-mini-card-vdivider"></span>
 
       <span class="kf-library-mini-card-stat">
         <div class="kf-library-mini-card-stat-title">Followers<div>
-        <div class="kf-library-mini-card-stat-num">{{numFollowers() || 0}}</div>
-      </span>
-
-      <span class="kf-library-mini-card-vdivider" ng-if="numNewKeeps()"></span>
-
-      <span class="kf-library-mini-card-stat" ng-if="numNewKeeps()">
-        <div class="kf-library-mini-card-stat-title">New Keeps<div>
-        <div class="kf-library-mini-card-stat-num">{{numNewKeeps()}}</div>
+        <div class="kf-library-mini-card-stat-num">{{library.numFollowers || 0}}</div>
       </span>
     </div>
   </div>
@@ -44,13 +37,13 @@
   <div class="kf-library-mini-card-hdivider"></div>
 
   <div>
-    <button ng-if="!isMine()"
-      ng-class="{'kf-library-mini-card-button-follow': !following() && !isMine(), 'kf-library-mini-card-button-unfollow': following()}"
+    <button ng-if="!library.isMine"
+      ng-class="{'kf-library-mini-card-button-follow': !following(), 'kf-library-mini-card-button-unfollow': following()}"
       class="kf-library-mini-card-button"
-      ng-click="toggleFollow()"
+      ng-click="toggleFollow($event)"
     ></button>
 
-    <button ng-if="isMine()"
+    <button ng-if="library.isMine"
       class="kf-library-mini-card-button kf-library-mini-card-button-view"
       ng-click="view()"
     >View my library</button>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -139,8 +139,9 @@ angular.module('kifi')
         if (invalidateCache) {
           userLibrarySummariesService.expire();
         }
-        return userLibrarySummariesService.get().then(function () {
+        return userLibrarySummariesService.get().then(function (response) {
           $rootScope.$emit('librarySummariesChanged');
+          return response;
         });
       },
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -89,7 +89,6 @@ angular.module('kifi')
             submitting = false;
 
             libraryService.fetchLibrarySummaries(true).then(function () {
-              $rootScope.$emit('librarySummariesChanged');
               scope.close();
 
               if (!returnAction) {

--- a/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
@@ -177,9 +177,7 @@ angular.module('kifi')
             modalData: { library : $scope.librarySelection.library, action: $scope.actionToLibrary }
           });
           // todo (aaron): call addToLibraryCount accordingly (make sure source libraries do NOT lose keep counts)
-          libraryService.fetchLibrarySummaries(true).then(function () {
-            $rootScope.$emit('librarySummariesChanged');
-          });
+          libraryService.fetchLibrarySummaries(true);
         });
       } else {
         tagActionResult = libraryService.moveKeepsFromTagToLibrary($scope.librarySelection.library.id, tagName).then(function () {
@@ -188,9 +186,7 @@ angular.module('kifi')
             modalData: { library : $scope.librarySelection.library, action: $scope.actionToLibrary }
           });
           // todo (aaron): call addToLibraryCount accordingly (make sure source libraries lose keep counts)
-          libraryService.fetchLibrarySummaries(true).then(function () {
-            $rootScope.$emit('librarySummariesChanged');
-          });
+          libraryService.fetchLibrarySummaries(true);
         });
       }
       tagActionResult['catch'](function () {


### PR DESCRIPTION
@andrewconner @stkem cc @ahsu1230 

I started working on the mini-hover card following and ended up with a medium-sized pull that fixes the following things:
(1) Address code review comments in https://github.com/kifi/keepit/pull/11753
(2) Actually fix https://app.asana.com/0/15523651812135/18585164429705 (the behavior was inconsistent due to a race condition and I couldn't reproduce earlier but now this should fix it)
(3) Refactor mini-hover-card code to not initiate network requests for individual library summaries when it's not needed (this is not needed when the hover card is in the left nav pane, but needed when the hover card is in the keep card)
(4) Hacky fix for the problem where the mini hover card has its bottom half hidden when we're hovering over a library in lower left part of the nav pane).
