### PR TITLE
short-circuiting

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryMembershipRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryMembershipRepo.scala
@@ -120,7 +120,11 @@ class LibraryMembershipRepoImpl @Inject() (
   }
 
   def getWithLibraryIdsAndUserId(libraryIds: Set[Id[Library]], userId: Id[User], excludeState: Option[State[LibraryMembership]] = Some(LibraryMembershipStates.INACTIVE))(implicit session: RSession): Map[Id[Library], LibraryMembership] = {
-    (for (b <- rows if b.libraryId.inSet(libraryIds) && b.userId === userId && b.state =!= excludeState.orNull) yield (b.libraryId, b)).list.toMap
+    if (libraryIds.isEmpty) {
+      Map.empty
+    } else {
+      (for (b <- rows if b.libraryId.inSet(libraryIds) && b.userId === userId && b.state =!= excludeState.orNull) yield (b.libraryId, b)).list.toMap
+    }
   }
 
   def getWithLibraryIdAndUserIds(libraryId: Id[Library], userIds: Set[Id[User]], excludeState: Option[State[LibraryMembership]] = Some(LibraryMembershipStates.INACTIVE))(implicit session: RSession): Map[Id[User], LibraryMembership] = {


### PR DESCRIPTION
@eishay @andrewconner @ahsu1230 
Short-circuiting getWithLibraryIdsAndUserId when there is no library ids.

Just found that Slick still issue SQL like this when there is no item for IN predicate.

select ...
from `library_membership` x2 where (false and (x2.`user_id` = 9827)) and (not (x2.`state` = 'inactive'))

`false` in the WHERE clause is the remnant of the IN predicate with no items.
