### PR TITLE
fixing tag links on keep cards

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/tags/tagList.js
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tagList.js
@@ -26,7 +26,14 @@ angular.module('kifi')
         scope.shouldGiveFocus = false;
 
         scope.searchTagUrl = function (tag) {
-          return '/find?q=tag:' + encodeURIComponent(tag);
+          var tagPath;
+          var n = tag;
+          if (n.indexOf(' ') !== -1) {
+            tagPath = '"' + n + '"';
+          } else {
+            tagPath = n;
+          }
+          return '/find?q=tag:' + encodeURIComponent(tagPath);
         };
 
         scope.$watch('getSelectedKeeps', function () {


### PR DESCRIPTION
didn’t work for tags with spaces in them
@yipingliao 
