### PR TITLE
Temp disabling public feed computation + data cleanup

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/CuratorTasksPlugin.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/CuratorTasksPlugin.scala
@@ -29,15 +29,15 @@ class CuratorTasksPlugin @Inject() (
     scheduleTaskOnLeader(system, 3 minutes, 2 minutes, "recommendation precomputation") {
       generationCommander.precomputeRecommendations()
     }
-    scheduleTaskOnLeader(system, 5 minutes, 5 minutes, "public feed precomputation") {
-      feedCommander.precomputePublicFeeds()
-    }
-    scheduleTaskOnLeader(system, 1 hours, 5 hours, "recommendation reaper") {
-      cleanupCommander.cleanupLowMasterScoreRecos()
-    }
-    scheduleTaskOnLeader(system, 1 hours, 5 hours, "public feed reaper") {
-      cleanupCommander.cleanupLowMasterScoreFeeds()
-    }
+    // scheduleTaskOnLeader(system, 5 minutes, 5 minutes, "public feed precomputation") {
+    //   feedCommander.precomputePublicFeeds()
+    // }
+    // scheduleTaskOnLeader(system, 1 hours, 5 hours, "recommendation reaper") {
+    //   cleanupCommander.cleanupLowMasterScoreRecos()
+    // }
+    // scheduleTaskOnLeader(system, 1 hours, 5 hours, "public feed reaper") {
+    //   cleanupCommander.cleanupLowMasterScoreFeeds()
+    // }
 
     scheduleTaskOnLeader(system, 10 minutes, 10 minutes, emailActor.ref, FeedDigestMessage.Send)
     scheduleFeedDigestEmails()


### PR DESCRIPTION
1) The public feed is not currently surfaced anywhere any more. Will
check soon with product if we can retire that completely, and thus
remove the code.
2) The data cleanup is having some lock contention issues with the
recommendation generation - it’s working in _very_ large batches. This
is going to need a rewrite. Just disabling it for now to stop the
exceptions.

@yingjieMiao 
cc @eishay 
