### PR TITLE
Fixing JS error when destroying during $digest cycle

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/modalService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/modalService.js
@@ -2,8 +2,8 @@
 
 angular.module('kifi')
 
-.factory('modalService', ['$compile', '$rootScope', '$templateCache',
-  function ($compile, $rootScope, $templateCache) {
+.factory('modalService', ['$compile', '$rootScope', '$templateCache', '$timeout',
+  function ($compile, $rootScope, $templateCache, $timeout) {
     var modals = [];
 
     function open (opts) {
@@ -36,7 +36,9 @@ angular.module('kifi')
       if (ref && ref.length > 0 && ref[0].length) {
         var $modal = ref[0];
         var scope = ref[1];
-        scope.$destroy();
+        $timeout(function () {
+          scope.$destroy();
+        });
         $modal.remove();
       }
     }


### PR DESCRIPTION
I believe this is the best fix for https://app.asana.com/0/17575799252940/19091436963747

We were getting a JS error that is caused by calling scope.$destroy _during_ a digest. Not sure if this is the best solution, but it seems to stop the error. @yipingliao @joshm1 Thoughts appreciated.
