### PR TITLE
Curator diverse recommendations by topic

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/cortex/models/lda/LDA.scala
+++ b/kifi-backend/modules/common/app/com/keepit/cortex/models/lda/LDA.scala
@@ -77,4 +77,9 @@ case class LDATopicDetail(
   topicScores: Seq[Float])
 
 @json case class LDAUserURIInterestScore(score: Float, confidence: Float) // confidence: [0,1]. higher better
-@json case class LDAUserURIInterestScores(global: Option[LDAUserURIInterestScore], recency: Option[LDAUserURIInterestScore], libraryInduced: Option[LDAUserURIInterestScore])
+@json case class LDAUserURIInterestScores(
+  global: Option[LDAUserURIInterestScore],
+  recency: Option[LDAUserURIInterestScore],
+  libraryInduced: Option[LDAUserURIInterestScore],
+  topic1: Option[LDATopic] = None,
+  topic2: Option[LDATopic] = None)

--- a/kifi-backend/modules/common/app/com/keepit/model/UserExperiment.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserExperiment.scala
@@ -64,11 +64,12 @@ object ExperimentType {
   val GRAPH_BASED_PEOPLE_TO_INVITE = ExperimentType("graph_based_people_to_invite")
   val NEW_KEEP_NOTIFICATIONS = ExperimentType("new_keep_notifications")
   val CORTEX_NEW_MODEL = ExperimentType("cortex_new_model")
+  val CURATOR_DIVERSE_TOPIC_RECOS = ExperimentType("curator_diverse_topic_recos")
 
   val _ALL = ADMIN :: AUTO_GEN :: FAKE :: VISITED :: NO_SEARCH_EXPERIMENTS ::
     CAN_MESSAGE_ALL_USERS :: DEMO :: EXTENSION_LOGGING :: SHOW_HIT_SCORES :: SHOW_DISCUSSIONS ::
     MOBILE_REDIRECT :: DELIGHTED_SURVEY_PERMANENT :: SPECIAL_CURATOR :: LIBRARIES :: SEND_DIGEST_EMAIL_ON_REFRESH ::
-    GRAPH_BASED_PEOPLE_TO_INVITE :: NEW_KEEP_NOTIFICATIONS :: CORTEX_NEW_MODEL :: Nil
+    GRAPH_BASED_PEOPLE_TO_INVITE :: NEW_KEEP_NOTIFICATIONS :: CORTEX_NEW_MODEL :: CURATOR_DIVERSE_TOPIC_RECOS :: Nil
 
   private val _ALL_MAP: Map[String, ExperimentType] = _ALL.map(e => e.value -> e).toMap
 

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/263.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/263.sql
@@ -1,0 +1,10 @@
+# CURATOR
+
+# --- !Ups
+
+ALTER TABLE uri_recommendation ADD COLUMN topic1 smallint(6) unsigned;
+ALTER TABLE uri_recommendation ADD COLUMN topic2 smallint(6) unsigned;
+
+INSERT INTO evolutions (name, description) VALUES('263.sql', 'add topic1 and topic2 to uri_recommendation table');
+
+# --- !Downs

--- a/kifi-backend/modules/common/test/com/keepit/cortex/FakeCortexServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/cortex/FakeCortexServiceClientImpl.scala
@@ -15,6 +15,8 @@ import com.google.inject.util.Providers
 import com.keepit.common.actor.FakeScheduler
 
 class FakeCortexServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) extends CortexServiceClient {
+  val batchUserURIsInterestsExpectations = collection.mutable.Map[Id[User], Seq[LDAUserURIInterestScores]]()
+
   val serviceCluster: ServiceCluster = new ServiceCluster(ServiceType.TEST_MODE, Providers.of(airbrakeNotifier), new FakeScheduler(), () => {})
   protected def httpClient: com.keepit.common.net.HttpClient = ???
 
@@ -36,7 +38,9 @@ class FakeCortexServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) extend
   override def saveEdits(configs: Map[String, LDATopicConfiguration])(implicit version: LDAVersionOpt = None): Unit = ???
   override def userUriInterest(userId: Id[User], uriId: Id[NormalizedURI])(implicit version: LDAVersionOpt = None): Future[LDAUserURIInterestScores] = Future.successful(LDAUserURIInterestScores(None, None, None))
   override def batchUserURIsInterests(userId: Id[User], uriIds: Seq[Id[NormalizedURI]])(implicit version: LDAVersionOpt = None): Future[Seq[LDAUserURIInterestScores]] = {
-    Future.successful((0 until uriIds.length).map(_ => LDAUserURIInterestScores(None, None, None)))
+    val result = batchUserURIsInterestsExpectations.getOrElse(userId,
+      (0 until uriIds.length).map(_ => LDAUserURIInterestScores(None, None, None)))
+    Future.successful(result)
   }
   override def userTopicMean(userId: Id[User])(implicit version: LDAVersionOpt = None): Future[(Option[Array[Float]], Option[Array[Float]])] = ???
   override def sampleURIsForTopic(topic: Int)(implicit version: LDAVersionOpt): Future[(Seq[Id[NormalizedURI]], Seq[Float])] = ???

--- a/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDACommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDACommander.scala
@@ -89,7 +89,8 @@ class LDACommander @Inject() (
           val s1 = computeCosineInterestScore(uriTopicOpt, userInterestOpt)
           val s2 = computeGaussianInterestScore(uriTopicOpt, userInterestStatOpt)
           val s3 = libraryInducedUserURIInterestScore(libFeats, uriTopicOpt)
-          LDAUserURIInterestScores(s2.global, s1.recency, s3)
+          LDAUserURIInterestScores(s2.global, s1.recency, s3,
+            uriTopicOpt.flatMap(_.firstTopic), uriTopicOpt.flatMap(_.secondTopic))
         } else {
           LDAUserURIInterestScores(None, None, None)
         }

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/sql/CortexTypeMappers.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/sql/CortexTypeMappers.scala
@@ -19,8 +19,6 @@ trait CortexTypeMappers { self: { val db: DataBaseComponent } =>
 
   implicit def statModelName = MappedColumnType.base[StatModelName, String](_.name, StatModelName(_))
 
-  implicit def ldaTopicMapper = MappedColumnType.base[LDATopic, Int](_.index, LDATopic(_))
-
   implicit def ldaTopicFeatureMapper = MappedColumnType.base[LDATopicFeature, Blob](
     { feat => new SerialBlob(FloatArrayFormmater.toBinary(feat.value)) },
     { blob => val len = blob.length().toInt; val arr = FloatArrayFormmater.fromBinary(blob.getBytes(1, len)); LDATopicFeature(arr) }

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/AttributionHelper.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/AttributionHelper.scala
@@ -31,7 +31,8 @@ class SeedAttributionHelper @Inject() (
     } yield {
       (0 until seeds.size).map { i =>
         val attr = SeedAttribution(userAttr(i), keepAttr(i), topicAttr(i), libraryAttr(i))
-        ScoredSeedItemWithAttribution(seeds(i).userId, seeds(i).uriId, seeds(i).uriScores, attr)
+        ScoredSeedItemWithAttribution(seeds(i).userId, seeds(i).uriId, seeds(i).uriScores, attr,
+          seeds(i).topic1, seeds(i).topic2)
       }
     }
   }

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
@@ -153,7 +153,9 @@ class RecommendationGenerationCommander @Inject() (
             state = UriRecommendationStates.ACTIVE,
             masterScore = computeMasterScore(item.uriScores),
             allScores = item.uriScores,
-            attribution = item.attribution))
+            attribution = item.attribution,
+            topic1 = item.topic1,
+            topic2 = item.topic2))
         } getOrElse {
           uriRecRepo.save(UriRecommendation(
             uriId = item.uriId,
@@ -164,7 +166,9 @@ class RecommendationGenerationCommander @Inject() (
             clicked = 0,
             kept = false,
             trashed = false,
-            attribution = item.attribution))
+            attribution = item.attribution,
+            topic1 = item.topic1,
+            topic2 = item.topic2))
         }
       }
 

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationRetrievalCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationRetrievalCommander.scala
@@ -1,6 +1,8 @@
 package com.keepit.curator.commanders
 
-import com.keepit.curator.model.{ RecommendationClientType, RecoInfo, UriRecommendationRepo, UriScores, PublicFeedRepo }
+import com.keepit.common.logging.Logging
+import com.keepit.cortex.models.lda.LDATopic
+import com.keepit.curator.model._
 import com.keepit.common.db.Id
 import com.keepit.model.User
 import com.keepit.common.db.slick.Database
@@ -8,9 +10,49 @@ import com.keepit.common.akka.SafeFuture
 
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
+import scala.collection.immutable.SortedSet
 import scala.util.Random
 
 import com.google.inject.{ Inject, Singleton }
+
+case class UriRecoScore(score: Float, reco: UriRecommendation)
+
+trait RecoSortStrategy {
+  def sort(recosByTopScore: Seq[UriRecoScore]): Seq[UriRecoScore]
+}
+
+class TopScoreRecoSortStrategy(val minScore: Float = 5f) extends RecoSortStrategy {
+  def sort(recosByTopScore: Seq[UriRecoScore]) = recosByTopScore filter (_.score > minScore) sortBy (-_.score)
+}
+
+class DiverseRecoSortStrategy(val minScore: Float = 5f, val limit: Int = 10) extends RecoSortStrategy with Logging {
+
+  implicit val recoOrdering = Ordering.by[UriRecoScore, Float](-_.score)
+  private val blankTopicMap = Map[Option[LDATopic], SortedSet[UriRecoScore]]().withDefaultValue(SortedSet.empty)
+
+  def sort(recosByTopScore: Seq[UriRecoScore]) = {
+    val recosByTopic1 = recosByTopScore.foldLeft(blankTopicMap) {
+      case (accTopic1, recoScore) =>
+        val (reco, score) = (recoScore.reco, recoScore.score)
+        if (score > minScore) accTopic1.updated(reco.topic1, accTopic1(reco.topic1) + recoScore)
+        else accTopic1
+    }
+
+    recosByTopic1.toSeq.map {
+      case (_, recoScores) => rescoreRecosWithDecay(recoScores.toSeq)
+    }.flatten sortBy (-_.score)
+  }
+
+  private def rescoreRecosWithDecay(recoScores: Seq[UriRecoScore]) = {
+    val decayRate = 1 / 15f
+
+    @inline def scoreDecay(i: Int): Float = Math.exp(-i * decayRate).toFloat
+
+    recoScores.zipWithIndex.map {
+      case (recoScore, idx) => recoScore.copy(score = recoScore.score * scoreDecay(idx))
+    }
+  }
+}
 
 @Singleton
 class RecommendationRetrievalCommander @Inject() (db: Database, uriRecoRepo: UriRecommendationRepo, analytics: CuratorAnalytics, publicFeedRepo: PublicFeedRepo) {
@@ -23,26 +65,29 @@ class RecommendationRetrievalCommander @Inject() (db: Database, uriRecoRepo: Uri
     (adjustedScore * finalPenaltyFactor).toFloat
   }
 
-  def topRecos(userId: Id[User], more: Boolean = false, recencyWeight: Float = 0.5f, clientType: RecommendationClientType): Seq[RecoInfo] = {
+  def topRecos(userId: Id[User], more: Boolean = false, recencyWeight: Float = 0.5f, clientType: RecommendationClientType, recoSortStrategy: RecoSortStrategy): Seq[RecoInfo] = {
     require(recencyWeight <= 1.0f && recencyWeight >= 0.0f, "recencyWeight must be between 0 and 1")
 
+    def scoreReco(reco: UriRecommendation) =
+      UriRecoScore(scoreItem(reco.masterScore, reco.allScores, reco.delivered, reco.clicked, reco.vote, more, recencyWeight), reco)
+
     val recos = db.readOnlyReplica { implicit session =>
-      uriRecoRepo.getRecommendableByTopMasterScore(userId, 1000)
-    } map { reco =>
-      (scoreItem(reco.masterScore, reco.allScores, reco.delivered, reco.clicked, reco.vote, more, recencyWeight), reco)
-    } filter (_._1 > 5.0f) sortBy (-1 * _._1) take 10
+      val recosByTopScore = uriRecoRepo.getRecommendableByTopMasterScore(userId, 1000) map scoreReco
+
+      recoSortStrategy.sort(recosByTopScore) take 10
+    }
 
     SafeFuture {
-      analytics.trackDeliveredItems(recos.map(_._2), Some(clientType))
+      analytics.trackDeliveredItems(recos.map(_.reco), Some(clientType))
       db.readWrite { implicit session =>
-        recos.map(_._2).map { reco =>
-          uriRecoRepo.incrementDeliveredCount(reco.id.get)
+        recos.map { recoScore =>
+          uriRecoRepo.incrementDeliveredCount(recoScore.reco.id.get)
         }
       }
     }
 
     recos.map {
-      case (score, reco) =>
+      case UriRecoScore(score, reco) =>
         RecoInfo(
           userId = Some(reco.userId),
           uriId = reco.uriId,

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/SeedItem.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/SeedItem.scala
@@ -1,6 +1,7 @@
 package com.keepit.curator.model
 
 import com.keepit.common.db.{ SequenceNumber, Id }
+import com.keepit.cortex.models.lda.LDATopic
 import com.keepit.model.{ NormalizedURI, User }
 import com.kifi.macros.json
 
@@ -88,6 +89,8 @@ case class PublicSeedItemWithMultiplier(
 
 case class PublicScoredSeedItem(uriId: Id[NormalizedURI], publicUriScores: PublicUriScores)
 
-case class ScoredSeedItem(userId: Id[User], uriId: Id[NormalizedURI], uriScores: UriScores)
+case class ScoredSeedItem(userId: Id[User], uriId: Id[NormalizedURI], uriScores: UriScores,
+  topic1: Option[LDATopic], topic2: Option[LDATopic])
 
-case class ScoredSeedItemWithAttribution(userId: Id[User], uriId: Id[NormalizedURI], uriScores: UriScores, attribution: SeedAttribution)
+case class ScoredSeedItemWithAttribution(userId: Id[User], uriId: Id[NormalizedURI], uriScores: UriScores,
+  attribution: SeedAttribution, topic1: Option[LDATopic], topic2: Option[LDATopic])

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendation.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendation.scala
@@ -3,6 +3,7 @@ package com.keepit.curator.model
 import com.keepit.common.crypto.ModelWithPublicId
 import com.keepit.common.db._
 import com.keepit.common.time._
+import com.keepit.cortex.models.lda.LDATopic
 import com.keepit.model.{ User, NormalizedURI }
 import org.joda.time.DateTime
 
@@ -21,7 +22,9 @@ case class UriRecommendation(
     kept: Boolean = false,
     trashed: Boolean = false,
     lastPushedAt: Option[DateTime] = None,
-    attribution: SeedAttribution) extends Model[UriRecommendation] with ModelWithPublicId[UriRecommendation] with ModelWithState[UriRecommendation] {
+    attribution: SeedAttribution,
+    topic1: Option[LDATopic],
+    topic2: Option[LDATopic]) extends Model[UriRecommendation] with ModelWithPublicId[UriRecommendation] with ModelWithState[UriRecommendation] {
 
   def withId(id: Id[UriRecommendation]): UriRecommendation = this.copy(id = Some(id))
   def withUpdateTime(updateTime: DateTime): UriRecommendation = this.copy(updatedAt = updateTime)

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendationRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendationRepo.scala
@@ -8,6 +8,7 @@ import com.keepit.common.db.slick.{ DBSession, DataBaseComponent, DbRepo }
 import com.keepit.common.logging.Logging
 import com.keepit.common.time._
 import com.keepit.common.time.Clock
+import com.keepit.cortex.models.lda.LDATopic
 import com.keepit.model.{ UriRecommendationFeedback, User, NormalizedURI }
 import org.joda.time.DateTime
 import play.api.libs.json.Json
@@ -79,8 +80,10 @@ class UriRecommendationRepoImpl @Inject() (
     def trashed = column[Boolean]("trashed", O.NotNull)
     def lastPushedAt = column[DateTime]("last_pushed_at", O.Nullable)
     def attribution = column[SeedAttribution]("attribution", O.NotNull)
+    def topic1 = column[LDATopic]("topic1", O.Nullable)
+    def topic2 = column[LDATopic]("topic2", O.Nullable)
     def * = (id.?, createdAt, updatedAt, state, vote.?, uriId, userId, masterScore, allScores, delivered, clicked,
-      kept, trashed, lastPushedAt.?, attribution) <> ((UriRecommendation.apply _).tupled, UriRecommendation.unapply _)
+      kept, trashed, lastPushedAt.?, attribution, topic1.?, topic2.?) <> ((UriRecommendation.apply _).tupled, UriRecommendation.unapply _)
   }
 
   def table(tag: Tag) = new UriRecommendationTable(tag)

--- a/kifi-backend/modules/curator/test/com/keepit/curator/CuratorTestHelpers.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/CuratorTestHelpers.scala
@@ -1,7 +1,7 @@
 package com.keepit.curator
 
 import com.google.inject.{ Module, Injector }
-import com.keepit.common.db.Id
+import com.keepit.common.db.{ SequenceNumber, Id }
 import com.keepit.common.db.slick.DBSession.RWSession
 import com.keepit.common.db.slick.Database
 import com.keepit.common.mail.EmailAddress
@@ -179,5 +179,13 @@ trait CuratorTestHelpers { this: CuratorTestInjector =>
     val savedUriReco = uriRecoRepo.save(uriReco)
     shoebox.saveURISummary(savedUri.id.get, uriSumm)
     (savedUri, savedUriReco, uriSumm)
+  }
+
+  def makeSeedItems(userId: Id[User]): Seq[SeedItem] = {
+    val seedItem1 = SeedItem(userId = userId, uriId = Id[NormalizedURI](1), url = "url1", seq = SequenceNumber[SeedItem](1), priorScore = None, timesKept = 1000, lastSeen = currentDateTime, keepers = Keepers.TooMany, discoverable = true)
+    val seedItem2 = SeedItem(userId = userId, uriId = Id[NormalizedURI](2), url = "url2", seq = SequenceNumber[SeedItem](2), priorScore = None, timesKept = 10, lastSeen = currentDateTime, keepers = Keepers.ReasonableNumber(Seq(Id[User](1), Id[User](3))), discoverable = true)
+    val seedItem3 = SeedItem(userId = userId, uriId = Id[NormalizedURI](3), url = "url3", seq = SequenceNumber[SeedItem](3), priorScore = None, timesKept = 93, lastSeen = currentDateTime, keepers = Keepers.ReasonableNumber(Seq(Id[User](2))), discoverable = true)
+    val seedItem4 = SeedItem(userId = userId, uriId = Id[NormalizedURI](4), url = "url4", seq = SequenceNumber[SeedItem](4), priorScore = None, timesKept = 20, lastSeen = currentDateTime, keepers = Keepers.ReasonableNumber(Seq(Id[User](1), Id[User](2))), discoverable = true)
+    seedItem1 :: seedItem2 :: seedItem3 :: seedItem4 :: Nil
   }
 }

--- a/kifi-backend/modules/curator/test/com/keepit/curator/CuratorTestHelpers.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/CuratorTestHelpers.scala
@@ -86,7 +86,9 @@ trait CuratorTestHelpers { this: CuratorTestInjector =>
       state = UriRecommendationStates.ACTIVE,
       allScores = allScores,
       delivered = 0, clicked = 0, kept = false,
-      attribution = makeSeedAttribution(userId))
+      attribution = makeSeedAttribution(userId),
+      topic1 = None,
+      topic2 = None)
   }
 
   def makeUriRecommendationWithUpdateTimestamp(uriId: Int, userIdInt: Int, masterScore: Float, updatedAt: DateTime) = {
@@ -110,7 +112,9 @@ trait CuratorTestHelpers { this: CuratorTestInjector =>
         discoveryScore = 1.0f,
         libraryInducedScore = Some(0f)),
       delivered = 0, clicked = 0, kept = false,
-      attribution = makeSeedAttribution(userId))
+      attribution = makeSeedAttribution(userId),
+      topic1 = None,
+      topic2 = None)
   }
 
   def makePublicFeed(uriId: Int, publicMasterScore: Float) = {

--- a/kifi-backend/modules/curator/test/com/keepit/curator/DiverseRecoSortStrategyTest.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/DiverseRecoSortStrategyTest.scala
@@ -1,0 +1,47 @@
+package com.keepit.curator
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.keepit.cortex.models.lda.LDATopic
+import com.keepit.curator.commanders.{ UriRecoScore, DiverseRecoSortStrategy }
+import org.specs2.mutable.Specification
+
+class DiverseRecoSortStrategyTest extends Specification with CuratorTestInjector with CuratorTestHelpers {
+
+  "DiverseRecoSortStrategy" should {
+    "sorts recommendations to include multiple topics" in {
+      withInjector() { implicit injector =>
+        // test is more of a sanity check to make sure (1) recos are sorted correctly and
+        // (2) some weight is applied to recos by the topics they are in
+        val topicScores = Map[Int, Seq[Float]](
+          1 -> Seq(8, 8, 9, 10),
+          2 -> Seq(8, 9, 10),
+          3 -> Seq(8, 9, 10),
+          4 -> Seq(7.9f, 8.9f)
+        )
+
+        val nextId = new AtomicInteger(1)
+        val recos = (for (topic <- topicScores.keys; score <- topicScores(topic)) yield makeUriRecommendation(
+          nextId.getAndIncrement, 42, score).copy(topic1 = Some(LDATopic(topic)))).toSeq
+
+        val sortedRecos = recos.sortBy(-_.masterScore) map { reco => UriRecoScore(reco.masterScore, reco) }
+
+        val strategy = new DiverseRecoSortStrategy()
+        val diverseSortedRecos = strategy.sort(sortedRecos)
+
+        // sort order sanity check
+        for (i <- 1 until diverseSortedRecos.size) {
+          diverseSortedRecos(i - i).score > diverseSortedRecos(i).score
+        }
+
+        // ensures that the 8.9f and 7.9f scores are ranked above the other scores of 9 and 8, respectively
+        // test is susceptible to fail from algorithm changes or changes to the topicScores Map above
+        diverseSortedRecos(3).reco.masterScore === 8.9f
+        diverseSortedRecos(4).reco.masterScore === 9
+        diverseSortedRecos(7).reco.masterScore === 7.9f
+        diverseSortedRecos(8).reco.masterScore === 8
+      }
+    }
+  }
+
+}

--- a/kifi-backend/modules/curator/test/com/keepit/curator/UriScoringHelperTest.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/UriScoringHelperTest.scala
@@ -3,10 +3,10 @@ package com.keepit.curator
 import com.keepit.common.cache.FakeCacheModule
 import com.keepit.common.db.Id
 import com.keepit.common.net.FakeHttpClientModule
-import com.keepit.cortex.models.lda.{LDATopic, LDAUserURIInterestScores}
-import com.keepit.cortex.{CortexServiceClient, FakeCortexServiceClientImpl, FakeCortexServiceClientModule}
-import com.keepit.curator.commanders.{UriScoringHelper, UriWeightingHelper}
-import com.keepit.graph.{FakeGraphServiceClientImpl, FakeGraphServiceModule, GraphServiceClient}
+import com.keepit.cortex.models.lda.{ LDATopic, LDAUserURIInterestScores }
+import com.keepit.cortex.{ CortexServiceClient, FakeCortexServiceClientImpl, FakeCortexServiceClientModule }
+import com.keepit.curator.commanders.{ UriScoringHelper, UriWeightingHelper }
+import com.keepit.graph.{ FakeGraphServiceClientImpl, FakeGraphServiceModule, GraphServiceClient }
 import com.keepit.heimdal.FakeHeimdalServiceClientModule
 import com.keepit.model.User
 import org.specs2.mutable.Specification

--- a/kifi-backend/modules/curator/test/com/keepit/curator/UriScoringHelperTest.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/UriScoringHelperTest.scala
@@ -1,36 +1,26 @@
 package com.keepit.curator
 
 import com.keepit.common.cache.FakeCacheModule
-import com.keepit.common.db.{ Id, SequenceNumber }
+import com.keepit.common.db.Id
 import com.keepit.common.net.FakeHttpClientModule
-import com.keepit.common.time._
-import com.keepit.cortex.FakeCortexServiceClientModule
-import com.keepit.curator.commanders.{ UriWeightingHelper, UriScoringHelper }
-import com.keepit.curator.model.{ ScoredSeedItem, Keepers, SeedItem }
-import com.keepit.graph.{ FakeGraphServiceClientImpl, GraphServiceClient, FakeGraphServiceModule }
-import com.keepit.model.{ User, NormalizedURI }
-import org.specs2.mutable.Specification
-import com.keepit.common.concurrent.ExecutionContext
+import com.keepit.cortex.models.lda.{LDATopic, LDAUserURIInterestScores}
+import com.keepit.cortex.{CortexServiceClient, FakeCortexServiceClientImpl, FakeCortexServiceClientModule}
+import com.keepit.curator.commanders.{UriScoringHelper, UriWeightingHelper}
+import com.keepit.graph.{FakeGraphServiceClientImpl, FakeGraphServiceModule, GraphServiceClient}
 import com.keepit.heimdal.FakeHeimdalServiceClientModule
+import com.keepit.model.User
+import org.specs2.mutable.Specification
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class UriScoringHelperTest extends Specification with CuratorTestInjector {
+class UriScoringHelperTest extends Specification with CuratorTestInjector with CuratorTestHelpers {
   val modules = Seq(
     FakeGraphServiceModule(),
     FakeHttpClientModule(),
     FakeCortexServiceClientModule(),
     FakeCacheModule(),
     FakeHeimdalServiceClientModule())
-
-  private def makeSeedItems(): Seq[SeedItem] = {
-    val seedItem1 = SeedItem(userId = Id[User](42), uriId = Id[NormalizedURI](1), url = "url1", seq = SequenceNumber[SeedItem](1), priorScore = None, timesKept = 1000, lastSeen = currentDateTime, keepers = Keepers.TooMany, discoverable = true)
-    val seedItem2 = SeedItem(userId = Id[User](42), uriId = Id[NormalizedURI](2), url = "url2", seq = SequenceNumber[SeedItem](2), priorScore = None, timesKept = 10, lastSeen = currentDateTime, keepers = Keepers.ReasonableNumber(Seq(Id[User](1), Id[User](3))), discoverable = true)
-    val seedItem3 = SeedItem(userId = Id[User](42), uriId = Id[NormalizedURI](3), url = "url3", seq = SequenceNumber[SeedItem](3), priorScore = None, timesKept = 93, lastSeen = currentDateTime, keepers = Keepers.ReasonableNumber(Seq(Id[User](2))), discoverable = true)
-    val seedItem4 = SeedItem(userId = Id[User](42), uriId = Id[NormalizedURI](4), url = "url4", seq = SequenceNumber[SeedItem](4), priorScore = None, timesKept = 20, lastSeen = currentDateTime, keepers = Keepers.ReasonableNumber(Seq(Id[User](1), Id[User](2))), discoverable = true)
-    seedItem1 :: seedItem2 :: seedItem3 :: seedItem4 :: Nil
-  }
 
   "UriScoringHelper" should {
 
@@ -39,9 +29,16 @@ class UriScoringHelperTest extends Specification with CuratorTestInjector {
         val graph = inject[GraphServiceClient].asInstanceOf[FakeGraphServiceClientImpl]
         graph.setUserAndScorePairs()
 
+        // set expectation for cortex client request to test that the topics get passed through
+        val userId = Id[User](42)
+        val cortex = inject[CortexServiceClient].asInstanceOf[FakeCortexServiceClientImpl]
+        cortex.batchUserURIsInterestsExpectations(userId) = (0 until 4).map { i =>
+          LDAUserURIInterestScores(None, None, None, topic1 = Some(LDATopic(i + 1)), topic2 = Some(LDATopic(i + 2)))
+        }
+
         val uriScoringHelper = inject[UriScoringHelper]
         val uriBoostingHelper = inject[UriWeightingHelper]
-        val res = uriScoringHelper(uriBoostingHelper(makeSeedItems), Set.empty)
+        val res = uriScoringHelper(uriBoostingHelper(makeSeedItems(userId)), Set.empty)
 
         val scores = Await.result(res, Duration(10, "seconds"))
 
@@ -50,6 +47,12 @@ class UriScoringHelperTest extends Specification with CuratorTestInjector {
         scores(2).uriScores.socialScore should be > 0.0f
         scores(3).uriScores.socialScore should be > 0.0f
 
+        scores(0).topic1 === Some(LDATopic(1))
+        scores(0).topic2 === Some(LDATopic(2))
+        scores(1).topic1 === Some(LDATopic(2))
+        scores(1).topic2 === Some(LDATopic(3))
+        scores(2).topic1 === Some(LDATopic(3))
+        scores(2).topic2 === Some(LDATopic(4))
       }
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/integration/AutogenReaper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/integration/AutogenReaper.scala
@@ -138,7 +138,7 @@ private[integration] class AutogenReaper @Inject() (
         }
         db.readWrite { implicit s =>
           dues foreach { exp =>
-            userExperimentRepo.getAllUserExperiments(exp.userId) filter(_.id.isDefined) foreach { exp =>
+            userExperimentRepo.getAllUserExperiments(exp.userId) filter (_.id.isDefined) foreach { exp =>
               userExperimentRepo.delete(exp)
             }
           }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/InviteControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/InviteControllerTest.scala
@@ -94,7 +94,11 @@ class InviteControllerTest extends Specification with ShoeboxApplicationInjector
         val result = inviteController.acceptInvite(invite1.externalId)(request)
         val code = status(result)
         code !== FORBIDDEN
+
+        // if you get a 404 here make sure you have pulled the marketing submodule modules/shoebox/marketing
+        // run from repository root: git submodule update --init
         code === 200
+
         // landing page at this point -- we'll make sure cookie is set
         val invCookie = cookies(result).get("inv")
         invCookie.isDefined === true

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
@@ -2,6 +2,7 @@ package com.keepit.common.db.slick
 
 import com.keepit.common.db._
 import com.keepit.common.time._
+import com.keepit.cortex.models.lda.LDATopic
 import com.keepit.heimdal.DelightedAnswerSource
 import com.keepit.model._
 import java.sql.{ Clob, Date, Timestamp }
@@ -76,6 +77,7 @@ trait FortyTwoGenericTypeMappers { self: { val db: DataBaseComponent } =>
   implicit val libraryKindTypeMapper = MappedColumnType.base[LibraryKind, String](_.value, LibraryKind.apply)
   implicit val userValueNameTypeMapper = MappedColumnType.base[UserValueName, String](_.name, UserValueName.apply)
   implicit val hashtagTypeMapper = MappedColumnType.base[Hashtag, String](_.tag, Hashtag.apply)
+  implicit def ldaTopicMapper = MappedColumnType.base[LDATopic, Int](_.index, LDATopic(_))
 
   implicit def experimentTypeProbabilityDensityMapper[T](implicit outcomeFormat: Format[T]) = MappedColumnType.base[ProbabilityDensity[T], String](
     obj => Json.stringify(ProbabilityDensity.format[T].writes(obj)),


### PR DESCRIPTION
@stkem @yingjieMiao @leogrim 

With topics stored for URI recommendations, the recommendation retrieval algorithm (enabled by experiment) groups recommendations by primary topic (topic1) and applies an exponential decay function the scores of URIs (sorted by score descending).

I tested a few coefficients for the function, and ended with going with 1/15, which would mean the 2nd recommendation in a topic has a score multiplier of 0.93, the 5th has .71.  Of course we'll adjust this coefficient (or improve the algorithm), but my goal was to not apply too big of a decay that we end up rejecting great recommendations in favor of mediocre ones.
