### PR TITLE
Analytics for follow / unfollow Library

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/heimdal/EventType.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/EventType.scala
@@ -43,6 +43,9 @@ object UserEventTypes {
 
   // recommendaton
   val RECOMMENDATION_USER_ACTION = EventType("reco_action")
+
+  // Libraries
+  val FOLLOWED_LIBRARY = EventType("followed_library")
 }
 
 object SystemEventTypes {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
@@ -41,7 +41,7 @@ class CollectionCommander @Inject() (
     collectionRepo: CollectionRepo,
     userValueRepo: UserValueRepo,
     searchClient: SearchServiceClient,
-    keptAnalytics: KeepingAnalytics,
+    libraryAnalytics: LibraryAnalytics,
     basicCollectionCache: BasicCollectionByIdCache,
     clock: Clock) extends Logging {
 
@@ -174,7 +174,7 @@ class CollectionCommander @Inject() (
             s.onTransactionSuccess { searchClient.updateKeepIndex() }
             val newColl = collectionRepo.save(Collection(userId = userId, name = name))
             updateCollectionOrdering(userId)
-            keptAnalytics.createdTag(newColl, context)
+            libraryAnalytics.createdTag(newColl, context)
             Left(BasicCollection.fromCollection(newColl.summary))
           } else {
             Right(CollectionSaveFail(s"Tag '$name' already exists"))
@@ -194,7 +194,7 @@ class CollectionCommander @Inject() (
       collectionRepo.save(collection.copy(state = CollectionStates.INACTIVE))
       updateCollectionOrdering(collection.userId)
     }
-    keptAnalytics.deletedTag(collection, context)
+    libraryAnalytics.deletedTag(collection, context)
     searchClient.updateKeepIndex()
   }
 
@@ -203,7 +203,7 @@ class CollectionCommander @Inject() (
       collectionRepo.save(collection.copy(state = CollectionStates.ACTIVE, createdAt = clock.now()))
       updateCollectionOrdering(collection.userId)
     }
-    keptAnalytics.undeletedTag(collection, context)
+    libraryAnalytics.undeletedTag(collection, context)
     searchClient.updateKeepIndex()
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -123,7 +123,7 @@ class KeepsCommander @Inject() (
     keepRepo: KeepRepo,
     collectionRepo: CollectionRepo,
     userRepo: UserRepo,
-    keptAnalytics: KeepingAnalytics,
+    libraryAnalytics: LibraryAnalytics,
     rawBookmarkFactory: RawBookmarkFactory,
     scheduler: Scheduler,
     heimdalClient: HeimdalServiceClient,
@@ -476,7 +476,7 @@ class KeepsCommander @Inject() (
     log.info(s"[unkeepMulti] deactivatedKeeps:(len=${deactivatedBookmarks.length}):${deactivatedBookmarks.mkString(",")}")
 
     val deactivatedKeepInfos = deactivatedBookmarks map KeepInfo.fromKeep
-    keptAnalytics.unkeptPages(userId, deactivatedBookmarks, context)
+    libraryAnalytics.unkeptPages(userId, deactivatedBookmarks, context)
     searchClient.updateKeepIndex()
     deactivatedKeepInfos
   }
@@ -549,7 +549,7 @@ class KeepsCommander @Inject() (
 
   private def finalizeUnkeeping(keeps: Seq[Keep], userId: Id[User])(implicit context: HeimdalContext): Unit = {
     // TODO: broadcast over any open user channels
-    keptAnalytics.unkeptPages(userId, keeps, context)
+    libraryAnalytics.unkeptPages(userId, keeps, context)
     searchClient.updateKeepIndex()
   }
 
@@ -558,7 +558,7 @@ class KeepsCommander @Inject() (
       val keeps = getKeepsInBulkSelection(selection, userId).filter(_.state != KeepStates.ACTIVE)
       keeps.map(setKeepStateWithSession(_, KeepStates.ACTIVE, userId))
     }
-    keptAnalytics.rekeptPages(userId, keeps, context)
+    libraryAnalytics.rekeptPages(userId, keeps, context)
     searchClient.updateKeepIndex()
     keeps.length
   }
@@ -577,7 +577,7 @@ class KeepsCommander @Inject() (
       val newKeeps = oldKeeps.map(updateKeepWithSession(_, Some(isPrivate), None))
       (oldKeeps, newKeeps)
     }
-    (oldKeeps zip newKeeps) map { case (oldKeep, newKeep) => keptAnalytics.updatedKeep(oldKeep, newKeep, context) }
+    (oldKeeps zip newKeeps) map { case (oldKeep, newKeep) => libraryAnalytics.updatedKeep(oldKeep, newKeep, context) }
     searchClient.updateKeepIndex()
     newKeeps.length
   }
@@ -587,7 +587,7 @@ class KeepsCommander @Inject() (
     if (shouldBeUpdated) Some {
       val updatedKeep = db.readWrite { implicit s => updateKeepWithSession(keep, isPrivate, title) }
       searchClient.updateKeepIndex()
-      keptAnalytics.updatedKeep(keep, updatedKeep, context)
+      libraryAnalytics.updatedKeep(keep, updatedKeep, context)
       updatedKeep
     }
     else None
@@ -619,7 +619,7 @@ class KeepsCommander @Inject() (
             case Some(keep) if normTitle.isDefined && normTitle != keep.title =>
               val keep2 = keepRepo.save(keep.withTitle(normTitle))
               searchClient.updateKeepIndex()
-              keptAnalytics.updatedKeep(keep, keep2, context)
+              libraryAnalytics.updatedKeep(keep, keep2, context)
               Right(keep2)
             case Some(keep) =>
               Right(keep)
@@ -665,7 +665,7 @@ class KeepsCommander @Inject() (
       val taggingAt = currentDateTime
       tagged.foreach { ktc =>
         keepRepo.save(keepsById(ktc.keepId)) // notify keep index
-        keptAnalytics.taggedPage(updatedCollection, keepsById(ktc.keepId), context, taggingAt)
+        libraryAnalytics.taggedPage(updatedCollection, keepsById(ktc.keepId), context, taggingAt)
       }
       tagged
     }
@@ -687,7 +687,7 @@ class KeepsCommander @Inject() (
       val removedAt = currentDateTime
       removed.foreach { ktc =>
         keepRepo.save(keepsById(ktc.keepId)) // notify keep index
-        keptAnalytics.untaggedPage(collection, keepsById(ktc.keepId), context, removedAt)
+        libraryAnalytics.untaggedPage(collection, keepsById(ktc.keepId), context, removedAt)
       }
       removed.toSet
     } tap { _ =>
@@ -721,8 +721,8 @@ class KeepsCommander @Inject() (
     }
     collection match {
       case Some(t) if t.isActive => t
-      case Some(t) => db.readWrite { implicit s => collectionRepo.save(t.copy(state = CollectionStates.ACTIVE, name = normalizedName, createdAt = clock.now())) } tap (keptAnalytics.createdTag(_, context))
-      case None => db.readWrite { implicit s => collectionRepo.save(Collection(userId = userId, name = normalizedName)) } tap (keptAnalytics.createdTag(_, context))
+      case Some(t) => db.readWrite { implicit s => collectionRepo.save(t.copy(state = CollectionStates.ACTIVE, name = normalizedName, createdAt = clock.now())) } tap (libraryAnalytics.createdTag(_, context))
+      case None => db.readWrite { implicit s => collectionRepo.save(Collection(userId = userId, name = normalizedName)) } tap (libraryAnalytics.createdTag(_, context))
     }
   }
 
@@ -736,7 +736,7 @@ class KeepsCommander @Inject() (
         keepToCollectionRepo.remove(keepId = keep.id.get, collectionId = collection.id.get)
         collectionRepo.collectionChanged(collection.id.get, inactivateIfEmpty = true)
         keepRepo.save(keep) // notify keep index
-        keptAnalytics.untaggedPage(collection, keep, context)
+        libraryAnalytics.untaggedPage(collection, keep, context)
         keep
       }
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryAnalytics.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryAnalytics.scala
@@ -10,7 +10,36 @@ import org.joda.time.DateTime
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 @Singleton
-class KeepingAnalytics @Inject() (heimdal: HeimdalServiceClient) {
+class LibraryAnalytics @Inject() (heimdal: HeimdalServiceClient) {
+
+  def followLibrary(userId: Id[User], library: Library, context: HeimdalContext): Unit = {
+    val followedAt = currentDateTime
+    SafeFuture {
+      val contextBuilder = new HeimdalContextBuilder
+      contextBuilder.data ++= context.data
+      contextBuilder += ("action", "followed")
+      contextBuilder += ("privacySetting", library.visibility.toString)
+      contextBuilder += ("libraryId", library.id.toString)
+      contextBuilder += ("libraryOwnerId", library.ownerId.toString)
+      contextBuilder += ("followerCount", library.memberCount - 1)
+      heimdal.trackEvent(UserEvent(userId, contextBuilder.build, UserEventTypes.FOLLOWED_LIBRARY, followedAt))
+    }
+  }
+
+  def unfollowLibrary(userId: Id[User], library: Library, context: HeimdalContext): Unit = {
+    val unfollowedAt = currentDateTime
+    SafeFuture {
+      val contextBuilder = new HeimdalContextBuilder
+      contextBuilder.data ++= context.data
+      contextBuilder += ("action", "unfollowed")
+      contextBuilder += ("privacySetting", library.visibility.toString)
+      contextBuilder += ("libraryId", library.id.toString)
+      contextBuilder += ("libraryOwnerId", library.ownerId.toString)
+      contextBuilder += ("followerCount", library.memberCount - 1)
+      heimdal.trackEvent(UserEvent(userId, contextBuilder.build, UserEventTypes.FOLLOWED_LIBRARY, unfollowedAt))
+    }
+  }
+
   def renamedTag(oldTag: Collection, newTag: Collection, context: HeimdalContext): Unit = {
     val renamedAt = currentDateTime
     SafeFuture {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/RawKeepImporterPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/RawKeepImporterPlugin.scala
@@ -39,7 +39,7 @@ private class RawKeepImporterActor @Inject() (
     airbrake: AirbrakeNotifier,
     urlRepo: URLRepo,
     scraper: ScrapeScheduler,
-    keptAnalytics: KeepingAnalytics,
+    libraryAnalytics: LibraryAnalytics,
     collectionRepo: CollectionRepo,
     kifiInstallationRepo: KifiInstallationRepo,
     bookmarksCommanderProvider: Provider[KeepsCommander],

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -93,7 +93,7 @@ class MobileLibraryController @Inject() (
       case Failure(ex) =>
         BadRequest(Json.obj("error" -> "invalid_id"))
       case Success(libId) =>
-        implicit val context = heimdalContextBuilder.withRequestInfo(request).build
+        implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
         val res = libraryCommander.joinLibrary(request.userId, libId)
         res match {
           case Left(fail) =>
@@ -122,6 +122,7 @@ class MobileLibraryController @Inject() (
       case Failure(ex) =>
         BadRequest(Json.obj("error" -> "invalid_id"))
       case Success(id) =>
+        implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
         libraryCommander.leaveLibrary(id, request.userId) match {
           case Left(fail) => BadRequest(Json.obj("error" -> fail.message))
           case Right(_) => Ok(JsString("success"))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -200,7 +200,7 @@ class LibraryController @Inject() (
       case Failure(ex) =>
         BadRequest(Json.obj("error" -> "invalid_id"))
       case Success(libId) =>
-        implicit val context = heimdalContextBuilder.withRequestInfo(request).build
+        implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
         val res = libraryCommander.joinLibrary(request.userId, libId)
         res match {
           case Left(fail) =>
@@ -229,6 +229,7 @@ class LibraryController @Inject() (
       case Failure(ex) =>
         BadRequest(Json.obj("error" -> "invalid_id"))
       case Success(id) =>
+        implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
         libraryCommander.leaveLibrary(id, request.userId) match {
           case Left(fail) => BadRequest(Json.obj("error" -> fail.message))
           case Right(_) => Ok(JsString("success"))


### PR DESCRIPTION
1) Adding Event Type `FOLLOWED_LIBRARY`
2) add trackings to joinLibrary() & leaveLibrary() in LibraryCommander, which passes contexts from LibraryController & MobileLibraryController
3) Rename KeepAnalytics to LibraryAnalytics

event: user_followed_library
- action (follow vs. unfollow)
- privacySetting
- libraryId
- libraryOwnerId
- followerCount
- source

@stkem @leogrim @andrewconner @yingjieMiao 
