### PR TITLE
sniffing the content type from a downloaded file if necessary

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -140,10 +140,8 @@ trait ProcessedImageHelper {
 
           if (headers.status != 200) {
             Future.failed(new RuntimeException(s"Image returned non-200 code, ${headers.status}, $imageUrl"))
-          } else if (formatOpt.isEmpty) {
-            Future.failed(new RuntimeException(s"Unknown image type, ${headers.headers.get("Content-Type")}, $imageUrl"))
           } else {
-            val tempFile = TemporaryFile(prefix = "remote-file", suffix = "." + formatOpt.get.value)
+            val tempFile = TemporaryFile(prefix = "remote-file")
             tempFile.file.deleteOnExit()
             val outputStream = new FileOutputStream(tempFile.file)
 
@@ -160,11 +158,17 @@ trait ProcessedImageHelper {
               }
             }
 
-            streamBody.run(iteratee).andThen {
-              case result =>
+            streamBody.run(iteratee) andThen {
+              case _ =>
                 outputStream.close()
-                result.get
-            }.map(_ => (formatOpt.get, tempFile))
+            } flatMap { _ =>
+              formatOpt.orElse(detectImageType(tempFile)) map { format =>
+                Future.successful((format, tempFile))
+              } getOrElse {
+                tempFile.file.delete
+                Future.failed(new Exception(s"Unknown image type, ${headers.headers.get("Content-Type")}, $imageUrl"))
+              }
+            }
           }
       }
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -165,7 +165,6 @@ trait ProcessedImageHelper {
               formatOpt.orElse(detectImageType(tempFile)) map { format =>
                 Future.successful((format, tempFile))
               } getOrElse {
-                tempFile.file.delete
                 Future.failed(new Exception(s"Unknown image type, ${headers.headers.get("Content-Type")}, $imageUrl"))
               }
             }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/ProcessedImageHelperTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/ProcessedImageHelperTest.scala
@@ -130,40 +130,44 @@ class ProcessedImageHelperTest extends Specification with ShoeboxTestInjector wi
           {
             respondWith(Some("image/png"), tinyPng)
             val respF = fetchRemoteImage("http://www.example.com/foo?bar=baz")
-            val (format, tmpFile) = Await.result(respF, Duration("1s"))
+            val (format, _) = Await.result(respF, Duration("1s"))
             format === ImageFormat.PNG
-            tmpFile.file.getName must endWith(".png")
           }
           {
             respondWith(Some("image/jpeg"), tinyJpg)
             val respF = fetchRemoteImage("http://www.example.com/")
-            val (format, tmpFile) = Await.result(respF, Duration("1s"))
+            val (format, _) = Await.result(respF, Duration("1s"))
             format === ImageFormat.JPG
-            tmpFile.file.getName must endWith(".jpg")
           }
 
           // detect image format from file extension in URL
           {
             respondWith(None, tinyPng)
             val respF = fetchRemoteImage("http://www.example.com/foo.png?crop=1xw:0.932295719844358xh;*,*&resize=2300:*&output-format=jpeg&output-quality=90")
-            val (format, tmpFile) = Await.result(respF, Duration("1s"))
+            val (format, _) = Await.result(respF, Duration("1s"))
             format === ImageFormat.PNG
-            tmpFile.file.getName must endWith(".png")
           }
           {
             respondWith(None, tinyJpg)
             val respF = fetchRemoteImage("http://www.example.com/foo.jpg")
-            val (format, tmpFile) = Await.result(respF, Duration("1s"))
+            val (format, _) = Await.result(respF, Duration("1s"))
             format === ImageFormat.JPG
-            tmpFile.file.getName must endWith(".jpg")
           }
 
-          // detect image format from file content (TODO)
+          // detect image format from file content
           {
             respondWith(None, tinyPng)
+            val respF = fetchRemoteImage("http://www.example.com/foo?bar=baz")
+            val (format, _) = Await.result(respF, Duration("1s"))
+            format === ImageFormat.PNG
+          }
+
+          // handle invalid images
+          {
+            respondWith(None, new Array[Byte](0))
             val respF = fetchRemoteImage("http://www.example.com/foo")
             Await.result(respF, Duration("1s"))
-          } must throwA[RuntimeException].like {
+          } must throwA[Exception].like {
             case e =>
               e.getMessage must startWith("Unknown image type, None")
           }


### PR DESCRIPTION
@andrewconner @eishay 

We were only using `URLConnection.guessContentTypeFromStream` on uploaded images, so this is a quick fix to use it on downloaded files too.

Potential optimizations:
- [`URLConnection.guessContentTypeFromStream`](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/7-b147/java/net/URLConnection.java#URLConnection.guessContentTypeFromStream%28java.io.InputStream%29) only uses the first 16 bytes of a stream. We could run it much sooner than when the download completes.
- We could also reject large files much earlier based on the `Content-Length` header.
