### PR TITLE
Add links to user profiles on user images throughout Angular app

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
@@ -1,12 +1,17 @@
 <span ng-if="!library.hidden">
   <span ng-if="!isBot">
-    <a class="kf-keep-who-pic-box" href="{{library.absPath}}" ng-class="{ 'secret': library.visibility === 'secret' }" ng-click="onLibraryAttributionClicked()">
-      <span class="kf-keep-who-pic" ng-attr-style="background-image: url({{library.keeperPic}})"></span>
-      <span class="kf-keep-who-lib">{{library.name}}</span>
+    <span class="kf-keep-who-pic-box" ng-class="{ 'secret': library.visibility === 'secret' }">
+      <a ng-if="inUserProfileBeta" href="{{library.keeperProfileUrl}}">
+        <span class="kf-keep-who-pic" ng-attr-style="background-image: url({{library.keeperPic}})"></span>
+      </a>
+      <span ng-if="!inUserProfileBeta" class="kf-keep-who-pic" ng-attr-style="background-image: url({{library.keeperPic}})"></span>
+      <a href="{{library.absPath}}" ng-click="onLibraryAttributionClicked()">
+        <span class="kf-keep-who-lib">{{library.name}}</span>
+      </a>
       <span kf-tooltip position="top" padding="10">
         <span kf-library-mini-card library="library"></span>
       </span>
-    </a>
+    </span>
   </span>
   <span ng-if="isBot" class="kf-keep-who-pic-box">
     <a href="{{library.absPath}}" target="_self">{{library.name}}</a>

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
@@ -1,9 +1,12 @@
 <span ng-if="!library.hidden">
   <span ng-if="!isBot">
     <span class="kf-keep-who-pic-box" ng-class="{ 'secret': library.visibility === 'secret' }">
-      <a ng-if="inUserProfileBeta" href="{{library.keeperProfileUrl}}">
-        <span class="kf-keep-who-pic" ng-attr-style="background-image: url({{library.keeperPic}})"></span>
-      </a>
+      <span ng-if="inUserProfileBeta" itemscope itemtype="http://data-vocabulary.org/Person">
+        <a href="{{library.keeperProfileUrl}}" itemprop="url">
+          <span class="kf-keep-who-pic" ng-attr-style="background-image: url({{library.keeperPic}})" itemprop="photo"></span>
+        </a>
+        <meta itemprop="name" content="{{library.keeperName}}" />
+      </span>
       <span ng-if="!inUserProfileBeta" class="kf-keep-who-pic" ng-attr-style="background-image: url({{library.keeperPic}})"></span>
       <a href="{{library.absPath}}" ng-click="onLibraryAttributionClicked()">
         <span class="kf-keep-who-lib">{{library.name}}</span>

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLibsAndPics.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLibsAndPics.js
@@ -61,8 +61,8 @@ angular.module('kifi')
   }
 ])
 
-.directive('kfKeepWhoLib', ['$rootScope', 'platformService',
-  function ($rootScope, platformService) {
+.directive('kfKeepWhoLib', ['$rootScope', 'platformService', 'userService',
+  function ($rootScope, platformService, userService) {
     return {
       restrict: 'A',
       replace: true,
@@ -75,19 +75,24 @@ angular.module('kifi')
           $rootScope.$emit('trackLibraryEvent', 'click', { action: 'clickedLibraryAttribution' });
         };
         scope.isBot = platformService.isBot();
+        scope.inUserProfileBeta = userService.inUserProfileBeta();
       }
     };
   }
 ])
 
-.directive('kfKeepWhoPic', [
-  function () {
+.directive('kfKeepWhoPic', ['userService',
+  function (userService) {
     return {
       restrict: 'A',
       replace: true,
       templateUrl: 'common/directives/keepWho/keepWhoPic.tpl.html',
       scope: {
         keeper: '='
+      },
+      link: function (scope) {
+        scope.inUserProfileBeta = userService.inUserProfileBeta();
+        scope.keeper.profileUrl = userService.getProfileUrl(scope.keeper.username);
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoPic.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoPic.tpl.html
@@ -2,7 +2,10 @@
    ng-mouseenter="showTooltip()"
    ng-mouseleave="hideTooltip()"
    ng-click="hideTooltip()">
-  <span class="kf-keep-who-pic" href="javascript:"
+  <a ng-if="inUserProfileBeta" class="kf-keep-who-pic" href="{{keeper.profileUrl}}"
    ng-attr-style="background-image: url({{getPicUrl(keeper)}})">
+  </a>
+  <span ng-if="!inUserProfileBeta" class="kf-keep-who-pic" href="javascript:"
+  	ng-attr-style="background-image: url({{getPicUrl(keeper)}})">
   </span>
 </span>

--- a/kifi-backend/modules/shoebox/angular/src/common/services/userService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/userService.js
@@ -22,7 +22,7 @@ angular.module('kifi')
       inUserProfileBeta: function () {
         return ($rootScope.userLoggedIn &&
                 profileService.me.experiments && profileService.me.experiments.indexOf('profiles_beta') > -1) ||
-               (!$rootScope.userLoggedIn && !$stateParams.upb);
+               (!$rootScope.userLoggedIn && $stateParams.upb);
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/common/services/userService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/userService.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .factory('userService', [
-  '$http', '$q', 'routeService',
-  function ($http, $q, routeService) {
+  '$http', '$q', 'routeService', '$rootScope', 'profileService', '$stateParams',
+  function ($http, $q, routeService, $rootScope, profileService, $stateParams) {
     return {
       getBasicUserInfo: function (id, friendCount) {
         var deferred = $q.defer();
@@ -14,6 +14,15 @@ angular.module('kifi')
           deferred.reject(res);
         });
         return deferred.promise;
+      },
+
+      // Returns true if the user is in user profiles beta experiment or if the
+      // user profiles beta query parameter is set. Temporarily lodged here because
+      // code that needs this also usually needs userService.
+      inUserProfileBeta: function () {
+        return ($rootScope.userLoggedIn &&
+                profileService.me.experiments && profileService.me.experiments.indexOf('profiles_beta') > -1) ||
+               (!$rootScope.userLoggedIn && !$stateParams.upb);
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/common/services/userService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/userService.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .factory('userService', [
-  '$http', '$q', 'routeService', '$rootScope', 'profileService', '$stateParams',
-  function ($http, $q, routeService, $rootScope, profileService, $stateParams) {
+  '$http', '$q', '$rootScope', '$stateParams', 'env', 'routeService', 'profileService',
+  function ($http, $q, $rootScope, env, $stateParams, routeService, profileService) {
     return {
       getBasicUserInfo: function (id, friendCount) {
         var deferred = $q.defer();
@@ -14,6 +14,10 @@ angular.module('kifi')
           deferred.reject(res);
         });
         return deferred.promise;
+      },
+
+      getProfileUrl: function (username) {
+        return username ? env.origin + '/' + username : null;
       },
 
       // Returns true if the user is in user profiles beta experiment or if the

--- a/kifi-backend/modules/shoebox/angular/src/common/services/userService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/userService.js
@@ -4,7 +4,7 @@ angular.module('kifi')
 
 .factory('userService', [
   '$http', '$q', '$rootScope', '$stateParams', 'env', 'routeService', 'profileService',
-  function ($http, $q, $rootScope, env, $stateParams, routeService, profileService) {
+  function ($http, $q, $rootScope, $stateParams, env, routeService, profileService) {
     return {
       getBasicUserInfo: function (id, friendCount) {
         var deferred = $q.defer();

--- a/kifi-backend/modules/shoebox/angular/src/common/services/userService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/userService.js
@@ -17,6 +17,4 @@ angular.module('kifi')
       }
     };
   }
-])
-
-;
+]);

--- a/kifi-backend/modules/shoebox/angular/src/friends/compactFriendsView.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/friends/compactFriendsView.tpl.html
@@ -4,9 +4,12 @@
     <a ng-href="{{friendsLink()}}">See all &#0187;</a>
   </div>
   <div class="kf-compact-friends-image-row">
-    <a href="/friends" ng-repeat="friend in friends | limitTo: 4">
-      <img class="kf-compact-friend-image" title="{{friend.firstName}}" ng-src="{{friend.pictureUrl}}">
-    </a>
+    <span ng-repeat="friend in friends | limitTo: 4">
+      <a ng-if="inUserProfileBeta" href="{{friend.profileUrl}}">
+        <img class="kf-compact-friend-image" title="{{friend.firstName}}" ng-src="{{friend.pictureUrl}}">
+      </a>
+      <img ng-if="!inUserProfileBeta" class="kf-compact-friend-image" title="{{friend.firstName}}" ng-src="{{friend.pictureUrl}}">
+    </span>
   </div>
 </div>
-  
+

--- a/kifi-backend/modules/shoebox/angular/src/friends/friendCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/friends/friendCard.js
@@ -4,8 +4,8 @@ angular.module('kifi')
 
 
 .directive('kfFriendCard', [
-  '$log', 'env', 'friendService', 'modalService', 'userService',
-  function ($log, env, friendService, modalService, userService) {
+  '$log', 'friendService', 'modalService', 'userService',
+  function ($log, friendService, modalService, userService) {
     return {
       scope: {
         'friend': '&'
@@ -21,7 +21,7 @@ angular.module('kifi')
         scope.friendCount = friend.friendCount;
         scope.unfriended = friend.unfriended;
         scope.searchFriend = friend.searchFriend;
-        scope.friendProfileUrl = env.origin + '/' + friend.username;
+        scope.friendProfileUrl = userService.getProfileUrl(friend.username);
         scope.inUserProfileBeta = userService.inUserProfileBeta();
 
         scope.unfriend = function () {

--- a/kifi-backend/modules/shoebox/angular/src/friends/friendCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/friends/friendCard.js
@@ -4,8 +4,8 @@ angular.module('kifi')
 
 
 .directive('kfFriendCard', [
-  '$log', 'friendService', 'modalService',
-  function ($log, friendService, modalService) {
+  '$log', 'env', 'friendService', 'modalService', 'userService',
+  function ($log, env, friendService, modalService, userService) {
     return {
       scope: {
         'friend': '&'
@@ -21,6 +21,8 @@ angular.module('kifi')
         scope.friendCount = friend.friendCount;
         scope.unfriended = friend.unfriended;
         scope.searchFriend = friend.searchFriend;
+        scope.friendProfileUrl = env.origin + '/' + friend.username;
+        scope.inUserProfileBeta = userService.inUserProfileBeta();
 
         scope.unfriend = function () {
           modalService.open({

--- a/kifi-backend/modules/shoebox/angular/src/friends/friendCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/friends/friendCard.tpl.html
@@ -1,5 +1,8 @@
 <div class="kf-friend-card">
-  <img class="kf-friend-card-image" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'" ng-src="{{mainImage}}">
+  <a ng-if="inUserProfileBeta" href="{{friendProfileUrl}}">
+    <img class="kf-friend-card-image" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'" ng-src="{{mainImage}}">
+  </a>
+  <img ng-if="!inUserProfileBeta" class="kf-friend-card-image" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'" ng-src="{{mainImage}}">
   <span class="kf-friend-card-who">
     <div class="kf-friend-card-name" title="{{name}}">{{name}}</div>
     <div class="kf-friend-card-count" title="{{friendCount}}"><ng-pluralize count="friendCount" when="{'one': '1 friend ', 'other': '{} friends '}"></ng-pluralize>on Kifi</div>

--- a/kifi-backend/modules/shoebox/angular/src/friends/friendRequestCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/friends/friendRequestCard.js
@@ -4,8 +4,8 @@ angular.module('kifi')
 
 
 .directive('kfFriendRequestCard', [
-  '$log', 'friendService', 'routeService',
-  function ($log, friendService, routeService) {
+  '$log', 'env', 'friendService', 'routeService', 'userService',
+  function ($log, env, friendService, routeService, userService) {
     return {
       scope: {
         'request': '&'
@@ -17,6 +17,8 @@ angular.module('kifi')
         var friend = scope.request();
         scope.name = friend.firstName + ' ' + friend.lastName;
         scope.mainImage = routeService.formatPicUrl(friend.id, friend.pictureName, 200);
+        scope.friendProfileUrl = env.origin + '/' + friend.username;
+        scope.inUserProfileBeta = userService.inUserProfileBeta();
 
         scope.accept = function () {
           friendService.acceptRequest(friend.id);

--- a/kifi-backend/modules/shoebox/angular/src/friends/friendRequestCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/friends/friendRequestCard.js
@@ -4,8 +4,8 @@ angular.module('kifi')
 
 
 .directive('kfFriendRequestCard', [
-  '$log', 'env', 'friendService', 'routeService', 'userService',
-  function ($log, env, friendService, routeService, userService) {
+  '$log', 'friendService', 'routeService', 'userService',
+  function ($log, friendService, routeService, userService) {
     return {
       scope: {
         'request': '&'
@@ -17,7 +17,7 @@ angular.module('kifi')
         var friend = scope.request();
         scope.name = friend.firstName + ' ' + friend.lastName;
         scope.mainImage = routeService.formatPicUrl(friend.id, friend.pictureName, 200);
-        scope.friendProfileUrl = env.origin + '/' + friend.username;
+        scope.friendProfileUrl = userService.getProfileUrl(friend.username);
         scope.inUserProfileBeta = userService.inUserProfileBeta();
 
         scope.accept = function () {

--- a/kifi-backend/modules/shoebox/angular/src/friends/friendRequestCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/friends/friendRequestCard.tpl.html
@@ -1,5 +1,8 @@
 <div class="kf-friend-card kf-friend-request-card"> <!-- Should really be ng-if but that causes some error for some reason -->
-  <img class="kf-friend-card-image" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'" ng-src="{{mainImage}}">
+  <a ng-if="inUserProfileBeta" href="{{friendProfileUrl}}">
+  	<img class="kf-friend-card-image" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'" ng-src="{{mainImage}}">
+  </a>
+  <img ng-if="!inUserProfileBeta" class="kf-friend-card-image" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'" ng-src="{{mainImage}}">
   <span class="kf-friend-card-who">
     <div class="kf-friend-card-name" title="{{name}}">{{name}}</div>
     <div>Accept as your Kifi friend?</div>

--- a/kifi-backend/modules/shoebox/angular/src/friends/friendRequestCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/friends/friendRequestCard.tpl.html
@@ -1,6 +1,6 @@
 <div class="kf-friend-card kf-friend-request-card"> <!-- Should really be ng-if but that causes some error for some reason -->
   <a ng-if="inUserProfileBeta" href="{{friendProfileUrl}}">
-  	<img class="kf-friend-card-image" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'" ng-src="{{mainImage}}">
+    <img class="kf-friend-card-image" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'" ng-src="{{mainImage}}">
   </a>
   <img ng-if="!inUserProfileBeta" class="kf-friend-card-image" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'" ng-src="{{mainImage}}">
   <span class="kf-friend-card-who">

--- a/kifi-backend/modules/shoebox/angular/src/friends/peopleYouMayKnowView.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/friends/peopleYouMayKnowView.tpl.html
@@ -13,7 +13,10 @@
         </span>
       </div>
     </div>
-    <img class="kf-pymk-image" title="{{person.fullName}}" ng-src="{{person.pictureUrl}}" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'">
+    <a ng-if="inUserProfileBeta" href="{{person.profileUrl}}">
+      <img class="kf-pymk-image" title="{{person.fullName}}" ng-src="{{person.pictureUrl}}" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'">
+    </a>
+    <img ng-if="!inUserProfileBeta" class="kf-pymk-image" title="{{person.fullName}}" ng-src="{{person.pictureUrl}}" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'">
   </div>
   <a href="/invite" class="kf-pymk-invite-link">See more &#0187;</a>
  </div>

--- a/kifi-backend/modules/shoebox/angular/src/friends/rightColFriendsView.js
+++ b/kifi-backend/modules/shoebox/angular/src/friends/rightColFriendsView.js
@@ -46,70 +46,75 @@ angular.module('kifi')
 }])
 
 .directive('kfPeopleYouMayKnowView',
-  ['$log', '$q', '$rootScope', '$timeout', 'friendService', 'inviteService', 'modalService', 'wtiService',
-  function ($log, $q, $rootScope, $timeout, friendService, inviteService, modalService, wtiService) {
+  ['$log', '$q', '$rootScope', '$timeout', 'env', 'friendService', 'inviteService', 'modalService', 'userService', 'wtiService',
+  function ($log, $q, $rootScope, $timeout, env, friendService, inviteService, modalService, userService, wtiService) {
   return {
     replace: true,
     restrict: 'A',
     templateUrl: 'friends/peopleYouMayKnowView.tpl.html',
     link: function (scope/*, element, attrs*/) {
-      friendService.getPeopleYouMayKnow().then(function (people) {
-        var peopleYouMayKnow = [];
+      function init() {
+        friendService.getPeopleYouMayKnow().then(function (people) {
+          var peopleYouMayKnow = [];
 
-        people.forEach(function (person) {
-          var name = person.firstName + ' ' + person.lastName;
-          var numMutualFriends = person.mutualFriends.length || 0;
+          people.forEach(function (person) {
+            var name = person.firstName + ' ' + person.lastName;
+            var numMutualFriends = person.mutualFriends.length || 0;
 
-          peopleYouMayKnow.push({
-            id: person.id,
-            fullName: name,
-            pictureUrl: friendService.getPictureUrlForUser(person),
-            actionText: 'Add',
-            clickable: true,
-            isKifiUser: true,
-            via: numMutualFriends > 0 ? '' : 'Kifi',
-            numMutualFriends: numMutualFriends,
-            mutualFriends: person.mutualFriends
-          });
-        });
-
-        var networkNamesMap = {
-          'facebook': 'Facebook',
-          'linkedin': 'LinkedIn',
-          'email': 'email'
-        };
-
-        if (peopleYouMayKnow.length < 3) {
-          (wtiService.list.length > 0 ? $q.when(wtiService.list) : wtiService.getMore()).then(function () {
-            var wtiList = wtiService.list;
-
-            wtiList.forEach(function (person) {
-              var name = '';
-              var via = '';
-
-              name = person.name;
-              via = (person.network === 'email' && person.identifier) || networkNamesMap[person.network];
-
-              peopleYouMayKnow.push({
-                networkType: person.network,
-                id: person.identifier,
-                fullName: name,
-                pictureUrl: person.pictureUrl || 'https://www.kifi.com/assets/img/ghost.100.png',
-                actionText: 'Invite',
-                clickable: true,
-                isKifiUser: false,
-                via: via
-              });
+            peopleYouMayKnow.push({
+              id: person.id,
+              fullName: name,
+              pictureUrl: friendService.getPictureUrlForUser(person),
+              profileUrl: env.origin + '/' + person.username,
+              actionText: 'Add',
+              clickable: true,
+              isKifiUser: true,
+              via: numMutualFriends > 0 ? '' : 'Kifi',
+              numMutualFriends: numMutualFriends,
+              mutualFriends: person.mutualFriends
             });
           });
 
-          scope.header = 'Find People to Invite';
-        } else {
-          scope.header = 'People You May Know';
-        }
+          var networkNamesMap = {
+            'facebook': 'Facebook',
+            'linkedin': 'LinkedIn',
+            'email': 'email'
+          };
 
-        scope.peopleYouMayKnow = peopleYouMayKnow;
-      });
+          if (peopleYouMayKnow.length < 3) {
+            (wtiService.list.length > 0 ? $q.when(wtiService.list) : wtiService.getMore()).then(function () {
+              var wtiList = wtiService.list;
+
+              wtiList.forEach(function (person) {
+                var name = '';
+                var via = '';
+
+                name = person.name;
+                via = (person.network === 'email' && person.identifier) || networkNamesMap[person.network];
+
+                peopleYouMayKnow.push({
+                  networkType: person.network,
+                  id: person.identifier,
+                  fullName: name,
+                  pictureUrl: person.pictureUrl || 'https://www.kifi.com/assets/img/ghost.100.png',
+                  actionText: 'Invite',
+                  clickable: true,
+                  isKifiUser: false,
+                  via: via
+                });
+              });
+            });
+
+            scope.header = 'Find People to Invite';
+          } else {
+            scope.header = 'People You May Know';
+          }
+
+          scope.peopleYouMayKnow = peopleYouMayKnow;
+        });
+
+        scope.inUserProfileBeta = userService.inUserProfileBeta();
+      }
 
       scope.action = function (person) {
         if (!person.clickable) {
@@ -166,6 +171,9 @@ angular.module('kifi')
           modalData: { savedPymk: person }
         });
       };
+
+
+      init();
     }
   };
 }])

--- a/kifi-backend/modules/shoebox/angular/src/friends/rightColFriendsView.js
+++ b/kifi-backend/modules/shoebox/angular/src/friends/rightColFriendsView.js
@@ -56,8 +56,8 @@ angular.module('kifi')
 ])
 
 .directive('kfPeopleYouMayKnowView',
-  ['$log', '$q', '$rootScope', '$timeout', 'env', 'friendService', 'inviteService', 'modalService', 'userService', 'wtiService',
-  function ($log, $q, $rootScope, $timeout, env, friendService, inviteService, modalService, userService, wtiService) {
+  ['$log', '$q', '$rootScope', '$timeout', 'friendService', 'inviteService', 'modalService', 'userService', 'wtiService',
+  function ($log, $q, $rootScope, $timeout, friendService, inviteService, modalService, userService, wtiService) {
   return {
     replace: true,
     restrict: 'A',
@@ -75,7 +75,7 @@ angular.module('kifi')
               id: person.id,
               fullName: name,
               pictureUrl: friendService.getPictureUrlForUser(person),
-              profileUrl: env.origin + '/' + person.username,
+              profileUrl: userService.getProfileUrl(person.username),
               actionText: 'Add',
               clickable: true,
               isKifiUser: true,

--- a/kifi-backend/modules/shoebox/angular/src/friends/seeMutualFriends.js
+++ b/kifi-backend/modules/shoebox/angular/src/friends/seeMutualFriends.js
@@ -2,8 +2,8 @@
 
 angular.module('kifi')
 
-.directive('kfSeeMutualFriends', ['$rootScope', '$timeout', 'env', 'friendService', 'inviteService', 'userService',
-  function ($rootScope, $timeout, env, friendService, inviteService, userService) {
+.directive('kfSeeMutualFriends', ['$rootScope', '$timeout', 'friendService', 'inviteService', 'userService',
+  function ($rootScope, $timeout, friendService, inviteService, userService) {
     return {
       replace: true,
       restrict: 'A',
@@ -35,7 +35,7 @@ angular.module('kifi')
           var mutualFriendPair = [];
           person.mutualFriends.forEach(function (mutualFriend, index) {
             mutualFriend.pictureUrl = friendService.getPictureUrlForUser(mutualFriend);
-            mutualFriend.profileUrl = env.origin + '/' + mutualFriend.username;
+            mutualFriend.profileUrl = userService.getProfileUrl(mutualFriend.username);
             mutualFriendPair.push(mutualFriend);
 
             if (index % 2 !== 0) {

--- a/kifi-backend/modules/shoebox/angular/src/friends/seeMutualFriends.js
+++ b/kifi-backend/modules/shoebox/angular/src/friends/seeMutualFriends.js
@@ -2,19 +2,21 @@
 
 angular.module('kifi')
 
-.directive('kfSeeMutualFriends', [
-  '$rootScope',
-  '$timeout',
-  'friendService',
-  'inviteService',
-  function ($rootScope, $timeout, friendService, inviteService) {
+.directive('kfSeeMutualFriends', ['$rootScope', '$timeout', 'env', 'friendService', 'inviteService', 'userService',
+  function ($rootScope, $timeout, env, friendService, inviteService, userService) {
     return {
       replace: true,
       restrict: 'A',
       templateUrl: 'friends/seeMutualFriends.tpl.html',
-      link: function (scope/*, element, attrs*/) {
+      require: '^kfModal',
+      link: function (scope, element, attrs, kfModalCtrl) {
         scope.actionText = 'Add Friend';
         scope.clickable = true;
+
+        function init() {
+          updateScopeValues(scope.modalData.savedPymk);
+          scope.inUserProfileBeta = userService.inUserProfileBeta();
+        }
 
         // Helper function to update scope values based on passed-in person.
         function updateScopeValues (person) {
@@ -25,6 +27,7 @@ angular.module('kifi')
           scope.name = person.fullName;
           scope.numMutualFriends = person.numMutualFriends;
           scope.pictureUrl = person.pictureUrl;
+          scope.userProfileUrl = person.profileUrl;
 
           // Divide up list of mutual friends into list of pairs of mutual
           // friends for two-column display in modal.
@@ -32,6 +35,7 @@ angular.module('kifi')
           var mutualFriendPair = [];
           person.mutualFriends.forEach(function (mutualFriend, index) {
             mutualFriend.pictureUrl = friendService.getPictureUrlForUser(mutualFriend);
+            mutualFriend.profileUrl = env.origin + '/' + mutualFriend.username;
             mutualFriendPair.push(mutualFriend);
 
             if (index % 2 !== 0) {
@@ -48,8 +52,6 @@ angular.module('kifi')
           scope.mutualFriendsPairs = mutualFriendsPairs;
         }
 
-        updateScopeValues(scope.modalData.savedPymk);
-
         scope.addFriend = function (id) {
           if (!scope.clickable) {
             return;
@@ -65,6 +67,13 @@ angular.module('kifi')
             inviteService.expireSocialSearch();
           });
         };
+
+        scope.close = function () {
+          kfModalCtrl.close();
+        };
+
+
+        init();
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/friends/seeMutualFriends.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/friends/seeMutualFriends.tpl.html
@@ -1,7 +1,11 @@
 <div class="kf-mutual-friends">
   <!-- Person who has mutual friends with the user -->
   <div class="kf-mutual-friends-pymk">
-    <img class="kf-mutual-friends-image" title="{{name}}" ng-src="{{pictureUrl}}" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'">
+    <a ng-if="inUserProfileBeta" href="{{userProfileUrl}}" ng-click="close()">
+      <img class="kf-mutual-friends-image" title="{{name}}" ng-src="{{pictureUrl}}" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'">
+    </a>
+    <img ng-if="!inUserProfileBeta" class="kf-mutual-friends-image" title="{{name}}" ng-src="{{pictureUrl}}" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'">
+
     <a href="javascript:" class="kf-mutual-friends-action" ng-click="addFriend(id)" ng-class="{clickable: clickable}"><span class="sprite sprite-tag-new-plus-icon"></span>{{actionText}}</a>
     <div class="kf-mutual-friends-pymk-info">
       <div class="kf-mutual-friends-pymk-number"><ng-pluralize count="numMutualFriends" when="{'one': '1 Mutual Friend ', 'other': '{} Mutual Friends '}"></ng-pluralize>With</div>
@@ -13,7 +17,10 @@
   <div class='kf-mutual-friends-friends'>
     <div ng-repeat="mutualFriendPair in mutualFriendsPairs" class="kf-mutual-friend-pair">
       <div ng-repeat="mutualFriend in mutualFriendPair" class="kf-mutual-friend-card">
-        <img class="kf-mutual-friends-image" title="{{mutualFriend.firstName}} {{mutualFriend.lastName}}" ng-src="{{mutualFriend.pictureUrl}}" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'">
+        <a ng-if="inUserProfileBeta" href="{{mutualFriend.profileUrl}}" ng-click="close()">
+          <img class="kf-mutual-friends-image" title="{{mutualFriend.firstName}} {{mutualFriend.lastName}}" ng-src="{{mutualFriend.pictureUrl}}" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'">
+        </a>
+        <img ng-if="!inUserProfileBeta" class="kf-mutual-friends-image" title="{{mutualFriend.firstName}} {{mutualFriend.lastName}}" ng-src="{{mutualFriend.pictureUrl}}" onerror="this.src='https://www.kifi.com/assets/img/ghost.100.png'">
         <div class="kf-mutual-friend-card-info">
           <div class="kf-mutual-friend-card-name">{{mutualFriend.firstName}} {{mutualFriend.lastName}}</div>
           <div><ng-pluralize count="mutualFriend.numFriends" when="{'one': '1 friend ', 'other': '{} friends '}"></ng-pluralize>on Kifi</div>

--- a/kifi-backend/modules/shoebox/angular/src/invite/friendRequestBanner.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/invite/friendRequestBanner.tpl.html
@@ -6,9 +6,10 @@
 
   <div class="kf-add-friend-banner">
     <div itemscope itemtype="http://data-vocabulary.org/Person">
-      <a href="{{userProfileUrl}}" itemprop="url">
+      <a ng-if="inUserProfileBeta" href="{{userProfileUrl}}" itemprop="url">
         <img class="kf-add-friend-banner-image" onerror="this.src='/assets/img/ghost.200.png'" ng-src="{{mainImage}}" itemprop="photo" />
       </a>
+      <img ng-if="!inUserProfileBeta" class="kf-add-friend-banner-image" onerror="this.src='/assets/img/ghost.200.png'" ng-src="{{mainImage}}" itemprop="photo" />
       <span class="kf-add-friend-banner-who">
         <span class="kf-add-friend-banner-main-label" title="{{mainLabel}}" itemprop="name">{{mainLabel}}</span>
         <div class="kf-friend-card-count" title="{{user.friendCount}}" ng-show="user.friendCount > 0">

--- a/kifi-backend/modules/shoebox/angular/src/invite/friendRequestBanner.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/invite/friendRequestBanner.tpl.html
@@ -5,14 +5,19 @@
   <h2 class="kf-add-friend-banner-title">{{friendRequestBannerHeader}}</h2>
 
   <div class="kf-add-friend-banner">
-    <img class="kf-add-friend-banner-image" onerror="this.src='/assets/img/ghost.200.png'" ng-src="{{mainImage}}"/>
-    <span class="kf-add-friend-banner-who">
-      <span class="kf-add-friend-banner-main-label" title="{{mainLabel}}">{{mainLabel}}</span>
-      <div class="kf-friend-card-count" title="{{user.friendCount}}" ng-show="user.friendCount > 0">
-        <span ng-pluralize count="friendCount" when="{'one': '1 friend ', 'other': '{} friends '}"></span>on Kifi
-      </div>
-      <div class="kf-friend-card-count" ng-show="friendCount < 1">Kifi user</div>
-    </span>
+    <div itemscope itemtype="http://data-vocabulary.org/Person">
+      <a href="{{userProfileUrl}}" itemprop="url">
+        <img class="kf-add-friend-banner-image" onerror="this.src='/assets/img/ghost.200.png'" ng-src="{{mainImage}}" itemprop="photo" />
+      </a>
+      <span class="kf-add-friend-banner-who">
+        <a href="{{userProfileUrl}}" class="kf-add-friend-banner-main-label" title="{{mainLabel}}" itemprop="name">{{mainLabel}}</a>
+        <div class="kf-friend-card-count" title="{{user.friendCount}}" ng-show="user.friendCount > 0">
+          <span ng-pluralize count="friendCount" when="{'one': '1 friend ', 'other': '{} friends '}"></span>on Kifi
+        </div>
+        <div class="kf-friend-card-count" ng-show="friendCount < 1">Kifi user</div>
+      </span>
+    </div>
+
     <div kf-social-invite-action class="clickable kf-add-friend-banner-action" result="result" on-after-invite="onAfterInvite()">
       <div class="kf-add-friend-banner-add-button clickable-target" href="javascript:" ng-click="invite(result, $event)">
         <span class="sprite sprite-tag-new-plus-icon"> </span>Add

--- a/kifi-backend/modules/shoebox/angular/src/invite/friendRequestBanner.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/invite/friendRequestBanner.tpl.html
@@ -5,19 +5,17 @@
   <h2 class="kf-add-friend-banner-title">{{friendRequestBannerHeader}}</h2>
 
   <div class="kf-add-friend-banner">
-    <div itemscope itemtype="http://data-vocabulary.org/Person">
-      <a ng-if="inUserProfileBeta" href="{{userProfileUrl}}" itemprop="url">
-        <img class="kf-add-friend-banner-image" onerror="this.src='/assets/img/ghost.200.png'" ng-src="{{mainImage}}" itemprop="photo" />
-      </a>
-      <img ng-if="!inUserProfileBeta" class="kf-add-friend-banner-image" onerror="this.src='/assets/img/ghost.200.png'" ng-src="{{mainImage}}" itemprop="photo" />
-      <span class="kf-add-friend-banner-who">
-        <span class="kf-add-friend-banner-main-label" title="{{mainLabel}}" itemprop="name">{{mainLabel}}</span>
-        <div class="kf-friend-card-count" title="{{user.friendCount}}" ng-show="user.friendCount > 0">
-          <span ng-pluralize count="friendCount" when="{'one': '1 friend ', 'other': '{} friends '}"></span>on Kifi
-        </div>
-        <div class="kf-friend-card-count" ng-show="friendCount < 1">Kifi user</div>
-      </span>
-    </div>
+    <a ng-if="inUserProfileBeta" href="{{userProfileUrl}}">
+      <img class="kf-add-friend-banner-image" onerror="this.src='/assets/img/ghost.200.png'" ng-src="{{mainImage}}" />
+    </a>
+    <img ng-if="!inUserProfileBeta" class="kf-add-friend-banner-image" onerror="this.src='/assets/img/ghost.200.png'" ng-src="{{mainImage}}" />
+    <span class="kf-add-friend-banner-who">
+      <span class="kf-add-friend-banner-main-label" title="{{mainLabel}}">{{mainLabel}}</span>
+      <div class="kf-friend-card-count" title="{{user.friendCount}}" ng-show="user.friendCount > 0">
+        <span ng-pluralize count="friendCount" when="{'one': '1 friend ', 'other': '{} friends '}"></span>on Kifi
+      </div>
+      <div class="kf-friend-card-count" ng-show="friendCount < 1">Kifi user</div>
+    </span>
 
     <div kf-social-invite-action class="clickable kf-add-friend-banner-action" result="result" on-after-invite="onAfterInvite()">
       <div class="kf-add-friend-banner-add-button clickable-target" href="javascript:" ng-click="invite(result, $event)">

--- a/kifi-backend/modules/shoebox/angular/src/invite/friendRequestBanner.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/invite/friendRequestBanner.tpl.html
@@ -10,7 +10,7 @@
         <img class="kf-add-friend-banner-image" onerror="this.src='/assets/img/ghost.200.png'" ng-src="{{mainImage}}" itemprop="photo" />
       </a>
       <span class="kf-add-friend-banner-who">
-        <a href="{{userProfileUrl}}" class="kf-add-friend-banner-main-label" title="{{mainLabel}}" itemprop="name">{{mainLabel}}</a>
+        <span class="kf-add-friend-banner-main-label" title="{{mainLabel}}" itemprop="name">{{mainLabel}}</span>
         <div class="kf-friend-card-count" title="{{user.friendCount}}" ng-show="user.friendCount > 0">
           <span ng-pluralize count="friendCount" when="{'one': '1 friend ', 'other': '{} friends '}"></span>on Kifi
         </div>

--- a/kifi-backend/modules/shoebox/angular/src/invite/invite.js
+++ b/kifi-backend/modules/shoebox/angular/src/invite/invite.js
@@ -274,8 +274,10 @@ angular.module('kifi')
 ])
 
 .directive('kfFriendRequestBanner', [
-  'injectedState', 'routeService', 'userService', 'keepWhoService', 'profileService', '$timeout', '$analytics', 'analyticsState',
-  function (injectedState, routeService, userService, keepWhoService, profileService, $timeout, $analytics, analyticsState) {
+  '$analytics', '$timeout', 'analyticsState', 'env', 'injectedState', 'keepWhoService',
+  'profileService', 'routeService', 'userService',
+  function ($analytics, $timeout, analyticsState, env, injectedState, keepWhoService,
+    profileService, routeService, userService) {
 
     function setupShowFriendRequestBanner(scope, externalId) {
       function closeBanner() {
@@ -292,6 +294,7 @@ angular.module('kifi')
         scope.user = user;
         scope.mainImage = picUrl;
         scope.mainLabel = user.firstName + ' ' + user.lastName;
+        scope.userProfileUrl = env.origin + '/' + user.username;
         scope.hidden = false;
         scope.actionText = 'Add';
         scope.result = {
@@ -329,6 +332,7 @@ angular.module('kifi')
 
     function link(scope) {
       var externalId = injectedState.state.friend;
+
       scope.hidden = true;
       if (!externalId) {
         return;
@@ -347,6 +351,4 @@ angular.module('kifi')
       link: link
     };
   }
-])
-
-;
+]);

--- a/kifi-backend/modules/shoebox/angular/src/invite/invite.js
+++ b/kifi-backend/modules/shoebox/angular/src/invite/invite.js
@@ -172,8 +172,8 @@ angular.module('kifi')
 ])
 
 .directive('kfSocialInviteSearch', [
-  '$document', '$log', 'inviteService', 'modalService',
-  function ($document, $log, inviteService, modalService) {
+  '$document', '$log', 'inviteService', 'modalService', 'userService',
+  function ($document, $log, inviteService, modalService, userService) {
     return {
       scope: {},
       replace: true,
@@ -186,6 +186,7 @@ angular.module('kifi')
 
         scope.results = [];
         scope.selected = inviteService.socialSelected;
+        scope.inUserProfileBeta = userService.inUserProfileBeta();
 
         scope.change = _.debounce(function () { // todo: integrate service-wide debounce into Clutch, remove me
           inviteService.socialSearch(scope.search.name).then(function (res) {
@@ -295,6 +296,7 @@ angular.module('kifi')
         scope.mainImage = picUrl;
         scope.mainLabel = user.firstName + ' ' + user.lastName;
         scope.userProfileUrl = env.origin + '/' + user.username;
+        scope.inUserProfileBeta = userService.inUserProfileBeta();
         scope.hidden = false;
         scope.actionText = 'Add';
         scope.result = {

--- a/kifi-backend/modules/shoebox/angular/src/invite/invite.js
+++ b/kifi-backend/modules/shoebox/angular/src/invite/invite.js
@@ -275,9 +275,9 @@ angular.module('kifi')
 ])
 
 .directive('kfFriendRequestBanner', [
-  '$analytics', '$timeout', 'analyticsState', 'env', 'injectedState', 'keepWhoService',
+  '$analytics', '$timeout', 'analyticsState', 'injectedState', 'keepWhoService',
   'profileService', 'routeService', 'userService',
-  function ($analytics, $timeout, analyticsState, env, injectedState, keepWhoService,
+  function ($analytics, $timeout, analyticsState, injectedState, keepWhoService,
     profileService, routeService, userService) {
 
     function setupShowFriendRequestBanner(scope, externalId) {
@@ -295,7 +295,7 @@ angular.module('kifi')
         scope.user = user;
         scope.mainImage = picUrl;
         scope.mainLabel = user.firstName + ' ' + user.lastName;
-        scope.userProfileUrl = env.origin + '/' + user.username;
+        scope.userProfileUrl = userService.getProfileUrl(user.username);
         scope.inUserProfileBeta = userService.inUserProfileBeta();
         scope.hidden = false;
         scope.actionText = 'Add';

--- a/kifi-backend/modules/shoebox/angular/src/invite/inviteSearch.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/invite/inviteSearch.tpl.html
@@ -3,8 +3,12 @@
   <ul class="social-invite-dropdown" ng-show="search.showDropdown">
     <li class="social-invite-element" ng-repeat="result in results" ng-class="'social-invite-{{result.status === 'joined' && result.network === 'fortytwoNF' ? '' : result.status}}'">
 
-      <div ng-if="!result.custom">
-        <div ng-if="result.networkType !== 'email'"><img ng-src="{{result.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="social-invite-image"></div>
+      <div ng-if="!result.custom" itemscope itemtype="http://data-vocabulary.org/Person">
+        <div ng-if="result.networkType !== 'email'">
+          <a href="{{result.userProfileUrl}}" itemprop="url">
+            <img ng-src="{{result.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="social-invite-image" itemprop="photo">
+          </a>
+        </div>
 
         <div ng-if="!result.status">
           <div class="social-invite-summary">
@@ -20,7 +24,7 @@
 
         <div ng-if="result.status === 'joined' && result.networkType === 'fortytwo'">
           <div class="social-invite-summary">
-            <div class="social-invite-name">{{result.label}}</div>
+            <div class="social-invite-name" itemprop="name">{{result.label}}</div>
             <div class="social-invite-network">
               Your friend on Kifi
             </div>
@@ -29,7 +33,7 @@
 
         <div ng-if="result.status === 'requested' && result.networkType === 'fortytwoNF'">
           <div class="social-invite-summary">
-            <div class="social-invite-name">{{result.label}}</div>
+            <div class="social-invite-name" itemprop="name">{{result.label}}</div>
             <div class="social-invite-network">
               Kifi user — request sent
             </div>
@@ -38,7 +42,7 @@
 
         <div ng-if="result.status === 'joined' && result.networkType === 'fortytwoNF'">
           <div class="social-invite-summary">
-            <div class="social-invite-name">{{result.label}}</div>
+            <div class="social-invite-name" itemprop="name">{{result.label}}</div>
             <div class="social-invite-network">
               Kifi user
             </div>

--- a/kifi-backend/modules/shoebox/angular/src/invite/inviteSearch.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/invite/inviteSearch.tpl.html
@@ -5,9 +5,10 @@
 
       <div ng-if="!result.custom" itemscope itemtype="http://data-vocabulary.org/Person">
         <div ng-if="result.networkType !== 'email'">
-          <a href="{{result.userProfileUrl}}" itemprop="url">
+          <a ng-if="inUserProfileBeta" href="{{result.userProfileUrl}}" itemprop="url">
             <img ng-src="{{result.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="social-invite-image" itemprop="photo">
           </a>
+          <img ng-if="!inUserProfileBeta" ng-src="{{result.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="social-invite-image" itemprop="photo">
         </div>
 
         <div ng-if="!result.status">

--- a/kifi-backend/modules/shoebox/angular/src/invite/inviteSearch.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/invite/inviteSearch.tpl.html
@@ -3,12 +3,12 @@
   <ul class="social-invite-dropdown" ng-show="search.showDropdown">
     <li class="social-invite-element" ng-repeat="result in results" ng-class="'social-invite-{{result.status === 'joined' && result.network === 'fortytwoNF' ? '' : result.status}}'">
 
-      <div ng-if="!result.custom" itemscope itemtype="http://data-vocabulary.org/Person">
+      <div ng-if="!result.custom">
         <div ng-if="result.networkType !== 'email'">
-          <a ng-if="inUserProfileBeta" href="{{result.userProfileUrl}}" itemprop="url">
-            <img ng-src="{{result.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="social-invite-image" itemprop="photo">
+          <a ng-if="inUserProfileBeta" href="{{result.userProfileUrl}}">
+            <img ng-src="{{result.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="social-invite-image">
           </a>
-          <img ng-if="!inUserProfileBeta" ng-src="{{result.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="social-invite-image" itemprop="photo">
+          <img ng-if="!inUserProfileBeta" ng-src="{{result.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="social-invite-image">
         </div>
 
         <div ng-if="!result.status">
@@ -25,7 +25,7 @@
 
         <div ng-if="result.status === 'joined' && result.networkType === 'fortytwo'">
           <div class="social-invite-summary">
-            <div class="social-invite-name" itemprop="name">{{result.label}}</div>
+            <div class="social-invite-name">{{result.label}}</div>
             <div class="social-invite-network">
               Your friend on Kifi
             </div>
@@ -34,7 +34,7 @@
 
         <div ng-if="result.status === 'requested' && result.networkType === 'fortytwoNF'">
           <div class="social-invite-summary">
-            <div class="social-invite-name" itemprop="name">{{result.label}}</div>
+            <div class="social-invite-name">{{result.label}}</div>
             <div class="social-invite-network">
               Kifi user — request sent
             </div>
@@ -43,7 +43,7 @@
 
         <div ng-if="result.status === 'joined' && result.networkType === 'fortytwoNF'">
           <div class="social-invite-summary">
-            <div class="social-invite-name" itemprop="name">{{result.label}}</div>
+            <div class="social-invite-name">{{result.label}}</div>
             <div class="social-invite-network">
               Kifi user
             </div>

--- a/kifi-backend/modules/shoebox/angular/src/invite/inviteService.js
+++ b/kifi-backend/modules/shoebox/angular/src/invite/inviteService.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .factory('inviteService', [
-  '$http', 'env', '$q', 'routeService', 'userService', 'util', 'Clutch', '$window', '$log', '$analytics', '$location', '$FB',
-  function ($http, env, $q, routeService, userService, util, Clutch, $window, $log, $analytics, $location, $FB) {
+  '$http', '$q', 'routeService', 'userService', 'util', 'Clutch', '$window', '$log', '$analytics', '$location', '$FB',
+  function ($http, $q, routeService, userService, util, Clutch, $window, $log, $analytics, $location, $FB) {
     /* Naming convention:
      *  - Kifi Friend is an existing connection on Kifi
      *  - Kifi User is a user of Kifi, may not be a friend.
@@ -47,7 +47,7 @@ angular.module('kifi')
         result.image = routeService.formatPicUrl(result.socialId, result.image);
 
         userService.getBasicUserInfo(result.socialId, false).then(function (res) {
-          result.userProfileUrl = env.origin + '/' + res.data && res.data.username;
+          result.userProfileUrl = userService.getProfileUrl(res.data.username);
         });
       }
       if (result.status === 'invited') {

--- a/kifi-backend/modules/shoebox/angular/src/invite/inviteService.js
+++ b/kifi-backend/modules/shoebox/angular/src/invite/inviteService.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .factory('inviteService', [
-  '$http', 'env', '$q', 'routeService', 'util', 'Clutch', '$window', '$log', '$analytics', '$location', '$FB',
-  function ($http, env, $q, routeService, util, Clutch, $window, $log, $analytics, $location, $FB) {
+  '$http', 'env', '$q', 'routeService', 'userService', 'util', 'Clutch', '$window', '$log', '$analytics', '$location', '$FB',
+  function ($http, env, $q, routeService, userService, util, Clutch, $window, $log, $analytics, $location, $FB) {
     /* Naming convention:
      *  - Kifi Friend is an existing connection on Kifi
      *  - Kifi User is a user of Kifi, may not be a friend.
@@ -45,6 +45,10 @@ angular.module('kifi')
       result.iconStyle = 'kf-' + result.networkType + '-icon-micro';
       if (result.networkType === 'fortytwo' || result.networkType === 'fortytwoNF') {
         result.image = routeService.formatPicUrl(result.socialId, result.image);
+
+        userService.getBasicUserInfo(result.socialId, false).then(function (res) {
+          result.userProfileUrl = env.origin + '/' + res.data && res.data.username;
+        });
       }
       if (result.status === 'invited') {
         var sendText = $window.moment(new Date(result.inviteLastSentAt)).fromNow();

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
@@ -2,14 +2,15 @@
 
 angular.module('kifi')
 
-.factory('keepDecoratorService', ['tagService', 'util', 'friendService', 'profileService',
-  function (tagService, util, friendService, profileService) {
+.factory('keepDecoratorService', ['tagService', 'util', 'friendService', 'profileService', 'userService',
+  function (tagService, util, friendService, profileService, userService) {
     function processLibraries(item) {
       if (item.libraries && item.libraries.length > 0 && Array.isArray(item.libraries[0])) {
         var cleanedLibraries = [];
         var usersWithLibs = {};
         item.libraries.forEach( function (lib) {
           lib[0].keeperPic = friendService.getPictureUrlForUser(lib[1]);
+          lib[0].keeperProfileUrl = userService.getProfileUrl(lib[1].username);
           if (lib[1].id !== profileService.me.id) {
             usersWithLibs[lib[1].id] = true;
             cleanedLibraries.push(lib[0]);

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
@@ -11,6 +11,7 @@ angular.module('kifi')
         item.libraries.forEach( function (lib) {
           lib[0].keeperPic = friendService.getPictureUrlForUser(lib[1]);
           lib[0].keeperProfileUrl = userService.getProfileUrl(lib[1].username);
+          lib[0].keeperName = lib[1].firstName + ' ' + lib[1].lastName;
           if (lib[1].id !== profileService.me.id) {
             usersWithLibs[lib[1].id] = true;
             cleanedLibraries.push(lib[0]);

--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
@@ -3,10 +3,10 @@
 angular.module('kifi')
 
 .directive('kfNav', [
-  '$location', '$window', '$rootScope', '$timeout', '$document', 'util',
-    'friendService', 'modalService', 'tagService', 'profileService', 'libraryService', '$interval',
-  function ($location, $window, $rootScope, $timeout, $document, util,
-    friendService, modalService, tagService, profileService, libraryService, $interval) {
+  '$location', '$window', '$rootScope', '$timeout', '$document', 'util', 'userService',
+    'friendService', 'modalService', 'tagService', 'profileService', 'libraryService', '$interval', 'env',
+  function ($location, $window, $rootScope, $timeout, $document, util, userService,
+    friendService, modalService, tagService, profileService, libraryService, $interval, env) {
     return {
       //replace: true,
       restrict: 'A',
@@ -35,6 +35,8 @@ angular.module('kifi')
           friendsCount: friendService.totalFriends(),
           friendsNotifCount: friendService.requests.length
         };
+
+        scope.inUserProfileBeta = userService.inUserProfileBeta();
 
         //
         // Internal methods.
@@ -162,8 +164,12 @@ angular.module('kifi')
           return loc === path || util.startsWith(loc, path + '/');
         };
 
-        scope.toggleMyLibsFirst = function() {
+        scope.toggleMyLibsFirst = function () {
           scope.sortingMenu.myLibsFirst = !scope.sortingMenu.myLibsFirst;
+        };
+
+        scope.getLibraryOwnerProfileUrl = function (library) {
+          return env.origin + '/' + library.owner.username;
         };
 
         //

--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.js
@@ -4,9 +4,9 @@ angular.module('kifi')
 
 .directive('kfNav', [
   '$location', '$window', '$rootScope', '$timeout', '$document', 'util', 'userService',
-    'friendService', 'modalService', 'tagService', 'profileService', 'libraryService', '$interval', 'env',
+    'friendService', 'modalService', 'tagService', 'profileService', 'libraryService', '$interval',
   function ($location, $window, $rootScope, $timeout, $document, util, userService,
-    friendService, modalService, tagService, profileService, libraryService, $interval, env) {
+    friendService, modalService, tagService, profileService, libraryService, $interval) {
     return {
       //replace: true,
       restrict: 'A',
@@ -169,7 +169,7 @@ angular.module('kifi')
         };
 
         scope.getLibraryOwnerProfileUrl = function (library) {
-          return env.origin + '/' + library.owner.username;
+          return userService.getProfileUrl(library.owner.username);
         };
 
         //

--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.tpl.html
@@ -98,7 +98,10 @@
                 <!-- TODO: remove this when discoverable libraries have been converted to public libraries in the db. -->
                 <div class="library-icon svg-yellow-card-with-globe" ng-if="library.visibility=='discoverable'"></div>
 
-                <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+                <a ng-if="inUserProfileBeta" href="{{getLibraryOwnerProfileUrl(library)}}">
+                  <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+                </a>
+                <ng-if="!inUserProfileBeta" img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
               </div>
               <div class="kf-nav-lib-info">
                 <div kf-ellipsis full-text="library.name" max-num-lines=2 class="kf-nav-lib-name"></div>
@@ -136,8 +139,10 @@
 
                 <!-- TODO: remove this when discoverable libraries have been converted to public libraries in the db. -->
                 <div class="library-icon svg-yellow-card-with-globe" ng-if="library.visibility=='discoverable'"></div>
-
-                <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+                <a ng-if="inUserProfileBeta" href="{{getLibraryOwnerProfileUrl(library)}}">
+                  <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+                </a>
+                <img ng-if="!inUserProfileBeta" class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
               </div>
               <div class="kf-nav-lib-info">
                 <div kf-ellipsis full-text="library.name" max-num-lines=2 class="kf-nav-lib-name"></div>
@@ -166,7 +171,10 @@
             <a class="kf-nav-link" ng-href="{{library.url}}">
               <div class="library-icon-holder">
                 <div class="library-icon svg-library-card"></div>
-                <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+                <a ng-if="inUserProfileBeta" href="{{getLibraryOwnerProfileUrl(library)}}">
+                  <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+                </a>
+                <img ng-if="!inUserProfileBeta" class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
               </div>
               <div class="kf-nav-lib-info">
                 <div kf-ellipsis full-text="library.name" max-num-lines=2 class="kf-nav-lib-name"></div>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -161,7 +161,7 @@ angular.module('kifi')
           scope.library.followers = scope.library.followers || [];
           scope.library.followers.forEach(function (follower) {
             follower.picUrl = friendService.getPictureUrlForUser(follower);
-            follower.profileUrl = env.origin + '/' + follower.username;
+            follower.profileUrl = userService.getProfileUrl(follower.username);
           });
 
           var maxLength = 150;

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -155,7 +155,7 @@ angular.module('kifi')
 
           if (scope.library.owner) {
             scope.library.owner.picUrl = friendService.getPictureUrlForUser(scope.library.owner);
-            scope.library.owner.profileUrl = env.origin + '/' + scope.library.owner.username;
+            scope.library.owner.profileUrl = userService.getProfileUrl(scope.library.owner.username);
           }
 
           scope.library.followers = scope.library.followers || [];

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -5,10 +5,10 @@ angular.module('kifi')
 .directive('kfLibraryCard', [
   '$FB', '$http', '$location', '$q', '$rootScope', '$state', '$stateParams', '$timeout', '$twitter', '$window',
   'env', 'friendService', 'libraryService', 'modalService','profileService', 'platformService', 'signupService',
-  'routeService', 'util',
+  'routeService', 'userService', 'util',
   function ($FB, $http, $location, $q, $rootScope, $state, $stateParams, $timeout, $twitter, $window,
             env, friendService, libraryService, modalService, profileService, platformService, signupService,
-            routeService, util) {
+            routeService, userService, util) {
     return {
       restrict: 'A',
       replace: true,
@@ -52,6 +52,7 @@ angular.module('kifi')
         scope.librarySearchInProgress = false;
         scope.search = { 'text': $stateParams.q || '' };
         scope.pageScrolled = false;
+        scope.inUserProfileBeta = userService.inUserProfileBeta();
 
         //
         // Internal methods.
@@ -154,11 +155,13 @@ angular.module('kifi')
 
           if (scope.library.owner) {
             scope.library.owner.picUrl = friendService.getPictureUrlForUser(scope.library.owner);
+            scope.library.owner.profileUrl = env.origin + '/' + scope.library.owner.username;
           }
 
           scope.library.followers = scope.library.followers || [];
           scope.library.followers.forEach(function (follower) {
             follower.picUrl = friendService.getPictureUrlForUser(follower);
+            follower.profileUrl = env.origin + '/' + follower.username;
           });
 
           var maxLength = 150;

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
@@ -91,7 +91,7 @@
             <div class="kf-keep-lib-follower-preview">
               <div class="kf-keep-lib-follower-pics">
                 <span ng-repeat="follower in followersToShow" itemscope itemtype="http://data-vocabulary.org/Person">
-                  <a ng-if="inUserProfileBeta" href="{{follower.profileUrl}}">
+                  <a ng-if="inUserProfileBeta" href="{{follower.profileUrl}}" itemprop="url">
                     <img ng-src="{{follower.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}"
                       class="kf-keep-lib-user-image"
                       kf-who-tooltip

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
@@ -101,9 +101,8 @@
                       ng-click="hideTooltip()"
                       itemprop="photo"
                       alt="{{follower.firstName}} {{follower.lastName}}"
-                    ><meta itemprop="name" content="{{follower.firstName}} {{follower.lastName}}" />
-                  </a>
-                  <img ng-if="!inUserProfileBeta" ng-src="{{follower.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}"
+                    ><meta itemprop="name" content="{{follower.firstName}} {{follower.lastName}}" /></a><img
+                      ng-if="!inUserProfileBeta" ng-src="{{follower.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}"
                       class="kf-keep-lib-user-image"
                       kf-who-tooltip
                       keeper="follower"

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.tpl.html
@@ -49,7 +49,10 @@
 
         <div class="kf-keep-lib-info">
           <div class="kf-keep-lib-owner" itemscope itemtype="http://data-vocabulary.org/Person">
-            <img ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="kf-keep-lib-user-image" itemprop="photo" alt="{{library.owner.firstName}} {{library.owner.lastName}}">
+            <a ng-if="inUserProfileBeta" href="{{library.owner.profileUrl}}" itemprop="url">
+              <img ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="kf-keep-lib-user-image" itemprop="photo" alt="{{library.owner.firstName}} {{library.owner.lastName}}">
+            </a>
+            <img ng-if="!inUserProfileBeta" ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="kf-keep-lib-user-image" itemprop="photo" alt="{{library.owner.firstName}} {{library.owner.lastName}}">
             <div class="kf-keep-lib-owner-text">
               <div class="kf-keep-lib-curator">Curator:</div>
               <div class="kf-keep-lib-owner-name" itemprop="name">{{library.owner.firstName}} {{library.owner.lastName}}</div>
@@ -88,16 +91,28 @@
             <div class="kf-keep-lib-follower-preview">
               <div class="kf-keep-lib-follower-pics">
                 <span ng-repeat="follower in followersToShow" itemscope itemtype="http://data-vocabulary.org/Person">
-                  <img ng-src="{{follower.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}"
-                    class="kf-keep-lib-user-image"
-                    kf-who-tooltip
-                    keeper="follower"
-                    ng-mouseenter="showTooltip()"
-                    ng-mouseleave="hideTooltip()"
-                    ng-click="hideTooltip()"
-                    itemprop="photo"
-                    alt="{{follower.firstName}} {{follower.lastName}}"
-                  ><meta itemprop="name" content="{{follower.firstName}} {{follower.lastName}}" />
+                  <a ng-if="inUserProfileBeta" href="{{follower.profileUrl}}">
+                    <img ng-src="{{follower.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}"
+                      class="kf-keep-lib-user-image"
+                      kf-who-tooltip
+                      keeper="follower"
+                      ng-mouseenter="showTooltip()"
+                      ng-mouseleave="hideTooltip()"
+                      ng-click="hideTooltip()"
+                      itemprop="photo"
+                      alt="{{follower.firstName}} {{follower.lastName}}"
+                    ><meta itemprop="name" content="{{follower.firstName}} {{follower.lastName}}" />
+                  </a>
+                  <img ng-if="!inUserProfileBeta" ng-src="{{follower.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}"
+                      class="kf-keep-lib-user-image"
+                      kf-who-tooltip
+                      keeper="follower"
+                      ng-mouseenter="showTooltip()"
+                      ng-mouseleave="hideTooltip()"
+                      ng-click="hideTooltip()"
+                      itemprop="photo"
+                      alt="{{follower.firstName}} {{follower.lastName}}"
+                    ><meta itemprop="name" content="{{follower.firstName}} {{follower.lastName}}" />
                 </span>
               </div>
               <div ng-if="numAdditionalFollowers" class="kf-keep-lib-additional-followers" ng-click="showFollowers()">

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryFollowers.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryFollowers.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .directive('kfLibraryFollowers', [
-  '$location', '$window', '$rootScope', 'env', 'friendService', 'libraryService', 'userService',
-  function ($location, $window, $rootScope, env, friendService, libraryService, userService) {
+  '$location', '$window', '$rootScope', 'friendService', 'libraryService', 'userService',
+  function ($location, $window, $rootScope, friendService, libraryService, userService) {
     return {
       restrict: 'A',
       require: '^kfModal',
@@ -45,7 +45,7 @@ angular.module('kifi')
                 members = _.reject(members, function(m) { return m.lastInvitedAt; });
                 members.forEach(function (member) {
                   member.picUrl = friendService.getPictureUrlForUser(member);
-                  member.profileUrl = env.origin + '/' + member.username;
+                  member.profileUrl = userService.getProfileUrl(member.username);
                 });
                 scope.followerList.push.apply(scope.followerList, members);
               }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryFollowers.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryFollowers.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .directive('kfLibraryFollowers', [
-  '$location', '$window', '$rootScope', 'friendService', 'libraryService',
-  function ($location, $window, $rootScope, friendService, libraryService) {
+  '$location', '$window', '$rootScope', 'env', 'friendService', 'libraryService', 'userService',
+  function ($location, $window, $rootScope, env, friendService, libraryService, userService) {
     return {
       restrict: 'A',
       require: '^kfModal',
@@ -17,6 +17,7 @@ angular.module('kifi')
         scope.moreFollowers = true;
         scope.followerList = [];
         scope.followerScrollDistance = '100%';
+        scope.inUserProfileBeta = userService.inUserProfileBeta();
 
         scope.isFollowerScrollDisabled = function () {
           return !(scope.moreFollowers);
@@ -44,6 +45,7 @@ angular.module('kifi')
                 members = _.reject(members, function(m) { return m.lastInvitedAt; });
                 members.forEach(function (member) {
                   member.picUrl = friendService.getPictureUrlForUser(member);
+                  member.profileUrl = env.origin + '/' + member.username;
                 });
                 scope.followerList.push.apply(scope.followerList, members);
               }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryFollowers.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryFollowers.tpl.html
@@ -17,13 +17,19 @@
 
           <ul class="lib-followers-list" itemscope itemtype="http://data-vocabulary.org/Person">
             <li class="lib-follower lib-owner">
-              <img ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="lib-follower-image" itemprop="photo" alt="{{library.owner.firstName}} {{library.owner.lastName}}">
+              <a ng-if="inUserProfileBeta" href="{{library.owner.profileUrl}}" itemprop="url">
+                <img ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="lib-follower-image" itemprop="photo" alt="{{library.owner.firstName}} {{library.owner.lastName}}">
+              </a>
+              <img ng-if="!inUserProfileBeta" ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="lib-follower-image" itemprop="photo" alt="{{library.owner.firstName}} {{library.owner.lastName}}">
               <div class="lib-follower-name" itemprop="name">{{library.owner.firstName}} {{library.owner.lastName}}</div>
             </li>
 
             <li class="lib-follower" ng-repeat="follower in followerList" itemscope itemtype="http://data-vocabulary.org/Person">
               <div class="lib-follower-user" ng-if="follower.id">
-                <img ng-src="{{follower.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="lib-follower-image" itemprop="photo" alt="{{follower.firstName}} {{follower.lastName}}">
+                <a ng-if="inUserProfileBeta" href="{{follower.profileUrl}}" itemprop="url">
+                  <img ng-src="{{follower.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="lib-follower-image" itemprop="photo" alt="{{follower.firstName}} {{follower.lastName}}">
+                </a>
+                <img ng-if="!inUserProfileBeta" ng-src="{{follower.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="lib-follower-image" itemprop="photo" alt="{{follower.firstName}} {{follower.lastName}}">
                 <div class="lib-follower-name" itemprop="name">{{follower.firstName}} {{follower.lastName}}</div>
               </div>
             </li>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryFollowers.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryFollowers.tpl.html
@@ -17,7 +17,7 @@
 
           <ul class="lib-followers-list" itemscope itemtype="http://data-vocabulary.org/Person">
             <li class="lib-follower lib-owner">
-              <a ng-if="inUserProfileBeta" href="{{library.owner.profileUrl}}" itemprop="url">
+              <a ng-if="inUserProfileBeta" href="{{library.owner.profileUrl}}" ng-click="close()" itemprop="url">
                 <img ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="lib-follower-image" itemprop="photo" alt="{{library.owner.firstName}} {{library.owner.lastName}}">
               </a>
               <img ng-if="!inUserProfileBeta" ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="lib-follower-image" itemprop="photo" alt="{{library.owner.firstName}} {{library.owner.lastName}}">
@@ -26,7 +26,7 @@
 
             <li class="lib-follower" ng-repeat="follower in followerList" itemscope itemtype="http://data-vocabulary.org/Person">
               <div class="lib-follower-user" ng-if="follower.id">
-                <a ng-if="inUserProfileBeta" href="{{follower.profileUrl}}" itemprop="url">
+                <a ng-if="inUserProfileBeta" href="{{follower.profileUrl}}" ng-click="close()" itemprop="url">
                   <img ng-src="{{follower.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="lib-follower-image" itemprop="photo" alt="{{follower.firstName}} {{follower.lastName}}">
                 </a>
                 <img ng-if="!inUserProfileBeta" ng-src="{{follower.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="lib-follower-image" itemprop="photo" alt="{{follower.firstName}} {{follower.lastName}}">

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .directive('kfLibraryMiniCard', [
-  '$rootScope', '$state', 'libraryService', 'profileService', 'friendService', 'modalService', '$location',
-  function ($rootScope, $state, libraryService, profileService, friendService, modalService, $location) {
+  '$rootScope', '$state', 'env', 'libraryService', 'profileService', 'friendService', 'modalService', 'userService', '$location',
+  function ($rootScope, $state, env, libraryService, profileService, friendService, modalService, userService, $location) {
     return {
       restrict: 'A',
       replace: true,
@@ -15,7 +15,9 @@ angular.module('kifi')
       templateUrl: 'libraries/libraryMiniCard.tpl.html',
       link: function (scope/*, element, attrs*/) {
         scope.library = _.cloneDeep(scope.refLibrary());
+        scope.library.owner.profileUrl = env.origin + '/' + scope.library.owner.username;
         scope.showMiniCard = true;
+        scope.inUserProfileBeta = userService.inUserProfileBeta();
 
 
         //

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.js
@@ -89,11 +89,14 @@ angular.module('kifi')
             _.assign(scope.library, data.library);
 
             scope.library.owner.image = friendService.getPictureUrlForUser(scope.library.owner);
+            scope.library.owner.profileUrl = userService.getProfileUrl(scope.library.owner.username);
             scope.library.access = data.membership;
             scope.library.isMine = scope.library.access === 'owner';
           })['catch'](function () {
             scope.showMiniCard = false;
           });
+        } else {
+          scope.library.owner.profileUrl = userService.getProfileUrl(scope.library.owner.username);
         }
       }
     };

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.js
@@ -15,7 +15,6 @@ angular.module('kifi')
       templateUrl: 'libraries/libraryMiniCard.tpl.html',
       link: function (scope/*, element, attrs*/) {
         scope.library = _.cloneDeep(scope.refLibrary());
-        scope.library.owner.profileUrl = env.origin + '/' + scope.library.owner.username;
         scope.showMiniCard = true;
         scope.inUserProfileBeta = userService.inUserProfileBeta();
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .directive('kfLibraryMiniCard', [
-  '$rootScope', '$state', 'env', 'libraryService', 'profileService', 'friendService', 'modalService', 'userService', '$location',
-  function ($rootScope, $state, env, libraryService, profileService, friendService, modalService, userService, $location) {
+  '$rootScope', '$state', 'libraryService', 'profileService', 'friendService', 'modalService', 'userService', '$location',
+  function ($rootScope, $state, libraryService, profileService, friendService, modalService, userService, $location) {
     return {
       restrict: 'A',
       replace: true,

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.tpl.html
@@ -8,7 +8,10 @@
 
   <div class="kf-library-mini-card-header">
     <div class="kf-library-mini-card-curator">
-      <img class="kf-library-mini-card-curator-img" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}">
+      <a ng-if="inUserProfileBeta" href="{{library.owner.profileUrl}}">
+        <img class="kf-library-mini-card-curator-img" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}">
+      </a>
+      <img ng-if="!inUserProfileBeta" class="kf-library-mini-card-curator-img" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}">
       <span class="kf-library-mini-card-curator-info">
         <div class="kf-library-mini-card-curator-heading">Library Curator:</div>
         <div class="kf-library-mini-card-curator-name">{{library.owner.firstName}} {{library.owner.lastName}}</div>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
@@ -2,8 +2,9 @@
 
 angular.module('kifi')
 
-.directive('kfLibraryShareSearch', ['$document', '$timeout', 'friendService', 'keyIndices', 'libraryService', 'socialService', 'util',
-  function ($document, $timeout, friendService, keyIndices, libraryService, socialService, util) {
+.directive('kfLibraryShareSearch', [
+  '$document', '$timeout', 'env', 'friendService', 'keyIndices', 'libraryService', 'socialService', 'userService', 'util',
+  function ($document, $timeout, env, friendService, keyIndices, libraryService, socialService, userService, util) {
     return {
       restrict: 'A',
       replace: true,
@@ -39,6 +40,15 @@ angular.module('kifi')
         //
         // Internal methods.
         //
+        function init() {
+          if (scope.manageLibInvite) {
+            searchInput.attr('placeholder', 'Type a name or email');
+            showMenu();
+          }
+
+          scope.inUserProfileBeta = userService.inUserProfileBeta();
+        }
+
         function showMenu() {
           resultIndex = -1;
           clearSelection();
@@ -147,6 +157,8 @@ angular.module('kifi')
                 if (result.email) {
                   result.emailFormatted = emphasizeMatchedPrefix(result.email, opt_query);
                 }
+
+                result.userProfileUrl = result.username ? env.origin + '/' + result.username : null;
               });
 
               if (opt_query) {
@@ -381,13 +393,7 @@ angular.module('kifi')
         };
 
 
-        //
-        // On link.
-        //
-        if (scope.manageLibInvite) {
-          searchInput.attr('placeholder', 'Type a name or email');
-          showMenu();
-        }
+        init();
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .directive('kfLibraryShareSearch', [
-  '$document', '$timeout', 'env', 'friendService', 'keyIndices', 'libraryService', 'socialService', 'userService', 'util',
-  function ($document, $timeout, env, friendService, keyIndices, libraryService, socialService, userService, util) {
+  '$document', '$timeout', 'friendService', 'keyIndices', 'libraryService', 'socialService', 'userService', 'util',
+  function ($document, $timeout, friendService, keyIndices, libraryService, socialService, userService, util) {
     return {
       restrict: 'A',
       replace: true,
@@ -158,7 +158,7 @@ angular.module('kifi')
                   result.emailFormatted = emphasizeMatchedPrefix(result.email, opt_query);
                 }
 
-                result.userProfileUrl = result.username ? env.origin + '/' + result.username : null;
+                result.userProfileUrl = userService.getProfileUrl(result.username);
               });
 
               if (opt_query) {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryShareSearch.tpl.html
@@ -15,7 +15,10 @@
         <li class="library-share-contact" ng-repeat="result in results" ng-mouseenter="onResultHover(result)" ng-mouseleave="onResultUnhover(result)" ng-class="{'library-share-selected': result.selected, 'library-share-actionable': result.actionable}">
           <!-- Kifi friend -->
           <div ng-if="result.id" class="library-share-contact-container library-share-kifi">
-            <img ng-src="{{result.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="library-share-contact-image">
+            <a ng-if="inUserProfileBeta" href="{{result.userProfileUrl}}">
+              <img ng-src="{{result.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="library-share-contact-image">
+            </a>
+            <img ng-if="!inUserProfileBeta" ng-src="{{result.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="library-share-contact-image">
             <div class="library-share-contact-summary">
               <div class="library-share-contact-name" ng-bind-html="result.name"></div>
               <div class="library-share-contact-network">Kifi user</div>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -3,9 +3,9 @@
 angular.module('kifi')
 
 .directive('kfManageLibrary', [
-  '$location', '$window', '$rootScope', 'env', 'friendService', 'libraryService', 'modalService',
+  '$location', '$window', '$rootScope', 'friendService', 'libraryService', 'modalService',
   'profileService', 'userService', 'util',
-  function ($location, $window, $rootScope, env, friendService, libraryService, modalService,
+  function ($location, $window, $rootScope, friendService, libraryService, modalService,
     profileService, userService, util) {
     return {
       restrict: 'A',
@@ -171,7 +171,7 @@ angular.module('kifi')
                 scope.offset += 1;
                 members.forEach(function (member) {
                   member.picUrl = friendService.getPictureUrlForUser(member);
-                  member.profileUrl = env.origin + '/' + member.username;
+                  member.profileUrl = userService.getProfileUrl(member.username);
                   member.status = setMemberStatus(member);
                 });
                 scope.memberList.push.apply(scope.memberList, members);

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -3,8 +3,10 @@
 angular.module('kifi')
 
 .directive('kfManageLibrary', [
-  '$location', '$window', '$rootScope', 'friendService', 'libraryService', 'modalService', 'profileService', 'util',
-  function ($location, $window, $rootScope, friendService, libraryService, modalService, profileService, util) {
+  '$location', '$window', '$rootScope', 'env', 'friendService', 'libraryService', 'modalService',
+  'profileService', 'userService', 'util',
+  function ($location, $window, $rootScope, env, friendService, libraryService, modalService,
+    profileService, userService, util) {
     return {
       restrict: 'A',
       require: '^kfModal',
@@ -169,6 +171,7 @@ angular.module('kifi')
                 scope.offset += 1;
                 members.forEach(function (member) {
                   member.picUrl = friendService.getPictureUrlForUser(member);
+                  member.profileUrl = env.origin + '/' + member.username;
                   member.status = setMemberStatus(member);
                 });
                 scope.memberList.push.apply(scope.memberList, members);
@@ -234,6 +237,8 @@ angular.module('kifi')
         }
 
         nameInput.focus();
+
+        scope.inUserProfileBeta = userService.inUserProfileBeta();
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
@@ -63,14 +63,20 @@
         <div class="manage-lib-members-content" smart-scroll scroll-distance="memberScrollDistance" scroll-disabled="isMemberScrollDisabled()" scroll-next="memberScrollNext()">
           <ul class="manage-lib-members">
             <li class="manage-lib-member manage-lib-owner">
-              <img ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="manage-lib-member-image">
+              <a ng-if="inUserProfileBeta" href="{{library.owner.profileUrl}}" ng-click="close()">
+                <img ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="manage-lib-member-image">
+              </a>
+              <img ng-if="!inUserProfileBeta" ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="manage-lib-member-image">
               <div class="manage-lib-member-name">{{library.owner.firstName}} {{library.owner.lastName}}</div>
               <div class="manage-lib-member-status">Owner</div>
             </li>
 
             <li class="manage-lib-member" ng-repeat="member in memberList">
               <div class="manage-lib-member-user" ng-if="member.id">
-                <img ng-src="{{member.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="manage-lib-member-image">
+                <a ng-if="inUserProfileBeta" href="{{member.profileUrl}}" ng-click="close()">
+                  <img ng-src="{{member.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="manage-lib-member-image">
+                </a>
+                <img ng-if="!inUserProfileBeta" ng-src="{{member.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" class="manage-lib-member-image">
                 <div class="manage-lib-member-name">{{member.firstName}} {{member.lastName}}</div>
               </div>
               <div class="manage-lib-member-email" ng-if="member.email">

--- a/kifi-backend/modules/shoebox/angular/src/recos/recoDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recoDecoratorService.js
@@ -25,6 +25,7 @@ angular.module('kifi')
         rawReco.itemInfo.libraries.forEach( function (lib) {
           lib.keeperPic = friendService.getPictureUrlForUser(lib.owner);
           lib.keeperProfileUrl = userService.getProfileUrl(lib.owner.username);
+          lib.keeperName = lib.owner.firstName + ' ' + lib.owner.lastName;
           libUsers[lib.owner.id] = true;
         });
         //don't show a face only if there is also a library for that person

--- a/kifi-backend/modules/shoebox/angular/src/recos/recoDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recoDecoratorService.js
@@ -2,8 +2,8 @@
 
 angular.module('kifi')
 
-.factory('recoDecoratorService', ['keepDecoratorService', 'util', 'friendService',
-  function (keepDecoratorService, util, friendService) {
+.factory('recoDecoratorService', ['keepDecoratorService', 'util', 'friendService', 'userService',
+  function (keepDecoratorService, util, friendService, userService) {
 
     function Recommendation(rawReco, type) {
       this.recoData = {
@@ -24,6 +24,7 @@ angular.module('kifi')
         var libUsers = {};
         rawReco.itemInfo.libraries.forEach( function (lib) {
           lib.keeperPic = friendService.getPictureUrlForUser(lib.owner);
+          lib.keeperProfileUrl = userService.getProfileUrl(lib.owner.username);
           libUsers[lib.owner.id] = true;
         });
         //don't show a face only if there is also a library for that person

--- a/kifi-backend/modules/shoebox/angular/src/route.js
+++ b/kifi-backend/modules/shoebox/angular/src/route.js
@@ -124,7 +124,7 @@ angular.module('kifi')
 
       // ↓↓↓↓↓ Important: This needs to be last! ↓↓↓↓↓
       .state('library', {
-        url: '/:username/:librarySlug',
+        url: '/:username/:librarySlug?upb',
         templateUrl: 'libraries/library.tpl.html',
         controller: 'LibraryCtrl',
         data: {

--- a/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
@@ -51,6 +51,7 @@ angular.module('kifi')
           user = users[idxUser];
           lib.keeperPic = friendService.getPictureUrlForUser(user);
           lib.keeperProfileUrl = userService.getProfileUrl(user.username);
+          lib.keeperName = user.firstName + ' ' + user.lastName;
           lib.owner = user;
           decompressedLibraries.push(lib);
           libUsers[idxUser] = true;
@@ -58,6 +59,7 @@ angular.module('kifi')
           user = profileService.me;
           lib.keeperPic = friendService.getPictureUrlForUser(user);
           lib.keeperProfileUrl = userService.getProfileUrl(user.username);
+          lib.keeperName = user.firstName + ' ' + user.lastName;
           lib.owner = user;
 
           if (!libraryService.isSystemLibrary(lib.id)) {

--- a/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
@@ -3,9 +3,10 @@
 angular.module('kifi')
 
 .factory('searchActionService', [
-  '$analytics', '$http', '$location', '$log', '$q', 'routeService', 'profileService', 'friendService', 'libraryService',
-
-  function ($analytics, $http, $location, $log, $q, routeService, profileService, friendService, libraryService) {
+  '$analytics', '$http', '$location', '$log', '$q',
+  'routeService', 'profileService', 'friendService', 'libraryService', 'userService',
+  function ($analytics, $http, $location, $log, $q,
+    routeService, profileService, friendService, libraryService, userService) {
     //
     // Internal helper methods.
     //
@@ -49,12 +50,14 @@ angular.module('kifi')
         if (idxUser !== -1) {
           user = users[idxUser];
           lib.keeperPic = friendService.getPictureUrlForUser(user);
+          lib.keeperProfileUrl = userService.getProfileUrl(user.username);
           lib.owner = user;
           decompressedLibraries.push(lib);
           libUsers[idxUser] = true;
         } else if (userLoggedIn) {
           user = profileService.me;
           lib.keeperPic = friendService.getPictureUrlForUser(user);
+          lib.keeperProfileUrl = userService.getProfileUrl(user.username);
           lib.owner = user;
 
           if (!libraryService.isSystemLibrary(lib.id)) {

--- a/kifi-backend/modules/shoebox/angular/test/unit/friends/seeMutualFriends.spec.js
+++ b/kifi-backend/modules/shoebox/angular/test/unit/friends/seeMutualFriends.spec.js
@@ -52,7 +52,9 @@ describe('kifi.friends.seeMutualFriends', function () {
         savedPymk: testSavedPerson
       };
 
-      elem = $compile('<div kf-see-mutual-friends></div>')(scope);
+      // Compile also the parent 'kfModal' directive because 'kfSeeMutualFriends' depends
+      // on the controller in 'kfModal'.
+      elem = $compile('<div kf-modal><div kf-see-mutual-friends></div></div>')(scope);
 
       spyOn(friendService, 'getPictureUrlForUser').andReturn('fake picture URL');
     });


### PR DESCRIPTION
@andrewconner cc @eishay 

This pull:
- Adds links to user profile pages for all user images throughout the Angular app (I think I've covered them all, but please let me know if you see anything missing)
- Displays these links only if a logged-in user is in the `profiles_beta` experiment or if a logged-out user has a query parameter of `upb`
- Adds microdata (`itemprop="url"`) to the newly links for all user images that are displayed on logged-out pages.
