### PR TITLE
Separate test website endpoints for getting library (by Id & username/slug)

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
@@ -22,7 +22,7 @@ case class LibraryMembership(
     state: State[LibraryMembership] = LibraryMembershipStates.ACTIVE,
     seq: SequenceNumber[LibraryMembership] = SequenceNumber.ZERO,
     showInSearch: Boolean = true,
-    listed: Boolean = true, // whether library appears on user's profile
+    listed: Boolean = true, // whether library may appear on user's profile
     lastViewed: Option[DateTime] = None,
     lastEmailSent: Option[DateTime] = None) extends ModelWithState[LibraryMembership] with ModelWithSeqNumber[LibraryMembership] {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -203,7 +203,7 @@ class LibraryCommander @Inject() (
     }
   }
 
-  def getLibrarySummaryAndAccess(userIdOpt: Option[Id[User]], id: Id[Library]): (LibraryInfo, Option[LibraryMembership]) = {
+  def getLibrarySummaryAndMembership(userIdOpt: Option[Id[User]], id: Id[Library]): (LibraryInfo, Option[LibraryMembership]) = {
     val Seq(libInfo) = getLibrarySummaries(Seq(id))
     val accessStr = getMaybeMembership(userIdOpt, id)
     (libInfo, accessStr)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -205,8 +205,8 @@ class LibraryCommander @Inject() (
 
   def getLibrarySummaryAndMembership(userIdOpt: Option[Id[User]], id: Id[Library]): (LibraryInfo, Option[LibraryMembership]) = {
     val Seq(libInfo) = getLibrarySummaries(Seq(id))
-    val accessStr = getMaybeMembership(userIdOpt, id)
-    (libInfo, accessStr)
+    val memOpt = getMaybeMembership(userIdOpt, id)
+    (libInfo, memOpt)
   }
 
   def getLibraryWithOwnerAndCounts(libraryId: Id[Library], viewerUserId: Id[User]): Either[LibraryFail, (Library, BasicUser, Int, Int, Option[Boolean])] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -90,10 +90,11 @@ class MobileLibraryController @Inject() (
   }
 
   def getLibraryById(pubId: PublicId[Library], imageSize: Option[String] = None) = (MaybeUserAction andThen LibraryViewAction(pubId)).async { request =>
-    val id = Library.decodePublicId(pubId).get
+    val libraryId = Library.decodePublicId(pubId).get
     val idealSize = imageSize.flatMap { s => Try(ImageSize(s)).toOption }.getOrElse(MobileLibraryController.defaultLibraryImageSize)
-    libraryCommander.getLibraryById(request.userIdOpt, false, id, idealSize) map {
-      case (libInfo, accessStr) => Ok(Json.obj("library" -> Json.toJson(libInfo), "membership" -> accessStr))
+    libraryCommander.getLibraryById(request.userIdOpt, false, libraryId, idealSize) map { libInfo =>
+      val accessStr = libraryCommander.getMaybeMembership(request.userIdOpt, libraryId).map(_.access.value).getOrElse("none")
+      Ok(Json.obj("library" -> Json.toJson(libInfo), "membership" -> accessStr))
     }
   }
 
@@ -104,11 +105,7 @@ class MobileLibraryController @Inject() (
           request.userIdOpt.map { userId => libraryCommander.updateLastView(userId, library.id.get) }
           val idealSize = imageSize.flatMap { s => Try(ImageSize(s)).toOption }.getOrElse(MobileLibraryController.defaultLibraryImageSize)
           libraryCommander.createFullLibraryInfo(request.userIdOpt, false, library, idealSize).map { libInfo =>
-            val accessStr = request.userIdOpt.map { userId =>
-              libraryCommander.getAccessStr(userId, library.id.get)
-            }.flatten.getOrElse {
-              "none"
-            }
+            val accessStr = libraryCommander.getMaybeMembership(request.userIdOpt, library.id.get).map(_.access.value).getOrElse("none")
             Ok(Json.obj("library" -> Json.toJson(libInfo), "membership" -> accessStr))
           }
         })

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
@@ -134,6 +134,8 @@ object MaybeLibraryMember {
   }
 }
 
+@json case class LibraryMembershipInfo(access: LibraryAccess, listed: Boolean)
+
 case class FullLibraryInfo(id: PublicId[Library],
   name: String,
   visibility: LibraryVisibility,

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
@@ -135,6 +135,9 @@ object MaybeLibraryMember {
 }
 
 @json case class LibraryMembershipInfo(access: LibraryAccess, listed: Boolean)
+object LibraryMembershipInfo {
+  def fromMembership(mem: LibraryMembership) = LibraryMembershipInfo(mem.access, mem.listed)
+}
 
 case class FullLibraryInfo(id: PublicId[Library],
   name: String,

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -339,6 +339,7 @@ POST    /site/collections/:id/addKeeps @com.keepit.controllers.website.KeepsCont
 GET     /site/collections/search    @com.keepit.controllers.website.KeepsController.searchUserTags(query: String, limit: Option[Int] = None)
 
 GET     /site/users/:userStr/libraries/:slug    @com.keepit.controllers.website.LibraryController.getLibraryByPath(userStr:String, slug: String, showPublishedLibraries: Boolean ?= false, is: Option[String] ?= None)
+GET     /site/users/:userStr/libraries1/:slug    @com.keepit.controllers.website.LibraryController.getLibraryByPathFake(userStr:String, slug: String, showPublishedLibraries: Boolean ?= false, is: Option[String] ?= None)
 POST    /site/users/:userStr/libraries/:slug/auth    @com.keepit.controllers.website.LibraryController.authToLibrary(userStr: String, slug: String, authToken: Option[String])
 
 # Profile pages
@@ -353,6 +354,7 @@ POST    /site/libraries/move        @com.keepit.controllers.website.LibraryContr
 GET     /site/libraries/marketing-suggestions   @com.keepit.controllers.website.LibraryController.marketingSiteSuggestedLibraries()
 
 GET     /site/libraries/:id         @com.keepit.controllers.website.LibraryController.getLibraryById(id: PublicId[Library], showPublishedLibraries: Boolean ?= false, is: Option[String] ?= None)
+GET     /site/libraries1/:id         @com.keepit.controllers.website.LibraryController.getLibraryByIdFake(id: PublicId[Library], showPublishedLibraries: Boolean ?= false, is: Option[String] ?= None)
 GET     /site/libraries/:id/summary         @com.keepit.controllers.website.LibraryController.getLibrarySummaryById(id: PublicId[Library])
 POST    /site/libraries/:id/modify  @com.keepit.controllers.website.LibraryController.modifyLibrary(id: PublicId[Library])
 POST    /site/libraries/:id/delete  @com.keepit.controllers.website.LibraryController.removeLibrary(id: PublicId[Library])


### PR DESCRIPTION
A lot of the website (getLibrary) depends on the format:

```
{ 
  "library" : {...},
  "membership" : "owner"                  // "read_only", "none"
}
```

to introduce `listed` into membership, we should add it to the `membership` object

```
{ 
  "library" : {...},
  "membership" : {
    "access" : "owner",
    "listed" : false
  }
}
```

If the user viewing does not have a membership to the library, then the `membership` object should not be present. I don't think it's that great to compare membership to an empty object or anything.
I'll remove the test endpoints once I confirm the FE part works with the new object layout! =)

@2is10 @yipingliao 
