### PR TITLE
non-linear scoring for library recommendations

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/LibraryRecommendationRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/LibraryRecommendationRepo.scala
@@ -23,6 +23,7 @@ trait LibraryRecommendationRepo extends DbRepo[LibraryRecommendation] {
   def getLibraryIdsForUser(userId: Id[User])(implicit session: RSession): Set[Id[Library]]
   def getUsersWithRecommendations()(implicit session: RSession): Set[Id[User]]
   def updateLibraryRecommendationFeedback(userId: Id[User], libraryId: Id[Library], feedback: LibraryRecommendationFeedback)(implicit session: RWSession): Boolean
+  def incrementDeliveredCount(recoId: Id[LibraryRecommendation])(implicit session: RWSession): Unit
 }
 
 @Singleton
@@ -127,6 +128,11 @@ class LibraryRecommendationRepoImpl @Inject() (
       else true
 
     clickedResult && trashedResult && followedResult
+  }
+
+  def incrementDeliveredCount(recoId: Id[LibraryRecommendation])(implicit session: RWSession): Unit = {
+    import StaticQuery.interpolation
+    sqlu"UPDATE library_recommendation SET delivered=delivered+1, updated_at=$currentDateTime WHERE id=$recoId".first()
   }
 
   def deleteCache(model: LibraryRecommendation)(implicit session: RSession): Unit = {}


### PR DESCRIPTION
@eishay @joshm1 @stkem @yingjieMiao 

Things done
- added non-linear scoring for library recommendations.
- added incrementDeliveredCount to LibraryRecommendationRepo and actually increment the counts when recommendations are delivered.

Things missing
- diversification is not in place because topic information is not available for each library reco, but I added the default selection strategy so that we can added the diversified selection strategy easily.
- analytics is missing
- feedback for library recos has not endpoint in shoebox.
