### PR TITLE
one time fix

### DIFF
--- a/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDACommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDACommander.scala
@@ -406,4 +406,25 @@ class LDACommander @Inject() (
     }
   }
 
+  def oneTimeFix() = {
+    val tofix = db.readOnlyReplica { implicit s => libTopicRepo.getToFix() }
+    assert(tofix.size < 200, "correct query should return < 200 items")
+    db.readWrite { implicit s =>
+      tofix.foreach { model =>
+        model.topic match {
+          case Some(mean) =>
+            // copied from LDALibraryUpdater
+            val sorted = mean.value.zipWithIndex.sortBy(-_._1).take(3)
+            val Array(first, second, third) = sorted.map { _._2 }
+            val firstTopicScore = sorted(0)._1
+            val entro = entropy(mean.value).toFloat
+            val newModel = model.copy(firstTopic = Some(LDATopic(first)), secondTopic = Some(LDATopic(second)), thirdTopic = Some(LDATopic(third)), firstTopicScore = Some(firstTopicScore), entropy = Some(entro))
+            libTopicRepo.save(newModel)
+          case None =>
+        }
+      }
+    }
+
+  }
+
 }

--- a/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
@@ -209,4 +209,9 @@ class LDAController @Inject() (
     Ok
   }
 
+  def oneTimeFix() = Action { request =>
+    lda.oneTimeFix()
+    Ok
+  }
+
 }

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/LibraryLDATopicRepo.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/LibraryLDATopicRepo.scala
@@ -20,6 +20,7 @@ trait LibraryLDATopicRepo extends DbRepo[LibraryLDATopic] {
   def getActiveByLibraryIds(libIds: Seq[Id[Library]], version: ModelVersion[DenseLDA])(implicit session: RSession): Seq[LibraryLDATopic]
   def getUserFollowedLibraryFeatures(userId: Id[User], version: ModelVersion[DenseLDA], minEvidence: Int = 5)(implicit session: RSession): Seq[LibraryTopicMean]
   def getLibraryByTopics(firstTopic: LDATopic, secondTopic: Option[LDATopic] = None, thirdTopic: Option[LDATopic] = None, version: ModelVersion[DenseLDA], minKeeps: Int = 5, limit: Int)(implicit session: RSession): Seq[LibraryLDATopic]
+  def getToFix()(implicit session: RSession): Seq[LibraryLDATopic]
 }
 
 @Singleton
@@ -85,5 +86,9 @@ class LibraryLDATopicRepoImpl @Inject() (
     } else {
       (for { r <- rows if r.firstTopic === firstTopic && r.version === version && r.numOfEvidence >= minKeeps && r.state === LibraryLDATopicStates.ACTIVE } yield r).sortBy(_.updatedAt.desc).list.take(limit)
     }
+  }
+
+  def getToFix()(implicit session: RSession): Seq[LibraryLDATopic] = {
+    (for { r <- rows if r.entropy.isNull && r.topic.isNotNull } yield r).list
   }
 }

--- a/kifi-backend/modules/cortex/conf/cortexService.routes
+++ b/kifi-backend/modules/cortex/conf/cortexService.routes
@@ -42,5 +42,6 @@ GET     /internal/cortex/lda/dumpFeature                                        
 GET     /internal/cortex/lda/similarURIs                                            @com.keepit.controllers.cortex.LDAController.getSimilarURIs(uriId: Id[NormalizedURI], version: Option[Int] ?= None)
 GET     /internal/cortex/lda/similarLibraries                                       @com.keepit.controllers.cortex.LDAController.getSimilarLibraries(libId: Id[Library], limit: Int, version: Option[Int] ?= None)
 POST    /internal/cortex/lda/uploadPMIScores                                        @com.keepit.controllers.cortex.LDAController.uploadPMIScores(version: ModelVersion[DenseLDA])
+GET     /internal/cortex/lda/oneTimeFix                                             @com.keepit.controllers.cortex.LDAController.oneTimeFix()
 
 GET     /internal/cortex/data/sparseLDAFeaturesChanged        @com.keepit.controllers.cortex.CortexDataPipeController.getSparseLDAFeaturesChanged(modelVersion: ModelVersion[DenseLDA], seqNum: SequenceNumber[NormalizedURI], fetchSize: Int)


### PR DESCRIPTION
@ymatsuda @stkem @joshm1 

there are 117 such bad rows (2 of them are active) in libraryTopicRepo. This was caused by adding 'topic columns and entropy column' to the repo. Most rows were fixed by setting seqNum to zero and run updater again. Somehow, these rows were left (for subtle reasons). 

This is a quick one time fix. Will apply once deployed. And will revert the change after that. 
