### PR TITLE
when keeping to main vs. private library, keep count of src library is o...

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -202,8 +202,12 @@ class KeepInterner @Inject() (
     val (isNewKeep, wasInactiveKeep, internedKeep) = currentBookmarkOpt match {
       case Some(bookmark) =>
         val wasInactiveKeep = !bookmark.isActive
-        if (bookmark.isActive && bookmark.inDisjointLib) // invalidate if keep URI is active in a system library
+        if (bookmark.isActive && bookmark.inDisjointLib && bookmark.libraryId.get != library.id.get) {
+          // invalidate if keep URI is active in a system library
           countByLibraryCache.remove(CountByLibraryKey(bookmark.libraryId.get))
+          countByLibraryCache.remove(CountByLibraryKey(library.id.get))
+        }
+
         val savedKeep = bookmark.copy(
           title = title orElse bookmark.title orElse uri.title,
           state = KeepStates.ACTIVE,

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -31,6 +31,7 @@ class KeepInterner @Inject() (
   scraper: ScrapeScheduler,
   keepRepo: KeepRepo,
   libraryRepo: LibraryRepo,
+  countByLibraryCache: CountByLibraryCache,
   keepToCollectionRepo: KeepToCollectionRepo,
   collectionRepo: CollectionRepo,
   urlRepo: URLRepo,
@@ -201,6 +202,8 @@ class KeepInterner @Inject() (
     val (isNewKeep, wasInactiveKeep, internedKeep) = currentBookmarkOpt match {
       case Some(bookmark) =>
         val wasInactiveKeep = !bookmark.isActive
+        if (bookmark.isActive && bookmark.inDisjointLib) // invalidate if keep URI is active in a system library
+          countByLibraryCache.remove(CountByLibraryKey(bookmark.libraryId.get))
         val savedKeep = bookmark.copy(
           title = title orElse bookmark.title orElse uri.title,
           state = KeepStates.ACTIVE,


### PR DESCRIPTION
...ff (caching issue)

If Main Library had 5 keeps and Private Library had 8 keeps...
Let's say I kept a keep in Main Library (now has 6 keeps)
Then I kept the same uri in Private Library
The count of main library should be back to 5, while Private Library has 9
Even after refresh, the destination library count does go up, but the source library does not decrement & will only go back to it's correct number when you do an operation that will change the count cache.

@andrewconner @2is10 
