### PR TITLE
add listed to get library (which uses FullLibraryInfo) website endpoint

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -94,16 +94,20 @@ class LibraryController @Inject() (
   }
 
   def getLibraryById(pubId: PublicId[Library], showPublishedLibraries: Boolean, imageSize: Option[String] = None) = (MaybeUserAction andThen LibraryViewAction(pubId)).async { request =>
-    val id = Library.decodePublicId(pubId).get
+    val libraryId = Library.decodePublicId(pubId).get
     val idealSize = imageSize.flatMap { s => Try(ImageSize(s)).toOption }.getOrElse(LibraryController.defaultLibraryImageSize)
-    libraryCommander.getLibraryById(request.userIdOpt, showPublishedLibraries, id, idealSize) map {
-      case (libInfo, accessStr) => Ok(Json.obj("library" -> Json.toJson(libInfo), "membership" -> accessStr))
+    libraryCommander.getLibraryById(request.userIdOpt, showPublishedLibraries, libraryId, idealSize) map { libInfo =>
+      val memOpt = libraryCommander.getMaybeMembership(request.userIdOpt, libraryId)
+      val accessStr = memOpt.map(_.access.value).getOrElse("none")
+      val listed = memOpt.map(_.listed)
+      Ok(Json.obj("library" -> Json.toJson(libInfo), "membership" -> accessStr, "listed" -> listed))
     }
   }
 
   def getLibrarySummaryById(pubId: PublicId[Library]) = (MaybeUserAction andThen LibraryViewAction(pubId)) { request =>
     val id = Library.decodePublicId(pubId).get
-    val (libInfo, accessStr) = libraryCommander.getLibrarySummaryAndAccessString(request.userIdOpt, id)
+    val (libInfo, memOpt) = libraryCommander.getLibrarySummaryAndMembership(request.userIdOpt, id)
+    val accessStr = memOpt.map(_.access.value).getOrElse("none")
     Ok(Json.obj("library" -> Json.toJson(libInfo), "membership" -> accessStr))
   }
 
@@ -114,12 +118,10 @@ class LibraryController @Inject() (
           val idealSize = imageSize.flatMap { s => Try(ImageSize(s)).toOption }.getOrElse(LibraryController.defaultLibraryImageSize)
           request.userIdOpt.map { userId => libraryCommander.updateLastView(userId, library.id.get) }
           libraryCommander.createFullLibraryInfo(request.userIdOpt, showPublishedLibraries, library, idealSize).map { libInfo =>
-            val accessStr = request.userIdOpt.map { userId =>
-              libraryCommander.getAccessStr(userId, library.id.get)
-            }.flatten.getOrElse {
-              "none"
-            }
-            Ok(Json.obj("library" -> Json.toJson(libInfo), "membership" -> accessStr))
+            val memOpt = libraryCommander.getMaybeMembership(request.userIdOpt, library.id.get)
+            val accessStr = memOpt.map(_.access.value).getOrElse("none")
+            val listed = memOpt.map(_.listed)
+            Ok(Json.obj("library" -> Json.toJson(libInfo), "membership" -> accessStr, "listed" -> listed))
           }
         })
       case Left(fail) => Future.successful {

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -207,7 +207,7 @@ GET     /m/1/contacts/search                    @com.keepit.controllers.mobile.M
 POST    /m/1/invite                             @com.keepit.controllers.mobile.MobileInviteController.inviteConnection
 
 # Profile Page
-GET     /m/1//user/:username/libraries          @com.keepit.controllers.mobile.MobileLibraryController.getProfileLibraries(username: Username, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")
+GET     /m/1/user/:username/libraries          @com.keepit.controllers.mobile.MobileLibraryController.getProfileLibraries(username: Username, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")
 
 POST    /m/1/user/:id/unfriend                  @com.keepit.controllers.mobile.MobileUserController.unfriend(id: ExternalId[User])
 POST    /m/1/user/:id/friend                    @com.keepit.controllers.mobile.MobileUserController.friend(id: ExternalId[User])

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -207,7 +207,7 @@ GET     /m/1/contacts/search                    @com.keepit.controllers.mobile.M
 POST    /m/1/invite                             @com.keepit.controllers.mobile.MobileInviteController.inviteConnection
 
 # Profile Page
-GET     /m/1/user/:username/libraries          @com.keepit.controllers.mobile.MobileLibraryController.getProfileLibraries(username: Username, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")
+GET     /m/1/user/:username/libraries           @com.keepit.controllers.mobile.MobileLibraryController.getProfileLibraries(username: Username, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")
 
 POST    /m/1/user/:id/unfriend                  @com.keepit.controllers.mobile.MobileUserController.unfriend(id: ExternalId[User])
 POST    /m/1/user/:id/friend                    @com.keepit.controllers.mobile.MobileUserController.friend(id: ExternalId[User])

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -302,7 +302,8 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
              |"numCollaborators":0,
              |"numFollowers":0
            |},
-           |"membership":"owner"
+           |"membership":"owner",
+           |"listed": true
           }""".stripMargin))
 
         // viewed by another user with an invite
@@ -343,7 +344,8 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
              |"numCollaborators":0,
              |"numFollowers":0
            |},
-           |"membership":"none"
+           |"membership":"none",
+           |"listed": null
           }""".stripMargin))
       }
     }
@@ -357,7 +359,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
         val (user1, lib1) = db.readWrite { implicit s =>
           val user = userRepo.save(User(firstName = "Aaron", lastName = "Hsu", createdAt = t1, username = Username("ahsu"), normalizedUsername = UsernameOps.normalize("ahsu")))
           val library = libraryRepo.save(Library(name = "Library1", ownerId = user.id.get, slug = LibrarySlug("lib1"), memberCount = 1, visibility = LibraryVisibility.SECRET))
-          libraryMembershipRepo.save(LibraryMembership(userId = user.id.get, libraryId = library.id.get, access = LibraryAccess.OWNER))
+          libraryMembershipRepo.save(LibraryMembership(userId = user.id.get, libraryId = library.id.get, access = LibraryAccess.OWNER, listed = false))
           (user, library)
         }
 
@@ -424,7 +426,8 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                |"numCollaborators":0,
                |"numFollowers":0
              |},
-             |"membership":"owner"
+             |"membership":"owner",
+             |"listed": false
             |}""".stripMargin)
         Json.parse(contentAsString(result1)) must equalTo(expected)
         Json.parse(contentAsString(result2)) must equalTo(expected)


### PR DESCRIPTION
The get response endpoints look like this:

```
{
 "library" : {...},
 "membership" : "none",           // "read_only", "owner", etc.
 "listed" : false
}
```

I was originally going to place `listed` into a membership object to look something like this

```
"membership" : {
   "access" : "read_only",
   "listed" : false
}
```

and if there's no membership, it doesn't show up in the JSON. However, changing it to an object could break some website stuff. So I figured I should make a change like that later when I'm sure it won't break the FE website

@2is10 @eishay 
