### PR TITLE
hardening reactivelock

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/concurrent/ReactiveLock.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/concurrent/ReactiveLock.scala
@@ -54,7 +54,7 @@ class ReactiveLock(numConcurrent: Int = 1) {
     //making sure the runner just starts a future and does nothing else (in case f does some other work, keeping dispatch very light)
     val wrapper = () => {
       val innerPromise = Promise[T]
-      Future { innerPromise.completeWith(f) }
+      innerPromise.completeWith(Future(f).flatMap(future => future))
       innerPromise.future
     }
     taskQueue.add(QueuedItem[T](wrapper, p, ec))


### PR DESCRIPTION
@stkem 

The existing `withLockFuture` has a problem when `f` throws an exception. The exception prevents `innerPromise.completeWith` from being executed.
