### PR TITLE
caching keep images

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -326,4 +326,8 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   def StateTokenCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new StateTokenCache(stats, accessLog, (outerRepo, 2 hours))
 
+  @Provides @Singleton
+  def keepImageCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new KeepImageCache(stats, accessLog, (outerRepo, 30 days))
+
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepImage.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepImage.scala
@@ -1,9 +1,13 @@
 package com.keepit.model
 
+import com.keepit.common.cache.{JsonCacheImpl, FortyTwoCachePlugin, CacheStatistics, Key}
 import com.keepit.common.db.{ States, State, Model, Id }
+import com.keepit.common.logging.AccessLog
 import com.keepit.common.store.ImageSize
 import com.keepit.common.time._
 import org.joda.time.DateTime
+
+import scala.concurrent.duration.Duration
 
 case class KeepImage(
     id: Option[Id[KeepImage]] = None,
@@ -45,3 +49,12 @@ object KeepImageSource {
 
 }
 case class ImageHash(hash: String)
+
+case class KeepImageKey(id: Id[Keep]) extends Key[Seq[KeepImage]] {
+  override val version = 0
+  val namespace = "keep_image"
+  def toKey(): String = id.toString
+}
+
+class KeepImageCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
+  extends JsonCacheImpl[KeepImageKey, Seq[KeepImage]](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)


### PR DESCRIPTION
There are two repo functions (getForKeepId & getAllForKeepId)
- getForKeepId only checks for active states
- getAllForKeepId checks for any state <- I put the cache here because retrieving images for `getBestImageForKeep()` uses only this repo function. If there are no active keep images for whatever reason, I believe `autoSetKeepImage` will persist a new image.

What do you think? @andrewconner 
