### PR TITLE
library image controller (3 endpoints -> upload, position, remove)

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
@@ -285,11 +285,11 @@ class KeepImageCommanderImpl @Inject() (
           uploadedImage.image.flush()
           ki
       }
-      val persistedHashes = db.readWrite(attempts = 3) { implicit session => // because of request consolidator, this can be very race-conditiony
+      db.readWrite(attempts = 3) { implicit session => // because of request consolidator, this can be very race-conditiony
         val existingImagesForKeep = keepImageRepo.getAllForKeepId(keepId).toSet
         replaceOldKeepImagesWithNew(existingImagesForKeep, keepImages)
       }.map(_.sourceFileHash).toSet
-      ImageProcessState.StoreSuccess(persistedHashes)
+      ImageProcessState.StoreSuccess
     }.recover {
       case ex: SQLException =>
         log.error("Could not persist keepimage", ex)
@@ -341,7 +341,7 @@ class KeepImageCommanderImpl @Inject() (
             if (existingForHash.nonEmpty) {
               val replacedImages = copyExistingImagesAndReplace(keepId, ImageSource.UserPicked, existingForHash)
               val replacedHashes = replacedImages.images.map(_.sourceFileHash).toSet
-              Some(ImageProcessState.StoreSuccess(replacedHashes))
+              Some(ImageProcessState.StoreSuccess)
             } else {
               None
             }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
@@ -288,7 +288,7 @@ class KeepImageCommanderImpl @Inject() (
       db.readWrite(attempts = 3) { implicit session => // because of request consolidator, this can be very race-conditiony
         val existingImagesForKeep = keepImageRepo.getAllForKeepId(keepId).toSet
         replaceOldKeepImagesWithNew(existingImagesForKeep, keepImages)
-      }.map(_.sourceFileHash).toSet
+      }
       ImageProcessState.StoreSuccess
     }.recover {
       case ex: SQLException =>
@@ -339,8 +339,7 @@ class KeepImageCommanderImpl @Inject() (
           db.readWrite(attempts = 3) { implicit session =>
             val existingForHash = keepImageRepo.getBySourceHash(ImageHash(hash))
             if (existingForHash.nonEmpty) {
-              val replacedImages = copyExistingImagesAndReplace(keepId, ImageSource.UserPicked, existingForHash)
-              val replacedHashes = replacedImages.images.map(_.sourceFileHash).toSet
+              copyExistingImagesAndReplace(keepId, ImageSource.UserPicked, existingForHash)
               Some(ImageProcessState.StoreSuccess)
             } else {
               None

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryImageCommander.scala
@@ -12,7 +12,6 @@ import com.keepit.common.net.WebService
 import com.keepit.common.store.{ ImageSize, LibraryImageStore, S3ImageConfig }
 import com.keepit.model._
 import play.api.libs.Files.TemporaryFile
-import play.api.http.Status._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 import scala.concurrent.Future
@@ -121,12 +120,11 @@ class LibraryImageCommanderImpl @Inject() (
       val libraryImages = results.map {
         case uploadedImage =>
           val isOriginal = uploadedImage.key.takeRight(7).indexOf(originalLabel) != -1
-
-          val setX = position.x.getOrElse(50)
-          val setY = position.y.getOrElse(50)
+          val setX = position.x.orElse(Some(50))
+          val setY = position.y.orElse(Some(50))
 
           val libImg = LibraryImage(libraryId = libraryId, imagePath = uploadedImage.key, format = uploadedImage.format,
-            width = uploadedImage.image.getWidth, height = uploadedImage.image.getHeight, positionX = Some(setX), positionY = Some(setY),
+            width = uploadedImage.image.getWidth, height = uploadedImage.image.getHeight, positionX = setX, positionY = setY,
             source = source, sourceFileHash = originalImage.hash, isOriginal = isOriginal, state = LibraryImageStates.ACTIVE)
           uploadedImage.image.flush()
           libImg

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryImageCommander.scala
@@ -162,7 +162,7 @@ class LibraryImageCommanderImpl @Inject() (
         }.isEmpty
       }
 
-      log.info("[kic] Activating:" + toActivate.map(_.imagePath) + "\nDeactivating:" + toDeactivate.map(_.imagePath) + "\nCreating:" + toCreate.map(_.imagePath))
+      log.info("[lic] Activating:" + toActivate.map(_.imagePath) + "\nDeactivating:" + toDeactivate.map(_.imagePath) + "\nCreating:" + toCreate.map(_.imagePath))
       toDeactivate.foreach(libraryImageRepo.save)
       (toActivate ++ toCreate).map(libraryImageRepo.save)
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryImageController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryImageController.scala
@@ -60,7 +60,7 @@ class LibraryImageController @Inject() (
     val posY = (request.body \ "y").asOpt[Int]
 
     imagePath match {
-      case LibraryImageController.pathRegex(hashStr, _, _) =>
+      case LibraryImageController.pathRegex(hashStr) =>
         val currentHash = db.readOnlyMaster { implicit s =>
           libraryImageRepo.getForLibraryId(libraryId)
         }.map(_.sourceFileHash).toSet
@@ -84,5 +84,5 @@ class LibraryImageController @Inject() (
 
 object LibraryImageController {
   val defaultImageSize = ImageSize(600, 480)
-  val pathRegex = """library/(.*)_(\d+)x(\d+).+""".r
+  val pathRegex = """^library/(.*?)_\d+x\d+.+""".r
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryImageController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryImageController.scala
@@ -1,0 +1,86 @@
+package com.keepit.controllers.website
+
+import com.google.inject.Inject
+import com.keepit.commanders.{ LibraryCommander, LibraryImageCommander }
+import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper }
+import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
+import com.keepit.common.db.slick.Database
+import com.keepit.common.store.ImageSize
+import com.keepit.common.time.Clock
+import com.keepit.inject.FortyTwoConfig
+import com.keepit.model._
+import com.keepit.shoebox.controllers.LibraryAccessActions
+import play.api.libs.json.{ Json }
+
+import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+import scala.util.Try
+
+class LibraryImageController @Inject() (
+  db: Database,
+  libraryRepo: LibraryRepo,
+  libraryImageRepo: LibraryImageRepo,
+  libraryImageRequestRepo: LibraryImageRequestRepo,
+  userRepo: UserRepo,
+  fortyTwoConfig: FortyTwoConfig,
+  clock: Clock,
+  libraryImageCommander: LibraryImageCommander,
+  val userActionsHelper: UserActionsHelper,
+  val libraryCommander: LibraryCommander,
+  val publicIdConfig: PublicIdConfiguration,
+  implicit val config: PublicIdConfiguration)
+    extends UserActions with LibraryAccessActions with ShoeboxServiceController {
+
+  def uploadLibraryImage(pubId: PublicId[Library], imageSize: Option[String] = None) = (UserAction andThen LibraryWriteAction(pubId)).async(parse.temporaryFile) { request =>
+    val libraryId = Library.decodePublicId(pubId).get
+    val imageRequest = db.readWrite { implicit session =>
+      libraryImageRequestRepo.save(LibraryImageRequest(libraryId = libraryId, source = ImageSource.UserUpload))
+    }
+    val uploadImageF = libraryImageCommander.uploadLibraryImageFromFile(request.body, libraryId, ImageSource.UserUpload, Some(imageRequest.id.get))
+    uploadImageF.map {
+      case fail: ImageStoreFailure =>
+        println("**************" + fail.reason)
+        InternalServerError(Json.obj("error" -> fail.reason))
+      case success: ImageProcessSuccess =>
+        val hash = success.hashes.head
+        val idealSize = imageSize.flatMap { s => Try(ImageSize(s)).toOption }.getOrElse(LibraryImageController.defaultImageSize)
+        libraryImageCommander.getBestImageForLibraryAndHash(libraryId, hash, idealSize) match {
+          case Some(img) =>
+            Ok(Json.obj("imagePath" -> img.imagePath))
+          case None =>
+            NotFound(Json.obj("error" -> "image_not_found"))
+        }
+    }
+  }
+
+  def positionLibraryImage(pubId: PublicId[Library]) = (UserAction andThen LibraryWriteAction(pubId))(parse.tolerantJson) { request =>
+    val libraryId = Library.decodePublicId(pubId).get
+    val imagePath = (request.body \ "imagePath").as[String]
+    val posX = (request.body \ "x").asOpt[Int]
+    val posY = (request.body \ "y").asOpt[Int]
+
+    val pathRegex = """library/(.*)_(\d+)x(\d+).+""".r
+    imagePath match {
+      case pathRegex(hashStr, _, _) =>
+        libraryImageCommander.positionLibraryImage(libraryId, ImageHash(hashStr), LibraryImagePosition(posX, posY)) match {
+          case Left((status, error)) =>
+            Status(status)(Json.obj("error" -> error))
+          case Right(_) =>
+            NoContent
+        }
+      case _ =>
+        BadRequest(Json.obj("error" -> "invalid_image_path"))
+    }
+  }
+
+  def removeLibraryImage(pubId: PublicId[Library]) = (UserAction andThen LibraryWriteAction(pubId)) { request =>
+    val libraryId = Library.decodePublicId(pubId).get
+    libraryImageCommander.removeImageForLibrary(libraryId)
+    NoContent
+  }
+}
+
+object LibraryImageController {
+  val defaultImageSize = ImageSize(600, 480)
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/BaseImage.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/BaseImage.scala
@@ -41,7 +41,7 @@ object ImageSource {
 sealed trait ImageProcessState
 sealed trait ImageStoreInProgress extends ImageProcessState
 sealed trait ImageProcessDone extends ImageProcessState
-sealed trait ImageProcessSuccess extends ImageProcessState with ImageProcessDone
+sealed trait ImageProcessSuccess extends ImageProcessDone
 
 sealed abstract class ImageStoreFailure(val reason: String) extends ImageProcessState with ImageProcessDone
 sealed abstract class ImageStoreFailureWithException(ex: Throwable, reason: String) extends ImageStoreFailure(reason)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/BaseImage.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/BaseImage.scala
@@ -41,8 +41,7 @@ object ImageSource {
 sealed trait ImageProcessState
 sealed trait ImageStoreInProgress extends ImageProcessState
 sealed trait ImageProcessDone extends ImageProcessState
-
-sealed abstract class ImageProcessSuccess(val hashes: Set[ImageHash]) extends ImageProcessState with ImageProcessDone
+sealed trait ImageProcessSuccess extends ImageProcessState with ImageProcessDone
 
 sealed abstract class ImageStoreFailure(val reason: String) extends ImageProcessState with ImageProcessDone
 sealed abstract class ImageStoreFailureWithException(ex: Throwable, reason: String) extends ImageStoreFailure(reason)
@@ -64,8 +63,8 @@ object ImageProcessState {
   case class CDNUploadFailed(ex: Throwable) extends ImageStoreFailureWithException(ex, "cdn_upload_failed")
 
   // Success
-  case class StoreSuccess(hashSet: Set[ImageHash]) extends ImageProcessSuccess(hashSet)
-  case class ExistingStoredImagesFound(images: Seq[BaseImage]) extends ImageProcessSuccess(images.map(_.sourceFileHash).toSet)
+  case object StoreSuccess extends ImageProcessState with ImageProcessSuccess
+  case class ExistingStoredImagesFound(images: Seq[BaseImage]) extends ImageProcessState with ImageProcessSuccess
 }
 
 case class ImageHash(hash: String)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/BaseImage.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/BaseImage.scala
@@ -41,8 +41,8 @@ object ImageSource {
 sealed trait ImageProcessState
 sealed trait ImageStoreInProgress extends ImageProcessState
 sealed trait ImageProcessDone extends ImageProcessState
-sealed trait ImageProcessSuccess extends ImageProcessDone
 
+sealed trait ImageProcessSuccess extends ImageProcessDone
 sealed abstract class ImageStoreFailure(val reason: String) extends ImageProcessState with ImageProcessDone
 sealed abstract class ImageStoreFailureWithException(ex: Throwable, reason: String) extends ImageStoreFailure(reason)
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryImageRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryImageRepo.scala
@@ -9,8 +9,6 @@ import com.keepit.common.time.Clock
 @ImplementedBy(classOf[LibraryImageRepoImpl])
 trait LibraryImageRepo extends Repo[LibraryImage] {
   def getForLibraryId(libraryId: Id[Library], excludeState: Option[State[LibraryImage]] = Some(LibraryImageStates.INACTIVE))(implicit session: RSession): Seq[LibraryImage]
-  def getForLibraryIdOrWithHash(libraryId: Id[Library], hash: ImageHash)(implicit session: RSession): Seq[LibraryImage]
-  def getByLibraryIdAndHash(libraryId: Id[Library], hash: ImageHash)(implicit session: RSession): Seq[LibraryImage]
 }
 
 @Singleton
@@ -64,20 +62,6 @@ class LibraryImageRepoImpl @Inject() (
       case Some(excludeState) =>
         getForLibraryIdAndStatesCompiled(libraryId, excludeState).list
     }
-  }
-
-  private val getForLibraryIdOrWithHashCompiled = Compiled { (libraryId: Column[Id[Library]], hash: Column[ImageHash]) =>
-    for (r <- rows if r.libraryId === libraryId && (r.sourceFileHash === hash || r.state === LibraryImageStates.ACTIVE)) yield r
-  }
-  def getForLibraryIdOrWithHash(libraryId: Id[Library], hash: ImageHash)(implicit session: RSession): Seq[LibraryImage] = {
-    getForLibraryIdOrWithHashCompiled(libraryId, hash).list
-  }
-
-  private val getBySourceHashCompiled = Compiled { (libraryId: Column[Id[Library]], hash: Column[ImageHash]) =>
-    for (r <- rows if r.libraryId === libraryId && r.sourceFileHash === hash) yield r
-  }
-  def getByLibraryIdAndHash(libraryId: Id[Library], hash: ImageHash)(implicit session: RSession): Seq[LibraryImage] = {
-    getBySourceHashCompiled(libraryId, hash).list
   }
 
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryImageRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryImageRepo.scala
@@ -9,7 +9,8 @@ import com.keepit.common.time.Clock
 @ImplementedBy(classOf[LibraryImageRepoImpl])
 trait LibraryImageRepo extends Repo[LibraryImage] {
   def getForLibraryId(libraryId: Id[Library], excludeState: Option[State[LibraryImage]] = Some(LibraryImageStates.INACTIVE))(implicit session: RSession): Seq[LibraryImage]
-  def getBySourceHash(hash: ImageHash)(implicit session: RSession): Seq[LibraryImage]
+  def getForLibraryIdOrWithHash(libraryId: Id[Library], hash: ImageHash)(implicit session: RSession): Seq[LibraryImage]
+  def getByLibraryIdAndHash(libraryId: Id[Library], hash: ImageHash)(implicit session: RSession): Seq[LibraryImage]
 }
 
 @Singleton
@@ -65,11 +66,18 @@ class LibraryImageRepoImpl @Inject() (
     }
   }
 
-  private val getBySourceHashCompiled = Compiled { hash: Column[ImageHash] =>
-    for (r <- rows if r.sourceFileHash === hash) yield r
+  private val getForLibraryIdOrWithHashCompiled = Compiled { (libraryId: Column[Id[Library]], hash: Column[ImageHash]) =>
+    for (r <- rows if r.libraryId === libraryId && (r.sourceFileHash === hash || r.state === LibraryImageStates.ACTIVE)) yield r
   }
-  def getBySourceHash(hash: ImageHash)(implicit session: RSession): Seq[LibraryImage] = {
-    getBySourceHashCompiled(hash).list
+  def getForLibraryIdOrWithHash(libraryId: Id[Library], hash: ImageHash)(implicit session: RSession): Seq[LibraryImage] = {
+    getForLibraryIdOrWithHashCompiled(libraryId, hash).list
+  }
+
+  private val getBySourceHashCompiled = Compiled { (libraryId: Column[Id[Library]], hash: Column[ImageHash]) =>
+    for (r <- rows if r.libraryId === libraryId && r.sourceFileHash === hash) yield r
+  }
+  def getByLibraryIdAndHash(libraryId: Id[Library], hash: ImageHash)(implicit session: RSession): Seq[LibraryImage] = {
+    getBySourceHashCompiled(libraryId, hash).list
   }
 
 }

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -365,6 +365,10 @@ POST    /site/libraries/:id/importTag   @com.keepit.controllers.website.LibraryC
 POST    /site/libraries/:id/moveTag     @com.keepit.controllers.website.LibraryController.moveKeepsFromCollectionToLibrary(id: PublicId[Library], tag: String)
 POST    /site/libraries/:id/import-file  @com.keepit.controllers.website.BookmarkImporter.importFileToLibrary(id: PublicId[Library])
 
+POST    /site/libraries/:id/image/upload    @com.keepit.controllers.website.LibraryImageController.uploadLibraryImage(id: PublicId[Library], is: Option[String] ?= None)
+POST    /site/libraries/:id/image/position  @com.keepit.controllers.website.LibraryImageController.positionLibraryImage(id: PublicId[Library])
+DELETE  /site/libraries/:id/image           @com.keepit.controllers.website.LibraryImageController.removeLibraryImage(id: PublicId[Library])
+
 POST    /site/recos/adHoc           @com.keepit.controllers.website.RecommendationsController.adHocRecos(n: Int)
 GET     /site/recos/top             @com.keepit.controllers.website.RecommendationsController.topRecos(more: Boolean, recency: Float)
 GET     /site/recos/public          @com.keepit.controllers.website.RecommendationsController.topPublicRecos()

--- a/kifi-backend/modules/shoebox/conf/shoebox.routes
+++ b/kifi-backend/modules/shoebox/conf/shoebox.routes
@@ -365,7 +365,7 @@ POST    /site/libraries/:id/importTag   @com.keepit.controllers.website.LibraryC
 POST    /site/libraries/:id/moveTag     @com.keepit.controllers.website.LibraryController.moveKeepsFromCollectionToLibrary(id: PublicId[Library], tag: String)
 POST    /site/libraries/:id/import-file  @com.keepit.controllers.website.BookmarkImporter.importFileToLibrary(id: PublicId[Library])
 
-POST    /site/libraries/:id/image/upload    @com.keepit.controllers.website.LibraryImageController.uploadLibraryImage(id: PublicId[Library], is: Option[String] ?= None)
+POST    /site/libraries/:id/image/upload    @com.keepit.controllers.website.LibraryImageController.uploadLibraryImage(id: PublicId[Library], is: Option[String] ?= None, x: Option[Int] ?= None, y: Option[Int] ?= None)
 POST    /site/libraries/:id/image/position  @com.keepit.controllers.website.LibraryImageController.positionLibraryImage(id: PublicId[Library])
 DELETE  /site/libraries/:id/image           @com.keepit.controllers.website.LibraryImageController.removeLibraryImage(id: PublicId[Library])
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepImageCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepImageCommanderTest.scala
@@ -62,12 +62,12 @@ class KeepImageCommanderTest extends Specification with ShoeboxTestInjector with
         {
           val savedF = commander.setKeepImageFromFile(fakeFile1, keep1.id.get, ImageSource.UserUpload)
           val saved = Await.result(savedF, Duration("10 seconds"))
-          saved === ImageProcessState.StoreSuccess
+          saved.isInstanceOf[ImageProcessState.StoreSuccess] === true // if this test fails, make sure imagemagick is installed. Use `brew install imagemagick`
         }
         {
           val savedF = commander.setKeepImageFromFile(fakeFile1, keep2.id.get, ImageSource.UserUpload)
           val saved = Await.result(savedF, Duration("10 seconds"))
-          saved === ImageProcessState.StoreSuccess
+          saved.isInstanceOf[ImageProcessState.StoreSuccess] === true
         }
         // If this complains about not having an `all`, then it's not using FakeKeepImageStore
         inject[KeepImageStore].asInstanceOf[FakeKeepImageStore].all.keySet.size === 1
@@ -93,7 +93,7 @@ class KeepImageCommanderTest extends Specification with ShoeboxTestInjector with
         {
           val savedF = commander.setKeepImageFromFile(fakeFile2, keep2.id.get, ImageSource.UserUpload)
           val saved = Await.result(savedF, Duration("10 seconds"))
-          saved === ImageProcessState.StoreSuccess // if this test fails, make sure imagemagick is installed. Use `brew install imagemagick`
+          saved.isInstanceOf[ImageProcessState.StoreSuccess] === true
         }
 
         inject[KeepImageStore].asInstanceOf[FakeKeepImageStore].all.keySet.size === 4
@@ -110,7 +110,7 @@ class KeepImageCommanderTest extends Specification with ShoeboxTestInjector with
         {
           val savedF = commander.setKeepImageFromFile(fakeFile1, keep2.id.get, ImageSource.UserUpload)
           val saved = Await.result(savedF, Duration("10 seconds"))
-          saved === ImageProcessState.StoreSuccess
+          saved.isInstanceOf[ImageProcessState.StoreSuccess] === true
         }
 
         val keepImage4 = commander.getBestImageForKeep(keep2.id.get, ImageSize(100, 100)).flatten
@@ -146,7 +146,7 @@ class KeepImageCommanderTest extends Specification with ShoeboxTestInjector with
         {
           val savedF = commander.setKeepImageFromFile(fakeFile1, keep1.id.get, ImageSource.UserUpload)
           val saved = Await.result(savedF, Duration("10 seconds"))
-          saved === ImageProcessState.StoreSuccess
+          saved.isInstanceOf[ImageProcessState.StoreSuccess] === true
         }
 
         {
@@ -158,7 +158,7 @@ class KeepImageCommanderTest extends Specification with ShoeboxTestInjector with
           val saved = Await.result(savedF, Duration("10 seconds"))
 
           // If this didn't de-dupe, it would fail, because the HTTP fetcher is disabled when no application is running
-          saved === ImageProcessState.StoreSuccess
+          saved.isInstanceOf[ImageProcessState.StoreSuccess] === true
         }
 
         true === true

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepImageCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepImageCommanderTest.scala
@@ -62,12 +62,12 @@ class KeepImageCommanderTest extends Specification with ShoeboxTestInjector with
         {
           val savedF = commander.setKeepImageFromFile(fakeFile1, keep1.id.get, ImageSource.UserUpload)
           val saved = Await.result(savedF, Duration("10 seconds"))
-          saved.isInstanceOf[ImageProcessState.StoreSuccess] === true // if this test fails, make sure imagemagick is installed. Use `brew install imagemagick`
+          saved === ImageProcessState.StoreSuccess // if this test fails, make sure imagemagick is installed. Use `brew install imagemagick`
         }
         {
           val savedF = commander.setKeepImageFromFile(fakeFile1, keep2.id.get, ImageSource.UserUpload)
           val saved = Await.result(savedF, Duration("10 seconds"))
-          saved.isInstanceOf[ImageProcessState.StoreSuccess] === true
+          saved === ImageProcessState.StoreSuccess
         }
         // If this complains about not having an `all`, then it's not using FakeKeepImageStore
         inject[KeepImageStore].asInstanceOf[FakeKeepImageStore].all.keySet.size === 1
@@ -93,7 +93,7 @@ class KeepImageCommanderTest extends Specification with ShoeboxTestInjector with
         {
           val savedF = commander.setKeepImageFromFile(fakeFile2, keep2.id.get, ImageSource.UserUpload)
           val saved = Await.result(savedF, Duration("10 seconds"))
-          saved.isInstanceOf[ImageProcessState.StoreSuccess] === true
+          saved === ImageProcessState.StoreSuccess
         }
 
         inject[KeepImageStore].asInstanceOf[FakeKeepImageStore].all.keySet.size === 4
@@ -110,7 +110,7 @@ class KeepImageCommanderTest extends Specification with ShoeboxTestInjector with
         {
           val savedF = commander.setKeepImageFromFile(fakeFile1, keep2.id.get, ImageSource.UserUpload)
           val saved = Await.result(savedF, Duration("10 seconds"))
-          saved.isInstanceOf[ImageProcessState.StoreSuccess] === true
+          saved === ImageProcessState.StoreSuccess
         }
 
         val keepImage4 = commander.getBestImageForKeep(keep2.id.get, ImageSize(100, 100)).flatten
@@ -146,7 +146,7 @@ class KeepImageCommanderTest extends Specification with ShoeboxTestInjector with
         {
           val savedF = commander.setKeepImageFromFile(fakeFile1, keep1.id.get, ImageSource.UserUpload)
           val saved = Await.result(savedF, Duration("10 seconds"))
-          saved.isInstanceOf[ImageProcessState.StoreSuccess] === true
+          saved === ImageProcessState.StoreSuccess
         }
 
         {
@@ -158,7 +158,7 @@ class KeepImageCommanderTest extends Specification with ShoeboxTestInjector with
           val saved = Await.result(savedF, Duration("10 seconds"))
 
           // If this didn't de-dupe, it would fail, because the HTTP fetcher is disabled when no application is running
-          saved.isInstanceOf[ImageProcessState.StoreSuccess] === true
+          saved === ImageProcessState.StoreSuccess
         }
 
         true === true

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryImageControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryImageControllerTest.scala
@@ -1,0 +1,175 @@
+package com.keepit.controllers.website
+
+import java.io.File
+
+import com.google.inject.Injector
+import com.keepit.abook.FakeABookServiceClientModule
+import com.keepit.common.controller.FakeUserActionsHelper
+import com.keepit.common.crypto.{ PublicIdConfiguration, PublicId, FakeCryptoModule }
+import com.keepit.common.net.FakeHttpClientModule
+import com.keepit.common.social.FakeSocialGraphModule
+import com.keepit.model._
+import com.keepit.scraper.{ FakeScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.shoebox.{ FakeKeepImportsModule, FakeShoeboxServiceModule }
+import com.keepit.test.{ DbInjectionHelper, ShoeboxTestInjector }
+import org.apache.commons.io.FileUtils
+import org.specs2.mutable.Specification
+import play.api.libs.Files.TemporaryFile
+import play.api.libs.json.{ Json, JsObject }
+import play.api.mvc.{ Call, Result }
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+import scala.concurrent.Future
+
+class LibraryImageControllerTest extends Specification with ShoeboxTestInjector with DbInjectionHelper {
+
+  val controllerTestModules = Seq(
+    FakeCryptoModule(),
+    FakeShoeboxServiceModule(),
+    FakeScrapeSchedulerModule(),
+    FakeScraperServiceClientModule(),
+    FakeKeepImportsModule(),
+    FakeSliderHistoryTrackerModule(),
+    FakeABookServiceClientModule(),
+    FakeSocialGraphModule(),
+    FakeHttpClientModule()
+  )
+
+  def setup()(implicit injector: Injector) = {
+    db.readWrite { implicit session =>
+      val user1 = userRepo.save(User(firstName = "Noraa", lastName = "Ush", username = Username("test"), normalizedUsername = "test"))
+      val lib1 = libraryRepo.save(Library(name = "L", ownerId = user1.id.get, visibility = LibraryVisibility.PUBLISHED, slug = LibrarySlug("l"), memberCount = 1))
+      libraryMembershipRepo.save(LibraryMembership(libraryId = lib1.id.get, userId = user1.id.get, access = LibraryAccess.OWNER, showInSearch = true))
+      val lib2 = libraryRepo.save(Library(name = "L2", ownerId = user1.id.get, visibility = LibraryVisibility.PUBLISHED, slug = LibrarySlug("l2"), memberCount = 1))
+      libraryMembershipRepo.save(LibraryMembership(libraryId = lib2.id.get, userId = user1.id.get, access = LibraryAccess.OWNER, showInSearch = true))
+
+      // user2 has READ_ONLY membership to user1's library
+      val user2 = userRepo.save(User(firstName = "Noraa", lastName = "Ush", username = Username("test2"), normalizedUsername = "test2"))
+      libraryMembershipRepo.save(LibraryMembership(libraryId = lib1.id.get, userId = user2.id.get, access = LibraryAccess.READ_ONLY, showInSearch = true))
+      (user1, lib1, lib2, user2)
+    }
+  }
+
+  "LibraryImageController" should {
+
+    "support image uploads" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val (user1, lib1, lib2, user2) = setup()
+        implicit val config = inject[PublicIdConfiguration]
+        val libPubId1 = Library.publicId(lib1.id.get)
+        val libPubId2 = Library.publicId(lib2.id.get)
+
+        // Invalid Access to Library (wrong user)
+        status(uploadFile(user2, libPubId1, fakeFile)) === FORBIDDEN
+
+        // Correct Upload
+        val uploadResp1 = uploadFile(user1, libPubId1, fakeFile)
+        status(uploadResp1) === OK
+        Json.parse(contentAsString(uploadResp1)) === Json.parse(
+          s"""
+             | { "imagePath" : "library/26dbdc56d54dbc94830f7cfc85031481_66x38_o.png" }
+           """.stripMargin)
+
+        // Upload again to same library - same image path
+        val uploadResp2 = uploadFile(user1, libPubId1, fakeFile)
+        status(uploadResp2) === OK
+        Json.parse(contentAsString(uploadResp2)) === Json.parse(
+          s"""
+             | { "imagePath" : "library/26dbdc56d54dbc94830f7cfc85031481_66x38_o.png" }
+           """.stripMargin)
+
+        // Upload again to different library - same image path
+        val uploadResp3 = uploadFile(user1, libPubId2, fakeFile)
+        status(uploadResp3) === OK
+        Json.parse(contentAsString(uploadResp3)) === Json.parse(
+          s"""
+             | { "imagePath" : "library/26dbdc56d54dbc94830f7cfc85031481_66x38_o.png" }
+           """.stripMargin)
+
+      }
+    }
+
+    "apply positioning to library images" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val (user1, lib1, _, user2) = setup()
+        implicit val config = inject[PublicIdConfiguration]
+        val libPubId1 = Library.publicId(lib1.id.get)
+
+        // Correct Upload
+        val uploadResp = uploadFile(user1, libPubId1, fakeFile)
+        status(uploadResp) === OK
+        val imagePath1 = (contentAsJson(uploadResp) \ "imagePath").as[String]
+
+        // apply positioning to bad imageUrl
+        status(positionImage(user1, libPubId1, Json.obj("imagePath" -> "keep/26dbdc56d54dbc94830f7cfc85031481_66x38_o.png", "x" -> 20))) === BAD_REQUEST
+        status(positionImage(user1, libPubId1, Json.obj("imagePath" -> "library/asdf_30x20.jpg", "x" -> 20))) === NOT_FOUND
+        status(positionImage(user1, libPubId1, Json.obj("imagePath" -> "library/26dbdc56d54dbc94830f7cfc85031481_30xa.jpg", "x" -> 20))) === BAD_REQUEST
+
+        // Invalid Access to Library (wrong user)
+        status(positionImage(user2, libPubId1, Json.obj("imagePath" -> imagePath1, "x" -> 5))) === FORBIDDEN
+
+        // apply positioning with one dimension specified
+        val position1 = Json.obj("imagePath" -> imagePath1, "x" -> 20)
+        status(positionImage(user1, libPubId1, position1)) === NO_CONTENT
+
+        // apply positioning with both dimensions specified
+        val position2 = Json.obj("imagePath" -> imagePath1, "x" -> 21, "y" -> 51)
+        status(positionImage(user1, libPubId1, position2)) === NO_CONTENT
+      }
+    }
+
+    "remove library image" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val (user1, lib1, _, user2) = setup()
+        implicit val config = inject[PublicIdConfiguration]
+        val libPubId1 = Library.publicId(lib1.id.get)
+
+        // Correct Upload
+        val uploadResp = uploadFile(user1, libPubId1, fakeFile)
+        status(uploadResp) === OK
+        val imagePath1 = (contentAsJson(uploadResp) \ "imagePath").as[String]
+
+        // apply positioning
+        val position1 = Json.obj("imagePath" -> imagePath1)
+        status(positionImage(user1, libPubId1, position1)) === NO_CONTENT
+
+        // Invalid Access to Library (wrong user)
+        status(removeImage(user2, libPubId1)) === FORBIDDEN
+
+        // remove image
+        val result1 = removeImage(user1, libPubId1)
+        status(result1) === NO_CONTENT
+
+        // remove image which doesn't exist
+        val result2 = removeImage(user1, libPubId1)
+        status(result2) === NO_CONTENT
+      }
+    }
+
+  }
+
+  private def uploadFile(user: User, libraryId: PublicId[Library], file: TemporaryFile)(implicit injector: Injector): Future[Result] = {
+    inject[FakeUserActionsHelper].setUser(user)
+    inject[LibraryImageController].uploadLibraryImage(libraryId)(request(routes.LibraryImageController.uploadLibraryImage(libraryId)).withBody(file))
+  }
+
+  private def positionImage(user: User, libraryId: PublicId[Library], body: JsObject)(implicit injector: Injector): Future[Result] = {
+    inject[FakeUserActionsHelper].setUser(user)
+    inject[LibraryImageController].positionLibraryImage(libraryId)(request(routes.LibraryImageController.positionLibraryImage(libraryId)).withBody(body))
+  }
+
+  private def removeImage(user: User, libraryId: PublicId[Library])(implicit injector: Injector): Future[Result] = {
+    inject[FakeUserActionsHelper].setUser(user)
+    inject[LibraryImageController].removeLibraryImage(libraryId)(request(routes.LibraryImageController.removeLibraryImage(libraryId)))
+  }
+
+  private def request(route: Call) = FakeRequest(route.method, route.url)
+
+  private def fakeFile = {
+    val tf = TemporaryFile(new File("test/data/image1-" + Math.random() + ".png"))
+    tf.file.deleteOnExit()
+    FileUtils.copyFile(new File("test/data/image1.png"), tf.file)
+    tf
+  }
+}

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryImageControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryImageControllerTest.scala
@@ -99,9 +99,9 @@ class LibraryImageControllerTest extends Specification with ShoeboxTestInjector 
         val imagePath1 = (contentAsJson(uploadResp) \ "imagePath").as[String]
 
         // apply positioning to bad imageUrl
-        status(positionImage(user1, libPubId1, Json.obj("imagePath" -> "keep/26dbdc56d54dbc94830f7cfc85031481_66x38_o.png", "x" -> 20))) === BAD_REQUEST
-        status(positionImage(user1, libPubId1, Json.obj("imagePath" -> "library/asdf_30x20.jpg", "x" -> 20))) === BAD_REQUEST
-        status(positionImage(user1, libPubId1, Json.obj("imagePath" -> "library/26dbdc56d54dbc94830f7cfc85031481_30xa.jpg", "x" -> 20))) === BAD_REQUEST
+        status(positionImage(user1, libPubId1, Json.obj("imagePath" -> "keep/26dbdc56d54dbc94830f7cfc85031481_66x38_o.png", "x" -> 20))) === BAD_REQUEST // wrong path
+        status(positionImage(user1, libPubId1, Json.obj("imagePath" -> "library/asdf_30x20.jpg", "x" -> 20))) === BAD_REQUEST // bad image hash
+        status(positionImage(user1, libPubId1, Json.obj("imagePath" -> "library/26dbdc56d54dbc94830f7cfc85031481_30xa.jpg", "x" -> 20))) === BAD_REQUEST // bad width or height
 
         // Invalid Access to Library (wrong user)
         status(positionImage(user2, libPubId1, Json.obj("imagePath" -> imagePath1, "x" -> 5))) === FORBIDDEN


### PR DESCRIPTION
LibraryImageController with 3 endpoints
- upload `POST /site/libraries/:id/image/upload?is=wxh&x=40&y=60`
  - request: { file }
  - response: `{ "imagePath" : "library/f293764f93g_640x480.jpg"}`
- position `POST /site/libraries/:id/image/position`
  - request: `{ "imagePath" : "library/f293764f93g_640x480.jpg", "x" : 30, "y": 25 }`
  - response: `NoContent`
- remove `DELETE /site/libraries/:id/image`
  - response: `NoContent`

Biggest Changes to other files:
- `LibraryImageCommander` to fit Controller signatures
- Tests

@andrewconner @2is10 
