### PR TITLE
Fixing undefined regex parsing when there's no description

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -107,7 +107,7 @@ angular.module('kifi')
 
 
         function processUrls(text) {
-          var parts = text.split(uriRe);
+          var parts = (text || '').split(uriRe);
 
           for (var i = 1; i < parts.length; i += 3) {
             var uri = parts[i];


### PR DESCRIPTION
@eishay @yipingliao This may not be the best holistic solution, but fixes the JS error.
