### PR TITLE
remove unnecessary endpoint calls on public libraries

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -118,9 +118,9 @@ angular.module('kifi', [
 ])
 
 .controller('AppCtrl', [
-  '$scope', 'profileService', '$window', '$rootScope', 'friendService', '$timeout', '$log',
+  '$scope', 'profileService', '$window', '$rootScope', 'friendService', 'libraryService','$timeout', '$log',
   'platformService', '$rootElement', '$analytics', '$location',
-  function ($scope, profileService, $window, $rootScope, friendService, $timeout, $log,
+  function ($scope, profileService, $window, $rootScope, friendService, libraryService, $timeout, $log,
       platformService, $rootElement, $analytics, $location) {
     $log.log('\n   █   ● ▟▛ ●        made with ❤\n   █▟▛ █ █■ █    kifi.com/about/team\n   █▜▙ █ █  █         join us!\n');
 
@@ -133,6 +133,7 @@ angular.module('kifi', [
           if ($rootScope.userLoggedIn) {
             profileService.fetchPrefs();
             friendService.getRequests();
+            libraryService.fetchLibrarySummaries(true);
           }
         });
       });

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
@@ -368,5 +368,6 @@ angular.module('kifi')
       }
     });
 
+    libraryService.fetchLibrarySummaries(true);
   }
 ]);

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
@@ -368,6 +368,5 @@ angular.module('kifi')
       }
     });
 
-    libraryService.fetchLibrarySummaries(true);
   }
 ]);

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
@@ -367,7 +367,5 @@ angular.module('kifi')
         header.css('padding-right', '');
       }
     });
-
-    libraryService.fetchLibrarySummaries(true);
   }
 ]);

--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
@@ -50,15 +50,10 @@ angular.module('kifi')
           scope.mainLib = _.find(libraryService.librarySummaries, { 'kind' : 'system_main' });
           scope.secretLib = _.find(libraryService.librarySummaries, { 'kind' : 'system_secret' });
           allUserLibs = _.filter(libraryService.librarySummaries, { 'kind' : 'user_created' });
-
-          var newLists = sortLibraries(allUserLibs, libraryService.invitedSummaries);
-          scope.userLibsToShow = newLists[0];
-          scope.invitedLibsToShow  = newLists[1];
-          scope.myLibsToShow = newLists[2];  // should be [] if myLibsFirst false
           librarySummarySearch = new Fuse(allUserLibs, fuseOptions);
           invitedSummarySearch = new Fuse(libraryService.invitedSummaries, fuseOptions);
 
-          scope.$broadcast('refreshScroll');
+          scope.changeList();
         }
 
         function setStickySeparator(refetchSeparators) {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -170,7 +170,7 @@ angular.module('kifi')
             '&kcid=na-vf_twitter-library_invite-lid_' + scope.library.id);
           scope.library.shareText = 'Discover this amazing @Kifi library about ' + scope.library.name + '!';
 
-          if (scope.isUserLoggedOut) {
+          if (scope.$root.userLoggedIn === false) {
             scope.$evalAsync(function () {
               angular.element('.white-background').height(element.height() + 20);
             });

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -170,28 +170,29 @@ angular.module('kifi')
             '&kcid=na-vf_twitter-library_invite-lid_' + scope.library.id);
           scope.library.shareText = 'Discover this amazing @Kifi library about ' + scope.library.name + '!';
 
-          // Figure out whether this library is a library that the user has been invited to.
-          // If so, display an invite header.
-          var promise = null;
-          if (libraryService.invitedSummaries.length) {
-            promise = $q.when(libraryService.invitedSummaries);
-          } else {
-            promise = libraryService.fetchLibrarySummaries(true).then(function () {
-              return libraryService.invitedSummaries;
-            });
-          }
 
-          promise.then(function (invitedSummaries) {
-            var maybeLib = _.find(invitedSummaries, { 'id' : scope.library.id });
-            if (maybeLib) {
-              scope.library.invite = {
-                inviterName: maybeLib.inviter.firstName + ' ' + maybeLib.inviter.lastName,
-                actedOn: false
-              };
+          if (scope.$root.userLoggedIn) {
+            // Figure out whether this library is a library that the user has been invited to.
+            // If so, display an invite header.
+            var promise = null;
+            if (libraryService.invitedSummaries.length) {
+              promise = $q.when(libraryService.invitedSummaries);
+            } else {
+              promise = libraryService.fetchLibrarySummaries(true).then(function () {
+                return libraryService.invitedSummaries;
+              });
             }
-          });
 
-          if (scope.$root.userLoggedIn === false) {
+            promise.then(function (invitedSummaries) {
+              var maybeLib = _.find(invitedSummaries, { 'id' : scope.library.id });
+              if (maybeLib) {
+                scope.library.invite = {
+                  inviterName: maybeLib.inviter.firstName + ' ' + maybeLib.inviter.lastName,
+                  actedOn: false
+                };
+              }
+            });
+          } else {
             scope.$evalAsync(function () {
               angular.element('.white-background').height(element.height() + 20);
             });

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -170,33 +170,12 @@ angular.module('kifi')
             '&kcid=na-vf_twitter-library_invite-lid_' + scope.library.id);
           scope.library.shareText = 'Discover this amazing @Kifi library about ' + scope.library.name + '!';
 
-
-          if (scope.$root.userLoggedIn) {
-            // Figure out whether this library is a library that the user has been invited to.
-            // If so, display an invite header.
-            var promise = null;
-            if (libraryService.invitedSummaries.length) {
-              promise = $q.when(libraryService.invitedSummaries);
-            } else {
-              promise = libraryService.fetchLibrarySummaries(true).then(function () {
-                return libraryService.invitedSummaries;
-              });
-            }
-
-            promise.then(function (invitedSummaries) {
-              var maybeLib = _.find(invitedSummaries, { 'id' : scope.library.id });
-              if (maybeLib) {
-                scope.library.invite = {
-                  inviterName: maybeLib.inviter.firstName + ' ' + maybeLib.inviter.lastName,
-                  actedOn: false
-                };
-              }
-            });
-          } else {
+          if (scope.isUserLoggedOut) {
             scope.$evalAsync(function () {
               angular.element('.white-background').height(element.height() + 20);
             });
           }
+
         }
 
         function preloadSocial () {
@@ -428,6 +407,20 @@ angular.module('kifi')
           if (!newVal) {
             augmentData();
             adjustFollowerPicsSize();
+          }
+        });
+
+        // Figure out whether this library is a library that the user has been invited to.
+        // If so, display an invite header.
+        scope.$watch(function() {
+          return libraryService.invitedSummaries.length;
+        }, function () {
+          var maybeLib = _.find(libraryService.invitedSummaries, { 'id' : scope.library.id });
+          if (maybeLib) {
+            scope.library.invite = {
+              inviterName: maybeLib.inviter.firstName + ' ' + maybeLib.inviter.lastName,
+              actedOn: false
+            };
           }
         });
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -144,9 +144,6 @@ angular.module('kifi')
       },
 
       fetchLibrarySummaries: function (invalidateCache) {
-        if (!$rootScope.userLoggedIn) {
-          return;
-        }
         if (invalidateCache) {
           userLibrarySummariesService.expire();
         }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -144,6 +144,9 @@ angular.module('kifi')
       },
 
       fetchLibrarySummaries: function (invalidateCache) {
+        if (!$rootScope.userLoggedIn) {
+          return;
+        }
         if (invalidateCache) {
           userLibrarySummariesService.expire();
         }


### PR DESCRIPTION
on public libraries, 
`/site/libraries` was being called for library summaries which is unneeded for public libraries.

@andrewconner @yipingliao 
