### PR TITLE
twtr: copy oauth1 info

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -489,7 +489,7 @@ class AuthHelper @Inject() (
       case Some(provider) =>
         provider.getUserProfileInfo(oauth1Info) map { info =>
           val filledUser = SecureSocialAdaptor.toSocialUser(info, AuthenticationMethod.OAuth1)
-          authCommander.signupWithTrustedSocialUser(providerName, filledUser, signUpUrl)
+          authCommander.signupWithTrustedSocialUser(providerName, filledUser.copy(oAuth1Info = Some(oauth1Info)), signUpUrl)
         } recover {
           case t: Throwable =>
             airbrakeNotifier.notify(s"[accessTokenSignup($providerName)] Caught Exception($t) during getUserProfileInfo; token=${oauth1Info}; Cause:${t.getCause}; StackTrace: ${t.getStackTraceString}")

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/oauth/OAuth1TokenTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/oauth/OAuth1TokenTest.scala
@@ -97,6 +97,9 @@ class OAuth1TokenTest extends Specification with ShoeboxApplicationInjector {
         val suiOpt = db.readOnlyMaster { implicit ro => socialUserInfoRepo.getOpt(SocialId(profile.userId.id), SocialNetworks.TWITTER) }
         suiOpt.isDefined === true
         suiOpt.exists { sui => sui.userId.isEmpty } === true // userId must not be set in this case
+
+        val socialUser = suiOpt.get.credentials.get
+        socialUser.oAuth1Info.isDefined === true
       }
     }
     "(signup) report invalid token when twtr reports error" in {

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/oauth/OAuth2TokenTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/oauth/OAuth2TokenTest.scala
@@ -102,6 +102,9 @@ class OAuth2TokenTest extends Specification with ShoeboxApplicationInjector {
         val suiOpt = db.readOnlyMaster { implicit ro => socialUserInfoRepo.getOpt(SocialId(profile.userId.id), SocialNetworks.FACEBOOK) }
         suiOpt.isDefined === true
         suiOpt.exists { sui => sui.userId.isEmpty } === true // userId must not be set in this case
+        suiOpt.get.credentials.isDefined === true
+        val socialUser = suiOpt.get.credentials.get
+        socialUser.oAuth2Info.isDefined === true
       }
     }
     "(signup) report invalid token when fb reports error" in {


### PR DESCRIPTION
- Added missing oauth1 info for the oauth1 signup code path used by mobile. 
- Added test coverage as well.

@andrewconner @thassss 
