### PR TITLE
[DO NOT MERGE] Add library attribute for users on library page and add system libraries too.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWho.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWho.styl
@@ -23,6 +23,9 @@
   &.secret
     background-color: libraryRed
 
+  &.system
+    background-color: #000
+
 
 .kf-keep-who-lib
   font-size: 10px

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
@@ -1,5 +1,5 @@
 <span ng-if="!library.hidden">
-  <a class="kf-keep-who-pic-box" ng-href="{{library.path}}" ng-class="{ 'secret': library.visibility === 'secret' }">
+  <a class="kf-keep-who-pic-box" ng-href="{{library.path}}" ng-class="{ 'secret': library.visibility === 'secret', 'system': library.system }">
     <span class="kf-keep-who-pic" ng-attr-style="background-image: url({{library.keeperPic}})"></span>
     <span class="kf-keep-who-lib">{{library.name}}</span>
     <span kf-tooltip position="top" padding="10">

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLibsAndPics.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLibsAndPics.js
@@ -13,46 +13,92 @@ angular.module('kifi')
         keep: '='
       },
       link: function (scope) {
-        scope.me = profileService.me;
-        scope.getPicUrl = keepWhoService.getPicUrl;
-        scope.getName = keepWhoService.getName;
-        scope.isMyBookmark = scope.keep && scope.keep.isMyBookmark;
-        scope.visibleKeepLibraries = scope.keep.libraries;
-
-        scope.$emit('getCurrentLibrary', { callback: function (lib) {
-          if (lib && lib.id) {
-            var library = _.find(scope.visibleKeepLibraries, { id: lib.id });
-            if (library) {
-              library.hidden = true;
-            }
+        //
+        // Internal functions.
+        //
+        function isSystemLibrary(library) {
+          if (library.kind) {
+            return library.kind === 'system_main' || library.kind === 'system_secret';
+          } else {
+            return libraryService.isSystemLibrary(library.id);
           }
-        }});
+        }
 
-        // For keep cards that search results on the search page, add and remove user library attribution
-        // on the client side when the user keeps or unkeeps.
+        function sortVisibleLibraries() {
+          scope.visibleKeepLibraries = _.sortBy(scope.visibleKeepLibraries, function (library) {
+            // List system libraries first.
+            if (library.system) { return 0; }
+
+            // List user-owned libraries next.
+            if (library.isMine) { return 1; }
+
+            // List friend libraries last.
+            return 2;
+          });
+        }
+
+        function init() {
+          scope.me = profileService.me;
+          scope.getPicUrl = keepWhoService.getPicUrl;
+          scope.getName = keepWhoService.getName;
+          scope.isMyBookmark = scope.keep && scope.keep.isMyBookmark;
+
+          scope.visibleKeepLibraries = _.map(scope.keep.libraries, function (library) {
+            library.system = isSystemLibrary(library);
+            return library;
+          });
+          sortVisibleLibraries();
+
+          // Do not show attribution for the library the page is displaying.
+          scope.$emit('getCurrentLibrary', {
+            callback: function (lib) {
+              if (lib && lib.id) {
+                var library = _.find(scope.visibleKeepLibraries, { id: lib.id });
+                if (library) {
+                  library.hidden = true;
+                }
+              }
+            }
+          });
+        }
+
+
+        //
+        // Watches and listeners.
+        //
+
+        // Add user library attribution when the user keeps.
         var deregisterKeepAddedListener = $rootScope.$on('keepAdded', function (e, libSlug, keeps, library) {
-          var visibleLibraryIds = _.pluck(scope.visibleKeepLibraries, 'id');
-
           _.each(keeps, function (keep) {
-            if (!scope.keep.id &&                      // No scope.keep.id if the keep is not on a library page.
-                scope.keep.url === keep.url &&
-                !libraryService.isSystemLibrary(library) &&     // Do not show system libraries as attributions.
-                !_.contains(visibleLibraryIds, library.id)) {
+            if (scope.keep.url === keep.url) {
               library.keeperPic = friendService.getPictureUrlForUser(profileService.me);
+              library.isMine = library.owner.id === profileService.me.id;
+              library.system = isSystemLibrary(library);
+
+              // A library is kept in only one system library at a time, so remove any
+              // previous system libraries.
+              if (library.system) {
+                scope.visibleKeepLibraries = _.reject(scope.visibleKeepLibraries, 'system');
+              }
+
               scope.visibleKeepLibraries.push(library);
             }
           });
+
+          sortVisibleLibraries();
         });
         scope.$on('$destroy', deregisterKeepAddedListener);
 
+        // Remove userlibrary attribution when the user unkeeps.
         var deregisterKeepRemovedListener = $rootScope.$on('keepRemoved', function (e, removedKeep, library) {
-          if (!scope.keep.id &&                        // No scope.keep.id if the keep is not on a library page.
-              (scope.keep.url === removedKeep.url) &&
-              (library.kind === 'user_created')) {     // Do not hide system libraries as attributions.
+          if (scope.keep.url === removedKeep.url) {
             _.remove(scope.visibleKeepLibraries, { id: library.id });
           }
         });
         scope.$on('$destroy', deregisterKeepRemovedListener);
+
+
+        init();
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
@@ -8,12 +8,12 @@ angular.module('kifi')
       if (item.libraries && item.libraries.length > 0 && Array.isArray(item.libraries[0])) {
         var cleanedLibraries = [];
         var usersWithLibs = {};
-        item.libraries.forEach( function (lib) {
+
+        item.libraries.forEach(function (lib) {
           lib[0].keeperPic = friendService.getPictureUrlForUser(lib[1]);
-          if (lib[1].id !== profileService.me.id) {
-            usersWithLibs[lib[1].id] = true;
-            cleanedLibraries.push(lib[0]);
-          }
+          usersWithLibs[lib[1].id] = true;
+          lib[0].isMine = lib[1].id === profileService.me.id;
+          cleanedLibraries.push(lib[0]);
         });
 
         item.keepers.forEach(function (keeper) {

--- a/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
@@ -56,11 +56,9 @@ angular.module('kifi')
           user = profileService.me;
           lib.keeperPic = friendService.getPictureUrlForUser(user);
           lib.owner = user;
+          lib.isMine = lib.owner.id === profileService.me.id;
 
-          if (!libraryService.isSystemLibrary(lib.id)) {
-            decompressedLibraries.push(lib);
-          }
-
+          decompressedLibraries.push(lib);
           myLibraries.push(lib);
         }
       }
@@ -154,7 +152,6 @@ angular.module('kifi')
         var resData = res.data;
 
         //$log.log('searchActionService.find() res', resData);
-
         var hits = resData.hits || [];
         _.forEach(hits, function (hit) {
           decompressHit(hit, resData.users, resData.libraries, userLoggedIn);


### PR DESCRIPTION
@andrewconner @ahsu1230 cc @leogrim 
https://app.asana.com/0/19898402862947/19898402863094

Add the front-end part of adding library attributions. Do not merge right now, because of [this issue](https://app.asana.com/0/15523651812135/20646352218293/), - the library attributions are not always consistent with the most recent keep-to-library activities. @leogrim is working on that; if it proves too difficult on the backend, front-end can also reconcile the inconsistencies. This is an existing bug but will become much more obvious once user library attribution is displayed.
