### PR TITLE
stop indexing main/private library names

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -131,10 +131,8 @@ object LibraryVisibility {
 sealed abstract class LibraryKind(val value: String)
 
 object LibraryKind {
-  trait SystemGenerated extends LibraryKind
-
-  case object SYSTEM_MAIN extends LibraryKind("system_main") with SystemGenerated
-  case object SYSTEM_SECRET extends LibraryKind("system_secret") with SystemGenerated
+  case object SYSTEM_MAIN extends LibraryKind("system_main")
+  case object SYSTEM_SECRET extends LibraryKind("system_secret")
   case object USER_CREATED extends LibraryKind("user_created")
 
   implicit def format[T]: Format[LibraryKind] =

--- a/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexable.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/graph/library/LibraryIndexable.scala
@@ -2,7 +2,7 @@ package com.keepit.search.graph.library
 
 import com.keepit.common.db.Id
 import com.keepit.model.view.LibraryMembershipView
-import com.keepit.model.{ LibraryVisibility, User, Library, BasicLibrary }
+import com.keepit.model._
 import com.keepit.search.index.{ DefaultAnalyzer, Indexable, FieldDecoder }
 import com.keepit.search.{ Searcher, LangDetector }
 
@@ -65,9 +65,13 @@ class LibraryIndexable(library: Library, memberships: Seq[LibraryMembershipView]
     import LibraryFields._
     val doc = super.buildDocument
 
-    val nameLang = LangDetector.detect(library.name)
-    doc.add(buildTextField(nameField, library.name, DefaultAnalyzer.getAnalyzer(nameLang)))
-    doc.add(buildTextField(nameStemmedField, library.name, DefaultAnalyzer.getAnalyzerWithStemmer(nameLang)))
+    library.kind match {
+      case LibraryKind.SYSTEM_MAIN | LibraryKind.SYSTEM_SECRET => // do not index the name of main/private libraries
+      case LibraryKind.USER_CREATED =>
+        val nameLang = LangDetector.detect(library.name)
+        doc.add(buildTextField(nameField, library.name, DefaultAnalyzer.getAnalyzer(nameLang)))
+        doc.add(buildTextField(nameStemmedField, library.name, DefaultAnalyzer.getAnalyzerWithStemmer(nameLang)))
+    }
 
     library.description.foreach { description =>
       val descriptionLang = LangDetector.detect(description)

--- a/kifi-backend/modules/search/app/com/keepit/search/index/IndexerVersion.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/IndexerVersion.scala
@@ -27,6 +27,6 @@ object IndexerVersionProviders {
   case object SearchFriend extends IndexerVersionProvider(0, 0)
   case object Message extends IndexerVersionProvider(0, 0)
   case object Phrase extends IndexerVersionProvider(0, 0)
-  case object Library extends IndexerVersionProvider(1, 1)
+  case object Library extends IndexerVersionProvider(1, 2)
   case object Keep extends IndexerVersionProvider(0, 0)
 }


### PR DESCRIPTION
@leogrim 
This stops indexing of system created library names (main and private).
They create noises. (and the name of private libraries are "Secret Library"!)
