### PR TITLE
renaming class in library card to avoid potential conflict with keep card

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
@@ -37,7 +37,7 @@ invite-header-orange = #ff7c3c
     content: ''
     z-index: -1
 
-  .kf-keep-body
+  .kf-keep-lib-body
   .kf-keep-lib-header
     max-height: 5000px
     transition: max-height 0.3s ease
@@ -115,7 +115,7 @@ html:not(.kf-mobile)
     &.pageScrolled::before
       box-shadow: 0px 5px 5px #ddd
 
-    .kf-keep-body
+    .kf-keep-lib-body
       max-height: 90px
 
     .kf-keep-lib-header
@@ -201,6 +201,9 @@ html:not(.kf-mobile)
     &.library-card-invite-header-ignore
       background: invite-header-orange
       color: #fff
+
+  .kf-keep-lib-body
+    padding: 0 30px 5px
 
   .kf-keep-lib-header
     padding-top: 20px

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
@@ -6,7 +6,7 @@
   </div>
   <button ng-if="!recommendation && isUserLoggedOut" ng-click="followLibrary()"
     class="kf-keep-lib-footer-button kf-keep-lib-footer-button-right kf-keep-lib-footer-button-follow-unfollow kf-keep-lib-footer-button-follow kf-keep-lib-footer-button-follow-in-search">Follow Library</button>
-  <div class="kf-keep-body">
+  <div class="kf-keep-lib-body">
     <div class="kf-keep-lib-header">
       <div ng-if="!isUserLoggedOut" ng-switch="library.kind" class="kf-keep-lib-icon-container">
         <div ng-switch-when="system_main" class="kf-keep-lib-icon svg-main-library-big"></div>


### PR DESCRIPTION
@yipingliao 

To be clear, because all of the library card rules are scoped with ancestor selectors, there isn’t an actual conflict. This just may help avoid conflicts going forward (e.g. keep card changes unintentionally affecting the library card).

By the way, I’d like to gradually simplify our selectors. Most rules shouldn’t need ancestor scoping.
