### PR TITLE
Redirect to home before reloading page.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
@@ -54,6 +54,7 @@ angular.module('kifi')
         $state.go('home');
       }
       if (!$rootScope.userLoggedIn && !$stateParams.upb) {
+        $state.go('home');
         $window.location = env.navBase;
       }
 


### PR DESCRIPTION
@andrewconner 

After the last fix, the user profile page flashes before the user is taken to Kifi logged out home. This fix will flash the recommendations page instead, but we need a non-flashing-at-all solution. Rolling this out as a temporary fix for now.
