### PR TITLE
add description field to related libraries and a caption to marketing site libraries

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -108,6 +108,7 @@ angular.module('kifi')
       this.numKeeps = library.numKeeps;
       this.ownerPicUrl = routeService.formatPicUrl(library.owner.id, library.owner.pictureName, 200);
       this.name = library.name;
+      this.description = library.description;
       this.image = library.image;
       this.imageUrl = library.image ? routeService.libraryImageUrl(library.image.path) : null;
       this.libraryUrl = library.url;

--- a/kifi-backend/modules/shoebox/angular/src/libraries/smallLibraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/smallLibraryCard.tpl.html
@@ -1,4 +1,4 @@
-<div class="kf-small-library-card" ng-attr-style="background-color: {{library.color}}">
+<div class="kf-small-library-card" ng-attr-style="background-color: {{library.color}}" ng-attr-title="{{library.description}}">
   <div class="kf-small-library-card-header">
     <a ng-href="{{library.libraryUrl}}" ng-click="clickLibraryReco($event)" class="kf-small-library-name">{{ library.name }}</a>
     <div class="kf-small-library-counts-row">

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/RelatedLibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/RelatedLibraryCommander.scala
@@ -80,6 +80,7 @@ class RelatedLibraryCommanderImpl @Inject() (
 case class RelatedLibraryInfo(
   id: PublicId[Library],
   name: String,
+  description: Option[String],
   url: String,
   owner: BasicUser,
   followers: Seq[BasicUser],
@@ -94,7 +95,7 @@ object RelatedLibraryInfo {
       val goodLooking = info.followers.filter(_.pictureName != "0.jpg")
       if (goodLooking.size < 8) goodLooking else goodLooking.take(3) // cannot show more than 8 avatars in frontend
     } else Seq.empty
-    RelatedLibraryInfo(info.id, info.name, info.url, info.owner, showableFollowers, info.numKeeps,
+    RelatedLibraryInfo(info.id, info.name, info.description, info.url, info.owner, showableFollowers, info.numKeeps,
       info.numFollowers, info.color, info.image)
   }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -1224,8 +1224,14 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
             membership().withLibraryFollower(lib2, user3).saved
 
             inject[SystemValueRepo].save(SystemValue(
-              name = MarketingSuggestedLibraryInfo.systemValueName,
-              value = s"[${lib1.id.get},${lib2.id.get},${lib3.id.get}]"))
+              name = MarketingSuggestedLibrarySystemValue.systemValueName,
+              value = s"""
+                   |[
+                   |  { "id": ${lib1.id.get}, "caption": "yo dawg" },
+                   |  { "id": ${lib2.id.get} },
+                   |  { "id": ${lib3.id.get} }
+                   |]
+                 """.stripMargin))
           }
 
           val call = com.keepit.controllers.website.routes.LibraryController.marketingSiteSuggestedLibraries()
@@ -1240,9 +1246,11 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
           libInfos(0).name === "Scala"
           libInfos(0).numFollowers === 2
           libInfos(0).owner.fullName === "John Doe"
+          libInfos(0).caption must beSome("yo dawg")
           libInfos(1).name === "Java"
           libInfos(1).numFollowers === 1
           libInfos(1).id.id must beMatching("^l.+") // tests public id
+          libInfos(1).caption must beNone
         }
       }
     }


### PR DESCRIPTION
marketing site library gets it's caption from the db system value, which allows us to set the value manually specific to the marketing site

@stkem 
