### PR TITLE
Add cutPoint field to old search API (mobile)

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
@@ -59,7 +59,7 @@ object SearchConfig {
       "usefulPageBoost" -> "importance of usefulPage (clicked page)",
       "sharingBoostInNetwork" -> "importance of the number of friends sharing the bookmark",
       "sharingBoostOutOfNetwork" -> "importance of the number of others sharing the bookmark",
-      "percentMatch" -> "the minimum percentage of search terms have to match (weighted by IDF)",
+      "percentMatch" -> "the minimum percentage of search terms have to match (weighted by IDF) for a keep to show up",
       "halfDecayHours" -> "the time the recency boost becomes half",
       "recencyBoost" -> "importance of the recent bookmarks",
       "newContentBoost" -> "importance of a new content introduced to the network",
@@ -71,7 +71,9 @@ object SearchConfig {
       "forbidEmptyFriendlyHits" -> "when hits do not contain bookmarks from me or my friends, collapse results in the initial search",
       "proximityGapPenalty" -> "unit gap penalty, used in proximity query",
       "proximityPowerFactor" -> "raise proximity score to a power. Usually used in content field to penalize more on loose matches",
-      "messageHalfLifeHours" -> "exponential time decay constant used in message search"
+      "messageHalfLifeHours" -> "exponential time decay constant used in message search",
+      "minMyLibraries" -> "the minimum number of my libraries in a library search result",
+      "myLibraryBoost" -> "boost value for my own libraries in library search"
     )
 
   val empty = new SearchConfig(Map.empty)

--- a/kifi-backend/modules/search/app/com/keepit/controllers/util/SearchControllerUtil.scala
+++ b/kifi-backend/modules/search/app/com/keepit/controllers/util/SearchControllerUtil.scala
@@ -76,6 +76,7 @@ trait SearchControllerUtil {
       decoratedResult.othersTotal,
       decoratedResult.mayHaveMoreHits,
       decoratedResult.show,
+      decoratedResult.cutPoint,
       decoratedResult.searchExperimentId,
       IdFilterCompressor.fromSetToBase64(decoratedResult.idFilter),
       Nil).json

--- a/kifi-backend/modules/search/app/com/keepit/search/SearchBackwardCompatibilitySupport.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/SearchBackwardCompatibilitySupport.scala
@@ -95,6 +95,6 @@ class SearchBackwardCompatibilitySupport @Inject() (
     }
 
     val detailedSearchHits = monitoredAwait.result(future, 3 seconds, "slow augmentation")
-    PartialSearchResult(detailedSearchHits, result.myTotal, result.friendsTotal, result.othersTotal, friendStats, result.show)
+    PartialSearchResult(detailedSearchHits, result.myTotal, result.friendsTotal, result.othersTotal, friendStats, result.show, result.cutPoint)
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/result/KifiShardResultMerger.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/result/KifiShardResultMerger.scala
@@ -66,7 +66,7 @@ class KifiShardResultMerger(enableTailCutting: Boolean, config: SearchConfig) {
     // compute high score excluding others (an orphan uri sometimes makes results disappear)
     // and others high score (used for tailcutting of others hits)
     val highScore = {
-      var highScore = max(myHits.highScore, friendsHits.highScore)
+      val highScore = max(myHits.highScore, friendsHits.highScore)
       if (highScore > 0.0f) highScore else max(othersHits.highScore, highScore)
     }
 
@@ -74,7 +74,7 @@ class KifiShardResultMerger(enableTailCutting: Boolean, config: SearchConfig) {
     if (myHits.size > 0) {
       myHits.toRankedIterator.foreach {
         case (hit, rank) =>
-          var score = (hit.score / highScore) * dampFunc(rank, dampingHalfDecayMine) // damping the scores by rank
+          val score = (hit.score / highScore) * dampFunc(rank, dampingHalfDecayMine) // damping the scores by rank
           hits.insert(score, null, hit.hit)
       }
     }

--- a/kifi-backend/modules/search/app/com/keepit/search/result/KifiSearchResult.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/result/KifiSearchResult.scala
@@ -28,6 +28,7 @@ object KifiSearchResult extends Logging {
     othersTotal: Int,
     mayHaveMoreHits: Boolean,
     show: Boolean,
+    cutPoint: Int,
     experimentId: Option[Id[SearchConfigExperiment]],
     context: String,
     collections: Seq[ExternalId[Collection]]): KifiSearchResult = {
@@ -41,6 +42,7 @@ object KifiSearchResult extends Logging {
         "othersTotal" -> JsNumber(othersTotal),
         "mayHaveMore" -> JsBoolean(mayHaveMoreHits),
         "show" -> JsBoolean(show),
+        "cutPoint" -> JsNumber(cutPoint),
         "experimentId" -> experimentId.map(id => JsNumber(id.id)).getOrElse(JsNull),
         "context" -> JsString(context),
         "experts" -> JsArray()
@@ -170,6 +172,7 @@ class PartialSearchResult(val json: JsValue) extends AnyVal {
   def othersTotal: Int = (json \ "othersTotal").as[Int]
   def friendStats: FriendStats = (json \ "friendStats").as[FriendStats]
   def show: Boolean = (json \ "show").as[Boolean] // TODO: remove
+  def cutPoint: Int = (json \ "cutPoint").as[Int]
 }
 
 object PartialSearchResult extends Logging {
@@ -179,8 +182,8 @@ object PartialSearchResult extends Logging {
     friendsTotal: Int,
     othersTotal: Int,
     friendStats: FriendStats,
-    show: Boolean // TODO: remove
-    ): PartialSearchResult = {
+    show: Boolean, // TODO: remove
+    cutPoint: Int): PartialSearchResult = {
     try {
       new PartialSearchResult(JsObject(List(
         "hits" -> JsArray(hits.map(_.json)),
@@ -188,7 +191,8 @@ object PartialSearchResult extends Logging {
         "friendsTotal" -> JsNumber(friendsTotal),
         "othersTotal" -> JsNumber(othersTotal),
         "friendStats" -> Json.toJson(friendStats),
-        "show" -> JsBoolean(show) // TODO: remove
+        "show" -> JsBoolean(show), // TODO: remove
+        "cutPoint" -> JsNumber(cutPoint)
       )))
     } catch {
       case e: Throwable =>

--- a/kifi-backend/modules/search/app/com/keepit/search/result/ResultDecorator.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/result/ResultDecorator.scala
@@ -68,6 +68,7 @@ class ResultDecorator(
       idFilter,
       mayHaveMoreHits,
       result.show,
+      result.cutPoint,
       searchExperimentId)
   }
 
@@ -177,4 +178,5 @@ case class DecoratedResult(
   idFilter: Set[Long],
   mayHaveMoreHits: Boolean,
   show: Boolean,
+  cutPoint: Int,
   searchExperimentId: Option[Id[SearchConfigExperiment]])

--- a/kifi-backend/modules/search/app/com/keepit/search/result/ResultMerger.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/result/ResultMerger.scala
@@ -28,13 +28,23 @@ class ResultMerger(enableTailCutting: Boolean, config: SearchConfig, isFinalMerg
     val hits = mergeHits(results, maxHits)
     val show = results.exists(_.show) // TODO: how to merge the show flag?
 
+    val cutPoint = {
+      if (!show) 0 else {
+        hits.headOption.map { head =>
+          val threshold = head.score * tailCutting
+          hits.iterator.count(_.score > threshold)
+        }.getOrElse(0)
+      }
+    }
+
     PartialSearchResult(
       hits,
       myTotal,
       friendsTotal,
       othersTotal,
       friendStats,
-      show
+      show,
+      cutPoint
     )
   }
 

--- a/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/ext/ExtSearchControllerTest.scala
@@ -88,6 +88,7 @@ class ExtSearchControllerTest extends Specification with SearchTestInjector {
             "othersTotal":123,
             "mayHaveMore":false,
             "show":true,
+            "cutPoint":1,
             "experimentId":10,
             "context":"AgFJAN8CZHg=",
             "experts":[]
@@ -214,6 +215,7 @@ object ExtSearchControllerTest {
       Set(100, 220), // idFilter
       false, // mayHaveMoreHits
       true, //show
+      1, //cutPoint
       Some(Id[SearchConfigExperiment](10)) //searchExperimentId
     )
   )

--- a/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/controllers/mobile/MobileSearchControllerTest.scala
@@ -86,6 +86,7 @@ class MobileSearchControllerTest extends SpecificationLike with SearchTestInject
             "othersTotal":123,
             "mayHaveMore":false,
             "show":true,
+            "cutPoint":1,
             "experimentId":10,
             "context":"AgFJAN8CZHg=",
             "experts":[]
@@ -140,6 +141,7 @@ object MobileSearchControllerTest {
       Set(100, 220), // idFilter
       false, // mayHaveMoreHits
       true, //show
+      1, //cutPoint
       Some(Id[SearchConfigExperiment](10)) //searchExperimentId
     )
   )

--- a/kifi-backend/modules/search/test/com/keepit/search/result/ResultMergerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/result/ResultMergerTest.scala
@@ -61,7 +61,8 @@ class ResultMergerTest extends Specification {
       friendsTotal = 2,
       othersTotal = 0,
       friendStats = FriendStats(ids = Array(2L), scores = Array(2.4f)),
-      show = true
+      show = true,
+      cutPoint = 2
     )
   }
 
@@ -72,7 +73,8 @@ class ResultMergerTest extends Specification {
       friendsTotal = 1,
       othersTotal = 0,
       friendStats = FriendStats(ids = Array(2L, 3L), scores = Array(2f, 1.8f)),
-      show = true
+      show = true,
+      cutPoint = 1
     )
   }
 
@@ -120,7 +122,8 @@ class ResultMergerTest extends Specification {
     friendsTotal = 3,
     othersTotal = 0,
     friendStats = FriendStats(Array(2L, 3L), Array(4.4f, 1.8f)),
-    show = true
+    show = true,
+    cutPoint = mergedDetailedSearchHits.length
   )
 
   "result merger" should {


### PR DESCRIPTION
@ymatsuda per @mrbrown14's request, I'm not confident this is necessary (the old merger tail cuts on the backend doesn't it?) but the number of results returned always seems to be maxHits.
