### PR TITLE
Adding neverblue conversion tracker to install page

### DIFF
--- a/kifi-backend/modules/shoebox/public/js/install.js
+++ b/kifi-backend/modules/shoebox/public/js/install.js
@@ -20,6 +20,8 @@
     $a.removeAttr('href').text('Installing...');
 
     if ($doc.hasClass('chrome')) {
+      $.get("https://cjsab.com/p.ashx?o=34878&f=js&t=INSTALL_PAGE_CHROME");
+      $.get("https://cjsab.com/p.ashx?o=34877&f=js&t=INSTALL_PAGE_CHROME");
       chrome.webstore.install($('link[rel="chrome-webstore-item"]').attr('href'), function () {
         console.log('[chrome.webstore.install] done');
         $a.text('Installed. Initializing...');


### PR DESCRIPTION
This is not 100% accurate, but it will do for this purpose. We’ll likely invest into a slightly smarter integration (e.g. only fire when the user actually came from them) when there is time and we stick with them.

@andrewconner 
