### PR TITLE
remove BE unused endpoints (for site) + unused commander functions

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -487,15 +487,6 @@ class KeepsCommander @Inject() (
     deactivatedKeepInfos
   }
 
-  def unkeepBulk(selection: BulkKeepSelection, userId: Id[User])(implicit context: HeimdalContext): Seq[KeepInfo] = {
-    val keeps = db.readWrite { implicit s =>
-      val keeps = getKeepsInBulkSelection(selection, userId)
-      keeps.map(setKeepStateWithSession(_, KeepStates.INACTIVE, userId))
-    }
-    finalizeUnkeeping(keeps, userId)
-    keeps map KeepInfo.fromKeep
-  }
-
   def unkeepBatch(ids: Seq[ExternalId[Keep]], userId: Id[User])(implicit context: HeimdalContext): (Seq[KeepInfo], Seq[ExternalId[Keep]]) = {
     val (keeps, failures) = db.readWrite { implicit s =>
       val keepMap = ids map { id =>
@@ -559,33 +550,11 @@ class KeepsCommander @Inject() (
     searchClient.updateKeepIndex()
   }
 
-  def rekeepBulk(selection: BulkKeepSelection, userId: Id[User])(implicit context: HeimdalContext): Int = {
-    val keeps = db.readWrite { implicit s =>
-      val keeps = getKeepsInBulkSelection(selection, userId).filter(_.state != KeepStates.ACTIVE)
-      keeps.map(setKeepStateWithSession(_, KeepStates.ACTIVE, userId))
-    }
-    libraryAnalytics.rekeptPages(userId, keeps, context)
-    searchClient.updateKeepIndex()
-    keeps.length
-  }
-
   private def setKeepStateWithSession(keep: Keep, state: State[Keep], userId: Id[User])(implicit context: HeimdalContext, session: RWSession): Keep = {
     val saved = keepRepo.save(keep withState state)
     log.info(s"[unkeep($userId)] deactivated keep=$saved")
     keepToCollectionRepo.getCollectionsForKeep(saved.id.get) foreach { cid => collectionRepo.collectionChanged(cid, inactivateIfEmpty = true) }
     saved
-  }
-
-  def setKeepPrivacyBulk(selection: BulkKeepSelection, userId: Id[User], isPrivate: Boolean)(implicit context: HeimdalContext): Int = {
-    val (oldKeeps, newKeeps) = db.readWrite { implicit s =>
-      val keeps = getKeepsInBulkSelection(selection, userId)
-      val oldKeeps = keeps.filter(_.isPrivate != isPrivate)
-      val newKeeps = oldKeeps.map(updateKeepWithSession(_, Some(isPrivate), None))
-      (oldKeeps, newKeeps)
-    }
-    (oldKeeps zip newKeeps) map { case (oldKeep, newKeep) => libraryAnalytics.updatedKeep(oldKeep, newKeep, context) }
-    searchClient.updateKeepIndex()
-    newKeeps.length
   }
 
   def updateKeep(keep: Keep, isPrivate: Option[Boolean], title: Option[String])(implicit context: HeimdalContext): Option[Keep] = {

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -308,24 +308,16 @@ POST    /site/events                @com.keepit.controllers.tracking.EventProxyC
 GET     /assets/sitemap.xml         @com.keepit.controllers.website.SiteMapController.sitemap()
 
 GET     /site/keeps/all             @com.keepit.controllers.website.KeepsController.allKeeps(before: Option[String], after: Option[String], collection: Option[String], helprank: Option[String], count: Int ?= Integer.MAX_VALUE, withPageInfo: Boolean ?= false)
-POST    /site/keeps/add             @com.keepit.controllers.website.KeepsController.keepMultiple(separateExisting: Boolean ?= false)
-POST    /site/keeps/remove          @com.keepit.controllers.website.KeepsController.unkeepMultiple()
-POST    /site/keeps/delete          @com.keepit.controllers.website.KeepsController.unkeepBatch()
 GET     /site/keeps/count           @com.keepit.controllers.website.KeepsController.numKeeps()
 GET     /site/keeps/import/status   @com.keepit.controllers.website.KeepsController.importStatus()
 GET     /site/keeps/export          @com.keepit.controllers.website.KeepsController.exportKeeps()
 GET     /site/keeps/:id             @com.keepit.controllers.website.KeepsController.getKeepInfo(id: ExternalId[Keep], withFullInfo: Boolean ?= false)
 POST    /site/keeps/:id/update      @com.keepit.controllers.website.KeepsController.updateKeepInfo(id: ExternalId[Keep])
-POST    /site/keeps/:id/delete      @com.keepit.controllers.website.KeepsController.unkeep(id: ExternalId[Keep])
 #### Deprecated: Used by Android now, should be dropped by Nov 1, 2014
 POST    /site/keeps/screenshot      @com.keepit.controllers.website.KeepsController.getScreenshotUrl()
 #### Deprecated: Used by Android and iOS now, should be dropped by Nov 1, 2014 when both will use the new /m/1/eliza/notifications endpoint
 POST    /site/keeps/imageUrls       @com.keepit.controllers.website.KeepsController.getImageUrls()
 
-POST    /site/keeps/unkeep          @com.keepit.controllers.website.KeepsController.unkeepBulk()
-POST    /site/keeps/rekeep          @com.keepit.controllers.website.KeepsController.rekeepBulk()
-POST    /site/keeps/public          @com.keepit.controllers.website.KeepsController.makePublicBulk()
-POST    /site/keeps/private         @com.keepit.controllers.website.KeepsController.makePrivateBulk()
 POST    /site/keeps/tag             @com.keepit.controllers.website.KeepsController.tagKeepBulk()
 POST    /site/keeps/untag           @com.keepit.controllers.website.KeepsController.untagKeepBulk()
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepsCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepsCommanderTest.scala
@@ -3,12 +3,9 @@ package com.keepit.commanders
 import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.common.concurrent.FakeExecutionContextModule
 import com.keepit.common.controller._
-import com.keepit.common.db.Id
-import com.keepit.common.db.slick.Database
 import com.keepit.common.external.FakeExternalServiceModule
 import com.keepit.common.social.FakeSocialGraphModule
 import com.keepit.common.time._
-import com.keepit.controllers.website.KeepsController
 import com.keepit.cortex.FakeCortexServiceClientModule
 import com.keepit.curator.FakeCuratorServiceClientModule
 import com.keepit.model._
@@ -19,9 +16,6 @@ import org.joda.time.DateTime
 import org.specs2.mutable.Specification
 import com.keepit.shoebox.{ FakeShoeboxServiceModule, FakeKeepImportsModule }
 import com.keepit.common.store.FakeShoeboxStoreModule
-import play.api.libs.json.{ JsArray, JsString, Json }
-import play.api.test.FakeRequest
-import play.api.test.Helpers._
 
 class KeepsCommanderTest extends Specification with ShoeboxTestInjector {
 


### PR DESCRIPTION
@andrewconner 

following endpoints are unused by site:
-POST    /site/keeps/add             - KeepsController.keepMultiple()
-POST    /site/keeps/remove       - KeepsController.unkeepMultiple()
-POST    /site/keeps/delete         - KeepsController.unkeepBatch()
-POST    /site/keeps/:id/delete    - KeepsController.unkeep()
-POST    /site/keeps/unkeep       - KeepsController.unkeepBulk() -> KeepsCommander.unkeepBulk() (not used)
-POST    /site/keeps/rekeep        - KeepsController.rekeepBulk() -> KeepsCommander.rekeepBulk() (not used)

-POST    /site/keeps/public          - KeepsController.setPublicBulk()
-POST    /site/keeps/private         - KeepsController.setPrivateBulk() -> KeepsCommander.setPrivacyBulk() (not used elsewhere)

and corresponding Keep controller methods were removed.
If any Keep commander function is not used anymore, that should be removed as well
