### PR TITLE
fix column order of curator library info required by GetResult

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/CuratorLibraryInfo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/CuratorLibraryInfo.scala
@@ -9,7 +9,6 @@ case class CuratorLibraryInfo(
   id: Option[Id[CuratorLibraryInfo]] = None,
   createdAt: DateTime = currentDateTime,
   updatedAt: DateTime = currentDateTime,
-  seq: SequenceNumber[CuratorLibraryInfo] = SequenceNumber.ZERO,
   libraryId: Id[Library],
   ownerId: Id[User],
   memberCount: Int,
@@ -17,9 +16,10 @@ case class CuratorLibraryInfo(
   visibility: LibraryVisibility,
   lastKept: Option[DateTime] = None,
   lastFollowed: Option[DateTime] = None,
+  state: State[CuratorLibraryInfo],
   kind: LibraryKind,
   libraryLastUpdated: DateTime,
-  state: State[CuratorLibraryInfo])
+  seq: SequenceNumber[CuratorLibraryInfo] = SequenceNumber.ZERO)
     extends Model[CuratorLibraryInfo] with ModelWithState[CuratorLibraryInfo] with ModelWithSeqNumber[CuratorLibraryInfo] {
 
   def withId(id: Id[CuratorLibraryInfo]): CuratorLibraryInfo = this.copy(id = Some(id))

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/CuratorLibraryInfoRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/CuratorLibraryInfoRepo.scala
@@ -39,8 +39,8 @@ class CuratorLibraryInfoRepoImpl @Inject() (
     def lastFollowed = column[DateTime]("last_followed", O.Nullable)
     def kind = column[LibraryKind]("kind", O.NotNull)
     def libraryLastUpdated = column[DateTime]("library_last_updated", O.NotNull)
-    def * = (id.?, createdAt, updatedAt, seq, libraryId, ownerId, memberCount, keepCount, visibility, lastKept.?,
-      lastFollowed.?, kind, libraryLastUpdated, state) <> ((CuratorLibraryInfo.apply _).tupled, CuratorLibraryInfo.unapply)
+    def * = (id.?, createdAt, updatedAt, libraryId, ownerId, memberCount, keepCount, visibility, lastKept.?,
+      lastFollowed.?, state, kind, libraryLastUpdated, seq) <> ((CuratorLibraryInfo.apply _).tupled, CuratorLibraryInfo.unapply)
   }
 
   def table(tag: Tag) = new CuratorLibraryInfoTable(tag)
@@ -80,7 +80,6 @@ class CuratorLibraryInfoRepoImpl @Inject() (
       id = r.<<[Option[Id[CuratorLibraryInfo]]],
       createdAt = r.<<[DateTime],
       updatedAt = r.<<[DateTime],
-      seq = r.<<[SequenceNumber[CuratorLibraryInfo]],
       libraryId = r.<<[Id[Library]],
       ownerId = r.<<[Id[User]],
       memberCount = r.<<[Int],
@@ -88,9 +87,10 @@ class CuratorLibraryInfoRepoImpl @Inject() (
       visibility = r.<<[LibraryVisibility],
       lastKept = r.<<[Option[DateTime]],
       lastFollowed = r.<<[Option[DateTime]],
+      state = r.<<[State[CuratorLibraryInfo]],
       kind = r.<<[LibraryKind],
       libraryLastUpdated = r.<<[DateTime],
-      state = r.<<[State[CuratorLibraryInfo]]
+      seq = r.<<[SequenceNumber[CuratorLibraryInfo]]
     )
   }
 


### PR DESCRIPTION
@stkem I think this will fix it... issue was get GetResult depends on the order of the columns in the database - wasn't an error in H2 I think because the order of the fields in the case class was the same
