### PR TITLE
remove library repo access from getBaicKeeps

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -253,14 +253,13 @@ class KeepsCommander @Inject() (
           val keeperId = keep.userId
           val mine = userId == keeperId
           val libraryId = keep.libraryId.get
-          val lib = libraryRepo.get(libraryId)
           val removable = libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, userId).exists(_.canWrite)
           BasicKeep(
             id = keep.externalId,
             mine = mine,
             removable = removable,
-            visibility = lib.visibility,
-            libraryId = Library.publicId(lib.id.get)
+            visibility = keep.visibility,
+            libraryId = Library.publicId(libraryId)
           )
         }
         uriId -> userKeeps


### PR DESCRIPTION
@leogrim 

Correct me if I am wrong. keep.visibility and library.visibility are same, thus we don't have to access library repo in this code.
