### PR TITLE
short-circuiting empty IN predicates

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainTagRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainTagRepo.scala
@@ -31,8 +31,13 @@ class DomainTagRepoImpl @Inject() (val db: DataBaseComponent, val clock: Clock) 
   override def deleteCache(model: DomainTag)(implicit session: RSession): Unit = {}
   override def invalidateCache(model: DomainTag)(implicit session: RSession): Unit = {}
 
-  def getTags(tagIds: Seq[Id[DomainTag]], excludeState: Option[State[DomainTag]] = Some(DomainTagStates.INACTIVE))(implicit session: RSession): Seq[DomainTag] =
-    (for (t <- rows if t.state =!= excludeState.getOrElse(null) && t.id.inSet(tagIds)) yield t).list
+  def getTags(tagIds: Seq[Id[DomainTag]], excludeState: Option[State[DomainTag]] = Some(DomainTagStates.INACTIVE))(implicit session: RSession): Seq[DomainTag] = {
+    if (tagIds.isEmpty) {
+      Seq.empty
+    } else {
+      (for (t <- rows if t.state =!= excludeState.getOrElse(null) && t.id.inSet(tagIds)) yield t).list
+    }
+  }
 
   def get(tag: DomainTagName, excludeState: Option[State[DomainTag]] = Some(DomainTagStates.INACTIVE))(implicit session: RSession): Option[DomainTag] =
     (for (t <- rows if t.state =!= excludeState.getOrElse(null) && t.name === tag) yield t).firstOption

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/RawKeepRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/RawKeepRepo.scala
@@ -66,7 +66,9 @@ class RawKeepRepoImpl @Inject() (val db: DataBaseComponent, val clock: Clock) ex
       .sortBy(row => row.id.asc)
       .take(batchSize)
       .list
-    (for (row <- rows if row.id inSet records.map(_.id.get).toSet) yield row.state).update(RawKeepStates.IMPORTING)
+    if (records.nonEmpty) {
+      (for (row <- rows if row.id inSet records.map(_.id.get).toSet) yield row.state).update(RawKeepStates.IMPORTING)
+    }
     records
   }
 


### PR DESCRIPTION
@eishay @andrewconner 

I see DomainTagRepo.getTags called with an empty IN Predicate (= false) quite frequently.
