### PR TITLE
trying to avoid org.apache.lucene.store.AlreadyClosedException

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/index/Indexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/Indexer.scala
@@ -175,7 +175,7 @@ abstract class Indexer[T, S, I <: Indexer[T, S, I]](
   }
 
   def close(): Unit = {
-    indexWriter.close()
+    indexWriterLock.synchronized { indexWriter.close() }
   }
 
   def getIndexerFor(id: Long): Indexer[T, S, I] = this


### PR DESCRIPTION
An indexer sometimes throws AlreadyClosedException (trying to write to an already closed IndexWriter) when a search instance is shutting down. There is no real harm, but airbrake messages are annoying. So, when shutting down, isClosing flag is turned and stops indexing in indexing actors.

@leogrim @yingjieMiao @eishay
