### PR TITLE
specifying height and width for user profile header picture

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
@@ -67,7 +67,7 @@ angular.module('kifi')
       $scope.profile.picUrl = keepWhoService.getPicUrl({
         id: $scope.profile.id,
         pictureName: $scope.profile.pictureName
-      }, 100);
+      }, 200);
     }
 
     function initViewingUserStatus() {

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.styl
@@ -16,6 +16,8 @@
   right: 30px
 
 .kf-user-profile-picture
+  height: 100px
+  width: 100px
   border-radius: 100%
 
 .kf-user-profile-name


### PR DESCRIPTION
Specifying the size of an `<img>` in the HTML or CSS allows the browser to reserve the proper amount of space for it until it loads, so the user won’t see content below jump down when the image loads.

@yipingliao 
