### PR TITLE
Fixing join_us.html link

### DIFF
--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -256,6 +256,7 @@ GET     /about/culture              @com.keepit.controllers.website.HomeControll
 GET     /about/investors            @com.keepit.controllers.website.HomeController.moved(uri = "/about")
 GET     /about/team                 @com.keepit.controllers.website.HomeController.route(path = "about/team")
 GET     /about/join_us              @com.keepit.controllers.website.HomeController.route(path = "about/join_us")
+GET     /about/join_us.html         @com.keepit.controllers.website.HomeController.moved(uri = "/about/join_us")
 GET     /how_it_works               @com.keepit.controllers.website.HomeController.route(path = "how_it_works")
 GET     /contact                    @com.keepit.controllers.website.HomeController.route(path = "contact")
 GET     /install                    @com.keepit.controllers.website.HomeController.install


### PR DESCRIPTION
@eishay Previous fix didn't work because `MarketingSiteRouter` isn't a wildcard router. Manually added the offending page.
