### PR TITLE
basic libraries info in search analytics (kifi.com)

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/search/search.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/search.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .controller('SearchCtrl', [
-  '$scope', '$rootScope', '$location', '$routeParams', '$window', 'keepDecoratorService', 'searchActionService',
-  function ($scope, $rootScope, $location, $routeParams, $window, keepDecoratorService, searchActionService) {
+  '$scope', '$rootScope', '$location', '$routeParams', '$window', 'keepDecoratorService', 'searchActionService', 'libraryService',
+  function ($scope, $rootScope, $location, $routeParams, $window, keepDecoratorService, searchActionService, libraryService) {
     //
     // Internal data.
     //
@@ -96,7 +96,7 @@ angular.module('kifi')
     };
 
     $scope.getNextKeeps = function (resetExistingResults) {
-      if ($scope.loading) {
+      if ($scope.loading || query === '') {
         return;
       }
 
@@ -201,7 +201,13 @@ angular.module('kifi')
 
     // Report search analytics on unload.
     var onUnload = function () {
-      searchActionService.reportSearchAnalyticsOnUnload($scope.resultKeeps.length);
+      var resultsWithLibs = 0;
+      $scope.resultKeeps.forEach( function (keep) {
+        if (_.some(keep.libraries, function (lib) { return !libraryService.isSystemLibrary(lib); })) {
+          resultsWithLibs++;
+        }
+      });
+      searchActionService.reportSearchAnalyticsOnUnload($scope.resultKeeps.length, resultsWithLibs);
     };
     $window.addEventListener('beforeunload', onUnload);
 

--- a/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
@@ -78,7 +78,7 @@ angular.module('kifi')
       hit.myLibraries = myLibraries;
     }
 
-    function reportSearchAnalytics(endedWith, numResults) {
+    function reportSearchAnalytics(endedWith, numResults, numResultsWithLibraries) {
       var url = routeService.searchedAnalytics;
       if (lastSearchContext && lastSearchContext.query) {
         var origin = $location.$$protocol + '://' + $location.$$host;
@@ -94,6 +94,7 @@ angular.module('kifi')
           maxResults: lastSearchContext.maxResults,
           kifiExpanded: true,
           kifiResults: numResults,
+          kifiResultsWithLibraries: numResultsWithLibraries,
           kifiTime: lastSearchContext.kifiTime,
           kifiShownTime: lastSearchContext.kifiShownTime,
           kifiResultsClicked: lastSearchContext.clicks,
@@ -182,12 +183,12 @@ angular.module('kifi')
       pageSession = createPageSession();
     }
 
-    function reportSearchAnalyticsOnUnload(numResults) {
-      reportSearchAnalytics('unload', numResults);
+    function reportSearchAnalyticsOnUnload(numResults, numResultsWithLibraries) {
+      reportSearchAnalytics('unload', numResults, numResultsWithLibraries);
     }
 
-    function reportSearchAnalyticsOnRefine(numResults) {
-      reportSearchAnalytics('refinement', numResults);
+    function reportSearchAnalyticsOnRefine(numResults, numResultsWithLibraries) {
+      reportSearchAnalytics('refinement', numResults, numResultsWithLibraries);
     }
 
     function reportSearchClickAnalytics(keep, resultPosition, numResults) {
@@ -197,7 +198,6 @@ angular.module('kifi')
         if ($location.$$port) {
           origin = origin + ':' + $location.$$port;
         }
-        var matches = keep.bookmark.matches || (keep.bookmark.matches = {});
         var hitContext = {
           isMyBookmark: keep.isMyBookmark,
           isPrivate: keep.isPrivate,
@@ -205,10 +205,13 @@ angular.module('kifi')
           keepers: keep.keepers.map(function (elem) {
             return elem.id;
           }),
+          libraries: keep.libraries.map(function (elem) {
+            return elem.id;
+          }),
           tags: keep.tags,
-          title: keep.bookmark.title,
-          titleMatches: (matches.title || []).length,
-          urlMatches: (matches.url || []).length
+          title: keep.summary.title,
+          titleMatches: 0, //This broke with new search api (the information is no longer available). Needs to be investigated if we still need it.
+          urlMatches: 0
         };
         var data = {
           origin: origin,


### PR DESCRIPTION
this stuff is going to need some more thought and love soon. Click tracking seems
to have been broken since we switched out the search endpoint, due to a
piece of data (`matches`) no longer being available. I’ve fixed the
exception, but we need to figure out if we still need that data and if
so get it back into the api.
Also, if a user completely eases the query that does _not_ cause a
‘searched’ event. I’m not sure that is what we want.
@andrewconner @leogrim 
