### PR TITLE
show library on profile (backend support)

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
@@ -22,7 +22,7 @@ case class LibraryMembership(
     state: State[LibraryMembership] = LibraryMembershipStates.ACTIVE,
     seq: SequenceNumber[LibraryMembership] = SequenceNumber.ZERO,
     showInSearch: Boolean = true,
-    listed: Boolean = true, // does library appear on user's profile?
+    listed: Boolean = true, // whether library appears on user's profile
     lastViewed: Option[DateTime] = None,
     lastEmailSent: Option[DateTime] = None) extends ModelWithState[LibraryMembership] with ModelWithSeqNumber[LibraryMembership] {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -67,8 +67,10 @@ class MobileLibraryController @Inject() (
     val newVisibility = (json \ "newVisibility").asOpt[LibraryVisibility]
     val newSlug = (json \ "newSlug").asOpt[String]
     val newColor = (json \ "newColor").asOpt[HexColor]
+    val newListed = (json \ "newListed").asOpt[Boolean]
 
-    val res = libraryCommander.modifyLibrary(libId, request.userId, newName, newDescription, newSlug, newVisibility, newColor)
+    val modifyRequest = LibraryModifyRequest(newName, newSlug, newVisibility, newDescription, newColor, newListed)
+    val res = libraryCommander.modifyLibrary(libId, request.userId, modifyRequest)
     res match {
       case Left(fail) =>
         Status(fail.status)(Json.obj("error" -> fail.message))

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
@@ -33,11 +33,21 @@ object LibraryError {
 
 case class LibraryFail(status: Int, message: String)
 
-@json case class LibraryAddRequest(name: String,
+@json case class LibraryAddRequest(
+  name: String,
   visibility: LibraryVisibility,
   description: Option[String] = None,
   slug: String,
-  color: Option[HexColor] = None)
+  color: Option[HexColor] = None,
+  listed: Option[Boolean] = None)
+
+@json case class LibraryModifyRequest(
+  name: Option[String] = None,
+  slug: Option[String] = None,
+  visibility: Option[LibraryVisibility] = None,
+  description: Option[String] = None,
+  color: Option[HexColor] = None,
+  listed: Option[Boolean] = None)
 
 case class LibraryInfo(id: PublicId[Library],
   name: String,

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -248,31 +248,31 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
         val libraryCommander = inject[LibraryCommander]
         val mod1 = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-          description = Some("Samuel L. Jackson was here"))
+          LibraryModifyRequest(description = Some("Samuel L. Jackson was here")))
         mod1.isRight === true
         mod1.right.get.description === Some("Samuel L. Jackson was here")
 
         val mod2 = libraryCommander.modifyLibrary(libraryId = libMurica.id.get, userId = userCaptain.id.get,
-          name = Some("MURICA #1!!!!!"), slug = Some("murica_#1"))
+          LibraryModifyRequest(name = Some("MURICA #1!!!!!"), slug = Some("murica_#1")))
         mod2.isRight === true
         mod2.right.get.name === "MURICA #1!!!!!"
         mod2.right.get.slug === LibrarySlug("murica_#1")
 
         val mod3 = libraryCommander.modifyLibrary(libraryId = libScience.id.get, userId = userIron.id.get,
-          visibility = Some(LibraryVisibility.PUBLISHED))
+          LibraryModifyRequest(visibility = Some(LibraryVisibility.PUBLISHED)))
         mod3.isRight === true
         mod3.right.get.visibility === LibraryVisibility.PUBLISHED
 
         val mod3NoChange = libraryCommander.modifyLibrary(libraryId = libScience.id.get, userId = userIron.id.get,
-          visibility = Some(LibraryVisibility.PUBLISHED))
+          LibraryModifyRequest(visibility = Some(LibraryVisibility.PUBLISHED)))
         mod3NoChange.isRight === true
         mod3NoChange.right.get.visibility === LibraryVisibility.PUBLISHED
 
         val mod4 = libraryCommander.modifyLibrary(libraryId = libScience.id.get, userId = userHulk.id.get,
-          name = Some("HULK SMASH"))
+          LibraryModifyRequest(name = Some("HULK SMASH")))
         mod4.isRight === false
         val mod5 = libraryCommander.modifyLibrary(libraryId = libScience.id.get, userId = userIron.id.get,
-          name = Some(""))
+          LibraryModifyRequest(name = Some("")))
         mod5.isRight === false
 
         db.readOnlyMaster { implicit s =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
@@ -87,7 +87,7 @@ class KifiSiteRouterTest extends Specification with ShoeboxTestInjector {
         router.route(NonUserRequest(FakeRequest.apply("GET", "/abe.z1234/awesome-lib"))) must beAnInstanceOf[Angular]
         router.route(NonUserRequest(FakeRequest.apply("GET", "/abe.z1234/awesome-lib/whatever?q=weee"))) must beAnInstanceOf[Angular]
 
-        libraryCommander.modifyLibrary(library.id.get, library.ownerId, slug = Some("most-awesome-lib"))
+        libraryCommander.modifyLibrary(library.id.get, library.ownerId, LibraryModifyRequest(slug = Some("most-awesome-lib")))
         router.route(NonUserRequest(FakeRequest.apply("GET", "/abe.z1234/awesome-lib"))) === MovedPermanentlyRoute("/abe.z1234/most-awesome-lib")
         router.route(NonUserRequest(FakeRequest.apply("GET", "/abe.z1234/most-awesome-lib"))) must beAnInstanceOf[Angular]
 


### PR DESCRIPTION
for createLibrary & modifyLibrary (website)
the response looks a tad different, but the response body is not being used on the FE website. 
The response looks like this:

```
{
  "library" : {...},
  "listed" : true
}
```

When we need to include more information about memberships, we can include `listed` as part of the `membership` object. But, for now, since we only have listed. I was thinking we'll just keep it like that =)

@eishay @2is10 
