### PR TITLE
Less misleading subtitle

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/helprank/helprank.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/helprank/helprank.tpl.html
@@ -6,7 +6,7 @@
         <span class="sprite sprite-edit-pencil-icon"></span>
         <span class="kf-edit-keeps-label">{{editKeepsLabel()}}</span>
       </div>
-      <span class="kf-subtitle-text">{{getSubtitle()}}</span>
+      <span class="kf-subtitle-text">Your Helpful Keeps</span>
     </div>
   </div>
 <div ng-if="librariesEnabled"


### PR DESCRIPTION
The current helprank page is subtitled "Showing your latest <num> keeps" and it's a bit confusing.

Just showing "Your Helpful Keeps" for now -- will make the number of helpful keeps available and show something like "showing x out of y helpful keeps"

@andrewconner @eishay 
