### PR TITLE
be more stingy

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -295,7 +295,7 @@ class KeepsCommander @Inject() (
 
       val colls = db.readOnlyMaster { implicit s =>
         keeps.map { keep =>
-          keepToCollectionRepo.getCollectionsForKeep(keep.id.get)
+          keepToCollectionRepo.getCollectionsForKeep(keep)
         }
       }.map(collectionCommander.getBasicCollections)
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/CollectionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/CollectionRepo.scala
@@ -1,5 +1,6 @@
 package com.keepit.model
 
+import com.keepit.commanders.{ BasicCollectionByIdKey, BasicCollectionByIdCache }
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 import com.google.inject.{ Inject, Singleton, ImplementedBy }
@@ -42,6 +43,7 @@ class CollectionRepoImpl @Inject() (
   val userCollectionsCache: UserCollectionsCache,
   val userCollectionSummariesCache: UserCollectionSummariesCache,
   val bookmarkCountForCollectionCache: KeepCountForCollectionCache,
+  val basicCollectionCache: BasicCollectionByIdCache,
   val keepToCollectionRepo: KeepToCollectionRepo,
   val elizaServiceClient: ElizaServiceClient,
   val db: DataBaseComponent,
@@ -73,6 +75,7 @@ class CollectionRepoImpl @Inject() (
   override def deleteCache(model: Collection)(implicit session: RSession): Unit = {
     userCollectionsCache.remove(UserCollectionsKey(model.userId))
     userCollectionSummariesCache.remove(UserCollectionSummariesKey(model.userId))
+    model.id.foreach { colectionId => basicCollectionCache.remove(BasicCollectionByIdKey(colectionId)) }
 
     val keepToCollections = keepToCollectionRepo.getByCollection(model.id.get)
     keepToCollections.foreach(keepToCollectionRepo.deleteCache)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToCollectionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToCollectionRepo.scala
@@ -1,6 +1,7 @@
 package com.keepit.model
 
 import com.google.inject.{ Provider, Inject, Singleton, ImplementedBy }
+import com.keepit.commanders.{ BasicCollectionByIdKey, BasicCollectionByIdCache }
 import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
 import com.keepit.common.db.slick._
 import com.keepit.common.db.{ State, Id }
@@ -11,6 +12,7 @@ import com.keepit.common.healthcheck.AirbrakeNotifier
 @ImplementedBy(classOf[KeepToCollectionRepoImpl])
 trait KeepToCollectionRepo extends Repo[KeepToCollection] {
   def getCollectionsForKeep(bookmarkId: Id[Keep])(implicit session: RSession): Seq[Id[Collection]]
+  def getCollectionsForKeep(keep: Keep)(implicit session: RSession): Seq[Id[Collection]]
   def getKeepsForTag(collectionId: Id[Collection],
     excludeState: Option[State[KeepToCollection]] = Some(KeepToCollectionStates.INACTIVE))(implicit seesion: RSession): Seq[Id[Keep]]
   def getUriIdsInCollection(collectionId: Id[Collection])(implicit session: RSession): Seq[KeepUriAndTime]
@@ -28,6 +30,7 @@ trait KeepToCollectionRepo extends Repo[KeepToCollection] {
 class KeepToCollectionRepoImpl @Inject() (
   airbrake: AirbrakeNotifier,
   collectionsForKeepCache: CollectionsForKeepCache,
+  basicCollectionCache: BasicCollectionByIdCache,
   collectionRepoProvider: Provider[CollectionRepoImpl],
   keepRepoProvider: Provider[KeepRepoImpl],
   val db: DataBaseComponent,
@@ -43,6 +46,7 @@ class KeepToCollectionRepoImpl @Inject() (
 
   override def deleteCache(ktc: KeepToCollection)(implicit session: RSession): Unit = {
     collectionsForKeepCache.remove(CollectionsForKeepKey(ktc.keepId))
+    basicCollectionCache.remove(BasicCollectionByIdKey(ktc.collectionId))
   }
 
   type RepoImpl = KeepToCollectionTable
@@ -65,6 +69,21 @@ class KeepToCollectionRepoImpl @Inject() (
       } yield kc
 
       query.sortBy(_.updatedAt).map(_.collectionId).list // todo(martin): we should add a column for explicit ordering of tags
+    }
+  }
+
+  def getCollectionsForKeep(keep: Keep)(implicit session: RSession): Seq[Id[Collection]] = {
+    if (keep.isActive) {
+      collectionsForKeepCache.getOrElse(CollectionsForKeepKey(keep.id.get)) {
+        val query = for {
+          kc <- rows if kc.bookmarkId === keep.id.get && kc.state === KeepToCollectionStates.ACTIVE
+          c <- collectionRepo.rows if c.id === kc.collectionId && c.state === CollectionStates.ACTIVE
+        } yield kc
+
+        query.sortBy(_.updatedAt).map(_.collectionId).list // todo(martin): we should add a column for explicit ordering of tags
+      }
+    } else {
+      Seq.empty
     }
   }
 


### PR DESCRIPTION
@andrewconner @ahsu1230 @stkem @eishay 
- added a different flavor of getCollectionsForKeep to KeepToCollectionRepo. It takes Keep instead of Id[Keep], so we don't have to access the bookmark table when we already have a Keep in memory. As the result, we do 2-way join instead of 3-way join.
- I noticed BasicCollectionCache is not invalidated when collections change. Invalidation is added to CollectionRepo and KeepToCollectionRepo.
