### PR TITLE
fix keep tracking for mobile

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -769,6 +769,7 @@ class KeepsCommander @Inject() (
             collectionRepo.collectionChanged(tagId, false, inactivateIfEmpty = true)
           }
           keepRepo.save(keep) // notify keep index
+          curator.updateUriRecommendationFeedback(userId, keep.uriId, UriRecommendationFeedback(kept = Some(true)))
           keepToCollectionRepo.getCollectionsForKeep(keep.id.get).map { id => collectionRepo.get(id) }
         }
         Right((keep, tags))


### PR DESCRIPTION
@stkem 

A quick fix. 

@leogrim suggested that we do tracking in keepInterner, this is where all keep endpoints converge. I think it's a great idea. Considering huge batch imports, I am not quite sure about the performance impact if we do all tracking there.
