### PR TITLE
User sign-up with different social

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -371,14 +371,6 @@ class AuthController @Inject() (
   }
 
   private def doSignupPage(implicit request: MaybeUserRequest[_]): Result = {
-    def emailAddressMatchesSomeKifiUser(identity: Identity): Boolean = {
-      identity.email.flatMap { addr =>
-        db.readOnlyMaster { implicit s =>
-          emailAddressRepo.getByAddressOpt(EmailAddress(addr))
-        }
-      }.isDefined
-    }
-
     val agentOpt = request.headers.get("User-Agent").map { agent =>
       UserAgent(agent)
     }
@@ -412,7 +404,7 @@ class AuthController @Inject() (
         case request: NonUserRequest[_] =>
           if (request.identityOpt.isDefined) {
             val identity = request.identityOpt.get
-            if (emailAddressMatchesSomeKifiUser(identity)) {
+            if (authHelper.emailAddressMatchesSomeKifiUser(identity)) {
               // No user exists, but social network identity’s email address matches a Kifi user
               Ok(views.html.auth.connectToAuthenticate(
                 emailAddress = identity.email.get,

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -27,7 +27,6 @@ POST    /auth/email-signup           @com.keepit.controllers.core.AuthController
 POST    /auth/upload-binary-image   @com.keepit.controllers.core.AuthController.uploadBinaryPicture()
 POST    /auth/upload-multipart-image @com.keepit.controllers.core.AuthController.uploadFormEncodedPicture()
 POST    /auth/cancel                @com.keepit.controllers.core.AuthController.cancelAuth()
-POST    /auth/connectOption         @com.keepit.controllers.core.AuthController.connectOption()
 
 # See common.routes for our better ProviderController routes.
 

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -27,6 +27,7 @@ POST    /auth/email-signup           @com.keepit.controllers.core.AuthController
 POST    /auth/upload-binary-image   @com.keepit.controllers.core.AuthController.uploadBinaryPicture()
 POST    /auth/upload-multipart-image @com.keepit.controllers.core.AuthController.uploadFormEncodedPicture()
 POST    /auth/cancel                @com.keepit.controllers.core.AuthController.cancelAuth()
+POST    /auth/connectOption         @com.keepit.controllers.core.AuthController.connectOption()
 
 # See common.routes for our better ProviderController routes.
 


### PR DESCRIPTION
As discussed, looks like redirecting to current signup endpoint should do the trick, as long as a secure social identity exists. It will then detect that it's a `NonUserRequest` but `identityOpt` is defined. 

Hopefully, this simplifies things. Do let me know if I have missed or misunderstood anything.

@andrewconner 
