### PR TITLE
Add errors to create library panel in library widget

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -46,13 +46,14 @@ angular.module('kifi')
         // Internal data.
         //
         var widget = null;
-        var selectedIndex = 0;
         var searchInput = null;
         var libraryList = null;
+        var newLibraryNameInput = null;
+
+        var selectedIndex = 0;
         var justScrolled = false;
         var removeTimeout = null;
         var resetJustScrolledTimeout = null;
-        var newLibraryNameInput = null;
         var submitting = false;
         var allLibraries = [];
         var widgetLibraries = [];
@@ -202,6 +203,7 @@ angular.module('kifi')
           }
 
           // Select the top listed library.
+          selectedIndex = 0;
           if (widgetLibraries.length) {
             widgetLibraries[selectedIndex].selected = true;
           }
@@ -287,11 +289,7 @@ angular.module('kifi')
           //
           // Initialize state.
           //
-          scope.keptToLibraryIds = scope.keptToLibraryIds || [];
-
           selectedIndex = 0;
-          libraryList = widget.find('.library-select-list');
-          searchInput = widget.find('.keep-to-library-search-input');
 
           scope.keptToLibraryIds = scope.keptToLibraryIds || [];
           scope.search = {};
@@ -299,6 +297,8 @@ angular.module('kifi')
           scope.newLibrary = {};
           scope.$error = {};
 
+          libraryList = widget.find('.library-select-list');
+          searchInput = widget.find('.keep-to-library-search-input');
           newLibraryNameInput = widget.find('.keep-to-library-create-name-input');
 
 
@@ -343,7 +343,7 @@ angular.module('kifi')
 
         scope.onSearchInputChange = function (name) {
           var matchedLibraries = libraryNameSearch.search(name);
-          groupWidgetLibraries(matchedLibraries.length ? matchedLibraries : allLibraries);
+          groupWidgetLibraries(!name ? allLibraries : matchedLibraries);
         };
 
         scope.processKeyEvent = function ($event) {
@@ -404,6 +404,13 @@ angular.module('kifi')
         scope.showCreatePanel = function () {
           scope.showCreate = true;
 
+          // If there are no libraries shown, prepopulate the create-library
+          // name input field with the search query.
+          if (!widget.find('.library-select-option').length) {
+            scope.newLibrary.name = scope.search.name;
+          }
+
+
           // Wait for the creation panel to be shown, and then focus on the
           // input.
           $timeout(function () {
@@ -413,7 +420,6 @@ angular.module('kifi')
 
         scope.hideCreatePanel = function () {
           scope.showCreate = false;
-          scope.search = {};
 
           // Wait for the libraries panel to be shown, and then focus on the
           // search input.

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -422,9 +422,10 @@ angular.module('kifi')
           scope.showCreate = false;
 
           // Wait for the libraries panel to be shown, and then focus on the
-          // search input.
+          // search input and scroll back to the top.
           $timeout(function () {
             searchInput.focus();
+            libraryList.scrollTop(0);
           }, 0);
         };
 

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -439,6 +439,21 @@ angular.module('kifi')
                 removeWidget();
               });
             });
+          })['catch'](function (err) {
+            var error = err.data && err.data.error;
+            switch (error) {
+              case 'library name already exists for user':  // deprecated
+              case 'library_name_exists':
+                scope.$error.general = 'You already have a library with this name';
+                break;
+              case 'invalid library name':  // deprecated
+              case 'invalid_name':
+                scope.$error.general = 'You already have a library with this name';
+                break;
+              default:
+                scope.$error.general = 'Hmm, something went wrong. Try again later?';
+                break;
+            }
           })['finally'](function () {
             submitting = false;
           });

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -60,14 +60,6 @@ angular.module('kifi')
 
 
         //
-        // Scope data.
-        //
-        scope.search = {};
-        scope.showCreate = false;
-        scope.newLibrary = {};
-
-
-        //
         // Internal methods.
         //
         function init() {
@@ -296,12 +288,17 @@ angular.module('kifi')
           // Initialize state.
           //
           scope.keptToLibraryIds = scope.keptToLibraryIds || [];
-          scope.search = {};
+
           selectedIndex = 0;
           libraryList = widget.find('.library-select-list');
           searchInput = widget.find('.keep-to-library-search-input');
+
+          scope.keptToLibraryIds = scope.keptToLibraryIds || [];
+          scope.search = {};
           scope.showCreate = false;
           scope.newLibrary = {};
+          scope.$error = {};
+
           newLibraryNameInput = widget.find('.keep-to-library-create-name-input');
 
 
@@ -422,9 +419,15 @@ angular.module('kifi')
         };
 
         scope.createLibrary = function (library) {
-          if (submitting || !library.name || (library.name.length < 3)) {
+          if (submitting || !library.name) {
             return;
           }
+
+          scope.$error.name = libraryService.getLibraryNameError(library.name);
+          if (scope.$error.name) {
+            return;
+          }
+          scope.$error = {};
 
           library.slug = util.generateSlug(library.name);
           library.visibility = library.visibility || 'published';
@@ -440,6 +443,17 @@ angular.module('kifi')
             submitting = false;
           });
         };
+
+
+        //
+        // Watches and listeners.
+        //
+        scope.$watch('newLibrary.name', function (newVal, oldVal) {
+          if (newVal !== oldVal) {
+            // Clear the error popover when the user changes the name field.
+            scope.$error.name = null;
+          }
+        });
 
 
         init();

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -385,6 +385,10 @@ angular.module('kifi')
                 invokeWidgetCallbacks(widgetLibraries[selectedIndex]);
                 removeWidget();
               } else {
+                // If there are no libraries shown, prepopulate the create-library
+                // name input field with the search query.
+                scope.newLibrary.name = scope.search.name;
+
                 scope.showCreatePanel();
               }
               break;

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.styl
@@ -114,7 +114,7 @@ keep-to-library-lib-icon =
   .library-select-list
     max-height: 305px
     overflow-x: hidden
-    overflow-y: scroll
+    overflow-y: auto
 
   .library-select-option
     position: relative

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.styl
@@ -229,13 +229,17 @@ keep-to-library-lib-icon =
     font-weight: 600
     background-color: #fff
     white-space: nowrap
-    overflow: hidden
 
   .keep-to-library-create-name-input
     border: none
     width: 230px
     font-size: 12px
     placeholder secondaryTextGray
+
+  .keep-to-library-create-name-error
+    pop-over 40px 18px redColor
+    font-size: 11px
+    font-weight: 500
 
   .keep-to-library-create-visibility
     margin-top: 10px

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.styl
@@ -247,6 +247,12 @@ keep-to-library-lib-icon =
   .keep-to-library-visibility-explanation
     padding: 15px 30px 35px
 
+  .keep-to-library-create-general-error
+    padding: 10px
+    background-color: redColor
+    color: #fff
+    text-align: center
+
   .keep-to-library-create-button-container
     padding: 10px
     background-color: #f3f5f7

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.tpl.html
@@ -64,6 +64,7 @@
         <span ng-switch-when="secret" class="keep-to-library-lib-icon svg-private-library-icon"></span>
       </span>
       <input class="keep-to-library-create-name-input" ng-model="newLibrary.name" placeholder="Inspiring videos, Recipes I love...">
+      <span ng-show="$error.name" class="keep-to-library-create-name-error">{{$error.name}}</span>
     </div>
     <div class="keep-to-library-create-heading">Make it private?</div>
     <div class="keep-to-library-create-visibility">

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.tpl.html
@@ -78,6 +78,7 @@
       <div ng-switch-default>Anyone will be able to see the keeps in this library.</div>
       <div ng-switch-when="secret">Only you will be able to see the keeps in this library.</div>
     </div>
+    <div ng-show="$error.general" class="keep-to-library-create-general-error">{{$error.general}}</div>
     <div class="keep-to-library-create-button-container">
       <button class="keep-to-library-create-button" ng-click="createLibrary(newLibrary)">Create Library</button>
     </div>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -145,6 +145,12 @@ angular.module('kifi')
         });
       },
 
+      duplicateName: function (name) {
+        return _.find(librarySummaries, function (librarySummary) {
+          return (librarySummary.name === name) && (librarySummary.access === 'owner');
+        });
+      },
+
       fetchLibrarySummaries: function (invalidateCache) {
         if (invalidateCache) {
           userLibrarySummariesService.expire();

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -126,6 +126,12 @@ angular.module('kifi')
       library.secondLine = lines[1];
     }
 
+    function duplicateName(name) {
+      return _.find(librarySummaries, function (librarySummary) {
+        return (librarySummary.name === name) && (librarySummary.access === 'owner');
+      });
+    }
+
 
     //
     // API methods.
@@ -145,10 +151,26 @@ angular.module('kifi')
         });
       },
 
-      duplicateName: function (name) {
-        return _.find(librarySummaries, function (librarySummary) {
-          return (librarySummary.name === name) && (librarySummary.access === 'owner');
-        });
+      getLibraryNameError: function (name) {
+        function hasInvalidCharacters (myString, invalidChars) {
+          return _.some(invalidChars, function (invalidChar) {
+            return myString.indexOf(invalidChar) !== -1;
+          });
+        }
+
+        if (!name.length) {
+          return 'Please enter a name for your library';
+        } else if (name.length < 3) {
+          return 'Please try a longer name';
+        } else if (name.length > 50) {
+          return 'Please try a shorter name';
+        } else if (hasInvalidCharacters(name, ['/', '\\', '"', '\''])) {
+          return 'Please no slashes or quotes in your library name';
+        } else if (duplicateName(name)) {
+          return 'You already have a library with this name';
+        }
+
+        return null;
       },
 
       fetchLibrarySummaries: function (invalidateCache) {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -46,6 +46,8 @@ angular.module('kifi')
             return 'Please try a shorter name';
           } else if (hasInvalidCharacters(scope.library.name, ['/', '\\', '"', '\''])) {
             return 'Please no slashes or quotes in your library name';
+          } else if (libraryService.duplicateName(name)) {
+            return 'You already have a library with this name';
           }
 
           return null;

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -29,32 +29,6 @@ angular.module('kifi')
 
 
         //
-        // Internal methods.
-        //
-        function getLibraryNameError(name) {
-          function hasInvalidCharacters (myString, invalidChars) {
-            return _.some(invalidChars, function (invalidChar) {
-              return myString.indexOf(invalidChar) !== -1;
-            });
-          }
-
-          if (!name.length) {
-            return 'Please enter a name for your library';
-          } else if (scope.library.name.length < 3) {
-            return 'Please try a longer name';
-          } else if (scope.library.name.length > 50) {
-            return 'Please try a shorter name';
-          } else if (hasInvalidCharacters(scope.library.name, ['/', '\\', '"', '\''])) {
-            return 'Please no slashes or quotes in your library name';
-          } else if (libraryService.duplicateName(name)) {
-            return 'You already have a library with this name';
-          }
-
-          return null;
-        }
-
-
-        //
         // Scope methods.
         //
         scope.close = function () {
@@ -72,7 +46,7 @@ angular.module('kifi')
             return;
           }
 
-          scope.$error.name = getLibraryNameError(scope.library.name);
+          scope.$error.name = libraryService.getLibraryNameError(scope.library.name);
           if (scope.$error.name) {
             return;
           }


### PR DESCRIPTION
@andrewconner 

Actually, addresses the following:
- https://app.asana.com/0/18079737520750/18688718389292
- https://app.asana.com/0/18079737520750/18998731396271
- https://app.asana.com/0/18079737520750/19402371355029

Also:
- Fixes small scroll issues
- Fixes logical error in Fuse search where no search results for a non-empty search query results in the entire list of user libraries being shown.
