### PR TITLE
remove obsolete tsearch, scale search count

### DIFF
--- a/kifi-backend/modules/shoebox/app/views/admin/engineeringDashboard.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/engineeringDashboard.scala.html
@@ -64,7 +64,7 @@
 
   // Search Chart
 
-  var searchTargets = baseTargets.concat('alias(summarize(stats.counters.search.extSearch.total.count,"1h"),"Searches per Hour")').concat(['alias(secondYAxis(stats.timers.search.routes.search.get.mean_99),"99% Mean Time (ms) S")', 'alias(secondYAxis(stats.timers.shoebox.routes.tsearch.get.mean_99),"99% Mean Time (ms) T")']);
+  var searchTargets = baseTargets.concat('alias(summarize(scale(stats.counters.search.extSearch.total.count, 10),"1h"),"Searches per Hour")').concat(['alias(secondYAxis(stats.timers.search.routes.search.get.mean_99),"99% Mean Time (ms) S")');
   options.target = searchTargets;
   options.title = "Searches per Hour vs 99% Mean Time in Milliseconds";
   options.yMinRight = 0;


### PR DESCRIPTION
- no need to ask graphite to render tsearch time
- search counter is incremented with the sampling rate of one tenth, so scale counts by 10x
