### PR TITLE
secret library visibility overrides listed setting

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -433,7 +433,7 @@ class LibraryCommander @Inject() (
           case Some(lib) if lib.slug == validSlug =>
             Left(LibraryFail(BAD_REQUEST, "library_slug_exists"))
           case None =>
-            val newListed = libAddReq.listed.getOrElse(true)
+            val newListed = (libAddReq.visibility == LibraryVisibility.PUBLISHED) && libAddReq.listed.getOrElse(true)
             val library = db.readWrite { implicit s =>
               libraryAliasRepo.reclaim(ownerId, validSlug)
               libraryRepo.getOpt(ownerId, validSlug) match {
@@ -518,7 +518,7 @@ class LibraryCommander @Inject() (
         val newDescription = modifyReq.description.orElse(targetLib.description)
         val newVisibility = modifyReq.visibility.getOrElse(targetLib.visibility)
         val newColor = modifyReq.color.orElse(targetLib.color)
-        val newListed = modifyReq.listed.getOrElse(targetMembership.listed)
+        val newListed = (newVisibility == LibraryVisibility.PUBLISHED) && modifyReq.listed.getOrElse(targetMembership.listed)
         future {
           val keeps = db.readOnlyMaster { implicit s =>
             keepRepo.getByLibrary(libraryId, 0, Int.MaxValue, None)
@@ -536,7 +536,9 @@ class LibraryCommander @Inject() (
             libraryAliasRepo.reclaim(ownerId, newSlug)
             libraryAliasRepo.alias(ownerId, targetLib.slug, targetLib.id.get)
           }
-          libraryMembershipRepo.save(targetMembership.copy(listed = newListed))
+          if (targetMembership.listed != newListed) {
+            libraryMembershipRepo.save(targetMembership.copy(listed = newListed))
+          }
           libraryRepo.save(targetLib.copy(name = newName, slug = newSlug, visibility = newVisibility, description = newDescription, color = newColor, state = LibraryStates.ACTIVE))
         }
       }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -345,8 +345,8 @@ GET     /site/users/:userStr/libraries/:slug    @com.keepit.controllers.website.
 POST    /site/users/:userStr/libraries/:slug/auth    @com.keepit.controllers.website.LibraryController.authToLibrary(userStr: String, slug: String, authToken: Option[String])
 
 # Profile pages
-GET     /site/user/:username/profile @com.keepit.controllers.website.UserController.profile(username)
-GET     /site/user/:username/libraries @com.keepit.controllers.website.LibraryController.getProfileLibraries(username: Username, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")
+GET     /site/user/:username/profile    @com.keepit.controllers.website.UserController.profile(username)
+GET     /site/user/:username/libraries  @com.keepit.controllers.website.LibraryController.getProfileLibraries(username: Username, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")
 
 GET     /site/libraries             @com.keepit.controllers.website.LibraryController.getLibrarySummariesByUser()
 POST    /site/libraries/add         @com.keepit.controllers.website.LibraryController.addLibrary()

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -90,7 +90,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
         (parseLibrary \ "visibility").as[LibraryVisibility].value === "secret"
         (parseLibrary \ "keeps").as[Seq[JsValue]].size === 0
         (parseLibrary \ "owner").as[BasicUser].externalId === user.externalId
-        (contentAsJson(result1) \ "listed").asOpt[Boolean].get === true
+        (contentAsJson(result1) \ "listed").asOpt[Boolean].get === false
 
         val inputJson2 = Json.obj(
           "name" -> "Invalid Library - Slug",
@@ -144,8 +144,8 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
         val (user1, lib1, lib2) = db.readWrite { implicit s =>
           val user = userRepo.save(User(firstName = "Aaron", lastName = "Hsu", createdAt = t1, username = Username("ahsu"), normalizedUsername = "test"))
           val library1 = libraryRepo.save(Library(name = "Library1", ownerId = user.id.get, slug = LibrarySlug("lib1"), memberCount = 1, visibility = LibraryVisibility.SECRET))
-
           libraryMembershipRepo.save(LibraryMembership(libraryId = library1.id.get, userId = user.id.get, access = LibraryAccess.OWNER))
+
           val library2 = libraryRepo.save(Library(name = "Library2", ownerId = user.id.get, slug = LibrarySlug("lib2"), memberCount = 1, visibility = LibraryVisibility.SECRET))
           libraryMembershipRepo.save(LibraryMembership(libraryId = library2.id.get, userId = user.id.get, access = LibraryAccess.OWNER))
           (user, library1, library2)
@@ -163,7 +163,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
         (contentAsJson(result1) \ "library" \ "name").as[String] === "LibraryA"
 
-        val inputJson2 = Json.obj("slug" -> "libA", "description" -> "asdf", "visibility" -> LibraryVisibility.PUBLISHED.value)
+        val inputJson2 = Json.obj("slug" -> "libA", "description" -> "asdf", "visibility" -> LibraryVisibility.PUBLISHED, "listed" -> true)
         val request2 = FakeRequest("POST", testPath).withBody(inputJson2)
         val result2 = libraryController.modifyLibrary(pubId)(request2)
         status(result2) must equalTo(OK)


### PR DESCRIPTION
If a library's visibility is `SECRET`, it should override the `listed` setting (become false) when stored in the database.

@andrewconner
cc: @yipingliao 
