### PR TITLE
move/unkeep number of keeps inconsistency

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
@@ -569,7 +569,7 @@ input.kf-keep-tag-input-new
 .kf-keep-tag-add-tag-wrapper
   float: left
   padding-top: 2px
-  margin-top: 3px 
+  margin-top: 3px
 
 .kf-keep-add-tag-button-new
 .kf-keep-add-tag-button-new

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
@@ -1,6 +1,6 @@
-<div class="kf-main-keeps">
+<div class="kf-main-keeps" ng-show="availableKeeps.length > 0">
   <div kf-sticky max-top="52" class="kf-keep-selection-tools" ng-if="editMode.enabled">
-    <div class="kf-keep-checkbox-icon sprite" ng-class="{ 'sprite-checkbox-icon': isUnchecked(keeps), 'sprite-checkbox-icon-partial': isMultiChecked(keeps), 'sprite-checkbox-icon-active': selection.isSelectedAll(keeps) }" ng-click="selection.toggleSelectAll(keeps)"></div>
+    <div class="kf-keep-checkbox-icon sprite" ng-class="{ 'sprite-checkbox-icon': isUnchecked(availableKeeps), 'sprite-checkbox-icon-partial': isMultiChecked(availableKeeps), 'sprite-checkbox-icon-active': selection.isSelectedAll(availableKeeps) }" ng-click="selection.toggleSelectAll(availableKeeps)"></div>
     <div class="kf-keep-selection-tools-body">
       <div class="kf-keep-selected-count">
         <span class="kf-keep-selected-count-number">{{selection.getSelected(keeps).length}}</span>


### PR DESCRIPTION
@andrewconner @yipingliao

Stories:
If you had 10 keeps, unkept 1, then selectAll. You will still see (selecting 10 keeps). Now, it should be the right number.
Also when you move keeps, the number of keeps in the library card should update & selection should be back to 0.
If you move all your keeps, you should have no keeps left, and you should automatically exit the 'Edit Keeps'
