### PR TITLE
Correct usage of "keep.keepersTotal" in the web site code.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoText.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoText.js
@@ -39,7 +39,7 @@ angular.module('kifi')
         };
 
         scope.hasOthers = function () {
-          return keep.keepersTotal > 0;
+          return keep.others > 0;
         };
 
         scope.hasLibraries = function () {
@@ -56,7 +56,7 @@ angular.module('kifi')
         };
 
         scope.getOthersText = function () {
-          var num = keep.keepersTotal ? keep.keepersTotal : 0;
+          var num = keep.others ? keep.others : 0;
           var text = (num === 1) ? '1 other' : num + ' others';
           if (scope.useDeprecated && (scope.hasKeepers() || keep.isMyBookmark)) {
             return 'and ' + text;

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
@@ -86,6 +86,7 @@ angular.module('kifi')
         this[shouldShowSmallImage(this.summary) ? 'hasSmallImage' : 'hasBigImage'] = true;
       }
       this.readTime = getKeepReadTime(this.summary);
+      this.others = this.keepersTotal - this.keepers.length - this.keepersOmitted;
       this.showSocial = this.keepersTotal || (this.keepers && this.keepers.length > 0) || (this.libraries && this.libraries.length > 0);
     }
 

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
@@ -78,6 +78,16 @@ angular.module('kifi')
         }
       }
 
+      function initializeOthersCount(numTotalKeepers, numFriendKeepers, numOmittedFriendKeepers, numKeptInUserLibraries) {
+        // "others" is the number of Kifi users who kept a keep besides the user and the user's Kifi friends.
+        var others = numTotalKeepers  - numFriendKeepers - numOmittedFriendKeepers;
+        if (numKeptInUserLibraries > 0) {
+          others--;
+        }
+
+        return others;
+      }
+
       // Add new properties to the keep.
       this.titleAttr = this.title || this.url;
       this.titleHtml = this.title || util.formatTitleFromUrl(this.url);
@@ -86,12 +96,7 @@ angular.module('kifi')
       }
       this.readTime = getKeepReadTime(this.summary);
       this.showSocial = this.keepersTotal || (this.keepers && this.keepers.length > 0) || (this.libraries && this.libraries.length > 0);
-
-      // "others" is the number of Kifi users who kept a keep besides the user and the user's Kifi friends.
-      this.others = this.keepersTotal - this.keepers.length - this.keepersOmitted;
-      if (this.keeps.length) {
-        this.others--;
-      }
+      this.others = initializeOthersCount(this.keepersTotal, this.keepers.length, this.keepersOmitted, this.keeps.length);
     }
 
     // Add properties that are specific to a really kept Keep.

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
@@ -23,7 +23,6 @@ angular.module('kifi')
         });
 
         item.libraries = cleanedLibraries;
-        item.keepers = [];
       }
     }
 
@@ -86,8 +85,13 @@ angular.module('kifi')
         this[shouldShowSmallImage(this.summary) ? 'hasSmallImage' : 'hasBigImage'] = true;
       }
       this.readTime = getKeepReadTime(this.summary);
-      this.others = this.keepersTotal - this.keepers.length - this.keepersOmitted;
       this.showSocial = this.keepersTotal || (this.keepers && this.keepers.length > 0) || (this.libraries && this.libraries.length > 0);
+
+      // "others" is the number of Kifi users who kept a keep besides the user and the user's Kifi friends.
+      this.others = this.keepersTotal - this.keepers.length - this.keepersOmitted;
+      if (this.keeps.length) {
+        this.others--;
+      }
     }
 
     // Add properties that are specific to a really kept Keep.

--- a/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
@@ -17,7 +17,7 @@ angular.module('kifi')
       _.extend(hit, hit.bookmark); //still need this??
 
       hit.isPrivate = hit.secret || false;
-      hit.others = hit.keepersTotal - hit.keepers.length;
+      hit.others = hit.keepersTotal - hit.keepers.length - hit.keepersOmitted;
       hit.isProtected = !hit.isMyBookmark; // will not be hidden if user keeps then unkeeps
     }
 
@@ -36,8 +36,6 @@ angular.module('kifi')
       hit.keepers = hit.keepers || [];
       hit.libraries = hit.libraries || [];
 
-
-
       for (var i=0; i<hit.libraries.length; i=i+2) {
         var idxLib = hit.libraries[i];
         var idxUser = hit.libraries[i+1];
@@ -55,7 +53,6 @@ angular.module('kifi')
             decompressedLibraries.push(lib);
           }
           myLibraries.push(lib);
-
         }
       }
 

--- a/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
@@ -17,8 +17,13 @@ angular.module('kifi')
       _.extend(hit, hit.bookmark); //still need this??
 
       hit.isPrivate = hit.secret || false;
-      hit.others = hit.keepersTotal - hit.keepers.length - hit.keepersOmitted;
       hit.isProtected = !hit.isMyBookmark; // will not be hidden if user keeps then unkeeps
+
+      // "others" is the number of Kifi users who kept a keep besides the user and the user's Kifi friends.
+      hit.others = hit.keepersTotal - hit.keepers.length - hit.keepersOmitted;
+      if (hit.keeps.length) {
+        hit.others--;
+      }
     }
 
     function copy(obj) {

--- a/kifi-backend/modules/shoebox/angular/test/unit/tags/hashtagService.spec.js
+++ b/kifi-backend/modules/shoebox/angular/test/unit/tags/hashtagService.spec.js
@@ -14,7 +14,8 @@ describe('kifi.hashtagService', function () {
       'libraryId': libraryId,
       'id': keepId,
       'url': 'https://www.kifi.com',
-      'hashtags': hashtags
+      'hashtags': hashtags,
+      'keepers': []
     });
     keep.buildKeep(keep);
     keep.makeKept();


### PR DESCRIPTION
@joshm1 Thanks for pointing this out. I'd like to also get a little help in reviewing this code in action to make sure that it works as expected.
https://app.asana.com/0/17575799252940/18870880724767

For reference, also see the commit that replaced "keep.others" with "keepersTotal" last week:
https://github.com/kifi/keepit/commit/266a885a1048ff75d31efdeacea9ab89fbaf71a1#diff-a08839942899da9f448d8d67c39afe47
