### PR TITLE
removing keywords from library meta tags

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -98,12 +98,7 @@ class LibraryCommander @Inject() (
           val fullUrl = s"${applicationConfig.applicationBaseUrl}$urlPathOnly"
           if (fullUrl.startsWith("http") || fullUrl.startsWith("https:")) fullUrl else s"http:$fullUrl"
         }
-        //should also get owr word2vec
-        val embedlyKeywords: Seq[String] = keeps map { keep =>
-          uriSummaryCommander.getStoredEmbedlyKeywords(keep.uriId).map(_.name)
-        } flatten
-        val tags: Seq[String] = collectionRepo.getTagsByLibrary(library.id.get).map(_.tag).toSeq
-        val allTags: Seq[String] = (embedlyKeywords ++ tags).toSet.toSeq
+
         PublicPageMetaFullTags(
           unsafeTitle = s"${library.name} by ${owner.firstName} ${owner.lastName} \u2022 Kifi",
           url = url,
@@ -113,7 +108,6 @@ class LibraryCommander @Inject() (
           facebookId = facebookId,
           createdAt = library.createdAt,
           updatedAt = library.updatedAt,
-          unsafeTags = allTags,
           unsafeFirstName = owner.firstName,
           unsafeLastName = owner.lastName)
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PublicPageMetaTags.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PublicPageMetaTags.scala
@@ -44,17 +44,14 @@ case class PublicPageMetaPrivateTags(urlPathOnly: String) extends PublicPageMeta
 }
 
 case class PublicPageMetaFullTags(unsafeTitle: String, url: String, urlPathOnly: String, unsafeDescription: String, images: Seq[String], facebookId: Option[String],
-    createdAt: DateTime, updatedAt: DateTime, unsafeTags: Seq[String], unsafeFirstName: String, unsafeLastName: String) extends PublicPageMetaTags {
+    createdAt: DateTime, updatedAt: DateTime, unsafeFirstName: String, unsafeLastName: String) extends PublicPageMetaTags {
 
   def clean(unsafeString: String) = scala.xml.Utility.escape(unsafeString)
 
   val title = clean(unsafeTitle)
   val description = clean(unsafeDescription)
-  val tags = unsafeTags.distinct.filter(_.length > 1).take(100).map(clean)
   val firstName = clean(unsafeFirstName)
   val lastName = clean(unsafeLastName)
-
-  def tagList = tags.mkString(",")
 
   def formatOpenGraph: String = {
 
@@ -93,10 +90,8 @@ case class PublicPageMetaFullTags(unsafeTitle: String, url: String, urlPathOnly:
       |<meta property="fb:app_id" content="${PublicPageMetaTags.appId}" />
       |<meta property="fb:first_name" content="${firstName}" />
       |<meta property="fb:last_name" content="${lastName}" />
-      |<meta property="fb:tag" content="$tagList" />
       |<meta property="fb:admins" content="646386018,71105121,7800404,1343280666,1367777495,575533310,636721190" />
       |<meta name="description" content="$description">
-      |<meta name="keywords" content="$tagList">
       |<meta name="author" content="${firstName} ${lastName}">
       |<link rel="canonical" href="$url" />
       |<meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
@eishay @andrewconner 

After a discussion with Eishay, we decided to remove keywords meta tag from library meta tags.
Keywords meta tag is not very effective for SEO. Some even says that it should not be used at all.
