### PR TITLE
Differentiate between missing keep image and no keep image

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
@@ -32,8 +32,8 @@ import com.keepit.common.akka.SafeFuture
 trait KeepImageCommander {
 
   def getUrl(keepImage: KeepImage): String
-  def getBestImageForKeep(keepId: Id[Keep], idealSize: ImageSize): Option[KeepImage]
-  def getBestImagesForKeeps(keepIds: Set[Id[Keep]], idealSize: ImageSize): Seq[KeepImage]
+  def getBestImageForKeep(keepId: Id[Keep], idealSize: ImageSize): Option[Option[KeepImage]]
+  def getBestImagesForKeeps(keepIds: Set[Id[Keep]], idealSize: ImageSize): Map[Id[Keep], Option[KeepImage]]
   def getExistingImageUrlForKeepUri(nUriId: Id[NormalizedURI])(implicit session: RSession): Option[String]
 
   def autoSetKeepImage(keepId: Id[Keep], localOnly: Boolean = true, overwriteExistingChoice: Boolean = false): Future[ImageProcessDone]
@@ -63,31 +63,31 @@ class KeepImageCommanderImpl @Inject() (
     s3ImageConfig.cdnBase + "/" + keepImage.imagePath
   }
 
-  def getBestImageForKeep(keepId: Id[Keep], idealSize: ImageSize): Option[KeepImage] = {
-    val allKeepImages = db.readOnlyReplica { implicit session =>
+  def getBestImageForKeep(keepId: Id[Keep], idealSize: ImageSize): Option[Option[KeepImage]] = {
+    val keepImages = db.readOnlyReplica { implicit session =>
       keepImageRepo.getAllForKeepId(keepId)
     }
-    if (allKeepImages.isEmpty) SafeFuture { autoSetKeepImage(keepId, localOnly = false, overwriteExistingChoice = false) }
-    val validKeepImages = allKeepImages.filter(_.state == KeepImageStates.ACTIVE)
-    KeepImageSize.pickBest(idealSize, validKeepImages)
+    if (keepImages.isEmpty) {
+      SafeFuture { autoSetKeepImage(keepId, localOnly = false, overwriteExistingChoice = false) }
+      None
+    } else Some {
+      val validKeepImages = keepImages.filter(_.state == KeepImageStates.ACTIVE)
+      KeepImageSize.pickBest(idealSize, validKeepImages)
+    }
   }
 
-  def getBestImagesForKeeps(keepIds: Set[Id[Keep]], idealSize: ImageSize): Seq[KeepImage] = {
-    if (keepIds.nonEmpty) {
-      val grouped = db.readOnlyReplica { implicit session => keepImageRepo.getAllForKeepIds(keepIds) }.groupBy(_.keepId)
-
-      keepIds.toSeq.map { keepId =>
-        grouped.get(keepId) match {
-          case None =>
-            SafeFuture { autoSetKeepImage(keepId, localOnly = false, overwriteExistingChoice = false) }
-            None
-          case Some(images) =>
-            val validKeepImages = images.filter(_.state == KeepImageStates.ACTIVE)
-            KeepImageSize.pickBest(idealSize, validKeepImages)
-        }
-      }.flatten
+  def getBestImagesForKeeps(keepIds: Set[Id[Keep]], idealSize: ImageSize): Map[Id[Keep], Option[KeepImage]] = {
+    if (keepIds.isEmpty) {
+      Map.empty[Id[Keep], Option[KeepImage]]
     } else {
-      Seq.empty
+      val allImagesByKeepId = db.readOnlyReplica { implicit session => keepImageRepo.getAllForKeepIds(keepIds) }.groupBy(_.keepId)
+      (keepIds -- allImagesByKeepId.keys).foreach { missingKeepId =>
+        SafeFuture { autoSetKeepImage(missingKeepId, localOnly = false, overwriteExistingChoice = false) }
+      }
+      allImagesByKeepId.mapValues { keepImages =>
+        val validKeepImages = keepImages.filter(_.state == KeepImageStates.ACTIVE)
+        KeepImageSize.pickBest(idealSize, validKeepImages)
+      }
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -351,10 +351,9 @@ class KeepsCommander @Inject() (
     val keepImageOpt = keepImageCommander.getBestImageForKeep(keep.id.get, idealImageSize)
     futureSummary.map { summary =>
       keepImageOpt match {
-        case Some(keepImage) =>
-          val url = keepImageCommander.getUrl(keepImage)
-          summary.copy(imageUrl = Some(url), imageWidth = Some(keepImage.width), imageHeight = Some(keepImage.height))
         case None => summary
+        case Some(keepImage) =>
+          summary.copy(imageUrl = keepImage.map(keepImageCommander.getUrl(_)), imageWidth = keepImage.map(_.width), imageHeight = keepImage.map(_.height))
       }
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -84,7 +84,7 @@ class LibraryCommander @Inject() (
         //facebook OG recommends:
         //We suggest that you use an image of at least 1200x630 pixels.
         val imageUrls: Seq[String] = {
-          val images: Seq[KeepImage] = keepImageCommander.getBestImagesForKeeps(keeps.map(_.id.get).toSet, KeepImageSize.XLarge.idealSize)
+          val images: Seq[KeepImage] = keepImageCommander.getBestImagesForKeeps(keeps.map(_.id.get).toSet, KeepImageSize.XLarge.idealSize).values.flatten.toSeq
           val sorted: Seq[KeepImage] = images.sortWith {
             case (image1, image2) =>
               (image1.imageSize.width * image1.imageSize.height) > (image2.imageSize.width * image2.imageSize.height)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtKeepImageController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtKeepImageController.scala
@@ -106,7 +106,7 @@ class ExtKeepImageController @Inject() (
               InternalServerError(Json.obj("error" -> fail.reason))
             case _: ImageProcessSuccess =>
               val idealSize = size.flatMap { s => Try(ImageSize(s)).toOption }.getOrElse(ExtLibraryController.defaultImageSize)
-              Ok(Json.obj("image" -> keepImageCommander.getBestImageForKeep(keep.id.get, idealSize).map(keepImageCommander.getUrl)))
+              Ok(Json.obj("image" -> keepImageCommander.getBestImageForKeep(keep.id.get, idealSize).flatten.map(keepImageCommander.getUrl)))
           }
         case JsString(badUrl) =>
           log.info(s"rejecting image url: $badUrl")

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -143,7 +143,7 @@ class ExtLibraryController @Inject() (
             val tags = db.readOnlyReplica { implicit s =>
               collectionRepo.getTagsByKeepId(keep.id.get)
             }
-            val image = keepImageCommander.getBestImageForKeep(keep.id.get, ExtLibraryController.defaultImageSize).map(keepImageCommander.getUrl)
+            val image = keepImageCommander.getBestImageForKeep(keep.id.get, ExtLibraryController.defaultImageSize).flatten.map(keepImageCommander.getUrl)
             (tags, image)
           }
 
@@ -171,7 +171,7 @@ class ExtLibraryController @Inject() (
         case Left((status, code)) => Status(status)(Json.obj("error" -> code))
         case Right(keep) =>
           val idealSize = imgSize.flatMap { s => Try(ImageSize(s)).toOption }.getOrElse(ExtLibraryController.defaultImageSize)
-          val keepImageUrl = keepImageCommander.getBestImageForKeep(keep.id.get, idealSize).map(keepImageCommander.getUrl)
+          val keepImageUrl = keepImageCommander.getBestImageForKeep(keep.id.get, idealSize).flatten.map(keepImageCommander.getUrl)
           val tags = db.readOnlyReplica { implicit s =>
             collectionRepo.getTagsByKeepId(keep.id.get)
           }


### PR DESCRIPTION
@andrewconner 
The `Option[Option[KeepImage]]` API looks a bit weird. An alternative would be `Either[MissingImage, Option[KeepImage]]` with `MissingImage` being a singleton object, so that's semantically equivalent to options.
