### PR TITLE
Update library search urls and enable non-logged-in user public library search.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/locationNoReloadService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/locationNoReloadService.js
@@ -1,0 +1,20 @@
+'use strict';
+
+angular.module('kifi')
+
+// A wrapper around $location that updates the browser url without
+// reloading or changing the $route state.
+.factory('locationNoReload', ['$location', '$route', '$rootScope',
+  function ($location, $route, $rootScope) {
+    $location.skipReload = function () {
+      var lastRoute = $route.current;
+      var un = $rootScope.$on('$locationChangeSuccess', function () {
+        $route.current = lastRoute;
+        un();
+      });
+
+      return $location;
+    };
+
+    return $location;
+}]);

--- a/kifi-backend/modules/shoebox/angular/src/layout/header/HeaderCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/header/HeaderCtrl.js
@@ -24,7 +24,6 @@ angular.module('kifi')
     $scope.isFocused = false;
     $scope.library = {};
     $scope.search = { text: '', showName: false };
-    $scope.stayInLibraryPath = '';
 
     // Temp callout method. Remove after most users know about libraries. (Oct 26 2014)
     var calloutName = 'tag_callout_shown';
@@ -38,18 +37,24 @@ angular.module('kifi')
       profileService.savePrefs(save);
     };
 
+
     //
     // Watchers & Listeners
     //
     var deregisterLibraryChip = $rootScope.$on('libraryUrl', function (e, library) {
       $scope.library = library;
-      $scope.search.text = '';
+
+      if ($scope.library.owner && !$scope.library.owner.picUrl) {
+        $scope.library.owner.picUrl = friendService.getPictureUrlForUser($scope.library.owner);
+      }
+
       if ($scope.library.id) {
         $scope.search.showName = true;
-        $scope.stayInLibraryPath = $scope.library.url;
       } else {
         $scope.clearLibraryName();
       }
+
+      $scope.search.text = $routeParams.q || '';
     });
     $scope.$on('$destroy', deregisterLibraryChip);
 
@@ -74,45 +79,44 @@ angular.module('kifi')
 
     $scope.clearLibraryName = function () {
       $scope.search.showName = false;
-      $scope.stayInLibraryPath = '';
       $scope.library = {};
-      if ($location.path() === '/find') {
-        $location.search('l', '');
-      }
+      $scope.changeSearchInput();
     };
 
     $scope.search.text = $routeParams.q || '';
     $scope.changeSearchInput = _.debounce(function () {
-      if ($scope.search.text === '' && $scope.stayInLibraryPath !== '') {
-        $timeout(function() {
-          $location.url($scope.stayInLibraryPath);
-        }, 0);
-        $scope.clearInput();
-      } else {
-        $timeout(function() {
-          var libId = $scope.library.id;
-          if ($location.path() !== '/find') {
-            if (libId) {
-              $location.url('/find?q=' + $scope.search.text + '&f=a' + '&l=' + libId);
-            } else {
-              $location.url('/find?q=' + $scope.search.text);
+      $timeout(function() {
+        // We are not already on the search page.
+        if ($location.path() !== '/find') {
+          if ($scope.library && $scope.library.url) {
+            if ($scope.search.text) {
+              /* jshint ignore:start */
+              if ($routeParams.q) {
+                $location.search('q', $scope.search.text).replace();
+              } else {
+                $location.url($scope.library.url + '/find?q=' + $scope.search.text + '&f=a');
+              }
+              /* jshint ignore:end */
+            } else {  // jshint ignore:line
+              $location.url($scope.library.url);
             }
-          } else {
-            $location.search('q', $scope.search.text).replace(); // this keeps any existing URL params
+          } else if ($scope.search.text) {
+            $location.url('/find?q=' + $scope.search.text);
           }
-        });
-      }
+        }
+
+        // We are already on the search page.
+        else {
+          $location.search('q', $scope.search.text).replace(); // this keeps any existing URL params
+        }
+      });
     }, 100, {
       'leading': true
     });
 
     $scope.clearInput = function () {
-      if ($scope.stayInLibraryPath !== '') {
-        $timeout(function () {
-          $location.url($scope.stayInLibraryPath);
-        }, 0);
-      }
       $scope.search.text = '';
+      $scope.changeSearchInput();
     };
 
     var KEY_ESC = 27, KEY_DEL = 8;

--- a/kifi-backend/modules/shoebox/angular/src/layout/header/header.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/header/header.tpl.html
@@ -8,28 +8,28 @@
     </div>
 
     <div class="kf-header-search-bar">
-        <div class="kf-query-lib-container" ng-class="{empty: isEmpty()}">
-          <div class="kf-query-lib-icon" ng-class="{'focused': isFocused}"></div>
+      <div class="kf-query-lib-container" ng-class="{empty: isEmpty()}">
+        <div class="kf-query-lib-icon" ng-class="{'focused': isFocused}"></div>
 
-          <img class="kf-search-bar-lib-owner-img" ng-show="search.showName" ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+        <img class="kf-search-bar-lib-owner-img" ng-show="search.showName" ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
 
-          <div class="kf-search-bar-lib-name" ng-show="search.showName" ng-class="library.kind != 'user_created' ? 'system-created' : library.visibility == 'secret' ? 'secret' : 'published'"> {{library.name}} </div>
-          <div class="kf-search-bar-lib-name-clear" ng-show="search.showName" ng-class="library.kind != 'user_created' ? 'system-created' : library.visibility == 'secret' ? 'secret' : 'published'" ng-click="clearLibraryName()">&times;</div>
+        <div class="kf-search-bar-lib-name" ng-show="search.showName" ng-class="library.kind != 'user_created' ? 'system-created' : library.visibility == 'secret' ? 'secret' : 'published'"> {{library.name}} </div>
+        <div class="kf-search-bar-lib-name-clear" ng-show="search.showName" ng-class="library.kind != 'user_created' ? 'system-created' : library.visibility == 'secret' ? 'secret' : 'published'" ng-click="clearLibraryName()">&times;</div>
 
-          <div class="kf-query-lib" ng-class="{'extend': !search.showName}">
-            <input type="text" placeholder="Search Kifi…" ng-model="search.text" ng-focus="focusInput()" ng-blur="blurInput()" ng-change="changeSearchInput()" ng-keydown="onKeydown($event)">
-          </div>
-          <div class="kf-search-bar-clear" ng-show="search.text" ng-click="clearInput()">Clear</div>
+        <div class="kf-query-lib" ng-class="{'extend': !search.showName}">
+          <input type="text" placeholder="Search Kifi…" ng-model="search.text" ng-focus="focusInput()" ng-blur="blurInput()" ng-change="changeSearchInput()" ng-keydown="onKeydown($event)">
+        </div>
+        <div class="kf-search-bar-clear" ng-show="search.text" ng-click="clearInput()">Clear</div>
       </div>
     </div>
 
     <div class="kf-header-right">
       <div class="sprite sprite-add-link" ng-click="addKeeps(library)">Add a link</div>
       <div kf-callout class="kf-callout-bubble-bottom kf-callout-tags" ng-if="showCallout()">
-          <div>Your tags are safe. Creating a new library from a tag is a snap.</div>
-          <div class="kf-callout-bubble-action">
-            <div class="kf-callout-bubble-button" ng-click="closeCallout()">Got it</div>
-          </div>
+        <div>Your tags are safe. Creating a new library from a tag is a snap.</div>
+        <div class="kf-callout-bubble-action">
+          <div class="kf-callout-bubble-button" ng-click="closeCallout()">Got it</div>
+        </div>
       </div>
       <a href="/tags/manage" class="kf-header-manage-tags sprite svg-tag-black" ng-class="{'svg-tag-hover': hover, 'kf-callout-tags-button': showCallout()}" ng-mouseenter="hover = true" ng-mouseleave="hover = false">Manage your tags</a>
       <div class="kf-header-icon-hover-container">

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/main.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/main.styl
@@ -17,10 +17,6 @@
   .kf-main-keeps
     margin-top: 42px
 
-.kf-logged-out .kf-main .library-search
-  .kf-main-keeps
-    margin-top: 18px
-
 @media only screen and (max-width: 1024px)
   .kf-main
     -webkit-transition: width sidebarTransitionDuration;

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/main.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/main.styl
@@ -17,6 +17,10 @@
   .kf-main-keeps
     margin-top: 42px
 
+.kf-logged-out .kf-main .library-search
+  .kf-main-keeps
+    margin-top: 18px
+
 @media only screen and (max-width: 1024px)
   .kf-main
     -webkit-transition: width sidebarTransitionDuration;

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -4,21 +4,20 @@ angular.module('kifi')
 
 .controller('LibraryCtrl', [
   '$scope', '$rootScope', '$location', '$routeParams', 'keepDecoratorService', 'libraryService',
-  'modalService', 'profileService', 'util', '$window', '$analytics',
+  'modalService', 'profileService', 'util', '$window', '$analytics', 'librarySearch',
   function ($scope, $rootScope, $location, $routeParams, keepDecoratorService, libraryService,
-            modalService, profileService, util, $window, $analytics) {
+            modalService, profileService, util, $window, $analytics, librarySearch) {
     //
     // Internal data.
     //
     var selectedCount = 0;
     var prePopulated = false;
-    var authToken = $location.search().authToken || $location.search().authCode || $location.search().accessToken || '';
-    //                   ↑↑↑ use this one ↑↑↑
+    var authToken = $location.search().authToken || '';
+
 
     //
     // Internal functions
     //
-
     function trackPageView(attributes) {
       var url = $analytics.settings.pageTracking.basePath + $location.url();
       var library = $scope.library;
@@ -32,10 +31,15 @@ angular.module('kifi')
       $analytics.pageTrack(url, trackLibraryAttributes);
     }
 
+    function setTitle(lib) {
+      $window.document.title = lib.name + ' by ' + lib.owner.firstName + ' ' + lib.owner.lastName + ' • Kifi' ;
+    }
+
 
     //
     // Scope data.
     //
+    $scope.librarySearch = librarySearch;
     $scope.username = $routeParams.username;
     $scope.librarySlug = $routeParams.librarySlug;
     $scope.keeps = [];
@@ -50,6 +54,7 @@ angular.module('kifi')
     $scope.userIsOwner = function () {
       return $scope.library && $scope.library.owner.id === profileService.me.id;
     };
+
 
     //
     // Scope methods.
@@ -103,10 +108,20 @@ angular.module('kifi')
       selectedCount = numSelected;
     };
 
+    $scope.libraryKeepClicked = function (keep, event) {
+      var target = event.target;
+      var eventAction = target.getAttribute('click-action');
+      if ($scope.$root.userLoggedIn) {
+        libraryService.trackEvent('user_clicked_page', $scope.library, { action: eventAction });
+      } else {
+        libraryService.trackEvent('visitor_clicked_page', $scope.library, { action: eventAction });
+      }
+    };
+
+
     //
     // Watches and listeners.
     //
-
     $scope.$watch('library.id', function (id) {
       $rootScope.$broadcast('currentLibraryChanged', $scope.library);
       if (id) {
@@ -161,19 +176,10 @@ angular.module('kifi')
     });
     $scope.$on('$destroy', deregisterTrackLibraryEvent);
 
-    $scope.libaryKeepClicked = function (keep, event) {
-      var target = event.target;
-      var eventAction = target.getAttribute('click-action');
-      if ($scope.$root.userLoggedIn) {
-        libraryService.trackEvent('user_clicked_page', $scope.library, { action: eventAction });
-      } else {
-        libraryService.trackEvent('visitor_clicked_page', $scope.library, { action: eventAction });
-      }
-    };
-
-    var setTitle = function (lib) {
-      $window.document.title = lib.name + ' by ' + lib.owner.firstName + ' ' + lib.owner.lastName + ' • Kifi' ;
-    };
+    var deregisterUpdateLibrarySearch = $rootScope.$on('librarySearchChanged', function (e, librarySearch) {
+      $scope.librarySearch = librarySearch;
+    });
+    $scope.$on('$destroy', deregisterUpdateLibrarySearch);
 
 
     //

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
@@ -142,6 +142,7 @@ invite-header-orange = #ff7c3c
       margin: 0 8px
 
   .kf-keep-lib-owner
+    position: relative
     padding-bottom: 10px
 
   .kf-keep-lib-user-image
@@ -159,6 +160,18 @@ invite-header-orange = #ff7c3c
 
   .kf-keep-lib-owner-name
     color: #939393
+
+  .kf-keep-lib-search
+    position: absolute
+    top: 10px
+    right: 0
+
+  .kf-keep-lib-search-input
+    border: 1px solid #ccc
+    border-radius: 10px
+    font-size: 14px
+    padding: 3px 8px
+    width: 140px
 
   .kf-keep-lib-description-container
     padding-bottom: 5px

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.tpl.html
@@ -1,7 +1,7 @@
 <div>
   <!-- Library page -->
   <div class="kf-main-library-keeps" ng-if="page === 'library'" ng-class="{'library-search': librarySearch}">
-    <div ng-hide="librarySearch && $root.userLoggedIn" class="kf-library-card-header">
+    <div ng-if="!librarySearch || !$root.userLoggedIn" class="kf-library-card-header">
       <div kf-library-card
         library="library"
         username="username"
@@ -13,7 +13,7 @@
       <div class="white-background"></div>
     </div>
 
-    <div ng-if="!librarySearch">
+    <div ng-if="!librarySearch || !$root.userLoggedIn">
       <div class="kf-empty-state" ng-if="keeps.length === 0 && userIsOwner()" ng-show="!loading">
         You don't have any keeps in this Library yet. You can:
         <ul>
@@ -44,7 +44,7 @@
       ></div>
     </div>
 
-    <div ng-if="librarySearch" ng-include="'search/search.tpl.html'" ng-controller="SearchCtrl"></div>
+    <div ng-if="librarySearch && $root.userLoggedIn" ng-include="'search/search.tpl.html'" ng-controller="SearchCtrl"></div>
   </div>
 
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.tpl.html
@@ -1,7 +1,7 @@
 <div>
   <!-- Library page -->
-  <div class="kf-main-library-keeps" ng-if="page === 'library'">
-    <div class="kf-library-card-header">
+  <div class="kf-main-library-keeps" ng-if="page === 'library'" ng-class="{'library-search': librarySearch}">
+    <div ng-hide="librarySearch && $root.userLoggedIn" class="kf-library-card-header">
       <div kf-library-card
         library="library"
         username="username"
@@ -12,33 +12,39 @@
       ></div>
       <div class="white-background"></div>
     </div>
-    <div class="kf-empty-state" ng-if="keeps.length === 0 && userIsOwner()" ng-show="!loading">
-      You don't have any keeps in this Library yet. You can:
-      <ul>
-        <li><a href="javascript:" ng-click="callAddKeep()"><span class="sprite sprite-add-link"></span>Add any page by pasting the URL here</a></li>
-        <li><a href="javascript:" ng-click="callImportBookmarks()"><span class="sprite sprite-import-bookmarks-icon"></span>Import your bookmarks from your browser</a></li>
-        <li><a href="javascript:" ng-click="callImportBookmarkFile()"><span class="sprite sprite-import-from-other-services-icon"></span>Import links from sites like Delicious, Pocket, Pinboard</a></li>
-        <li kf-max-version><a href="javascript:" ng-click="callTriggerInstall()"><span class="sprite sprite-install-extension-icon"></span>Install our browser extension on Chrome and Firefox</a></li>
-      </ul>
-    </div>
-    <div class="kf-empty-state" ng-if="keeps.length === 0 && !userIsOwner()" ng-show="!loading">
-      <p class="public-library-empty-explain">{{library.owner.firstName || 'The curator'}} hasn't added anything to this library yet.</p>
-      <p class="public-library-empty-explain" ng-hide="$root.userLoggedIn">Want to create and share your own libraries? <a href="/signup">Sign up</a> to join the Kifi family.</p>
+
+    <div ng-if="!librarySearch">
+      <div class="kf-empty-state" ng-if="keeps.length === 0 && userIsOwner()" ng-show="!loading">
+        You don't have any keeps in this Library yet. You can:
+        <ul>
+          <li><a href="javascript:" ng-click="callAddKeep()"><span class="sprite sprite-add-link"></span>Add any page by pasting the URL here</a></li>
+          <li><a href="javascript:" ng-click="callImportBookmarks()"><span class="sprite sprite-import-bookmarks-icon"></span>Import your bookmarks from your browser</a></li>
+          <li><a href="javascript:" ng-click="callImportBookmarkFile()"><span class="sprite sprite-import-from-other-services-icon"></span>Import links from sites like Delicious, Pocket, Pinboard</a></li>
+          <li kf-max-version><a href="javascript:" ng-click="callTriggerInstall()"><span class="sprite sprite-install-extension-icon"></span>Install our browser extension on Chrome and Firefox</a></li>
+        </ul>
+      </div>
+
+      <div class="kf-empty-state" ng-if="keeps.length === 0 && !userIsOwner()" ng-show="!loading">
+        <p class="public-library-empty-explain">{{library.owner.firstName || 'The curator'}} hasn't added anything to this library yet.</p>
+        <p class="public-library-empty-explain" ng-hide="$root.userLoggedIn">Want to create and share your own libraries? <a href="/signup">Sign up</a> to join the Kifi family.</p>
+      </div>
+
+      <div kf-keeps
+        library="library"
+        keeps="keeps"
+        keeps-loading="loading"
+        keeps-has-more="hasMore"
+        scroll-disabled="!hasMore"
+        scroll-distance="scrollDistance"
+        scroll-next="getNextKeeps"
+        edit-mode="editMode"
+        toggle-edit="toggleEdit"
+        update-selected-count="updateSelectedCount(numSelected)"
+        keep-click="libraryKeepClicked"
+      ></div>
     </div>
 
-    <div kf-keeps
-      library="library"
-      keeps="keeps"
-      keeps-loading="loading"
-      keeps-has-more="hasMore"
-      scroll-disabled="!hasMore"
-      scroll-distance="scrollDistance"
-      scroll-next="getNextKeeps"
-      edit-mode="editMode"
-      toggle-edit="toggleEdit"
-      update-selected-count="updateSelectedCount(numSelected)"
-      keep-click="libaryKeepClicked"
-    ></div>
+    <div ng-if="librarySearch" ng-include="'search/search.tpl.html'" ng-controller="SearchCtrl"></div>
   </div>
 
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -4,9 +4,11 @@ angular.module('kifi')
 
 .directive('kfLibraryCard', [
   '$FB', '$location', '$q', '$rootScope', '$window', 'env', 'friendService', 'libraryService', 'modalService',
-  'profileService', 'platformService', 'signupService', '$twitter', '$timeout',
+  'profileService', 'platformService', 'signupService', '$twitter', '$timeout', '$routeParams', '$route',
+  'locationNoReload',
   function ($FB, $location, $q, $rootScope, $window, env, friendService, libraryService, modalService,
-      profileService, platformService, signupService, $twitter, $timeout) {
+      profileService, platformService, signupService, $twitter, $timeout, $routeParams, $route,
+      locationNoReload) {
     return {
       restrict: 'A',
       replace: true,
@@ -23,8 +25,9 @@ angular.module('kifi')
         //
         // Internal data.
         //
-        var authToken = $location.search().authToken || $location.search().authCode || $location.search().accessToken || '';
-        //                   ↑↑↑ use this one ↑↑↑
+        var authToken = $location.search().authToken || '';
+        var prevQuery = '';
+
 
         //
         // Scope data.
@@ -34,6 +37,7 @@ angular.module('kifi')
         scope.followersToShow = 0;
         scope.numAdditionalFollowers = 0;
         scope.editKeepsText = 'Edit Keeps';
+        scope.search = { 'text': $routeParams.q || '' };
 
         var magicImages = {
           'l7SZ3gr3kUQJ': '//djty7jcqog9qu.cloudfront.net/special-libs/l7SZ3gr3kUQJ.png',
@@ -341,8 +345,47 @@ angular.module('kifi')
               }
             });
           }
-
         };
+
+        scope.onSearchInputChange = _.debounce(function (query) {
+          $timeout(function () {
+            if (query) {
+              if (prevQuery) {
+                locationNoReload.skipReload().search('q', query).replace();
+
+                // When we search using the input inside the library card header, we don't
+                // want to reload the page. One consequence of this is that we need to kick
+                // SearchController to initialize a search when the search query changes if
+                // we initially started with a url that is a library url that has no search
+                // parameters.
+                if (!$route.current.params.q) {
+                  $timeout(function () {
+                    $rootScope.$emit('librarySearched');
+                  });
+                }
+              } else {
+                locationNoReload.skipReload().url(scope.library.url + '/find?q=' + query + '&f=a');
+              }
+
+              $routeParams.q = query;
+              $routeParams.f = 'a';
+
+              $timeout(function () {
+                $rootScope.$emit('librarySearchChanged', true);
+              });
+            } else {
+              locationNoReload.skipReload().url(scope.library.url);
+
+              $timeout(function () {
+                $rootScope.$emit('librarySearchChanged', false);
+              });
+            }
+
+            prevQuery = query;
+          });
+        }, 100, {
+          'leading': true
+        });
 
         //
         // Watches and listeners.

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
@@ -31,6 +31,10 @@
           <div class="kf-keep-lib-curator">Curator:</div>
           <div class="kf-keep-lib-owner-name">{{library.owner.firstName}} {{library.owner.lastName}}</div>
         </div>
+
+        <div ng-if="!recommendation && isUserLoggedOut" class="kf-keep-lib-search">
+          <input class="kf-keep-lib-search-input" type="text" placeholder="Search this library" ng-model="search.text" ng-focus="" ng-blur="" ng-change="onSearchInputChange(search.text)" ng-keydown="">
+        </div>
       </div>
 
       <div ng-switch="clippedDescription" class="kf-keep-lib-description-container">

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
@@ -32,7 +32,7 @@
           <div class="kf-keep-lib-owner-name">{{library.owner.firstName}} {{library.owner.lastName}}</div>
         </div>
 
-        <div ng-if="!recommendation && isUserLoggedOut" class="kf-keep-lib-search">
+        <div ng-if="!recommendation && isUserLoggedOut && false" class="kf-keep-lib-search">
           <input class="kf-keep-lib-search-input" type="text" placeholder="Search this library" ng-model="search.text" ng-focus="" ng-blur="" ng-change="onSearchInputChange(search.text)" ng-keydown="">
         </div>
       </div>

--- a/kifi-backend/modules/shoebox/angular/src/route.js
+++ b/kifi-backend/modules/shoebox/angular/src/route.js
@@ -49,9 +49,17 @@ angular.module('kifi')
       controller: 'ManageTagCtrl'
     })
     // ↓↓↓↓↓ Important: This needs to be last! ↓↓↓↓↓
+    .when('/:username/:librarySlug/find', {
+      templateUrl: 'libraries/library.tpl.html',
+      controller: 'LibraryCtrl',
+      resolve: { librarySearch: function () { return true; } },
+      reloadOnSearch: false
+    })
+
     .when('/:username/:librarySlug', {
       templateUrl: 'libraries/library.tpl.html',
-      controller: 'LibraryCtrl'
+      controller: 'LibraryCtrl',
+      resolve: { librarySearch: function () { return false; } }
     });
     // ↑↑↑↑↑ Important: This needs to be last! ↑↑↑↑↑
 

--- a/kifi-backend/modules/shoebox/angular/src/search/search.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/search/search.tpl.html
@@ -1,18 +1,19 @@
 <div class="kf-main-search">
   <div class="kf-main-head">
-    <div class="kf-search-filters">
+    <div ng-if="$root.userLoggedIn" class="kf-search-filters">
       <a class="kf-search-filter" ng-class="{ selected: isFilterSelected('a'), enabled: isEnabled('a') }" ng-href="{{getFilterUrl('a')}}">All keeps</a>
       <a class="kf-search-filter" ng-class="{ selected: isFilterSelected('m'), enabled: isEnabled('m') }" ng-href="{{getFilterUrl('m')}}">Your keeps ({{resultTotals.myTotal}})</a>
       <a class="kf-search-filter" ng-class="{ selected: isFilterSelected('f'), enabled: isEnabled('f') }" ng-href="{{getFilterUrl('f')}}">Friends keeps ({{resultTotals.friendsTotal}})</a>
     </div>
     <div class="kf-subtitle">
       <span class="kf-subtitle-text">{{getSubtitle()}}</span>
-      <div class="kf-edit-keeps" ng-click="toggleEdit()">
+      <div ng-if="$root.userLoggedIn" class="kf-edit-keeps" ng-click="toggleEdit()">
         <span class="sprite sprite-edit-pencil-icon"></span>
         <span class="kf-edit-keeps-label">{{editKeepsLabel()}}</span>
       </div>
     </div>
   </div>
+
   <div
     kf-keeps
     keeps="resultKeeps"

--- a/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
@@ -30,50 +30,56 @@ angular.module('kifi')
       return JSON.parse(JSON.stringify(obj));
     }
 
-    function decompressHit(hit, users, libraries) {
+    function decompressHit(hit, users, libraries, userLoggedIn) {
       var decompressedKeepers = [];
       var decompressedLibraries = [];
-      var myLibraries = [];
+      var myLibraries = [];  // myLibraries doesn't seem to be used anywhere.
       var libUsers = {};
+
       hit.isMyBookmark = false;
       hit.keepers = hit.keepers || [];
       hit.libraries = hit.libraries || [];
 
-      for (var i=0; i<hit.libraries.length; i=i+2) {
+      for (var i = 0; i < hit.libraries.length; i = i + 2) {
         var idxLib = hit.libraries[i];
-        var idxUser = hit.libraries[i+1];
+        var idxUser = hit.libraries[i + 1];
         var lib = libraries[idxLib];
         var user;
+
         if (idxUser !== -1) {
           user = users[idxUser];
           lib.keeperPic = friendService.getPictureUrlForUser(user);
           lib.owner = user;
           decompressedLibraries.push(lib);
           libUsers[idxUser] = true;
-        } else {
+        } else if (userLoggedIn) {
           user = profileService.me;
           lib.keeperPic = friendService.getPictureUrlForUser(user);
           lib.owner = user;
+
           if (!libraryService.isSystemLibrary(lib.id)) {
             decompressedLibraries.push(lib);
           }
+
           myLibraries.push(lib);
         }
       }
 
-      hit.keepers.forEach( function (keeperIdx) {
-        if (keeperIdx === -1) {
-          hit.isMyBookmark = true;
-        } else {
-          if (!libUsers[keeperIdx]){
-            decompressedKeepers.push(users[keeperIdx]);
+      if (userLoggedIn) {
+        hit.keepers.forEach(function (keeperIdx) {
+          if (keeperIdx === -1) {
+            hit.isMyBookmark = true;
           } else {
-            var user = copy(users[keeperIdx]);
-            user.hidden = true;
-            decompressedKeepers.push(user);
+            if (!libUsers[keeperIdx]){
+              decompressedKeepers.push(users[keeperIdx]);
+            } else {
+              var user = copy(users[keeperIdx]);
+              user.hidden = true;
+              decompressedKeepers.push(user);
+            }
           }
-        }
-      });
+        });
+      }
 
       hit.keepers = decompressedKeepers;
       hit.libraries = decompressedLibraries;
@@ -123,7 +129,7 @@ angular.module('kifi')
     //
     // Exposed API methods.
     //
-    function find(query, filter, library, context) {
+    function find(query, filter, library, context, userLoggedIn) {
       var url = routeService.search,
         reqData = {
           params: {
@@ -139,7 +145,7 @@ angular.module('kifi')
       //$log.log('searchActionService.find() req', reqData);
 
       var searchActionPromise = $http.get(url, reqData);
-      var librarySummariesPromise = libraryService.fetchLibrarySummaries(false);
+      var librarySummariesPromise = userLoggedIn ? libraryService.fetchLibrarySummaries(false) : true;
       var resultsFetched = $q.all([librarySummariesPromise, searchActionPromise]);
 
       // ensures that the libraries have been loaded before the hits are decompressed
@@ -151,8 +157,9 @@ angular.module('kifi')
 
         var hits = resData.hits || [];
         _.forEach(hits, function (hit) {
-          decompressHit(hit, resData.users, resData.libraries);
+          decompressHit(hit, resData.users, resData.libraries, userLoggedIn);
         });
+
         _.forEach(hits, processHit);
 
         $analytics.eventTrack('user_clicked_page', {


### PR DESCRIPTION
@andrewconner @ahsu1230 
https://app.asana.com/0/18079737520750/18807532114522

UI is still pending discussion with Danny. Current UI for dev purposes is attached as screenshot. Please review for functionality.

Besides allowing for public library search for non-logged-in users, this pull also:
- Uses a `/:userName/:librarySlug/find?q=` url for library searches for both logged-in and logged-out users; this url can be pasted and the correct search results will render along with the correct library chip in the header search input.
- Moves library search into `LibraryController` and `library.tpl.html` (so as to enable non-logged-in user library search to render search results under the library header card)
- Fixes a small bug where the "All Keeps" link on a search results page is disabled if no other users besides the user and the users' friend have keeps that match the search query

![screen shot 2014-11-12 at 1 12 47 pm](https://cloud.githubusercontent.com/assets/593801/5018745/54812ca8-6a6e-11e4-9cdf-63bfad76d029.png)
