### PR TITLE
mobile endpoints: add, modify, delete libraries

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -35,11 +35,11 @@ class MobileLibraryController @Inject() (
 
   def createLibrary() = UserAction(parse.tolerantJson) { request =>
     val jsonBody = request.body
-    val title = (jsonBody \ "title").as[String]
+    val name = (jsonBody \ "name").as[String]
     val description = (jsonBody \ "description").asOpt[String]
     val visibility = (jsonBody \ "visibility").as[LibraryVisibility]
-    val slug = LibrarySlug.generateFromName(title)
-    val addRequest = LibraryAddRequest(title, visibility, description, slug)
+    val slug = LibrarySlug.generateFromName(name)
+    val addRequest = LibraryAddRequest(name, visibility, description, slug)
 
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
     libraryCommander.addLibrary(addRequest, request.userId) match {
@@ -53,7 +53,7 @@ class MobileLibraryController @Inject() (
   def modifyLibrary(pubId: PublicId[Library]) = (UserAction andThen LibraryWriteAction(pubId))(parse.tolerantJson) { request =>
     val libId = Library.decodePublicId(pubId).get
     val json = request.body
-    val newName = (json \ "newTitle").asOpt[String]
+    val newName = (json \ "newName").asOpt[String]
     val newDescription = (json \ "newDescription").asOpt[String]
     val newVisibility = (json \ "newVisibility").asOpt[LibraryVisibility]
     val newSlug = (json \ "newSlug").asOpt[String]

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -33,6 +33,49 @@ class MobileLibraryController @Inject() (
   implicit val config: PublicIdConfiguration)
     extends UserActions with LibraryAccessActions with ShoeboxServiceController {
 
+  def createLibrary() = UserAction(parse.tolerantJson) { request =>
+    val jsonBody = request.body
+    val title = (jsonBody \ "title").as[String]
+    val description = (jsonBody \ "description").asOpt[String]
+    val visibility = (jsonBody \ "visibility").as[LibraryVisibility]
+    val slug = LibrarySlug.generateFromName(title)
+    val addRequest = LibraryAddRequest(title, visibility, description, slug)
+
+    implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
+    libraryCommander.addLibrary(addRequest, request.userId) match {
+      case Left(fail) => Status(fail.status)(Json.obj("error" -> fail.message))
+      case Right(lib) =>
+        val (owner, numKeeps) = db.readOnlyMaster { implicit s => (basicUserRepo.load(lib.ownerId), keepRepo.getCountByLibrary(lib.id.get)) }
+        Ok(Json.toJson(LibraryInfo.fromLibraryAndOwner(lib, owner, numKeeps, None)))
+    }
+  }
+
+  def modifyLibrary(pubId: PublicId[Library]) = (UserAction andThen LibraryWriteAction(pubId))(parse.tolerantJson) { request =>
+    val libId = Library.decodePublicId(pubId).get
+    val json = request.body
+    val newName = (json \ "newTitle").asOpt[String]
+    val newDescription = (json \ "newDescription").asOpt[String]
+    val newVisibility = (json \ "newVisibility").asOpt[LibraryVisibility]
+    val newSlug = (json \ "newSlug").asOpt[String]
+    val res = libraryCommander.modifyLibrary(libId, request.userId, newName, newDescription, newSlug, newVisibility)
+    res match {
+      case Left(fail) =>
+        Status(fail.status)(Json.obj("error" -> fail.message))
+      case Right(lib) =>
+        val (owner, numKeeps) = db.readOnlyMaster { implicit s => (basicUserRepo.load(lib.ownerId), keepRepo.getCountByLibrary(libId)) }
+        Ok(Json.toJson(LibraryInfo.fromLibraryAndOwner(lib, owner, numKeeps, None)))
+    }
+  }
+
+  def deleteLibrary(pubId: PublicId[Library]) = (UserAction andThen LibraryWriteAction(pubId)) { request =>
+    val libId = Library.decodePublicId(pubId).get
+    implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
+    libraryCommander.removeLibrary(libId, request.userId) match {
+      case Some(fail) => Status(fail.status)(Json.obj("error" -> fail.message))
+      case _ => NoContent
+    }
+  }
+
   def getLibraryById(pubId: PublicId[Library]) = (MaybeUserAction andThen LibraryViewAction(pubId)).async { request =>
     val id = Library.decodePublicId(pubId).get
     libraryCommander.getLibraryById(request.userIdOpt, false, id) map {
@@ -212,7 +255,6 @@ class MobileLibraryController @Inject() (
       case _ => Future.successful(Forbidden)
     }
   }
-
 }
 
 private object ImplicitHelper {

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -229,6 +229,9 @@ GET     /m/1/recos/public                       @com.keepit.controllers.mobile.M
 POST    /m/1/recos/trash                        @com.keepit.controllers.mobile.MobileRecommendationsController.trash(id: ExternalId[NormalizedURI])
 
 GET     /m/1/users/:userStr/libraries/:slug     @com.keepit.controllers.mobile.MobileLibraryController.getLibraryByPath(userStr:String, slug: String)
+POST    /m/1/libraries/add                      @com.keepit.controllers.mobile.MobileLibraryController.createLibrary()
+POST    /m/1/libraries/:id/modify               @com.keepit.controllers.mobile.MobileLibraryController.modifyLibrary(id: PublicId[Library])
+POST    /m/1/libraries/:id/delete               @com.keepit.controllers.mobile.MobileLibraryController.deleteLibrary(id: PublicId[Library])
 GET     /m/1/libraries                          @com.keepit.controllers.mobile.MobileLibraryController.getLibrarySummariesByUser()
 GET     /m/1/libraries/:id                      @com.keepit.controllers.mobile.MobileLibraryController.getLibraryById(id: PublicId[Library])
 POST    /m/1/libraries/:id/join                 @com.keepit.controllers.mobile.MobileLibraryController.joinLibrary(id: PublicId[Library])

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
@@ -60,7 +60,7 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
         }
 
         // add new library
-        val jsBody1 = Json.obj("title" -> "Drones stuff", "visibility" -> "published")
+        val jsBody1 = Json.obj("name" -> "Drones stuff", "visibility" -> "published")
         val result1 = createLibrary(user, jsBody1)
         status(result1) must equalTo(OK)
         contentType(result1) must beSome("application/json")
@@ -71,7 +71,7 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
         (resultJson \ "url").as[String] === "/r2d2/drones-stuff"
 
         // add library with same title
-        val jsBody2 = Json.obj("title" -> "Drones stuff", "visibility" -> "secret")
+        val jsBody2 = Json.obj("name" -> "Drones stuff", "visibility" -> "secret")
         val result2 = createLibrary(user, jsBody2)
         status(result2) must equalTo(BAD_REQUEST)
 
@@ -93,7 +93,7 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
         lib1.slug.value === "krabby-patty"
 
         // change fields (to something different)
-        val jsBody1 = Json.obj("newTitle" -> "Feed Gary", "newDescription" -> "qwer", "newVisibility" -> "secret", "newSlug" -> "feed-gary")
+        val jsBody1 = Json.obj("newName" -> "Feed Gary", "newDescription" -> "qwer", "newVisibility" -> "secret", "newSlug" -> "feed-gary")
         val result1 = modifyLibrary(user, pubLib1, jsBody1)
         status(result1) must equalTo(OK)
         contentType(result1) must beSome("application/json")
@@ -104,7 +104,7 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
         (resultJson \ "url").as[String] === "/spongebob/feed-gary"
 
         // change a library title to an existing library's title
-        val result2 = modifyLibrary(user, pubLib1, Json.obj("newTitle" -> lib2.name))
+        val result2 = modifyLibrary(user, pubLib1, Json.obj("newName" -> lib2.name))
         status(result2) must equalTo(BAD_REQUEST)
 
         // change a library slug to an existing library's slug

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
@@ -11,6 +11,7 @@ import com.keepit.common.mail.EmailAddress
 import com.keepit.common.social.FakeSocialGraphModule
 import com.keepit.common.store.FakeShoeboxStoreModule
 import com.keepit.common.time._
+import com.keepit.controllers.ext.routes
 import com.keepit.cortex.FakeCortexServiceClientModule
 import com.keepit.curator.FakeCuratorServiceClientModule
 import com.keepit.heimdal.FakeHeimdalServiceClientModule
@@ -18,11 +19,12 @@ import com.keepit.model._
 import com.keepit.scraper.{ FakeScraperServiceClientModule, FakeScrapeSchedulerModule }
 import com.keepit.search.FakeSearchServiceClientModule
 import com.keepit.shoebox.FakeShoeboxServiceModule
+import com.keepit.social.BasicUser
 import com.keepit.test.ShoeboxTestInjector
 import org.joda.time.DateTime
 import com.keepit.common.time.internalTime.DateTimeJsonLongFormat
 import org.specs2.mutable.Specification
-import play.api.libs.json.Json
+import play.api.libs.json.{ JsObject, Json }
 import play.api.mvc.{ Result, Call }
 import scala.concurrent.Future
 import play.api.test.FakeRequest
@@ -47,6 +49,211 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
   )
 
   "MobileLibraryController" should {
+
+    "create library" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val t1 = new DateTime(2013, 2, 14, 21, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
+        val user = db.readWrite { implicit s =>
+          val user = userRepo.save(User(firstName = "R2", lastName = "D2", createdAt = t1, username = Username("r2d2"), normalizedUsername = "r2d2"))
+          libraryRepo.getAllByOwner(user.id.get).length === 0
+          user
+        }
+
+        // add new library
+        val jsBody1 = Json.obj("title" -> "Drones stuff", "visibility" -> "published")
+        val result1 = createLibrary(user, jsBody1)
+        status(result1) must equalTo(OK)
+        contentType(result1) must beSome("application/json")
+        val resultJson = contentAsJson(result1)
+        (resultJson \ "name").as[String] === "Drones stuff"
+        (resultJson \ "visibility").as[LibraryVisibility] === LibraryVisibility.PUBLISHED
+        (resultJson \ "owner").as[BasicUser].firstName === "R2"
+        (resultJson \ "url").as[String] === "/r2d2/drones-stuff"
+
+        // add library with same title
+        val jsBody2 = Json.obj("title" -> "Drones stuff", "visibility" -> "secret")
+        val result2 = createLibrary(user, jsBody2)
+        status(result2) must equalTo(BAD_REQUEST)
+
+        db.readOnlyMaster { implicit s =>
+          libraryRepo.getAllByOwner(user.id.get).length === 1
+        }
+      }
+    }
+
+    "modify library" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val (user, lib1, lib2, _, _) = setupTwoUsersThreeLibraries()
+        val pubLib1 = Library.publicId(lib1.id.get)(inject[PublicIdConfiguration])
+        val pubLib2 = Library.publicId(lib2.id.get)(inject[PublicIdConfiguration])
+
+        lib1.name === "Krabby Patty"
+        lib1.description.isEmpty === true
+        lib1.visibility === LibraryVisibility.SECRET
+        lib1.slug.value === "krabby-patty"
+
+        // change fields (to something different)
+        val jsBody1 = Json.obj("newTitle" -> "Feed Gary", "newDescription" -> "qwer", "newVisibility" -> "secret", "newSlug" -> "feed-gary")
+        val result1 = modifyLibrary(user, pubLib1, jsBody1)
+        status(result1) must equalTo(OK)
+        contentType(result1) must beSome("application/json")
+        val resultJson = contentAsJson(result1)
+        (resultJson \ "name").as[String] === "Feed Gary"
+        (resultJson \ "shortDescription").asOpt[String] === Some("qwer")
+        (resultJson \ "visibility").as[LibraryVisibility] === LibraryVisibility.SECRET
+        (resultJson \ "url").as[String] === "/spongebob/feed-gary"
+
+        // change a library title to an existing library's title
+        val result2 = modifyLibrary(user, pubLib1, Json.obj("newTitle" -> lib2.name))
+        status(result2) must equalTo(BAD_REQUEST)
+
+        // change a library slug to an existing library's slug
+        val result3 = modifyLibrary(user, pubLib1, Json.obj("newSlug" -> lib2.slug.value))
+        status(result3) must equalTo(BAD_REQUEST)
+      }
+    }
+
+    "delete library" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val (user, lib1, lib2, _, _) = setupTwoUsersThreeLibraries()
+        val pubLib1 = Library.publicId(lib1.id.get)(inject[PublicIdConfiguration])
+        val pubLib2 = Library.publicId(lib2.id.get)(inject[PublicIdConfiguration])
+
+        db.readOnlyMaster { implicit s =>
+          libraryRepo.getAllByOwner(user.id.get).length === 2
+        }
+
+        // delete both libraries
+        val result1 = deleteLibrary(user, pubLib1)
+        status(result1) must equalTo(NO_CONTENT)
+        val result2 = deleteLibrary(user, pubLib2)
+        status(result2) must equalTo(NO_CONTENT)
+
+        db.readOnlyMaster { implicit s =>
+          libraryRepo.getAllByOwner(user.id.get).length === 0
+        }
+      }
+    }
+
+    "get library by id" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val (user1, lib1) = setupOneUserOneLibrary()
+        val pubLib1 = Library.publicId(lib1.id.get)(inject[PublicIdConfiguration])
+
+        val result1 = getLibraryById(user1, pubLib1)
+        status(result1) must equalTo(OK)
+        contentType(result1) must beSome("application/json")
+        Json.parse(contentAsString(result1)) === Json.parse(
+          s"""
+             |{
+             |  "library" : {
+             |    "id" : "${pubLib1.id}",
+             |    "name" : "Krabby Patty",
+             |    "visibility" : "secret",
+             |    "slug" : "krabby-patty",
+             |    "url" : "/spongebob/krabby-patty",
+             |    "kind" : "user_created",
+             |    "owner" : {
+             |      "id" : "${user1.externalId}",
+             |      "firstName" : "Spongebob",
+             |      "lastName": "Squarepants",
+             |      "pictureName":"0.jpg",
+             |      "username":"spongebob"
+             |    },
+             |    "followers" : [],
+             |    "keeps" : [],
+             |    "numKeeps" : 0,
+             |    "numCollaborators" : 0,
+             |    "numFollowers" : 0 },
+             |  "membership" : "owner"
+             |}
+           """.stripMargin)
+      }
+    }
+
+    "join library" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val (user1, lib1, lib2, user2, _) = setupTwoUsersThreeLibraries()
+        val pubLib1 = Library.publicId(lib1.id.get)(inject[PublicIdConfiguration])
+        val pubLib2 = Library.publicId(lib2.id.get)(inject[PublicIdConfiguration])
+
+        db.readOnlyMaster { implicit s =>
+          libraryMembershipRepo.countWithLibraryId(lib1.id.get) === 1
+          libraryMembershipRepo.countWithLibraryId(lib2.id.get) === 1
+        }
+
+        // join a published library
+        val result1 = joinLibrary(user2, pubLib2)
+        status(result1) must equalTo(OK)
+
+        db.readOnlyMaster { implicit s =>
+          libraryMembershipRepo.countWithLibraryId(lib2.id.get) === 2
+        }
+
+        // join a secret library (no invite)
+        val result2 = joinLibrary(user2, pubLib1)
+        status(result2) must equalTo(FORBIDDEN)
+
+        // join a secret library (with invite)
+        val invite = db.readWrite { implicit s =>
+          libraryInviteRepo.save(LibraryInvite(inviterId = user1.id.get, libraryId = lib1.id.get, userId = Some(user2.id.get), access = LibraryAccess.READ_ONLY))
+        }
+        val result3 = joinLibrary(user2, pubLib1)
+        status(result3) must equalTo(OK)
+
+        db.readOnlyMaster { implicit s =>
+          libraryMembershipRepo.countWithLibraryId(lib1.id.get) === 2
+          libraryInviteRepo.get(invite.id.get).state === LibraryInviteStates.ACCEPTED
+        }
+      }
+    }
+
+    "decline library" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val (user1, lib1, _, user2, _) = setupTwoUsersThreeLibraries()
+        val pubLib1 = Library.publicId(lib1.id.get)(inject[PublicIdConfiguration])
+
+        val invite = db.readWrite { implicit s =>
+          libraryInviteRepo.save(LibraryInvite(inviterId = user1.id.get, libraryId = lib1.id.get, userId = Some(user2.id.get), access = LibraryAccess.READ_ONLY))
+        }
+
+        // decline library invite
+        val result1 = declineLibrary(user2, pubLib1)
+        status(result1) must equalTo(OK)
+
+        db.readOnlyMaster { implicit s =>
+          libraryInviteRepo.get(invite.id.get).state === LibraryInviteStates.DECLINED
+        }
+      }
+
+    }
+
+    "leave library" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val (user1, lib1, lib2, user2, _) = setupTwoUsersThreeLibraries()
+        val pubLib1 = Library.publicId(lib1.id.get)(inject[PublicIdConfiguration])
+        val pubLib2 = Library.publicId(lib2.id.get)(inject[PublicIdConfiguration])
+
+        db.readWrite { implicit s =>
+          libraryMembershipRepo.save(LibraryMembership(libraryId = lib1.id.get, userId = user2.id.get, access = LibraryAccess.READ_ONLY, showInSearch = true))
+          libraryMembershipRepo.countWithLibraryId(lib1.id.get) === 2
+        }
+
+        // leave a library (with membership)
+        val result1 = leaveLibrary(user2, pubLib1)
+        status(result1) must equalTo(OK)
+
+        // leave a library (is owner)
+        val result2 = leaveLibrary(user1, pubLib1)
+        status(result2) must equalTo(BAD_REQUEST)
+
+        db.readWrite { implicit s =>
+          libraryMembershipRepo.countWithLibraryId(lib1.id.get) === 1
+          libraryMembershipRepo.countWithLibraryId(lib2.id.get) === 1
+        }
+      }
+    }
+
     "get library members" in {
       withDb(controllerTestModules: _*) { implicit injector =>
         val t1 = new DateTime(2013, 2, 14, 21, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
@@ -120,9 +327,72 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
     }
   }
 
+  private def createLibrary(user: User, body: JsObject)(implicit injector: Injector): Future[Result] = {
+    inject[FakeUserActionsHelper].setUser(user)
+    controller.createLibrary()(request(routes.MobileLibraryController.createLibrary()).withBody(body))
+  }
+
+  private def modifyLibrary(user: User, libId: PublicId[Library], body: JsObject)(implicit injector: Injector): Future[Result] = {
+    inject[FakeUserActionsHelper].setUser(user)
+    controller.modifyLibrary(libId)(request(routes.MobileLibraryController.modifyLibrary(libId)).withBody(body))
+  }
+
+  private def deleteLibrary(user: User, libId: PublicId[Library])(implicit injector: Injector): Future[Result] = {
+    inject[FakeUserActionsHelper].setUser(user)
+    controller.deleteLibrary(libId)(request(routes.MobileLibraryController.deleteLibrary(libId)))
+  }
+
+  private def joinLibrary(user: User, libId: PublicId[Library])(implicit injector: Injector): Future[Result] = {
+    inject[FakeUserActionsHelper].setUser(user)
+    controller.joinLibrary(libId)(request(routes.MobileLibraryController.joinLibrary(libId)))
+  }
+
+  private def declineLibrary(user: User, libId: PublicId[Library])(implicit injector: Injector): Future[Result] = {
+    inject[FakeUserActionsHelper].setUser(user)
+    controller.declineLibrary(libId)(request(routes.MobileLibraryController.declineLibrary(libId)))
+  }
+
+  private def leaveLibrary(user: User, libId: PublicId[Library])(implicit injector: Injector): Future[Result] = {
+    inject[FakeUserActionsHelper].setUser(user)
+    controller.leaveLibrary(libId)(request(routes.MobileLibraryController.leaveLibrary(libId)))
+  }
+
+  private def getLibraryById(user: User, libId: PublicId[Library])(implicit injector: Injector): Future[Result] = {
+    inject[FakeUserActionsHelper].setUser(user)
+    controller.getLibraryById(libId)(request(routes.MobileLibraryController.getLibraryById(libId)))
+  }
+
   private def getMembers(user: User, libId: PublicId[Library], offset: Int, limit: Int)(implicit injector: Injector): Future[Result] = {
     inject[FakeUserActionsHelper].setUser(user)
     controller.getLibraryMembers(libId, offset, limit)(request(routes.MobileLibraryController.getLibraryMembers(libId, offset, limit)))
+  }
+
+  // User 'Spongebob' has one library called "Krabby Patty" (secret)
+  private def setupOneUserOneLibrary()(implicit injector: Injector) = {
+    val t1 = new DateTime(2014, 12, 1, 12, 0, 0, 0, DEFAULT_DATE_TIME_ZONE)
+    db.readWrite { implicit s =>
+      val user = userRepo.save(User(firstName = "Spongebob", lastName = "Squarepants", username = Username("spongebob"), normalizedUsername = "spongebob", createdAt = t1))
+      val library = libraryRepo.save(Library(name = "Krabby Patty", ownerId = user.id.get, visibility = LibraryVisibility.SECRET, slug = LibrarySlug("krabby-patty"), memberCount = 1, createdAt = t1.plusMinutes(1)))
+      libraryMembershipRepo.save(LibraryMembership(userId = user.id.get, libraryId = library.id.get, access = LibraryAccess.OWNER, showInSearch = true))
+      (user, library)
+    }
+  }
+
+  // User 'Spongebob' has two libraries called "Krabby Patty" (secret), "Catching Jellyfish" (published)
+  // User 'Patrick' has one library called "Nothing" (secret)
+  private def setupTwoUsersThreeLibraries()(implicit injector: Injector) = {
+    val t1 = new DateTime(2014, 12, 1, 12, 0, 0, 0, DEFAULT_DATE_TIME_ZONE)
+    val (user1, library1a) = setupOneUserOneLibrary()
+    val (library1b, user2, library2a) = db.readWrite { implicit s =>
+      val library1b = libraryRepo.save(Library(name = "Catching Jellyfish", ownerId = user1.id.get, visibility = LibraryVisibility.PUBLISHED, slug = LibrarySlug("catching-jellyfish"), memberCount = 1, createdAt = t1.plusMinutes(1)))
+      libraryMembershipRepo.save(LibraryMembership(userId = user1.id.get, libraryId = library1b.id.get, access = LibraryAccess.OWNER, showInSearch = true))
+
+      val user2 = userRepo.save(User(firstName = "C", lastName = "3PO", username = Username("c3po"), normalizedUsername = "c3po", createdAt = t1))
+      val library2a = libraryRepo.save(Library(name = "Nothing", ownerId = user2.id.get, visibility = LibraryVisibility.SECRET, slug = LibrarySlug("nothing"), memberCount = 1, createdAt = t1.plusMinutes(1)))
+      libraryMembershipRepo.save(LibraryMembership(userId = user2.id.get, libraryId = library2a.id.get, access = LibraryAccess.OWNER, showInSearch = true))
+      (library1b, user2, library2a)
+    }
+    (user1, library1a, library1b, user2, library2a)
   }
 
   private def controller(implicit injector: Injector) = inject[MobileLibraryController]


### PR DESCRIPTION
Mobile endpoints for:
- Create Library (POST /m/1/libraries/add)
  request: `{name, description, visibility}`, response: LibraryInfo + membership
- Modify Library (POST /m/1/libraries/:id/modify)
  request: `{newName, newDescription, newVisibility, newSlug}`, response: LibraryInfo + membership
- Delete Library (POST /m/1/libraries/:id/delete)
  (no body), response: `No Content`

with extra tests

keeps for libraries coming in a bit
@andrewconner @thassss @jaredpetker 
