### PR TITLE
[Tutorial] Switch SocialConnectionRepo to deferred sequence number

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxDbSequencingModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxDbSequencingModule.scala
@@ -1,7 +1,7 @@
 package com.keepit.shoebox
 
 import com.keepit.inject.AppScoped
-import com.keepit.model.{ LibraryMembershipSequencingPluginImpl, LibraryMembershipSequencingPlugin, LibrarySequencingPluginImpl, LibrarySequencingPlugin }
+import com.keepit.model._
 import net.codingwell.scalaguice.ScalaModule
 
 case class ShoeboxDbSequencingModule() extends ScalaModule {
@@ -11,5 +11,6 @@ case class ShoeboxDbSequencingModule() extends ScalaModule {
     bind[UserConnectionSequencingPlugin].to[UserConnectionSequencingPluginImpl].in[AppScoped]
     bind[LibrarySequencingPlugin].to[LibrarySequencingPluginImpl].in[AppScoped]
     bind[LibraryMembershipSequencingPlugin].to[LibraryMembershipSequencingPluginImpl].in[AppScoped]
+    bind[SocialConnectionSequencingPlugin].to[SocialConnectionSequencingPluginImpl].in[AppScoped]
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxGlobal.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxGlobal.scala
@@ -14,7 +14,7 @@ import com.keepit.integrity.{ UriIntegrityPlugin, DataIntegrityPlugin }
 import com.keepit.common.integration.AutogenReaperPlugin
 import com.keepit.normalizer.NormalizationUpdaterPlugin
 import com.keepit.common.concurrent.{ ForkJoinExecContextPlugin }
-import com.keepit.model.{ LibrarySequencingPlugin, LibraryMembershipSequencingPlugin, UrlPatternRuleRepo }
+import com.keepit.model.{ SocialConnectionSequencingPlugin, LibrarySequencingPlugin, LibraryMembershipSequencingPlugin, UrlPatternRuleRepo }
 
 object ShoeboxGlobal extends FortyTwoGlobal(Prod) with ShoeboxServices {
 
@@ -53,5 +53,6 @@ trait ShoeboxServices { self: FortyTwoGlobal =>
     require(injector.instance[UserConnectionSequencingPlugin] != null) //make sure its not lazy loaded
     require(injector.instance[LibrarySequencingPlugin] != null) //make sure its not lazy loaded
     require(injector.instance[LibraryMembershipSequencingPlugin] != null) //make sure its not lazy loaded
+    require(injector.instance[SocialConnectionSequencingPlugin] != null) //make sure its not lazy loaded
   }
 }


### PR DESCRIPTION
Here are the required steps to to switch a repo deferred / batch sequence number assignment:
1. Switch from `sequence.incrementAndGet` to `deferredSeqNum` in the repo `save` method
2. Implement a `DbSequenceAssigner`, a `SequencingActor` and a `SequencingPlugin`
3. Bind the repo's sequencing plugin to its implementation in the service's DBSequencingModule
4. Make sure the sequencing plugin is not lazy loaded by adding an explicit injection to the service's Global
5. After pushing to production, make sure everything is ok by querying the database table for rows with negative sequence numbers: you should find some but they should _not_ accumulate: 
`select min(seq) from yourTableName where seq < 0`

See comments for actual exemples. 
