### PR TITLE
optimize library pages (a little bit) -> save counting on libraryMembers...

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
@@ -58,4 +58,6 @@ object LibraryAccess {
       case OWNER.value => OWNER
     }
   }
+
+  def getAll() = Seq(OWNER, READ_WRITE, READ_INSERT, READ_ONLY)
 }

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
@@ -371,7 +371,7 @@ angular.module('kifi')
 
             if (scope.availableKeeps.length < 10) {
               scope.scrollNext()(scope.availableKeeps.length).then(function () {
-                scope.availableKeeps = _.filter(scope.keeps, function(k) { return k.unkept === false; });
+                scope.availableKeeps = _.reject(scope.keeps, function(k) { return k.unkept; });
               });
             }
           })['catch'](function () {
@@ -493,7 +493,7 @@ angular.module('kifi')
 
             if (scope.availableKeeps.length < 10) {
               scope.scrollNext()(scope.availableKeeps.length).then(function () {
-                scope.availableKeeps = _.filter(scope.keeps, function(k) { return k.unkept === false; });
+                scope.availableKeeps = _.reject(scope.keeps, function(k) { return k.unkept; });
               });
             }
           });

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -180,7 +180,7 @@ class LibraryCommander @Inject() (
         libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, viewerUserId).isDefined) {
         val owner = basicUserRepo.load(library.ownerId)
         val keepCount = keepRepo.getCountByLibrary(library.id.get)
-        val followerCount = libraryMembershipRepo.countWithLibraryIdAndAccess(library.id.get, Set(LibraryAccess.READ_ONLY))
+        val followerCount = libraryMembershipRepo.countWithLibraryIdByAccess(library.id.get).apply(LibraryAccess.READ_ONLY)
         Right(library, owner, keepCount, followerCount)
       } else {
         Left(403, "library_access_denied")
@@ -194,20 +194,21 @@ class LibraryCommander @Inject() (
       library.id.get -> keepsCommanderProvider.get.decorateKeepsIntoKeepInfos(viewerUserIdOpt, keeps)
     }.toMap
 
-    val followerIdsByLibraryId = libraries.map { library =>
-      val (collaborators, followers, _) = getLibraryMembers(library.id.get, 0, maxMembersShown, fillInWithInvites = false)
-      library.id.get -> (collaborators ++ followers).map(_.userId)
+    val followerInfosByLibraryId = libraries.map { library =>
+      val (collaborators, followers, _, counts) = getLibraryMembers(library.id.get, 0, maxMembersShown, fillInWithInvites = false)
+      library.id.get -> ((collaborators ++ followers).map(_.userId), counts)
     }.toMap
 
     val usersById = {
-      val allUsersShown = libraries.flatMap { library => followerIdsByLibraryId(library.id.get) :+ library.ownerId }.toSet
+      val allUsersShown = libraries.flatMap { library => followerInfosByLibraryId(library.id.get)._1 :+ library.ownerId }.toSet
       db.readOnlyReplica { implicit s => basicUserRepo.loadAll(allUsersShown) }
     }
 
     val countsByLibraryId = db.readOnlyReplica { implicit s =>
       libraries.map { library =>
-        val collaboratorCount = libraryMembershipRepo.countWithLibraryIdAndAccess(library.id.get, Set(LibraryAccess.READ_WRITE, LibraryAccess.READ_INSERT))
-        val followerCount = libraryMembershipRepo.countWithLibraryIdAndAccess(library.id.get, Set(LibraryAccess.READ_ONLY))
+        val counts = followerInfosByLibraryId(library.id.get)._2
+        val collaboratorCount = counts(LibraryAccess.READ_WRITE)
+        val followerCount = counts(LibraryAccess.READ_INSERT) + counts(LibraryAccess.READ_ONLY)
         val keepCount = keepRepo.getCountByLibrary(library.id.get)
         library.id.get -> (collaboratorCount, followerCount, keepCount)
       }
@@ -217,7 +218,7 @@ class LibraryCommander @Inject() (
       futureKeepInfosByLibraryId(lib.id.get).map { keepInfos =>
         val (collaboratorCount, followerCount, keepCount) = countsByLibraryId(lib.id.get)
         val owner = usersById(lib.ownerId)
-        val followers = followerIdsByLibraryId(lib.id.get).map(usersById(_))
+        val followers = followerInfosByLibraryId(lib.id.get)._1.map(usersById(_))
         FullLibraryInfo(
           id = Library.publicId(lib.id.get),
           name = lib.name,
@@ -243,22 +244,25 @@ class LibraryCommander @Inject() (
     createFullLibraryInfos(viewerUserIdOpt, 10, 10, Seq(library)).imap { case Seq(fullLibraryInfo) => fullLibraryInfo }
   }
 
-  def getLibraryMembers(libraryId: Id[Library], offset: Int, limit: Int, fillInWithInvites: Boolean): (Seq[LibraryMembership], Seq[LibraryMembership], Seq[(Either[Id[User], EmailAddress], Set[LibraryInvite])]) = {
+  def getLibraryMembers(libraryId: Id[Library], offset: Int, limit: Int, fillInWithInvites: Boolean): (Seq[LibraryMembership], Seq[LibraryMembership], Seq[(Either[Id[User], EmailAddress], Set[LibraryInvite])], Map[LibraryAccess, Int]) = {
     val collaboratorsAccess: Set[LibraryAccess] = Set(LibraryAccess.READ_INSERT, LibraryAccess.READ_WRITE)
     val followersAccess: Set[LibraryAccess] = Set(LibraryAccess.READ_ONLY)
-    val membersAccess = collaboratorsAccess ++ followersAccess
     val relevantInviteStates = Set(LibraryInviteStates.ACTIVE)
 
     if (limit > 0) db.readOnlyMaster { implicit session =>
       // Get Collaborators
       val collaborators = libraryMembershipRepo.pageWithLibraryIdAndAccess(libraryId, offset, limit, collaboratorsAccess)
+      val collaboratorsShown = collaborators.length
+
+      val memberCount = libraryMembershipRepo.countWithLibraryIdByAccess(libraryId)
+      val numCollaborators = memberCount(LibraryAccess.READ_INSERT) + memberCount(LibraryAccess.READ_WRITE)
+      val numMembers = numCollaborators + memberCount(LibraryAccess.READ_ONLY)
 
       // Get Followers
-      val collaboratorsShown = collaborators.length
       val followersLimit = limit - collaboratorsShown
       val followers = if (followersLimit == 0) Seq.empty[LibraryMembership] else {
         val followersOffset = if (collaboratorsShown > 0) 0 else {
-          val collaboratorsTotal = libraryMembershipRepo.countWithLibraryIdAndAccess(libraryId, collaboratorsAccess)
+          val collaboratorsTotal = numCollaborators
           offset - collaboratorsTotal
         }
         libraryMembershipRepo.pageWithLibraryIdAndAccess(libraryId, followersOffset, followersLimit, followersAccess)
@@ -269,14 +273,14 @@ class LibraryCommander @Inject() (
       val inviteesLimit = limit - membersShown
       val inviteesWithInvites = if (inviteesLimit == 0 || !fillInWithInvites) Seq.empty[(Either[Id[User], EmailAddress], Set[LibraryInvite])] else {
         val inviteesOffset = if (membersShown > 0) 0 else {
-          val membersTotal = libraryMembershipRepo.countWithLibraryIdAndAccess(libraryId, membersAccess)
+          val membersTotal = numMembers
           offset - membersTotal
         }
         libraryInviteRepo.pageInviteesByLibraryId(libraryId, inviteesOffset, inviteesLimit, relevantInviteStates)
       }
-      (collaborators, followers, inviteesWithInvites)
+      (collaborators, followers, inviteesWithInvites, memberCount)
     }
-    else (Seq.empty, Seq.empty, Seq.empty)
+    else (Seq.empty, Seq.empty, Seq.empty, Map.empty)
   }
 
   def buildMaybeLibraryMembers(collaborators: Seq[LibraryMembership], followers: Seq[LibraryMembership], inviteesWithInvites: Seq[(Either[Id[User], EmailAddress], Set[LibraryInvite])]): Seq[MaybeLibraryMember] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -244,7 +244,7 @@ class LibraryController @Inject() (
     else Library.decodePublicId(pubId) match {
       case Failure(ex) => BadRequest(Json.obj("error" -> "invalid_id"))
       case Success(libraryId) =>
-        val (collaborators, followers, inviteesWithInvites) = libraryCommander.getLibraryMembers(libraryId, offset, limit, fillInWithInvites = true)
+        val (collaborators, followers, inviteesWithInvites, _) = libraryCommander.getLibraryMembers(libraryId, offset, limit, fillInWithInvites = true)
         val maybeMembers = libraryCommander.buildMaybeLibraryMembers(collaborators, followers, inviteesWithInvites)
         Ok(Json.obj("members" -> maybeMembers))
     }


### PR DESCRIPTION
...hipRepo

Right now, the bulk of library pages comes up `createFullLibraryInfo`
and a part of that is `getLibraryMembers` which pages memberships and counts the total number of collaborators, followers, etc. It would also look through the table repo twice (one for collaborators and one for followers)

`createFullLibraryInfo` ends up calling this counting twice (since `getLibraryMembers` already does it)
so the two main changes were:
- have createFullLibraryInfo only search the library_membership_repo once
- the repo function returns a map (access -> count) on every library access so you won't have to look through the table again for a different access
  but `getLibraryMembers` now also returns a map (access -> count)
  @andrewconner @leogrim 
