### PR TITLE
Clear email address on share widget show.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
@@ -44,6 +44,7 @@ angular.module('kifi')
           clearSelection();
           scope.search.name = '';
           scope.share.message = '';
+          scope.email = 'Send to any email';
           $document.on('click', onClick);
           show = true;
           shareMenu.show();


### PR DESCRIPTION
https://app.asana.com/0/search/18783354695217/18771079334797

Tiny fix to clear the share email address whenever the share widget is shown. Currently it maintains the previously typed email address.

@andrewconner 
