### PR TITLE
admin page differentiate between libraries I've created & I'm following

### DIFF
--- a/kifi-backend/modules/shoebox/app/views/admin/userLibraries.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/userLibraries.scala.html
@@ -24,7 +24,8 @@
           <th>Secret</th>
           <th>Active</th>
           <th>Library</th>
-		      <th>Kind</th>
+          <th>Access</th>
+          <th>Kind</th>
           <th>Updated At</th>
           <th>Created At</th>
           <th>State</th>
@@ -43,6 +44,7 @@
               <center><input type="checkbox" id="active_@lib.id.get.id" name="active_@{lib.id.get.id}" value="1" @if(lib.state.value == "active") {checked="checked"}></input></center>
             </td>
 		        <td>@adminHelper.libraryDisplay(lib)</td>
+            <td>@access</td>
             <td>@lib.kind</td>
             <td>@adminHelper.dateTimeDisplay(lib.updatedAt)</td>
             <td>@adminHelper.dateTimeDisplay(lib.createdAt)</td>


### PR DESCRIPTION
For example, `https://admin.kifi.com/admin/user/7100/libraries`
access field should allow you to figure out which libraries I'm an OWNER of and which I have READ_ONLY access
@andrewconner 
