### PR TITLE
add response status to LibraryFail -> allow LibraryCommander to persist ...

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -169,7 +169,7 @@ class LibraryCommander @Inject() (
     (libInfo, accessStr)
   }
 
-  def getLibraryWithOwnerAndCounts(libraryId: Id[Library], viewerUserId: Id[User]): Either[(Int, String), (Library, BasicUser, Int, Int)] = {
+  def getLibraryWithOwnerAndCounts(libraryId: Id[Library], viewerUserId: Id[User]): Either[LibraryFail, (Library, BasicUser, Int, Int)] = {
     db.readOnlyReplica { implicit s =>
       val library = libraryRepo.get(libraryId)
       if (library.visibility == LibraryVisibility.PUBLISHED ||
@@ -180,7 +180,7 @@ class LibraryCommander @Inject() (
         val followerCount = libraryMembershipRepo.countWithLibraryIdByAccess(library.id.get).apply(LibraryAccess.READ_ONLY)
         Right(library, owner, keepCount, followerCount)
       } else {
-        Left(403, "library_access_denied")
+        Left(LibraryFail(FORBIDDEN, "library_access_denied"))
       }
     }
   }
@@ -364,12 +364,12 @@ class LibraryCommander @Inject() (
       else { None }
     }
     badMessage match {
-      case Some(x) => Left(LibraryFail(x))
+      case Some(x) => Left(LibraryFail(BAD_REQUEST, x))
       case _ => {
         val validSlug = LibrarySlug(libAddReq.slug)
         db.readOnlyReplica { implicit s => libraryRepo.getByNameOrSlug(ownerId, libAddReq.name, validSlug) } match {
           case Some(lib) =>
-            Left(LibraryFail("library_name_or_slug_exists"))
+            Left(LibraryFail(BAD_REQUEST, "library_name_or_slug_exists"))
           case None =>
             val (collaboratorIds, followerIds) = db.readOnlyReplica { implicit s =>
               val collabs = libAddReq.collaborators.getOrElse(Seq()).map { x =>
@@ -425,15 +425,15 @@ class LibraryCommander @Inject() (
 
     val targetLib = db.readOnlyMaster { implicit s => libraryRepo.get(libraryId) }
     if (targetLib.ownerId != userId) {
-      Left(LibraryFail("permission_denied"))
+      Left(LibraryFail(FORBIDDEN, "permission_denied"))
     } else {
       def validName(name: String): Either[LibraryFail, String] = {
         if (Library.isValidName(name)) Right(name)
-        else Left(LibraryFail("invalid_name"))
+        else Left(LibraryFail(BAD_REQUEST, "invalid_name"))
       }
       def validSlug(slug: String): Either[LibraryFail, LibrarySlug] = {
         if (LibrarySlug.isValidSlug(slug)) Right(LibrarySlug(slug))
-        else Left(LibraryFail("invalid_slug"))
+        else Left(LibraryFail(BAD_REQUEST, "invalid_slug"))
       }
 
       val result = for {
@@ -467,12 +467,12 @@ class LibraryCommander @Inject() (
     }
   }
 
-  def removeLibrary(libraryId: Id[Library], userId: Id[User])(implicit context: HeimdalContext): Option[(Int, String)] = {
+  def removeLibrary(libraryId: Id[Library], userId: Id[User])(implicit context: HeimdalContext): Option[LibraryFail] = {
     val oldLibrary = db.readOnlyMaster { implicit s => libraryRepo.get(libraryId) }
     if (oldLibrary.ownerId != userId) {
-      Some((FORBIDDEN, "permission_denied"))
+      Some(LibraryFail(FORBIDDEN, "permission_denied"))
     } else if (oldLibrary.kind == LibraryKind.SYSTEM_MAIN || oldLibrary.kind == LibraryKind.SYSTEM_SECRET) {
-      Some((BAD_REQUEST, "cant_delete_system_generated_library"))
+      Some(LibraryFail(BAD_REQUEST, "cant_delete_system_generated_library"))
     } else {
       val keepsInLibrary = db.readWrite { implicit s =>
         libraryMembershipRepo.getWithLibraryId(oldLibrary.id.get).map { m =>
@@ -690,9 +690,9 @@ class LibraryCommander @Inject() (
       libraryRepo.get(libraryId)
     }
     if (!(targetLib.ownerId == inviterId || targetLib.visibility == LibraryVisibility.PUBLISHED))
-      Left(LibraryFail("permission_denied"))
+      Left(LibraryFail(FORBIDDEN, "permission_denied"))
     else if (targetLib.kind == LibraryKind.SYSTEM_MAIN || targetLib.kind == LibraryKind.SYSTEM_SECRET)
-      Left(LibraryFail("cant_invite_to_system_generated_library"))
+      Left(LibraryFail(BAD_REQUEST, "cant_invite_to_system_generated_library"))
     else {
       val successInvites = db.readOnlyMaster { implicit s =>
         for (i <- inviteList) yield {
@@ -739,9 +739,9 @@ class LibraryCommander @Inject() (
       val listInvites = libraryInviteRepo.getWithLibraryIdAndUserId(libraryId, userId)
 
       if (lib.kind == LibraryKind.SYSTEM_MAIN || lib.kind == LibraryKind.SYSTEM_SECRET)
-        Left(LibraryFail("cant_join_system_generated_library"))
+        Left(LibraryFail(FORBIDDEN, "cant_join_system_generated_library"))
       else if (lib.visibility != LibraryVisibility.PUBLISHED && listInvites.isEmpty)
-        Left(LibraryFail("cant_join_nonpublished_library"))
+        Left(LibraryFail(FORBIDDEN, "cant_join_nonpublished_library"))
       else {
         val maxAccess = if (listInvites.isEmpty) LibraryAccess.READ_ONLY else listInvites.sorted.last.access
         libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, userId, None) match {
@@ -775,7 +775,7 @@ class LibraryCommander @Inject() (
     db.readWrite { implicit s =>
       libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, userId, None) match {
         case None => Right()
-        case Some(mem) if mem.access == LibraryAccess.OWNER => Left(LibraryFail("cannot_leave_own_library"))
+        case Some(mem) if mem.access == LibraryAccess.OWNER => Left(LibraryFail(BAD_REQUEST, "cannot_leave_own_library"))
         case Some(mem) => {
           libraryMembershipRepo.save(mem.copy(state = LibraryMembershipStates.INACTIVE))
           val lib = libraryRepo.get(libraryId)
@@ -839,7 +839,7 @@ class LibraryCommander @Inject() (
       collectionRepo.getByUserAndName(userId, tagName)
     } match {
       case None =>
-        Left(LibraryFail("tag_not_found"))
+        Left(LibraryFail(NOT_FOUND, "tag_not_found"))
       case Some(tag) =>
         val keeps = db.readOnlyMaster { implicit s =>
           keepToCollectionRepo.getKeepsForTag(tag.id.get).map { kId => keepRepo.get(kId) }
@@ -853,7 +853,7 @@ class LibraryCommander @Inject() (
       collectionRepo.getByUserAndName(userId, tagName)
     } match {
       case None =>
-        Left(LibraryFail("tag_not_found"))
+        Left(LibraryFail(NOT_FOUND, "tag_not_found"))
       case Some(tag) =>
         val keeps = db.readOnlyMaster { implicit s =>
           keepToCollectionRepo.getKeepsForTag(tag.id.get).map { kId => keepRepo.get(kId) }
@@ -993,19 +993,19 @@ class LibraryCommander @Inject() (
     (main, secret)
   }
 
-  def getLibraryWithUsernameAndSlug(username: String, slug: LibrarySlug, followRedirect: Boolean = false): Either[(Int, String), Library] = {
+  def getLibraryWithUsernameAndSlug(username: String, slug: LibrarySlug, followRedirect: Boolean = false): Either[LibraryFail, Library] = {
     val ownerIdentifier = ExternalId.asOpt[User](username).map(Left(_)) getOrElse Right(Username(username))
     val ownerOpt = ownerIdentifier match {
       case Left(externalId) => db.readOnlyMaster { implicit s => userRepo.getOpt(externalId).map((_, false)) }
       case Right(username) => userCommander.get.getUserByUsernameOrAlias(username)
     }
     ownerOpt match {
-      case None => Left((BAD_REQUEST, "invalid_username"))
+      case None => Left(LibraryFail(BAD_REQUEST, "invalid_username"))
       case Some((owner, isUserAlias)) =>
         getLibraryBySlugOrAlias(owner.id.get, slug) match {
-          case None => Left((NOT_FOUND, "no_library_found"))
+          case None => Left(LibraryFail(NOT_FOUND, "no_library_found"))
           case Some((library, isLibraryAlias)) =>
-            if ((isUserAlias || isLibraryAlias) && !followRedirect) Left((MOVED_PERMANENTLY, Library.formatLibraryPath(owner.username, owner.externalId, library.slug)))
+            if ((isUserAlias || isLibraryAlias) && !followRedirect) Left(LibraryFail(MOVED_PERMANENTLY, Library.formatLibraryPath(owner.username, owner.externalId, library.slug)))
             else Right(library)
         }
     }
@@ -1055,7 +1055,7 @@ object LibraryError {
   }
 }
 
-case class LibraryFail(message: String) extends AnyVal
+case class LibraryFail(status: Int, message: String)
 
 @json case class LibraryAddRequest(
   name: String,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -62,7 +62,7 @@ class ExtLibraryController @Inject() (
     val addRequest = LibraryAddRequest(name, visibility, description = None, slug, collaborators = None, followers = None)
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.keeper).build
     libraryCommander.addLibrary(addRequest, request.userId) match {
-      case Left(fail) => BadRequest(Json.obj("error" -> fail.message))
+      case Left(fail) => Status(fail.status)(Json.obj("error" -> fail.message))
       case Right(lib) =>
         Ok(Json.toJson(LibraryData(
           id = Library.publicId(lib.id.get),
@@ -75,7 +75,7 @@ class ExtLibraryController @Inject() (
   def getLibrary(libraryPubId: PublicId[Library]) = UserAction { request =>
     decode(libraryPubId) { libraryId =>
       libraryCommander.getLibraryWithOwnerAndCounts(libraryId, request.userId) match {
-        case Left((status, message)) => Status(status)(Json.obj("error" -> message))
+        case Left(fail) => Status(fail.status)(Json.obj("error" -> fail.message))
         case Right((library, owner, keepCount, followerCount)) => Ok(Json.obj(
           "name" -> library.name,
           "slug" -> library.slug,
@@ -92,7 +92,7 @@ class ExtLibraryController @Inject() (
     decode(libraryPubId) { libraryId =>
       implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.keeper).build
       libraryCommander.removeLibrary(libraryId, request.userId) match {
-        case Some((status, message)) => Status(status)(Json.obj("error" -> message))
+        case Some(fail) => Status(fail.status)(Json.obj("error" -> fail.message))
         case _ => NoContent
       }
     }
@@ -102,10 +102,8 @@ class ExtLibraryController @Inject() (
     decode(libraryPubId) { libraryId =>
       implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.keeper).build
       libraryCommander.joinLibrary(request.userId, libraryId) match {
-        case Left(fail) =>
-          BadRequest(Json.obj("error" -> fail.message))
-        case Right(lib) =>
-          NoContent
+        case Left(fail) => Status(fail.status)(Json.obj("error" -> fail.message))
+        case Right(lib) => NoContent
       }
     }
   }
@@ -114,7 +112,7 @@ class ExtLibraryController @Inject() (
     decode(libraryPubId) { libraryId =>
       implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.keeper).build
       libraryCommander.leaveLibrary(libraryId, request.userId) match {
-        case Left(fail) => BadRequest(Json.obj("error" -> fail.message))
+        case Left(fail) => Status(fail.status)(Json.obj("error" -> fail.message))
         case Right(_) => NoContent
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
@@ -220,7 +220,7 @@ class ExtLibraryControllerTest extends Specification with ShoeboxTestInjector wi
         }
 
         // join a secret library (with no invite)
-        status(joinLibrary(user2, libPubId2)) === BAD_REQUEST
+        status(joinLibrary(user2, libPubId2)) === FORBIDDEN
         db.readWrite { implicit s =>
           libraryMembershipRepo.getWithLibraryIdAndUserId(lib2.id.get, user2.id.get).isEmpty === true
           libraryMembershipRepo.countWithLibraryId(lib2.id.get) === 1

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -532,7 +532,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
         // permission denied sharing a SECRET library that you don't own
         val request3 = FakeRequest("POST", testPath1).withBody(inputJson2)
         val result3 = libraryController.inviteUsersToLibrary(pubId1)(request3)
-        status(result3) must equalTo(BAD_REQUEST)
+        status(result3) must equalTo(FORBIDDEN)
         // success sharing a PUBLISHED library that you don't own
         val request4 = FakeRequest("POST", testPath2).withBody(inputJson2)
         val result4 = libraryController.inviteUsersToLibrary(pubId2)(request4)


### PR DESCRIPTION
...specific response status to Controllers

I've decided to add a `status` field to LibraryFail to easily differentiate 4xx status codes, so they may (1) persist to the Controllers and (2) be easily changed in the future to be consistent among all clients.
I know right now, the site & mobile don't check for 4xx status codes when it comes to library, but in case they would like them in the future, we can easily change responses accordingly

@andrewconner @2is10 
