### PR TITLE
splitting library and user sitemaps, giving them a numerical (starts wit...

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminSiteMapController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminSiteMapController.scala
@@ -3,17 +3,25 @@ package com.keepit.controllers.admin
 import com.google.inject.Inject
 import com.keepit.common.controller.{ UserActionsHelper, AdminUserActions }
 import com.keepit.common.healthcheck.AirbrakeNotifier
-import com.keepit.common.seo.LibrarySiteMapGenerator
+import com.keepit.common.seo.{ UserSiteMapGenerator, LibrarySiteMapGenerator }
 import play.api.libs.concurrent.Execution.Implicits._
 
 class AdminSiteMapController @Inject() (
     airbrake: AirbrakeNotifier,
     val userActionsHelper: UserActionsHelper,
-    generator: LibrarySiteMapGenerator) extends AdminUserActions {
+    librarySitemap: LibrarySiteMapGenerator,
+    userSitemap: UserSiteMapGenerator) extends AdminUserActions {
 
   // expensive
-  def generate() = AdminUserPage.async { implicit request =>
-    generator.generate() map { elem =>
+  def generateLibrarySitemap() = AdminUserPage.async { implicit request =>
+    librarySitemap.generate() map { elem =>
+      Ok(elem).withHeaders("Content-Type" -> "text/xml")
+    }
+  }
+
+  // expensive
+  def generateUserSitemap() = AdminUserPage.async { implicit request =>
+    userSitemap.generate() map { elem =>
       Ok(elem).withHeaders("Content-Type" -> "text/xml")
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -289,7 +289,7 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Singleton
   @Provides
   def siteMapCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new SiteMapCache(stats, accessLog, (innerRepo, 1 hours), (outerRepo, 1 hours))
+    new SiteMapCache(stats, accessLog, (innerRepo, 1 hour), (outerRepo, 7 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
@@ -76,7 +76,7 @@ class HomeController @Inject() (
         |User-agent: *
         |Disallow: /admin/
         |
-        |SITEMAP: https://www.kifi.com/assets/sitemap.xml
+        |SITEMAP: https://www.kifi.com/sitemap/libraries-0.xml
       """.stripMargin)
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SiteMapController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SiteMapController.scala
@@ -4,16 +4,25 @@ import play.api.mvc._
 import com.google.inject.Inject
 import com.keepit.common.controller.{ AdminUserActions, UserActionsHelper }
 import com.keepit.common.healthcheck.AirbrakeNotifier
-import com.keepit.common.seo.LibrarySiteMapGenerator
+import com.keepit.common.seo.{ UserSiteMapGenerator, LibrarySiteMapGenerator }
 import play.api.libs.concurrent.Execution.Implicits._
 
 class SiteMapController @Inject() (
     airbrake: AirbrakeNotifier,
     val userActionsHelper: UserActionsHelper,
-    generator: LibrarySiteMapGenerator) extends AdminUserActions {
+    libraries: LibrarySiteMapGenerator,
+    users: UserSiteMapGenerator) extends AdminUserActions {
 
-  def sitemap() = Action.async { implicit request =>
-    generator.intern() map { elem =>
+  def librariesSitemapLegacy() = librariesSitemap()
+
+  def librariesSitemap() = Action.async { implicit request =>
+    libraries.intern() map { elem =>
+      Ok(elem).withHeaders("Content-Type" -> "text/xml")
+    }
+  }
+
+  def usersSitemap() = Action.async { implicit request =>
+    users.intern() map { elem =>
       Ok(elem).withHeaders("Content-Type" -> "text/xml")
     }
   }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -311,7 +311,9 @@ GET     /feeds/libraries/new        @com.keepit.controllers.website.FeedControll
 
 POST    /site/events                @com.keepit.controllers.tracking.EventProxyController.track()
 
-GET     /assets/sitemap.xml         @com.keepit.controllers.website.SiteMapController.sitemap()
+GET     /assets/sitemap.xml                     @com.keepit.controllers.website.SiteMapController.librariesSitemapLegacy()
+GET     /assets/sitemap/libraries-0.xml         @com.keepit.controllers.website.SiteMapController.librariesSitemap()
+GET     /assets/sitemap/users-0.xml             @com.keepit.controllers.website.SiteMapController.usersSitemap()
 
 GET     /site/keeps/all             @com.keepit.controllers.website.KeepsController.allKeeps(before: Option[String], after: Option[String], collection: Option[String], helprank: Option[String], count: Int ?= Integer.MAX_VALUE, withPageInfo: Boolean ?= false)
 GET     /site/keeps/count           @com.keepit.controllers.website.KeepsController.numKeeps()
@@ -521,7 +523,8 @@ POST    /admin/reKeepStats/user/update  @com.keepit.controllers.admin.AdminAttri
 POST    /admin/reKeepStats/users/update @com.keepit.controllers.admin.AdminAttributionController.updateUsersReKeepStats
 POST    /admin/reKeepStats/all/update   @com.keepit.controllers.admin.AdminAttributionController.updateAllReKeepStats
 
-GET    /admin/sitemap                  @com.keepit.controllers.admin.AdminSiteMapController.generate()
+GET     /admin/sitemap/library          @com.keepit.controllers.admin.AdminSiteMapController.generateLibrarySitemap()
+GET     /admin/sitemap/user             @com.keepit.controllers.admin.AdminSiteMapController.generateUserSitemap()
 
 GET     /admin/data/integrity       @com.keepit.controllers.admin.UrlController.documentIntegrity(page: Int ?= 0, size: Int ?= 50)
 GET     /admin/data/dupe            @com.keepit.controllers.admin.UrlController.duplicateDocumentDetection

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/LibrarySitemapTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/LibrarySitemapTest.scala
@@ -10,7 +10,7 @@ import org.specs2.mutable.Specification
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class SitemapTest extends Specification with ShoeboxTestInjector {
+class LibrarySitemapTest extends Specification with ShoeboxTestInjector {
 
   def setup()(implicit injector: Injector) = {
     val t1 = new DateTime(2014, 7, 4, 21, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)


### PR DESCRIPTION
...h 0) for future compatibility;

making sure sitemap is cached before calling the search engine
