### PR TITLE
Position keep-to-library widget so that it's always visible.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/addKeep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/addKeep.js
@@ -146,7 +146,8 @@ angular.module('kifi')
           });
           scope.librarySelection = {};
           scope.librarySelection.library = _.find(scope.libraries, { 'kind': 'system_main' });
-          scope.libSelectTopOffset = 110;
+          scope.libSelectDownOffset = 0;
+          scope.libSelectMaxUpOffset = 110;
         }
 
         scope.resetAndHide = function () {

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -922,6 +922,9 @@ angular.module('kifi')
         //
         scope.librarySelection = {};
         scope.keptToLibraries = [];
+        scope.libSelectDownOffset = 100;
+        scope.libSelectMaxUpOffset = 500;
+        scope.libSelectLeftOffset = 190;
 
 
         //
@@ -984,7 +987,7 @@ angular.module('kifi')
                 }
               });
             } else {
-              // used for keeping recommendations
+              // When there is no id on the keep object (e.g., recommendations), use the keep's url instead.
               var keepInfo = { title: scope.keep.title, url: scope.keep.url };
               keepToLibrary = keepActionService.keepToLibrary([keepInfo], scope.librarySelection.library.id).then(function (result) {
                 if ((!result.failures || !result.failures.length) && result.alreadyKept.length === 0) {

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
@@ -26,7 +26,8 @@ angular.module('kifi')
           return lib.access !== 'read_only';
         });
         $scope.librarySelection = {};
-        $scope.libSelectTopOffset = 220;
+        $scope.libSelectDownOffset = 0;
+        $scope.libSelectMaxUpOffset = 220;
       });
     }
 

--- a/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
@@ -79,7 +79,8 @@ angular.module('kifi')
           });
           $scope.librarySelection = {};
           $scope.librarySelection.library = _.find($scope.libraries, { 'kind': 'system_main' });
-          $scope.libSelectTopOffset = false;  // This overrides the scope.libSelectTopOffset set by MainCtrl.js
+          $scope.libSelectDownOffset = 100;
+          $scope.libSelectMaxUpOffset = 200;
         });
       }
     });
@@ -162,8 +163,13 @@ angular.module('kifi')
     $scope.actionToLibrary = '';
 
     $scope.changeSelection = function (tag, action) {
+      tag.selected = true;
       $scope.selectedTag = tag;
       $scope.actionToLibrary = action;
+    };
+
+    $scope.exitAction = function () {
+      $scope.selectedTag.selected = false;
     };
 
     // click action when selecting a library from widget

--- a/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.styl
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.styl
@@ -14,7 +14,7 @@
   padding: 18px 32px 20px 32px
 
 .manage-tag-container
-  background-color: #ffffff
+  background-color: #fff
   box-shadow: defaultBoxShadow
   border: defaultBorder
   border-radius: 3px
@@ -42,7 +42,7 @@
   box-sizing: border-box
   border: 1px solid #e6e6e6
   border-radius: 4px
-  background: #eeeeee
+  background: #eee
   font-weight: 200
   cursor: text
   transition: all .16s
@@ -97,7 +97,7 @@
   width: 85px
   border: 1px solid #c1c1c1
   border-radius: 4px
-  background-color: #ffffff
+  background-color: #fff
   border-color: #c1c1c1
   font-weight: 200
   font-size: 12px
@@ -106,8 +106,8 @@
   cursor: pointer
 
   &.on
-    background-color: #333333
-    border-color: #333333
+    background-color: #333
+    border-color: #333
 
 
 ////// ROWS OF TAGS //////
@@ -126,8 +126,11 @@
   display: inline-block
   width: 50%
 
-.manage-tag-row-name-section a
-  color: #333333
+.manage-tag-row-name
+  color: #333
+
+  &.selected-tag
+    background-color: #eee
 
 .manage-tag-row-name
   float: left
@@ -144,8 +147,8 @@
   cursor: pointer
 
 .manage-tag-row-name:hover
-  background-color: #eeeeee
-  border-color: #333333
+  background-color: #eee
+  border-color: #333
 
 .manage-tag-row-num-keeps-section
   position: relative

--- a/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.tpl.html
@@ -24,7 +24,7 @@
           <ul class="manage-tag-list">
             <li class="manage-tag-row" ng-repeat="tag in tagsToShow">
               <div class="manage-tag-row-name-section">
-                <a class="manage-tag-row-name" title="{{tag.name}}" ng-href="{{tag.href}}">{{tag.name}}</a>
+                <a class="manage-tag-row-name" title="{{tag.name}}" ng-href="{{tag.href}}" ng-class="{'selected-tag': tag.selected}">{{tag.name}}</a>
               </div>
               <span class="manage-tag-row-num-keeps-section">
                 <ng-pluralize count="tag.keeps | number:0"


### PR DESCRIPTION
@andrewconner Merge conflicts resolved version. Please feel free to comment on the original pull and I'll address them post-merge.

Also, add more customizable up/down offsets.
Highlight tag when a widget is open for that tag.
https://app.asana.com/0/18079737520750/18785877576576
