### PR TITLE
Remove fetching of library summaries in library widget; let all keeps get library summaries

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -174,24 +174,18 @@ angular.module('kifi')
           scope.newLibrary = {};
           newLibraryNameInput = widget.find('.keep-to-library-create-name-input');
 
-          // May remove this fetch; awaiting discussion with Josh.
-          libraryService.fetchLibrarySummaries(false).then(function (data) {
-            var libraries = _.filter(data.libraries, { access: 'owner' });
-
-            libraries = _.filter(libraries, function (library) {
-              return !_.find(scope.excludeLibraries, { 'id': library.id });
-            });
-
-            libraries.forEach(function (library) {
-              library.keptTo = false;
-              if (_.indexOf(scope.keptToLibraries, library.id) !== -1) {
-                library.keptTo = true;
-              }
-            });
-
-            libraries[selectedIndex].selected = true;
-            scope.widgetLibraries = libraries;
+          scope.widgetLibraries = _.filter(scope.libraries, function (library) {
+            return !_.find(scope.excludeLibraries, { 'id': library.id });
           });
+
+          scope.widgetLibraries.forEach(function (library) {
+            library.keptTo = false;
+            if (_.indexOf(scope.keptToLibraries, library.id) !== -1) {
+              library.keptTo = true;
+            }
+          });
+
+          scope.widgetLibraries[selectedIndex].selected = true;
 
           // Focus on search input.
           searchInput.focus();

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
@@ -297,6 +297,7 @@ angular.module('kifi')
         var lastSizedAt = $window.innerWidth;
         scope.availableKeeps = scope.keeps;
 
+
         //
         // Internal methods.
         //
@@ -502,7 +503,7 @@ angular.module('kifi')
           if (!newVal) {
             if (scope.librariesEnabled) {
               libraryService.fetchLibrarySummaries().then(function () {
-                scope.libraries = !scope.library ? [] : _.filter(libraryService.librarySummaries, function (library) {
+                scope.libraries = _.filter(libraryService.librarySummaries, function (library) {
                   return library.access !== 'read_only';
                 });
 


### PR DESCRIPTION
This addresses:
https://app.asana.com/0/15523651812135/18673889383145

@joshm1 @andrewconner 

When @joshm1 added the fetching of library summaries in the initialization code of the library widget, the above bug is fixed. However, when that fetching is removed, I see the bug.

The problem is that the `kfKeeps` directive, a parent of the widget, was not populating `scope.libraries` when there is no `scope.library`. Detailed explanation inline.

This commit populates `scope.libraries` to fix the bug, and removes the fetching from the widget. Since this does not "fix" anything that's actually broken on the master branch, I am not going to merge this until this is actually approved.
