### PR TITLE
Display email address when there is no affiliated name in library share widget.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
@@ -87,6 +87,7 @@ angular.module('kifi')
         }
 
         function emphasizeMatchedPrefix (text, prefix) {
+          prefix = prefix || '';
           if (util.startsWithCaseInsensitive(text, prefix)) {
             return '<b>' + text.substr(0, prefix.length) + '</b>' + text.substr(prefix.length);
           }
@@ -130,13 +131,12 @@ angular.module('kifi')
                   result.name = (result.firstName || '') + (result.lastName ? ' ' + result.lastName : '');
                 }
 
-                if (opt_query) {
-                  if (result.name) {
-                    result.name = emphasizeMatchedNames(result.name, opt_query);
-                  }
-                  if (result.email) {
-                    result.emailFormatted = emphasizeMatchedPrefix(result.email, opt_query);
-                  }
+                if (result.name) {
+                  result.name = emphasizeMatchedNames(result.name, opt_query);
+                }
+
+                if (result.email) {
+                  result.emailFormatted = emphasizeMatchedPrefix(result.email, opt_query);
                 }
               });
 


### PR DESCRIPTION
@andrewconner Found this when I went into that share widget.

https://app.asana.com/0/17575799252940/18783354695223
