### PR TITLE
Dynamically size keep cards on first load.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
@@ -94,6 +94,7 @@ angular.module('kifi')
           scope.availableKeeps = _.reject(keeps, { 'unkept': true });
         });
 
+
         //
         // Internal methods.
         //
@@ -314,6 +315,15 @@ angular.module('kifi')
         }, function(enabled) {
           if (!enabled) {
             scope.selection.unselectAll();
+          }
+        });
+
+        scope.$watch('keepsLoading', function (newVal) {
+          // Size the keeps dynamically once the keeps are loaded and visible.
+          if (!newVal) {
+            scope.$evalAsync(function () {
+              sizeKeeps();
+            });
           }
         });
 


### PR DESCRIPTION
https://app.asana.com/0/17575799252940/19282420960489
@andrewconner Please let me know if keep cards are supposed to be triggered into resizing some other way. What I saw was that in the resizing code in `keep.js`, the initial card width variable was set to 0 because at the time the card sizing code was executed, the keep card wasn't visible yet. This bug fix forces the resizing code to execute after the cards are visible, but I am not sure if this is the best way. Thanks!
