### PR TITLE
Fix race condition where a user can join a library they already joined.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -265,22 +265,24 @@ angular.module('kifi')
       },
 
       joinLibrary: function (libraryId) {
-        var alreadyJoined = _.some(librarySummaries, { id: libraryId });
+        return this.fetchLibrarySummaries(true).then(function () {
+          var alreadyJoined = _.some(librarySummaries, { id: libraryId });
 
-        if (!alreadyJoined) {
-          return $http.post(routeService.joinLibrary(libraryId)).then(function (response) {
-            var library = response.data;
-            augmentLibrarySummary(library);
+          if (!alreadyJoined) {
+            return $http.post(routeService.joinLibrary(libraryId)).then(function (response) {
+              var library = response.data;
+              augmentLibrarySummary(library);
 
-            librarySummaries.push(library);
-            _.remove(invitedSummaries, { id: libraryId });
+              librarySummaries.push(library);
+              _.remove(invitedSummaries, { id: libraryId });
 
-            $rootScope.$emit('librarySummariesChanged');
-            $rootScope.$emit('libraryUpdated', library);
-          });
-        }
+              $rootScope.$emit('librarySummariesChanged');
+              $rootScope.$emit('libraryUpdated', library);
+            });
+          }
 
-        return $q.when('already_joined');
+          return $q.when('already_joined');
+        });
       },
 
       leaveLibrary: function (libraryId) {


### PR DESCRIPTION
@eishay @andrewconner 

Fixes an issue where a user can join a library he has already joined, resulting in the user's photo showing up twice in the followers list. For example, the user goes to kifi.com and sees that he is invited to library A. Then, from an email he joins library A. Then, he goes back to the website and without refreshing, joins library A. At this point his picture shows up twice.

On the front end, the detection of whether a user is already following a library is based on whether that library is contained in a list of library summaries that are pulled from the server when the page is loaded. This fix reloads the library summaries anew whenever a user wishes to join a library.

Note that the backend endpoint does not give any indication as to whether a user is trying to follow a library that he is already following. An alternative solution is to have the backend indicate this instead of having the front end reload the summaries. 
