### PR TITLE
[DO NOT MERGE] Twitter token (oauth1a) support

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OAuth2TokenInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OAuth2TokenInfo.scala
@@ -2,7 +2,7 @@ package com.keepit.model
 
 import com.keepit.common.oauth2.OAuth2AccessToken
 import com.kifi.macros.json
-import securesocial.core.OAuth2Info
+import securesocial.core.{ OAuth1Info, OAuth2Info }
 
 // replaces securesocial.core.OAuth2Info
 @json case class OAuth2TokenInfo(
@@ -18,4 +18,11 @@ object OAuth2TokenInfo {
     OAuth2Info(token.accessToken.token, token.tokenType, token.expiresIn, token.refreshToken)
   implicit def fromOAuth2Info(old: OAuth2Info): OAuth2TokenInfo =
     OAuth2TokenInfo(accessToken = OAuth2AccessToken(old.accessToken), old.tokenType, old.expiresIn, old.refreshToken)
+}
+
+@json case class OAuth1TokenInfo(token: String, secret: String)
+
+object OAuth1TokenInfo {
+  implicit def toOAuth1Info(token: OAuth1TokenInfo): OAuth1Info = OAuth1Info(token.token, token.secret)
+  implicit def fromOAuth1Info(old: OAuth1Info): OAuth1TokenInfo = OAuth1TokenInfo(old.token, old.secret)
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -212,6 +212,24 @@ class AuthController @Inject() (
     }
   }
 
+  def oauth1TokenSignup(providerName: String) = MaybeUserAction.async(parse.tolerantJson) { implicit request =>
+    request.body.asOpt[OAuth1TokenInfo] match {
+      case None =>
+        Future.successful(BadRequest(Json.obj("error" -> "invalid_token")))
+      case Some(oauth1Info) =>
+        authHelper.doOAuth1TokenSignup(providerName, oauth1Info)
+    }
+  }
+
+  def oauth1TokenLogin(providerName: String) = MaybeUserAction.async(parse.tolerantJson) { implicit request =>
+    request.body.asOpt[OAuth1TokenInfo] match {
+      case None =>
+        Future.successful(BadRequest(Json.obj("error" -> "invalid_token")))
+      case Some(oauth1Info) =>
+        authHelper.doOAuth1TokenLogin(providerName, oauth1Info)
+    }
+  }
+
   // one-step sign-up
   def emailSignup() = MaybeUserAction.async(parse.tolerantJson) { implicit request =>
     request.body.asOpt[UserPassFinalizeInfo] match {
@@ -400,7 +418,7 @@ class AuthController @Inject() (
         case request: NonUserRequest[_] =>
           if (request.identityOpt.isDefined) {
             val identity = request.identityOpt.get
-            if (identity.email.exists(e => authHelper.emailAddressMatchesSomeKifiUser(EmailAddress(e)))) {
+            if (identity.email.exists(e => authCommander.emailAddressMatchesSomeKifiUser(EmailAddress(e)))) {
               // No user exists, but social network identity’s email address matches a Kifi user
               Ok(views.html.auth.connectToAuthenticate(
                 emailAddress = identity.email.get,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -7,6 +7,7 @@ import com.keepit.common.net.UserAgent
 import com.google.inject.Inject
 import com.keepit.common.oauth2.adaptor.SecureSocialAdaptor
 import com.keepit.common.oauth2.{ OAuth2AccessToken, ProviderIds, ProviderRegistry }
+import play.api.libs.oauth.RequestToken
 import play.api.mvc._
 import play.api.http.{ Status, HeaderNames }
 import securesocial.core._
@@ -71,12 +72,6 @@ class AuthHelper @Inject() (
     implicit val secureSocialClientIds: SecureSocialClientIds,
     resetPasswordEmailSender: ResetPasswordEmailSender,
     fortytwoConfig: FortyTwoConfig) extends HeaderNames with Results with Status with Logging {
-
-  def emailAddressMatchesSomeKifiUser(addr: EmailAddress): Boolean = {
-    db.readOnlyMaster { implicit s =>
-      emailAddressRepo.getByAddressOpt(addr).isDefined
-    }
-  }
 
   def connectOptionView(email: EmailAddress, providerId: String) = {
     log.info(s"[connectOptionView] $email matches some kifi user, but no (social) user exists given $providerId")
@@ -475,65 +470,28 @@ class AuthHelper @Inject() (
               OAuth2TokenInfo.fromOAuth2Info(oauth2InfoOrig)
           }
           longTermTokenInfoF map { oauth2InfoNew =>
-            val updatedUser = filledUser.copy(oAuth2Info = Some(oauth2InfoNew))
-            authCommander.getSocialUserOpt(updatedUser.identityId) match {
-              case None =>
-                db.readWrite { implicit rw =>
-                  // userId must not be set in this case
-                  socialRepo.save(SocialUserInfo(
-                    fullName = updatedUser.fullName,
-                    pictureUrl = updatedUser.avatarUrl,
-                    state = SocialUserInfoStates.FETCHED_USING_SELF,
-                    socialId = SocialId(updatedUser.identityId.userId),
-                    networkType = SocialNetworkType(updatedUser.identityId.providerId),
-                    credentials = Some(updatedUser)
-                  ))
-                } tap { sui => log.info(s"[doAccessTokenSignup] created socialUserInfo(${sui.id}) $updatedUser") }
-                val payload = if (updatedUser.email.exists(e => emailAddressMatchesSomeKifiUser(EmailAddress(e))))
-                  Json.obj("code" -> "connect_option", "uri" -> signUpUrl)
-                else
-                  Json.obj("code" -> "continue_signup")
-                log.info(s"[accessTokenSignup($providerName)] created social user(${updatedUser.identityId}) email=${updatedUser.email}; payload=$payload")
-                Authenticator.create(updatedUser).fold(
-                  error => throw error,
-                  authenticator =>
-                    Ok(payload ++ Json.obj("sessionId" -> authenticator.id))
-                      .withSession(request.session - SecureSocial.OriginalUrlKey - IdentityProvider.SessionId - OAuth1Provider.CacheKey)
-                      .withCookies(authenticator.toCookie)
-                )
-              case Some(identity) => // social user exists
-                db.readOnlyMaster(attempts = 2) { implicit s =>
-                  socialRepo.getOpt(SocialId(identity.identityId.userId), SocialNetworkType(identity.identityId.providerId)) flatMap (_.userId)
-                } match {
-                  case None => // kifi user does not exist
-                    val payload = if (updatedUser.email.exists(e => emailAddressMatchesSomeKifiUser(EmailAddress(e))))
-                      Json.obj("code" -> "connect_option", "uri" -> signUpUrl)
-                    else
-                      Json.obj("code" -> "continue_signup")
-                    log.info(s"[accessTokenSignup($providerName)] no kifi user associated with ${updatedUser.identityId} email=${updatedUser.email}; payload=$payload")
-                    Authenticator.create(identity).fold(
-                      error => throw error,
-                      authenticator =>
-                        Ok(payload ++ Json.obj("sessionId" -> authenticator.id))
-                          .withSession(request.session - SecureSocial.OriginalUrlKey - IdentityProvider.SessionId - OAuth1Provider.CacheKey)
-                          .withCookies(authenticator.toCookie)
-                    )
-                  case Some(userId) =>
-                    val newSession = Events.fire(new LoginEvent(identity)).getOrElse(request.session)
-                    Authenticator.create(identity).fold(
-                      error => throw error,
-                      authenticator =>
-                        Ok(Json.obj("code" -> "user_logged_in", "sessionId" -> authenticator.id))
-                          .withSession(newSession - SecureSocial.OriginalUrlKey - IdentityProvider.SessionId - OAuth1Provider.CacheKey)
-                          .withCookies(authenticator.toCookie)
-                    )
-                }
-            }
+            authCommander.signupWithTrustedSocialUser(providerName, filledUser.copy(oAuth2Info = Some(oauth2InfoNew)), signUpUrl)
           }
         } recover {
           case t: Throwable =>
             airbrakeNotifier.notify(s"[accessTokenSignup($providerName)] Caught Exception($t) during getUserProfileInfo; token=${oauth2InfoOrig}; Cause:${t.getCause}; StackTrace: ${t.getStackTraceString}")
             BadRequest(Json.obj("error" -> "invalid_token"))
+        }
+    }
+  }
+
+  def doOAuth1TokenSignup(providerName: String, oauth1Info: OAuth1Info)(implicit request: Request[JsValue]): Future[Result] = {
+    Registry.providers.get(providerName) match {
+      case None =>
+        log.error(s"[accessTokenSignup($providerName)] Failed to retrieve provider; request=${request.body}")
+        Future.successful(BadRequest(Json.obj("error" -> "invalid_arguments")))
+      case Some(provider) =>
+        authCommander.fillUserProfile(provider, oauth1Info) match {
+          case Failure(t) =>
+            airbrakeNotifier.notify(s"[accessTokenSignup($providerName)] Caught Exception($t) during getUserProfileInfo; token=${oauth1Info}; Cause:${t.getCause}; StackTrace: ${t.getStackTraceString}")
+            Future.successful(BadRequest(Json.obj("error" -> "invalid_token")))
+          case Success(filledUser) =>
+            Future.successful(authCommander.signupWithTrustedSocialUser(providerName, filledUser, signUpUrl))
         }
     }
   }
@@ -550,6 +508,21 @@ class AuthHelper @Inject() (
           case t: Throwable =>
             log.error(s"[accessTokenLogin($providerName)] Caught Exception($t) during getUserProfileInfo; token=${oAuth2Info}; Cause:${t.getCause}; StackTrace: ${t.getStackTraceString}")
             BadRequest(Json.obj("error" -> "invalid_token"))
+        }
+    }
+  }
+
+  def doOAuth1TokenLogin(providerName: String, oauth1Info: OAuth1Info)(implicit request: Request[JsValue]): Future[Result] = {
+    Registry.providers.get(providerName) match {
+      case None =>
+        Future.successful(BadRequest(Json.obj("error" -> "invalid_arguments")))
+      case Some(provider) =>
+        authCommander.fillUserProfile(provider, oauth1Info) match {
+          case Failure(t) =>
+            log.error(s"[doOAuth1TokenLogin($providerName)] Caught Exception($t) during getUserProfileInfo; token=${oauth1Info}; Cause:${t.getCause}; StackTrace: ${t.getStackTraceString}")
+            Future.successful(BadRequest(Json.obj("error" -> "invalid_token")))
+          case Success(filledUser) =>
+            Future.successful(authCommander.loginWithTrustedSocialIdentity(filledUser.identityId))
         }
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileAuthController.scala
@@ -16,8 +16,9 @@ import com.keepit.social.providers.ProviderController
 import com.keepit.social.{ SocialNetworkType, UserIdentity }
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.{ JsNumber, JsValue, Json }
+import play.api.libs.oauth.RequestToken
 import play.api.mvc.{ Cookie, Result, Session }
-import securesocial.core.{ IdentityId, OAuth2Info, Registry, SecureSocial, SocialUser, UserService }
+import securesocial.core._
 
 import scala.concurrent.Future
 import scala.util.{ Failure, Success, Try }
@@ -135,6 +136,24 @@ class MobileAuthController @Inject() (
         Future.successful(BadRequest(Json.obj("error" -> "invalid_token")))
       case Some(oauth2Info) =>
         authHelper.doAccessTokenLogin(providerName, oauth2Info)
+    }
+  }
+
+  def oauth1TokenSignup(providerName: String) = MaybeUserAction.async(parse.tolerantJson) { implicit request =>
+    request.body.asOpt[OAuth1TokenInfo] match {
+      case None =>
+        Future.successful(BadRequest(Json.obj("error" -> "invalid_token")))
+      case Some(oauth1Info) =>
+        authHelper.doOAuth1TokenSignup(providerName, oauth1Info)
+    }
+  }
+
+  def oauth1TokenLogin(providerName: String) = MaybeUserAction.async(parse.tolerantJson) { implicit request =>
+    request.body.asOpt[OAuth1TokenInfo] match {
+      case None =>
+        Future.successful(BadRequest(Json.obj("error" -> "invalid_token")))
+      case Some(oauth1Info) =>
+        authHelper.doOAuth1TokenLogin(providerName, oauth1Info)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileAuthController.scala
@@ -18,7 +18,7 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.{ JsNumber, JsValue, Json }
 import play.api.libs.oauth.RequestToken
 import play.api.mvc.{ Cookie, Result, Session }
-import securesocial.core._
+import securesocial.core.{ IdentityId, OAuth2Info, Registry, SecureSocial, SocialUser, UserService }
 
 import scala.concurrent.Future
 import scala.util.{ Failure, Success, Try }

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -22,6 +22,8 @@ POST    /auth/email-finalize        @com.keepit.controllers.core.AuthController.
 POST    /auth/social-finalize       @com.keepit.controllers.core.AuthController.socialFinalizeAccountAction()
 POST    /auth/token-login/:provider  @com.keepit.controllers.core.AuthController.accessTokenLogin(provider: String)
 POST    /auth/token-signup/:provider @com.keepit.controllers.core.AuthController.accessTokenSignup(provider: String)
+POST    /auth/oauth1-login/:provider  @com.keepit.controllers.core.AuthController.oauth1TokenLogin(provider: String)
+POST    /auth/oauth1-signup/:provider @com.keepit.controllers.core.AuthController.oauth1TokenSignup(provider: String)
 POST    /auth/token-finalize         @com.keepit.controllers.core.AuthController.tokenFinalizeAccountAction()
 POST    /auth/email-signup           @com.keepit.controllers.core.AuthController.emailSignup()
 POST    /auth/upload-binary-image   @com.keepit.controllers.core.AuthController.uploadBinaryPicture()
@@ -46,6 +48,7 @@ GET     /link/:provider             @com.keepit.controllers.core.AuthController.
 
 GET     /signup/:provider           @com.keepit.controllers.core.AuthController.signup(provider)
 
+# do we still use this endpoint?
 POST    /mobileauth/:provider       @com.keepit.controllers.mobile.MobileAuthController.accessTokenLogin(provider)
 
 GET     /verify/:code               @com.keepit.controllers.core.AuthController.verifyEmail(code)
@@ -179,13 +182,15 @@ GET     /m/1/keeps/all                      @com.keepit.controllers.mobile.Mobil
 POST    /m/1/tags/:id/addToKeep             @com.keepit.controllers.mobile.MobileKeepsController.addTag(id: ExternalId[Collection])
 POST    /m/1/tags/:id/removeFromKeep        @com.keepit.controllers.mobile.MobileKeepsController.removeTag(id: ExternalId[Collection])
 
+POST    /m/1/auth/accessTokenSignup/:provider   @com.keepit.controllers.mobile.MobileAuthController.accessTokenSignup(provider)
 POST    /m/1/auth/accessTokenLogin/:provider    @com.keepit.controllers.mobile.MobileAuthController.accessTokenLogin(provider)
+POST    /m/1/auth/oauth1TokenSignup/:provider   @com.keepit.controllers.mobile.MobileAuthController.oauth1TokenSignup(provider)
+POST    /m/1/auth/oauth1TokenLogin/:provider    @com.keepit.controllers.mobile.MobileAuthController.oauth1TokenLogin(provider)
 POST    /m/1/auth/log-in                        @com.keepit.controllers.mobile.MobileAuthController.loginWithUserPass(link: String ?= "")
 POST    /m/1/auth/upload-binary-image           @com.keepit.controllers.mobile.MobileAuthController.uploadBinaryPicture()
 POST    /m/1/auth/upload-multipart-image        @com.keepit.controllers.mobile.MobileAuthController.uploadFormEncodedPicture()
 POST    /m/1/auth/sign-up                       @com.keepit.controllers.mobile.MobileAuthController.userPasswordSignup()
 POST    /m/1/auth/email-finalize                @com.keepit.controllers.mobile.MobileAuthController.userPassFinalizeAccountAction()
-POST    /m/1/auth/accessTokenSignup/:provider   @com.keepit.controllers.mobile.MobileAuthController.accessTokenSignup(provider)
 POST    /m/1/auth/social-finalize               @com.keepit.controllers.mobile.MobileAuthController.socialFinalizeAccountAction()
 
 POST    /m/1/social-link/:provider              @com.keepit.controllers.mobile.MobileAuthController.linkSocialNetwork(provider)


### PR DESCRIPTION
Twitter token (oauth1a) support
Refactored token-based sign-up/login code for sharing

OAuth2 token based code paths are already covered
OAuth1a token based code paths are still based on `SecureSocial` -- tested locally
If we have time, will try to factor out OAuth1a from `SecureSocial` similar to how OAuth2 providers were factored out earlier

Actually this can be merged -- the `DO NOT MERGE` is really `hold off` until tomorrow when everyone is in office and can test/react in a timely manner.

@andrewconner 

cc: @jaredpetker @thassss -- in theory, you can start testing the endpoints
