### PR TITLE
Use result.session in UserPage

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
@@ -247,7 +247,7 @@ trait UserActions extends Logging { self: Controller =>
           val nRes = Redirect("/login")
           // Less than ideal, but we can't currently test this:
           Play.maybeApplication match {
-            case Some(_) => nRes.withSession(request.session + ("original-url" -> request.uri))
+            case Some(_) => nRes.withSession(result.session + ("original-url" -> request.uri))
             case None => nRes
           }
         case result =>


### PR DESCRIPTION
Small change. To be consistent and to prevent any loss of session state that might be added for non-users (e.g. kcid)

@andrewconner 
