### PR TITLE
mobile invite / share typeahead endpoints

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -4,15 +4,16 @@ import com.google.inject.Inject
 import com.keepit.commanders._
 import com.keepit.common.controller._
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
-import com.keepit.common.db.Id
+import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.db.slick.Database
+import com.keepit.common.mail.EmailAddress
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.controllers.mobile.ImplicitHelper._
 import com.keepit.heimdal.HeimdalContextBuilderFactory
 import com.keepit.model._
 import com.keepit.shoebox.controllers.LibraryAccessActions
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.api.libs.json.{ JsObject, JsString, Json }
+import play.api.libs.json.{ JsArray, JsObject, JsString, Json }
 
 import scala.concurrent.Future
 import scala.util.{ Failure, Success }
@@ -21,6 +22,7 @@ class MobileLibraryController @Inject() (
   db: Database,
   libraryRepo: LibraryRepo,
   keepRepo: KeepRepo,
+  userRepo: UserRepo,
   basicUserRepo: BasicUserRepo,
   keepsCommander: KeepsCommander,
   heimdalContextBuilder: HeimdalContextBuilderFactory,
@@ -87,6 +89,42 @@ class MobileLibraryController @Inject() (
     Ok(Json.obj("libraries" -> libsFollowing, "invited" -> libsInvitedTo))
   }
 
+  def inviteUsersToLibrary(pubId: PublicId[Library]) = UserAction(parse.tolerantJson) { request =>
+    val idTry = Library.decodePublicId(pubId)
+    idTry match {
+      case Failure(ex) =>
+        BadRequest(Json.obj("error" -> "invalid_id"))
+      case Success(id) =>
+        val invites = (request.body \ "invites").as[JsArray].value
+        val msgOpt = (request.body \ "message").asOpt[String]
+        val message = if (msgOpt == Some("")) None else msgOpt
+
+        val validInviteList = db.readOnlyMaster { implicit s =>
+          invites.map { i =>
+            val access = (i \ "access").as[LibraryAccess]
+            val id = (i \ "type").as[String] match {
+              case "user" if userRepo.getOpt((i \ "id").as[ExternalId[User]]).nonEmpty =>
+                Left(userRepo.getOpt((i \ "id").as[ExternalId[User]]).get.id.get)
+              case "email" => Right((i \ "id").as[EmailAddress])
+            }
+            (id, access, message)
+          }
+        }
+        implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
+        val res = libraryCommander.inviteUsersToLibrary(id, request.userId, validInviteList)
+        res match {
+          case Left(fail) =>
+            BadRequest(Json.obj("error" -> fail.message))
+          case Right(info) =>
+            val res = info.map {
+              case (Left(externalId), access) => Json.obj("user" -> externalId, "access" -> access)
+              case (Right(email), access) => Json.obj("email" -> email, "access" -> access)
+            }
+            Ok(Json.toJson(res))
+        }
+    }
+  }
+
   def joinLibrary(pubId: PublicId[Library]) = UserAction { request =>
     val idTry = Library.decodePublicId(pubId)
     idTry match {
@@ -141,6 +179,19 @@ class MobileLibraryController @Inject() (
         } yield {
           Ok(Json.obj("keeps" -> keepInfos))
         }
+    }
+  }
+
+  def suggestMembers(pubId: PublicId[Library], query: Option[String], limit: Int) = (UserAction andThen LibraryViewAction(pubId)).async { request =>
+    request match {
+      case req: UserRequest[_] => {
+        if (limit > 30) { Future.successful(BadRequest(Json.obj("error" -> "invalid_limit"))) }
+        else Library.decodePublicId(pubId) match {
+          case Failure(ex) => Future.successful(BadRequest(Json.obj("error" -> "invalid_id")))
+          case Success(libraryId) => libraryCommander.suggestMembers(req.userId, libraryId, query, Some(limit)).map { members => Ok(Json.obj("members" -> members)) }
+        }
+      }
+      case _ => Future.successful(Forbidden)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -179,7 +179,7 @@ class LibraryController @Inject() (
             (id, access, message)
           }
         }
-        implicit val context = heimdalContextBuilder.withRequestInfo(request).build
+        implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
         val res = libraryCommander.inviteUsersToLibrary(id, request.userId, validInviteList)
         res match {
           case Left(fail) =>

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -237,6 +237,8 @@ POST    /m/1/libraries/:id/join                 @com.keepit.controllers.mobile.M
 POST    /m/1/libraries/:id/decline              @com.keepit.controllers.mobile.MobileLibraryController.declineLibrary(id: PublicId[Library])
 POST    /m/1/libraries/:id/leave                @com.keepit.controllers.mobile.MobileLibraryController.leaveLibrary(id: PublicId[Library])
 GET     /m/1/libraries/:id/keeps                @com.keepit.controllers.mobile.MobileLibraryController.getKeeps(id: PublicId[Library], offset: Int ?= 0, limit: Int ?= 10)
+POST    /m/1/libraries/:id/invite               @com.keepit.controllers.mobile.MobileLibraryController.inviteUsersToLibrary(id: PublicId[Library])
+GET     /m/1/libraries/:id/members/suggest      @com.keepit.controllers.mobile.MobileLibraryController.suggestMembers(id: PublicId[Library], q: Option[String] ?= None, n: Int ?= 5)
 
 GET     /m/1/keeps/:id                      @com.keepit.controllers.mobile.MobileKeepsController.getKeepInfo(id: ExternalId[Keep], withFullInfo: Boolean ?= false)
 


### PR DESCRIPTION
@andrewconner 
@thassss @jaredpetker 

(similar to how the site handles these two endpoints)
To invite users, use endpoint: 
/m/1/libraries/:id/invite
POST request body looks like this:
{ 
invites: [ {type: "user", id: user_external_id, access: "read_only"}, 
              {type: "email", id: email_address, access: "read_only"} 
            ],
message: "View this library, bruh" (*message is optional field)
 }

To use the typeahead, call GET request:
/m/1/libraries/:id/members/suggest?n=10&q=aaron

n means the number of suggestions to provide (default is 5)
q means the query string (could be empty string)

Please let me know if you have any questions =)
