### PR TITLE
Add empty state to own libraries on user profiles; fix flash of empty state.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
@@ -145,7 +145,7 @@ angular.module('kifi')
     var loading = false;
 
     $scope.libraryType = $state.current.data.libraryType;
-    $scope.libraries = [];
+    $scope.libraries = null;
 
     var deregister$stateChangeSuccess = $rootScope.$on('$stateChangeSuccess', function (event, toState) {
       if (/^userProfile\.libraries\./.test(toState.name)) {
@@ -167,7 +167,7 @@ angular.module('kifi')
           hasMoreLibraries = data[filter].length === fetchPageSize;
 
           var owner = filter === 'own' ? _.extend({username: username}, $scope.profile) : null;
-          $scope.libraries = $scope.libraries.concat(data[filter].map(augmentLibrary.bind(null, owner)));
+          $scope.libraries = ($scope.libraries || []).concat(data[filter].map(augmentLibrary.bind(null, owner)));
 
           fetchPageNumber++;
           loading = false;
@@ -180,7 +180,7 @@ angular.module('kifi')
     };
 
     function resetFetchState() {
-      $scope.libraries = [];
+      $scope.libraries = null;
       fetchPageNumber = 0;
       hasMoreLibraries = true;
       loading = false;

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibrariesList.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibrariesList.tpl.html
@@ -31,6 +31,7 @@
     </div>
   </div>
   <div class="kf-upl-empty" ng-if="libraries && libraries.length === 0">
+    <span ng-if="libraryType == 'own'">{{viewingOwnProfile ? 'You have' : profile.firstName + ' has'}} not created any publicly viewable libraries.</span>
     <span ng-if="libraryType == 'following'">{{viewingOwnProfile ? 'You are' : profile.firstName + ' is'}} not following any libraries.</span>
     <span ng-if="libraryType == 'invited'">{{viewingOwnProfile ? 'You have' : profile.firstName + ' has'}} no pending invitations to follow a library.</span>
   </div>


### PR DESCRIPTION
@2is10 

A previous change I made causes a "flash" of empty state on "following" and "invited" libraries; this fixes that.

Also, add empty state language to "own" libraries, when the user is viewing the profile page of a user who has not created any publicly viewable libraries.
