### PR TITLE
Do not submit feedback for recommended libraries.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.js
@@ -42,7 +42,9 @@ angular.module('kifi')
     };
 
     $scope.trash = function (reco) {
-      recoActionService.trash(reco.recoKeep);
+      if (reco.recoData && reco.recoData.kind === 'keep') {
+        recoActionService.trash(reco.recoKeep);
+      }
 
       var trashedRecoIndex = _.findIndex($scope.recos, reco);
       var trashedReco = $scope.recos.splice(trashedRecoIndex, 1)[0];
@@ -185,7 +187,9 @@ angular.module('kifi')
     };
 
     $scope.submitImprovement = function (reco) {
-      recoActionService.improve(reco.recoKeep, $scope.improvement.type);
+      if (reco.recoData && reco.recoData.kind === 'keep') {
+        recoActionService.improve(reco.recoKeep, $scope.improvement.type);
+      }
     };
 
     $scope.trackRecoKeep = function (recoKeep) {
@@ -243,12 +247,18 @@ angular.module('kifi')
 
         scope.upVote = function (reco) {
           hideMenu();
-          recoActionService.vote(reco.recoKeep, true);
+
+          if (reco.recoData && reco.recoData.kind === 'keep') {
+            recoActionService.vote(reco.recoKeep, true);
+          }
         };
 
         scope.downVote = function (reco) {
           hideMenu();
-          recoActionService.vote(reco.recoKeep, false);
+
+          if (reco.recoData && reco.recoData.kind === 'keep') {
+            recoActionService.vote(reco.recoKeep, false);
+          }
         };
 
         scope.showModal = function () {


### PR DESCRIPTION
@andrewconner @stkem @joshm1 cc @eishay 

All the feedback we submit for recommendations are based on the assumption that the recommendation is a keep. AFAIK there is no backend support for feedback for recommended libraries. This pull fixes a bug where we get a JavaScript error when we try to submit feedback for a recommended library by first checking that the recommendation is a keep.

Feedback for recommended libraries perhaps coming in the future? :)
