### PR TITLE
fix scrolling keeps over nav bar

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/app.styl
+++ b/kifi-backend/modules/shoebox/angular/src/app.styl
@@ -90,7 +90,6 @@ a[href]
   display: inline-block
   vertical-align: top
   background: appBackgroundColor
-  margin-top: 15px
   box-sizing: border-box
   z-index: 1
 

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/main.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/main.styl
@@ -1,6 +1,7 @@
 .kf-logged-in .kf-main
   min-width: 454px
   width: calc(100% - 310px)
+  margin-top: 15px
 
   @media screen and (max-width: 1280px)
     width: calc(100% - 270px)

--- a/kifi-backend/modules/shoebox/angular/src/layout/rightCol/rightCol.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/rightCol/rightCol.styl
@@ -3,4 +3,3 @@
   width: 310px
   @media screen and (max-width: 1280px)
     width: 270px
-

--- a/kifi-backend/modules/shoebox/angular/src/layout/rightCol/rightCol.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/rightCol/rightCol.styl
@@ -1,4 +1,6 @@
 .kf-col-right
+  margin-top: 5px
   width: 310px
   @media screen and (max-width: 1280px)
     width: 270px
+

--- a/kifi-backend/modules/shoebox/angular/src/layout/sidebar/sidebar.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/sidebar/sidebar.styl
@@ -2,11 +2,14 @@
   position: fixed
   width: 270px
   padding: 0 0 0 20px
-  border-right: 1px solid #dbdee3
   z-index: 1
 
   .kf-tag-count
     float: right
+
+.kf-sidebar-inner
+  margin-top: 15px
+  border-right: 1px solid #dbdee3
 
 .kf-sidebar-nav
   margin: 0 40px 0 20px


### PR DESCRIPTION
Currently you can do this, if the window is small (hamburger is up) and you scroll to the right, the nav bar seems like it just hovers over the keeps

![left-col-scroll-left](https://cloud.githubusercontent.com/assets/4695528/4962785/fb1fb5ae-66e8-11e4-962e-165b3db6903a.jpg)

Have a change to keep content behind the nav bar hidden while still keeping things aligned.

@andrewconner @joshm1 @yipingliao 
