### PR TITLE
Add float property to related libraries bottom footer element.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/relatedLibraries.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/relatedLibraries.styl
@@ -3,111 +3,96 @@ relatedLibrariesColumnWidth = 226px
 desktopBorderRadius = 19px
 mobileBorderRadius = 54px
 
-.kf-logged-out {
-  .kf-library-results-wrapper {
-    width: keepsColumnWidth;
-    float: left;
-  }
-  &.kf-mobile .kf-library-results-wrapper {
-    max-width: initial;
-    float: none;
-  }
+.kf-logged-out
+  .kf-library-results-wrapper
+    width: keepsColumnWidth
+    float: left
 
-  .kf-library-body {
-    min-width: keepsColumnWidth + relatedLibrariesColumnWidth;
-    .kf-main-keeps {
-      max-width: keepsColumnWidth;
+  &.kf-mobile .kf-library-results-wrapper
+    max-width: initial
+    float: none
+
+  .kf-library-body
+    min-width: keepsColumnWidth + relatedLibrariesColumnWidth
+    .kf-main-keeps
+      max-width: keepsColumnWidth
+
+  &.kf-mobile .kf-library-body
+    min-width: initial
+    .kf-main-keeps
+      max-width: initial
+
+.kf-related-libraries
+  margin-top: 42px
+  float: left
+  width: relatedLibrariesColumnWidth
+  box-sizing: border-box
+  padding: 0
+  .kf-mobile &
+    margin-top: 0
+    float: none
+    width: initial
+
+.kf-related-libraries-see-more
+  margin: 0 4px
+  font-size: 15px
+  &, &:link, &:hover, &:visited
+    color: #74a6e5
+    text-decoration: none
+  .kf-mobile &
+    font-size: 36px
+    margin: 60px 38px
+
+.kf-related-libraries-card-your-own-card
+  background: #73c785
+  border-radius: desktopBorderRadius
+  font-size: 20px
+  text-align: center
+  color: #fff
+  padding: 21px 10px
+  margin: 1em 0
+
+  .kf-related-libraries-card-your-own-card-btn
+    &, &:link, &:visited, &:hover
+      color: #fff
+      text-decoration: none
     }
-  }
-  &.kf-mobile .kf-library-body {
-    min-width: initial;
-    .kf-main-keeps {
-      max-width: initial;
-    }
-  }
-}
+    background: #418cc9
+    display: inline-block
+    margin: 18px auto 0
+    font-size: 16px
+    font-weight: bold
+    border-radius: 4px
+    padding: 6px 16px
 
-.kf-related-libraries {
-  margin-top: 42px;
-  float: left;
-  width: relatedLibrariesColumnWidth;
-  box-sizing: border-box;
-  padding: 0;
-  .kf-mobile & {
-    margin-top: 0;
-    float: none;
-    width: initial;
-  }
-}
+  .kf-mobile &
+    display: none
 
-.kf-related-libraries-see-more {
-  display: block;
-  margin: 0 4px 16px;
-  font-size: 15px;
-  &, &:link, &:hover, &:visited {
-    color: #74a6e5;
-    text-decoration: none;
-  }
-  .kf-mobile & {
-    font-size: 36px;
-    margin: 60px 38px;
-  }
-}
+.kf-related-library-explore-more-header
+  text-transform: uppercase
+  color: #4e4754
+  display: block
+  font-size: 14px
+  font-weight: bold
+  text-align: left
+  margin-bottom: 1em
+  .kf-mobile &
+    text-align: center
+    background: #e8e8e8
+    font-size: 30px
+    line-height: 3em
+    clear: both
+    float: none
+    margin-bottom: 0
 
-.kf-related-libraries-card-your-own-card {
-  background: #73c785;
-  border-radius: desktopBorderRadius;
-  font-size: 20px;
-  text-align: center;
-  color: #fff;
-  padding: 21px 10px;
-  margin-bottom: 1em;
+.kf-related-library-card
+  float: left
+  width: 100%
+  margin-bottom: 1em
+  .kf-mobile &
+    margin: 40px 25px 10px 30px
+    float: none
+    width: auto
 
-  .kf-related-libraries-card-your-own-card-btn {
-    &, &:link, &:visited, &:hover {
-      color: #fff;
-      text-decoration: none;
-    }
-    background: #418cc9;
-    display: inline-block;
-    margin: 18px auto 0;
-    font-size: 16px;
-    font-weight: bold;
-    border-radius: 4px;
-    padding: 6px 16px;
-  }
-
-  .kf-mobile & {
-    display: none;
-  }
-}
-
-.kf-related-library-explore-more-header {
-  text-transform: uppercase;
-  color: #4e4754;
-  display: block;
-  font-size: 14px;
-  font-weight: bold;
-  text-align: left;
-  margin-bottom: 1em;
-  .kf-mobile & {
-    text-align: center;
-    background: #e8e8e8;
-    font-size: 30px;
-    line-height: 3em;
-    clear: both;
-    float: none;
-    margin-bottom: 0;
-  }
-}
-
-.kf-related-library-card {
-  float: left;
-  width: 100%;
-  margin-bottom: 1em;
-  .kf-mobile & {
-    margin: 40px 25px 10px 30px;
-    float: none;
-    width: auto;
-  }
-}
+.kf-related-library-footer
+  float: left

--- a/kifi-backend/modules/shoebox/angular/src/libraries/relatedLibraries.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/relatedLibraries.tpl.html
@@ -1,14 +1,14 @@
-<div class="kf-related-libraries">
-  <div class="kf-related-library-explore-more-header" ng-if="!$root.userLoggedIn">Explore More Kifi Libraries</div>
+<section class="kf-related-libraries">
+  <header class="kf-related-library-explore-more-header" ng-if="!$root.userLoggedIn">Explore More Kifi Libraries</header>
   <div class="kf-related-library-card" ng-repeat="library in relatedLibraries">
     <div kf-small-library-card library="library" origin="rl" action="clickedLibraryRec"></div>
   </div>
-  <div ng-if="!$root.userLoggedIn">
+  <footer ng-if="!$root.userLoggedIn" class="kf-related-library-footer">
     <a href="/libraries/featured" class="kf-related-libraries-see-more" ng-click="clickSeeMore($event)" target="_blank">See more &raquo;</a>
     <div class="kf-related-libraries-card-your-own-card">
       <div>Create Your Own Library</div>
       <a href="/signup" ng-click="join($event)" class="kf-related-libraries-card-your-own-card-btn">Join now</a>
     </div>
-  </div>
+  </footer>
   <div class="clearfix"></div>
-</div>
+</section>


### PR DESCRIPTION
@2is10 cc @joshm1 

Fixes a problem where sometimes the related library card "run into" each other because the last element in that section was not floated. Could be caused by a race condition where this problem is visible when the data for the related libraries is returned with different delays.

Tested with logged-in, logged-out, and mobile views.
