### PR TITLE
[DO NOT MERGE] landing a/b

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
@@ -77,7 +77,7 @@ class HomeController @Inject() (
     }
   }
 
-  def route(path: String) = Action {
+  def route(path: String) = Action { implicit request =>
     MarketingSiteRouter.marketingSite(path)
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/MarketingSiteRouter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/MarketingSiteRouter.scala
@@ -48,7 +48,7 @@ object MarketingSiteRouter extends AssetsBuilder with Controller with Logging {
     pickOpt match {
       case Some(idx) if (idx == 1 || idx == 2) =>
         "index." + idx
-      case None =>
+      case _ =>
         val ip = request.remoteAddress // remoteAddress looks up 'X-Forwarded-For'
         val hash = (Math.abs(ip.hashCode()) % 100) // rough
         val winner = if (hash < 50) "index.1" else "index.2"

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/MarketingSiteRouter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/MarketingSiteRouter.scala
@@ -52,7 +52,7 @@ object MarketingSiteRouter extends AssetsBuilder with Controller with Logging {
 
     pickOpt match {
       case Some(idx) if (idx == 1 || idx == 2) =>
-        "index" + idx
+        "index." + idx
       case None =>
         val ip = Try {
           request.remoteAddress // remoteAddress looks up 'X-Forwarded-For'
@@ -63,7 +63,7 @@ object MarketingSiteRouter extends AssetsBuilder with Controller with Logging {
         val hasher = hashFunction.newHasher()
         val hc = hasher.putString(ip, Charsets.UTF_8).hash()
         val hash = (Math.abs(hc.asInt()) % 100) // rough
-        val winner = if (hash < 50) "index1" else "index2"
+        val winner = if (hash < 50) "index.1" else "index.2"
         log.info(s"[landing] remoteAddr=${request.remoteAddress} ip=$ip hc=$hc winner=$winner")
         winner
     }


### PR DESCRIPTION
Added simple A/B landing based on the assumption that the files will be named "index1" and "index2"

Don't merge. Want to send this out first because I have been losing internet connectivity regularly these days.

For hashing I picked murmur3 but feel free to suggest other alternatives. For our simple case probably doesn't matter too much -- might even be an overkill. Will monitor. Also I chose not to convert to `InetAddress` (just hash the string) to avoid overhead.

Tested locally. No unit tests yet. I will look into adding one as well.

@andrewconner @eishay 
