### PR TITLE
Invalidating UserValue Cache

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
@@ -25,7 +25,7 @@ case class UserValue(
 }
 
 case class UserValueKey(userId: Id[User], key: UserValueName) extends Key[String] {
-  override val version = 2
+  override val version = 3
   val namespace = "uservalue"
   def toKey(): String = userId.id + "_" + key.name
 }


### PR DESCRIPTION
I added a bunch of rows to the table (backfilling kcids for pre-kcid users) and forgot that we do `None` caching. Should have done it in code; sorry about the need for the heavy handed fix.

@andrewconner 
