### PR TITLE
new libraries feed

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/common/seo/FeedCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/seo/FeedCommander.scala
@@ -1,0 +1,129 @@
+package com.keepit.common.seo
+
+import com.google.inject.{ Inject, Singleton }
+import com.keepit.commanders.{ LibraryCommander, PublicPageMetaFullTags }
+import com.keepit.common.CollectionHelpers
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.logging.Logging
+import com.keepit.common.time._
+import com.keepit.inject.FortyTwoConfig
+import com.keepit.model.{ Library, LibraryMembershipRepo, LibraryRepo, UserRepo }
+import org.joda.time.format.DateTimeFormat
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.libs.iteratee.{ Enumeratee, Enumerator }
+
+import scala.concurrent.Future
+import scala.xml.{ Elem, Node, Unparsed }
+
+@Singleton
+class FeedCommander @Inject() (
+    airbrake: AirbrakeNotifier,
+    db: Database,
+    clock: Clock,
+    fortyTwoConfig: FortyTwoConfig,
+    userRepo: UserRepo,
+    libraryRepo: LibraryRepo,
+    libraryMembershipRepo: LibraryMembershipRepo,
+    libraryCommander: LibraryCommander) extends Logging {
+
+  def wrap(elem: Elem): Enumerator[Array[Byte]] = {
+    val elems = Enumerator.enumerate(elem)
+    val toBytes = Enumeratee.map[Node] { n => n.toString.getBytes }
+    val header = Enumerator("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n".getBytes)
+    header.andThen(elems &> toBytes)
+  }
+
+  def rss(feedTitle: String, feedUrl: String, libs: Seq[Library]): Future[Elem] = {
+    val ownerIds = CollectionHelpers.dedupBy(libs.map(_.ownerId))(id => id)
+    val owners = db.readOnlyMaster { implicit ro => userRepo.getUsers(ownerIds) } // cached
+
+    val metaTagsF = Future.sequence(libs.map { lib =>
+      libraryCommander.libraryMetaTags(lib) map { tags =>
+        lib.id.get -> (tags match {
+          case pub: PublicPageMetaFullTags => pub
+          case _ => throw new IllegalStateException(s"Failed to retrieve public meta tags for $lib; tags=$tags") // shouldn't happen (can add recovery)
+        })
+      }
+    })
+
+    val logo = "https://d1dwdv9wd966qu.cloudfront.net/img/favicon64x64.7cc6dd4.png"
+
+    metaTagsF map { metaTags =>
+      val idToMetaTags = metaTags.toMap
+      val formatter = DateTimeFormat.forPattern("E, d MMM y HH:mm:ss Z")
+      val items = libs map { lib =>
+        val metaTags = idToMetaTags(lib.id.get)
+        val owner = owners(lib.ownerId)
+        val libImg = metaTags.images.headOption.getOrElse(logo)
+        val itemUrl = s"${fortyTwoConfig.applicationBaseUrl}${Library.formatLibraryPath(owner.username, owner.externalId, lib.slug)}"
+        val desc = Unparsed(
+          s"""
+               |<![CDATA[
+               |<img src="$libImg"/>
+               |${metaTags.description}
+               |]]>
+               |""".stripMargin)
+        <item>
+          <title>
+            { metaTags.title }
+          </title>
+          <description>
+            { desc }
+          </description>
+          <link>
+            { itemUrl }
+          </link>
+          <guid>
+            { itemUrl }
+          </guid>
+          <pubDate>
+            { metaTags.updatedAt.toString(formatter) }
+          </pubDate>
+          <dc:creator>
+            { metaTags.fullName }
+          </dc:creator>
+          <media:thumbnail url={ libImg } medium="image"/>
+          <media:content url={ libImg } medium="image">
+            <media:title type="html">
+              { metaTags.title }
+            </media:title>
+          </media:content>
+        </item>
+      }
+
+      val year = currentDateTime.getYear
+      val rss =
+        <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:media="http://search.yahoo.com/mrss/" xmlns:atom="http://www.w3.org/2005/Atom">
+          <channel>
+            <title>
+              { feedTitle }
+            </title>
+            <link>
+              { feedUrl }
+            </link>
+            <description>
+              { feedTitle }
+            </description>
+            <image>
+              <url>
+                { feedUrl }
+              </url>
+              <title>
+                { feedTitle }
+              </title>
+              <link>
+                { fortyTwoConfig.applicationBaseUrl }
+              </link>
+            </image>
+            <copyright>Copyright { year }, FortyTwo Inc.</copyright>
+            <atom:link ref="self" type="application/rss+xml" href={ feedUrl }/>
+            <atom:link ref="hub" href="https://pubsubhubbub.appspot.com/"/>{ items }
+          </channel>
+        </rss>
+
+      log.info(s"[rss($feedTitle)] #items=${items.size}")
+      rss
+    }
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/FeedController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/FeedController.scala
@@ -1,0 +1,63 @@
+package com.keepit.controllers.website
+
+import com.google.inject.Inject
+import com.keepit.commanders.LibraryCommander
+import com.keepit.common.controller.{ AdminUserActions, UserActionsHelper }
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.seo.{ FeedCommander, SiteMapGenerator }
+import com.keepit.common.time._
+import com.keepit.inject.FortyTwoConfig
+import com.keepit.model._
+import play.api.libs.concurrent.Execution.Implicits._
+import play.api.mvc._
+
+class FeedController @Inject() (
+    db: Database,
+    clock: Clock,
+    libraryRepo: LibraryRepo,
+    libraryMembershipRepo: LibraryMembershipRepo,
+    libraryInviteRepo: LibraryInviteRepo,
+    userRepo: UserRepo,
+    keepRepo: KeepRepo,
+    feedCommander: FeedCommander,
+    libraryCommander: LibraryCommander,
+    fortyTwoConfig: FortyTwoConfig,
+    airbrake: AirbrakeNotifier,
+    val userActionsHelper: UserActionsHelper,
+    generator: SiteMapGenerator) extends AdminUserActions {
+
+  def getNewLibraries() = Action.async { request =>
+    db.readOnlyReplicaAsync { implicit ro =>
+      libraryRepo.getNewPublishedLibraries()
+    } flatMap { libs =>
+      val feedUrl = s"${fortyTwoConfig.applicationBaseUrl}${com.keepit.controllers.website.routes.FeedController.getNewLibraries().url.toString()}"
+      feedCommander.rss("New Libraries on Kifi", feedUrl, libs) map { rss =>
+        Result(
+          header = ResponseHeader(200, Map(CONTENT_TYPE -> "application/rss+xml")),
+          body = feedCommander.wrap(rss)
+        )
+      }
+    }
+  }
+
+  def getTopLibraries() = Action.async { request =>
+    db.readOnlyReplicaAsync { implicit ro =>
+      libraryMembershipRepo.mostMembersSince(20, clock.now().minusHours(24))
+    } flatMap { tops =>
+      val libIds = tops.map(_._1)
+      val libMap = db.readOnlyReplica { implicit ro =>
+        libraryRepo.getLibraries(libIds.toSet)
+      }
+      val libs = libIds.map(libMap(_))
+      val feedUrl = s"${fortyTwoConfig.applicationBaseUrl}${com.keepit.controllers.website.routes.FeedController.getTopLibraries().url.toString()}"
+      feedCommander.rss("Top Libraries on Kifi", feedUrl, libs) map { rss =>
+        Result(
+          header = ResponseHeader(200, Map(CONTENT_TYPE -> "application/rss+xml")),
+          body = feedCommander.wrap(rss)
+        )
+      }
+    }
+  }
+
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -1,12 +1,15 @@
 package com.keepit.controllers.website
 
 import com.google.inject.Inject
-import com.keepit.commanders._
+import com.keepit.commanders.{ LibraryAddRequest, RawBookmarkRepresentation, _ }
 import com.keepit.common.akka.SafeFuture
-import com.keepit.common.controller._
-import com.keepit.common.crypto.{ PublicIdConfiguration, PublicId }
-import com.keepit.common.db.{ Id, ExternalId }
+import com.keepit.common.controller.{ UserRequest, _ }
+import com.keepit.common.core._
+import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.db.slick.Database
+import com.keepit.common.db.{ ExternalId, Id }
+import com.keepit.common.json
+import com.keepit.common.json.TupleFormat
 import com.keepit.common.mail.EmailAddress
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.common.time.Clock
@@ -14,35 +17,11 @@ import com.keepit.heimdal.HeimdalContextBuilderFactory
 import com.keepit.inject.FortyTwoConfig
 import com.keepit.model._
 import com.keepit.shoebox.controllers.LibraryAccessActions
-import org.joda.time.DateTime
-import org.joda.time.format.{ DateTimeFormat, DateTimeFormatter }
-import play.api.Mode.Mode
-import play.api.Mode.Mode
-import play.api.{ Mode, Play }
-import play.api.libs.iteratee.{ Enumeratee, Iteratee, Enumerator }
-import play.api.libs.json.{ JsObject, JsArray, JsString, Json }
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.api.mvc._
+import play.api.libs.json.{ JsArray, JsObject, JsString, Json }
 
 import scala.concurrent.Future
-import scala.util.{ Success, Failure }
-import ImplicitHelper._
-import com.keepit.common.core._
-import com.keepit.common.{ CollectionHelpers, json }
-import com.keepit.common.json.TupleFormat
-import play.api.http.Status._
-import com.keepit.commanders.RawBookmarkRepresentation
-import com.keepit.commanders.LibraryFail
-import play.api.libs.json.JsArray
-import scala.util.Failure
-import play.api.libs.json.JsString
-import scala.util.Success
-import com.keepit.common.crypto.PublicIdConfiguration
-import com.keepit.common.controller.UserRequest
-import play.api.libs.json.JsObject
-import com.keepit.commanders.LibraryAddRequest
-
-import scala.xml.{ Unparsed, Node, Elem }
+import scala.util.{ Failure, Success }
 
 class LibraryController @Inject() (
   db: Database,
@@ -62,92 +41,6 @@ class LibraryController @Inject() (
   val publicIdConfig: PublicIdConfiguration,
   implicit val config: PublicIdConfiguration)
     extends UserActions with LibraryAccessActions with ShoeboxServiceController {
-
-  def getTopLibraries() = Action.async { request =>
-    import com.keepit.common.time._
-    val tops = db.readOnlyReplica { implicit ro =>
-      libraryMembershipRepo.mostMembersSince(20, clock.now().minusHours(24))
-    }
-
-    val libIds = tops.map(_._1)
-    val libMap = db.readOnlyReplica { implicit ro =>
-      libraryRepo.getLibraries(libIds.toSet)
-    }
-    val libraries = libIds.map(libMap(_))
-    val metaTagsF = Future.sequence(libraries.map { lib =>
-      libraryCommander.libraryMetaTags(lib) map { tags =>
-        lib.id.get -> (tags match {
-          case pub: PublicPageMetaFullTags => pub
-          case _ => throw new IllegalStateException(s"Failed to retrieve public meta tags for $lib; tags=$tags") // shouldn't happen (can add recovery)
-        })
-      }
-    })
-
-    val logo = "https://d1dwdv9wd966qu.cloudfront.net/img/favicon64x64.7cc6dd4.png"
-    metaTagsF map { metaTags =>
-      val idToMetaTags = metaTags.toMap
-      val ownerIds = CollectionHelpers.dedupBy(libraries.map(_.ownerId))(id => id)
-      val ownerMap = db.readOnlyMaster { implicit ro => userRepo.getUsers(ownerIds) }
-      val formatter = DateTimeFormat.forPattern("E, d MMM y HH:mm:ss Z")
-      val items = tops map {
-        case (libId, count) =>
-          val lib = libMap(libId)
-          val metaTags = idToMetaTags(libId)
-          val owner = ownerMap(lib.ownerId)
-          val libImg = metaTags.images.headOption.getOrElse(logo)
-          val itemUrl = s"${fortyTwoConfig.applicationBaseUrl}${Library.formatLibraryPath(owner.username, owner.externalId, lib.slug)}"
-          val desc = Unparsed(
-            s"""
-               |<![CDATA[
-               |<img src="$libImg"/>
-               |${metaTags.description}
-               |]]>
-               |""".stripMargin)
-          <item>
-            <title>{ metaTags.title }</title>
-            <description>{ desc }</description>
-            <link>{ itemUrl }</link>
-            <guid>{ itemUrl }</guid>
-            <pubDate>{ metaTags.updatedAt.toString(formatter) }</pubDate>
-            <dc:creator>{ metaTags.fullName }</dc:creator>
-            <media:thumbnail url={ libImg } medium="image"/>
-            <media:content url={ libImg } medium="image">
-              <media:title type="html">{ metaTags.title }</media:title>
-            </media:content>
-          </item>
-      }
-      val year = currentDateTime.getYear
-      val feedTitle = "Top Libraries on Kifi"
-      val channelUrl = s"${fortyTwoConfig.applicationBaseUrl}${com.keepit.controllers.website.routes.LibraryController.getTopLibraries().url.toString()}"
-      val rss =
-        <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:media="http://search.yahoo.com/mrss/" xmlns:atom="http://www.w3.org/2005/Atom">
-          <channel>
-            <title>{ feedTitle }</title>
-            <link>{ channelUrl }</link>
-            <description>{ feedTitle }</description>
-            <image>
-              <url>{ channelUrl }</url>
-              <title>{ feedTitle }</title>
-              <link>{ fortyTwoConfig.applicationBaseUrl }</link>
-            </image>
-            <copyright>Copyright { year }, FortyTwo Inc.</copyright>
-            <atom:link ref="self" type="application/rss+xml" href={ channelUrl }/>
-            <atom:link ref="hub" href="https://pubsubhubbub.appspot.com/"/>
-            { items }
-          </channel>
-        </rss>
-
-      val elems = Enumerator.enumerate(rss)
-      val toBytes = Enumeratee.map[Node] { n => n.toString.getBytes }
-      val header = Enumerator("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n".getBytes)
-      val combined = header.andThen(elems &> toBytes)
-      log.info(s"[getTopLibraries] published #${libIds.size} libraries. ${libIds.take(20)} ...")
-      Result(
-        header = ResponseHeader(200, Map(CONTENT_TYPE -> "application/rss+xml")),
-        body = combined
-      )
-    }
-  }
 
   def addLibrary() = UserAction.async(parse.tolerantJson) { request =>
     val addRequest = request.body.as[LibraryAddRequest]

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -25,6 +25,7 @@ trait LibraryRepo extends Repo[Library] with SeqNumberFunction[Library] {
   def updateLastKept(libraryId: Id[Library])(implicit session: RWSession): Unit
   def getLibraries(libraryIds: Set[Id[Library]])(implicit session: RSession): Map[Id[Library], Library]
   def getAllPublishedLibraries()(implicit session: RSession): Seq[Library]
+  def getNewPublishedLibraries(size: Int = 20)(implicit session: RSession): Seq[Library]
   def pagePublished(page: Int = 0, size: Int = 20)(implicit session: RSession): Seq[Library]
   def countPublished(implicit session: RSession): Int
 }
@@ -170,6 +171,10 @@ class LibraryRepoImpl @Inject() (
 
   def getAllPublishedLibraries()(implicit session: RSession): Seq[Library] = {
     (for (r <- rows if r.visibility === (LibraryVisibility("published"): LibraryVisibility) && r.state === LibraryStates.ACTIVE) yield r).list
+  }
+
+  def getNewPublishedLibraries(size: Int = 20)(implicit session: RSession): Seq[Library] = {
+    (for (r <- rows if r.visibility === (LibraryVisibility("published"): LibraryVisibility) && r.state === LibraryStates.ACTIVE) yield r).sortBy(_.id.desc).take(size).list
   }
 
   def pagePublished(page: Int = 0, size: Int = 20)(implicit session: RSession): Seq[Library] = {

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -296,7 +296,8 @@ POST    /users/pics/update          @com.keepit.controllers.assets.UserPictureCo
 ##########################################
 # Feeds (RSS)
 ##########################################
-GET     /feeds/libraries/top        @com.keepit.controllers.website.LibraryController.getTopLibraries()
+GET     /feeds/libraries/top        @com.keepit.controllers.website.FeedController.getTopLibraries()
+GET     /feeds/libraries/new        @com.keepit.controllers.website.FeedController.getNewLibraries()
 
 ##########################################
 # Web API

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/seo/FeedControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/seo/FeedControllerTest.scala
@@ -1,0 +1,118 @@
+package com.keepit.common.seo
+
+import com.google.inject.Injector
+import com.keepit.abook.FakeABookServiceClientModule
+import com.keepit.common.crypto.FakeCryptoModule
+import com.keepit.common.external.FakeExternalServiceModule
+import com.keepit.common.mail.FakeMailModule
+import com.keepit.common.social.FakeSocialGraphModule
+import com.keepit.common.store.FakeShoeboxStoreModule
+import com.keepit.common.time._
+import com.keepit.controllers.website.FeedController
+import com.keepit.cortex.FakeCortexServiceClientModule
+import com.keepit.model._
+import com.keepit.scraper.{ FakeScrapeSchedulerModule, FakeScrapeSchedulerConfigModule }
+import com.keepit.search.FakeSearchServiceClientModule
+import com.keepit.shoebox.{ FakeShoeboxServiceModule, FakeKeepImportsModule }
+import com.keepit.test.ShoeboxTestInjector
+import org.joda.time.DateTime
+import org.specs2.mutable.Specification
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import scala.xml._
+
+class FeedControllerTest extends Specification with ShoeboxTestInjector {
+
+  val modules = Seq(
+    FakeCryptoModule(),
+    FakeShoeboxStoreModule(),
+    FakeABookServiceClientModule(),
+    FakeKeepImportsModule(),
+    FakeMailModule(),
+    FakeExternalServiceModule(),
+    FakeCortexServiceClientModule(),
+    FakeSearchServiceClientModule(),
+    FakeScrapeSchedulerConfigModule(),
+    FakeSocialGraphModule(),
+    FakeScrapeSchedulerModule(),
+    FakeShoeboxServiceModule()
+  )
+
+  def setup()(implicit injector: Injector) = {
+    val t1 = new DateTime(2014, 7, 4, 21, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
+    val u1 = User(firstName = "Aaron", lastName = "H", createdAt = t1, username = Username("test"), normalizedUsername = "test")
+    val u2 = User(firstName = "Jackie", lastName = "Chan", createdAt = t1.plusHours(2), username = Username("test"), normalizedUsername = "test")
+
+    db.readWrite { implicit s =>
+      val user1 = userRepo.save(u1)
+      val user2 = userRepo.save(u2)
+
+      val lib1 = libraryRepo.save(Library(name = "lib1A", ownerId = user1.id.get, visibility = LibraryVisibility.PUBLISHED,
+        createdAt = t1.plusMinutes(1), slug = LibrarySlug("A"), memberCount = 1))
+      libraryMembershipRepo.save(LibraryMembership(libraryId = lib1.id.get, userId = user1.id.get, access = LibraryAccess.OWNER, showInSearch = true))
+
+      val lib2 = libraryRepo.save(Library(name = "lib1B", ownerId = user1.id.get, visibility = LibraryVisibility.PUBLISHED,
+        createdAt = t1.plusMinutes(2), slug = LibrarySlug("B"), memberCount = 1))
+      libraryMembershipRepo.save(LibraryMembership(libraryId = lib2.id.get, userId = user1.id.get, access = LibraryAccess.OWNER, showInSearch = true))
+      libraryMembershipRepo.save(LibraryMembership(libraryId = lib2.id.get, userId = user2.id.get, access = LibraryAccess.READ_ONLY, showInSearch = true))
+
+      val lib3 = libraryRepo.save(Library(name = "lib2", ownerId = user2.id.get, visibility = LibraryVisibility.PUBLISHED,
+        createdAt = t1.plusMinutes(3), slug = LibrarySlug("C"), memberCount = 1))
+      libraryMembershipRepo.save(LibraryMembership(libraryId = lib3.id.get, userId = user2.id.get, access = LibraryAccess.OWNER, showInSearch = true))
+
+      val s1 = libraryRepo.save(Library(name = "Main Library", ownerId = user1.id.get, visibility = LibraryVisibility.DISCOVERABLE, createdAt = t1.plusMinutes(1), kind = LibraryKind.SYSTEM_MAIN, slug = LibrarySlug("main"), memberCount = 1))
+      libraryMembershipRepo.save(LibraryMembership(libraryId = s1.id.get, userId = user1.id.get, access = LibraryAccess.OWNER, showInSearch = true))
+
+      val s2 = libraryRepo.save(Library(name = "Secret Library", ownerId = user1.id.get, visibility = LibraryVisibility.SECRET, createdAt = t1.plusMinutes(1), kind = LibraryKind.SYSTEM_SECRET, slug = LibrarySlug("secret"), memberCount = 1))
+      libraryMembershipRepo.save(LibraryMembership(libraryId = s2.id.get, userId = user1.id.get, access = LibraryAccess.OWNER, showInSearch = true))
+
+      val uri1 = uriRepo.save(NormalizedURI.withHash("http://www.google.com/", Some("Google")))
+      val uri2 = uriRepo.save(NormalizedURI.withHash("http://www.amazon.com/", Some("Amazon")))
+      val uri3 = uriRepo.save(NormalizedURI.withHash("http://www.amazon.com/foo", Some("AmazonFoo")))
+
+      val url1 = urlRepo.save(URLFactory(url = uri1.url, normalizedUriId = uri1.id.get))
+      val url2 = urlRepo.save(URLFactory(url = uri2.url, normalizedUriId = uri2.id.get))
+
+      val hover = KeepSource.keeper
+
+      keepRepo.save(Keep(title = Some("G1"), userId = user1.id.get, url = url1.url, urlId = url1.id.get,
+        uriId = uri1.id.get, source = hover, createdAt = t1.plusMinutes(3),
+        visibility = LibraryVisibility.PUBLISHED, libraryId = Some(lib1.id.get), inDisjointLib = lib1.isDisjoint))
+      keepRepo.save(Keep(title = Some("A1"), userId = user1.id.get, url = url2.url, urlId = url2.id.get,
+        uriId = uri2.id.get, source = hover, createdAt = t1.plusHours(50),
+        visibility = LibraryVisibility.PUBLISHED, libraryId = Some(lib1.id.get), inDisjointLib = lib1.isDisjoint))
+      keepRepo.save(Keep(title = Some("A2"), userId = user1.id.get, url = url2.url, urlId = url2.id.get,
+        uriId = uri3.id.get, source = hover, createdAt = t1.plusHours(50),
+        visibility = LibraryVisibility.PUBLISHED, libraryId = Some(lib1.id.get), inDisjointLib = lib1.isDisjoint))
+      keepRepo.save(Keep(title = None, userId = user2.id.get, url = url1.url, urlId = url1.id.get,
+        uriId = uri1.id.get, source = hover, createdAt = t1.plusDays(1),
+        visibility = LibraryVisibility.PUBLISHED, libraryId = Some(lib1.id.get), inDisjointLib = lib1.isDisjoint))
+
+      (user1, user2, lib1, lib2, lib3)
+    }
+  }
+
+  "FeedController" should {
+    "supports new library feed" in {
+      withDb(modules: _*) { implicit injector =>
+        val (u1, u2, lib1, lib2, lib3) = setup()
+        val path = com.keepit.controllers.website.routes.FeedController.getNewLibraries().toString()
+        path === "/feeds/libraries/new"
+
+        val feedController = inject[FeedController]
+        val request = FakeRequest("GET", path)
+        val result = feedController.getNewLibraries()(request)
+        status(result) === OK
+        contentType(result) === Some("application/rss+xml")
+        val stringResult = contentAsString(result)
+        val elem = XML.loadString(stringResult)
+        val channel = (elem \ "channel")
+        (channel \ "link").text.trim === s"http://dev.ezkeep.com:9000$path"
+        val items = (elem \\ "item")
+        items.size === 3
+        (items.head \ "link").text.trim === s"http://dev.ezkeep.com:9000${Library.formatLibraryPath(u2.username, u2.externalId, lib3.slug)}"
+
+      }
+    }
+  }
+}


### PR DESCRIPTION
Factored out common logic to `FeedCommander`
Moved endpoint to `FeedController`
DRY-er implementation in general
Simple test added for new feed
More work to do (kcid, auto-ping google pubsubhub, etc.)

@eishay @andrewconner 
