### PR TITLE
bugs with share library search & keep to library from keep card

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -958,9 +958,9 @@ angular.module('kifi')
             });
           } else {
             var keepInfo = { title: scope.keep.title, url: scope.keep.url };
-            keepActionService.keepToLibrary([keepInfo], scope.librarySelection.library.id).then(function (result) {
-              if ((!result.failures || !result.failures.length) && result.alreadyKept.length === 0) {
-                return keepActionService.fetchFullKeepInfo(result.keeps[0]).then(function (fullKeep) {
+            keepActionService.copyToLibrary([scope.keep.id], scope.librarySelection.library.id).then(function (result) {
+              if (result.successes > 0) {
+                return keepActionService.fetchFullKeepInfo(scope.keep).then(function (fullKeep) {
                   libraryService.fetchLibrarySummaries(true);
                   libraryService.addToLibraryCount(scope.librarySelection.library.id, 1);
                   tagService.addToKeepCount(1);

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -957,7 +957,6 @@ angular.module('kifi')
               libraryService.addToLibraryCount(scope.librarySelection.library.id, -1);
             });
           } else {
-            var keepInfo = { title: scope.keep.title, url: scope.keep.url };
             keepActionService.copyToLibrary([scope.keep.id], scope.librarySelection.library.id).then(function (result) {
               if (result.successes > 0) {
                 return keepActionService.fetchFullKeepInfo(scope.keep).then(function (fullKeep) {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
@@ -129,7 +129,7 @@ angular.module('kifi')
                 if (result.id) {
                   result.image = friendService.getPictureUrlForUser(result);
                   result.isInvited = !!result.lastInvitedAt;
-                  result.isFollowing = !!result.membership & !result.isInvited;
+                  result.isFollowing = !!result.membership && !result.isInvited;
                   result.name = (result.firstName || '') + (result.lastName ? ' ' + result.lastName : '');
                 }
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
@@ -128,7 +128,8 @@ angular.module('kifi')
               newResults.forEach(function (result) {
                 if (result.id) {
                   result.image = friendService.getPictureUrlForUser(result);
-                  result.isFollowing = !!result.membership;
+                  result.isInvited = !!result.lastInvitedAt;
+                  result.isFollowing = !!result.membership & !result.isInvited;
                   result.name = (result.firstName || '') + (result.lastName ? ' ' + result.lastName : '');
                 }
 


### PR DESCRIPTION
@andrewconner @yipingliao 

Share Library Search showed users who were invited (but not accepted) as Following
Keep to Library (from Keep Card) now persists tags - uses copyKEeps instead of addKeeps
