### PR TITLE
remove UserIdentity.allowSignup (outdated)

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/social/UserIdentity.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/UserIdentity.scala
@@ -8,7 +8,6 @@ import securesocial.core.SocialUser
 class UserIdentity(
   val userId: Option[Id[User]],
   val socialUser: SocialUser,
-  val allowSignup: Boolean,
   val isComplete: Boolean)
     extends SocialUser(
       socialUser.identityId,
@@ -27,8 +26,7 @@ object UserIdentity {
   def apply(
     userId: Option[Id[User]],
     socialUser: SocialUser,
-    allowSignup: Boolean = false,
-    isComplete: Boolean = true) = new UserIdentity(userId, socialUser, allowSignup, isComplete)
+    isComplete: Boolean = true) = new UserIdentity(userId, socialUser, isComplete)
 
-  def unapply(u: UserIdentity) = Some(u.userId, u.socialUser, u.allowSignup, u.isComplete)
+  def unapply(u: UserIdentity) = Some(u.userId, u.socialUser, u.isComplete)
 }

--- a/kifi-backend/modules/common/app/com/keepit/social/UserIdentityProvider.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/UserIdentityProvider.scala
@@ -38,7 +38,7 @@ trait UserIdentityProvider extends IdentityProvider with Logging {
     doAuth()(request) match {
       case Right(socialUser) =>
         val filledSocialUser = fillProfile(socialUser)
-        val saved = UserService.save(UserIdentity(userIdOpt, filledSocialUser, allowSignup = false))
+        val saved = UserService.save(UserIdentity(userIdOpt, filledSocialUser))
         Right(saved)
       case left => left
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
@@ -135,7 +135,6 @@ class AuthCommander @Inject() (
         authMethod = AuthenticationMethod.UserPassword,
         passwordInfo = Some(passwordInfo)
       ),
-      allowSignup = true,
       isComplete = isComplete
     )
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileAuthController.scala
@@ -201,7 +201,7 @@ class MobileAuthController @Inject() (
           } match {
             case Failure(err) => BadRequest(Json.obj("error" -> "invalid token"))
             case Success(filledUser) =>
-              val saved = UserService.save(UserIdentity(Some(request.userId), filledUser)) // todo: check allowSignup
+              val saved = UserService.save(UserIdentity(Some(request.userId), filledUser))
               log.info(s"[accessTokenSignup($providerName)] created social user: $saved")
               Ok(Json.obj("code" -> "link_created"))
           }

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/oauth2/TokenAuthTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/oauth2/TokenAuthTest.scala
@@ -144,6 +144,12 @@ class TokenAuthTest extends Specification with ShoeboxApplicationInjector {
         val json = contentAsJson(result)
         (json \ "code").as[String] === "connect_option" // success!
         (json \ "sessionId").asOpt[String].isDefined === true // sessionId is set
+
+        val suiOpt = db.readOnlyMaster { implicit ro =>
+          socialUserInfoRepo.getOpt(SocialId(lnkdInfo.userId.id), SocialNetworks.LINKEDIN)
+        }
+        suiOpt.isDefined == true
+        suiOpt.exists { sui => sui.userId.isEmpty } === true // userId must not be set in this case
       }
     }
     "(login) handle successful token login" in {


### PR DESCRIPTION
A small bite. `isComplete` is next and then (hopefully) `UserIdentity` follows

Sanity check added to `TokenAuthTest` where this code path is covered

@andrewconner 
