### PR TITLE
avoid autoboxing of Long in ProbabilityDensity

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/math/ProbabilityDensity.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/math/ProbabilityDensity.scala
@@ -2,23 +2,26 @@ package com.keepit.common.math
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{ JsNumber, JsArray, Json, Format }
+import scala.collection.mutable
+
+case class Probability[A](outcome: A, probability: Double)
 
 //Note: The order of the argument Seq here is very important. It, along with the salt, uniquely determines which users go in which bin.
-case class ProbabilityDensity[A](density: Seq[(A, Double)]) {
-  require(density.forall(_._2 >= 0), "Probabilities must be non-negative")
-  require(density.map(_._2).sum <= 1.1, "Probabilities sum up to more than 1")
-  private val cumulative: Array[(A, Double)] = { // The order of the density sequence is implied to compute the CDF
+case class ProbabilityDensity[A](density: Seq[Probability[A]]) {
+  require(density.forall(_.probability >= 0), "Probabilities must be non-negative")
+  require(density.map(_.probability).sum <= 1.1, "Probabilities sum up to more than 1")
+  private val cumulative: Array[Probability[A]] = { // The order of the density sequence is implied to compute the CDF
     var cdf = 0.0
     density.collect {
-      case (outcome, probability) if probability > 0 =>
+      case Probability(outcome, probability) if probability > 0 =>
         cdf += probability
-        outcome -> cdf
+        Probability(outcome, cdf)
     }.toArray
   }
 
   def sample(x: Double): Option[A] = if (cumulative.size < 32) linearSample(x) else binarySample(x) // solve x = 8 * log2(x)
 
-  def linearSample(x: Double): Option[A] = cumulative.collectFirst { case (outcome, cdf) if x <= cdf => outcome }
+  def linearSample(x: Double): Option[A] = cumulative.collectFirst { case Probability(outcome, cdf) if x <= cdf => outcome }
   def binarySample(x: Double): Option[A] = {
     val n = cumulative.length
     var low = 0
@@ -26,10 +29,10 @@ case class ProbabilityDensity[A](density: Seq[(A, Double)]) {
     var mid = 0
     while (low < up) {
       mid = low + (up - low) / 2
-      if (x > cumulative(mid)._2) low = mid + 1
+      if (x > cumulative(mid).probability) low = mid + 1
       else up = mid
     }
-    if (low < n) Some(cumulative(low)._1) else None
+    if (low < n) Some(cumulative(low).outcome) else None
   }
 }
 
@@ -38,22 +41,32 @@ object ProbabilityDensity {
 
     {
       case JsArray(density) => ProbabilityDensity(
-        density.sliding(2, 2).map { case Seq(outcome, JsNumber(probability)) => (outcome.as[A], probability.toDouble) }.toSeq
+        density.sliding(2, 2).map { case Seq(outcome, JsNumber(probability)) => Probability(outcome.as[A], probability.toDouble) }.toSeq
       )
     },
 
     { density: ProbabilityDensity[A] =>
       JsArray(
-        density.density.flatMap { case (outcome, probability) => Seq(Json.toJson(outcome), JsNumber(probability)) }
+        density.density.flatMap { case Probability(outcome, probability) => Seq(Json.toJson(outcome), JsNumber(probability)) }
       )
     }
   )
 
-  def normalized[A](density: Seq[(A, Double)]): ProbabilityDensity[A] = {
-    val sum = density.map { case (outcome, probability) => probability }.sum
+  def normalized[A](density: Seq[Probability[A]]): ProbabilityDensity[A] = {
+    val sum = density.map { case Probability(outcome, probability) => probability }.sum
     if (sum == 0) ProbabilityDensity(density) else {
-      val normalizedDensity = density.map { case (outcome, probability) => outcome -> probability / sum }
+      val normalizedDensity = density.map { case Probability(outcome, probability) => Probability(outcome, probability / sum) }
       ProbabilityDensity(normalizedDensity)
     }
   }
+}
+
+class ProbabilityDensityBuilder[A] {
+  private[this] val buf = new mutable.ArrayBuffer[Probability[A]]
+
+  def add(outcome: A, weight: Double) = {
+    buf += Probability(outcome, weight)
+  }
+
+  def build(): ProbabilityDensity[A] = ProbabilityDensity.normalized(buf)
 }

--- a/kifi-backend/modules/common/app/com/keepit/search/SearchConfigExperiment.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchConfigExperiment.scala
@@ -12,7 +12,7 @@ import play.api.libs.json._
 import scala.concurrent.duration._
 import com.keepit.common.cache.TransactionalCaching
 import com.keepit.model.{ ProbabilisticExperimentGenerator, Name, ExperimentType }
-import com.keepit.common.math.ProbabilityDensity
+import com.keepit.common.math.{ Probability, ProbabilityDensity }
 
 case class SearchConfigExperiment(
     id: Option[Id[SearchConfigExperiment]] = None,
@@ -41,7 +41,7 @@ case class SearchConfigExperiment(
 object SearchConfigExperiment {
   val probabilisticGenerator = Name[ProbabilisticExperimentGenerator]("searchConfigExperiment")
   def getDensity(searchExperiments: Seq[SearchConfigExperiment]): ProbabilityDensity[ExperimentType] = {
-    ProbabilityDensity(searchExperiments.sortBy(_.id.get.id).map { se => se.experiment -> se.weight })
+    ProbabilityDensity(searchExperiments.sortBy(_.id.get.id).map { se => Probability(se.experiment, se.weight) })
   }
   private implicit val idFormat = Id.format[SearchConfigExperiment]
   private implicit val stateFormat = State.format[SearchConfigExperiment]

--- a/kifi-backend/modules/graph/app/com/keepit/graph/wander/Teleporter.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/wander/Teleporter.scala
@@ -1,7 +1,7 @@
 package com.keepit.graph.wander
 
 import com.keepit.graph.model.{ VertexDataReader, VertexKind, VertexReader, VertexId }
-import com.keepit.common.math.ProbabilityDensity
+import com.keepit.common.math.{ Probability, ProbabilityDensity }
 
 trait Teleporter {
   def surely: VertexId
@@ -13,7 +13,7 @@ case class UniformTeleporter(destinations: Set[VertexId])(mayTeleport: VertexRea
 
   private val teleportAlmostSurely = {
     val probability = 1d / destinations.size
-    val density = destinations.map { vertexId => vertexId -> probability }.toSeq
+    val density = destinations.map { vertexId => Probability(vertexId, probability) }.toSeq
     ProbabilityDensity(density)
   }
 

--- a/kifi-backend/modules/graph/app/com/keepit/graph/wander/URIWanderingCommander.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/wander/URIWanderingCommander.scala
@@ -4,7 +4,7 @@ import com.google.inject.Inject
 import com.keepit.common.concurrent.ReactiveLock
 import com.keepit.common.db.Id
 import com.keepit.common.logging.Logging
-import com.keepit.common.math.ProbabilityDensity
+import com.keepit.common.math.{ ProbabilityDensityBuilder, ProbabilityDensity }
 import com.keepit.common.time._
 
 import com.keepit.graph.manager.GraphManager
@@ -108,8 +108,9 @@ class URIWanderingCommander @Inject() (
       val scout = reader.getNewVertexReader()
       wanderer.moveTo(source)
 
-      val weights = getDestinationWeights(wanderer, scout, Component(component._1, component._2, component._3), edgeResolver)
-      val density = ProbabilityDensity.normalized(weights)
+      val builder = new ProbabilityDensityBuilder[VertexId]
+      getDestinationWeights(wanderer, scout, Component(component._1, component._2, component._3), edgeResolver) { (vertexId, weight) => builder.add(vertexId, weight) }
+      val density = builder.build()
       val scores = mutable.Map[VertexDataId[D], Int]().withDefaultValue(0)
       (0 until trials).foreach { i =>
         density.sample(Math.random()) foreach { vertex => scores(vertex.asId[D]) += 1 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UserExperimentTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UserExperimentTest.scala
@@ -5,7 +5,7 @@ import com.keepit.common.db.slick._
 import com.keepit.test.ShoeboxTestInjector
 import com.keepit.common.db.Id
 import play.api.libs.json.Json
-import com.keepit.common.math.ProbabilityDensity
+import com.keepit.common.math.{ Probability, ProbabilityDensity }
 
 class UserExperimentTest extends Specification with ShoeboxTestInjector {
 
@@ -78,15 +78,15 @@ class UserExperimentTest extends Specification with ShoeboxTestInjector {
     val salt = "pepper"
 
     val firstDensity = ProbabilityDensity(Seq(
-      firstExp -> 0.2,
-      secondExp -> 0.7,
-      thirdExp -> 0.1
+      Probability(firstExp, 0.2),
+      Probability(secondExp, 0.7),
+      Probability(thirdExp, 0.1)
     ))
 
     val secondDensity = ProbabilityDensity(Seq(
-      firstExp -> 0.2,
-      secondExp -> 0.3,
-      thirdExp -> 0.3
+      Probability(firstExp, 0.2),
+      Probability(secondExp, 0.3),
+      Probability(thirdExp, 0.3)
     ))
 
     val firstGen = ProbabilisticExperimentGenerator(name = Name("first test generator"), condition = Some(conditionExp), salt = salt, density = firstDensity)
@@ -132,7 +132,7 @@ class UserExperimentTest extends Specification with ShoeboxTestInjector {
       val n = 47
       val p = 1.0 / n
       val eps = 1.0 / (2 * n)
-      val density = ProbabilityDensity((0 until n - 1).map { i => (i, p) })
+      val density = ProbabilityDensity((0 until n - 1).map { i => Probability(i, p) })
       (0 until n - 1).map { i =>
         val x = eps + i * p
         density.linearSample(x).get === i
@@ -143,7 +143,7 @@ class UserExperimentTest extends Specification with ShoeboxTestInjector {
     }
 
     "work in edge cases" in {
-      var density = ProbabilityDensity(Seq((1, 0.5)))
+      var density = ProbabilityDensity(Seq(Probability(1, 0.5)))
       density.binarySample(0.7) === None
       density.binarySample(0.3) === Some(1)
 


### PR DESCRIPTION
@eishay @leogrim @yingjieMiao @stkem 

It seems that the autoboxing of Long in ProbabilityDensity creates a huge number of objects and consuming Graph's heap rapidly (analyzed using yourkit). This could be a cause of full GCs.
