### PR TITLE
simple guard for topic names of version 3.

### DIFF
--- a/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDAInfoCommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDAInfoCommander.scala
@@ -90,7 +90,7 @@ case class LDAConfigCommander(db: Database, topicInfoRepo: LDAInfoRepo, topicWor
 
   def getTopicName(topicId: Int)(implicit version: ModelVersion[DenseLDA]): Option[String] = {
     val conf = currentConfigs(version).configs(topicId.toString)
-    if (conf.isNameable && conf.topicName != LDAInfo.DEFUALT_NAME) Some(conf.topicName) else None
+    if (version.version < 3 && conf.isNameable && conf.topicName != LDAInfo.DEFUALT_NAME) Some(conf.topicName) else None
   }
 
   def topicConfigs(fromId: Int, toId: Int)(implicit version: ModelVersion[DenseLDA]): Map[String, LDATopicConfiguration] = {


### PR DESCRIPTION
@stkem @joshm1 @ymatsuda  FYI

product people want to edit topic names for version 3. Since there are some outside users (only 1?) who are exposed to the new version, I temp disable this function.
