### PR TITLE
fixing user value string DB storage/retrieval issue

### DIFF
--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserControllerTest.scala
@@ -56,7 +56,7 @@ class UserControllerTest extends Specification with ShoeboxTestInjector {
           user
         }
 
-        val path = com.keepit.controllers.website.routes.UserController.currentUser().toString
+        val path = routes.UserController.currentUser().url
         path === "/site/user/me"
 
         inject[FakeUserActionsHelper].setUser(user, Set(ExperimentType.ADMIN))
@@ -95,7 +95,7 @@ class UserControllerTest extends Specification with ShoeboxTestInjector {
           inject[UserExperimentRepo].save(UserExperiment(userId = user.id.get, experimentType = ExperimentType.ADMIN))
           user
         }
-        val path = com.keepit.controllers.website.routes.UserController.updateUsername().url
+        val path = routes.UserController.updateUsername().url
         path === "/site/user/me/username"
 
         inject[FakeUserActionsHelper].setUser(user, Set(ExperimentType.ADMIN))
@@ -118,8 +118,8 @@ class UserControllerTest extends Specification with ShoeboxTestInjector {
           userRepo.save(User(firstName = "George", lastName = "Washington", username = Username("GeorgeWash"), normalizedUsername = "foo"))
         }
         val userController = inject[UserController]
-        val pathName = com.keepit.controllers.website.routes.UserController.updateName().url
-        val pathDescription = com.keepit.controllers.website.routes.UserController.updateDescription().url
+        val pathName = routes.UserController.updateName().url
+        val pathDescription = routes.UserController.updateDescription().url
         pathName === "/site/user/me/name"
         pathDescription === "/site/user/me/description"
 
@@ -161,7 +161,7 @@ class UserControllerTest extends Specification with ShoeboxTestInjector {
 
         inject[FakeUserActionsHelper].setUser(user, Set(ExperimentType.ADMIN))
         val userController = inject[UserController]
-        val path = com.keepit.controllers.website.routes.UserController.savePrefs().url
+        val path = routes.UserController.savePrefs().url
 
         val inputJson1 = Json.obj(
           "library_sorting_pref" -> "name",
@@ -179,6 +179,10 @@ class UserControllerTest extends Specification with ShoeboxTestInjector {
              |}
            """.stripMargin
         ))
+
+        db.readOnlyMaster { implicit s =>
+          inject[UserValueRepo].getValueStringOpt(user.id.get, UserValueName.LIBRARY_SORTING_PREF) === Some("name")
+        }
 
         val request2 = FakeRequest("GET", path)
         val result2: Future[Result] = userController.getPrefs()(request2)
@@ -205,7 +209,7 @@ class UserControllerTest extends Specification with ShoeboxTestInjector {
         }
         val userController = inject[UserController]
         val userValueRepo = inject[UserValueRepo]
-        val path = com.keepit.controllers.website.routes.UserController.addEmail().url
+        val path = routes.UserController.addEmail().url
         path === "/site/user/me/email"
 
         val address1 = "vampireXslayer@gmail.com"


### PR DESCRIPTION
Looks like we have inconsistent use of quotes now:

```
mysql> select * from user_value where value like '"%' or name = 'library_sorting_pref';
+--------+---------+----------------------+-----------------------------------+--------+---------------------+---------------------+
| id     | user_id | name                 | value                             | state  | created_at          | updated_at          |
+--------+---------+----------------------+-----------------------------------+--------+---------------------+---------------------+
|  72931 |    4684 | user_description     | "All your bookmarks belong to me" | active | 2014-05-22 18:44:54 | 2014-05-22 18:44:54 |
| 103247 |    7100 | library_sorting_pref | last_kept                         | active | 2014-10-24 00:00:47 | 2014-10-24 02:11:34 |
| 103274 |    1757 | library_sorting_pref | "last_viewed"                     | active | 2014-10-24 03:11:37 | 2014-10-24 03:11:40 |
+--------+---------+----------------------+-----------------------------------+--------+---------------------+---------------------+
3 rows in set (0.14 sec)

```
