### PR TITLE
not updating updated_at when incrementing delivered counts

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/LibraryRecommendationRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/LibraryRecommendationRepo.scala
@@ -132,6 +132,8 @@ class LibraryRecommendationRepoImpl @Inject() (
 
   def incrementDeliveredCount(recoId: Id[LibraryRecommendation])(implicit session: RWSession): Unit = {
     import StaticQuery.interpolation
+
+    // do not change updated_at
     sqlu"UPDATE library_recommendation SET delivered=delivered+1 WHERE id=$recoId".first()
   }
 

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/LibraryRecommendationRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/LibraryRecommendationRepo.scala
@@ -132,7 +132,7 @@ class LibraryRecommendationRepoImpl @Inject() (
 
   def incrementDeliveredCount(recoId: Id[LibraryRecommendation])(implicit session: RWSession): Unit = {
     import StaticQuery.interpolation
-    sqlu"UPDATE library_recommendation SET delivered=delivered+1, updated_at=$currentDateTime WHERE id=$recoId".first()
+    sqlu"UPDATE library_recommendation SET delivered=delivered+1 WHERE id=$recoId".first()
   }
 
   def deleteCache(model: LibraryRecommendation)(implicit session: RSession): Unit = {}

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendationRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendationRepo.scala
@@ -127,13 +127,8 @@ class UriRecommendationRepoImpl @Inject() (
 
   def incrementDeliveredCount(recoId: Id[UriRecommendation], withlastPushedAt: Boolean = false)(implicit session: RWSession): Unit = {
     import StaticQuery.interpolation
-    if (withlastPushedAt) sqlu"UPDATE uri_recommendation SET delivered=delivered+1, last_pushed_at=$currentDateTime, updated_at=$currentDateTime WHERE id=$recoId".first()
+    if (withlastPushedAt) sqlu"UPDATE uri_recommendation SET delivered=delivered+1, last_pushed_at=$currentDateTime WHERE id=$recoId".first()
     else sqlu"UPDATE uri_recommendation SET delivered=delivered+1, updated_at=$currentDateTime WHERE id=$recoId".first()
-  }
-
-  def incrementDeliveredCount(recoId: Id[UriRecommendation])(implicit session: RWSession): Unit = {
-    import StaticQuery.interpolation
-    sqlu"UPDATE uri_recommendation SET delivered=delivered+1, updated_at=$currentDateTime WHERE id=$recoId".first()
   }
 
   def cleanupLowMasterScoreRecos(userId: Id[User], limitNumRecosForUser: Int, before: DateTime)(implicit session: RWSession): Unit = {

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendationRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendationRepo.scala
@@ -127,8 +127,10 @@ class UriRecommendationRepoImpl @Inject() (
 
   def incrementDeliveredCount(recoId: Id[UriRecommendation], withlastPushedAt: Boolean = false)(implicit session: RWSession): Unit = {
     import StaticQuery.interpolation
+
+    // do not change updated_at
     if (withlastPushedAt) sqlu"UPDATE uri_recommendation SET delivered=delivered+1, last_pushed_at=$currentDateTime WHERE id=$recoId".first()
-    else sqlu"UPDATE uri_recommendation SET delivered=delivered+1, updated_at=$currentDateTime WHERE id=$recoId".first()
+    else sqlu"UPDATE uri_recommendation SET delivered=delivered+1 WHERE id=$recoId".first()
   }
 
   def cleanupLowMasterScoreRecos(userId: Id[User], limitNumRecosForUser: Int, before: DateTime)(implicit session: RWSession): Unit = {


### PR DESCRIPTION
@stkem @yingjieMiao @joshm1 

I think we shouldn't update the `updated_at` columns when incrementing the `delivered` column, otherwise the clean up process are not able to pick up delivered recommendations.
