### PR TITLE
extra check for displaying small images in keep card

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/ellipsis/ellipsis.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/ellipsis/ellipsis.js
@@ -25,7 +25,7 @@ angular.module('kifi')
     },
     compile: function(/*elem, attr, linker*/) {
 
-      return function(scope, element, attributes) {
+      return function(scope, element) {
         var copyElement = element.clone()
           .css({
             'display': 'block',
@@ -51,7 +51,7 @@ angular.module('kifi')
             var currentHeight = copyElement.height();
             var currentNumLines = currentHeight / heightPerLine;
             var maxIndex = scope.ngBind.length;
-            var maxNumLines = attributes.maxNumLines || 1;
+            var maxNumLines = scope.maxNumLines || currentNumLines;
 
             if (currentHeight === 0) {
               element.html(scope.ngBind);

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/youtube.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/youtube.js
@@ -7,13 +7,16 @@ angular.module('kifi')
   function () {
 
     function videoIdToSrc(videoId) {
-      return '//www.youtube.com/v/' + videoId +
-        '&rel=0&theme=light&showinfo=0&disablekb=1&modestbranding=1&controls=1&hd=1&autohide=1&color=white&iv_load_policy=3';
+      // return '//www.youtube.com/v/' + videoId +
+        // '&rel=0&theme=light&showinfo=0&disablekb=1&modestbranding=1&controls=1&hd=1&autohide=1&color=white&iv_load_policy=3';
+      return '//www.youtube.com/embed/' + videoId +
+        '?rel=0&theme=light&showinfo=0&disablekb=1&modestbranding=1&controls=1&hd=1&autohide=1&color=white&iv_load_policy=3';
     }
 
     function videoEmbed(src) {
-      return '<embed src="' + src +
-        '" type="application/x-shockwave-flash" allowfullscreen="true" style="width:100%; height: 100%;" allowscriptaccess="always"></embed>';
+      // return '<embed src="' + src +'"
+      //    type="application/x-shockwave-flash" allowfullscreen="true" style="width:100%; height: 100%;" allowscriptaccess="always"></embed>';
+      return '<iframe width="100%" height="100%" src="' + src + '" frameborder="none" allowfullscreen="true" allowscriptaccess="always"/>';
     }
 
     return {

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/youtube.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/youtube.js
@@ -7,16 +7,22 @@ angular.module('kifi')
   function () {
 
     function videoIdToSrc(videoId) {
-      // return '//www.youtube.com/v/' + videoId +
-        // '&rel=0&theme=light&showinfo=0&disablekb=1&modestbranding=1&controls=1&hd=1&autohide=1&color=white&iv_load_policy=3';
       return '//www.youtube.com/embed/' + videoId +
-        '?rel=0&theme=light&showinfo=0&disablekb=1&modestbranding=1&controls=1&hd=1&autohide=1&color=white&iv_load_policy=3';
+        '?rel=0&theme=light&showinfo=0&disablekb=1&modestbranding=1&controls=1&hd=1&autoplay=1&autohide=1&color=white&iv_load_policy=3';
     }
 
     function videoEmbed(src) {
-      // return '<embed src="' + src +'"
-      //    type="application/x-shockwave-flash" allowfullscreen="true" style="width:100%; height: 100%;" allowscriptaccess="always"></embed>';
       return '<iframe width="100%" height="100%" src="' + src + '" frameborder="none" allowfullscreen="true" allowscriptaccess="always"/>';
+    }
+
+    function getVideoImage(videoId) {
+      return '//img.youtube.com/vi/' + videoId + '/hqdefault.jpg';
+    }
+
+    function imageEmbed(src) {
+      var videoImg = '<img src="' + src + '" width="100%" height="100%">';
+      var playImg = '<img class="kf-youtube-play" src="http://www.clker.com/cliparts/Z/C/1/n/M/2/youtube-style-play-button-md.png">';
+      return videoImg + playImg;
     }
 
     return {
@@ -25,7 +31,8 @@ angular.module('kifi')
       scope: {
         videoId: '='
       },
-      template: '<div class="kf-youtube"></div>',
+      template:
+        '<div class="kf-youtube" ng-click="replaceWithVideo()"></div>',
       link: function (scope, element) {
 
         var lastId = null;
@@ -37,9 +44,13 @@ angular.module('kifi')
           lastId = videoId;
 
           if (videoId) {
-            element.html(videoEmbed(videoIdToSrc(videoId)));
+            element.html(imageEmbed(getVideoImage(videoId)));
           }
         }
+
+        scope.replaceWithVideo = function() {
+          element.html(videoEmbed(videoIdToSrc(lastId)));
+        };
 
         updateSrc(scope.videoId);
 

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/youtube.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/youtube.js
@@ -21,7 +21,7 @@ angular.module('kifi')
 
     function imageEmbed(src) {
       var videoImg = '<img src="' + src + '" width="100%" height="100%">';
-      var playImg = '<img class="kf-youtube-play" src="http://www.clker.com/cliparts/Z/C/1/n/M/2/youtube-style-play-button-md.png">';
+      var playImg = '<img class="kf-youtube-play" src="http://lh4.googleusercontent.com/-CPSDAus0Z7s/AAAAAAAAAAI/AAAAAAAAABQ/B7u3agfdbIY/photo.jpg">';
       return videoImg + playImg;
     }
 

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -235,12 +235,10 @@ angular.module('kifi')
           keep.sizeCard = function () {
             var $content = element.find('.kf-keep-content-line');
             //$content.height(Math.floor(bestRes.hi) + 4); // 4px padding on image
-            if ($content && $content.length > 0) {
-              $content.find('.kf-keep-small-image').width(asideWidthPercent + '%');
-              $content.find('.kf-keep-image').on('error', function () {
-                $content.find('.kf-keep-small-image').hide();
-              });
-            }
+            $content.find('.kf-keep-small-image').width(asideWidthPercent + '%');
+            $content.find('.kf-keep-image').on('error', function () {
+              $content.find('.kf-keep-small-image').hide();
+            });
           };
         }
 

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -95,7 +95,7 @@ angular.module('kifi')
         scope.isDragTarget = false;
         scope.isDragging = false;
         scope.userLoggedIn = $rootScope.userLoggedIn;
-        scope.isYoutubeCard = false;
+        scope.cardType = '';
         scope.youtubeId = '';
 
         //
@@ -103,7 +103,7 @@ angular.module('kifi')
         //
         function init() {
           updateSiteDescHtml(scope.keep);
-          isYoutubeCard(scope.keep.url);
+          setCardType(scope.keep.url);
         }
 
         function bolded(text, start, len) {
@@ -125,10 +125,19 @@ angular.module('kifi')
           var strippedSchemeLen = (url.match(strippedSchemeRe) || [''])[0].length;
           var match = url.substr(strippedSchemeLen).match(youtubeLinkRe);
           if (match && match[1]) {
-            scope.isYoutubeCard = true;
             scope.youtubeId = match[1];
           }
-          return match;
+          return scope.youtubeId;
+        }
+
+        function setCardType(url) {
+          if (isYoutubeCard(url)) {
+            scope.cardType = 'youtube';
+          } else if (scope.keep.hasBigImage) {
+            scope.cardType = 'big';
+          } else {
+            scope.cardType = 'small';
+          }
         }
 
         function formatDesc(url, matches) {
@@ -183,6 +192,7 @@ angular.module('kifi')
           if (!keep.summary.trimmedDesc) {
             var trimmed = trimDesc(keep.summary.description);
             if (trimmed === false) {
+              scope.cardType = 'big';
               useBigLayout = true;
               return;
             }
@@ -269,12 +279,12 @@ angular.module('kifi')
 
         scope.showSmallImage = function (keep) {
           var hasImage = keep.summary.imageWidth > 110 && keep.summary.imageHeight > 110;
-          return hasImage && keep.hasSmallImage && !useBigLayout && !scope.isYoutubeCard;
+          return hasImage && keep.hasSmallImage && !useBigLayout && scope.cardType === 'small';
         };
 
         scope.showBigImage = function (keep) {
           var bigImageReady = keep.hasBigImage || (keep.summary && useBigLayout);
-          return bigImageReady && !scope.isYoutubeCard;
+          return bigImageReady && scope.cardType === 'big';
         };
 
         scope.hasTag = function (keep) {

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -229,23 +229,18 @@ angular.module('kifi')
           }
 
           var asideWidthPercent = Math.floor(((cardWidth - bestRes.guess) / cardWidth) * 100);
-          //var calcTextWidth = 100 - asideWidthPercent;
           var linesToShow = Math.ceil((bestRes.hi / textHeight)); // line height
-          var calcTextHeight = linesToShow * textHeight;
+          scope.linesToShow = linesToShow;
 
           keep.sizeCard = function () {
             var $content = element.find('.kf-keep-content-line');
             //$content.height(Math.floor(bestRes.hi) + 4); // 4px padding on image
-            $content.find('.kf-keep-small-image').width(asideWidthPercent + '%');
-            if (calcTextHeight > 20) {
-              element.find('.kf-keep-info').css({
-                'height': calcTextHeight + 'px'
-              }).addClass('kf-dyn-positioned');
+            if ($content && $content.length > 0) {
+              $content.find('.kf-keep-small-image').width(asideWidthPercent + '%');
+              $content.find('.kf-keep-image').on('error', function () {
+                $content.find('.kf-keep-small-image').hide();
+              });
             }
-
-            $content.find('.kf-keep-image').on('error', function () {
-              $content.find('.kf-keep-small-image').hide();
-            });
           };
         }
 

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -275,7 +275,8 @@ angular.module('kifi')
         };
 
         scope.showSmallImage = function (keep) {
-          return keep.hasSmallImage && !useBigLayout && !scope.isYoutubeCard;
+          var hasImage = keep.summary.imageWidth > 110 && keep.summary.imageHeight > 110;
+          return hasImage && keep.hasSmallImage && !useBigLayout && !scope.isYoutubeCard;
         };
 
         scope.showBigImage = function (keep) {

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -192,7 +192,9 @@ angular.module('kifi')
           if (!keep.summary.trimmedDesc) {
             var trimmed = trimDesc(keep.summary.description);
             if (trimmed === false) {
-              scope.cardType = 'big';
+              if (scope.cardType === 'small') {
+                scope.cardType = 'big';
+              }
               useBigLayout = true;
               return;
             }

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
@@ -313,8 +313,21 @@ kifiGreen = #73c583
   width: 100%
 
 .kf-youtube
-  height: 350px
+  height: 360px
   margin-bottom: 5px
+  cursor: pointer
+  background-color: #000
+
+.kf-youtube-play
+  position: relative
+  top: calc(-50% - 45px)
+  left: calc(50% - 60px)
+  width: 120px
+  height: 90px
+  opacity: 0.8
+
+  &:hover
+    opacity: 0.9
 
 .kf-keep-loading
   padding-right: 5px

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
@@ -296,10 +296,6 @@ kifiGreen = #73c583
   overflow: hidden
   margin-right: 30px
 
-.kf-keep-info
-  vertical-align: top
-  width: 100%
-
 .kf-keep-title
   margin-bottom: 12px
   font-family: 'Lato', serif

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
@@ -341,9 +341,6 @@ kifiGreen = #73c583
   color: textBlackColor
   word-break: break-word
 
-.kf-dyn-positioned
-  overflow: hidden
-
 .kf-keep-description-sizer
   position: absolute
   visibility: hidden

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
@@ -320,14 +320,14 @@ kifiGreen = #73c583
 
 .kf-youtube-play
   position: relative
-  top: calc(-50% - 45px)
-  left: calc(50% - 60px)
-  width: 120px
-  height: 90px
+  top: calc(-50% - 35px)
+  left: calc(50% - 40px)
+  width: 80px
+  height: 70px
   opacity: 0.8
 
   &:hover
-    opacity: 0.9
+    opacity: 1.0
 
 .kf-keep-loading
   padding-right: 5px

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
@@ -31,11 +31,7 @@
         </div>
 
         <div class="kf-keep-info-wrap" ng-if="!isYoutubeCard">
-          <div class="kf-keep-info">
-            <div class="kf-keep-description">
-              {{keep.summary.description}}
-            </div>
-          </div>
+          <div kf-ellipsis data-ng-bind="keep.summary.description" data-max-num-lines="linesToShow" class="kf-keep-description"></div>
         </div>
 
       </div>

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
@@ -31,17 +31,17 @@
         </div>
 
         <div class="kf-keep-info-wrap" ng-if="!isYoutubeCard">
-          <div kf-ellipsis data-ng-bind="keep.summary.description" data-max-num-lines="linesToShow" class="kf-keep-description"></div>
+          <div kf-ellipsis ng-bind="keep.summary.description" max-num-lines="linesToShow" class="kf-keep-description"></div>
         </div>
 
       </div>
 
       <!-- Large Image or Special Card -->
-      <a ng-href="{{keep.url}}" target="_blank" rel="nofollow"><img class="kf-keep-big-image" ng-if="showBigImage(keep) && !isYoutubeCard" ng-src="{{keep.summary.imageUrl}}" ng-click="clickCallback({ 'keep': keep, event: $event })" click-action="articleImageBig"></a>
+      <a ng-href="{{keep.url}}" target="_blank" rel="nofollow"><img class="kf-keep-big-image" ng-if="showBigImage(keep)" ng-src="{{keep.summary.imageUrl}}" ng-click="clickCallback({ 'keep': keep, event: $event })" click-action="articleImageBig"></a>
 
       <div ng-if="isYoutubeCard" class="kf-keep-youtube-content">
         <div kf-youtube video-id=youtubeId></div>
-        <div kf-ellipsis data-ng-bind="keep.summary.description" data-max-num-lines=3 class="kf-keep-description"></div>
+        <div kf-ellipsis ng-bind="keep.summary.description" max-num-lines=3 class="kf-keep-description"></div>
       </div>
 
     </div>

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
@@ -30,7 +30,7 @@
           </a>
         </div>
 
-        <div class="kf-keep-info-wrap" ng-if="!isYoutubeCard">
+        <div class="kf-keep-info-wrap" ng-if="cardType=='small'">
           <div kf-ellipsis ng-bind="keep.summary.description" max-num-lines="linesToShow" class="kf-keep-description"></div>
         </div>
 
@@ -39,7 +39,7 @@
       <!-- Large Image or Special Card -->
       <a ng-href="{{keep.url}}" target="_blank" rel="nofollow"><img class="kf-keep-big-image" ng-if="showBigImage(keep)" ng-src="{{keep.summary.imageUrl}}" ng-click="clickCallback({ 'keep': keep, event: $event })" click-action="articleImageBig"></a>
 
-      <div ng-if="isYoutubeCard" class="kf-keep-youtube-content">
+      <div ng-if="cardType=='youtube'" class="kf-keep-youtube-content">
         <div kf-youtube video-id=youtubeId></div>
         <div kf-ellipsis ng-bind="keep.summary.description" max-num-lines=3 class="kf-keep-description"></div>
       </div>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
@@ -218,9 +218,6 @@ invite-header-orange = #ff7c3c
     cursor: pointer
     min-width: 31px
 
-    &:hover
-      background-color: #444
-
   .kf-keep-lib-additional-followers-text
     display: block
     padding-top: 12px


### PR DESCRIPTION
Try keeping this:
https://en.wikipedia.org/wiki/Chromesthesia

You will see in your keep card that the entire description is left as is (no truncation). 
Turns out `maybeSizeImage()` in keep.js looks for images above 110px height & width. 
But `showSmallImage()` doesn't check for that so it accidentally displays small images.

Hopefully I'm not missing an edge case.

Also, keep descriptions now use kf-ellipsis directive!!
@andrewconner @yipingliao 
