### PR TITLE
and then there are two

### DIFF
--- a/kifi-backend/modules/scraper/app/com/keepit/commanders/ScraperURISummaryCommander.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/commanders/ScraperURISummaryCommander.scala
@@ -39,8 +39,11 @@ class ScraperURISummaryCommanderImpl @Inject() (
 
   private def fetchAndInternImage(uri: NormalizedURI, imageInfo: ImageInfo): Future[Option[ImageInfo]] = {
     imageInfo.url match {
-      case Some(imageUrl) => imageFetcher.fetchRawImage(URI.parse(imageUrl).get).map { rawImageOpt =>
-        rawImageOpt flatMap { rawImage => internImage(imageInfo, rawImage, uri) }
+      case Some(imageUrl) => imageFetcher.fetchRawImage(URI.parse(imageUrl).get) flatMap { rawImageOpt =>
+        rawImageOpt match {
+          case None => Future.successful(None)
+          case Some(rawImage) => internImage(imageInfo, rawImage, uri)
+        }
       }
       case None => Future.successful(None)
     }
@@ -49,16 +52,17 @@ class ScraperURISummaryCommanderImpl @Inject() (
   /**
    * Stores image to S3
    */
-  private def internImage(info: ImageInfo, image: BufferedImage, nUri: NormalizedURI): Option[ImageInfo] = {
+  private def internImage(info: ImageInfo, image: BufferedImage, nUri: NormalizedURI): Future[Option[ImageInfo]] = {
     uriImageStore.storeImage(info, image, nUri) match {
       case Success(result) =>
         val (url, size) = result
         val imageInfoWithUrl = if (info.url.isEmpty) info.copy(url = Some(url), size = Some(size)) else info
-        callback.syncSaveImageInfo(imageInfoWithUrl)
-        Some(imageInfoWithUrl)
+        callback.saveImageInfo(imageInfoWithUrl) map { _ =>
+          Some(imageInfoWithUrl)
+        }
       case Failure(ex) =>
         airbrake.notify(s"Failed to upload URL image to S3: ${ex.getMessage}")
-        None
+        Future.successful(None)
     }
   }
 
@@ -82,50 +86,47 @@ class ScraperURISummaryCommanderImpl @Inject() (
     val fullEmbedlyInfo = embedlyClient.getEmbedlyInfo(nUri.url) flatMap { embedlyInfoOpt =>
       watch.logTimeWith(s"got info: $embedlyInfoOpt") //this could be lots of logging, should remove it after problems resolved
 
-      val summary = for {
+      val summaryOptF = for {
         nUriId <- nUri.id
         embedlyInfo <- embedlyInfoOpt
       } yield {
+        callback.savePageInfo(embedlyInfo.toPageInfo(nUriId)) flatMap { _ =>
+          if (descriptionOnly) {
+            Future.successful(Some(URISummary(None, embedlyInfo.title, embedlyInfo.description)))
+          } else {
+            val images = embedlyInfo.buildImageInfo(nUriId)
+            val nonBlankImages = images.filter { image => image.url.exists(ScraperURISummaryCommander.filterImageByUrl) }
+            val (smallImages, selectedImageOpt) = partitionImages(nonBlankImages, minSize)
 
-        //here we call back shoebox, in the middle of shoebox calling us, right?
-        timing(s"[embedly] syncSavePageInfo for uri ${nUriId.id}") {
-          callback.syncSavePageInfo(embedlyInfo.toPageInfo(nUriId))
-        }
-        watch.logTimeWith(s"saved page info")
-
-        if (descriptionOnly) {
-          Future.successful(Some(URISummary(None, embedlyInfo.title, embedlyInfo.description)))
-        } else {
-          val images = embedlyInfo.buildImageInfo(nUriId)
-          val nonBlankImages = images.filter { image => image.url.exists(ScraperURISummaryCommander.filterImageByUrl) }
-          val (smallImages, selectedImageOpt) = partitionImages(nonBlankImages, minSize)
-
-          timing(s"fetching ${smallImages.size} small images") {
-            //Why are we fetching all those small images? Why do we do in in sync?
-            smallImages.foreach { fetchAndInternImage(nUri, _) }
-          }
-          watch.logTimeWith(s"all ${smallImages.size} small images")
-
-          selectedImageOpt match {
-            case None =>
-              watch.logTimeWith(s"no selected image")
-              Future.successful(Some(URISummary(None, embedlyInfo.title, embedlyInfo.description)))
-            case Some(image) =>
-              watch.logTimeWith(s"got a selected image : $image")
-              val future = fetchAndInternImage(nUri, image) map { imageInfoOpt =>
-                val urlOpt = imageInfoOpt.flatMap(getS3URL(_, nUri))
-                val widthOpt = imageInfoOpt.flatMap(_.width)
-                val heightOpt = imageInfoOpt.flatMap(_.height)
-                Some(URISummary(urlOpt, embedlyInfo.title, embedlyInfo.description, widthOpt, heightOpt))
+            timing(s"fetching ${smallImages.size} small images") {
+              //Why are we fetching all those small images? Why do we do in in sync?
+              smallImages.foreach {
+                fetchAndInternImage(nUri, _)
               }
-              future.onComplete { res =>
-                watch.logTimeWith(s"[success = ${res.isSuccess}}] fetched a selected image for : $image")
-              }
-              future
+            }
+            watch.logTimeWith(s"all ${smallImages.size} small images")
+
+            selectedImageOpt match {
+              case None =>
+                watch.logTimeWith(s"no selected image")
+                Future.successful(Some(URISummary(None, embedlyInfo.title, embedlyInfo.description)))
+              case Some(image) =>
+                watch.logTimeWith(s"got a selected image : $image")
+                val future = fetchAndInternImage(nUri, image) map { imageInfoOpt =>
+                  val urlOpt = imageInfoOpt.flatMap(getS3URL(_, nUri))
+                  val widthOpt = imageInfoOpt.flatMap(_.width)
+                  val heightOpt = imageInfoOpt.flatMap(_.height)
+                  Some(URISummary(urlOpt, embedlyInfo.title, embedlyInfo.description, widthOpt, heightOpt))
+                }
+                future.onComplete { res =>
+                  watch.logTimeWith(s"[success = ${res.isSuccess}}] fetched a selected image for : $image")
+                }
+                future
+            }
           }
         }
       }
-      summary getOrElse Future.successful(None)
+      summaryOptF getOrElse Future.successful(None)
     }
     fullEmbedlyInfo.onComplete { res =>
       watch.stop()


### PR DESCRIPTION
Removed a bunch of sync\* calls (now there are two left).
Aside from 'async-ify' -- no major behavior/functional change. 
Note that alongside with the sync calls, the locks also go away. Given @ymatsuda's new async seqNum update scheme we should be ok.
In general the changes are rather mechanical in nature -- as mechanical as this sort of change allows. 

@ymatsuda @leogrim @yingjieMiao @andrewconner 
