### PR TITLE
Analytics: Create/Edit/Delete Libraries

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/heimdal/EventType.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/EventType.scala
@@ -45,6 +45,7 @@ object UserEventTypes {
   val RECOMMENDATION_USER_ACTION = EventType("reco_action")
 
   // Libraries
+  val MODIFIED_LIBRARY = EventType("modified_library")
   val FOLLOWED_LIBRARY = EventType("followed_library")
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryAnalytics.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryAnalytics.scala
@@ -28,7 +28,7 @@ class LibraryAnalytics @Inject() (heimdal: HeimdalServiceClient) {
     heimdal.trackEvent(UserEvent(userId, builder.build, UserEventTypes.INVITED))
   }
 
-  def acceptLibraryInvite(userId: Id[User], libId: Id[Library], inviteeList: Seq[(Either[Id[User], EmailAddress])], eventContext: HeimdalContext) = {
+  def acceptLibraryInvite(userId: Id[User], libId: Id[Library], eventContext: HeimdalContext) = {
     val builder = new HeimdalContextBuilder
     builder.addExistingContext(eventContext)
     builder += ("action", "accepted")

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryAnalytics.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryAnalytics.scala
@@ -37,7 +37,7 @@ class LibraryAnalytics @Inject() (heimdal: HeimdalServiceClient) {
     heimdal.trackEvent(UserEvent(userId, builder.build, UserEventTypes.INVITED))
   }
 
-  def followLibrary(userId: Id[User], library: Library, context: HeimdalContext): Unit = {
+  def followLibrary(userId: Id[User], library: Library, keepCount: Int, context: HeimdalContext): Unit = {
     val followedAt = currentDateTime
     SafeFuture {
       val contextBuilder = new HeimdalContextBuilder
@@ -47,11 +47,12 @@ class LibraryAnalytics @Inject() (heimdal: HeimdalServiceClient) {
       contextBuilder += ("libraryId", library.id.toString)
       contextBuilder += ("libraryOwnerId", library.ownerId.toString)
       contextBuilder += ("followerCount", library.memberCount - 1)
+      contextBuilder += ("keepCount", keepCount)
       heimdal.trackEvent(UserEvent(userId, contextBuilder.build, UserEventTypes.FOLLOWED_LIBRARY, followedAt))
     }
   }
 
-  def unfollowLibrary(userId: Id[User], library: Library, context: HeimdalContext): Unit = {
+  def unfollowLibrary(userId: Id[User], library: Library, keepCount: Int, context: HeimdalContext): Unit = {
     val unfollowedAt = currentDateTime
     SafeFuture {
       val contextBuilder = new HeimdalContextBuilder
@@ -61,7 +62,57 @@ class LibraryAnalytics @Inject() (heimdal: HeimdalServiceClient) {
       contextBuilder += ("libraryId", library.id.toString)
       contextBuilder += ("libraryOwnerId", library.ownerId.toString)
       contextBuilder += ("followerCount", library.memberCount - 1)
+      contextBuilder += ("keepCount", keepCount)
       heimdal.trackEvent(UserEvent(userId, contextBuilder.build, UserEventTypes.FOLLOWED_LIBRARY, unfollowedAt))
+    }
+  }
+
+  def createLibrary(userId: Id[User], library: Library, context: HeimdalContext): Unit = {
+    val createdLibraryAt = currentDateTime
+    SafeFuture {
+      val contextBuilder = new HeimdalContextBuilder
+      contextBuilder.data ++= context.data
+      contextBuilder += ("action", "created")
+      contextBuilder += ("privacySetting", library.visibility.toString)
+      contextBuilder += ("libraryId", library.id.toString)
+      contextBuilder += ("libraryOwnerId", library.ownerId.toString)
+      contextBuilder += ("description", library.description.map(_.length).getOrElse(0))
+      heimdal.trackEvent(UserEvent(userId, contextBuilder.build, UserEventTypes.MODIFIED_LIBRARY, createdLibraryAt))
+    }
+  }
+  def deleteLibrary(userId: Id[User], library: Library, context: HeimdalContext): Unit = {
+    val createdLibraryAt = currentDateTime
+    SafeFuture {
+      val contextBuilder = new HeimdalContextBuilder
+      contextBuilder.data ++= context.data
+      contextBuilder += ("action", "deleted")
+      contextBuilder += ("privacySetting", library.visibility.toString)
+      contextBuilder += ("libraryId", library.id.toString)
+      contextBuilder += ("libraryOwnerId", library.ownerId.toString)
+      contextBuilder += ("description", library.description.map(_.length).getOrElse(0))
+      heimdal.trackEvent(UserEvent(userId, contextBuilder.build, UserEventTypes.MODIFIED_LIBRARY, createdLibraryAt))
+    }
+  }
+  def editLibrary(userId: Id[User], library: Library, context: HeimdalContext, subAction: Option[String] = None): Unit = {
+    val createdLibraryAt = currentDateTime
+    SafeFuture {
+      val contextBuilder = new HeimdalContextBuilder
+      contextBuilder.data ++= context.data
+      contextBuilder += ("action", "edited")
+      subAction match {
+        case Some("move_keeps") =>
+          contextBuilder += ("subAction", "movedKeeps")
+        case Some("copy_keeps") =>
+          contextBuilder += ("subAction", "copiedKeeps")
+        case Some("import_keeps") =>
+          contextBuilder += ("subAction", "importedKeeps")
+        case _ =>
+      }
+      contextBuilder += ("privacySetting", library.visibility.toString)
+      contextBuilder += ("libraryId", library.id.toString)
+      contextBuilder += ("libraryOwnerId", library.ownerId.toString)
+      contextBuilder += ("description", library.description.map(_.length).getOrElse(0))
+      heimdal.trackEvent(UserEvent(userId, contextBuilder.build, UserEventTypes.MODIFIED_LIBRARY, createdLibraryAt))
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -756,8 +756,8 @@ class LibraryCommander @Inject() (
         listInvites.map(inv => libraryInviteRepo.save(inv.copy(state = LibraryInviteStates.ACCEPTED)))
 
         SafeFuture {
-          libraryAnalytics.acceptLibraryInvite(userId, libraryId, Seq(), eventContext)
-          val keepCount = keepRepo.getByLibrary(libraryId, 0, Int.MaxValue)
+          libraryAnalytics.acceptLibraryInvite(userId, libraryId, eventContext)
+          val keepCount = keepRepo.getCountByLibrary(libraryId)
           libraryAnalytics.followLibrary(userId, lib, keepCount, eventContext)
         }
 
@@ -784,7 +784,7 @@ class LibraryCommander @Inject() (
           val lib = libraryRepo.get(libraryId)
           libraryRepo.save(lib.copy(memberCount = libraryMembershipRepo.countWithLibraryId(libraryId)))
           SafeFuture {
-            val keepCount = keepRepo.getByLibrary(libraryId, 0, Int.MaxValue)
+            val keepCount = keepRepo.getCountByLibrary(libraryId)
             libraryAnalytics.unfollowLibrary(userId, lib, keepCount, eventContext)
           }
           searchClient.updateLibraryIndex()

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -755,12 +755,9 @@ class LibraryCommander @Inject() (
         val updatedLib = libraryRepo.save(lib.copy(memberCount = libraryMembershipRepo.countWithLibraryId(libraryId)))
         listInvites.map(inv => libraryInviteRepo.save(inv.copy(state = LibraryInviteStates.ACCEPTED)))
 
-        SafeFuture {
-          libraryAnalytics.acceptLibraryInvite(userId, libraryId, eventContext)
-          val keepCount = keepRepo.getCountByLibrary(libraryId)
-          libraryAnalytics.followLibrary(userId, lib, keepCount, eventContext)
-        }
-
+        val keepCount = keepRepo.getCountByLibrary(libraryId)
+        libraryAnalytics.acceptLibraryInvite(userId, libraryId, eventContext)
+        libraryAnalytics.followLibrary(userId, lib, keepCount, eventContext)
         searchClient.updateLibraryIndex()
         Right(updatedLib)
       }
@@ -783,10 +780,9 @@ class LibraryCommander @Inject() (
           libraryMembershipRepo.save(mem.copy(state = LibraryMembershipStates.INACTIVE))
           val lib = libraryRepo.get(libraryId)
           libraryRepo.save(lib.copy(memberCount = libraryMembershipRepo.countWithLibraryId(libraryId)))
-          SafeFuture {
-            val keepCount = keepRepo.getCountByLibrary(libraryId)
-            libraryAnalytics.unfollowLibrary(userId, lib, keepCount, eventContext)
-          }
+
+          val keepCount = keepRepo.getCountByLibrary(libraryId)
+          libraryAnalytics.unfollowLibrary(userId, lib, keepCount, eventContext)
           searchClient.updateLibraryIndex()
           Right()
         }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -60,6 +60,7 @@ class ExtLibraryController @Inject() (
     val visibility = (body \ "visibility").as[LibraryVisibility]
     val slug = LibrarySlug.generateFromName(name)
     val addRequest = LibraryAddRequest(name, visibility, description = None, slug, collaborators = None, followers = None)
+    implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.keeper).build
     libraryCommander.addLibrary(addRequest, request.userId) match {
       case Left(fail) => BadRequest(Json.obj("error" -> fail.message))
       case Right(lib) =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -58,6 +58,7 @@ class LibraryController @Inject() (
   def addLibrary() = UserAction.async(parse.tolerantJson) { request =>
     val addRequest = request.body.as[LibraryAddRequest]
 
+    implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
     libraryCommander.addLibrary(addRequest, request.userId) match {
       case Left(LibraryFail(message)) =>
         Future.successful(BadRequest(Json.obj("error" -> message)))
@@ -87,7 +88,7 @@ class LibraryController @Inject() (
 
   def removeLibrary(pubId: PublicId[Library]) = (UserAction andThen LibraryWriteAction(pubId)) { request =>
     val id = Library.decodePublicId(pubId).get
-    implicit val context = heimdalContextBuilder.withRequestInfo(request).build
+    implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
     libraryCommander.removeLibrary(id, request.userId) match {
       case Some((status, message)) => Status(status)(Json.obj("error" -> message))
       case _ => Ok(JsString("success"))
@@ -270,6 +271,7 @@ class LibraryController @Inject() (
     val hashtag = Hashtag(tag)
     val id = Library.decodePublicId(libraryId).get
     SafeFuture {
+      implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
       libraryCommander.copyKeepsFromCollectionToLibrary(request.userId, id, hashtag) match {
         case Left(fail) => BadRequest(Json.obj("error" -> fail.message))
         case Right((goodKeeps, badKeeps)) =>
@@ -293,6 +295,7 @@ class LibraryController @Inject() (
     val hashtag = Hashtag(tag)
     val id = Library.decodePublicId(libraryId).get
     SafeFuture {
+      implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
       libraryCommander.moveKeepsFromCollectionToLibrary(request.userId, id, hashtag) match {
         case Left(fail) => BadRequest(Json.obj("error" -> fail.message))
         case Right((goodKeeps, badKeeps)) =>
@@ -326,6 +329,7 @@ class LibraryController @Inject() (
     Library.decodePublicId(toPubId) match {
       case Failure(ex) => BadRequest(Json.obj("error" -> "dest_invalid_id"))
       case Success(toId) =>
+        implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
         val targetKeeps = db.readOnlyMaster { implicit s => targetKeepsExt.map(keepRepo.getOpt) }.flatten
         val (goodKeeps, badKeeps) = libraryCommander.copyKeeps(request.userId, toId, targetKeeps, Some(KeepSource.userCopied))
         val errors = badKeeps.map {
@@ -352,6 +356,7 @@ class LibraryController @Inject() (
     Library.decodePublicId(toPubId) match {
       case Failure(ex) => BadRequest(Json.obj("error" -> "dest_invalid_id"))
       case Success(toId) =>
+        implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
         val targetKeeps = db.readOnlyReplica { implicit s => targetKeepsExt.map { keepRepo.getOpt } }.flatten
         val (goodKeeps, badKeeps) = libraryCommander.moveKeeps(request.userId, toId, targetKeeps)
         val errors = badKeeps.map {

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -535,7 +535,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           (Left(userAgent.id.get), LibraryAccess.READ_ONLY, None),
           (Left(userHulk.id.get), LibraryAccess.READ_ONLY, None),
           (Right(thorEmail), LibraryAccess.READ_ONLY, Some("America > Asgard")))
-        val res1 = libraryCommander.inviteUsersToLibrary(libMurica.id.get, userCaptain.id.get, inviteList1)(HeimdalContext(Map()))
+        val res1 = libraryCommander.inviteUsersToLibrary(libMurica.id.get, userCaptain.id.get, inviteList1)
         res1.isRight === true
         res1.right.get === Seq((Left(userIron.externalId), LibraryAccess.READ_ONLY),
           (Left(userAgent.externalId), LibraryAccess.READ_ONLY),
@@ -558,10 +558,10 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
         val inviteList2_RW = Seq((Left(userIron.id.get), LibraryAccess.READ_WRITE, None))
         val inviteList2_RO = Seq((Left(userIron.id.get), LibraryAccess.READ_ONLY, None))
         // Scumbag Ironman tries to invite himself for READ_ONLY access (OK for Published Library)
-        libraryCommander.inviteUsersToLibrary(libMurica.id.get, userIron.id.get, inviteList2_RO)(HeimdalContext(Map())).isRight === true
+        libraryCommander.inviteUsersToLibrary(libMurica.id.get, userIron.id.get, inviteList2_RO).isRight === true
 
         // Scumbag Ironman tries to invite himself for READ_WRITE access (NOT OK for Published Library)
-        libraryCommander.inviteUsersToLibrary(libMurica.id.get, userIron.id.get, inviteList2_RW)(HeimdalContext(Map())).isRight === true
+        libraryCommander.inviteUsersToLibrary(libMurica.id.get, userIron.id.get, inviteList2_RW).isRight === true
       }
     }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
@@ -13,6 +13,7 @@ import com.keepit.common.store.FakeShoeboxStoreModule
 import com.keepit.controllers.mobile.MobileKeepsController
 import com.keepit.cortex.FakeCortexServiceClientModule
 import com.keepit.curator.FakeCuratorServiceClientModule
+import com.keepit.heimdal.HeimdalContext
 import com.keepit.model._
 import com.keepit.scraper.{ FakeScrapeSchedulerModule, FakeScraperServiceClientModule }
 import com.keepit.search.FakeSearchServiceClientModule
@@ -48,6 +49,7 @@ class KifiSiteRouterTest extends Specification with ShoeboxTestInjector {
   )
 
   "KifiSiteRouter" should {
+    implicit val context = HeimdalContext.empty
 
     "route requests correctly" in {
       withDb(modules: _*) { implicit injector =>


### PR DESCRIPTION
Adding "user_modified_library" 
- action: created, edited, deleted
- subAction: copiedKeeps, movedKeeps
- privacySetting
- libraryId
- libraryOwnerId
- description
- source

and add keepCount to follow/unfollow libraries

@leogrim @stkem 
