### PR TITLE
Scroll to top on new search

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/search/search.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/search.js
@@ -83,6 +83,10 @@ angular.module('kifi')
           // TODO(yiping): how should we handle this case?
         }
       });  //jshint ignore:line
+
+      $timeout(function () {
+        $window.document.body.scrollTop = 0;
+      });
     }
 
 


### PR DESCRIPTION
@andrewconner 

I figured out why I put in the scroll-to-top code that broken scrolling on search. The reason was that after you do a search, and scroll down, and then if you do a new search, the new search results are rendered correctly but the scroll was at the previous scroll position so you're not looking at the top of the new search results! This is due to the migration to ui-router because now the search controller is not entirely reloaded for a new search.

It was my mistake to put the scroll-to-top code in a function that is called when infinite scroll triggers a search for further results. The right place to put this code is in a function that is called only when a new search query is initiated.

This PR fixes that.
