### PR TITLE
remove unused mobile endpoints

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -487,19 +487,6 @@ class KeepsCommander @Inject() (
     deactivatedKeepInfos
   }
 
-  def unkeepBatch(ids: Seq[ExternalId[Keep]], userId: Id[User])(implicit context: HeimdalContext): (Seq[KeepInfo], Seq[ExternalId[Keep]]) = {
-    val (keeps, failures) = db.readWrite { implicit s =>
-      val keepMap = ids map { id =>
-        id -> keepRepo.getByExtIdAndUser(id, userId)
-      }
-      val (successes, failures) = keepMap.partition(_._2.nonEmpty)
-      val keeps = successes.map(_._2).flatten.map(setKeepStateWithSession(_, KeepStates.INACTIVE, userId))
-      (keeps, failures.map(_._1))
-    }
-    finalizeUnkeeping(keeps, userId)
-    (keeps map KeepInfo.fromKeep, failures)
-  }
-
   def unkeep(extId: ExternalId[Keep], userId: Id[User])(implicit context: HeimdalContext): Option[KeepInfo] = {
     db.readWrite { implicit session =>
       keepRepo.getByExtIdAndUser(extId, userId).map(setKeepStateWithSession(_, KeepStates.INACTIVE, userId))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
@@ -70,7 +70,6 @@ class MobileKeepsController @Inject() (
     }
   }
 
-  @deprecated(message = "use addKeeps instead", since = "2014-03-28")
   def keepMultiple() = UserAction(parse.tolerantJson) { request =>
     val fromJson = request.body.as[RawBookmarksWithCollection]
     val source = KeepSource.mobile
@@ -87,25 +86,6 @@ class MobileKeepsController @Inject() (
     val (keeps, addedToCollection, _, _) = keepsCommander.keepMultiple(fromJson.keeps, libraryId, request.userId, source, fromJson.collection)
     Ok(Json.obj(
       "keeps" -> keeps,
-      "addedToCollection" -> addedToCollection
-    ))
-  }
-
-  def addKeeps() = UserAction(parse.tolerantJson) { request =>
-    val fromJson = request.body.as[RawBookmarksWithCollection]
-    val source = KeepSource.mobile
-    implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, source).build
-    val libraryId = {
-      db.readWrite { implicit session =>
-        val (main, secret) = libraryCommander.getMainAndSecretLibrariesForUser(request.userId)
-        fromJson.keeps.headOption.flatMap(_.isPrivate).map { priv =>
-          if (priv) secret.id.get else main.id.get
-        }.getOrElse(main.id.get)
-      }
-    }
-    val (keeps, addedToCollection, _, _) = keepsCommander.keepMultiple(fromJson.keeps, libraryId, request.userId, source, fromJson.collection)
-    Ok(Json.obj(
-      "keepCount" -> keeps.size,
       "addedToCollection" -> addedToCollection
     ))
   }
@@ -138,30 +118,6 @@ class MobileKeepsController @Inject() (
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
     request.body.asJson.flatMap(Json.fromJson[Seq[RawBookmarkRepresentation]](_).asOpt) map { rawBookmarks =>
       Ok(Json.obj("removedKeeps" -> keepsCommander.unkeepMultiple(rawBookmarks, request.userId)))
-    } getOrElse {
-      BadRequest(Json.obj("error" -> "parse_error"))
-    }
-  }
-
-  def unkeep(id: ExternalId[Keep]) = UserAction { request =>
-    implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
-    keepsCommander.unkeep(id, request.userId) map { ki =>
-      Ok(Json.toJson(ki))
-    } getOrElse {
-      NotFound(Json.obj("error" -> "not_found"))
-    }
-  }
-
-  def unkeepBatch() = UserAction(parse.tolerantJson) { request =>
-    implicit val keepFormat = ExternalId.format[Keep]
-    val idsOpt = (request.body \ "ids").asOpt[Seq[ExternalId[Keep]]]
-    idsOpt map { ids =>
-      implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
-      val (successes, failures) = keepsCommander.unkeepBatch(ids, request.userId)
-      Ok(Json.obj(
-        "removedKeeps" -> successes,
-        "errors" -> failures.map(id => Json.obj("id" -> id, "error" -> "not_found"))
-      ))
     } getOrElse {
       BadRequest(Json.obj("error" -> "parse_error"))
     }

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -163,14 +163,9 @@ GET     /m/1/user/friends/recommended       @com.keepit.controllers.mobile.Mobil
 POST    /m/1/page/details                   @com.keepit.controllers.mobile.MobilePageController.getPageDetails()
 POST    /m/1/page/extensionQuery            @com.keepit.controllers.mobile.MobilePageController.queryExtension(page: Int ?= 0, pageSize: Int ?= 1000)
 
-## Deprecated
 POST    /m/1/keeps/add                      @com.keepit.controllers.mobile.MobileKeepsController.keepMultiple()
-POST    /m/2/keeps/add                      @com.keepit.controllers.mobile.MobileKeepsController.addKeeps()
 POST    /m/1/keeps/addWithTags              @com.keepit.controllers.mobile.MobileKeepsController.addKeepWithTags()
-
 POST    /m/1/keeps/remove                   @com.keepit.controllers.mobile.MobileKeepsController.unkeepMultiple()
-POST    /m/1/keeps/delete                   @com.keepit.controllers.mobile.MobileKeepsController.unkeepBatch()
-POST    /m/1/keeps/:id/delete               @com.keepit.controllers.mobile.MobileKeepsController.unkeep(id: ExternalId[Keep])
 
 #Used by both Android and iOS
 POST    /m/1/keeps/imageUrl                 @com.keepit.controllers.mobile.MobileKeepsController.getImageUrl()

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -710,50 +710,6 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
       }
     }
 
-    "addKeeps" in {
-      withDb(controllerTestModules: _*) { implicit injector =>
-        val user = db.readWrite { implicit session =>
-          userRepo.save(User(firstName = "Eishay", lastName = "Smith", username = Username("test"), normalizedUsername = "test"))
-        }
-        inject[LibraryCommander].internSystemGeneratedLibraries(user.id.get)
-
-        val withCollection =
-          RawBookmarkRepresentation(title = Some("title 11"), url = "http://www.hi.com11", isPrivate = None) ::
-            RawBookmarkRepresentation(title = Some("title 21"), url = "http://www.hi.com21", isPrivate = None) ::
-            RawBookmarkRepresentation(title = Some("title 31"), url = "http://www.hi.com31", isPrivate = None) ::
-            Nil
-        val keepsAndCollections = RawBookmarksWithCollection(Some(Right("myTag")), withCollection)
-
-        val path = com.keepit.controllers.mobile.routes.MobileKeepsController.addKeeps().url
-        path === "/m/2/keeps/add"
-
-        val json = Json.obj(
-          "collectionName" -> JsString(keepsAndCollections.collection.get.right.get),
-          "keeps" -> JsArray(keepsAndCollections.keeps map { k => Json.toJson(k) })
-        )
-        inject[FakeUserActionsHelper].setUser(user)
-        val request = FakeRequest("POST", path).withBody(json)
-        val result = inject[MobileKeepsController].addKeeps()(request)
-        status(result) must equalTo(OK);
-        contentType(result) must beSome("application/json");
-
-        db.readOnlyMaster { implicit session =>
-          val keeps = keepRepo.all
-          keeps.length === 3
-          keeps.map(_.source) === Seq(KeepSource.mobile, KeepSource.mobile, KeepSource.mobile)
-          keeps.map(_.state.value) === Seq("active", "active", "active")
-        }
-
-        val expected = Json.parse(s"""
-          {
-            "keepCount":3,
-            "addedToCollection":3
-          }
-        """)
-        Json.parse(contentAsString(result)) must equalTo(expected)
-      }
-    }
-
     "unkeepMultiple" in {
       withDb(controllerTestModules: _*) { implicit injector =>
         val user = db.readWrite { implicit session =>
@@ -769,15 +725,15 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
             Nil
         val keepsAndCollections = RawBookmarksWithCollection(Some(Right("myTag")), withCollection)
 
-        val addPath = com.keepit.controllers.mobile.routes.MobileKeepsController.addKeeps().url
-        addPath === "/m/2/keeps/add"
+        val addPath = com.keepit.controllers.mobile.routes.MobileKeepsController.keepMultiple().url
+        addPath === "/m/1/keeps/add"
 
         val addJson = Json.obj(
           "collectionName" -> JsString(keepsAndCollections.collection.get.right.get),
           "keeps" -> JsArray(keepsAndCollections.keeps map { k => Json.toJson(k) })
         )
         val addRequest = FakeRequest("POST", addPath).withBody(addJson)
-        val addResult = inject[MobileKeepsController].addKeeps()(addRequest)
+        val addResult = inject[MobileKeepsController].keepMultiple()(addRequest)
         status(addResult) must equalTo(OK);
         contentType(addResult) must beSome("application/json");
 
@@ -809,78 +765,6 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
           ]}
         """)
         Json.parse(contentAsString(result)) must equalTo(expected)
-      }
-    }
-
-    "unkeepBatch" in {
-      withDb(controllerTestModules: _*) { implicit injector =>
-        val user = db.readWrite { implicit session =>
-          userRepo.save(User(firstName = "Eishay", lastName = "Smith", username = Username("test"), normalizedUsername = "test"))
-        }
-        inject[LibraryCommander].internSystemGeneratedLibraries(user.id.get)
-
-        val withCollection =
-          RawBookmarkRepresentation(title = Some("title 11"), url = "http://www.hi.com11", isPrivate = None) ::
-            RawBookmarkRepresentation(title = Some("title 21"), url = "http://www.hi.com21", isPrivate = None) ::
-            RawBookmarkRepresentation(title = Some("title 31"), url = "http://www.hi.com31", isPrivate = None) ::
-            Nil
-        val keepsAndCollections = RawBookmarksWithCollection(Some(Right("myTag")), withCollection)
-
-        inject[FakeUserActionsHelper].setUser(user)
-        val keepJson = Json.obj(
-          "collectionName" -> JsString(keepsAndCollections.collection.get.right.get),
-          "keeps" -> JsArray(keepsAndCollections.keeps map { k => Json.toJson(k) })
-        )
-        val keepReq = FakeRequest("POST", com.keepit.controllers.mobile.routes.MobileKeepsController.keepMultiple().url).withBody(keepJson)
-        val keepRes = inject[MobileKeepsController].keepMultiple()(keepReq)
-        status(keepRes) must equalTo(OK)
-        contentType(keepRes) must beSome("application/json")
-
-        val keepJsonRes = Json.parse(contentAsString(keepRes))
-        val keepIds = (keepJsonRes \ "keeps").as[Seq[JsObject]].map(k => (k \ "id").as[ExternalId[Keep]])
-        keepIds.length === withCollection.size
-        val expectedKeeps = Json.parse(s"""
-          [
-            {"id":"${keepIds(0)}","title":"title 11","url":"http://www.hi.com11","isPrivate":false,"libraryId":"l7jlKlnA36Su"},
-            {"id":"${keepIds(1)}","title":"title 21","url":"http://www.hi.com21","isPrivate":false,"libraryId":"l7jlKlnA36Su"},
-            {"id":"${keepIds(2)}","title":"title 31","url":"http://www.hi.com31","isPrivate":false,"libraryId":"l7jlKlnA36Su"}
-          ]
-        """)
-        (keepJsonRes \ "keeps") === expectedKeeps
-
-        db.readOnlyMaster { implicit session =>
-          val keeps = keepRepo.all
-          keeps.map(_.source) === Seq(KeepSource.mobile, KeepSource.mobile, KeepSource.mobile)
-        }
-
-        val path = com.keepit.controllers.mobile.routes.MobileKeepsController.unkeepBatch().url
-        path === "/m/1/keeps/delete" // remove already taken
-
-        implicit val keepFormat = ExternalId.format[Keep]
-        val json = Json.obj("ids" -> keepIds.take(2))
-        val request = FakeRequest("POST", path).withBody(json)
-        val result = inject[MobileKeepsController].unkeepBatch()(request)
-        status(result) must equalTo(OK)
-        contentType(result) must beSome("application/json")
-
-        val (ext1, ext2) = db.readOnlyMaster { implicit session =>
-          val keeps = keepRepo.all
-          keeps.map(_.state.value) === Seq("inactive", "inactive", "active")
-          (keeps(0).externalId, keeps(1).externalId)
-        }
-
-        val expected = Json.parse(s"""
-          {
-            "removedKeeps":[
-              {"id":"$ext1","title":"title 11","url":"http://www.hi.com11","isPrivate":false,"libraryId":"l7jlKlnA36Su"},
-              {"id":"$ext2","title":"title 21","url":"http://www.hi.com21","isPrivate":false,"libraryId":"l7jlKlnA36Su"}
-            ],
-            "errors":[]
-          }
-        """)
-        Json.parse(contentAsString(result)) must equalTo(expected)
-
-        // todo: add test for error conditions
       }
     }
 


### PR DESCRIPTION
endpoints to remove:
-POST    /m/2/keeps/add           -> `MobileKeepsController.addKeeps()` -> unused for a while
-POST    /m/1/keeps/:id/delete  -> `MobileKeepsController.unkeep(id)` -> unused for a while
-POST    /m/1/keeps/delete       -> `MobileKeepsController.unkeepBatch()` -> unused for a while

by removing `.unkeepBatch()`, `KeepsCommander.unkeepBatch()` becomes unused.

@andrewconner @thassss @jaredpetker 
