### PR TITLE
Remove unnecessary relative positioning that is causing friends hover in...

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/layout/header/header.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/header/header.styl
@@ -209,7 +209,6 @@ a.kf-header-callout:hover
   cursor: pointer
 
 .kf-header-right
-  position: relative
   overflow: hidden
   height: 100%
   margin-right: 60px


### PR DESCRIPTION
... header to be behind main columns.

@andrewconner Noticed this small bug caused by public library search rollout.
