### PR TITLE
Implement front-end for per-library listing visibility.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -64,6 +64,7 @@ angular.module('kifi')
         //       on the library object.
         if (res.data && res.data.library) {
           res.data.library.access = res.data.membership;
+          res.data.library.listed = res.data.listed;
           return res.data.library;
         }
         return null;

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -57,12 +57,15 @@ angular.module('kifi')
           }
 
           submitting = true;
+          console.log('listed: ' + scope.library.listed);
+
           var saveData = {
             id: scope.library.id,
             name: scope.library.name,
             description: scope.library.description,
             slug: scope.library.slug,
-            visibility: scope.library.visibility
+            visibility: scope.library.visibility,
+            listed: scope.library.listed
           };
           var promise;
           if (scope.modifyingExistingLibrary && scope.library.id) {
@@ -231,7 +234,8 @@ angular.module('kifi')
             'slug': '',
 
             // By default, the create library form selects the "published" visibility for a new library.
-            'visibility': 'published'
+            'visibility': 'published',
+            'listed': true
           };
           scope.modalTitle = 'Create a library';
         }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -57,7 +57,6 @@ angular.module('kifi')
           }
 
           submitting = true;
-          console.log('listed: ' + scope.library.listed);
 
           var saveData = {
             id: scope.library.id,

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
@@ -155,9 +155,50 @@
     vertical-align: top
 
   .manage-lib-visibility-description-content
+    height: 52px
     font-size: 15px
     line-height: 18px
     overflow: auto
+
+  .manage-lib-listed-visibility
+    color: #9b9b9b
+    text-align: center
+
+    input[type="checkbox"]
+      display: none;
+
+    input[type="checkbox"] + label span
+      position: relative
+      display: inline-block
+      margin: -5px 5px 0 0
+      border-radius: 3px
+      width: 15px
+      height: 15px
+      background-color: #3b99fa
+      vertical-align: middle
+      cursor: pointer
+
+    input[type="checkbox"]:checked + label span
+      &::before
+      &::after
+        content: ' '
+        position: absolute;
+        border-radius: 2px
+        width: 2px;
+        background: #fff
+        font-size: 0
+
+      &::before
+        left: 60%
+        top: 2px
+        bottom: 2px
+        transform: translate(-1px) rotate(45deg)
+
+      &::after
+        left: 30%
+        top: 6px
+        bottom: 4px
+        transform: translate(-1px) rotate(-45deg)
 
   .manage-lib-choice-card
     display: inline-block

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
@@ -172,8 +172,8 @@
       display: inline-block
       margin: -5px 5px 0 0
       border-radius: 3px
-      width: 15px
-      height: 15px
+      width: 12px
+      height: 12px
       background-color: #3b99fa
       vertical-align: middle
       cursor: pointer
@@ -192,12 +192,12 @@
         left: 60%
         top: 2px
         bottom: 2px
-        transform: translate(-1px) rotate(45deg)
+        transform: translate(-1px) rotate(35deg)
 
       &::after
-        left: 30%
-        top: 6px
-        bottom: 4px
+        left: 35%
+        top: 5px
+        bottom: 2px
         transform: translate(-1px) rotate(-45deg)
 
   .manage-lib-choice-card

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
@@ -155,12 +155,12 @@
     vertical-align: top
 
   .manage-lib-visibility-description-content
-    height: 52px
     font-size: 15px
     line-height: 18px
     overflow: auto
 
   .manage-lib-listed-visibility
+    margin-top: 8px
     color: #9b9b9b
     text-align: center
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
@@ -47,6 +47,14 @@
                 <div ng-switch="library.visibility" class="manage-lib-visibility-description">
                   <div ng-switch-default class="manage-lib-visibility-description-content">It's public. Everyone in the world can see and follow this public library.</div>
                   <div ng-switch-when="secret" class="manage-lib-visibility-description-content">Make it private. Only you and the people you invite to your private library can see its content.</div>
+
+                  <div class="manage-lib-listed-visibility">
+                    <input type="checkbox" id="listed-visibility-checkbox" ng-model="library.listed">
+                    <label for="listed-visibility-checkbox">
+                      <span></span>
+                      Show this Library on my Public Profile
+                    </label>
+                  </div>
                 </div>
 
                 <div ng-switch="library.visibility" class="manage-lib-choice-card">

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
@@ -45,16 +45,17 @@
                 </div>
 
                 <div ng-switch="library.visibility" class="manage-lib-visibility-description">
-                  <div ng-switch-default class="manage-lib-visibility-description-content">It's public. Everyone in the world can see and follow this public library.</div>
-                  <div ng-switch-when="secret" class="manage-lib-visibility-description-content">Make it private. Only you and the people you invite to your private library can see its content.</div>
-
-                  <div class="manage-lib-listed-visibility">
-                    <input type="checkbox" id="listed-visibility-checkbox" ng-model="library.listed">
-                    <label for="listed-visibility-checkbox">
-                      <span></span>
-                      Show this Library on my Public Profile
-                    </label>
+                  <div ng-switch-default class="manage-lib-visibility-description-content">It's public. Everyone in the world can see and follow this public library.
+                    <div class="manage-lib-listed-visibility">
+                      <input type="checkbox" id="listed-visibility-checkbox" ng-model="library.listed">
+                      <label for="listed-visibility-checkbox">
+                        <span></span>
+                        Show this Library on my Public Profile
+                      </label>
+                    </div>
                   </div>
+
+                  <div ng-switch-when="secret" class="manage-lib-visibility-description-content">Make it private. Only you and the people you invite to your private library can see its content.</div>
                 </div>
 
                 <div ng-switch="library.visibility" class="manage-lib-choice-card">

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
@@ -46,7 +46,7 @@
 
                 <div ng-switch="library.visibility" class="manage-lib-visibility-description">
                   <div ng-switch-default class="manage-lib-visibility-description-content">It's public. Everyone in the world can see and follow this public library.
-                    <div class="manage-lib-listed-visibility">
+                    <div ng-if="inUserProfileBeta" class="manage-lib-listed-visibility">
                       <input type="checkbox" id="listed-visibility-checkbox" ng-model="library.listed">
                       <label for="listed-visibility-checkbox">
                         <span></span>


### PR DESCRIPTION
@ahsu1230 

Aaron, this is the front-end work that I've done to allow the user to adjust a library's listing visibility.

A couple of issues:
- Adjusting the `listed` field does not seem to affect the libraries being displayed. That is, after making a library `listed` be `false`, I still see that library on my public user profile page. :(
- Also, when we create/modify a library with a visibility of `secret`, then `listed` should be `false` regardless of the what `listed` value is being sent in the post payload. That is, `secret` should override `listed`. However, I still see `listed` being `true` in the response when I send over a `secret` visibility for the library.

Screenshot of the UI pasted.
![Uploading Screen Shot 2014-12-30 at 5.37.33 PM.png . . .]()
