### PR TITLE
CollectionHelpers (rename)

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/abook/commanders/ABookRecommendationCommander.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/commanders/ABookRecommendationCommander.scala
@@ -14,7 +14,7 @@ import SocialNetworks.{ FACEBOOK, LINKEDIN, EMAIL }
 import com.keepit.common.mail.EmailAddress
 import com.keepit.common.time._
 import scala.inline
-import com.keepit.common.Collection
+import com.keepit.common.CollectionHelpers
 import com.keepit.common.logging.Logging
 import java.text.Normalizer
 
@@ -175,7 +175,7 @@ class ABookRecommendationCommander @Inject() (
       emailInviteRecommendations <- futureEmailInviteRecommendations
     } yield {
       // Relying on aggregateBy stability, breaks ties by picking Facebook over LinkedIn, and LinkedIn over Email
-      Collection.interleaveBy(facebookInviteRecommendations, linkedInInviteRecommendations, emailInviteRecommendations)(_.score)
+      CollectionHelpers.interleaveBy(facebookInviteRecommendations, linkedInInviteRecommendations, emailInviteRecommendations)(_.score)
     }
   }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/CollectionHelpers.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/CollectionHelpers.scala
@@ -2,7 +2,7 @@ package com.keepit.common
 
 import com.keepit.common.core._
 
-object Collection {
+object CollectionHelpers {
   def interleaveBy[R, T](priorityStreams: Stream[R]*)(f: R => T)(implicit ord: Ordering[T]): Stream[R] = {
     priorityStreams.foldLeft(Stream.empty[R]) { case (aggregatedStream, nextStream) => interleaveBy(aggregatedStream, nextStream)(f) }
   }

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/AttributionHelper.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/AttributionHelper.scala
@@ -6,7 +6,7 @@ import com.keepit.cortex.CortexServiceClient
 import com.keepit.curator.model._
 import com.keepit.search.{ SearchServiceClient }
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import com.keepit.common.Collection
+import com.keepit.common.CollectionHelpers
 
 import scala.concurrent.Future
 import com.keepit.search.augmentation.{ LimitedAugmentationInfo, AugmentableItem }
@@ -100,7 +100,7 @@ class SeedAttributionHelper @Inject() (
 
   def toUserAttribution(info: LimitedAugmentationInfo): UserAttribution = {
     val others = info.keepersTotal - info.keepers.size - info.keepersOmitted
-    val userToLib = Collection.dedupBy(info.libraries)(_._2).map(_.swap).toMap // a user could have kept this page in several libraries, retain the first (most relevant) one.
+    val userToLib = CollectionHelpers.dedupBy(info.libraries)(_._2).map(_.swap).toMap // a user could have kept this page in several libraries, retain the first (most relevant) one.
     UserAttribution(info.keepers, others, Some(userToLib))
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/augmentation/AugmentedItem.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/augmentation/AugmentedItem.scala
@@ -5,7 +5,7 @@ import com.keepit.model.{ NormalizedURI, Library, User }
 import com.keepit.search.{ Searcher }
 import com.keepit.search.graph.library.LibraryIndexable
 import scala.collection.mutable.{ ListBuffer }
-import com.keepit.common.Collection
+import com.keepit.common.CollectionHelpers
 
 class AugmentedItem(userId: Id[User], allFriends: Set[Id[User]], allLibraries: Set[Id[Library]], scores: AugmentationScores)(item: AugmentableItem, info: FullAugmentationInfo) {
   def uri: Id[NormalizedURI] = item.uri
@@ -27,7 +27,7 @@ class AugmentedItem(userId: Id[User], allFriends: Set[Id[User]], allLibraries: S
 
   // Keepers
 
-  lazy val keepers = Collection.dedupBy(keeps.flatMap(_.keptBy))(identity)
+  lazy val keepers = CollectionHelpers.dedupBy(keeps.flatMap(_.keptBy))(identity)
 
   lazy val (relatedKeepers, otherKeepers) = keepers.partition(keeperId => allFriends.contains(keeperId) || userId == keeperId)
 
@@ -38,7 +38,7 @@ class AugmentedItem(userId: Id[User], allFriends: Set[Id[User]], allLibraries: S
   private lazy val myTags = myKeeps.flatMap(_.tags.toSeq.sortBy(-scores.byTag(_)))
   private lazy val moreTags = moreKeeps.flatMap(_.tags.toSeq.sortBy(-scores.byTag(_))).toSeq
 
-  def tags = Collection.dedupBy(myTags ++ primaryTags.filterNot(_.isSensitive) ++ moreTags.filterNot(_.isSensitive))(_.normalized)
+  def tags = CollectionHelpers.dedupBy(myTags ++ primaryTags.filterNot(_.isSensitive) ++ moreTags.filterNot(_.isSensitive))(_.normalized)
 
   def toLimitedAugmentationInfo(maxKeepersShown: Int, maxLibrariesShown: Int, maxTagsShown: Int) = {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
@@ -21,7 +21,7 @@ import com.keepit.typeahead.{ KifiUserTypeahead, SocialUserTypeahead }
 import com.kifi.macros.json
 import org.joda.time.DateTime
 import play.api.libs.concurrent.Execution.Implicits._
-import com.keepit.common.Collection.dedupBy
+import com.keepit.common.CollectionHelpers.dedupBy
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future


### PR DESCRIPTION
Thanks @leogrim for collecting some helper functions into `Collection`. 

I was looking for `dedupBy` and Idea got confused with `Collection` -- renaming to align with `FutureHelpers` and maybe help save a few seconds here and there.

@leogrim 
