### PR TITLE
Get Facebook Invites to behave (hopefully)

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/InviteCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/InviteCommander.scala
@@ -331,6 +331,9 @@ class InviteCommander @Inject() (
     s"https://www.facebook.com/dialog/send?app_id=${secureSocialClientIds.facebook}&link=$link&redirect_uri=$redirectUri&to=$socialId"
   }
 
+  def fbTitle(inviterName: Option[String]): String = inviterName.map { name => s"$name has invited you to join Kifi!" } getOrElse "You've been invited to join Kifi!"
+  val fbDescription: String = "Kifi is a remarkable new way to collect, discover, and share knowledge. Powered by people, search, and recommendations."
+
   def confirmFacebookInvite(request: Option[UserRequest[_]], id: ExternalId[Invitation], source: String, errorMsg: Option[String], errorCode: Option[Int]): InviteStatus = {
     val inviteStatus = db.readWrite { implicit session =>
       val existingInvitation = invitationRepo.getOpt(id)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KifiSiteRouter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KifiSiteRouter.scala
@@ -19,6 +19,8 @@ import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.Result
 
 import scala.concurrent.Future
+import scala.util.matching.Regex
+import java.util.regex.Pattern
 
 sealed trait Routeable
 private case class MovedPermanentlyRoute(url: String) extends Routeable
@@ -36,6 +38,14 @@ case class Path(requestPath: String) {
   val split = path.split("/").map(URLDecoder.decode(_, "UTF-8"))
   val primary = split.head
   val secondary = split.tail.headOption
+}
+
+object KifiSiteRouter {
+  def substituteMetaProperty(property: String, newContent: String): (Regex, String) = {
+    val pattern = ("""<meta\s+property="""" + Pattern.quote(property) + """"\s+content=".*"\s*/?>""").r
+    val newValue = s"""<meta property="$property" content="$newContent"/>"""
+    pattern -> newValue
+  }
 }
 
 @Singleton // holds state for performance reasons

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
@@ -125,5 +125,17 @@ class KifiSiteRouterTest extends Specification with ShoeboxTestInjector {
       }
     }
 
+    "substitute meta properties" in {
+      def substitute(property: String, newContent: String)(html: String) = {
+        val (pattern, newValue) = KifiSiteRouter.substituteMetaProperty(property, newContent)
+        pattern.replaceAllIn(html, newValue)
+      }
+      substitute("og:title", "Hi there!")("""<meta property="og:title" content="Connecting People With Knowledge" />""") === """<meta property="og:title" content="Hi there!"/>"""
+      substitute("og:title", "Hi there!")("""<meta property="og:title" content="Connecting People With Knowledge">""") === """<meta property="og:title" content="Hi there!"/>"""
+      substitute("og:title", "Hi there!")("""<meta property="og:title" content="Connecting People With Knowledge" >""") === """<meta property="og:title" content="Hi there!"/>"""
+      substitute("og:description", "Hi there!")("""<meta property="og:description" content="Connecting People With Knowledge" />""") === """<meta property="og:description" content="Hi there!"/>"""
+      substitute("og:title", "Hi there!")("""<meta property="og:description" content="Connecting People With Knowledge" />""") === """<meta property="og:description" content="Connecting People With Knowledge" />"""
+    }
+
   }
 }


### PR DESCRIPTION
@andrewconner @stkem @joshm1 
This code gets rid of redirects for invites and replaces OpenGraph tags with the invite text. 
It does not insert the tag if it's not already there, and we need to fix one of the two marketing pages in that regard.
