### PR TITLE
linkedin config fix (dev mode)

### DIFF
--- a/kifi-backend/modules/common/conf/dev-securesocial.conf
+++ b/kifi-backend/modules/common/conf/dev-securesocial.conf
@@ -58,8 +58,8 @@ securesocial {
   linkedin {
     authorizationUrl="https://www.linkedin.com/uas/oauth2/authorization"
     accessTokenUrl="https://www.linkedin.com/uas/oauth2/accessToken"
-    clientId=ovlhms1y0fjr
-    clientSecret=5nz8568RERDuTNpu
+    clientId="ovlhms1y0fjr"
+    clientSecret="5nz8568RERDuTNpu"
     scope="r_basicprofile,r_fullprofile,r_emailaddress,r_network,r_contactinfo,w_messages"
   }
 }


### PR DESCRIPTION
This fixes the LinkedIn dev mode issue. 

Turns out this likely never worked -- 2 issues:
1) The LinkedIn Kifi app (dev) config settings is mis-configured. OAuth2 redirect URLs are not configured properly. This has been fixed.
2) Our dev mode config is also incorrect. This is specific to dev-mode config.

Simple fixes but should help shorten develop/test cycle with local mode.

@andrewconner 
