### PR TITLE
Refactoring and pulling code out of KeepImageCommander

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/net/WebService.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/WebService.scala
@@ -1,0 +1,16 @@
+package com.keepit.common.net
+
+import com.google.inject.ImplementedBy
+import play.api.libs.ws.WSRequestHolder
+
+@ImplementedBy(classOf[PlayWS])
+trait WebService {
+  def url(url: String): WSRequestHolder
+}
+
+class PlayWS extends WebService {
+  import play.api.Play.current
+  import play.api.libs.ws.WS
+
+  def url(url: String): WSRequestHolder = WS.url(url)(current)
+}

--- a/kifi-backend/modules/common/test/com/keepit/common/net/FakeWebService.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/net/FakeWebService.scala
@@ -1,0 +1,102 @@
+package com.keepit.common.net
+
+import com.google.inject.Singleton
+import play.api.libs.iteratee.Enumerator
+import play.api.libs.json.{ JsString, JsValue }
+import play.api.libs.ws._
+import play.libs.ws.WSClient
+import com.keepit.common.core._
+
+import scala.concurrent.Future
+import scala.xml.Elem
+
+case class FakeWSRequestHolder(
+    url: String,
+    calc: Option[WSSignatureCalculator] = None,
+    queryString: Map[String, Seq[String]] = Map.empty,
+    method: String = "GET",
+    followRedirects: Option[Boolean] = None,
+    body: WSBody = EmptyBody,
+    requestTimeout: Option[Int] = None,
+    virtualHost: Option[String] = None,
+    proxyServer: Option[WSProxyServer] = None,
+    auth: Option[(String, String, WSAuthScheme)] = None,
+    headers: Map[String, Seq[String]] = Map.empty,
+    var response: Option[WSResponse] = None,
+    var streamResponse: Option[(WSResponseHeaders, Enumerator[Array[Byte]])] = None) extends WSRequestHolder {
+
+  def withHeaders(hdrs: (String, String)*): WSRequestHolder = this.copy(headers = hdrs.map(r => r._1 -> Seq(r._2)).toMap)
+  override def withAuth(username: String, password: String, scheme: WSAuthScheme): WSRequestHolder = this.copy(auth = Some((username, password, scheme)))
+  override def withQueryString(parameters: (String, String)*): WSRequestHolder = this.copy(queryString = parameters.map(r => r._1 -> Seq(r._2)).toMap)
+  override def execute(): Future[WSResponse] = Future.successful(response.getOrElse(emptyResponse))
+  override def sign(calc: WSSignatureCalculator): WSRequestHolder = this.copy(calc = Some(calc))
+  override def stream(): Future[(WSResponseHeaders, Enumerator[Array[Byte]])] = Future.successful {
+    streamResponse.getOrElse((emptyResponseHeader, emptyResponseBody))
+  }
+  override def withVirtualHost(vh: String): WSRequestHolder = this.copy(virtualHost = Some(vh))
+  override def withMethod(method: String): WSRequestHolder = this.copy(method = method)
+  override def withRequestTimeout(timeout: Int): WSRequestHolder = this.copy(requestTimeout = Some(timeout))
+  override def withProxyServer(proxyServer: WSProxyServer): WSRequestHolder = this.copy(proxyServer = Some(proxyServer))
+  override def withFollowRedirects(follow: Boolean): WSRequestHolder = this.copy(followRedirects = Some(follow))
+  override def withBody(body: WSBody): WSRequestHolder = this.copy(body = body)
+
+  // Testing methods:
+  val emptyResponse: WSResponse = new FakeWSResponse()
+  def setResponse(resp: WSResponse): Unit = {
+    response = Some(resp)
+  }
+
+  val emptyResponseHeader = new FakeWSResponseHeaders()
+  val emptyResponseBody = Enumerator(Array[Byte](0xc, 0x0, 0xf, 0xf, 0xe, 0xe))
+
+  def setStreamResponse(hdrs: WSResponseHeaders, body: Enumerator[Array[Byte]]): Unit = {
+    streamResponse = Some((hdrs, body))
+  }
+
+}
+
+class FakeWSResponseHeaders extends WSResponseHeaders {
+  override def status: Int = 200
+  override def headers: Map[String, Seq[String]] = Map.empty
+}
+
+class FakeWSResponse extends WSResponse {
+  override def statusText: String = "OK"
+  override def underlying[T]: T = ???
+  override def xml: Elem = <result></result>
+  override def body: String = "blank"
+  override def header(key: String): Option[String] = None
+  override def cookie(name: String): Option[WSCookie] = None
+  override def cookies: Seq[WSCookie] = Seq.empty
+  override def status: Int = 200
+  override def json: JsValue = JsString("blank")
+  override def allHeaders: Map[String, Seq[String]] = Map.empty
+}
+
+@Singleton
+class FakeWebService extends WebService {
+  private var _responseGenerator: Option[String => WSResponse] = None
+  def setGlobalResponse(f: String => WSResponse): Unit = {
+    _responseGenerator = Some(f)
+  }
+
+  private var _streamResponseGenerator: Option[String => (WSResponseHeaders, Enumerator[Array[Byte]])] = None
+  def setGlobalStreamResponse(f: String => (WSResponseHeaders, Enumerator[Array[Byte]])): Unit = {
+    _streamResponseGenerator = Some(f)
+  }
+
+  def url(url: String): WSRequestHolder = {
+    FakeWSRequestHolder(url) |> { resp =>
+      if (_responseGenerator.isDefined) {
+        resp.setResponse(_responseGenerator.get(url))
+        resp
+      } else resp
+    } |> { resp =>
+      if (_streamResponseGenerator.isDefined) {
+        val (header, body) = _streamResponseGenerator.get(url)
+        resp.setStreamResponse(header, body)
+        resp
+      } else resp
+    }
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
@@ -1,32 +1,24 @@
 package com.keepit.commanders
 
-import java.awt.image.BufferedImage
-import java.io._
-import java.net.URLConnection
 import java.sql.SQLException
 
-import com.google.inject.{ Singleton, ImplementedBy, Inject }
-import com.keepit.common.db.slick.DBSession.{ RWSession, RSession }
-import com.keepit.common.db.{ State, Id }
+import com.google.inject.{ ImplementedBy, Inject, Singleton }
+import com.keepit.common.akka.SafeFuture
+import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
 import com.keepit.common.db.slick.Database
+import com.keepit.common.db.{ Id, State }
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
+import com.keepit.common.net.WebService
 import com.keepit.common.service.RequestConsolidator
 import com.keepit.common.store._
 import com.keepit.model._
-import org.imgscalr.Scalr
-import play.api.{ Mode, Play }
-import play.api.Play.current
 import play.api.libs.Files.TemporaryFile
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.api.libs.iteratee.Iteratee
-import play.api.libs.ws.WS
-import com.keepit.common.core._
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.util.{ Failure, Success, Try }
-import com.keepit.common.akka.SafeFuture
 
 @ImplementedBy(classOf[KeepImageCommanderImpl])
 trait KeepImageCommander {
@@ -57,7 +49,8 @@ class KeepImageCommanderImpl @Inject() (
     normalizedUriRepo: NormalizedURIRepo,
     keepImageRequestRepo: KeepImageRequestRepo,
     airbrake: AirbrakeNotifier,
-    keepImageRepo: KeepImageRepo) extends KeepImageCommander with KeepImageHelper with Logging {
+    keepImageRepo: KeepImageRepo,
+    val webService: WebService) extends KeepImageCommander with ProcessedImageHelper with Logging {
 
   def getUrl(keepImage: KeepImage): String = {
     s3ImageConfig.cdnBase + "/" + keepImage.imagePath
@@ -146,26 +139,33 @@ class KeepImageCommanderImpl @Inject() (
     }
   }
 
+  private def exceptionToFailureReason(ex: Throwable) = {
+    ex.getMessage + "\n\n" + ex.getStackTrace.collect {
+      case t if t.getClassName.startsWith("com.keepit") =>
+        t.getFileName + ":" + t.getLineNumber
+    }.take(5).mkString("\n")
+  }
+
   private def finalizeImageRequestState(keepId: Id[Keep], requestIdOpt: Option[Id[KeepImageRequest]], doneResult: ImageProcessDone): Unit = {
-    import ImageProcessState._
-    import KeepImageRequestStates._
+    import com.keepit.commanders.ImageProcessState._
+    import com.keepit.model.KeepImageRequestStates._
 
     requestIdOpt.map { requestId =>
       val (state, failureCode, failureReason) = doneResult match {
         case err: UpstreamProviderFailed =>
-          (UPSTREAM_FAILED, Some(err.reason), Some(err.ex.getMessage))
+          (UPSTREAM_FAILED, Some(err.reason), Some(exceptionToFailureReason(err.ex)))
         case UpstreamProviderNoImage =>
           (UPSTREAM_FAILED, Some(UpstreamProviderNoImage.reason), None)
         case err: SourceFetchFailed =>
-          (FETCHING_FAILED, Some(err.reason), Some(err.ex.getMessage))
+          (FETCHING_FAILED, Some(err.reason), Some(exceptionToFailureReason(err.ex)))
         case err: HashFailed =>
-          (FETCHING_FAILED, Some(err.reason), Some(err.ex.getMessage))
+          (FETCHING_FAILED, Some(err.reason), Some(exceptionToFailureReason(err.ex)))
         case err: InvalidImage =>
-          (PROCESSING_FAILED, Some(err.reason), Some(err.ex.getMessage))
+          (PROCESSING_FAILED, Some(err.reason), Some(exceptionToFailureReason(err.ex)))
         case err: DbPersistFailed =>
-          (PERSISTING, Some(err.reason), Some(err.ex.getMessage))
+          (PERSISTING, Some(err.reason), Some(exceptionToFailureReason(err.ex)))
         case err: CDNUploadFailed =>
-          (PERSISTING, Some(err.reason), Some(err.ex.getMessage))
+          (PERSISTING, Some(err.reason), Some(exceptionToFailureReason(err.ex)))
         case success: ImageProcessSuccess =>
           (INACTIVE, None, None)
       }
@@ -366,13 +366,7 @@ class KeepImageCommanderImpl @Inject() (
   private def fetchAndHashLocalImage(file: TemporaryFile): Future[Either[KeepImageStoreFailure, ImageProcessState.ImageLoadedAndHashed]] = {
     log.info(s"[kic] Fetching ${file.file.getAbsolutePath}")
 
-    val is = new BufferedInputStream(new FileInputStream(file.file))
-    val formatOpt = Option(URLConnection.guessContentTypeFromStream(is)).flatMap { mimeType =>
-      mimeTypeToImageFormat(mimeType)
-    }.orElse {
-      imageFilenameToFormat(file.file.getName)
-    }
-    is.close()
+    val formatOpt = detectImageType(file)
 
     formatOpt match {
       case Some(format) =>
@@ -407,55 +401,6 @@ class KeepImageCommanderImpl @Inject() (
     }
   }
 
-  private val remoteFetchConsolidater = new RequestConsolidator[String, (ImageFormat, TemporaryFile)](2.minutes)
-
-  private def fetchRemoteImage(imageUrl: String, timeoutMs: Int = 20000): Future[(ImageFormat, TemporaryFile)] = {
-    remoteFetchConsolidater(imageUrl) { imageUrl =>
-      WS.url(imageUrl).withRequestTimeout(20000).getStream().flatMap {
-        case (headers, streamBody) =>
-          val formatOpt = headers.headers.get("Content-Type").flatMap(_.headOption)
-            .flatMap(mimeTypeToImageFormat).orElse {
-              imageFilenameToFormat(imageUrl.substring(imageUrl.lastIndexOf(".") + 1))
-            }
-
-          if (headers.status != 200) {
-            Future.failed(new RuntimeException(s"Image returned non-200 code, ${headers.status}"))
-          } else if (formatOpt.isEmpty) {
-            Future.failed(new RuntimeException(s"Unknown image type, ${headers.headers.get("Content-Type")}"))
-          } else {
-            val tempFile = TemporaryFile(prefix = "remote-file", suffix = "." + formatOpt.get.value)
-            tempFile.file.deleteOnExit()
-            val outputStream = new FileOutputStream(tempFile.file)
-
-            val maxSize = 1024 * 1024 * 16
-
-            var len = 0
-            val iteratee = Iteratee.foreach[Array[Byte]] { bytes =>
-              len += bytes.length
-              if (len > maxSize) { // max original size
-                throw new Exception(s"Original image too large (> $len bytes): $imageUrl")
-              } else {
-                outputStream.write(bytes)
-              }
-            }
-
-            streamBody.run(iteratee).andThen {
-              case result =>
-                outputStream.close()
-                result.get
-            }.map(_ => (formatOpt.get, tempFile))
-          }
-      }
-    }
-
-  }
-
-  private def resizeImage(image: BufferedImage, boundingBox: Int): Try[BufferedImage] = Try {
-    val img = Scalr.resize(image, Scalr.Method.QUALITY, Scalr.Mode.AUTOMATIC, boundingBox)
-    log.info(s"[kic] Bounding box $boundingBox resized to ${img.getHeight} x ${img.getWidth}")
-    img
-  }
-
   private def updateRequestState(state: State[KeepImageRequest])(implicit requestIdOpt: Option[Id[KeepImageRequest]]): Unit = {
     requestIdOpt.map { requestId =>
       db.readWrite { implicit session =>
@@ -464,9 +409,7 @@ class KeepImageCommanderImpl @Inject() (
     }
   }
 
-  private val cdnUrl = {
-    s3ImageConfig.cdnBase.drop(s3ImageConfig.cdnBase.indexOf("//"))
-  }
+  private val cdnUrl = s3ImageConfig.cdnBase.drop(s3ImageConfig.cdnBase.indexOf("//"))
   private val ourOwnImageUrl = s"(https?\\:)?$cdnUrl/keep/([0-9a-f]{32})_\\d+x\\d+.*".r
   private def detectUserPickedImageFromExistingHashAndReplace(imageUrl: String, keepId: Id[Keep]): Option[ImageProcessSuccess] = {
     Try {

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/FakeProcessedImageHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/FakeProcessedImageHelper.scala
@@ -1,0 +1,33 @@
+package com.keepit.commanders
+
+import java.io.{ FileInputStream, File }
+
+import com.google.inject.Singleton
+import com.keepit.common.logging.Logging
+import com.keepit.common.net.FakeWebService
+import net.codingwell.scalaguice.ScalaModule
+import org.apache.commons.io.{ IOUtils, FileUtils }
+import play.api.Logger
+import play.api.libs.Files.TemporaryFile
+import play.api.libs.iteratee.Enumerator
+import play.api.libs.ws.WSResponseHeaders
+
+class FakeProcessedImageHelper extends ProcessedImageHelper with Logging {
+  val webService = new FakeWebService()
+
+  val fakeFile1 = {
+    val tf = TemporaryFile(new File("test/data/image1-" + Math.random() + ".png"))
+    tf.file.deleteOnExit()
+    FileUtils.copyFile(new File("test/data/image1.png"), tf.file)
+    tf
+  }
+
+  webService.setGlobalStreamResponse { _ =>
+    val header: WSResponseHeaders = new WSResponseHeaders {
+      override def status: Int = 200
+      override def headers: Map[String, Seq[String]] = Map("Content-Type" -> Seq("image/png"))
+    }
+    val body = Enumerator(IOUtils.toByteArray(new FileInputStream(fakeFile1.file)))
+    (header, body)
+  }
+}

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepImageCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepImageCommanderTest.scala
@@ -22,10 +22,6 @@ class KeepImageCommanderTest extends Specification with ShoeboxTestInjector with
 
   def modules = Seq()
 
-  def dummyImage(width: Int, height: Int) = {
-    new BufferedImage(width, height, BufferedImage.TYPE_BYTE_BINARY)
-  }
-
   def fakeFile1 = {
     val tf = TemporaryFile(new File("test/data/image1-" + Math.random() + ".png"))
     tf.file.deleteOnExit()
@@ -55,130 +51,6 @@ class KeepImageCommanderTest extends Specification with ShoeboxTestInjector with
         visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib.id.get), inDisjointLib = lib.isDisjoint))
       (user, lib, uri, keep1, keep2)
     }
-  }
-
-  "KeepImageHelper" should {
-    "calculate resize sizes for an image" in {
-      withInjector(modules: _*) { implicit injector =>
-        val helper = new KeepImageHelper {
-          val log = logger
-
-          calcSizesForImage(dummyImage(100, 100)).toSeq.sorted === Seq()
-          calcSizesForImage(dummyImage(300, 100)).toSeq.sorted === Seq(150)
-          calcSizesForImage(dummyImage(100, 700)).toSeq.sorted === Seq(150, 400)
-          calcSizesForImage(dummyImage(300, 300)).toSeq.sorted === Seq(150)
-          calcSizesForImage(dummyImage(1001, 1001)).toSeq.sorted === Seq(150, 400, 1000)
-          calcSizesForImage(dummyImage(2000, 1500)).toSeq.sorted === Seq(150, 400, 1000, 1500)
-          calcSizesForImage(dummyImage(1500, 1400)).toSeq.sorted === Seq(150, 400, 1000)
-        }
-        helper === helper
-      }
-    }
-
-    "convert format types in several ways" in {
-      withInjector(modules: _*) { implicit injector =>
-        val helper = new KeepImageHelper {
-          val log = logger
-
-          ImageFormat.JPG !== ImageFormat.PNG
-
-          inputFormatToOutputFormat(ImageFormat.JPG) === ImageFormat.JPG
-          inputFormatToOutputFormat(ImageFormat.UNKNOWN) === ImageFormat.PNG
-
-          imageFormatToJavaFormatName(ImageFormat.JPG) === "jpeg"
-          imageFormatToJavaFormatName(ImageFormat("gif")) === "png"
-
-          imageFormatToMimeType(ImageFormat.JPG) === "image/jpeg"
-          imageFormatToMimeType(ImageFormat.PNG) === "image/png"
-
-          mimeTypeToImageFormat("image/jpeg") === Some(ImageFormat.JPG)
-          mimeTypeToImageFormat("image/png") === Some(ImageFormat.PNG)
-          mimeTypeToImageFormat("image/bmp") === Some(ImageFormat("bmp"))
-
-          imageFilenameToFormat("jpeg") === imageFilenameToFormat("jpg")
-          imageFilenameToFormat("png") === Some(ImageFormat.PNG)
-
-        }
-        helper === helper
-      }
-    }
-
-    "convert image to input stream" in {
-      withInjector(modules: _*) { implicit injector =>
-        val helper = new KeepImageHelper {
-          val log = logger;
-
-          {
-            val image = dummyImage(200, 300)
-            val res = bufferedImageToInputStream(image, ImageFormat.PNG)
-            res.isSuccess === true
-            res.get._1 !== null
-            res.get._1.read === 137 // first byte of PNG image
-            res.get._2 must be_>(50) // check if file is greater than 50B
-          }
-          {
-            val image = dummyImage(200, 300)
-            val res = bufferedImageToInputStream(image, ImageFormat.JPG)
-            res.isSuccess === true
-            res.get._1 !== null
-            res.get._1.read === 255 // first byte of JPEG image
-            res.get._1.read === 216 // second byte of JPEG image
-            res.get._2 must be_>(256) // check if file is greater than 256B, which is smaller than any legit jpeg
-          }
-          {
-            val res = bufferedImageToInputStream(null, ImageFormat.JPG)
-            res.isSuccess === false
-          }
-
-        }
-        helper === helper
-      }
-    }
-
-    "hash files with MD5" in {
-      withInjector(modules: _*) { implicit injector =>
-        val helper = new KeepImageHelper {
-          val log = logger
-
-          val hashed1 = hashImageFile(fakeFile1.file)
-          hashed1.isSuccess === true
-          hashed1.get.hash === "26dbdc56d54dbc94830f7cfc85031481"
-
-          val hashed2 = hashImageFile(fakeFile2.file)
-          hashed2.isSuccess === true
-          hashed2.get.hash === "1b3d95541538044c2a26598fbe1d06ae"
-
-        }
-        helper === helper
-      }
-    }
-  }
-
-  "KeepImageSize" should {
-    "have several image sizes" in {
-      KeepImageSize.allSizes.length must be_>(3)
-    }
-
-    "pick the closest KeepImageSize to a given ImageSize" in {
-      KeepImageSize(ImageSize(0, 0)) === KeepImageSize.Small
-      KeepImageSize(ImageSize(1000, 100)) === KeepImageSize.Medium
-      KeepImageSize(ImageSize(900, 900)) === KeepImageSize.Large
-    }
-
-    "pick the best KeepImage for a target size" in {
-      def genKeepImage(width: Int, height: Int) = {
-        KeepImage(keepId = Id[Keep](0), imagePath = "", format = ImageFormat.PNG, width = width, height = height, source = KeepImageSource.UserPicked, sourceFileHash = ImageHash("000"), sourceImageUrl = None, isOriginal = false)
-      }
-      val keepImages = for {
-        width <- 10 to 140 by 11
-        height <- 10 to 150 by 17
-      } yield genKeepImage(width * 9, height * 9)
-
-      KeepImageSize.pickBest(ImageSize(201, 399), keepImages).get.imageSize === ImageSize(189, 396)
-      KeepImageSize.pickBest(ImageSize(800, 840), keepImages).get.imageSize === ImageSize(783, 855)
-
-    }
-
   }
 
   "KeepImageCommander" should {
@@ -265,9 +137,7 @@ class KeepImageCommanderTest extends Specification with ShoeboxTestInjector with
         true === true
       }
     }
-  }
 
-  "KeepImageCommander" should {
     "de-dupe known (by hash) images" in {
       withDb(modules: _*) { implicit injector =>
         val commander = inject[KeepImageCommander]

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/ProcessedImageHelperTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/ProcessedImageHelperTest.scala
@@ -1,0 +1,173 @@
+package com.keepit.commanders
+
+import java.awt.image.BufferedImage
+import java.io.File
+
+import com.google.inject.Injector
+import com.keepit.common.db.Id
+import com.keepit.common.logging.Logging
+import com.keepit.common.store.{ S3ImageConfig, FakeKeepImageStore, ImageSize, KeepImageStore }
+import com.keepit.model._
+import com.keepit.test.ShoeboxTestInjector
+import org.apache.commons.io.FileUtils
+import org.specs2.mutable.Specification
+import play.api.libs.Files.TemporaryFile
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class ProcessedImageHelperTest extends Specification with ShoeboxTestInjector with Logging {
+
+  val logger = log
+
+  def modules = Seq()
+
+  def dummyImage(width: Int, height: Int) = {
+    new BufferedImage(width, height, BufferedImage.TYPE_BYTE_BINARY)
+  }
+
+  def fakeFile1 = {
+    val tf = TemporaryFile(new File("test/data/image1-" + Math.random() + ".png"))
+    tf.file.deleteOnExit()
+    FileUtils.copyFile(new File("test/data/image1.png"), tf.file)
+    tf
+  }
+  def fakeFile2 = {
+    val tf = TemporaryFile(new File("test/data/image2-" + Math.random() + ".png"))
+    tf.file.deleteOnExit()
+    FileUtils.copyFile(new File("test/data/image2.png"), tf.file)
+    tf
+  }
+
+  "ProcessedImageHelper" should {
+    "calculate resize sizes for an image" in {
+      withInjector(modules: _*) { implicit injector =>
+        val helper = new FakeProcessedImageHelper {
+          calcSizesForImage(dummyImage(100, 100)).toSeq.sorted === Seq()
+          calcSizesForImage(dummyImage(300, 100)).toSeq.sorted === Seq(150)
+          calcSizesForImage(dummyImage(100, 700)).toSeq.sorted === Seq(150, 400)
+          calcSizesForImage(dummyImage(300, 300)).toSeq.sorted === Seq(150)
+          calcSizesForImage(dummyImage(1001, 1001)).toSeq.sorted === Seq(150, 400, 1000)
+          calcSizesForImage(dummyImage(2000, 1500)).toSeq.sorted === Seq(150, 400, 1000, 1500)
+          calcSizesForImage(dummyImage(1500, 1400)).toSeq.sorted === Seq(150, 400, 1000)
+        }
+        helper === helper
+      }
+    }
+
+    "convert format types in several ways" in {
+      withInjector(modules: _*) { implicit injector =>
+        val helper = new FakeProcessedImageHelper {
+          ImageFormat.JPG !== ImageFormat.PNG
+
+          inputFormatToOutputFormat(ImageFormat.JPG) === ImageFormat.JPG
+          inputFormatToOutputFormat(ImageFormat.UNKNOWN) === ImageFormat.PNG
+
+          imageFormatToJavaFormatName(ImageFormat.JPG) === "jpeg"
+          imageFormatToJavaFormatName(ImageFormat("gif")) === "png"
+
+          imageFormatToMimeType(ImageFormat.JPG) === "image/jpeg"
+          imageFormatToMimeType(ImageFormat.PNG) === "image/png"
+
+          mimeTypeToImageFormat("image/jpeg") === Some(ImageFormat.JPG)
+          mimeTypeToImageFormat("image/jpeg;charset=utf-8") === Some(ImageFormat.JPG)
+          mimeTypeToImageFormat("image/png") === Some(ImageFormat.PNG)
+          mimeTypeToImageFormat("image/bmp") === Some(ImageFormat("bmp"))
+
+          imageFilenameToFormat("jpeg") === imageFilenameToFormat("jpg")
+          imageFilenameToFormat("png") === Some(ImageFormat.PNG)
+
+        }
+        helper === helper
+      }
+    }
+
+    "convert image to input stream" in {
+      withInjector(modules: _*) { implicit injector =>
+        val helper = new FakeProcessedImageHelper {
+
+          {
+            val image = dummyImage(200, 300)
+            val res = bufferedImageToInputStream(image, ImageFormat.PNG)
+            res.isSuccess === true
+            res.get._1 !== null
+            res.get._1.read === 137 // first byte of PNG image
+            res.get._2 must be_>(50) // check if file is greater than 50B
+          }
+          {
+            val image = dummyImage(200, 300)
+            val res = bufferedImageToInputStream(image, ImageFormat.JPG)
+            res.isSuccess === true
+            res.get._1 !== null
+            res.get._1.read === 255 // first byte of JPEG image
+            res.get._1.read === 216 // second byte of JPEG image
+            res.get._2 must be_>(256) // check if file is greater than 256B, which is smaller than any legit jpeg
+          }
+          {
+            val res = bufferedImageToInputStream(null, ImageFormat.JPG)
+            res.isSuccess === false
+          }
+
+        }
+        helper === helper
+      }
+    }
+
+    "hash files with MD5" in {
+      withInjector(modules: _*) { implicit injector =>
+        val helper = new FakeProcessedImageHelper {
+
+          val hashed1 = hashImageFile(fakeFile1.file)
+          hashed1.isSuccess === true
+          hashed1.get.hash === "26dbdc56d54dbc94830f7cfc85031481"
+
+          val hashed2 = hashImageFile(fakeFile2.file)
+          hashed2.isSuccess === true
+          hashed2.get.hash === "1b3d95541538044c2a26598fbe1d06ae"
+
+        }
+        helper === helper
+      }
+    }
+
+    "fetch images by URL" in {
+      withInjector(modules: _*) { implicit injector =>
+        val helper = new FakeProcessedImageHelper {
+          val respF = fetchRemoteImage("http://www.doesntmatter.com/")
+          val resp = Await.result(respF, Duration("10 seconds"))
+          resp._1 === ImageFormat.PNG
+          resp._2.file.getName.endsWith(".png") === true
+        }
+        helper === helper
+      }
+    }
+
+  }
+
+  "KeepImageSize" should {
+    "have several image sizes" in {
+      KeepImageSize.allSizes.length must be_>(3)
+    }
+
+    "pick the closest KeepImageSize to a given ImageSize" in {
+      KeepImageSize(ImageSize(0, 0)) === KeepImageSize.Small
+      KeepImageSize(ImageSize(1000, 100)) === KeepImageSize.Medium
+      KeepImageSize(ImageSize(900, 900)) === KeepImageSize.Large
+    }
+
+    "pick the best KeepImage for a target size" in {
+      def genKeepImage(width: Int, height: Int) = {
+        KeepImage(keepId = Id[Keep](0), imagePath = "", format = ImageFormat.PNG, width = width, height = height, source = KeepImageSource.UserPicked, sourceFileHash = ImageHash("000"), sourceImageUrl = None, isOriginal = false)
+      }
+      val keepImages = for {
+        width <- 10 to 140 by 11
+        height <- 10 to 150 by 17
+      } yield genKeepImage(width * 9, height * 9)
+
+      KeepImageSize.pickBest(ImageSize(201, 399), keepImages).get.imageSize === ImageSize(189, 396)
+      KeepImageSize.pickBest(ImageSize(800, 840), keepImages).get.imageSize === ImageSize(783, 855)
+
+    }
+  }
+
+}


### PR DESCRIPTION
- Moved several methods to KeepImageHelper, renamed that to ProcessedImageHelper.
- Created an implementation of `WS` that's injectable, with it's fake counterpart.
- Finally have a test for fetching an image by URL.
- Fixed a few bugs that I noticed.

No implementation for URIImage yet, but this makes it a bit easier to roll your own image processing class.

@leogrim @stkem @eishay 
