### PR TITLE
Better type ahead behavior

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/engine/UriFromLibraryScoreVectorSource.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/UriFromLibraryScoreVectorSource.scala
@@ -188,7 +188,6 @@ class UriFromLibraryScoreVectorSource(
       protected val monitoredAwait: MonitoredAwait,
       libraryNameBoost: Float) extends ScoreVectorSourceLike {
 
-
     private[this] lazy val libIdFilter = new IdSetFilter(memberLibraryIds)
 
     override protected def preprocess(query: Query): Query = QueryProjector.project(query, LibraryFields.nameSearchFields) // trim down to name fields

--- a/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
@@ -62,11 +62,11 @@ angular.module('kifi')
       tagOrdering: route('/collections/ordering'),
       reorderTag: route('/collections/reorderTag'),
       pageTags: route('/collections/page'),
-      
+
       searchTags: function (query, limit) {
         return route('/collections/search') + '?query=' + query + '&limit=' + limit;
       },
-      
+
       suggestTags: function (libraryId, keepId, query) {
         return env.navBase + '/ext/libraries/' + libraryId + '/keeps/' + keepId + '/tags/suggest?q=' + query;
       },
@@ -86,7 +86,7 @@ angular.module('kifi')
         return env.xhrBase + '/user/' + id + '/friend';
       },
       contactSearch: function (opt_query) {
-        return route('/user/contacts/search' + (opt_query ? '?query=' + opt_query : ''));
+        return route('/user/contacts/search?query=' + (opt_query || '') + '&limit=10');
       },
       incomingFriendRequests: route('/user/incomingFriendRequests'),
       invite: route('/user/invite'),

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -226,7 +226,7 @@ angular.module('kifi')
       },
 
       getLibraryShareContacts: function (opt_query) {
-        return contactSearchService.get(opt_query);
+        return contactSearchService.get(opt_query || '');
       },
 
       shareLibrary: function (libraryId, opts) {


### PR DESCRIPTION
This tiny change actually makes it so the backend doesn't send duplicates. Also fixes an issue where two requests are made: one for `query === undefined` and one where `query === ''`
