### PR TITLE
quick fix for keep to library widget

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -944,7 +944,7 @@ angular.module('kifi')
         // Scope methods.
         //
         scope.clickAction = function () {
-          if (scope.librarySelection.library.keptTo) {
+          if (scope.librarySelection.library && scope.librarySelection.library.keptTo) {
             var keepToUnkeep = _.find(scope.keep.keeps, { libraryId: scope.librarySelection.library.id });
             keepActionService.unkeepFromLibrary(scope.librarySelection.library.id, keepToUnkeep.id).then(function () {
               if (scope.librarySelection.library.id === scope.keep.libraryId) {

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -298,8 +298,23 @@ angular.module('kifi')
           library.visibility = library.visibility || 'published';
 
           libraryService.createLibrary(library).then(function () {
-            libraryService.fetchLibrarySummaries(true).then(function () {
+            libraryService.fetchLibrarySummaries(true).then(function (data) {
               scope.$evalAsync(function () {
+                var libraries = _.filter(data.libraries, { access: 'owner' });
+
+                libraries = _.filter(libraries, function (library) {
+                  return !_.find(scope.excludeLibraries, { 'id': library.id });
+                });
+
+                libraries.forEach(function (library) {
+                  library.keptTo = false;
+                  if (_.indexOf(scope.keptToLibraries, library.id) !== -1) {
+                    library.keptTo = true;
+                  }
+                });
+
+                libraries[selectedIndex].selected = true;
+                scope.widgetLibraries = libraries;
                 scope.librarySelection.library = _.find(scope.widgetLibraries, { 'name': library.name });
                 if (_.isFunction(scope.clickAction)) {
                   scope.clickAction(element);


### PR DESCRIPTION
@yipingliao @andrewconner 

There was a bug for keeping to a newly created library using the library widget (from a keep card) reported by Danny that needed to be quickly fix

The `scope.librarySelection` couldn't find the new library id and just had an error & hung.

This is a quick fix - happy to do things better in a future PR!!!!!!!!
