### PR TITLE
During a search session, replace the URL instead of pushing a new one in the history

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/layout/header/HeaderCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/header/HeaderCtrl.js
@@ -98,7 +98,7 @@ angular.module('kifi')
               $location.url('/find?q=' + $scope.search.text + '&f=' + 'm');
             }
           } else {
-            $location.search('q', $scope.search.text); // this keeps any existing URL params
+            $location.search('q', $scope.search.text).replace(); // this keeps any existing URL params
           }
         });
       }


### PR DESCRIPTION
Thanks @ymatsuda for the bug report. This fixes the history issue where searching would create many browser history entries.
