### PR TITLE
excluding viewer from count of total keepers in /ext/page response

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
@@ -126,8 +126,9 @@ class PageCommander @Inject() (
         items = Seq(AugmentableItem(normUri.id.get))).map {
           case Seq(info) =>
             db.readOnlyMaster { implicit session =>
-              val userIdSet = info.keepers.toSet - userId
-              (basicUserRepo.loadAll(userIdSet).values.toSeq, info.keepersOmitted, info.keepersTotal)
+              val userIdSet = info.keepers.toSet
+              val otherkeepersTotal = info.keepersTotal - (if (userIdSet.contains(userId)) 1 else 0)
+              (basicUserRepo.loadAll(userIdSet - userId).values.toSeq, info.keepersOmitted, otherKeepersTotal)
             }
         }
 


### PR DESCRIPTION
@leogrim 

This should minimize the impact of any discrepancy between the search service and shoebox. Also, this way the extension will not have to update this value in its cache each time the viewer keeps or unkeeps.
