### PR TITLE
In library widget, use the libraryService.librariesSummaries instead of ...

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -228,24 +228,21 @@ angular.module('kifi')
           scope.newLibrary = {};
           newLibraryNameInput = widget.find('.keep-to-library-create-name-input');
 
-          // May remove this fetch; awaiting discussion with Josh.
-          libraryService.fetchLibrarySummaries(false).then(function (data) {
-            var libraries = _.filter(data.libraries, { access: 'owner' });
+          var libraries = _.filter(libraryService.librarySummaries, { access: 'owner' });
 
-            libraries = _.filter(libraries, function (library) {
-              return !_.find(scope.excludeLibraries, { 'id': library.id });
-            });
-
-            libraries.forEach(function (library) {
-              library.keptTo = false;
-              if (_.indexOf(scope.keptToLibraries, library.id) !== -1) {
-                library.keptTo = true;
-              }
-            });
-
-            libraries[selectedIndex].selected = true;
-            scope.widgetLibraries = libraries;
+          libraries = _.filter(libraries, function (library) {
+            return !_.find(scope.excludeLibraries, { 'id': library.id });
           });
+
+          libraries.forEach(function (library) {
+            library.keptTo = false;
+            if (_.indexOf(scope.keptToLibraries, library.id) !== -1) {
+              library.keptTo = true;
+            }
+          });
+
+          libraries[selectedIndex].selected = true;
+          scope.widgetLibraries = libraries;
         };
 
         scope.onHover = function (library) {


### PR DESCRIPTION
...fetching the libraries.

Continuing to fix:
https://app.asana.com/0/18079737520750/18785877576576

The problem is that the widget is not positioned correctly if we end up fetching the libraries from the network, since while we wait for network data the height of the widget is not accurate (it has no libraries).

Updating to not fetch from network, but use the stored state in libraryService. Also saves us network calls.

@andrewconner @joshm1 
