### PR TITLE
library indexing request should be made after commit

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -817,11 +817,12 @@ class LibraryCommander @Inject() (
           case Right(successKeep) => goodKeeps += successKeep
         }
       }
-      searchClient.updateKeepIndex()
       if (badKeeps.size != keeps.size)
         libraryRepo.updateLastKept(dstLibraryId)
       groupedKeeps.keys.flatten
     }
+    searchClient.updateKeepIndex()
+
     implicit val dca = TransactionalCaching.Implicits.directCacheAccess
     srcLibs.map { srcLibId =>
       countByLibraryCache.remove(CountByLibraryKey(srcLibId))


### PR DESCRIPTION
@andrewconner @ahsu1230 

Do not send indexing requests until the transaction is committed. Otherwise, it is very likely that the indexer is unable to see the new values when the request reaches it. The change won't be picked up until indexing is invoked later either by another request or by the 1-min periodical indexing cycle.
