### PR TITLE
misc lda version clean up

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -352,6 +352,7 @@ object Cortex extends Service {
     def word2vecUserUriSimilarity() = ServiceRoute(POST, "/internal/cortex/word2vec/userUriSimilarity")
     def word2vecFeedUserUris() = ServiceRoute(POST, "/internal/cortex/word2vec/feedUserUris")
 
+    def defulatLDAVersion() = ServiceRoute(GET, "/internal/cortex/lda/defaultVersion")
     def ldaNumOfTopics(implicit version: LDAVersionOpt) = ServiceRoute(GET, "/internal/cortex/lda/numOfTopics", Param("version", version))
     def ldaShowTopics(fromId: Int, toId: Int, topN: Int)(implicit version: LDAVersionOpt) = ServiceRoute(GET, "/internal/cortex/lda/showTopics", Param("fromId", fromId), Param("toId", toId), Param("topN", topN), Param("version", version))
     def ldaWordTopic(word: String)(implicit version: LDAVersionOpt) = ServiceRoute(GET, "/internal/cortex/lda/wordTopic", Param("word", word), Param("version", version))

--- a/kifi-backend/modules/common/app/com/keepit/cortex/CortexServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/cortex/CortexServiceClient.scala
@@ -31,6 +31,7 @@ trait CortexServiceClient extends ServiceClient {
   def word2vecUserUriSimilarity(userUris: Seq[Id[NormalizedURI]], uri: Id[NormalizedURI]): Future[Map[String, Float]]
   def word2vecFeedUserUris(userUris: Seq[Id[NormalizedURI]], feedUris: Seq[Id[NormalizedURI]]): Future[Seq[Id[NormalizedURI]]]
 
+  def defaultLDAVersion(): Future[ModelVersion[DenseLDA]]
   def ldaNumOfTopics(implicit version: LDAVersionOpt = None): Future[Int]
   def ldaShowTopics(fromId: Int, toId: Int, topN: Int)(implicit version: LDAVersionOpt = None): Future[Seq[LDATopicInfo]]
   def ldaConfigurations(implicit version: LDAVersionOpt): Future[LDATopicConfigurations]
@@ -117,6 +118,10 @@ class CortexServiceClientImpl(
     call(Cortex.internal.word2vecFeedUserUris(), payload).map { r =>
       Json.fromJson[Seq[Id[NormalizedURI]]](r.json).get
     }
+  }
+
+  def defaultLDAVersion(): Future[ModelVersion[DenseLDA]] = {
+    call(Cortex.internal.defulatLDAVersion()).map { r => (r.json).as[ModelVersion[DenseLDA]] }
   }
 
   def ldaNumOfTopics(implicit version: LDAVersionOpt = None): Future[Int] = {

--- a/kifi-backend/modules/common/test/com/keepit/cortex/FakeCortexServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/cortex/FakeCortexServiceClientImpl.scala
@@ -31,6 +31,7 @@ class FakeCortexServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) extend
   override def word2vecUserUriSimilarity(userUris: Seq[Id[NormalizedURI]], uri: Id[NormalizedURI]): Future[Map[String, Float]] = ???
   override def word2vecFeedUserUris(userUris: Seq[Id[NormalizedURI]], feedUris: Seq[Id[NormalizedURI]]): Future[Seq[Id[NormalizedURI]]] = ???
 
+  override def defaultLDAVersion(): Future[ModelVersion[DenseLDA]] = ???
   override def ldaNumOfTopics(implicit version: LDAVersionOpt = None): Future[Int] = ???
   override def ldaShowTopics(fromId: Int, toId: Int, topN: Int)(implicit version: LDAVersionOpt = None): Future[Seq[LDATopicInfo]] = ???
   override def ldaConfigurations(implicit version: LDAVersionOpt): Future[LDATopicConfigurations] = Future.successful(LDATopicConfigurations(Map()))

--- a/kifi-backend/modules/cortex/app/com/keepit/common/commanders/FeatureRetrievalCommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/commanders/FeatureRetrievalCommander.scala
@@ -6,7 +6,7 @@ import com.keepit.cortex.models.lda._
 import com.keepit.cortex.core.ModelVersion
 import com.keepit.common.db.SequenceNumber
 import com.keepit.model.NormalizedURI
-import com.keepit.cortex.PublishingVersions
+import com.keepit.cortex.ModelVersions
 
 @Singleton
 class FeatureRetrievalCommander @Inject() (
@@ -14,7 +14,7 @@ class FeatureRetrievalCommander @Inject() (
     ldaCommander: LDACommander) {
 
   private val defaultSparsity = 2
-  private val allowedVersion = PublishingVersions.denseLDAVersion
+  private val allowedVersion = ModelVersions.defaultLDAVersion
 
   def getSparseLDAFeaturesChanged(lowSeq: SequenceNumber[NormalizedURI], fetchSize: Int, version: ModelVersion[DenseLDA], sparsity: Int = defaultSparsity): Seq[UriSparseLDAFeatures] = {
     assume(version == allowedVersion, s"allowed lda version = ${allowedVersion}, queried for version = ${version}")

--- a/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDAInfoCommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDAInfoCommander.scala
@@ -3,7 +3,7 @@ package com.keepit.common.commanders
 import com.google.inject.{ Inject, Singleton }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.time._
-import com.keepit.cortex.{ ModelVersions, MiscPrefix, PublishingVersions }
+import com.keepit.cortex.{ ModelVersions, MiscPrefix }
 import com.keepit.cortex.core.ModelVersion
 import com.keepit.cortex.dbmodel.{ LDAInfo, LDAInfoRepo }
 import com.keepit.cortex.models.lda._

--- a/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/CortexDataPipeController.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/CortexDataPipeController.scala
@@ -7,7 +7,7 @@ import com.keepit.model.NormalizedURI
 import com.keepit.common.commanders.FeatureRetrievalCommander
 import com.keepit.common.db.SequenceNumber
 import com.keepit.cortex.models.lda.DenseLDA
-import com.keepit.cortex.PublishingVersions
+import com.keepit.cortex.ModelVersions
 import play.api.mvc.Action
 import com.keepit.cortex.core.ModelVersion
 
@@ -16,7 +16,7 @@ class CortexDataPipeController @Inject() (
 
   def getSparseLDAFeaturesChanged(modelVersion: ModelVersion[DenseLDA], seqNum: SequenceNumber[NormalizedURI], fetchSize: Int) = Action { request =>
 
-    val publishedLDAVersion = PublishingVersions.denseLDAVersion
+    val publishedLDAVersion = ModelVersions.defaultLDAVersion
     require(modelVersion <= publishedLDAVersion, s"Version $modelVersion of LDA has not been published yet.")
     val lowUriSeq = if (modelVersion < publishedLDAVersion) SequenceNumber.ZERO[NormalizedURI] else seqNum
 

--- a/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
@@ -2,9 +2,8 @@ package com.keepit.controllers.cortex
 
 import com.google.inject.Inject
 import com.keepit.common.logging.Logging
-import com.keepit.cortex.PublishingVersions
+import com.keepit.cortex.ModelVersions
 import com.keepit.cortex.core.{ CortexVersionCommander, ModelVersion }
-import com.keepit.macros.MonitoredAwaitMacro
 import play.api.mvc.Action
 import play.api.libs.json._
 import com.keepit.common.controller.CortexServiceController
@@ -25,7 +24,7 @@ class LDAController @Inject() (
   infoCommander: LDAInfoCommander)
     extends CortexServiceController with Logging {
 
-  private val defaultVersion = PublishingVersions.denseLDAVersion
+  private val defaultVersion = ModelVersions.defaultLDAVersion
 
   implicit def toVersion(implicit version: Option[Int]): ModelVersion[DenseLDA] = version.map { ModelVersion[DenseLDA](_) } getOrElse defaultVersion
 
@@ -35,6 +34,10 @@ class LDAController @Inject() (
       case (None, Some(uid)) => Await.result(versionCommander.getLDAVersionForUser(uid), 1 second) // use of Await is temp. (Only during model experimenting)
       case (None, None) => defaultVersion
     }
+  }
+
+  def getDefaultVersion() = Action { request =>
+    Ok(Json.toJson(defaultVersion))
   }
 
   def numOfTopics(implicit version: Option[Int]) = Action { request =>

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/core/StatModelVersionCommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/core/StatModelVersionCommander.scala
@@ -20,14 +20,14 @@ class CortexVersionCommander @Inject() (userExpCmdr: RemoteUserExperimentCommand
 
   def getLDAVersionForUser(userId: Id[User]): Future[ModelVersion[DenseLDA]] = {
     if (ModelVersions.experimentalLDAVersion.isEmpty) {
-      Future.successful(ModelVersions.denseLDAVersion)
+      Future.successful(ModelVersions.defaultLDAVersion)
     } else {
       userIsOnNewModel(userId).map { useNewModel =>
         if (useNewModel) {
           val v = ModelVersions.experimentalLDAVersion.head
           log.info(s"using experimental LDA version ${v} for user ${userId}")
           v
-        } else ModelVersions.denseLDAVersion
+        } else ModelVersions.defaultLDAVersion
       }
     }
   }

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDAUserDbUpdater.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDAUserDbUpdater.scala
@@ -98,7 +98,7 @@ class LDAUserDbUpdaterImpl @Inject() (
       }
       val (snaphShotChanged, tosave) = updateSnapshotIfNecessary(newModel)
       db.readWrite { implicit s => userTopicRepo.save(tosave) }
-      if (snaphShotChanged && version == ModelVersions.denseLDAVersion) { curator.refreshUserRecos(user) }
+      if (snaphShotChanged && version == ModelVersions.defaultLDAVersion) { curator.refreshUserRecos(user) }
     }
   }
 

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/package.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/package.scala
@@ -10,15 +10,10 @@ package object cortex {
 
   // version of feature representers/updaters
   object ModelVersions {
-    val denseLDAVersion = ModelVersion[DenseLDA](2)
+    val defaultLDAVersion = ModelVersion[DenseLDA](2)
     val experimentalLDAVersion = List(ModelVersion[DenseLDA](3))
-    val availableLDAVersions = List(ModelVersion[DenseLDA](2)) ++ experimentalLDAVersion
+    val availableLDAVersions = List(defaultLDAVersion) ++ experimentalLDAVersion
     val word2vecVersion = ModelVersion[Word2Vec](2)
-  }
-
-  // default version provided to consumers, unless they specify a particular version
-  object PublishingVersions {
-    val denseLDAVersion = ModelVersion[DenseLDA](2)
   }
 
   object ModelStorePrefix {

--- a/kifi-backend/modules/cortex/conf/cortexService.routes
+++ b/kifi-backend/modules/cortex/conf/cortexService.routes
@@ -16,6 +16,7 @@ POST    /internal/cortex/word2vec/queryUriSimilarity                            
 POST    /internal/cortex/word2vec/userUriSimilarity                                 @com.keepit.controllers.cortex.CortexController.userUriSimilarity
 POST    /internal/cortex/word2vec/feedUserUris                                      @com.keepit.controllers.cortex.CortexController.feedUserUris
 
+GET     /internal/cortex/lda/defaultVersion                                         @com.keepit.controllers.cortex.LDAController.getDefaultVersion()
 GET     /internal/cortex/lda/numOfTopics                                            @com.keepit.controllers.cortex.LDAController.numOfTopics(version: Option[Int] ?= None)
 GET     /internal/cortex/lda/showTopics                                             @com.keepit.controllers.cortex.LDAController.showTopics(fromId: Int, toId: Int, topN: Int, version: Option[Int] ?= None)
 GET     /internal/cortex/lda/wordTopic                                              @com.keepit.controllers.cortex.LDAController.wordTopic(word, version: Option[Int] ?= None)

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLDAController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLDAController.scala
@@ -6,13 +6,14 @@ import com.keepit.cortex.CortexServiceClient
 import com.keepit.cortex.core.ModelVersion
 import com.keepit.shoebox.ShoeboxServiceClient
 import play.api.libs.json._
-import scala.concurrent.Future
+import scala.concurrent.{ Await, Future }
 import com.keepit.cortex.models.lda.{ DenseLDA, LDATopicDetail, LDATopicConfiguration }
 import com.keepit.common.db.slick.Database
 import com.keepit.model._
 import com.keepit.common.db.Id
 import play.api.libs.concurrent.Execution.Implicits._
 import views.html
+import scala.concurrent.duration._
 
 class AdminLDAController @Inject() (
     cortex: CortexServiceClient,
@@ -28,7 +29,8 @@ class AdminLDAController @Inject() (
   implicit def int2VersionOpt(n: Int) = Some(ModelVersion[DenseLDA](n))
   implicit def int2Version(n: Int) = ModelVersion[DenseLDA](n)
 
-  val defaultVersion = ModelVersion[DenseLDA](2) // TODO soon: get this from cortex client
+  val defaultVersionF = cortex.defaultLDAVersion()
+  lazy val defaultVersion = Await.result(defaultVersionF, 1 second)
 
   def index() = versionPage(defaultVersion)
 


### PR DESCRIPTION
@ymatsuda @stkem @joshm1 

minor clean ups
- admin gets the default version from `cortexClient`, instead of hard-coded number
- renamed `ModelVersions.denseLDAVersion` to `ModelVersions.defaultLDAVersion`
- removed `PublishingVersions`. Semantically, this is equivalent to `ModelVersions.defaultLDAVersion`
