### PR TITLE
refactored how library deliveries are tracked and updated

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -407,6 +407,7 @@ object Curator extends Service {
     def refreshUserRecos(userId: Id[User]) = ServiceRoute(POST, "/internal/curator/refreshUserRecos", Param("userId", userId))
     def topLibraryRecos(userId: Id[User], limit: Option[Int]) = ServiceRoute(POST, "/internal/curator/topLibraryRecos", Param("userId", userId), Param("limit", limit))
     def refreshLibraryRecos(userId: Id[User], await: Boolean) = ServiceRoute(POST, "/internal/curator/refreshLibraryRecos", Param("userId", userId), Param("await", await))
+    def notifyLibraryRecosDelivered(userId: Id[User]) = ServiceRoute(POST, "/internal/curator/notifyLibraryRecosDelivered", Param("userId", userId))
   }
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/curator/CuratorServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/curator/CuratorServiceClient.scala
@@ -24,8 +24,9 @@ trait CuratorServiceClient extends ServiceClient {
   def updateLibraryRecommendationFeedback(userId: Id[User], libraryId: Id[Library], feedback: LibraryRecommendationFeedback): Future[Boolean]
   def triggerEmailToUser(code: String, userId: Id[User]): Future[String]
   def refreshUserRecos(userId: Id[User]): Future[Unit]
-  def topLibraryRecos(userId: Id[User], limit: Option[Int] = None, source: RecommendationSource, subSource: RecommendationSubSource): Future[Seq[LibraryRecoInfo]]
+  def topLibraryRecos(userId: Id[User], limit: Option[Int] = None): Future[Seq[LibraryRecoInfo]]
   def refreshLibraryRecos(userId: Id[User], await: Boolean = false, selectionParams: Option[LibraryRecoSelectionParams] = None): Future[Unit]
+  def notifyLibraryRecosDelivered(userId: Id[User], libraryIds: Set[Id[Library]], source: RecommendationSource, subSource: RecommendationSubSource): Future[Unit]
 }
 
 class CuratorServiceClientImpl(
@@ -87,18 +88,21 @@ class CuratorServiceClientImpl(
     callLeader(Curator.internal.refreshUserRecos(userId), callTimeouts = longTimeout).map { x => }
   }
 
-  def topLibraryRecos(userId: Id[User], limit: Option[Int] = None, source: RecommendationSource, subSource: RecommendationSubSource): Future[Seq[LibraryRecoInfo]] = {
-    val payload = Json.obj(
-      "source" -> source,
-      "subSource" -> subSource
-    )
-    call(Curator.internal.topLibraryRecos(userId, limit), body = payload).map { response =>
-      response.json.as[Seq[LibraryRecoInfo]]
-    }
+  def topLibraryRecos(userId: Id[User], limit: Option[Int] = None): Future[Seq[LibraryRecoInfo]] = {
+    call(Curator.internal.topLibraryRecos(userId, limit)).map { response => response.json.as[Seq[LibraryRecoInfo]] }
   }
 
   def refreshLibraryRecos(userId: Id[User], await: Boolean = false, selectionParams: Option[LibraryRecoSelectionParams] = None) = {
     val payload = Json.toJson(selectionParams)
     call(Curator.internal.refreshLibraryRecos(userId, await), body = payload).map { _ => Unit }
+  }
+
+  def notifyLibraryRecosDelivered(userId: Id[User], libraryIds: Set[Id[Library]], source: RecommendationSource, subSource: RecommendationSubSource) = {
+    val payload = Json.obj(
+      "libraryIds" -> libraryIds,
+      "source" -> source,
+      "subSource" -> subSource
+    )
+    call(Curator.internal.notifyLibraryRecosDelivered(userId), body = payload).map { _ => Unit }
   }
 }

--- a/kifi-backend/modules/common/test/com/keepit/curator/FakeCuratorServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/curator/FakeCuratorServiceClientImpl.scala
@@ -41,10 +41,14 @@ class FakeCuratorServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
 
   def refreshUserRecos(userId: Id[User]): Future[Unit] = { Future.successful() }
 
-  def topLibraryRecos(userId: Id[User], limit: Option[Int] = None, source: RecommendationSource, subSource: RecommendationSubSource): Future[Seq[LibraryRecoInfo]] =
+  def topLibraryRecos(userId: Id[User], limit: Option[Int] = None): Future[Seq[LibraryRecoInfo]] =
     Future.successful(topLibraryRecosExpectations(userId))
 
   def refreshLibraryRecos(userId: Id[User], await: Boolean = false, selectionParams: Option[LibraryRecoSelectionParams] = None): Future[Unit] = {
+    Future.successful()
+  }
+
+  def notifyLibraryRecosDelivered(userId: Id[User], libraryIds: Set[Id[Library]], source: RecommendationSource, subSource: RecommendationSubSource): Future[Unit] = {
     Future.successful()
   }
 

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/LibraryRecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/LibraryRecommendationGenerationCommander.scala
@@ -37,21 +37,33 @@ class LibraryRecommendationGenerationCommander @Inject() (
     experimentCommander.getUsersByExperiment(ExperimentType.CURATOR_LIBRARY_RECOS).
       map(users => users.map(_.id.get).toSeq)
 
-  def getTopRecommendations(userId: Id[User], howManyMax: Int, source: RecommendationSource, subSource: RecommendationSubSource,
-    recoSortStrategy: LibraryRecoSelectionStrategy, scoringStrategy: LibraryRecoScoringStrategy): Seq[LibraryRecoInfo] = {
+  def getLibraryRecommendations(userId: Id[User], libraryIds: Set[Id[Library]]): Seq[LibraryRecommendation] = {
+    db.readOnlyReplica { implicit s => libraryRecRepo.getByLibraryIdsAndUserId(libraryIds, userId) }
+  }
+
+  def trackDeliveredRecommendations(userId: Id[User], libraryIds: Set[Id[Library]], source: RecommendationSource, subSource: RecommendationSubSource): Future[Unit] = {
+    val recos = getLibraryRecommendations(userId, libraryIds)
+
+    if (recos.size != libraryIds.size) {
+      airbrake.notify(s"[trackDeliveredRecommendations] unexpected # of library recommendations; userId=$userId expected=${libraryIds.size} actual=${recos.size} libIds=$libraryIds")
+    }
+
+    if (source != RecommendationSource.Admin) SafeFuture {
+      analytics.trackDeliveredItems(recos, Some(source), Some(subSource))
+
+      // TODO this can be optimized to only 1 update query but slick doesn't include support for WHERE id IN (...) SQL interpolation
+      recos.map { reco => db.readWrite { implicit rw => libraryRecRepo.incrementDeliveredCount(reco.id.get) } }
+    }
+    else Future.successful(Unit)
+  }
+
+  def getTopRecommendations(userId: Id[User], howManyMax: Int, recoSortStrategy: LibraryRecoSelectionStrategy, scoringStrategy: LibraryRecoScoringStrategy): Seq[LibraryRecoInfo] = {
     def scoreReco(reco: LibraryRecommendation) =
       LibraryRecoScore(scoringStrategy.scoreItem(reco.masterScore, reco.allScores, reco.delivered, reco.clicked, None, false, 0f), reco)
 
     val recos = db.readOnlyReplica { implicit session =>
       val recosByTopScore = libraryRecRepo.getRecommendableByTopMasterScore(userId, 1000) map scoreReco
       recoSortStrategy.sort(recosByTopScore) take howManyMax
-    }
-
-    if (source != RecommendationSource.Admin) SafeFuture {
-      db.readWrite { implicit session =>
-        recos.map { recoScore => libraryRecRepo.incrementDeliveredCount(recoScore.reco.id.get) }
-        analytics.trackDeliveredItems(recos.map(_.reco), Some(source), Some(subSource))
-      }
     }
 
     recos.map { case LibraryRecoScore(s, r) => LibraryRecommendation.toLibraryRecoInfo(r) }

--- a/kifi-backend/modules/curator/app/com/keepit/curator/controllers/internal/CuratorController.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/controllers/internal/CuratorController.scala
@@ -120,8 +120,6 @@ class CuratorController @Inject() (
 
   def topLibraryRecos(userId: Id[User], limit: Int) = Action.async(parse.tolerantJson) { request =>
     log.info(s"topLibraryRecos called userId=$userId limit=$limit")
-    val source = (request.body \ "source").as[RecommendationSource]
-    val subSource = (request.body \ "subSource").as[RecommendationSubSource]
 
     userExperimentCommander.getExperimentsByUser(userId) map { experiments =>
       val sortStrategy = topScoreLibraryRecoStrategy
@@ -129,7 +127,7 @@ class CuratorController @Inject() (
         if (experiments.contains(ExperimentType.CURATOR_NONLINEAR_SCORING)) nonlinearLibraryRecoScoringStrategy
         else defaultLibraryRecoScoringStrategy
 
-      val libRecoInfos = libraryRecoGenCommander.getTopRecommendations(userId, limit, source, subSource, sortStrategy, scoringStrategy)
+      val libRecoInfos = libraryRecoGenCommander.getTopRecommendations(userId, limit, sortStrategy, scoringStrategy)
       log.info(s"topLibraryRecos returning userId=$userId resultCount=${libRecoInfos.size}")
       Ok(Json.toJson(libRecoInfos))
     }
@@ -140,6 +138,24 @@ class CuratorController @Inject() (
     log.info(s"refreshLibraryRecos called userId=$userId await=$await selectionParams=$selectionParams")
     val precomputeF = libraryRecoGenCommander.precomputeRecommendationsForUser(userId, selectionParams)
     (if (await) precomputeF else Future.successful()) map { _ => Ok }
+  }
+
+  def notifyLibraryRecosDelivered(userId: Id[User]) = Action(parse.tolerantJson) { request =>
+    log.info(s"[notifyLibraryRecosDelivered] called userId=$userId")
+    val libIds = (request.body \ "libraryIds").as[Set[Id[Library]]]
+    val source = (request.body \ "source").asOpt[RecommendationSource]
+    val subSource = (request.body \ "subSource").asOpt[RecommendationSubSource]
+
+    if (source.isEmpty || subSource.isEmpty) {
+      airbrake.notify("[notifyLibraryRecosDelivered] missing source or subSource payload")
+      log.warn("[notifyLibraryRecosDelivered] missing source or subSource payload: " + Json.stringify(request.body))
+    }
+
+    libraryRecoGenCommander.trackDeliveredRecommendations(userId, libIds,
+      source getOrElse RecommendationSource.Unknown,
+      subSource getOrElse RecommendationSubSource.Unknown)
+
+    NoContent
   }
 
   private def scheduleToSendDigestEmail(userId: Id[User]) = {

--- a/kifi-backend/modules/curator/conf/curatorService.routes
+++ b/kifi-backend/modules/curator/conf/curatorService.routes
@@ -20,3 +20,5 @@ POST   /internal/curator/refreshUserRecos @com.keepit.curator.controllers.intern
 
 POST   /internal/curator/topLibraryRecos  @com.keepit.curator.controllers.internal.CuratorController.topLibraryRecos(userId: Id[User], limit: Int ?= 100)
 POST   /internal/curator/refreshLibraryRecos  @com.keepit.curator.controllers.internal.CuratorController.refreshLibraryRecos(userId: Id[User], await: Boolean ?= false)
+
+POST   /internal/curator/notifyLibraryRecosDelivered  @com.keepit.curator.controllers.internal.CuratorController.notifyLibraryRecosDelivered(userId: Id[User])

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryRecommendationsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryRecommendationsController.scala
@@ -28,7 +28,7 @@ class AdminLibraryRecommendationsController @Inject() (
   def view() = AdminUserAction.async { implicit request =>
     val userId = request.request.getQueryString("userId")
       .filter(_.nonEmpty) map (s => Id[User](s.toInt)) getOrElse request.userId
-    val recosF = curator.topLibraryRecos(userId, Some(100), RecommendationSource.Admin, RecommendationSubSource.Unknown) map { libRecos =>
+    val recosF = curator.topLibraryRecos(userId, Some(100)) map { libRecos =>
       val libIds = libRecos.map(_.libraryId)
       val libInfos = (libIds zip libCommander.getLibrarySummaries(libIds)).toMap
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/RecommendationsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/RecommendationsCommander.scala
@@ -1,5 +1,6 @@
 package com.keepit.commanders
 
+import com.keepit.common.akka.SafeFuture
 import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.model._
 import com.keepit.common.crypto.{ PublicIdConfiguration, PublicId }
@@ -231,7 +232,7 @@ class RecommendationsCommander @Inject() (
 
   def topPublicLibraryRecos(userId: Id[User], limit: Int, source: RecommendationSource, subSource: RecommendationSubSource): Future[Seq[FullLibRecoInfo]] = {
     // get extra recos from curator incase we filter out some below
-    curator.topLibraryRecos(userId, Some(limit * 4), source, subSource) flatMap { libInfos =>
+    curator.topLibraryRecos(userId, Some(limit * 4)) flatMap { libInfos =>
       val libIds = libInfos.map(_.libraryId).toSet
       val libraries = db.readOnlyReplica { implicit s =>
         libRepo.getLibraries(libIds).toSeq.filter(_._2.visibility == LibraryVisibility.PUBLISHED)
@@ -243,6 +244,13 @@ class RecommendationsCommander @Inject() (
       }.flatten
 
       val libToRecoInfoMap = libsAndRecoInfos.map { case (lib, info) => info.libraryId -> info }.toMap
+
+      // for analytics and delivery tracking
+      SafeFuture {
+        val deliveredIds = libraries.map(_._1).toSet
+        curator.notifyLibraryRecosDelivered(userId, deliveredIds, source, subSource)
+      }
+
       createFullLibraryInfos(userId, libraries map (_._2), id => Some(libToRecoInfoMap(id).explain))
     }
   }


### PR DESCRIPTION
@ymatsuda @yingjieMiao
cc @stkem 

I separated the 2 concerns of fetching library recommendations and analytics for delivering library recommendations.

This is to solve 2 problems:
1) curator doesn't actually know that the library recommendations it returns are delivered to the client
2) the logic required to fetch a library recommendations for a user doesn't care what the source/subSource are. Only Heimdal (mixpanel) care about these values (at this point).
