### PR TITLE
gracefully handle potential exceptions during library recommendation scoring

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/LibraryRecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/LibraryRecommendationGenerationCommander.scala
@@ -104,12 +104,12 @@ class LibraryRecommendationGenerationCommander @Inject() (
   private def precomputeRecommendationsForUser(userId: Id[User], alwaysInclude: Set[Id[Library]]): Future[Unit] = recommendationGenerationLock.withLockFuture {
     if (serviceDiscovery.isLeader()) {
       timing(s"precomputeRecommendationsForUser userId=$userId") {
-        val state: LibraryRecommendationGenerationState = db.readOnlyReplica { implicit session => getStateOfUser(userId)}
+        val state: LibraryRecommendationGenerationState = db.readOnlyReplica { implicit session => getStateOfUser(userId) }
         val (candidateLibraries, newSeqNum) = getCandidateLibrariesForUser(userId, state)
 
         val newState = state.copy(seq = newSeqNum)
         if (candidateLibraries.isEmpty) {
-          db.readWrite { implicit session => genStateRepo.save(newState)}
+          db.readWrite { implicit session => genStateRepo.save(newState) }
           if (state.seq < newSeqNum) precomputeRecommendationsForUser(userId, alwaysInclude) else Future.successful()
         } else {
           processLibraries(candidateLibraries, newState, userId, alwaysInclude)


### PR DESCRIPTION
there seems to be jobs "stuck" in the reactive lock that never finish and don't bubble up to release the lock because they are swallowed by futures (just a theory)

@stkem 
