### PR TITLE
parsing the keep image file extension from the URL path

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -8,7 +8,7 @@ import java.security.MessageDigest
 import javax.imageio.ImageIO
 
 import com.keepit.common.core.File
-import com.keepit.common.net.WebService
+import com.keepit.common.net.{ URI, WebService }
 import com.keepit.common.service.RequestConsolidator
 import com.keepit.common.store.ImageSize
 import com.keepit.model.{ ImageFormat, ImageHash, KeepImage }
@@ -134,7 +134,8 @@ trait ProcessedImageHelper {
         case (headers, streamBody) =>
           val formatOpt = headers.headers.get("Content-Type").flatMap(_.headOption)
             .flatMap(mimeTypeToImageFormat).orElse {
-              imageFilenameToFormat(imageUrl.substring(imageUrl.lastIndexOf(".") + 1))
+              val path = URI.parse(imageUrl).toOption.flatMap(_.path).getOrElse(imageUrl)
+              imageFilenameToFormat(path.substring(path.lastIndexOf('.') + 1))
             }
 
           if (headers.status != 200) {

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/ProcessedImageHelperTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/ProcessedImageHelperTest.scala
@@ -145,7 +145,7 @@ class ProcessedImageHelperTest extends Specification with ShoeboxTestInjector wi
           // detect image format from file extension in URL
           {
             respondWith(None, tinyPng)
-            val respF = fetchRemoteImage("http://www.example.com/foo.png")
+            val respF = fetchRemoteImage("http://www.example.com/foo.png?crop=1xw:0.932295719844358xh;*,*&resize=2300:*&output-format=jpeg&output-quality=90")
             val (format, tmpFile) = Await.result(respF, Duration("1s"))
             format === ImageFormat.PNG
             tmpFile.file.getName must endWith(".png")


### PR DESCRIPTION
@eishay 

This fixes the exact case I encountered, at least, which was:
http://images.vice.com/motherboard/content-images/article/17117/1416839855864368.png?crop=1xw:0.932295719844358xh;*,*&resize=2300:*&output-format=jpeg&output-quality=90

https://app.asana.com/0/18005085042422/21147414406232
