### PR TITLE
Public library search no mobile

### DIFF
--- a/kifi-backend/modules/shoebox/angular/dev.html
+++ b/kifi-backend/modules/shoebox/angular/dev.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-<meta name="viewport" content="width=device-width">
+<meta name="viewport" content="width=800px, initial-scale=1.0">
 <title>Kifi</title>
 <link rel="shortcut icon" type="image/png" href="/img/favicon64x64.png">
 <link rel="stylesheet" type="text/css" href="/dist/lib.css">

--- a/kifi-backend/modules/shoebox/angular/dev.html
+++ b/kifi-backend/modules/shoebox/angular/dev.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-<meta name="viewport" content="width=800px, initial-scale=1.0">
+<meta name="viewport" content="width=device-width">
 <title>Kifi</title>
 <link rel="shortcut icon" type="image/png" href="/img/favicon64x64.png">
 <link rel="stylesheet" type="text/css" href="/dist/lib.css">

--- a/kifi-backend/modules/shoebox/angular/index.html
+++ b/kifi-backend/modules/shoebox/angular/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-<meta name="viewport" content="width=800px, initial-scale=1.0">
+<meta name="viewport" content="width=device-width">
 
 <link rel="shortcut icon" type="image/png" href="/img/favicon64x64.png">
 <link rel="stylesheet" type="text/css" href="/dist/lib.min.css">

--- a/kifi-backend/modules/shoebox/angular/index.html
+++ b/kifi-backend/modules/shoebox/angular/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-<meta name="viewport" content="width=device-width">
+<meta name="viewport" content="width=800px, initial-scale=1.0">
 
 <link rel="shortcut icon" type="image/png" href="/img/favicon64x64.png">
 <link rel="stylesheet" type="text/css" href="/dist/lib.min.css">

--- a/kifi-backend/modules/shoebox/angular/src/app.styl
+++ b/kifi-backend/modules/shoebox/angular/src/app.styl
@@ -103,20 +103,7 @@ a[href]
   border-bottom: separatorBorder
   margin: 10px 0
 
-.white-background
-  display: none
-
 .kf-logged-out
-  .white-background
-    display: block
-    content: ' '
-    position: absolute
-    top: 0
-    width: 100%
-    left: 0
-    background-color: #fff
-    z-index: -1
-
   .public-body
     position: relative
 

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
@@ -1,5 +1,5 @@
 <span ng-if="!library.hidden">
-  <a class="kf-keep-who-pic-box" ng-href="{{library.path}}" ng-class="{ 'secret': library.visibility === 'secret' }">
+  <a class="kf-keep-who-pic-box" ng-href="{{library.path}}" ng-class="{ 'secret': library.visibility === 'secret' }" ng-click="onLibraryAttributionClicked()">
     <span class="kf-keep-who-pic" ng-attr-style="background-image: url({{library.keeperPic}})"></span>
     <span class="kf-keep-who-lib">{{library.name}}</span>
     <span kf-tooltip position="top" padding="10">

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLibsAndPics.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLibsAndPics.js
@@ -58,14 +58,19 @@ angular.module('kifi')
   }
 ])
 
-.directive('kfKeepWhoLib', [
-  function () {
+.directive('kfKeepWhoLib', ['$rootScope',
+  function ($rootScope) {
     return {
       restrict: 'A',
       replace: true,
       templateUrl: 'common/directives/keepWho/keepWhoLib.tpl.html',
       scope: {
         library: '='
+      },
+      link: function (scope) {
+        scope.onLibraryAttributionClicked = function () {
+          $rootScope.$emit('trackLibraryEvent', 'click', { action: 'clickedLibraryAttribution' });
+        };
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/sticky.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/sticky.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .directive('kfSticky', [
-  '$window',
-  function ($window) {
+  '$window', '$timeout',
+  function ($window, $timeout) {
     return {
       restrict: 'A',
       scope: {
@@ -48,14 +48,20 @@ angular.module('kifi')
           borderTopWidth = getCssPixelProperty('borderTopWidth');
           borderRightWidth = getCssPixelProperty('borderRightWidth');
           borderBottomWidth = getCssPixelProperty('borderBottomWidth');
-          offsetTop = element.offset().top - marginTop;
-          offsetLeft = element.offset().left - marginLeft;
-          if (isWidthCalculated) {
-            width = element.width() + borderLeftWidth + borderRightWidth;
-          }
-          height = element.height() + borderTopWidth + borderBottomWidth;
+
+          // This timeout is needed for mobile Safari.
+          $timeout(function () {
+            offsetTop = element.offset().top - marginTop;
+            offsetLeft = element.offset().left - marginLeft;
+
+            if (isWidthCalculated) {
+              width = element.width() + borderLeftWidth + borderRightWidth;
+            }
+            height = element.height() + borderTopWidth + borderBottomWidth;
+          });
         }
         updateProperties();
+
         /*
           TODO: test & cover wider variety of cases:
           * border-box vs content-box
@@ -162,14 +168,17 @@ angular.module('kifi')
           }, 2000);
         }
 
-        $win.on('mousewheel', onScroll);
-        $win.on('touchmove', onScrollTouch);
-        $win.on('touchend', onTouchEnd);
+        // This timeout is needed for mobile Safari.
+        $timeout(function () {
+          $win.on('mousewheel', onScroll);
+          $win.on('touchmove', onScrollTouch);
+          $win.on('touchend', onTouchEnd);
 
-        scope.$on('$destroy', function () {
-          $win.off('mousewheel', onScroll);
-          $win.off('touchmove', onScrollTouch);
-          $win.off('touchend', onTouchEnd);
+          scope.$on('$destroy', function () {
+            $win.off('mousewheel', onScroll);
+            $win.off('touchmove', onScrollTouch);
+            $win.off('touchend', onTouchEnd);
+          });
         });
       }
     };

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/youtube.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/youtube.js
@@ -20,8 +20,8 @@ angular.module('kifi')
     }
 
     function imageEmbed(src) {
-      var videoImg = '<div class="kf-youtube-img" style="background-image:url(' + src + ')"></div>';
-      var playImg = '<div class="kf-youtube-play"></div>';
+      var videoImg = '<div class="kf-youtube-img" style="background-image:url(' + src + ')" click-action="playedYoutubeVideo"></div>';
+      var playImg = '<div class="kf-youtube-play" click-action="playedYoutubeVideo"></div>';
       return videoImg + playImg;
     }
 

--- a/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
@@ -266,14 +266,14 @@
 
           .kf-keep-lib-mobile-search-icon
             position: absolute
-            top: 20px
+            top: 26px
             left: 66px
-            width: 31px
-            height: 42px
+            width: 32px
+            height: 48px
             display: block
             background-image: url('/img/sprites.png')
-            background-position: -159px -205px
-            background-size: 310px auto
+            background-position: -163px -205px
+            background-size: 318px auto
 
           .kf-keep-lib-search-input
             border: none
@@ -281,7 +281,7 @@
             border-radius: 0
             padding: 24px 80px 24px 108px
             width: 100%
-            font-size: 28px
+            font-size: 2.5em
 
         // In mobile, hide desktop search box.
         .kf-keep-lib-search

--- a/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
@@ -1,6 +1,18 @@
+//
+// Hide mobile-only elements when not on mobile platform.
+//
+.library-card
+  .kf-keep-lib-mobile-search
+    display: none
+
+.kf-main-search
+  .kf-mobile-search-no-results-message
+    display: none
+
+
+//
 // Mobile styles, logged out
-
-
+//
 .kf-logged-out.kf-mobile
 
   .kf-header.public-header
@@ -15,7 +27,7 @@
       top: -2px
 
     .kf-header-left
-      width: 450px
+      width: 410px
       margin-top: 23px
 
       .public-header-tagline
@@ -43,7 +55,7 @@
         font-size: 20px
 
   .kf-col-island
-    margin-top: 40px
+    margin-top: 180px
 
   .kf-main-library-keeps
 
@@ -51,6 +63,7 @@
       margin-bottom: -10px
 
       .library-card
+        overflow: hidden
 
         .kf-keep-lib-name-container
           padding-top: 70px
@@ -148,7 +161,6 @@
             line-height 52px
             margin-bottom: 20px
 
-
           .kf-keep-subtitle
             font-size: 32px
             height: 50px
@@ -196,7 +208,89 @@
               vertical-align: middle
               max-width: 230px
 
+        .kf-keep-tag-new
+          margin: 5px 8px
+          padding: 10px 8px
+          max-width: 200px
+
+          .kf-keep-tag-link-new > a
+            line-height: 36px
+            font-size: 28px
+
       .kf-keeps-load-more
         font-size: 42px
         line-height: 100px
         margin-bottom: 30px
+
+  .kf-main-library-keeps
+    .kf-library-card-header
+
+      // Hide most of library card header when
+      // displaying seach results in mobile.
+      .library-search .library-card
+      .library-card.library-search-in-progress
+        .kf-keep-body
+        .kf-keep-lib-image
+        .kf-keep-footer
+          display: none
+
+  // When displaying mobile results, hide small subtitle that is
+  // displayed on desktop. Instead, display a big "no results"
+  // message when there are no search results.
+  .kf-main-search
+    .kf-subtitle
+      display: none
+
+    .kf-mobile-search-no-results-message
+      display: block
+      margin: 100px auto
+      width: 400px
+      font-size: 30px
+
+  //
+  // Mobile search.
+  //
+  .kf-main-library-keeps
+    .kf-library-card-header
+      .library-card
+
+        // Mobile-only search box.
+        .kf-keep-lib-mobile-search
+          position: fixed
+          top: 120px
+          left: 0
+          display: block
+          width: 100%
+          height: 80px
+          z-index: 501
+
+          .kf-keep-lib-mobile-search-icon
+            position: absolute
+            top: 20px
+            left: 66px
+            width: 31px
+            height: 42px
+            display: block
+            background-image: url('/img/sprites.png')
+            background-position: -159px -205px
+            background-size: 310px auto
+
+          .kf-keep-lib-search-input
+            border: none
+            border-bottom: 1px solid #ccc
+            padding: 24px 80px 24px 108px
+            width: 100%
+            font-size: 28px
+
+        // In mobile, hide desktop search box.
+        .kf-keep-lib-search
+          display: none
+
+        .kf-keep-lib-info
+          .kf-keep-lib-owner
+
+            // During transition to search results display.
+            .kf-keep-lib-user-image
+            .kf-keep-lib-owner-text
+              transition: opacity 3s ease
+              opacity: 1

--- a/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
@@ -1,16 +1,4 @@
 //
-// Hide mobile-only elements when not on mobile platform.
-//
-.library-card
-  .kf-keep-lib-mobile-search
-    display: none
-
-.kf-main-search
-  .kf-mobile-search-no-results-message
-    display: none
-
-
-//
 // Mobile styles, logged out
 //
 .kf-logged-out.kf-mobile
@@ -55,7 +43,7 @@
         font-size: 20px
 
   .kf-col-island
-    margin-top: 180px
+    margin-top: 90px
 
   .kf-main-library-keeps
 
@@ -222,87 +210,11 @@
         line-height: 100px
         margin-bottom: 30px
 
-  .kf-main-library-keeps
-    .kf-library-card-header
-
-      // Hide most of library card header when
-      // displaying seach results in mobile.
-      .library-search .library-card
-      .library-card.library-search-in-progress
-        .kf-keep-body
-        .kf-keep-lib-image
-        .kf-keep-footer
-          display: none
-
-  // When displaying mobile results, hide small subtitle that is
-  // displayed on desktop. Instead, display a big "no results"
-  // message when there are no search results.
-  .kf-main-search
-    .kf-subtitle
-      display: none
-
-    .kf-mobile-search-no-results-message
-      display: block
-      margin: 100px auto
-      width: 400px
-      font-size: 30px
-
   //
-  // Mobile search.
+  // In mobile, hide desktop search box.
   //
   .kf-main-library-keeps
     .kf-library-card-header
       .library-card
-
-        // Mobile-only search box.
-        .kf-keep-lib-mobile-search
-          position: fixed
-          top: 120px
-          left: 0
-          display: block
-          width: 100%
-          height: 80px
-          z-index: 501
-
-          .kf-keep-lib-mobile-search-icon
-            position: absolute
-            top: 22px
-            left: 66px
-            width: 32px
-            height: 48px
-            display: block
-            background-image: url('/img/sprites.png')
-            background-position: -163px -205px
-            background-size: 318px auto
-
-          .kf-keep-lib-search-input
-            border: none
-            border-bottom: 1px solid #ccc
-            border-radius: 0
-            padding: 24px 80px 24px 108px
-            width: 100%
-            font-size: 2.5em
-
-          .dialog-x
-            top: 30px
-            right: 60px
-            width: 36px
-            height: 36px
-
-        // In mobile, hide desktop search box.
         .kf-keep-lib-search
           display: none
-
-        .kf-keep-lib-info
-          .kf-keep-lib-owner
-
-            // During transition to search results display.
-            .kf-keep-lib-user-image
-            .kf-keep-lib-owner-text
-              transition: opacity 3s ease
-              opacity: 1
-
-    .library-search .library-card
-    .library-card.library-search-in-progress
-      .dialog-x
-        display: block

--- a/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
@@ -266,7 +266,7 @@
 
           .kf-keep-lib-mobile-search-icon
             position: absolute
-            top: 26px
+            top: 22px
             left: 66px
             width: 32px
             height: 48px
@@ -283,6 +283,12 @@
             width: 100%
             font-size: 2.5em
 
+          .dialog-x
+            top: 30px
+            right: 60px
+            width: 36px
+            height: 36px
+
         // In mobile, hide desktop search box.
         .kf-keep-lib-search
           display: none
@@ -295,3 +301,8 @@
             .kf-keep-lib-owner-text
               transition: opacity 3s ease
               opacity: 1
+
+    .library-search .library-card
+    .library-card.library-search-in-progress
+      .dialog-x
+        display: block

--- a/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
@@ -278,6 +278,7 @@
           .kf-keep-lib-search-input
             border: none
             border-bottom: 1px solid #ccc
+            border-radius: 0
             padding: 24px 80px 24px 108px
             width: 100%
             font-size: 28px

--- a/kifi-backend/modules/shoebox/angular/src/common/services/locationNoReloadService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/locationNoReloadService.js
@@ -4,16 +4,38 @@ angular.module('kifi')
 
 // A wrapper around $location that updates the browser url without
 // reloading or changing the $route state.
-.factory('locationNoReload', ['$location', '$route', '$rootScope',
-  function ($location, $route, $rootScope) {
+.factory('locationNoReload', ['$location', '$route', '$rootScope', '$timeout',
+  function ($location, $route, $rootScope, $timeout) {
+    var cancelReloadNextRouteChange = null;
+
     $location.skipReload = function () {
       var lastRoute = $route.current;
+
       var un = $rootScope.$on('$locationChangeSuccess', function () {
         $route.current = lastRoute;
         un();
       });
 
       return $location;
+    };
+
+    $location.reloadNextRouteChange = function () {
+      $timeout(function () {
+        cancelReloadNextRouteChange = $rootScope.$on('$locationChangeSuccess', function () {
+          if (cancelReloadNextRouteChange) {
+            $route.reload();
+            cancelReloadNextRouteChange();
+            cancelReloadNextRouteChange = null;
+          }
+        });
+      }, 0);
+    };
+
+    $location.cancelReloadNextRouteChange = function () {
+      if (cancelReloadNextRouteChange) {
+        cancelReloadNextRouteChange();
+        cancelReloadNextRouteChange = null;
+      }
     };
 
     return $location;

--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.styl
@@ -4,6 +4,8 @@ kifiGreen = #73c583
 
 .kf-my-keeps
   .kf-keep
+    margin-bottom: 10px
+
   .kf-keep-selection-tools
     margin-top: 10px
 
@@ -11,6 +13,7 @@ kifiGreen = #73c583
 .kf-keep-selection-tools
   box-sizing: border-box
   box-shadow: defaultBoxShadow
+  margin-bottom: 10px
   border: defaultBorder
   background-color: white
   border-radius: keepBorderRadius

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
@@ -12,7 +12,7 @@
     <div class="kf-keep-contents">
       <div class="kf-keep-title">
         <div class="kf-keep-loader" ng-show="false"></div>
-        <a class="kf-keep-title-link" ng-href="{{keep.url}}" target="_blank" ng-attr-title="{{keep.titleAttr}}" ng-bind-html="keep.titleHtml" ng-click="clickCallback({ 'keep': keep, event: $event })" rel="nofollow" click-action="articleTitle"></a>
+        <a class="kf-keep-title-link" ng-href="{{keep.url}}" target="_blank" ng-attr-title="{{keep.titleAttr}}" ng-bind-html="keep.titleHtml" ng-click="clickCallback({ 'keep': keep, event: $event })" rel="nofollow" click-action="clickedArticleTitle"></a>
       </div>
       <div class="kf-keep-subtitle">
         <span class="kf-keep-subtitle-element kf-keep-url" ng-attr-title="{{keep.url}}" ng-bind-html="keep.descHtml"></span>
@@ -26,7 +26,7 @@
       <div class="kf-keep-content-line">
         <div class="kf-keep-small-image" ng-if="showSmallImage(keep)">
           <a ng-href="{{keep.url}}" target="_blank" rel="nofollow">
-            <img class="kf-keep-image" ng-src="{{keep.summary.imageUrl}}" ng-click="clickCallback({ 'keep': keep, event: $event })" click-action="articleImageSmall" alt="{{keep.titleAttr}}">
+            <img class="kf-keep-image" ng-src="{{keep.summary.imageUrl}}" ng-click="clickCallback({ 'keep': keep, event: $event })" click-action="clickedArticleImage" alt="{{keep.titleAttr}}">
           </a>
         </div>
 
@@ -37,10 +37,10 @@
       </div>
 
       <!-- Large Image or Special Card -->
-      <a ng-href="{{keep.url}}" target="_blank" rel="nofollow"><img class="kf-keep-big-image" ng-if="showBigImage(keep)" ng-src="{{keep.summary.imageUrl}}" ng-click="clickCallback({ 'keep': keep, event: $event })" click-action="articleImageBig"></a>
+      <a ng-href="{{keep.url}}" target="_blank" rel="nofollow"><img class="kf-keep-big-image" ng-if="showBigImage(keep)" ng-src="{{keep.summary.imageUrl}}" ng-click="clickCallback({ 'keep': keep, event: $event })" click-action="clickedArticleImage"></a>
 
       <div ng-if="cardType=='youtube'" class="kf-keep-youtube-content">
-        <div kf-youtube video-id=youtubeId></div>
+        <div ng-click="clickCallback({ 'keep': keep, event: $event })"><div kf-youtube video-id=youtubeId></div></div>
         <div kf-ellipsis full-text="keep.summary.description" max-num-lines=3 class="kf-keep-description"></div>
       </div>
 
@@ -51,7 +51,7 @@
       <div kf-keep-who-libs-and-pics keep="keep" class="kf-keep-who-libs-and-pics"></div>
     </div>
 
-    <div kf-tag-list ng-if="userLoggedIn" class="kf-keep-tag-list" get-selected-keeps="getSingleSelectedKeep(keep)" adding-tag="addingTag" is-shown="showTags(keep)" ng-show="showTags(keep)" keep="keep" read-only-mode="!isTaggable(keep)"></div>
+    <div kf-tag-list class="kf-keep-tag-list" get-selected-keeps="getSingleSelectedKeep(keep)" adding-tag="addingTag" is-shown="showTags(keep)" ng-show="showTags(keep)" keep="keep" read-only-mode="!isTaggable(keep)" user-logged-in="userLoggedIn" library="library"></div>
   </div>
 
   <div class="kf-keep-footer kf-keep-footer-buttons-wrapper clearfix" ng-if="userLoggedIn">

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.styl
@@ -21,11 +21,10 @@
 
 .kf-keeps-loading
 .kf-friends-loading
-  position: relative
-  left: -22px
+  display: block
   width: 44px
   height: 8px
-  margin: 21px 50%
+  margin: 40px auto
 
 .kf-shadow-dragged-keeps
 .kf-my-keeps

--- a/kifi-backend/modules/shoebox/angular/src/layout/header/HeaderCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/header/HeaderCtrl.js
@@ -114,6 +114,14 @@ angular.module('kifi')
       'leading': true
     });
 
+    $scope.onSearchBarClicked = function () {
+      if ($scope.library && $scope.library.id) {
+        $rootScope.$emit('trackLibraryEvent', 'click', {
+          action: 'clickedSearchBar'
+        });
+      }
+    };
+
     $scope.clearInput = function () {
       $scope.search.text = '';
       $scope.changeSearchInput();

--- a/kifi-backend/modules/shoebox/angular/src/layout/header/PublicHeaderCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/header/PublicHeaderCtrl.js
@@ -2,31 +2,65 @@
 
 angular.module('kifi')
 
-.controller('PublicHeaderCtrl', ['$scope', 'env', 'signupService', 'platformService',
-  function ($scope, env, signupService, platformService) {
+.controller('PublicHeaderCtrl', ['$scope', '$rootScope', 'env', 'signupService', 'platformService', 'libraryService',
+  function ($scope, $rootScope, env, signupService, platformService, libraryService) {
     $scope.navBase = env.navBase;
+
+    $scope.clickLogo = function () {
+      $scope.$emit('getCurrentLibrary', { callback: function (lib) {
+        if (lib && lib.id) {
+          libraryService.trackEvent('visitor_clicked_page', lib, {
+            type: 'libraryLanding',
+            action: 'clickedLogo'
+          });
+        }
+      }});
+    };
 
     $scope.join = function ($event) {
       $event.preventDefault();
 
-      if (platformService.isSupportedMobilePlatform()) {
-        platformService.goToAppOrStore();
-      } else {
-        $scope.$emit('getCurrentLibrary', { callback: function (lib) {
+      $scope.$emit('getCurrentLibrary', {
+        callback: function (lib) {
           var userData;
+
           if (lib && lib.id) {
             userData = { libraryId: lib.id };
+
+            libraryService.trackEvent('visitor_clicked_page', lib, {
+              type: 'libraryLanding',
+              action: 'clickedSignupHeader'
+            });
           }
-          signupService.register(userData);
-        }});
-      }
+
+          if (platformService.isSupportedMobilePlatform()) {
+            platformService.goToAppOrStore();
+          } else {
+            signupService.register(userData);
+          }
+        }
+      });
     };
 
     $scope.login = function ($event) {
       if (platformService.isSupportedMobilePlatform()) {
         $event.preventDefault();
-        platformService.goToAppOrStore();
       }
+
+      $scope.$emit('getCurrentLibrary', {
+        callback: function (lib) {
+          if (lib && lib.id) {
+            libraryService.trackEvent('visitor_clicked_page', lib, {
+              type: 'libraryLanding',
+              action: 'clickedLoginHeader'
+            });
+          }
+
+          if (platformService.isSupportedMobilePlatform()) {
+            platformService.goToAppOrStore();
+          }
+        }
+      });
     };
   }
 ]);

--- a/kifi-backend/modules/shoebox/angular/src/layout/header/header.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/header/header.styl
@@ -209,6 +209,7 @@ a.kf-header-callout:hover
   cursor: pointer
 
 .kf-header-right
+  position: relative
   overflow: hidden
   height: 100%
   margin-right: 60px
@@ -329,5 +330,3 @@ a.kf-header-callout:hover
 
   .public-header-dot
     margin: 0 10px
-
-

--- a/kifi-backend/modules/shoebox/angular/src/layout/header/header.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/header/header.tpl.html
@@ -17,7 +17,7 @@
         <div class="kf-search-bar-lib-name-clear" ng-show="search.showName" ng-class="library.kind != 'user_created' ? 'system-created' : library.visibility == 'secret' ? 'secret' : 'published'" ng-click="clearLibraryName()">&times;</div>
 
         <div class="kf-query-lib" ng-class="{'extend': !search.showName}">
-          <input type="text" placeholder="Search Kifi…" ng-model="search.text" ng-focus="focusInput()" ng-blur="blurInput()" ng-change="changeSearchInput()" ng-keydown="onKeydown($event)">
+          <input type="text" placeholder="Search Kifi…" ng-model="search.text" ng-focus="focusInput()" ng-blur="blurInput()" ng-change="changeSearchInput()" ng-keydown="onKeydown($event)" ng-click="onSearchBarClicked()">
         </div>
         <div class="kf-search-bar-clear" ng-show="search.text" ng-click="clearInput()">Clear</div>
       </div>

--- a/kifi-backend/modules/shoebox/angular/src/layout/header/publicHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/header/publicHeader.tpl.html
@@ -1,7 +1,7 @@
 <div class="kf-header public-header" ng-controller="PublicHeaderCtrl">
   <div class="kf-header-inner">
     <div class="kf-header-left">
-      <a href="/" target="_self">
+      <a href="/" target="_self" ng-click="clickLogo()">
         <span class="kifi-clover-logo-icon svg-kifi-clover-logo"></span>
         <span class="kf-header-logo svg-kifi-name"></span>
         <span class="public-header-tagline">Connecting people with knowledge</span>

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/main.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/main.styl
@@ -15,7 +15,14 @@
   width: 100%
 
   .kf-main-keeps
-    margin-top: 42px
+    padding-top: 42px
+
+.kf-logged-out .kf-main .library-search
+  .kf-main-head
+    padding-top: 0
+
+  .kf-main-keeps
+    padding-top: 0
 
 @media only screen and (max-width: 1024px)
   .kf-main
@@ -44,6 +51,7 @@
   font-weight: 300
 
 .kf-subtitle
+  padding: 10px 0
   font-size: 13px
   line-height: 20px
   -webkit-font-smoothing: antialiased;

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -13,6 +13,7 @@ angular.module('kifi')
     var selectedCount = 0;
     var prePopulated = false;
     var authToken = $location.search().authToken || '';
+    var prevLibrarySearch = false;
 
 
     //
@@ -114,13 +115,8 @@ angular.module('kifi')
     };
 
     $scope.libraryKeepClicked = function (keep, event) {
-      var target = event.target;
-      var eventAction = target.getAttribute('click-action');
-      if ($scope.$root.userLoggedIn) {
-        libraryService.trackEvent('user_clicked_page', $scope.library, { action: eventAction });
-      } else {
-        libraryService.trackEvent('visitor_clicked_page', $scope.library, { action: eventAction });
-      }
+      var eventAction = event.target.getAttribute('click-action');
+      $rootScope.$emit('trackLibraryEvent', 'click', { action: eventAction });
     };
 
 
@@ -171,8 +167,10 @@ angular.module('kifi')
     var deregisterTrackLibraryEvent = $rootScope.$on('trackLibraryEvent', function (e, eventType, attributes) {
       if (eventType === 'click') {
         if (!$rootScope.userLoggedIn) {
+          attributes.type = attributes.type || 'libraryLanding';
           libraryService.trackEvent('visitor_clicked_page', $scope.library, attributes);
         } else {
+          attributes.type = attributes.type || 'library';
           libraryService.trackEvent('user_clicked_page', $scope.library, attributes);
         }
       } else if (eventType === 'view') {
@@ -182,7 +180,9 @@ angular.module('kifi')
     $scope.$on('$destroy', deregisterTrackLibraryEvent);
 
     var deregisterUpdateLibrarySearch = $rootScope.$on('librarySearchChanged', function (e, librarySearch) {
+      prevLibrarySearch = $scope.librarySearch;
       $scope.librarySearch = librarySearch;
+      $scope.librarySearchFallingEdge = prevLibrarySearch && !$scope.librarySearch;
     });
     $scope.$on('$destroy', deregisterUpdateLibrarySearch);
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
@@ -72,7 +72,19 @@ invite-header-orange = #ff7c3c
     transition: right 0.3s ease
 
   .kf-keep-lib-search-input
+    padding-left: 30px
     transition: width 0.3s ease
+
+  .kf-keep-lib-search-icon
+    position: absolute
+    top: 8px
+    left: 8px
+    width: 18px
+    height: 18px
+    display: block
+    background-image: url('/img/sprites.png')
+    background-position: -103px -328px
+    background-size: 200px auto
 
   .dialog-x
     display: none

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
@@ -80,10 +80,10 @@ invite-header-orange = #ff7c3c
     top: 8px
     left: 8px
     width: 18px
-    height: 18px
+    height: 22px
     display: block
     background-image: url('/img/sprites.png')
-    background-position: -103px -328px
+    background-position: -103px -327px
     background-size: 200px auto
 
   .dialog-x

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
@@ -146,6 +146,9 @@ html:not(.kf-mobile)
       top: -10px
       right: -10px
 
+    .kf-keep-lib-image
+      display: none
+
 
 .public-library-empty-explain
   font-size: 18px

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
@@ -8,11 +8,8 @@ invite-header-orange = #ff7c3c
   padding: 0 25px 0 30px
 
 .kf-logged-out .kf-library-card-header
+  margin-bottom: 0
   background-color: #fff
-
-
-  .kf-logged-out &
-    margin-bottom: -30px
 
 .delighted-visible ~ div .kf-library-card-header
   margin-top: 10px
@@ -21,13 +18,36 @@ invite-header-orange = #ff7c3c
 // is no logged in user.
 .library-card.loggedOutUser
   border: none
-  box-shadow: none
+  margin: 0 auto
   padding-bottom: 20px
+  width: 745px
+  max-height: 5000px
+  transition: max-height 0.2s ease
+  box-shadow: none
+
+  &::before
+    position: absolute
+    top: 0
+    left: -5000px
+    display: block
+    box-shadow: none
+    width: 9999px
+    height: 100%
+    background-color: #fff
+    content: ''
+    z-index: -1
+
+  .kf-keep-body
+  .kf-keep-lib-header
+    max-height: 5000px
+    transition: max-height 0.2s ease
 
   .kf-keep-lib-name-container
     width: 100%
     height: auto
+    max-height: 5000px
     padding-top: 20px
+    transition: opacity 0.2s ease, max-height 0.2s ease
 
   .kf-keep-lib-name
     text-align: center
@@ -40,13 +60,85 @@ invite-header-orange = #ff7c3c
     font-family: Merriweather, Lato, Helvetica, Arial, sans-serif
 
   .kf-keep-lib-info
-    margin: 36px 40px 0
+    margin: 30px 40px 0
+    transition: margin-top 0.2s ease
+
+  .kf-keep-lib-owner
+    position: relative
+    left: 0
+    transition: left 0.4s ease
+
+  .kf-keep-lib-search
+    transition: right 0.3s ease
+
+  .kf-keep-lib-search-input
+    transition: width 0.3s ease
+
+  .dialog-x
+    display: none
+
+  .kf-keep-lib-description-container
+  .kf-keep-lib-stats-and-followers
+  .kf-keep-footer
+    max-height: 5000px
+    transition: opacity 0.2s ease, max-height 0.2s ease, visibility 0.2s ease
+
+  .kf-keep-lib-footer-button-follow-in-search
+    position: fixed
+    top: -100px
+    min-width: 82px
+    z-index: 501
+
+//
+// For logged-out library search.
+//
+html:not(.kf-mobile)
+  .library-search .library-card
+  .library-card.library-search-in-progress
+    max-height: 90px
+    position: fixed
+    top: 62px
+    z-index: 500
+
+    &.pageScrolled::before
+      box-shadow: 0px 5px 5px #ddd
+
+    .kf-keep-body
+      max-height: 90px
+
+    .kf-keep-lib-header
+      max-height: 0
+
+    .kf-keep-lib-name-container
+    .kf-keep-lib-description-container
+    .kf-keep-lib-stats-and-followers
+    .kf-keep-footer
+      opacity: 0
+      max-height: 0
+      visibility: hidden
+
+    .kf-keep-lib-info
+      margin-top: 0
+
+    .kf-keep-lib-owner
+      left: -55px
+
+    .kf-keep-lib-search
+      right: -100px
+
+    .kf-keep-lib-search-input
+      width: 495px
+
+    .dialog-x
+      display: block
+      top: -10px
+      right: -10px
+
 
 .public-library-empty-explain
   font-size: 18px
   margin: 0
   color: #666
-
 
 .library-card
   // Do not display text on buttons when the card is very narrow
@@ -144,6 +236,7 @@ invite-header-orange = #ff7c3c
   .kf-keep-lib-owner
     position: relative
     padding-bottom: 10px
+    padding-top: 5px
 
   .kf-keep-lib-user-image
     display: inline-block
@@ -170,7 +263,7 @@ invite-header-orange = #ff7c3c
     border: 1px solid #ccc
     border-radius: 10px
     font-size: 14px
-    padding: 3px 8px
+    padding: 8px 8px
     width: 140px
 
   .kf-keep-lib-description-container

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
@@ -22,7 +22,7 @@ invite-header-orange = #ff7c3c
   padding-bottom: 20px
   width: 745px
   max-height: 5000px
-  transition: max-height 0.2s ease
+  transition: max-height 0.3s ease
   box-shadow: none
 
   &::before
@@ -40,14 +40,14 @@ invite-header-orange = #ff7c3c
   .kf-keep-body
   .kf-keep-lib-header
     max-height: 5000px
-    transition: max-height 0.2s ease
+    transition: max-height 0.3s ease
 
   .kf-keep-lib-name-container
     width: 100%
     height: auto
     max-height: 5000px
     padding-top: 20px
-    transition: opacity 0.2s ease, max-height 0.2s ease
+    transition: opacity 0.3s ease, max-height 0.3s ease
 
   .kf-keep-lib-name
     text-align: center
@@ -61,12 +61,12 @@ invite-header-orange = #ff7c3c
 
   .kf-keep-lib-info
     margin: 30px 40px 0
-    transition: margin-top 0.2s ease
+    transition: margin-top 0.3s ease
 
   .kf-keep-lib-owner
     position: relative
     left: 0
-    transition: left 0.4s ease
+    transition: left 0.3s ease
 
   .kf-keep-lib-search
     transition: right 0.3s ease
@@ -93,7 +93,7 @@ invite-header-orange = #ff7c3c
   .kf-keep-lib-stats-and-followers
   .kf-keep-footer
     max-height: 5000px
-    transition: opacity 0.2s ease, max-height 0.2s ease, visibility 0.2s ease
+    transition: opacity 0.3s ease, max-height 0.3s ease, visibility 0.3s ease
 
   .kf-keep-lib-footer-button-follow-in-search
     position: fixed

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.tpl.html
@@ -1,6 +1,6 @@
 <div>
   <!-- Library page -->
-  <div class="kf-main-library-keeps" ng-if="page === 'library'" ng-class="{'library-search': librarySearch}">
+  <div class="kf-main-library-keeps" ng-if="page === 'library'" ng-class="{'library-search': librarySearch, 'library-search-falling-edge': librarySearchFallingEdge}">
     <div ng-if="!librarySearch || !$root.userLoggedIn" class="kf-library-card-header">
       <div kf-library-card
         library="library"
@@ -9,42 +9,44 @@
         loading="loading"
         toggle-edit="toggleEdit"
         recommendation="false"
-      ></div>
-      <div class="white-background"></div>
-    </div>
-
-    <div ng-if="!librarySearch || !$root.userLoggedIn">
-      <div class="kf-empty-state" ng-if="keeps.length === 0 && userIsOwner()" ng-show="!loading">
-        You don't have any keeps in this Library yet. You can:
-        <ul>
-          <li><a href="javascript:" ng-click="callAddKeep()"><span class="sprite sprite-add-link"></span>Add any page by pasting the URL here</a></li>
-          <li><a href="javascript:" ng-click="callImportBookmarks()"><span class="sprite sprite-import-bookmarks-icon"></span>Import your bookmarks from your browser</a></li>
-          <li><a href="javascript:" ng-click="callImportBookmarkFile()"><span class="sprite sprite-import-from-other-services-icon"></span>Import links from sites like Delicious, Pocket, Pinboard</a></li>
-          <li kf-max-version><a href="javascript:" ng-click="callTriggerInstall()"><span class="sprite sprite-install-extension-icon"></span>Install our browser extension on Chrome and Firefox</a></li>
-        </ul>
-      </div>
-
-      <div class="kf-empty-state" ng-if="keeps.length === 0 && !userIsOwner()" ng-show="!loading">
-        <p class="public-library-empty-explain">{{library.owner.firstName || 'The curator'}} hasn't added anything to this library yet.</p>
-        <p class="public-library-empty-explain" ng-hide="$root.userLoggedIn">Want to create and share your own libraries? <a href="/signup">Sign up</a> to join the Kifi family.</p>
-      </div>
-
-      <div kf-keeps
-        library="library"
-        keeps="keeps"
-        keeps-loading="loading"
-        keeps-has-more="hasMore"
-        scroll-disabled="!hasMore"
-        scroll-distance="scrollDistance"
-        scroll-next="getNextKeeps"
-        edit-mode="editMode"
-        toggle-edit="toggleEdit"
-        update-selected-count="updateSelectedCount(numSelected)"
-        keep-click="libraryKeepClicked"
+        library-search="librarySearch"
       ></div>
     </div>
 
-    <div ng-if="librarySearch && $root.userLoggedIn" ng-include="'search/search.tpl.html'" ng-controller="SearchCtrl"></div>
+    <div class="kf-library-body">
+      <div ng-if="!librarySearch">
+        <div class="kf-empty-state" ng-if="keeps.length === 0 && userIsOwner()" ng-show="!loading">
+          You don't have any keeps in this Library yet. You can:
+          <ul>
+            <li><a href="javascript:" ng-click="callAddKeep()"><span class="sprite sprite-add-link"></span>Add any page by pasting the URL here</a></li>
+            <li><a href="javascript:" ng-click="callImportBookmarks()"><span class="sprite sprite-import-bookmarks-icon"></span>Import your bookmarks from your browser</a></li>
+            <li><a href="javascript:" ng-click="callImportBookmarkFile()"><span class="sprite sprite-import-from-other-services-icon"></span>Import links from sites like Delicious, Pocket, Pinboard</a></li>
+            <li kf-max-version><a href="javascript:" ng-click="callTriggerInstall()"><span class="sprite sprite-install-extension-icon"></span>Install our browser extension on Chrome and Firefox</a></li>
+          </ul>
+        </div>
+
+        <div class="kf-empty-state" ng-if="keeps.length === 0 && !userIsOwner()" ng-show="!loading">
+          <p class="public-library-empty-explain">{{library.owner.firstName || 'The curator'}} hasn't added anything to this library yet.</p>
+          <p class="public-library-empty-explain" ng-hide="$root.userLoggedIn">Want to create and share your own libraries? <a href="/signup">Sign up</a> to join the Kifi family.</p>
+        </div>
+
+        <div kf-keeps
+          library="library"
+          keeps="keeps"
+          keeps-loading="loading"
+          keeps-has-more="hasMore"
+          scroll-disabled="!hasMore"
+          scroll-distance="scrollDistance"
+          scroll-next="getNextKeeps"
+          edit-mode="editMode"
+          toggle-edit="toggleEdit"
+          update-selected-count="updateSelectedCount(numSelected)"
+          keep-click="libraryKeepClicked"
+        ></div>
+      </div>
+
+      <div ng-if="librarySearch" ng-include="'search/search.tpl.html'" ng-controller="SearchCtrl"></div>
+    </div>
   </div>
 
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -480,7 +480,7 @@ angular.module('kifi')
         scope.onSearchInputFocus = function () {
           // Track click/focus on search bar.
           $rootScope.$emit('trackLibraryEvent', 'click', {
-            action: platformService.isSupportedMobilePlatform() ? 'clickedSearchPinned' : 'clickedSearchBody'
+            action: 'clickedSearchBody'
           });
 
           showLibrarySearchBar();
@@ -560,9 +560,6 @@ angular.module('kifi')
               $routeParams.f = 'a';
 
               $timeout(function () {
-                if (platformService.isSupportedMobilePlatform()) {
-                  scope.librarySearchInProgress = true;  // For mobile.
-                }
                 $rootScope.$emit('librarySearchChanged', true);
               });
 
@@ -576,9 +573,6 @@ angular.module('kifi')
               prevQuery = '';
 
               $timeout(function () {
-                if (platformService.isSupportedMobilePlatform()) {
-                  scope.librarySearchInProgress = false;  // For mobile.
-                }
                 $rootScope.$emit('librarySearchChanged', false);
                 scope.search = { 'text': '' };
               });

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -18,7 +18,8 @@ angular.module('kifi')
         librarySlug: '=',
         recommendation: '=',
         loading: '=',
-        toggleEdit: '='
+        toggleEdit: '=',
+        librarySearch: '='
       },
       templateUrl: 'libraries/libraryCard.tpl.html',
       link: function (scope, element/*, attrs*/) {
@@ -28,6 +29,14 @@ angular.module('kifi')
         var uriRe = /(?:\b|^)((?:(?:(https?|ftp):\/\/|www\d{0,3}[.])?(?:[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\.)+(?:com|edu|biz|gov|in(?:t|fo)|mil|net|org|name|coop|aero|museum|a[cdegilmoqrstuz]|b[abefghimnrtyz]|c[acdfghiklmnoruxyz]|d[ejko]|e[cegst]|f[ijkmor]|g[befghilmnpqrstu]|h[kmnru]|i[delmnorst]|j[eop]|k[eghrwyz]|l[bciktuvy]|m[cdghkmnoqrstuwxyz]|n[acfilouz]|om|p[aeghklmnrty]|qa|r[eouw]|s[abcdeghikmnotuvz]|t[cdfhjmnoprtvwz]|u[agkmsyz]|v[eginu]|wf|y[t|u]|z[amrw]\b))(?::[0-9]{1,5})?(?:\/(?:[^\s()<>]*[^\s`!\[\]{};:.'",<>?«»()“”‘’]|\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\))*|\b))(?=[\s`!()\[\]{};:.'",<>?«»“”‘’]|$)/;  // jshint ignore:line
         var authToken = $location.search().authToken || '';
         var prevQuery = '';
+        var headerLinksShifted = false;
+        var headerLinksWidth = '60px';
+        var updateSearchText = false;
+
+        var kfColsElement = angular.element('.kf-cols');
+        var headerLinksElement = angular.element('.kf-header-right');
+        var searchFollowElement = angular.element('.kf-keep-lib-footer-button-follow-in-search');
+        var libraryBodyElement = angular.element('.kf-library-body');
 
 
         //
@@ -38,7 +47,10 @@ angular.module('kifi')
         scope.followersToShow = 0;
         scope.numAdditionalFollowers = 0;
         scope.editKeepsText = 'Edit Keeps';
+        scope.librarySearchInProgress = scope.librarySearch;
+        scope.librarySearchBarShown = false;
         scope.search = { 'text': $routeParams.q || '' };
+        scope.pageScrolled = false;
 
         var magicImages = {
           'l7SZ3gr3kUQJ': '//djty7jcqog9qu.cloudfront.net/special-libs/l7SZ3gr3kUQJ.png',
@@ -65,6 +77,24 @@ angular.module('kifi')
         //
         // Internal methods.
         //
+        function init() {
+          if (scope.isUserLoggedOut && !platformService.isSupportedMobilePlatform()) {
+            showKfColsOverflow();
+            $timeout(hideKfColsOverflow);
+          }
+        }
+
+        function hideKfColsOverflow() {
+          // Hide overflow so that there is no horizontal scrollbar due to the very
+          // wide white background on the library header.
+          kfColsElement.css({ 'overflow-x': 'hidden' });
+        }
+
+        function showKfColsOverflow() {
+          // Show overflow so that infinite scroll can be initialized correctly.
+          kfColsElement.css({ 'overflow-x': 'visible' });
+        }
+
         function adjustFollowerPicsSize() {
           var statsAndFollowersDiv = element.find('.kf-keep-lib-stats-and-followers');
           var followerPicsDiv = element.find('.kf-keep-lib-follower-pics');
@@ -97,14 +127,11 @@ angular.module('kifi')
           });
         }
 
-        function trackShareEvent(medium) {
+        function trackShareEvent(action) {
           $timeout(function () {
-            var attrs = { action: 'shareLibrary', subAction: medium };
-            var eventName = (scope.isUserLoggedOut ? 'visitor' : 'user') + '_clicked_page';
-            libraryService.trackEvent(eventName, scope.library, attrs);
+            $rootScope.$emit('trackLibraryEvent', 'click', { action: action });
           });
         }
-
 
         function processUrls(text) {
           var parts = (text || '').split(uriRe);
@@ -127,6 +154,33 @@ angular.module('kifi')
         // TODO(yiping): make new libraryDecoratorService to do this. Then, DRY up the code that is
         // currently in nav.js too.
         function augmentData() {
+
+          // Figure out whether this library is a library that the user has been invited to.
+          function getInvitePromise() {
+            var promise = null;
+
+            if (libraryService.invitedSummaries.length) {
+              promise = $q.when(libraryService.invitedSummaries);
+            } else {
+              promise = libraryService.fetchLibrarySummaries(true).then(function () {
+                return libraryService.invitedSummaries;
+              });
+            }
+
+            return promise.then(function (invitedSummaries) {
+              var maybeLib = _.find(invitedSummaries, { 'id' : scope.library.id });
+
+              if (maybeLib) {
+                return {
+                  inviterName: maybeLib.inviter.firstName + ' ' + maybeLib.inviter.lastName,
+                  actedOn: false
+                };
+              } else {
+                return null;
+              }
+            });
+          }
+
           // Libraries created with the extension do not have the description field.
           if (!scope.library.description) {
             scope.library.description = '';
@@ -170,15 +224,12 @@ angular.module('kifi')
             '&kcid=na-vf_twitter-library_share-lid_' + scope.library.id);
           scope.library.shareText = 'Discover this amazing @Kifi library about ' + scope.library.name + '!';
 
-          if (scope.$root.userLoggedIn === false) {
-            scope.$evalAsync(function () {
-              angular.element('.white-background').height(element.height() + 20);
-            });
-          }
-
+          getInvitePromise().then(function (invite) {
+            scope.library.invite = invite;
+          });
         }
 
-        function preloadSocial () {
+        function preloadSocial() {
           if (!$FB.failedToLoad && !$FB.loaded) {
             $FB.init();
           }
@@ -187,6 +238,17 @@ angular.module('kifi')
           }
         }
         scope.$evalAsync(preloadSocial);
+
+        function onScroll() {
+          scope.$apply(function () {
+            scope.pageScrolled = $window.document.body.scrollTop > 0;
+          });
+        }
+
+        function scrollToTop() {
+          $window.document.body.scrollTop = 0;
+          scope.pageScrolled = false;
+        }
 
 
         //
@@ -213,7 +275,7 @@ angular.module('kifi')
         };
 
         scope.isMyLibrary = function (library) {
-          return library.owner && library.owner.id === profileService.me.id;
+          return libraryService.isMyLibrary(library);
         };
 
         scope.canBeShared = function (library) {
@@ -230,7 +292,7 @@ angular.module('kifi')
         };
 
         scope.shareFB = function () {
-          trackShareEvent('facebook');
+          trackShareEvent('clickedShareFacebook');
           $FB.ui({
             method: 'share',
             href: scope.library.shareFbUrl
@@ -238,7 +300,7 @@ angular.module('kifi')
         };
 
         scope.shareTwitter = function () {
-          trackShareEvent('twitter');
+          trackShareEvent('clickedShareTwitter');
         };
 
         // TODO: determine this on the server side in the library response. For now, doing it client side.
@@ -247,11 +309,12 @@ angular.module('kifi')
         };
 
         scope.alreadyFollowingLibrary = function (library) {
-          return (library.access && (library.access === 'read_only')) ||
-            (_.some(libraryService.librarySummaries, { id: library.id }) && !scope.isMyLibrary(library));
+          return libraryService.isFollowingLibrary(library);
         };
 
         scope.followLibrary = function (library) {
+          $rootScope.$emit('trackLibraryEvent', 'click', { action: 'clickedFollowButton' });
+
           if (platformService.isSupportedMobilePlatform()) {
             var url = $location.absUrl();
             if (url.indexOf('?') !== -1) {
@@ -262,11 +325,8 @@ angular.module('kifi')
             platformService.goToAppOrStore(url);
             return;
           } else if ($rootScope.userLoggedIn === false) {
-            libraryService.trackEvent('visitor_clicked_page', library, { action: 'followButton' });
             return signupService.register({libraryId: scope.library.id});
           }
-
-          libraryService.trackEvent('user_clicked_page', library, { action: 'followed' });
 
           libraryService.joinLibrary(library.id).then(function (result) {
             if (library.invite) {
@@ -295,11 +355,18 @@ angular.module('kifi')
         };
 
         scope.unfollowLibrary = function (library) {
+          // TODO(yrl): ask Jen about whether we can remove this.
           libraryService.trackEvent('user_clicked_page', library, { action: 'unfollow' });
+
+          $rootScope.$emit('trackLibraryEvent', 'click', { action: 'clickedUnfollowButton' });
           libraryService.leaveLibrary(library.id)['catch'](modalService.openGenericErrorModal);
         };
 
         scope.followStick = function (isStuck) {
+          if (scope.librarySearchInProgress) {
+            return;
+          }
+
           if (isStuck) {
             angular.element('html.kf-mobile .kf-header-right').css({'display': 'none'});
             angular.element('.kf-header-right').css({'margin-right': '150px'});
@@ -340,6 +407,8 @@ angular.module('kifi')
         };
 
         scope.showFollowers = function () {
+          $rootScope.$emit('trackLibraryEvent', 'click', { action: 'clickedViewFollowers' });
+
           if (scope.library.owner.id === profileService.me.id) {
             modalService.open({
               template: 'libraries/manageLibraryModal.tpl.html',
@@ -358,10 +427,115 @@ angular.module('kifi')
           }
         };
 
+        function positionSearchFollow() {
+          $timeout(function () {
+            searchFollowElement.css({
+              'left': headerLinksElement.offset().left + headerLinksElement.width() + 15 + 'px'
+            });
+          }, 200);
+        }
+
+        function showLibrarySearchBar() {
+          if (platformService.isSupportedMobilePlatform() || scope.librarySearchBarShown) {
+            return;
+          }
+
+          scope.librarySearchInProgress = true;
+          scope.librarySearchBarShown = true;
+
+          scrollToTop();
+
+          if (!searchFollowElement.length) {
+            searchFollowElement = angular.element('.kf-keep-lib-footer-button-follow-in-search');
+          }
+
+          // Reset any previous shifts of the right header.
+          headerLinksElement.css({ 'margin-right': headerLinksWidth });
+
+          // Shift header to the left and drop down follow button.
+          $timeout(function () {
+            if (!headerLinksShifted) {
+              headerLinksElement.css({
+                'margin-right': '150px'
+              });
+
+              headerLinksShifted = true;
+            }
+
+            searchFollowElement.css({
+              'left': headerLinksElement.offset().left + headerLinksElement.width() + 15 + 'px'
+            });
+
+            searchFollowElement.css({
+              'transition': 'top 0.5s ease 0.3s',
+              'top': '15px'
+            });
+
+            libraryBodyElement.css({
+              'margin-top': '90px'
+            });
+          }, 0);
+        }
+
+        scope.onSearchInputFocus = function () {
+          // Track click/focus on search bar.
+          $rootScope.$emit('trackLibraryEvent', 'click', {
+            action: platformService.isSupportedMobilePlatform() ? 'clickedSearchPinned' : 'clickedSearchBody'
+          });
+
+          showLibrarySearchBar();
+        };
+
+        scope.onSearchExit = function () {
+          scrollToTop();
+
+          if (scope.isUserLoggedOut && !platformService.isSupportedMobilePlatform()) {
+            showKfColsOverflow();
+          }
+          locationNoReload.skipReload().url(scope.library.url);
+          locationNoReload.reloadNextRouteChange();
+
+          scope.librarySearchInProgress = false;
+          scope.librarySearchBarShown = false;
+          $rootScope.$emit('librarySearchChanged', false);
+          prevQuery = '';
+
+          if (!searchFollowElement.length) {
+            searchFollowElement = angular.element('.kf-keep-lib-footer-button-follow-in-search');
+          }
+
+          searchFollowElement.css({
+            'transition': 'top 0.2s ease',
+            'top': '-100px'
+          });
+
+          if (headerLinksShifted) {
+            headerLinksElement.css({
+              'margin-right': headerLinksWidth
+            });
+
+            headerLinksShifted = false;
+          }
+
+          libraryBodyElement.css({
+            'transition': 'margin-top 0.1s ease',
+            'margin-top': '0px'
+          });
+
+          $timeout(function () {
+            scope.search.text = '';
+          });
+        };
+
         scope.onSearchInputChange = _.debounce(function (query) {
           $timeout(function () {
             if (query) {
+              locationNoReload.cancelReloadNextRouteChange();
+
               if (prevQuery) {
+                if (scope.isUserLoggedOut && !platformService.isSupportedMobilePlatform()) {
+                  showKfColsOverflow();
+                }
                 locationNoReload.skipReload().search('q', query).replace();
 
                 // When we search using the input inside the library card header, we don't
@@ -375,6 +549,9 @@ angular.module('kifi')
                   });
                 }
               } else {
+                if (scope.isUserLoggedOut && !platformService.isSupportedMobilePlatform()) {
+                  showKfColsOverflow();
+                }
                 locationNoReload.skipReload().url(scope.library.url + '/find?q=' + query + '&f=a');
               }
 
@@ -382,21 +559,34 @@ angular.module('kifi')
               $routeParams.f = 'a';
 
               $timeout(function () {
+                if (platformService.isSupportedMobilePlatform()) {
+                  scope.librarySearchInProgress = true;  // For mobile.
+                }
                 $rootScope.$emit('librarySearchChanged', true);
               });
+
+              prevQuery = query;
             } else {
+              if (scope.isUserLoggedOut && !platformService.isSupportedMobilePlatform()) {
+                showKfColsOverflow();
+              }
               locationNoReload.skipReload().url(scope.library.url);
+              locationNoReload.reloadNextRouteChange();
+              prevQuery = '';
 
               $timeout(function () {
+                if (platformService.isSupportedMobilePlatform()) {
+                  scope.librarySearchInProgress = false;  // For mobile.
+                }
                 $rootScope.$emit('librarySearchChanged', false);
+                scope.search.text = '';
               });
             }
-
-            prevQuery = query;
           });
-        }, 100, {
-          'leading': true
+        }, 50, {
+          leading: true
         });
+
 
         //
         // Watches and listeners.
@@ -407,20 +597,12 @@ angular.module('kifi')
           if (!newVal) {
             augmentData();
             adjustFollowerPicsSize();
-          }
-        });
 
-        // Figure out whether this library is a library that the user has been invited to.
-        // If so, display an invite header.
-        scope.$watch(function() {
-          return libraryService.invitedSummaries.length;
-        }, function () {
-          var maybeLib = _.find(libraryService.invitedSummaries, { 'id' : scope.library.id });
-          if (maybeLib) {
-            scope.library.invite = {
-              inviterName: maybeLib.inviter.firstName + ' ' + maybeLib.inviter.lastName,
-              actedOn: false
-            };
+            if (scope.librarySearch) {
+              $timeout(function () {
+                showLibrarySearchBar();
+              });
+            }
           }
         });
 
@@ -433,12 +615,40 @@ angular.module('kifi')
         });
         scope.$on('$destroy', deregisterLibraryUpdated);
 
+        var deregisterNewSearchUrl = $rootScope.$on('newSearchUrl', function () {
+          updateSearchText = true;
+        });
+        scope.$on('$destroy', deregisterNewSearchUrl);
+
+        var deregisterNewSearchQuery = $rootScope.$on('newSearchQuery', function (e, query) {
+          if (updateSearchText) {
+            scope.search.text = query;
+            updateSearchText = false;
+          }
+        });
+        scope.$on('$destroy', deregisterNewSearchQuery);
+
         // Update how many follower pics are shown when the window is resized.
         var adjustFollowerPicsSizeOnResize = _.debounce(adjustFollowerPicsSize, 200);
         $window.addEventListener('resize', adjustFollowerPicsSizeOnResize);
         scope.$on('$destroy', function () {
           $window.removeEventListener('resize', adjustFollowerPicsSizeOnResize);
         });
+
+        // Update follower button in search when the window is resized.
+        var positionSearchFollowOnResize = _.debounce(positionSearchFollow, 100);
+        $window.addEventListener('resize', positionSearchFollowOnResize);
+        scope.$on('$destroy', function () {
+          $window.removeEventListener('resize', positionSearchFollowOnResize);
+        });
+
+        $window.addEventListener('scroll', onScroll);
+        scope.$on('$destroy', function () {
+          $window.removeEventListener('scroll', onScroll);
+        });
+
+
+        init();
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -491,6 +491,7 @@ angular.module('kifi')
 
           if (scope.isUserLoggedOut && !platformService.isSupportedMobilePlatform()) {
             showKfColsOverflow();
+            $timeout(hideKfColsOverflow);
           }
           locationNoReload.skipReload().url(scope.library.url);
           locationNoReload.reloadNextRouteChange();

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -524,7 +524,7 @@ angular.module('kifi')
           });
 
           $timeout(function () {
-            scope.search.text = '';
+            scope.search = { text: '' };
           });
         };
 
@@ -580,7 +580,7 @@ angular.module('kifi')
                   scope.librarySearchInProgress = false;  // For mobile.
                 }
                 $rootScope.$emit('librarySearchChanged', false);
-                scope.search.text = '';
+                scope.search = { 'text': '' };
               });
             }
           });
@@ -623,7 +623,7 @@ angular.module('kifi')
 
         var deregisterNewSearchQuery = $rootScope.$on('newSearchQuery', function (e, query) {
           if (updateSearchText) {
-            scope.search.text = query;
+            scope.search = { 'text': query };
             updateSearchText = false;
           }
         });

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
@@ -6,7 +6,7 @@
   </div>
   <div ng-if="!recommendation && isUserLoggedOut" class="kf-keep-lib-mobile-search">
     <span class="kf-keep-lib-mobile-search-icon"></span>
-    <input class="kf-keep-lib-search-input" type="search" placeholder="Search this library" ng-model="search.text" ng-focus="onSearchInputFocus()" ng-change="onSearchInputChange(search.text)">
+    <input class="kf-keep-lib-search-input" type="text" placeholder="Search this library" ng-model="search.text" ng-focus="onSearchInputFocus()" ng-change="onSearchInputChange(search.text)">
   </div>
   <button ng-if="!recommendation && isUserLoggedOut" ng-click="followLibrary(library)"
     class="kf-keep-lib-footer-button kf-keep-lib-footer-button-right kf-keep-lib-footer-button-follow-unfollow kf-keep-lib-footer-button-follow kf-keep-lib-footer-button-follow-in-search">Follow Library</button>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
@@ -1,9 +1,15 @@
-<div class="kf-keep library-card" ng-class="{ 'loggedOutUser': isUserLoggedOut }">
+<div class="kf-keep library-card" ng-class="{ 'loggedOutUser': isUserLoggedOut, 'library-search-in-progress': librarySearchInProgress, 'pageScrolled': pageScrolled }">
   <div ng-show="library.invite && !library.invite.actedOn" class="library-card-invite-header">
     <button class="library-card-invite-header-button library-card-invite-header-accept" ng-click="acceptInvitation(library)">Accept</button>
     <button class="library-card-invite-header-button library-card-invite-header-ignore" ng-click="ignoreInvitation(library)">Ignore</button>
     <span class="library-card-invite-header-info">{{library.invite.inviterName}} has invited you to follow this library</span>
   </div>
+  <div ng-if="!recommendation && isUserLoggedOut" class="kf-keep-lib-mobile-search">
+    <span class="kf-keep-lib-mobile-search-icon"></span>
+    <input class="kf-keep-lib-search-input" type="search" placeholder="Search this library" ng-model="search.text" ng-focus="onSearchInputFocus()" ng-change="onSearchInputChange(search.text)">
+  </div>
+  <button ng-if="!recommendation && isUserLoggedOut" ng-click="followLibrary(library)"
+    class="kf-keep-lib-footer-button kf-keep-lib-footer-button-right kf-keep-lib-footer-button-follow-unfollow kf-keep-lib-footer-button-follow kf-keep-lib-footer-button-follow-in-search">Follow Library</button>
   <div class="kf-keep-body">
     <div class="kf-keep-lib-header">
       <div ng-if="!isUserLoggedOut" ng-switch="library.kind" class="kf-keep-lib-icon-container">
@@ -32,8 +38,9 @@
           <div class="kf-keep-lib-owner-name" itemprop="name">{{library.owner.firstName}} {{library.owner.lastName}}</div>
         </div>
 
-        <div ng-if="!recommendation && isUserLoggedOut && false" class="kf-keep-lib-search">
-          <input class="kf-keep-lib-search-input" type="text" placeholder="Search this library" ng-model="search.text" ng-focus="" ng-blur="" ng-change="onSearchInputChange(search.text)" ng-keydown="">
+        <div ng-if="!recommendation && isUserLoggedOut" class="kf-keep-lib-search">
+          <input class="kf-keep-lib-search-input" type="search" placeholder="Search this library" ng-model="search.text" ng-focus="onSearchInputFocus()" ng-change="onSearchInputChange(search.text)">
+          <a class="dialog-x" href="javascript:" ng-click="onSearchExit()"></a>
         </div>
       </div>
 
@@ -88,9 +95,7 @@
     <button ng-if="isMyLibrary(library) && library.numKeeps > 0" class="kf-keep-lib-footer-button kf-keep-lib-footer-button-right kf-keep-lib-edit-keeps-button" ng-click="toggleEditKeeps()">
       {{editKeepsText}}
     </button>
-    <button kf-sticky sticky-if="isUserLoggedOut" max-top="followButtonMaxTop" sticky-width-mode="ignored" on-stick="followStick"
-        ng-class="{stickable: isUserLoggedOut}" ng-if="canFollowLibrary(library)" ng-click="followLibrary(library)"
-        class="kf-keep-lib-footer-button kf-keep-lib-footer-button-right kf-keep-lib-footer-button-follow-unfollow kf-keep-lib-footer-button-follow">
+    <button kf-sticky sticky-if="isUserLoggedOut" max-top="followButtonMaxTop" sticky-width-mode="ignored" on-stick="followStick" ng-class="{stickable: isUserLoggedOut}" ng-if="canFollowLibrary(library) && !librarySearchInProgress" ng-click="followLibrary(library)" class="kf-keep-lib-footer-button kf-keep-lib-footer-button-right kf-keep-lib-footer-button-follow-unfollow kf-keep-lib-footer-button-follow kf-keep-lib-footer-sticky-follow-button">
       Follow Library
     </button>
     <button ng-if="alreadyFollowingLibrary(library)" class="kf-keep-lib-footer-button kf-keep-lib-footer-button-right kf-keep-lib-footer-button-follow-unfollow kf-keep-lib-footer-button-unfollow" ng-click="unfollowLibrary(library)"></button>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
@@ -39,6 +39,7 @@
         </div>
 
         <div ng-if="!recommendation && isUserLoggedOut" class="kf-keep-lib-search">
+          <span class="kf-keep-lib-search-icon"></span>
           <input class="kf-keep-lib-search-input" type="search" placeholder="Search this library" ng-model="search.text" ng-focus="onSearchInputFocus()" ng-change="onSearchInputChange(search.text)">
           <a class="dialog-x" href="javascript:" ng-click="onSearchExit()"></a>
         </div>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
@@ -7,6 +7,7 @@
   <div ng-if="!recommendation && isUserLoggedOut" class="kf-keep-lib-mobile-search">
     <span class="kf-keep-lib-mobile-search-icon"></span>
     <input class="kf-keep-lib-search-input" type="text" placeholder="Search this library" ng-model="search.text" ng-focus="onSearchInputFocus()" ng-change="onSearchInputChange(search.text)">
+    <a class="dialog-x" href="javascript:" ng-click="onSearchExit()"></a>
   </div>
   <button ng-if="!recommendation && isUserLoggedOut" ng-click="followLibrary(library)"
     class="kf-keep-lib-footer-button kf-keep-lib-footer-button-right kf-keep-lib-footer-button-follow-unfollow kf-keep-lib-footer-button-follow kf-keep-lib-footer-button-follow-in-search">Follow Library</button>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
@@ -4,11 +4,6 @@
     <button class="library-card-invite-header-button library-card-invite-header-ignore" ng-click="ignoreInvitation(library)">Ignore</button>
     <span class="library-card-invite-header-info">{{library.invite.inviterName}} has invited you to follow this library</span>
   </div>
-  <div ng-if="!recommendation && isUserLoggedOut" class="kf-keep-lib-mobile-search">
-    <span class="kf-keep-lib-mobile-search-icon"></span>
-    <input class="kf-keep-lib-search-input" type="text" placeholder="Search this library" ng-model="search.text" ng-focus="onSearchInputFocus()" ng-change="onSearchInputChange(search.text)">
-    <a class="dialog-x" href="javascript:" ng-click="onSearchExit()"></a>
-  </div>
   <button ng-if="!recommendation && isUserLoggedOut" ng-click="followLibrary(library)"
     class="kf-keep-lib-footer-button kf-keep-lib-footer-button-right kf-keep-lib-footer-button-follow-unfollow kf-keep-lib-footer-button-follow kf-keep-lib-footer-button-follow-in-search">Follow Library</button>
   <div class="kf-keep-body">

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -331,13 +331,24 @@ angular.module('kifi')
         }
       },
 
+      isMyLibrary: function (library) {
+        return library.owner && library.owner.id === profileService.me.id;
+      },
+
+      isFollowingLibrary: function (library) {
+        return (library.access && (library.access === 'read_only')) ||
+               (_.some(librarySummaries, { id: library.id }) && !this.isMyLibrary(library));
+      },
+
       getCommonTrackingAttributes: function (library) {
         var defaultAttributes = {
+          followerCount: library.numFollowers,
+          followingLibrary: this.isFollowingLibrary(library),
+          keepCount: library.numKeeps,
           libraryId: library.id,
           libraryOwnerUserId: library.owner.id,
           libraryOwnerUserName: library.owner.username,
-          followerCount: library.numFollowers,
-          keepCount: library.numKeeps,
+          owner: this.isMyLibrary(library),
           privacySetting: library.visibility,
           source: 'site'
         };

--- a/kifi-backend/modules/shoebox/angular/src/search/search.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/search.js
@@ -151,6 +151,7 @@ angular.module('kifi')
         $scope.hasMore = !!result.mayHaveMore;
         lastResult = result;
         $scope.loading = false;
+        $rootScope.$emit('newSearchQuery', query);
       });
     };
 

--- a/kifi-backend/modules/shoebox/angular/src/search/search.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/search/search.tpl.html
@@ -14,6 +14,8 @@
     </div>
   </div>
 
+  <div ng-if="!loading && !resultKeeps.length" class="kf-mobile-search-no-results-message">Sorry, no search results found.</div>
+
   <div
     kf-keeps
     keeps="resultKeeps"

--- a/kifi-backend/modules/shoebox/angular/src/tags/tagList.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/tags/tagList.tpl.html
@@ -1,7 +1,7 @@
 <div class="kf-keep-tags-new">
   <ul class="kf-tag-list-new clearfix">
     <li class="kf-keep-tag-new" data-id="{{tag.id}}" ng-repeat="tag in tagsToShow">
-      <div class="kf-keep-tag-link-new"><a ng-href="{{searchTagUrl(tag.name)}}">{{tag.name}}</a></div>
+      <div class="kf-keep-tag-link-new"><a ng-href="{{searchTagUrl(tag.name)}}" ng-click="onTagClick()">{{tag.name}}</a></div>
       <div class="kf-keep-tag-x-new" ng-if="!tag.readOnly" ng-click="removeTag(tag.name)">×</div>
     </li>
     <li class="kf-keep-tag-add-tag-wrapper" ng-if="!readOnlyMode()">


### PR DESCRIPTION
@andrewconner Same as the last pull, with one more commit that takes out mobile search code. "Follow" button still jumps slightly as you observed. This is caused by adding some timeouts to `sticky.js`, which were needed because otherwise the library header will not show up in mobile at all, as we saw on Friday. :(
