### PR TITLE
ignore sensitivity for keeper

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/URISummaryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/URISummaryCommander.scala
@@ -6,7 +6,7 @@ import com.keepit.common.performance._
 
 import com.keepit.common.cache.TransactionalCaching
 import com.keepit.common.logging.Logging
-import com.google.inject.{Singleton, Inject}
+import com.google.inject.{ Singleton, Inject }
 import scala.concurrent.Future
 import java.util.concurrent.TimeoutException
 import com.keepit.model._

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtPageController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtPageController.scala
@@ -21,7 +21,7 @@ class ExtPageController @Inject() (
     URI.parse(url) match {
       case Success(_) =>
         val info = pageCommander.getPageDetails(url, request.userId, request.experiments)
-        Ok(Json.toJson(info))
+        Ok(Json.toJson(info.copy(sensitive = false)))
       case Failure(e) =>
         log.error(s"Error parsing url: $url", e)
         BadRequest(Json.obj("error" -> s"Error parsing url: $url"))
@@ -33,7 +33,7 @@ class ExtPageController @Inject() (
     URI.parse(url) match {
       case Success(uri) =>
         pageCommander.getPageInfo(uri, request.userId, request.experiments).map { info =>
-          Ok(Json.toJson(info))
+          Ok(Json.toJson(info.copy(sensitive = false)))
         }
       case Failure(e) =>
         log.error(s"Error parsing url: $url", e)


### PR DESCRIPTION
@2is10 

I chose to overwrite `sensitive` field in the controller. In the future, if we ignore `sensitive` in the extension, we can remove the `sensitive` field from the `KeeperPageInfo` object. 
