### PR TITLE
update state token handling

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -1,5 +1,6 @@
 package com.keepit.common.cache
 
+import com.keepit.controllers.core.StateTokenCache
 import com.keepit.model.cache.UserSessionViewExternalIdCache
 
 import scala.concurrent.duration._
@@ -320,4 +321,9 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Provides @Singleton
   def userHashtagTypeaheadCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
     new UserHashtagTypeaheadCache(stats, accessLog, (outerRepo, 7 days))
+
+  @Provides @Singleton
+  def StateTokenCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new StateTokenCache(stats, accessLog, (outerRepo, 2 hours))
+
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/OAuth2Controller.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/OAuth2Controller.scala
@@ -1,9 +1,11 @@
 package com.keepit.controllers.core
 
 import com.google.inject.Inject
+import com.keepit.common.cache._
 import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper, UserRequest }
-import com.keepit.common.logging.{ LogPrefix, Logging }
+import com.keepit.common.logging.{ AccessLog, LogPrefix, Logging }
 import java.net.{ URLDecoder, URLEncoder }
+import com.kifi.macros.json
 import play.api.mvc._
 import play.api.libs.ws.WS
 import play.api.libs.concurrent.Execution.Implicits._
@@ -19,16 +21,14 @@ import com.keepit.model.{ ABookInfo, User, OAuth2Token }
 import com.keepit.common.db.{ ExternalId, Id }
 import scala.concurrent._
 import com.keepit.common.healthcheck.AirbrakeNotifier
+import scala.concurrent.duration.Duration
 import scala.util.{ Try, Failure, Success }
 import play.api.libs.ws.WSResponse
+import Logging._
 
 case class OAuth2Config(provider: String, authUrl: String, accessTokenUrl: String, clientId: String, clientSecret: String, scope: String)
 
 case class OAuth2CommonConfig(approvalPrompt: String)
-
-object OAuth2 {
-  val STATE_TOKEN_KEY = "stateToken"
-}
 
 object OAuth2Providers { // TODO: wire-in (securesocial) config
   val GOOGLE = OAuth2Config(
@@ -85,13 +85,16 @@ case class OAuth2AccessTokenResponse(
     )
 }
 
-case class StateToken(token: String, redirectUrl: Option[String])
-object StateToken {
-  implicit val formatStateToken: Format[StateToken] = (
-    (__ \ 'token).format[String] and
-    (__ \ 'redirectUrl).formatNullable[String]
-  )(StateToken.apply, unlift(StateToken.unapply))
+@json case class StateToken(token: String, redirectUrl: Option[String])
+
+case class StateTokenKey(userId: Id[User]) extends Key[StateToken] {
+  override val version = 1
+  val namespace = "oauth2_state_token"
+  def toKey(): String = userId.id.toString
 }
+
+class StateTokenCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
+  extends JsonCacheImpl[StateTokenKey, StateToken](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
 
 object OAuth2AccessTokenResponse {
 
@@ -113,11 +116,10 @@ object OAuth2Controller {
   }
 }
 
-import Logging._
-import OAuth2._
 class OAuth2Controller @Inject() (
     db: Database,
     airbrake: AirbrakeNotifier,
+    stateTokenCache: StateTokenCache,
     abookServiceClient: ABookServiceClient,
     val userActionsHelper: UserActionsHelper,
     oauth2CommonConfig: OAuth2CommonConfig) extends UserActions with ShoeboxServiceController with Logging {
@@ -131,7 +133,7 @@ class OAuth2Controller @Inject() (
     stateTokenOpt match {
       case None =>
         log.warnP(s"state token is not provided; body=${request.body} headers=${request.headers}")
-        Redirect("/").withSession(request.session - STATE_TOKEN_KEY)
+        Redirect("/")
       case Some(stateToken) =>
         val redirectUri = routes.OAuth2Controller.callback(provider).absoluteURL(Play.isProd)
         val params = Map(
@@ -146,33 +148,35 @@ class OAuth2Controller @Inject() (
         )
         val url = authUrl + params.foldLeft("?") { (a, c) => a + c._1 + "=" + URLEncoder.encode(c._2, "UTF-8") + "&" }
         log.infoP(s"REDIRECT to: $url with params: $params")
-        Redirect(authUrl, params.map(kv => (kv._1, Seq(kv._2)))).withSession(request.session + (STATE_TOKEN_KEY -> stateToken))
+        Redirect(authUrl, params.map(kv => (kv._1, Seq(kv._2))))
     }
   }
 
   // redirect/GET
   def callback(provider: String) = UserAction.async { implicit request =>
     implicit val prefix: LogPrefix = LogPrefix(s"oauth2.callback(${request.userId},$provider)")
-    log.infoP(s"headers=${request.headers} session=${request.session}")
-    val redirectHome = Redirect(com.keepit.controllers.website.routes.HomeController.home).withSession(request.session - STATE_TOKEN_KEY)
-    val redirectInvite = Redirect("/invite").withSession(request.session - STATE_TOKEN_KEY) // todo: make configurable
+    log.infoP(s"headers=${request.headers} session=${request.session.data}")
+    val redirectHome = Redirect(com.keepit.controllers.website.routes.HomeController.home)
+    val redirectInvite = Redirect("/invite")
 
     val providerConfig = OAuth2Providers.SUPPORTED.get(provider).getOrElse(GOOGLE)
     val stateOpt = request.queryString.get("state").flatMap(_.headOption)
     val codeOpt = request.queryString.get("code").flatMap(_.headOption)
-    val stateOptFromSession = request.session.get("stateToken") orElse Some("")
-    log.infoP(s"code=$codeOpt state=$stateOpt stateFromSession=$stateOptFromSession")
 
-    val stateTokenOpt = stateOpt flatMap { tk => OAuth2Helper.getStateToken(tk) }
-    val stateTokenOptFromSession = stateOptFromSession flatMap { tk => OAuth2Helper.getStateToken(tk) }
+    implicit val dca = TransactionalCaching.Implicits.directCacheAccess
+    val cachedTokenOpt = stateTokenCache.get(StateTokenKey(request.userId))
+    log.infoP(s"code=$codeOpt state=$stateOpt cached=$cachedTokenOpt state==cached is ${stateOpt.exists(_ == cachedTokenOpt.get.token)}")
 
-    if (stateTokenOpt.isEmpty) { // todo(ray): validate stateFromSession
-      log.warnP(s"invalid state token: callback-state=$stateOpt session-stateToken=$stateOptFromSession headers=${request.headers}")
+    if (stateOpt.isEmpty || cachedTokenOpt.isEmpty) {
+      log.warnP(s"invalid state token: callback-state=$stateOpt cached=$cachedTokenOpt")
       resolve(redirectInvite)
     } else if (codeOpt.isEmpty) {
       log.warnP(s"code is empty; consent might not have been granted") // for server app
       resolve(redirectInvite)
     } else {
+      if (stateOpt.get != cachedTokenOpt.get.token) { // todo: make this a real guard
+        airbrake.notify(s"state token mismatch state=$stateOpt cached=$cachedTokenOpt")
+      }
       val redirectUri = routes.OAuth2Controller.callback(provider).absoluteURL(Play.isProd)
       val params = Map(
         "code" -> codeOpt.get,
@@ -181,7 +185,7 @@ class OAuth2Controller @Inject() (
         "redirect_uri" -> redirectUri,
         "grant_type" -> "authorization_code"
       )
-      val call = WS.url(providerConfig.accessTokenUrl).post(params.map(kv => (kv._1, Seq(kv._2)))) // POST does not need url encoding
+      val call = WS.url(providerConfig.accessTokenUrl).post(params.map(kv => (kv._1, Seq(kv._2))))
       log.infoP(s"POST to: ${providerConfig.accessTokenUrl} with params: $params")
 
       val tokenRespOptF = call.map { resp: WSResponse =>
@@ -221,17 +225,17 @@ class OAuth2Controller @Inject() (
             provider match {
               case "google" => {
                 val resF = abookServiceClient.importContacts(request.userId, tokenResp.toOAuth2Token(request.userId))
-                val redirectUrlOpt = stateTokenOpt flatMap (_.redirectUrl)
+                val redirectUrlOpt = cachedTokenOpt flatMap (_.redirectUrl)
                 resF map { trRes =>
                   trRes match {
                     case Failure(t) =>
                       airbrake.notify(s"$prefix Caught exception $t while importing contacts", t)
                       val route = com.keepit.controllers.website.routes.ContactsImportController.importContactsFailure(redirectUrlOpt)
-                      Redirect(route).withSession(request.session - STATE_TOKEN_KEY)
+                      Redirect(route)
                     case Success(abookInfo) =>
                       log.infoP(s"abook imported: $abookInfo")
                       val route = com.keepit.controllers.website.routes.ContactsImportController.importContactsSuccess(redirectUrlOpt, abookInfo.numContacts)
-                      Redirect(route).withSession(request.session - STATE_TOKEN_KEY)
+                      Redirect(route)
                   }
                 }
               }
@@ -242,7 +246,7 @@ class OAuth2Controller @Inject() (
                   friendsF.map { friendsResp =>
                     val friends = friendsResp.json
                     log.infoP("friends:\n${Json.prettyPrint(friends)}")
-                    Ok(friends).withSession(request.session - STATE_TOKEN_KEY)
+                    Ok(friends)
                   }
                 } else redirectHomeF
               }
@@ -278,7 +282,7 @@ class OAuth2Controller @Inject() (
 
   private def refreshContactsHelper(abookId: Id[ABookInfo], provider: Option[String])(implicit request: UserRequest[_]): Future[Result] = {
     implicit val prefix = LogPrefix(s"oauth2.refreshContacts($abookId,$provider)")
-    val redirectInvite = Redirect("/friends/invite/email").withSession(request.session - STATE_TOKEN_KEY)
+    val redirectInvite = Redirect("/friends/invite/email")
     log.infoP(s"userId=${request.userId}")
     val userId = request.userId
     val tokenRespOptF = abookServiceClient.getOAuth2Token(userId, abookId) flatMap { tokenOpt =>
@@ -335,10 +339,12 @@ class OAuth2Controller @Inject() (
   }
 
   def importContacts(provider: Option[String], approvalPromptOpt: Option[String], redirectUrl: Option[String] = None) = UserPage { implicit request =>
-    val stateToken = Json.toJson(StateToken(new BigInteger(130, new SecureRandom()).toString(32), redirectUrl)).toString()
-    val route = routes.OAuth2Controller.start(provider.getOrElse("google"), Some(stateToken), approvalPromptOpt)
+    val stateToken = StateToken(new BigInteger(130, new SecureRandom()).toString(32), redirectUrl)
+    implicit val dca = TransactionalCaching.Implicits.directCacheAccess
+    stateTokenCache.set(StateTokenKey(request.userId), stateToken)
+    val route = routes.OAuth2Controller.start(provider.getOrElse("google"), Some(stateToken.token), approvalPromptOpt)
     log.info(s"[importContacts(${request.userId}, $provider, $approvalPromptOpt)] redirect to $route")
-    Redirect(route).withSession(request.session - STATE_TOKEN_KEY)
+    Redirect(route)
   }
 
 }


### PR DESCRIPTION
To keep up with latest changes from Google
1. Add state token (short TTL) cache for tokens
2. Removed dependency on session state
3. Simplified token handling

Validated locally (yay dev mode!) Need to figure out a way to automate this (like social login ...)

Code can use some streamlining. Refactor PR is next.

@andrewconner 
