### PR TITLE
3.3.7: fixing keep result filtering on google.com

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.3.6
+version=3.3.7

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -256,11 +256,10 @@ if (searchUrlRe.test(document.URL)) !function () {
   var observer = new MutationObserver(withMutations);
   function withMutations(mutations) {
     if (isVertical) return;
-    var ires = document.getElementById('ires');
-    if (ires) {
+    if (attachKifiRes() > 0) {
       log('[withMutations] Google results inserted');
       tGoogleResultsShown = Date.now();
-      if (attachKifiRes(ires) && !(tKifiResultsShown >= tKifiResultsReceived)) {
+      if (!(tKifiResultsShown >= tKifiResultsReceived)) {
         tKifiResultsShown = tGoogleResultsShown;
       }
       if (document.readyState !== 'loading') {  // avoid searching for input value if not yet updated to URL hash
@@ -281,8 +280,9 @@ if (searchUrlRe.test(document.URL)) !function () {
     observer.observe(document.getElementById('main'), whatToObserve);
   });
 
-  function attachKifiRes(ires) {
-    if ((ires = ires || document.getElementById('ires'))) {
+  function attachKifiRes() {
+    var ires = document.getElementById('ires');
+    if (ires) {
       if ($res[0].nextElementSibling !== ires) {
         $res.insertBefore(ires);
         if (!$res[0].firstElementChild.classList.contains('kifi-collapsed')) {
@@ -292,8 +292,9 @@ if (searchUrlRe.test(document.URL)) !function () {
           setTimeout(bindResHandlers);
           boundResHandlers = true;
         }
+        return 1; // just attached
       }
-      return true;
+      return -1; // already attached
     }
   }
 


### PR DESCRIPTION
This fixes a bug introduced in 3.3.5 (d9989af4e656815a6246058f263aa272ed107a1d), which was a quick fix in response to a change in the structure of the Google search results.
