### PR TITLE
Fixing massive inefficency in our CSS output

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/animation.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/animation.styl
@@ -1,0 +1,33 @@
+
+//
+// Styles.
+//
+[contenteditable]:empty::before
+  content: attr(placeholder)
+
+
+@keyframes jump-spin
+  0%
+    transform: translate(-50%, -50%) rotate(0deg)
+  12.5%
+    transform: translate(-50%, -50%) rotate(10deg)
+  25%
+    transform: translate(-50%, -50%) rotate(90deg)
+  37.5%
+    transform: translate(-50%, -50%) rotate(100deg)
+  50%
+    transform: translate(-50%, -50%) rotate(180deg)
+  62.5%
+    transform: translate(-50%, -50%) rotate(190deg)
+  75%
+    transform: translate(-50%, -50%) rotate(270deg)
+  87.5%
+    transform: translate(-50%, -50%) rotate(280deg)
+  100%
+    transform: translate(-50%, -50%) rotate(360deg)
+
+@keyframes fade-in
+  from
+    opacity: 0
+  to
+    opacity: 1

--- a/kifi-backend/modules/shoebox/angular/src/common/build-css/common.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/build-css/common.styl
@@ -48,35 +48,3 @@ pop-over(top, left, color)
     z-index: 10
 
 
-//
-// Styles.
-//
-[contenteditable]:empty::before
-  content: attr(placeholder)
-
-
-@keyframes jump-spin
-  0%
-    transform: translate(-50%, -50%) rotate(0deg)
-  12.5%
-    transform: translate(-50%, -50%) rotate(10deg)
-  25%
-    transform: translate(-50%, -50%) rotate(90deg)
-  37.5%
-    transform: translate(-50%, -50%) rotate(100deg)
-  50%
-    transform: translate(-50%, -50%) rotate(180deg)
-  62.5%
-    transform: translate(-50%, -50%) rotate(190deg)
-  75%
-    transform: translate(-50%, -50%) rotate(270deg)
-  87.5%
-    transform: translate(-50%, -50%) rotate(280deg)
-  100%
-    transform: translate(-50%, -50%) rotate(360deg)
-
-@keyframes fade-in
-  from
-    opacity: 0
-  to
-    opacity: 1


### PR DESCRIPTION
Whoops, my fault. Anything in `build-css/` get included in every Stylus file. This means this snippet was included quite a few times. The uncompressed CSS output was ~700kb (it _did_ compress quite well, though).

@yipingliao 
