### PR TITLE
keep and follower counts for /ext/page libraries

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeeperInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeeperInfo.scala
@@ -40,7 +40,6 @@ case class KeeperPageInfo(
   neverOnSite: Boolean,
   shown: Boolean,
   keepers: Seq[BasicUser],
-  keepersOmitted: Int,
   keepersTotal: Int,
   libraries: Seq[JsObject],
   keeps: Seq[KeepData])
@@ -51,7 +50,6 @@ object KeeperPageInfo {
     (__ \ 'neverOnSite).writeNullable[Boolean].contramap[Boolean](Some(_).filter(identity)) and
     (__ \ 'shown).writeNullable[Boolean].contramap[Boolean](Some(_).filter(identity)) and
     (__ \ 'keepers).writeNullable[Seq[BasicUser]].contramap[Seq[BasicUser]](Some(_).filter(_.nonEmpty)) and
-    (__ \ 'keepersOmitted).writeNullable[Int].contramap[Int](Some(_).filter(_ > 0)) and
     (__ \ 'keepersTotal).writeNullable[Int].contramap[Int](Some(_).filter(_ > 0)) and
     (__ \ 'libraries).writeNullable[Seq[JsObject]].contramap[Seq[JsObject]](Some(_).filter(_.nonEmpty)) and
     (__ \ 'keeps).write[Seq[KeepData]]


### PR DESCRIPTION
and excluding libraries that the user already follows or collaborates on (in addition to those he/she owns)

also removing `keepersOmitted` from the response because we aren’t planning to use the total count of friends who’ve kept anywhere in the UI

@eishay 
