### PR TITLE
prevent users who already have a membership to a library to be invited (...

### DIFF
--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -519,12 +519,15 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
         }
 
         val thorEmail = EmailAddress("thorishere@gmail.com")
+
+        // Captain America invites everybody to his Published Library
         val inviteList1 = Seq(
           (Left(userIron.id.get), LibraryAccess.READ_ONLY, None),
           (Left(userAgent.id.get), LibraryAccess.READ_ONLY, None),
           (Left(userHulk.id.get), LibraryAccess.READ_ONLY, None),
           (Right(thorEmail), LibraryAccess.READ_ONLY, Some("America > Asgard")))
         val res1 = Await.result(libraryCommander.inviteUsersToLibrary(libMurica.id.get, userCaptain.id.get, inviteList1), Duration(5, "seconds"))
+
         res1.isRight === true
         res1.right.get === Seq((Left(BasicUser.fromUser(userIron)), LibraryAccess.READ_ONLY),
           (Left(BasicUser.fromUser(userAgent)), LibraryAccess.READ_ONLY),
@@ -540,8 +543,13 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
               (None, LibraryAccess.READ_ONLY))
         }
 
+        // Agent Nick Fury accepts invite & joins the Library
+        libraryCommander.joinLibrary(userAgent.id.get, libMurica.id.get)
+        // Tests that users can have multiple invitations multiple times,
+        // but users with active membership to a library should not get invites with same access level
+        Await.result(libraryCommander.inviteUsersToLibrary(libMurica.id.get, userCaptain.id.get, inviteList1), Duration(5, "seconds")).isRight === true
         db.readOnlyMaster { implicit s =>
-          libraryInviteRepo.count === 4
+          libraryInviteRepo.count === 7
         }
 
         val inviteList2_RW = Seq((Left(userIron.id.get), LibraryAccess.READ_WRITE, None))


### PR DESCRIPTION
...backend check)

https://app.asana.com/0/19898402862947/20521229605002/f
Not sure how it happened since our site has a guard to see if a user already following a library. 
But this backend guard prevents an invite from being created if the invitee user already has an active membership to the library.

@andrewconner 
