### PR TITLE
refactored lib reco generation, add refreshLibRecos endpoint, and improved lib reco admin page

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -1,6 +1,7 @@
 package com.keepit.common.routes
 
 import com.keepit.common.db.{ Id, ExternalId, State, SurrogateExternalId, SequenceNumber }
+import com.keepit.curator.model.LibraryRecoSelectionParams
 import com.keepit.model._
 import com.keepit.shoebox.model.ids.UserSessionExternalId
 import com.keepit.search.SearchConfigExperiment
@@ -399,6 +400,7 @@ object Curator extends Service {
     def triggerEmailToUser(code: String, userId: Id[User]) = ServiceRoute(POST, "/internal/curator/triggerEmailToUser", Param("code", code), Param("userId", userId))
     def refreshUserRecos(userId: Id[User]) = ServiceRoute(POST, "/internal/curator/refreshUserRecos", Param("userId", userId))
     def topLibraryRecos(userId: Id[User], limit: Option[Int]) = ServiceRoute(POST, "/internal/curator/topLibraryRecos", Param("userId", userId), Param("limit", limit))
+    def refreshLibraryRecos(userId: Id[User], await: Boolean) = ServiceRoute(POST, "/internal/curator/refreshLibraryRecos", Param("userId", userId), Param("await", await))
   }
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/curator/CuratorServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/curator/CuratorServiceClient.scala
@@ -7,7 +7,7 @@ import com.keepit.common.net.{ HttpClient, CallTimeouts }
 import com.keepit.common.routes.Curator
 import com.keepit.common.db.Id
 import com.keepit.model._
-import com.keepit.curator.model.{ LibraryRecoInfo, RecoInfo, RecommendationClientType }
+import com.keepit.curator.model.{ LibraryRecoSelectionParams, LibraryRecoInfo, RecoInfo, RecommendationClientType }
 
 import scala.concurrent.Future
 import play.api.libs.json._
@@ -23,6 +23,7 @@ trait CuratorServiceClient extends ServiceClient {
   def triggerEmailToUser(code: String, userId: Id[User]): Future[String]
   def refreshUserRecos(userId: Id[User]): Future[Unit]
   def topLibraryRecos(userId: Id[User], limit: Option[Int] = None): Future[Seq[LibraryRecoInfo]]
+  def refreshLibraryRecos(userId: Id[User], await: Boolean = false, selectionParams: Option[LibraryRecoSelectionParams] = None): Future[Unit]
 }
 
 class CuratorServiceClientImpl(
@@ -75,5 +76,10 @@ class CuratorServiceClientImpl(
     call(Curator.internal.topLibraryRecos(userId, limit)).map { response =>
       response.json.as[Seq[LibraryRecoInfo]]
     }
+  }
+
+  def refreshLibraryRecos(userId: Id[User], await: Boolean = false, selectionParams: Option[LibraryRecoSelectionParams] = None) = {
+    val payload = Json.toJson(selectionParams)
+    call(Curator.internal.refreshLibraryRecos(userId, await), body = payload).map { _ => Unit }
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/curator/model/LibraryRecommendationInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/curator/model/LibraryRecommendationInfo.scala
@@ -9,3 +9,25 @@ import com.kifi.macros.json
   libraryId: Id[Library],
   masterScore: Float,
   explain: String)
+
+@json case class LibraryRecoSelectionParams(
+  recencyScoreWeight: Float,
+  interestScoreWeight: Float,
+  sizeScoreWeight: Float,
+  popularityScoreWeight: Float,
+  socialScoreWeight: Float,
+  minMembers: Int,
+  minKeeps: Int,
+  reset: Boolean = false)
+
+object LibraryRecoSelectionParams {
+  val default = LibraryRecoSelectionParams(
+    recencyScoreWeight = 0.8f,
+    interestScoreWeight = 1f,
+    sizeScoreWeight = 0.7f,
+    popularityScoreWeight = 0.8f,
+    socialScoreWeight = 0.9f,
+    minKeeps = 3,
+    minMembers = 1,
+    reset = false)
+}

--- a/kifi-backend/modules/common/test/com/keepit/curator/FakeCuratorServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/curator/FakeCuratorServiceClientImpl.scala
@@ -9,7 +9,7 @@ import com.keepit.common.service.ServiceType
 import com.google.inject.util.Providers
 import com.keepit.common.actor.FakeScheduler
 import com.keepit.common.db.Id
-import com.keepit.curator.model.{ LibraryRecoInfo, RecoInfo, RecommendationClientType }
+import com.keepit.curator.model.{ LibraryRecoSelectionParams, LibraryRecoInfo, RecoInfo, RecommendationClientType }
 import collection.mutable.ListBuffer
 
 class FakeCuratorServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) extends CuratorServiceClient {
@@ -21,7 +21,7 @@ class FakeCuratorServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
   var fakeTopRecos: Map[Id[User], Seq[RecoInfo]] = Map.empty
 
   def topRecos(userId: Id[User], clientType: RecommendationClientType, more: Boolean, recencyWeight: Float): Future[Seq[RecoInfo]] =
-    Future.successful(fakeTopRecos.get(userId).getOrElse(Seq[RecoInfo]()))
+    Future.successful(fakeTopRecos.getOrElse(userId, Seq[RecoInfo]()))
 
   def topPublicRecos(): Future[Seq[RecoInfo]] = Future.successful(Seq.empty)
 
@@ -36,6 +36,10 @@ class FakeCuratorServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
 
   def topLibraryRecos(userId: Id[User], limit: Option[Int] = None): Future[Seq[LibraryRecoInfo]] =
     Future.successful(Seq.empty)
+
+  def refreshLibraryRecos(userId: Id[User], await: Boolean = false, selectionParams: Option[LibraryRecoSelectionParams] = None): Future[Unit] = {
+    Future.successful()
+  }
 
   // test helpers
   val updatedUriRecommendationFeedback = ListBuffer[(Id[User], Id[NormalizedURI], UriRecommendationFeedback)]()

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/LibraryRecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/LibraryRecommendationGenerationCommander.scala
@@ -10,7 +10,7 @@ import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.common.time._
 import com.keepit.common.zookeeper.ServiceDiscovery
-import com.keepit.curator.model.{ CuratorLibraryInfo, CuratorLibraryInfoRepo, LibraryRecommendation, LibraryRecommendationGenerationState, LibraryRecommendationGenerationStateRepo, LibraryRecommendationRepo, LibraryRecommendationStates }
+import com.keepit.curator.model.{ LibraryRecoSelectionParams, CuratorLibraryInfo, CuratorLibraryInfoRepo, LibraryRecommendation, LibraryRecommendationGenerationState, LibraryRecommendationGenerationStateRepo, LibraryRecommendationRepo, LibraryRecommendationStates }
 import com.keepit.curator.{ LibraryScoringHelper, ScoredLibraryInfo }
 import com.keepit.model.{ ExperimentType, Library, LibraryVisibility, User }
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -29,6 +29,7 @@ class LibraryRecommendationGenerationCommander @Inject() (
     serviceDiscovery: ServiceDiscovery) extends Logging {
 
   val recommendationGenerationLock = new ReactiveLock(8)
+  val defaultLibraryScoreParams = LibraryRecoSelectionParams.default
 
   private def usersToPrecomputeRecommendationsFor(): Future[Seq[Id[User]]] =
     experimentCommander.getUsersByExperiment(ExperimentType.CURATOR_LIBRARY_RECOS).
@@ -40,89 +41,19 @@ class LibraryRecommendationGenerationCommander @Inject() (
     }
   }
 
-  private def shouldInclude(scoredLibrary: ScoredLibraryInfo): Boolean = {
-    true // TODO(josh)
-  }
+  /**
+   * @param userIds override the users to generate library recommendations for
+   */
+  def precomputeRecommendations(userIds: Option[Seq[Id[User]]] = None): Future[Unit] = {
+    val usersToPrecomputeForF = userIds.map { ids => Future.successful(ids) } getOrElse usersToPrecomputeRecommendationsFor()
 
-  private def getStateOfUser(userId: Id[User]): LibraryRecommendationGenerationState = {
-    db.readOnlyMaster { implicit session =>
-      genStateRepo.getByUserId(userId)
-    } getOrElse {
-      LibraryRecommendationGenerationState(userId = userId)
-    }
-  }
-
-  private def initialLibraryRecoFilterForUser(userId: Id[User])(libraryInfo: CuratorLibraryInfo): Boolean = {
-    libraryInfo.ownerId != userId && libraryInfo.keepCount > 0 && libraryInfo.visibility != LibraryVisibility.SECRET
-    // TODO(josh) more checks (min followers? max age?)
-  }
-
-  private def getCandidateLibrariesForUser(userId: Id[User], state: LibraryRecommendationGenerationState): (Seq[CuratorLibraryInfo], SequenceNumber[CuratorLibraryInfo]) = {
-    val libs = db.readOnlyReplica { implicit session => libraryInfoRepo.getBySeqNum(state.seq, 200) }
-    val filteredLibs = libs filter initialLibraryRecoFilterForUser(userId)
-    val maxLibSeqNum = libs.lastOption map (_.seq) getOrElse state.seq
-
-    // returns the last seq number we looked at whether we're using it or not, to ensure we don't keep fetching it
-    (filteredLibs, maxLibSeqNum)
-  }
-
-  private def saveLibraryRecommendations(scoredLibraryInfos: Seq[ScoredLibraryInfo], userId: Id[User]): Unit =
-    db.readWrite { implicit s =>
-      scoredLibraryInfos foreach { scoredLibraryInfo =>
-        val recoOpt = libraryRecRepo.getByLibraryAndUserId(scoredLibraryInfo.libraryId, userId, None)
-        recoOpt.map { reco =>
-          libraryRecRepo.save(reco.copy(
-            state = LibraryRecommendationStates.ACTIVE,
-            updatedAt = currentDateTime,
-            masterScore = scoredLibraryInfo.masterScore,
-            allScores = scoredLibraryInfo.allScores
-          ))
-        } getOrElse {
-          libraryRecRepo.save(LibraryRecommendation(
-            libraryId = scoredLibraryInfo.libraryId,
-            userId = userId,
-            masterScore = scoredLibraryInfo.masterScore,
-            allScores = scoredLibraryInfo.allScores))
-        }
-      }
-    }
-
-  private def processLibraries(candidates: Seq[CuratorLibraryInfo], newState: LibraryRecommendationGenerationState,
-    userId: Id[User], alwaysInclude: Set[Id[Library]]): Future[Unit] = {
-    scoringHelper(userId, candidates) flatMap { scores =>
-      val toBeSaved = scores filter (si => alwaysInclude.contains(si.libraryId) || shouldInclude(si))
-      saveLibraryRecommendations(toBeSaved, userId)
-      precomputeRecommendationsForUser(userId, alwaysInclude, newState)
-    }
-  }
-
-  private def precomputeRecommendationsForUser(userId: Id[User], alwaysInclude: Set[Id[Library]], recoGenState: LibraryRecommendationGenerationState): Future[Unit] = {
-    if (serviceDiscovery.isLeader()) {
-      log.info(s"precomputeRecommendationsForUser called userId=$userId seq=${recoGenState.seq}")
-      val (candidateLibraries, newSeqNum) = getCandidateLibrariesForUser(userId, recoGenState)
-
-      val newState = recoGenState.copy(seq = newSeqNum)
-      if (candidateLibraries.isEmpty) {
-        val savedNewState = db.readWrite { implicit session => genStateRepo.save(newState) }
-        if (recoGenState.seq < newSeqNum) precomputeRecommendationsForUser(userId, alwaysInclude, savedNewState)
-        else Future.successful()
-      } else processLibraries(candidateLibraries, newState, userId, alwaysInclude)
-    } else {
-      log.warn("precomputeRecommendationsForUser doing nothing on non-leader")
-      Future.successful()
-    }
-  }
-
-  def precomputeRecommendations(): Future[Unit] = {
-    usersToPrecomputeRecommendationsFor() flatMap { userIds =>
+    usersToPrecomputeForF flatMap { userIds =>
       Future.sequence {
         if (recommendationGenerationLock.waiting < userIds.length + 1) {
           userIds map { userId =>
             statsd.time("curator.libRecosGenForUser", 1) { _ =>
-              val alwaysInclude: Set[Id[Library]] = db.readOnlyReplica { implicit session => libraryRecRepo.getLibraryIdsForUser(userId) }
               recommendationGenerationLock.withLockFuture {
-                val state: LibraryRecommendationGenerationState = db.readOnlyReplica { implicit session => getStateOfUser(userId) }
-                new SafeFuture(precomputeRecommendationsForUser(userId, alwaysInclude, state))
+                precomputeRecommendationsForUser(userId)
               }
             }
           }
@@ -132,6 +63,99 @@ class LibraryRecommendationGenerationCommander @Inject() (
         }
       }
     } map (_ => ())
+  }
+
+  // public for admin/adhoc purpose only
+  def precomputeRecommendationsForUser(userId: Id[User], selectionParams: Option[LibraryRecoSelectionParams] = None): Future[Unit] = {
+    val recoGenForUser = LibraryRecoGenerationForUserHelper(userId, selectionParams getOrElse defaultLibraryScoreParams)
+    new SafeFuture(recoGenForUser.precomputeRecommendations())
+  }
+
+  case class LibraryRecoGenerationForUserHelper(userId: Id[User], selectionParams: LibraryRecoSelectionParams) {
+
+    def precomputeRecommendations() = {
+      val state: LibraryRecommendationGenerationState = db.readOnlyReplica { implicit session =>
+        val state = getStateOfUser()
+        if (state.id.exists(_ => selectionParams.reset)) state.copy(seq = SequenceNumber.ZERO) else state
+      }
+      val alwaysInclude: Set[Id[Library]] = db.readOnlyReplica { implicit session => libraryRecRepo.getLibraryIdsForUser(userId) }
+      precomputeRecommendationsForUser(alwaysInclude, state)
+    }
+
+    private def precomputeRecommendationsForUser(alwaysInclude: Set[Id[Library]], recoGenState: LibraryRecommendationGenerationState): Future[Unit] = {
+      if (serviceDiscovery.isLeader()) {
+        log.info(s"precomputeRecommendationsForUser called userId=$userId seq=${recoGenState.seq}")
+        val (candidateLibraries, newSeqNum) = getCandidateLibrariesForUser(recoGenState)
+
+        val newState = recoGenState.copy(seq = newSeqNum)
+        if (candidateLibraries.isEmpty) {
+          val savedNewState = db.readWrite { implicit session => genStateRepo.save(newState) }
+          if (recoGenState.seq < newSeqNum) precomputeRecommendationsForUser(alwaysInclude, savedNewState)
+          else Future.successful()
+        } else processLibraries(candidateLibraries, newState, alwaysInclude)
+      } else {
+        log.warn("precomputeRecommendationsForUser doing nothing on non-leader")
+        Future.successful()
+      }
+    }
+
+    private def shouldInclude(scoredLibrary: ScoredLibraryInfo): Boolean = {
+      true // TODO(josh)
+    }
+
+    private def getStateOfUser(): LibraryRecommendationGenerationState = {
+      db.readOnlyMaster { implicit session =>
+        genStateRepo.getByUserId(userId)
+      } getOrElse {
+        LibraryRecommendationGenerationState(userId = userId)
+      }
+    }
+
+    private def initialLibraryRecoFilterForUser(libraryInfo: CuratorLibraryInfo): Boolean = {
+      libraryInfo.ownerId != userId && libraryInfo.visibility != LibraryVisibility.SECRET &&
+        libraryInfo.keepCount >= selectionParams.minKeeps &&
+        libraryInfo.memberCount >= selectionParams.minMembers
+    }
+
+    private def getCandidateLibrariesForUser(state: LibraryRecommendationGenerationState): (Seq[CuratorLibraryInfo], SequenceNumber[CuratorLibraryInfo]) = {
+      val libs = db.readOnlyReplica { implicit session => libraryInfoRepo.getBySeqNum(state.seq, 200) }
+      val filteredLibs = libs filter initialLibraryRecoFilterForUser
+      val maxLibSeqNum = libs.lastOption map (_.seq) getOrElse state.seq
+
+      // returns the last seq number we looked at whether we're using it or not, to ensure we don't keep fetching it
+      (filteredLibs, maxLibSeqNum)
+    }
+
+    private def saveLibraryRecommendations(scoredLibraryInfos: Seq[ScoredLibraryInfo]): Unit =
+      db.readWrite { implicit s =>
+        scoredLibraryInfos foreach { scoredLibraryInfo =>
+          val recoOpt = libraryRecRepo.getByLibraryAndUserId(scoredLibraryInfo.libraryId, userId, None)
+          recoOpt.map { reco =>
+            libraryRecRepo.save(reco.copy(
+              state = LibraryRecommendationStates.ACTIVE,
+              updatedAt = currentDateTime,
+              masterScore = scoredLibraryInfo.masterScore,
+              allScores = scoredLibraryInfo.allScores
+            ))
+          } getOrElse {
+            libraryRecRepo.save(LibraryRecommendation(
+              libraryId = scoredLibraryInfo.libraryId,
+              userId = userId,
+              masterScore = scoredLibraryInfo.masterScore,
+              allScores = scoredLibraryInfo.allScores))
+          }
+        }
+      }
+
+    private def processLibraries(candidates: Seq[CuratorLibraryInfo], newState: LibraryRecommendationGenerationState,
+      alwaysInclude: Set[Id[Library]]): Future[Unit] = {
+      scoringHelper(userId, candidates, selectionParams) flatMap { scores =>
+        val toBeSaved = scores filter (si => alwaysInclude.contains(si.libraryId) || shouldInclude(si))
+        saveLibraryRecommendations(toBeSaved)
+        precomputeRecommendationsForUser(alwaysInclude, newState)
+      }
+    }
+
   }
 
 }

--- a/kifi-backend/modules/curator/conf/curator.routes
+++ b/kifi-backend/modules/curator/conf/curator.routes
@@ -15,3 +15,4 @@ POST   /internal/curator/triggerEmailToUser 	@com.keepit.curator.controllers.int
 POST   /internal/curator/refreshUserRecos @com.keepit.curator.controllers.internal.CuratorController.refreshUserRecos(userId: Id[User])
 
 POST   /internal/curator/topLibraryRecos  @com.keepit.curator.controllers.internal.CuratorController.topLibraryRecos(userId: Id[User], limit: Int ?= 100)
+POST   /internal/curator/refreshLibraryRecos  @com.keepit.curator.controllers.internal.CuratorController.refreshLibraryRecos(userId: Id[User], await: Boolean ?= false)

--- a/kifi-backend/modules/curator/test/com/keepit/curator/CuratorTestHelpers.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/CuratorTestHelpers.scala
@@ -189,9 +189,9 @@ trait CuratorTestHelpers { this: CuratorTestInjector =>
     seedItem1 :: seedItem2 :: seedItem3 :: seedItem4 :: Nil
   }
 
-  def saveLibraryInfo(libraryId: Int, ownerId: Int)(implicit rw: RWSession, injector: Injector): CuratorLibraryInfo = {
+  def saveLibraryInfo(libraryId: Int, ownerId: Int, keepCount: Int = 3, memberCount: Int = 9)(implicit rw: RWSession, injector: Injector): CuratorLibraryInfo = {
     val libInfo = CuratorLibraryInfo(libraryId = Id[Library](libraryId), ownerId = Id[User](ownerId), state = CuratorLibraryInfoStates.ACTIVE,
-      keepCount = 1, memberCount = 1, visibility = LibraryVisibility.PUBLISHED, lastKept = None, lastFollowed = None,
+      keepCount = keepCount, memberCount = memberCount, visibility = LibraryVisibility.PUBLISHED, lastKept = None, lastFollowed = None,
       kind = LibraryKind.USER_CREATED, libraryLastUpdated = currentDateTime)
     inject[CuratorLibraryInfoRepo].save(libInfo)
   }


### PR DESCRIPTION
- allow custom score weights
- remove the redudantly passing around params by moving the generation logic for a user in it's own class
- admin page will in the future allow us to input custom selection parameters
- ability to reset already processed library recommendations
- adjusted default score weights

@stkem 
