### PR TITLE
adding .sbtopts for our project

### DIFF
--- a/kifi-backend/.sbtopts
+++ b/kifi-backend/.sbtopts
@@ -1,0 +1,9 @@
+-J-Xms1g
+-J-Xmx4g
+-J-Xss4M
+-J-XX:+CMSClassUnloadingEnabled
+-J-XX:ReservedCodeCacheSize=2g
+-J-XX:+HeapDumpOnOutOfMemoryError
+-J-XX:+DoEscapeAnalysis
+-J-XX:+UseCodeCacheFlushing
+-J-XX:+UseConcMarkSweepGC


### PR DESCRIPTION
As described in [this post](https://medium.com/@jan______/sbtconfig-is-deprecated-650d6ff10236).

Also relevant is this message from [the homebrew sbt formula](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/sbt.rb):

> This formula is now using the standard typesafe sbt launcher script.
> Project specific options should be placed in .sbtopts in the root of your project.
> Global settings should be placed in /etc/sbtopts

Feel free to tweak the values. These are just what I’ve been using recently. The `PermGen` options are omitted because they’re [obsolete in Java 8](http://www.infoq.com/articles/Java-PERMGEN-Removed). I haven’t needed any Metaspace options.

This file will not get deployed to production, correct?

@andrewconner @stkem @ymatsuda @eishay 
