### PR TITLE
Remove unused Angular routes.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/route.js
+++ b/kifi-backend/modules/shoebox/angular/src/route.js
@@ -27,20 +27,12 @@ angular.module('kifi')
     }).when('/profile', {
       templateUrl: 'profile/profile.tpl.html',
       controller: 'ProfileCtrl'
-    }).when('/kifeeeed', {
-      templateUrl: 'recos/adhoc.tpl.html'
     }).when('/recommendations', {
       redirectTo: '/'
-    }).when('/keeps', {
-      templateUrl: 'home/home.tpl.html',
-      controller: 'HomeCtrl'
     }).when('/find', {
       templateUrl: 'search/search.tpl.html',
       controller: 'SearchCtrl',
       reloadOnSearch: false
-    }).when('/tag/:tagId', {
-      templateUrl: 'tagKeeps/tagKeeps.tpl.html',
-      controller: 'TagKeepsCtrl'
     }).when('/keep/:keepId', {
       templateUrl: 'keep/keepView.tpl.html',
       controller: 'KeepViewCtrl'


### PR DESCRIPTION
@andrewconner @ahsu1230 

When writing the protractor tests, I noticed that these old routes were still hanging around.
