### PR TITLE
updating formatLibraryPath not to take the owner's external ID

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -91,9 +91,8 @@ object Library extends ModelWithPublicIdCompanion[Library] {
     name.nonEmpty && name.length <= 200 && !name.contains('"') && !name.contains('/')
   }
 
-  def formatLibraryPath(ownerUsername: Username, ownerExternalId: ExternalId[User], slug: LibrarySlug): String = {
-    val usernameString = ownerUsername.value
-    s"/$usernameString/${slug.value}"
+  def formatLibraryPath(ownerUsername: Username, slug: LibrarySlug): String = {
+    s"/$ownerUsername.value/${slug.value}"
   }
 
   def toLibraryView(lib: Library): LibraryView = LibraryView(id = lib.id, ownerId = lib.ownerId, state = lib.state, seq = lib.seq, kind = lib.kind)
@@ -203,7 +202,7 @@ case class BasicLibrary(id: PublicId[Library], name: String, path: String, visib
 object BasicLibrary {
 
   def apply(library: Library, owner: BasicUser)(implicit publicIdConfig: PublicIdConfiguration): BasicLibrary = {
-    val path = Library.formatLibraryPath(owner.username, owner.externalId, library.slug)
+    val path = Library.formatLibraryPath(owner.username, library.slug)
     BasicLibrary(Library.publicId(library.id.get), library.name, path, library.visibility)
   }
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/mobile/MobileSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/mobile/MobileSearchController.scala
@@ -75,7 +75,7 @@ class MobileSearchController @Inject() (
           libraryRecordsAndVisibilityById.get(hit.id).map {
             case (library, visibility) =>
               val owner = usersById(library.ownerId)
-              val path = Library.formatLibraryPath(owner.username, owner.externalId, library.slug)
+              val path = Library.formatLibraryPath(owner.username, library.slug)
               val statistics = libraryStatisticsById(library.id)
               val description = library.description.getOrElse("")
               Json.obj(

--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/util/SearchControllerUtil.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/util/SearchControllerUtil.scala
@@ -155,7 +155,7 @@ trait SearchControllerUtil {
   }.toMap
 
   private def makeBasicLibrary(library: LibraryRecord, visibility: LibraryVisibility, owner: BasicUser)(implicit publicIdConfig: PublicIdConfiguration): BasicLibrary = {
-    val path = Library.formatLibraryPath(owner.username, owner.externalId, library.slug)
+    val path = Library.formatLibraryPath(owner.username, library.slug)
     BasicLibrary(Library.publicId(library.id), library.name, path, visibility)
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -94,7 +94,7 @@ class LibraryCommander @Inject() (
   def libraryMetaTags(library: Library): Future[PublicPageMetaTags] = {
     db.readOnlyMasterAsync { implicit s =>
       val owner = userRepo.get(library.ownerId)
-      val urlPathOnly = Library.formatLibraryPath(owner.username, owner.externalId, library.slug)
+      val urlPathOnly = Library.formatLibraryPath(owner.username, library.slug)
       if (library.visibility != PUBLISHED) {
         PublicPageMetaPrivateTags(urlPathOnly)
       } else {
@@ -278,7 +278,7 @@ class LibraryCommander @Inject() (
           owner = owner,
           description = lib.description,
           slug = lib.slug,
-          url = Library.formatLibraryPath(owner.username, owner.externalId, lib.slug),
+          url = Library.formatLibraryPath(owner.username, lib.slug),
           color = lib.color,
           kind = lib.kind,
           visibility = lib.visibility,
@@ -662,7 +662,7 @@ class LibraryCommander @Inject() (
           }
           val imgUrl = s3ImageStore.avatarUrlByExternalId(Some(200), inviter.externalId, inviter.pictureName, Some("https"))
           val inviterImage = if (imgUrl.endsWith(".jpg.jpg")) imgUrl.dropRight(4) else imgUrl // basicUser appends ".jpg" which causes an extra .jpg in this case
-          val libLink = s"""https://www.kifi.com${Library.formatLibraryPath(libOwner.username, libOwner.externalId, lib.slug)}"""
+          val libLink = s"""https://www.kifi.com${Library.formatLibraryPath(libOwner.username, lib.slug)}"""
 
           // send notifications to kifi users only
           val inviteeIdSet = key._2.map(_.userId).flatten.toSet
@@ -821,7 +821,7 @@ class LibraryCommander @Inject() (
       title = "New Library Follower",
       body = s"${follower.firstName} ${follower.lastName} is now following your Library ${lib.name}",
       linkText = "Go to Library",
-      linkUrl = "https://kifi.com" + Library.formatLibraryPath(owner.username, owner.externalId, lib.slug),
+      linkUrl = "https://www.kifi.com" + Library.formatLibraryPath(owner.username, lib.slug),
       imageUrl = s3ImageStore.avatarUrlByUser(follower),
       sticky = false,
       category = NotificationCategory.User.LIBRARY_FOLLOWED
@@ -847,7 +847,7 @@ class LibraryCommander @Inject() (
           title = s"New Keep in ${library.name}",
           body = s"${keeper.firstName} has just kept ${newKeep.title.getOrElse("a new item")}",
           linkText = "Go to Library",
-          linkUrl = "https://kifi.com" + Library.formatLibraryPath(owner.username, owner.externalId, library.slug),
+          linkUrl = "https://www.kifi.com" + Library.formatLibraryPath(owner.username, library.slug),
           imageUrl = s3ImageStore.avatarUrlByUser(keeper),
           sticky = false,
           category = NotificationCategory.User.NEW_KEEP
@@ -1128,7 +1128,7 @@ class LibraryCommander @Inject() (
         getLibraryBySlugOrAlias(owner.id.get, slug) match {
           case None => Left(LibraryFail(NOT_FOUND, "no_library_found"))
           case Some((library, isLibraryAlias)) =>
-            if ((isUserAlias || isLibraryAlias) && !followRedirect) Left(LibraryFail(MOVED_PERMANENTLY, Library.formatLibraryPath(owner.username, owner.externalId, library.slug)))
+            if ((isUserAlias || isLibraryAlias) && !followRedirect) Left(LibraryFail(MOVED_PERMANENTLY, Library.formatLibraryPath(owner.username, library.slug)))
             else Right(library)
         }
     }
@@ -1343,7 +1343,7 @@ object LibraryInfo {
       name = lib.name,
       visibility = lib.visibility,
       shortDescription = lib.description,
-      url = Library.formatLibraryPath(owner.username, owner.externalId, lib.slug),
+      url = Library.formatLibraryPath(owner.username, lib.slug),
       color = lib.color,
       owner = owner,
       numKeeps = keepCount,

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/RecommendationsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/RecommendationsCommander.scala
@@ -94,7 +94,7 @@ class RecommendationsCommander @Inject() (
           owner = owner,
           id = Library.publicId(libraryId),
           name = lib.name,
-          path = Library.formatLibraryPath(owner.username, owner.externalId, lib.slug)
+          path = Library.formatLibraryPath(owner.username, lib.slug)
         )
     }
 
@@ -123,7 +123,7 @@ class RecommendationsCommander @Inject() (
         RecoAttributionInfo(
           kind = RecoAttributionKind.Library,
           name = Some(lib.name),
-          url = Some(Library.formatLibraryPath(owner.username, owner.externalId, lib.slug)),
+          url = Some(Library.formatLibraryPath(owner.username, lib.slug)),
           when = None
         )
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
@@ -146,7 +146,7 @@ class EmailTemplateProcessorImpl @Inject() (
         case tags.avatarUrl => toHttpsUrl(input.imageUrls(userId))
         case tags.libraryUrl =>
           val libOwner = input.users(library.ownerId)
-          config.applicationBaseUrl + Library.formatLibraryPath(libOwner.username, libOwner.externalId, library.slug)
+          config.applicationBaseUrl + Library.formatLibraryPath(libOwner.username, library.slug)
         case tags.libraryName => library.name
         case tags.unsubscribeUrl =>
           getUnsubUrl(emailToSend.to match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/seo/FeedCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/seo/FeedCommander.scala
@@ -56,7 +56,7 @@ class FeedCommander @Inject() (
         val metaTags = idToMetaTags(lib.id.get)
         val owner = owners(lib.ownerId)
         val libImg = metaTags.images.headOption.getOrElse(logo)
-        val itemUrl = s"${fortyTwoConfig.applicationBaseUrl}${Library.formatLibraryPath(owner.username, owner.externalId, lib.slug)}"
+        val itemUrl = s"${fortyTwoConfig.applicationBaseUrl}${Library.formatLibraryPath(owner.username, lib.slug)}"
         val desc = Unparsed(
           s"""
                |<![CDATA[

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/seo/SiteMapGenerator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/seo/SiteMapGenerator.scala
@@ -106,7 +106,7 @@ class SiteMapGenerator @Inject() (
 
       def path(lib: Library): String = {
         val owner = owners(lib.ownerId)
-        s"${fortyTwoConfig.applicationBaseUrl}${Library.formatLibraryPath(owner.username, owner.externalId, lib.slug)}"
+        s"${fortyTwoConfig.applicationBaseUrl}${Library.formatLibraryPath(owner.username, lib.slug)}"
       }
 
       def lastMod(lib: Library): LocalDate = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -49,7 +49,7 @@ class ExtLibraryController @Inject() (
         id = Library.publicId(lib.id.get),
         name = lib.name,
         visibility = lib.visibility,
-        path = Library.formatLibraryPath(owner.username, owner.externalId, lib.slug))
+        path = Library.formatLibraryPath(owner.username, lib.slug))
     }
     Ok(Json.obj("libraries" -> datas))
   }
@@ -68,7 +68,7 @@ class ExtLibraryController @Inject() (
           id = Library.publicId(lib.id.get),
           name = lib.name,
           visibility = lib.visibility,
-          path = Library.formatLibraryPath(request.user.username, request.user.externalId, lib.slug))))
+          path = Library.formatLibraryPath(request.user.username, lib.slug))))
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/views/admin/graph/wanderView.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/graph/wanderView.scala.html
@@ -68,7 +68,7 @@
         <table class = "table table-bordered">
             <tr><th colspan="3"><h3>Library Collisions</h3></th></tr>
             <tr> <th>Public Id</th> <th>Title</th> <th>Owner</th><th>Score</th> </tr>
-            @libraries.map { case (library, owner, count) => <tr> <td>@library.id.get</td> <td><a href=https://www.kifi.com@{com.keepit.model.Library.formatLibraryPath(owner.username, owner.externalId, library.slug)}>@library.name</a></td><td>@owner.fullName</td> <td>@count</td> </tr> }
+            @libraries.map { case (library, owner, count) => <tr> <td>@library.id.get</td> <td><a href=https://www.kifi.com@{com.keepit.model.Library.formatLibraryPath(owner.username, library.slug)}>@library.name</a></td><td>@owner.fullName</td> <td>@count</td> </tr> }
         </table>
     }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/seo/FeedControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/seo/FeedControllerTest.scala
@@ -110,7 +110,7 @@ class FeedControllerTest extends Specification with ShoeboxTestInjector {
         (channel \ "link").text.trim === s"http://dev.ezkeep.com:9000$path"
         val items = (elem \\ "item")
         items.size === 3
-        (items.head \ "link").text.trim === s"http://dev.ezkeep.com:9000${Library.formatLibraryPath(u2.username, u2.externalId, lib3.slug)}"
+        (items.head \ "link").text.trim === s"http://dev.ezkeep.com:9000${Library.formatLibraryPath(u2.username, lib3.slug)}"
 
       }
     }
@@ -131,7 +131,7 @@ class FeedControllerTest extends Specification with ShoeboxTestInjector {
         (channel \ "link").text.trim === s"http://dev.ezkeep.com:9000$path"
         val items = (elem \\ "item")
         items.size === 1
-        (items.head \ "link").text.trim === s"http://dev.ezkeep.com:9000${Library.formatLibraryPath(u1.username, u1.externalId, lib1.slug)}"
+        (items.head \ "link").text.trim === s"http://dev.ezkeep.com:9000${Library.formatLibraryPath(u1.username, lib1.slug)}"
 
       }
     }


### PR DESCRIPTION
@andrewconner 

I wish we’d been consistent about formatting paths. I like how this one begins with `/`. The keep and library image paths omit the initial `/`.
