### PR TITLE
creating component iterator lazily

### DIFF
--- a/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraphReader.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraphReader.scala
@@ -44,7 +44,7 @@ trait SimpleLocalEdgeReader extends LocalEdgeReader {
   def data: EdgeDataReader = edge._3
   def kind: EdgeType = component._3
   def moveToNextComponent(): Boolean = {
-    if (components == null) throw new UninitializedReaderException(s"$this is not initialized over a valid vertex")
+    if (components == null) components = getComponentIterator()
     if (components.hasNext) {
       currentComponent = components.next()
       edges = null
@@ -63,7 +63,7 @@ trait SimpleLocalEdgeReader extends LocalEdgeReader {
     }
   }
   def reset(): Unit = {
-    components = getComponentIterator()
+    components = null
     edges = null
     currentComponent = null
     currentEdge = null


### PR DESCRIPTION
@leogrim @yingjieMiao 

A component iterator of IncomingEdgeReader is not used in wandering. We can save memory by opening the iterator lazily.
