### PR TITLE
towards multi-versioned models

### DIFF
--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDALibraryUpdater.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDALibraryUpdater.scala
@@ -18,7 +18,7 @@ import org.joda.time.DateTime
 
 @Singleton
 class LDALibraryUpdaterImpl @Inject() (
-    representer: LDAURIRepresenter,
+    representer: MultiVersionedLDAURIRepresenter,
     db: Database,
     keepRepo: CortexKeepRepo,
     libRepo: CortexLibraryRepo,
@@ -32,10 +32,11 @@ class LDALibraryUpdaterImpl @Inject() (
   protected val min_num_evidence = 1
 
   def update(): Unit = {
-    implicit val version = representer.version
-    val tasks = fetchTasks
-    log.info(s"fetched ${tasks.size} tasks")
-    processTasks(tasks)
+    representer.versions.foreach { implicit version =>
+      val tasks = fetchTasks
+      log.info(s"fetched ${tasks.size} tasks")
+      processTasks(tasks)
+    }
   }
 
   private def fetchTasks(implicit version: ModelVersion[DenseLDA]): Seq[CortexKeep] = {

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDARepresenters.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDARepresenters.scala
@@ -11,18 +11,25 @@ import com.keepit.search.Lang
 
 case class LDAWordRepresenter(val version: ModelVersion[DenseLDA], lda: DenseLDA) extends HashMapWordRepresenter[DenseLDA](lda.dimension, lda.mapper)
 
-case class LDADocRepresenter @Inject() (wordRep: LDAWordRepresenter, stopwords: Stopwords) extends NaiveSumDocRepresenter(wordRep, Some(stopwords)) {
+case class LDADocRepresenter(wordRep: LDAWordRepresenter, stopwords: Stopwords) extends NaiveSumDocRepresenter(wordRep, Some(stopwords)) {
   override def normalize(vec: Array[Float]): Array[Float] = {
     val s = vec.sum
     vec.map { x => x / s }
   }
 }
 
-case class LDAURIRepresenter @Inject() (docRep: LDADocRepresenter, articleStore: ArticleStore) extends BaseURIFeatureRepresenter(docRep, articleStore) {
+case class LDAURIRepresenter(docRep: LDADocRepresenter, articleStore: ArticleStore) extends BaseURIFeatureRepresenter(docRep, articleStore) {
 
   override def isDefinedAt(article: Article): Boolean = article.contentLang == Some(Lang("en"))
 
   override def toDocument(article: Article): Document = {
     Document(TextUtils.TextTokenizer.LowerCaseTokenizer.tokenize(article.content))
   }
+}
+
+case class MultiVersionedLDAURIRepresenter(representers: LDAURIRepresenter*) {
+  private val dimMap = representers.map { rep => (rep.version, rep.dimension) }.toMap
+  def versions: Seq[ModelVersion[DenseLDA]] = representers.map { _.version }
+  def getRepresenter(version: ModelVersion[DenseLDA]): Option[LDAURIRepresenter] = representers.find(_.version == version)
+  def getDimension(version: ModelVersion[DenseLDA]): Option[Int] = dimMap.get(version)
 }

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDAUserStatDbUpdater.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDAUserStatDbUpdater.scala
@@ -50,7 +50,7 @@ trait LDAUserStatDbUpdater extends BaseFeatureUpdater[Id[User], User, DenseLDA, 
 
 @Singleton
 class LDAUserStatDbUpdaterImpl @Inject() (
-    representer: LDAURIRepresenter,
+    representer: MultiVersionedLDAURIRepresenter,
     db: Database,
     keepRepo: CortexKeepRepo,
     uriTopicRepo: URILDATopicRepo,
@@ -63,15 +63,17 @@ class LDAUserStatDbUpdaterImpl @Inject() (
   protected val min_num_evidence = 5
 
   def update(): Unit = {
-    implicit val version = representer.version
-    val tasks = fetchTasks
-    log.info(s"fetched ${tasks.size} tasks")
-    processTasks(tasks)
+    representer.versions.foreach { implicit version =>
+      val tasks = fetchTasks
+      log.info(s"fetched ${tasks.size} tasks")
+      processTasks(tasks)
+    }
   }
 
   def updateUser(userId: Id[User]): Unit = {
-    implicit val version = representer.version
-    processUser(userId)
+    representer.versions.foreach { implicit version =>
+      processUser(userId)
+    }
   }
 
   private def fetchTasks(implicit version: ModelVersion[DenseLDA]): Seq[CortexKeep] = {

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDADbUpdaterTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDADbUpdaterTest.scala
@@ -29,7 +29,7 @@ class LDADbUpdaterTest extends Specification with CortexTestInjector with LDADbT
           uris.map { CortexURI.fromURI(_) }.foreach { uriRepo.save(_) }
         }
 
-        val updater = new LDADbUpdaterImpl(uriRep, db, uriRepo, topicRepo, commitRepo)
+        val updater = new LDADbUpdaterImpl(uriReps, db, uriRepo, topicRepo, commitRepo)
         updater.update
 
         db.readOnlyMaster { implicit s =>
@@ -63,7 +63,7 @@ class LDADbUpdaterTest extends Specification with CortexTestInjector with LDADbT
           uris.map { CortexURI.fromURI(_) }.foreach { uriRepo.save(_) }
         }
 
-        val updater = new LDADbUpdaterImpl(uriRep, db, uriRepo, topicRepo, commitRepo)
+        val updater = new LDADbUpdaterImpl(uriReps, db, uriRepo, topicRepo, commitRepo)
         updater.update
 
         db.readOnlyMaster { implicit s =>
@@ -100,7 +100,7 @@ class LDADbUpdaterTest extends Specification with CortexTestInjector with LDADbT
           uris.map { CortexURI.fromURI(_) }.foreach { uriRepo.save(_) }
         }
 
-        val updater = new LDADbUpdaterImpl(uriRep, db, uriRepo, topicRepo, commitRepo)
+        val updater = new LDADbUpdaterImpl(uriReps, db, uriRepo, topicRepo, commitRepo)
         updater.update
 
         db.readOnlyMaster { implicit s =>
@@ -122,7 +122,7 @@ class LDADbUpdaterTest extends Specification with CortexTestInjector with LDADbT
           uris.map { CortexURI.fromURI(_).copy(state = State[CortexURI]("active")) }.foreach { uriRepo.save(_) }
         }
 
-        val updater = new LDADbUpdaterImpl(uriRep, db, uriRepo, topicRepo, commitRepo)
+        val updater = new LDADbUpdaterImpl(uriReps, db, uriRepo, topicRepo, commitRepo)
         updater.update
 
         db.readOnlyMaster { implicit s =>
@@ -152,6 +152,7 @@ trait LDADbTestHelper extends URIFeatureTestHelper {
   }
   val articleStore = new InMemoryArticleStoreImpl()
   val uriRep = LDAURIRepresenter(docRep, articleStore)
+  val uriReps = MultiVersionedLDAURIRepresenter(uriRep)
 
   def makeURI(idx: Int, seq: Option[SequenceNumber[NormalizedURI]] = None, state: State[NormalizedURI] = NormalizedURIStates.SCRAPED) = {
     NormalizedURI(id = Some(Id[NormalizedURI](idx)), url = s"http://page${idx}.com", urlHash = UrlHash(s"page${idx}"), seq = seq.getOrElse(SequenceNumber[NormalizedURI](idx)), state = state)

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDALibraryUpdaterTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDALibraryUpdaterTest.scala
@@ -18,7 +18,7 @@ class LDALibraryUpdaterTest extends Specification with CortexTestInjector with L
         val commitRepo = inject[FeatureCommitInfoRepo]
         val uriTopicRepo = inject[URILDATopicRepo]
         val libLDARepo = inject[LibraryLDATopicRepo]
-        val updater = new LDALibraryUpdaterImpl(uriRep, db, keepRepo, libRepo, libLDARepo, uriTopicRepo, commitRepo)
+        val updater = new LDALibraryUpdaterImpl(uriReps, db, keepRepo, libRepo, libLDARepo, uriTopicRepo, commitRepo)
 
         val time = new DateTime(2014, 1, 30, 17, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
 

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDAUserDbUpdaterTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDAUserDbUpdaterTest.scala
@@ -31,8 +31,8 @@ class LDAUserDbUpdaterTest extends Specification with CortexTestInjector with LD
           keeps.foreach { keepRepo.save(_) }
         }
 
-        val uriUpdater = new LDADbUpdaterImpl(uriRep, db, uriRepo, uriTopicRepo, commitRepo)
-        val userTopicUpdater = new LDAUserDbUpdaterImpl(uriRep, db, keepRepo, uriTopicRepo, userTopicRepo, commitRepo, new FakeCuratorServiceClientImpl(null))
+        val uriUpdater = new LDADbUpdaterImpl(uriReps, db, uriRepo, uriTopicRepo, commitRepo)
+        val userTopicUpdater = new LDAUserDbUpdaterImpl(uriReps, db, keepRepo, uriTopicRepo, userTopicRepo, commitRepo, new FakeCuratorServiceClientImpl(null))
 
         uriUpdater.update()
         userTopicUpdater.update()
@@ -66,8 +66,8 @@ class LDAUserDbUpdaterTest extends Specification with CortexTestInjector with LD
             keeps.foreach { keepRepo.save(_) }
           }
 
-          val uriUpdater = new LDADbUpdaterImpl(uriRep, db, uriRepo, uriTopicRepo, commitRepo)
-          val userTopicUpdater = new LDAUserDbUpdaterImpl(uriRep, db, keepRepo, uriTopicRepo, userTopicRepo, commitRepo, new FakeCuratorServiceClientImpl(null))
+          val uriUpdater = new LDADbUpdaterImpl(uriReps, db, uriRepo, uriTopicRepo, commitRepo)
+          val userTopicUpdater = new LDAUserDbUpdaterImpl(uriReps, db, keepRepo, uriTopicRepo, userTopicRepo, commitRepo, new FakeCuratorServiceClientImpl(null))
 
           uriUpdater.update()
           userTopicUpdater.update()

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDAUserStatDbUpdaterTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDAUserStatDbUpdaterTest.scala
@@ -26,7 +26,7 @@ class LDAUserStatDbUpdaterTest extends Specification with CortexTestInjector wit
           uriTopicRepo.save(URILDATopic(uriId = Id[NormalizedURI](2L), uriSeq = SequenceNumber[NormalizedURI](2L), version = ModelVersion[DenseLDA](1), numOfWords = 200, feature = Some(LDATopicFeature(Array(1f, 0f))), state = URILDATopicStates.ACTIVE))
         }
 
-        val updater = new LDAUserStatDbUpdaterImpl(uriRep, db, keepRepo, uriTopicRepo, userLDAStatsRepo, commitRepo) {
+        val updater = new LDAUserStatDbUpdaterImpl(uriReps, db, keepRepo, uriTopicRepo, userLDAStatsRepo, commitRepo) {
           override val min_num_evidence = 1
         }
 
@@ -57,7 +57,7 @@ class LDAUserStatDbUpdaterTest extends Specification with CortexTestInjector wit
         uriTopicRepo.save(URILDATopic(uriId = Id[NormalizedURI](2L), uriSeq = SequenceNumber[NormalizedURI](2L), version = ModelVersion[DenseLDA](1), numOfWords = 200, feature = Some(LDATopicFeature(Array(1f, 0f))), state = URILDATopicStates.ACTIVE))
       }
 
-      val updater = new LDAUserStatDbUpdaterImpl(uriRep, db, keepRepo, uriTopicRepo, userLDAStatsRepo, commitRepo) {
+      val updater = new LDAUserStatDbUpdaterImpl(uriReps, db, keepRepo, uriTopicRepo, userLDAStatsRepo, commitRepo) {
         override val min_num_evidence = 1
       }
 
@@ -74,4 +74,3 @@ class LDAUserStatDbUpdaterTest extends Specification with CortexTestInjector wit
   }
 
 }
-

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/UserLDAStatisticsTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/UserLDAStatisticsTest.scala
@@ -26,7 +26,7 @@ class UserLDAStatisticsTest extends Specification with CortexTestInjector with L
         val cache = inject[UserLDAStatisticsCache]
         val store = new InMemoryUserLDAStatisticsStore
 
-        val updater = new UserLDAStatisticsUpdater(db, repo, uriRep, store, cache)
+        val updater = new UserLDAStatisticsUpdater(db, repo, uriReps, store, cache)
         updater.update()
 
         val stat = cache.get(UserLDAStatisticsCacheKey(uriRep.version)).get


### PR DESCRIPTION
@stkem 

one model, wrapped in a new interface `MultiVersionedLDAURIRepresenter` 
