### PR TITLE
updated library info for kept/unkept pages analytics

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -121,7 +121,7 @@ class KeepInterner @Inject() (
     val (newKeeps, existingKeeps) = persistedBookmarksWithUris.partition(obj => obj.isNewKeep || obj.wasInactiveKeep) match {
       case (newKeeps, existingKeeps) => (newKeeps map (_.bookmark), existingKeeps map (_.bookmark))
     }
-    libraryAnalytics.keptPages(userId, createdKeeps, context)
+    libraryAnalytics.keptPages(userId, createdKeeps, library, context)
     heimdalClient.processKeepAttribution(userId, createdKeeps)
     (newKeeps, existingKeeps, failures)
   }
@@ -133,7 +133,7 @@ class KeepInterner @Inject() (
       val bookmark = persistedBookmarksWithUri.bookmark
       if (persistedBookmarksWithUri.isNewKeep) {
         if (library.kind == LibraryKind.USER_CREATED) SafeFuture { libraryCommander.notifyFollowersOfNewKeeps(library, bookmark) }
-        libraryAnalytics.keptPages(userId, Seq(bookmark), context)
+        libraryAnalytics.keptPages(userId, Seq(bookmark), library, context)
         heimdalClient.processKeepAttribution(userId, Seq(bookmark))
       }
       db.readWrite { implicit s => libraryRepo.updateLastKept(library.id.get) } // do not update seq num, only update if successful keep

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryAnalytics.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryAnalytics.scala
@@ -14,9 +14,8 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 @Singleton
 class LibraryAnalytics @Inject() (
-  db: Database,
-  keepRepo : KeepRepo
-) (heimdal: HeimdalServiceClient) {
+    db: Database,
+    keepRepo: KeepRepo)(heimdal: HeimdalServiceClient) {
 
   def sendLibraryInvite(userId: Id[User], libId: Id[Library], inviteeList: Seq[(Either[Id[User], EmailAddress])], eventContext: HeimdalContext) = {
     val builder = new HeimdalContextBuilder

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -523,7 +523,7 @@ class LibraryCommander @Inject() (
         keepRepo.save(keep.sanitizeForDelete())(s)
       }
       libraryAnalytics.deleteLibrary(userId, oldLibrary, context)
-      libraryAnalytics.unkeptPages(userId, savedKeeps.keySet.toSeq, context)
+      libraryAnalytics.unkeptPages(userId, savedKeeps.keySet.toSeq, oldLibrary, context)
       searchClient.updateKeepIndex()
       //Note that this is at the end, if there was an error while cleaning other library assets
       //we would want to be able to get back to the library and clean it again


### PR DESCRIPTION
add `libraryId`, `libraryOwnerId`, `libraryKeepCount`, `daysSinceLibraryCreated` to analytics for `keptPages` and `unkeptPages`
@stkem @andrewconner 
