### PR TITLE
fix last_viewed sorting (doesn't update as users visit libraries)

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
@@ -98,6 +98,19 @@ angular.module('kifi')
         });
         scope.$on('$destroy', deregisterChangedLibrary);
 
+        var deregisterLibraryVisited = $rootScope.$on('lastViewedLib', function (e, lib) {
+          if (lib.name) {
+            var ind = _.findIndex(scope.userLibsToShow, function(l) { return l.name === lib.name; });
+            if (scope.userLibsToShow[ind]) {
+              scope.userLibsToShow[ind].lastViewed = Date.now();
+            }
+            if (scope.sortingMenu.option === 'last_viewed') {
+              updateNavLibs();
+            }
+          }
+        });
+        scope.$on('$destroy', deregisterLibraryVisited);
+
         scope.$watch(function () {
           return friendService.requests.length;
         }, function (value) {

--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
@@ -100,9 +100,9 @@ angular.module('kifi')
 
         var deregisterLibraryVisited = $rootScope.$on('lastViewedLib', function (e, lib) {
           if (lib.name) {
-            var ind = _.findIndex(scope.userLibsToShow, function(l) { return l.name === lib.name; });
-            if (scope.userLibsToShow[ind]) {
-              scope.userLibsToShow[ind].lastViewed = Date.now();
+            var idx = _.findIndex(scope.userLibsToShow, { 'name' : lib.name });
+            if (scope.userLibsToShow[idx]) {
+              scope.userLibsToShow[idx].lastViewed = Date.now();
             }
             if (scope.sortingMenu.option === 'last_viewed') {
               updateNavLibs();

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -177,6 +177,9 @@ angular.module('kifi')
         $scope.page = 'library';
         setTitle(library);
         $rootScope.$emit('libraryUrl', $scope.library);
+        if ($scope.library.kind === 'user_created' && $scope.library.access !== 'none') {
+          $rootScope.$emit('lastViewedLib', $scope.library);
+        }
       }, function onError(resp) {
         if (resp.data && resp.data.error) {
           $scope.loading = false;


### PR DESCRIPTION
Last Viewed sorting doesn't dynamically resort whenever you visit your libraries. You'd have to refresh in order to get the correct ordering. This uses angular's `Date.now()` to dynamically update the nav libs list.

@andrewconner @yipingliao 
