### PR TITLE
Use keeps not my libraries

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoPics.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoPics.js
@@ -32,16 +32,11 @@ angular.module('kifi')
         scope.isMyBookmark = scope.keep && scope.keep.isMyBookmark;
         scope.librariesEnabled = libraryService.isAllowed();
 
-        function updateVisibleKeepLibraries() {
-          if (scope.librariesEnabled) {
-            scope.visibleKeepLibraries = scope.keep.libraries;
-          } else {
-            scope.visibleKeepLibraries = [];
-          }
+        if (scope.librariesEnabled) {
+          scope.visibleKeepLibraries = scope.keep.libraries;
+        } else {
+          scope.visibleKeepLibraries = [];
         }
-
-        scope.$watch('keep.myLibraries.length', updateVisibleKeepLibraries);
-        updateVisibleKeepLibraries();
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -970,7 +970,6 @@ angular.module('kifi')
                   var keep = new keepDecoratorService.Keep(fullKeep);
                   keep.buildKeep(keep);
                   keep.makeKept();
-
                   scope.$emit('keepAdded', libraryService.getSlugById(scope.librarySelection.library.id), keep);
                 });
               }

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -959,22 +959,19 @@ angular.module('kifi')
           } else {
             keepActionService.keepToLibrary([scope.keep.url], scope.librarySelection.library.id).then(function (result) {
               if ((!result.failures || !result.failures.length) && result.alreadyKept.length === 0) {
-                // TODO: check with Leo that this endpoint will be consistent after switching from search to database.
                 return keepActionService.fetchFullKeepInfo(result.keeps[0]).then(function (fullKeep) {
-                  var keep = new keepDecoratorService.Keep(fullKeep);
                   libraryService.fetchLibrarySummaries(true);
                   libraryService.addToLibraryCount(scope.librarySelection.library.id, 1);
                   tagService.addToKeepCount(1);
 
-                  var library = scope.librarySelection.library;
+                  scope.keep.keeps = fullKeep.keeps;
+                  scope.keptToLibraries = _.pluck(scope.keep.keeps, 'libraryId');
+
+                  var keep = new keepDecoratorService.Keep(fullKeep);
                   keep.buildKeep(keep);
                   keep.makeKept();
 
-                  // May not want to do this since this is actually a keep from a different library!
-                  _.assign(scope.keep, keep);
-                  scope.keptToLibraries = scope.keep.myLibraries;
-
-                  scope.$emit('keepAdded', libraryService.getSlugById(library.id), keep);
+                  scope.$emit('keepAdded', libraryService.getSlugById(scope.librarySelection.library.id), keep);
                 });
               }
             });

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -982,7 +982,7 @@ angular.module('kifi')
         // Watches and listeners.
         //
         scope.$watchCollection(function () {
-          return _.pluck(scope.keep.myLibraries, 'secret');
+          return _.pluck(scope.keep.keeps, 'visibility');
         }, updateKeepStatus);
 
         scope.$watch('keep.isMyBookmark', updateKeepStatus);

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
@@ -5,8 +5,7 @@ angular.module('kifi')
 .factory('keepDecoratorService', ['tagService', 'util', 'friendService', 'profileService',
   function (tagService, util, friendService, profileService) {
     function processLibraries(item) {
-      item.myLibraries = [];
-      if (item.libraries && item.libraries.length>0 && Array.isArray(item.libraries[0])) {
+      if (item.libraries && item.libraries.length > 0 && Array.isArray(item.libraries[0])) {
         var cleanedLibraries = [];
         var usersWithLibs = {};
         item.libraries.forEach( function (lib) {
@@ -14,8 +13,6 @@ angular.module('kifi')
           if (lib[1].id !== profileService.me.id) {
             usersWithLibs[lib[1].id] = true;
             cleanedLibraries.push(lib[0]);
-          } else {
-            item.myLibraries.push(lib[0]);
           }
         });
 

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -16,7 +16,7 @@ angular.module('kifi')
        *
        *  Optional properties on parent scope:
        *   excludeLibraries - an array of libraries to exclude from libraries when populating the widget.
-       *   keptToLibraries - an array of library objects that are already keeping the keep.
+       *   keptToLibraries - an array of library ids that are already keeping the keep.
        *   clickAction() - a function that can be called once a library is selected;
        *                   called with the element that this widget is on.
        *   libSelectTopOffset - amount to shift up relative to the element that has this directive as an attribute.

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -183,7 +183,7 @@ angular.module('kifi')
 
             libraries.forEach(function (library) {
               library.keptTo = false;
-              if (scope.keptToLibraries && _.find(scope.keptToLibraries, { 'id': library.id })) {
+              if (_.indexOf(scope.keptToLibraries, library.id) !== -1) {
                 library.keptTo = true;
               }
             });

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -174,6 +174,7 @@ angular.module('kifi')
           scope.newLibrary = {};
           newLibraryNameInput = widget.find('.keep-to-library-create-name-input');
 
+          // May remove this fetch; awaiting discussion with Josh.
           libraryService.fetchLibrarySummaries(false).then(function (data) {
             var libraries = _.filter(data.libraries, { access: 'owner' });
 


### PR DESCRIPTION
Using `keep.keeps` as indicator of which other libraries a particular keep is in. This is more accurate than the previous `keep.libraries` field (which was filtered into `keep.myLibraries` for the user's libraries) because `keeps` is pulled from the db, whereas `libraries` was pulled form search index (which may take some time to update).

Moreover, we can now unkeep from libraries other than the library being viewed because `keeps` gives us those keep ids!

@andrewconner cc @joshm1 
