### PR TITLE
There's some bad sessions out there that contains the id in the format o...

### DIFF
--- a/kifi-backend/modules/common/test/com/keepit/common/controller/UserActionsTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/controller/UserActionsTest.scala
@@ -1,6 +1,7 @@
 package com.keepit.common.controller
 
 import com.google.inject.util.Providers
+import com.keepit.common.controller.KifiSession.HttpSessionWrapper
 import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.model.{ User, Username }
 import com.keepit.test.CommonTestInjector
@@ -28,6 +29,13 @@ class UserActionsTest extends Specification with CommonTestInjector {
 
   class FakeController(val actionsHelper: UserActionsHelper) extends Controller with UserActions {
     val userActionsHelper = actionsHelper
+  }
+
+  "HttpSessionWrapper" should {
+    "parse ids" in {
+      new HttpSessionWrapper(null).parseUserId("123") === Id[User](123)
+      new HttpSessionWrapper(null).parseUserId("Some(123)") === Id[User](123)
+    }
   }
 
   "UserActions" should {


### PR DESCRIPTION
...f "Some(1234)" instead of just "1234". This is an attempt to let these ids through in spite of the bad formatting. The following is the full error log

getUserIdOpt] Caught exception java.lang.NumberFormatException: For input string: "Some(287)" while retrieving userId from request; cause=null. Path: /m/1/eliza/notifications, headers: Map(Accept-Encoding -> ArrayBuffer(gzip), Connection -> ArrayBuffer(close), Content-Type -> ArrayBuffer(application/json), Cookie -> ArrayBuffer(KIFI_SECURESOCIAL=efbdd71a-cf01-4d1c-bcb3-9b6359dec5ba; KIFI_SESSION=dcfe9917978d25b2c70da6ad9e4f1c0046326bdb-fortytwo_user_id=Some%28287%29&kcid=organic-na; AWSELB=2179FD5506F133FFB722C0720618E71A07C25FCDC2D8EB62F31A0E81402C52994E3E1525C64E55A3CF12803CA8CE94DFAB0528971D6D8E7524E00E8793016A2BE8DBBF9099;), Host -> ArrayBuffer(eliza.kifi.com, eliza.kifi.com), User-Agent -> ArrayBuffer(Dalvik/1.6.0 (Linux; U; Android 4.4.2; SM-P600 Build/KOT49H)), X-Forwarded-For -> ArrayBuffer(10.197.75.155), X-Real-IP -> ArrayBuffer(10.197.75.155), X-Scheme -> ArrayBuffer(http)) java.lang.NumberFormatException: For input string: "Some(287)"
  Cause: [No Cause]

Total Errors since start: 2
Total Errors since last alert: 1
Server: b07
Server started at: 2014-12-29T22:07:29.763Z
Full Details

2014-12-30T14:41:30.665Z: [b97eb40b-28aa-4d59-851f-2f58bb642dbf]
error message [[getUserIdOpt] Caught exception java.lang.NumberFormatException: For input string: "Some(287)" while retrieving userId from request; cause=null. Path: /m/1/eliza/notifications, headers: Map(Accept-Encoding -> ArrayBuffer(gzip), Connection -> ArrayBuffer(close), Content-Type -> ArrayBuffer(application/json), Cookie -> ArrayBuffer(KIFI_SECURESOCIAL=efbdd71a-cf01-4d1c-bcb3-9b6359dec5ba; KIFI_SESSION=dcfe9917978d25b2c70da6ad9e4f1c0046326bdb-fortytwo_user_id=Some%28287%29&kcid=organic-na; AWSELB=2179FD5506F133FFB722C0720618E71A07C25FCDC2D8EB62F31A0E81402C52994E3E1525C64E55A3CF12803CA8CE94DFAB0528971D6D8E7524E00E8793016A2BE8DBBF9099;), Host -> ArrayBuffer(eliza.kifi.com, eliza.kifi.com), User-Agent -> ArrayBuffer(Dalvik/1.6.0 (Linux; U; Android 4.4.2; SM-P600 Build/KOT49H)), X-Forwarded-For -> ArrayBuffer(10.197.75.155), X-Real-IP -> ArrayBuffer(10.197.75.155), X-Scheme -> ArrayBuffer(http))]
Exception stack trace:
Cause:
java.lang.NumberFormatException: For input string: "Some(287)"
java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
java.lang.Long.parseLong(Long.java:441)
java.lang.Long.parseLong(Long.java:483)
scala.collection.immutable.StringLike$class.toLong(StringLike.scala:230)
scala.collection.immutable.StringOps.toLong(StringOps.scala:31)
com.keepit.common.controller.KifiSession$HttpSessionWrapper[a].apply(UserActions.scala:301)
com.keepit.common.controller.KifiSession$HttpSessionWrapper[a].apply(UserActions.scala:301)
scala.Option.map(Option.scala:145)
