### PR TITLE
scraper cleanups/logging

### DIFF
--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/fetcher/HttpFetcherModule.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/fetcher/HttpFetcherModule.scala
@@ -21,7 +21,6 @@ case class ProdHttpFetcherModule() extends HttpFetcherModule {
       userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17",
       connectionTimeout = scheduler.scrapePendingFrequency * 1000,
       soTimeOut = scheduler.scrapePendingFrequency * 1000,
-      trustBlindly = true,
       schedulingProperties,
       scraperConfig.httpConfig
     )
@@ -39,7 +38,6 @@ case class DevHttpFetcherModule() extends HttpFetcherModule {
       userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17",
       connectionTimeout = 5 * 1000,
       soTimeOut = 5 * 1000,
-      trustBlindly = true,
       schedulingProperties,
       scraperConfig.httpConfig
     )


### PR DESCRIPTION
trying to figure out why the scraper would not scrape //www.autotrader.com/research/article/car-reviews/217339/2014-honda-odyssey-vs-2014-toyota-sienna-which-is-better.jsp (curl from that machine works). the error message from the server is "status:HTTP/1.1 403 Forbidden"
