### PR TITLE
some small refactors in LibraryCommander

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -59,7 +59,7 @@ class ExtLibraryController @Inject() (
     val name = (body \ "name").as[String]
     val visibility = (body \ "visibility").as[LibraryVisibility]
     val slug = LibrarySlug.generateFromName(name)
-    val addRequest = LibraryAddRequest(name, visibility, description = None, slug, collaborators = None, followers = None)
+    val addRequest = LibraryAddRequest(name, visibility, description = None, slug)
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.keeper).build
     libraryCommander.addLibrary(addRequest, request.userId) match {
       case Left(fail) => Status(fail.status)(Json.obj("error" -> fail.message))

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -89,22 +89,43 @@ class LibraryRepoImpl @Inject() (
     }
   }
 
-  private def getByNameAndUserCompiled(userId: Column[Id[User]], name: Column[String], excludeState: Option[State[Library]]) =
-    Compiled { (for (b <- rows if b.name === name && b.ownerId === userId && b.state =!= excludeState.orNull) yield b) }
-  def getByNameAndUserId(userId: Id[User], name: String, excludeState: Option[State[Library]])(implicit session: RSession): Option[Library] = {
-    getByNameAndUserCompiled(userId, name, excludeState).firstOption
+  private val getByNameAndUserCompiled = Compiled { (userId: Column[Id[User]], name: Column[String]) =>
+    (for (b <- rows if b.name === name && b.ownerId === userId) yield b)
+  }
+  private val getByNameAndUserWithExcludeCompiled = Compiled { (userId: Column[Id[User]], name: Column[String], excludeState: Column[State[Library]]) =>
+    (for (b <- rows if b.name === name && b.ownerId === userId && b.state =!= excludeState) yield b)
+  }
+  def getByNameAndUserId(userId: Id[User], name: String, excludeState: Option[State[Library]] = Some(LibraryStates.INACTIVE))(implicit session: RSession): Option[Library] = {
+    excludeState match {
+      case None => getByNameAndUserCompiled(userId, name).firstOption
+      case Some(exclude) => getByNameAndUserWithExcludeCompiled(userId, name, exclude).firstOption
+    }
   }
 
-  private def getBySlugAndUserCompiled(userId: Column[Id[User]], slug: Column[LibrarySlug], excludeState: Option[State[Library]]) =
-    Compiled { (for (b <- rows if b.slug === slug && b.ownerId === userId && b.state =!= excludeState.orNull) yield b) }
-  def getBySlugAndUserId(userId: Id[User], slug: LibrarySlug, excludeState: Option[State[Library]])(implicit session: RSession): Option[Library] = {
-    getBySlugAndUserCompiled(userId, slug, excludeState).firstOption
+  private val getBySlugAndUserCompiled = Compiled { (userId: Column[Id[User]], slug: Column[LibrarySlug]) =>
+    (for (b <- rows if b.slug === slug && b.ownerId === userId) yield b)
+  }
+  private val getBySlugAndUserWithExcludeCompiled = Compiled { (userId: Column[Id[User]], slug: Column[LibrarySlug], excludeState: Column[State[Library]]) =>
+    (for (b <- rows if b.slug === slug && b.ownerId === userId && b.state =!= excludeState) yield b)
+  }
+  def getBySlugAndUserId(userId: Id[User], slug: LibrarySlug, excludeState: Option[State[Library]] = Some(LibraryStates.INACTIVE))(implicit session: RSession): Option[Library] = {
+    excludeState match {
+      case None => getBySlugAndUserCompiled(userId, slug).firstOption
+      case Some(exclude) => getBySlugAndUserWithExcludeCompiled(userId, slug, exclude).firstOption
+    }
   }
 
-  private def getByNameOrSlugCompiled(userId: Column[Id[User]], name: Column[String], slug: Column[LibrarySlug], excludeState: Option[State[Library]]) =
-    Compiled { (for (b <- rows if (b.name === name || b.slug === slug) && b.ownerId === userId && b.state =!= excludeState.orNull) yield b) }
-  def getByNameOrSlug(userId: Id[User], name: String, slug: LibrarySlug, excludeState: Option[State[Library]])(implicit session: RSession): Option[Library] = {
-    getByNameOrSlugCompiled(userId, name, slug, excludeState).firstOption
+  private val getByNameOrSlugCompiled = Compiled { (userId: Column[Id[User]], name: Column[String], slug: Column[LibrarySlug]) =>
+    (for (b <- rows if (b.name === name || b.slug === slug) && b.ownerId === userId) yield b)
+  }
+  private val getByNameOrSlugWithExcludeCompiled = Compiled { (userId: Column[Id[User]], name: Column[String], slug: Column[LibrarySlug], excludeState: Column[State[Library]]) =>
+    (for (b <- rows if (b.name === name || b.slug === slug) && b.ownerId === userId && b.state =!= excludeState) yield b)
+  }
+  def getByNameOrSlug(userId: Id[User], name: String, slug: LibrarySlug, excludeState: Option[State[Library]] = Some(LibraryStates.INACTIVE))(implicit session: RSession): Option[Library] = {
+    excludeState match {
+      case None => getByNameOrSlugCompiled(userId, name, slug).firstOption
+      case Some(exclude) => getByNameOrSlugWithExcludeCompiled(userId, name, slug, exclude).firstOption
+    }
   }
 
   def getByUser(userId: Id[User], excludeState: Option[State[Library]], excludeAccess: Option[LibraryAccess])(implicit session: RSession): Seq[(LibraryMembership, Library)] = {
@@ -125,7 +146,7 @@ class LibraryRepoImpl @Inject() (
     invalidateCache(get(libraryId).copy(lastKept = updateTime))
   }
 
-  private def getOptCompiled(ownerId: Column[Id[User]], slug: Column[LibrarySlug]) = Compiled {
+  private val getOptCompiled = Compiled { (ownerId: Column[Id[User]], slug: Column[LibrarySlug]) =>
     (for (r <- rows if r.ownerId === ownerId && r.slug === slug) yield r)
   }
   def getOpt(ownerId: Id[User], slug: LibrarySlug)(implicit session: RSession): Option[Library] = {
@@ -143,16 +164,12 @@ class LibraryRepoImpl @Inject() (
 
   def getLibraries(libraryIds: Set[Id[Library]])(implicit session: RSession): Map[Id[Library], Library] = {
     idCache.bulkGetOrElse(libraryIds.map(LibraryIdKey(_))) { missingKeys =>
-      getLibrariesCompiled(missingKeys.map(_.id)).list.map(library => LibraryIdKey(library.id.get) -> library).toMap
+      (for (r <- rows if r.id.inSet(libraryIds)) yield r).list.map(library => LibraryIdKey(library.id.get) -> library).toMap
     }.map { case (libraryKey, library) => libraryKey.id -> library }
   }
 
   def getAllPublishedLibraries()(implicit session: RSession): Seq[Library] = {
     (for (r <- rows if r.visibility === (LibraryVisibility("published"): LibraryVisibility) && r.state === LibraryStates.ACTIVE) yield r).list
-  }
-
-  private def getLibrariesCompiled(libraryIds: Set[Id[Library]]) = Compiled {
-    (for (r <- rows if r.id.inSet(libraryIds)) yield r)
   }
 
   def pagePublished(page: Int = 0, size: Int = 20)(implicit session: RSession): Seq[Library] = {

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -193,21 +193,13 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           libraryRepo.count === 0
         }
 
-        val noInvites = None
-        val inv2 = Some(userIron.externalId :: userAgent.externalId :: userHulk.externalId :: Nil)
-        val inv3 = Some(userHulk.externalId :: Nil)
+        val lib1Request = LibraryAddRequest(name = "Avengers Missions", slug = "avengers", visibility = LibraryVisibility.SECRET)
 
-        val lib1Request = LibraryAddRequest(name = "Avengers Missions", slug = "avengers",
-          visibility = LibraryVisibility.SECRET, collaborators = noInvites, followers = noInvites)
+        val lib2Request = LibraryAddRequest(name = "MURICA", slug = "murica", visibility = LibraryVisibility.PUBLISHED)
 
-        val lib2Request = LibraryAddRequest(name = "MURICA", slug = "murica",
-          visibility = LibraryVisibility.PUBLISHED, collaborators = noInvites, followers = inv2)
+        val lib3Request = LibraryAddRequest(name = "Science and Stuff", slug = "science", visibility = LibraryVisibility.DISCOVERABLE)
 
-        val lib3Request = LibraryAddRequest(name = "Science and Stuff", slug = "science",
-          visibility = LibraryVisibility.DISCOVERABLE, collaborators = inv3, followers = noInvites)
-
-        val lib5Request = LibraryAddRequest(name = "Invalid Param", slug = "",
-          visibility = LibraryVisibility.SECRET, collaborators = noInvites, followers = noInvites)
+        val lib5Request = LibraryAddRequest(name = "Invalid Param", slug = "", visibility = LibraryVisibility.SECRET)
 
         val libraryCommander = inject[LibraryCommander]
         val add1 = libraryCommander.addLibrary(lib1Request, userAgent.id.get)
@@ -230,16 +222,6 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           allMemberships.length === 3
           allMemberships.map(_.userId) === Seq(userAgent.id.get, userCaptain.id.get, userIron.id.get)
           allMemberships.map(_.access) === Seq(LibraryAccess.OWNER, LibraryAccess.OWNER, LibraryAccess.OWNER)
-
-          val allInvites = libraryInviteRepo.all
-          allInvites.length === 4
-          val invitePairs = for (i <- allInvites) yield (i.inviterId, i.userId.get)
-
-          invitePairs === (userCaptain.id.get, userIron.id.get) ::
-            (userCaptain.id.get, userAgent.id.get) ::
-            (userCaptain.id.get, userHulk.id.get) ::
-            (userIron.id.get, userHulk.id.get) ::
-            Nil
         }
 
         // test re-activating inactive library

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
@@ -81,7 +81,7 @@ class KifiSiteRouterTest extends Specification with ShoeboxTestInjector {
 
         val libraryCommander = inject[LibraryCommander]
         val Right(library) = {
-          val libraryRequest = LibraryAddRequest("Awesome Lib", LibraryVisibility.PUBLISHED, None, "awesome-lib", None, None)
+          val libraryRequest = LibraryAddRequest("Awesome Lib", LibraryVisibility.PUBLISHED, None, "awesome-lib")
           libraryCommander.addLibrary(libraryRequest, user1.id.get)
         }
         router.route(NonUserRequest(FakeRequest.apply("GET", "/abe.z1234/awesome-lib"))) must beAnInstanceOf[Angular]


### PR DESCRIPTION
1) change error message from `createLibrary()` when name already exists or slug already exists @yipingliao errors are { `invalid_name`, `invalid_slug`, `library_name_exists`, `library_slug_exists`}
2) remove followers & collaborators from `LibraryAddRequest` -> right now, we have no front-end support for inviting users right when you create a library. Since it's unused, might as well clean it up now. If we want that support later, happy to add it back in =) 
3) switch compiled queries in LibraryRepo from functions to vals (actually pre-compiled)

@andrewconner 
