### PR TITLE
Limiting init as well

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -24,7 +24,7 @@ angular.module('kifi')
     $scope.keeps = [];
     $scope.library = {};
     $scope.scrollDistance = '100%';
-    $scope.loading = true;
+    $scope.loading = false;
     $scope.hasMore = true;
     $scope.page = null; // This is used to decide which page to show (library, permission denied, login)
     $scope.passphrase = $scope.passphrase || {};
@@ -136,6 +136,11 @@ angular.module('kifi')
 
 
     var init = function (invalidateCache) {
+      if ($scope.loading) {
+        return;
+      }
+      $scope.loading = true;
+
       // Request for library object also retrieves an initial set of keeps in the library.
       libraryService.getLibraryByUserSlug($scope.username, $scope.librarySlug, authToken, invalidateCache || false).then(function (library) {
         // If library information has already been prepopulated, extend the library object.


### PR DESCRIPTION
`init` in `LibraryCtrl` didn't respect `$scope.loading`, so _if_ you somehow had it called twice before it returned for the first time, it could double load. @yipingliao 
