### PR TITLE
turn links on nav bar back to <a> tags

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.tpl.html
@@ -90,19 +90,10 @@
         </li>
 
         <li ng-show="sortingMenu.myLibsFirst" ng-repeat="library in myLibsToShow" class="kf-nav-lib-item" ng-class="{ active: isActive(library.url) }">
-          <div class="kf-nav-link-box" ng-click="redirectTo(library.url)">
-            <div class="library-icon-holder">
-              <div class="library-icon svg-private-library-icon" ng-if="library.visibility=='secret'"></div>
-              <div class="library-icon svg-public-library-icon" ng-if="library.visibility=='published'"></div>
-
-              <!-- TODO: remove this when discoverable libraries have been converted to public libraries in the db. -->
-              <div class="library-icon svg-yellow-card-with-globe" ng-if="library.visibility=='discoverable'"></div>
-
-              <a ng-if="inUserProfileBeta" href="{{getLibraryOwnerProfileUrl(library)}}">
-                <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
-              </a>
-              <img ng-if="!inUserProfileBeta" class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
-            </div>
+          <a class="kf-nav-link" ng-href="{{library.url}}">
+            <div class="library-icon svg-private-library-icon" ng-if="library.visibility=='secret'"></div>
+            <div class="library-icon svg-public-library-icon" ng-if="library.visibility=='published'"></div>
+            <div class="library-icon svg-yellow-card-with-globe" ng-if="library.visibility=='discoverable'"></div> <!-- TODO: remove when discoverable libraries are converted -->
             <div class="kf-nav-lib-info">
               <div kf-ellipsis full-text="library.name" max-num-lines=2 class="kf-nav-lib-name"></div>
               <div class="kf-nav-lib-text">
@@ -119,7 +110,7 @@
             <div kf-tooltip position="right" padding="3">
               <div kf-library-mini-card library="library"></div>
             </div>
-          </div>
+          </a>
         </li>
 
 
@@ -130,18 +121,10 @@
           <div class="kf-nav-lib-separator-title">LIBRARIES YOU FOLLOW</div>
         </li>
         <li ng-repeat="library in userLibsToShow" class="kf-nav-lib-item" ng-class="{ active: isActive(library.url) }">
-          <div class="kf-nav-link-box" ng-click="redirectTo(library.url)">
-            <div class="library-icon-holder">
-              <div class="library-icon svg-private-library-icon" ng-if="library.visibility=='secret'"></div>
-              <div class="library-icon svg-public-library-icon" ng-if="library.visibility=='published'"></div>
-
-              <!-- TODO: remove this when discoverable libraries have been converted to public libraries in the db. -->
-              <div class="library-icon svg-yellow-card-with-globe" ng-if="library.visibility=='discoverable'"></div>
-              <a ng-if="inUserProfileBeta" href="{{getLibraryOwnerProfileUrl(library)}}">
-                <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
-              </a>
-              <img ng-if="!inUserProfileBeta" class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
-            </div>
+          <a class="kf-nav-link" ng-href="{{library.url}}">
+            <div class="library-icon svg-private-library-icon" ng-if="library.visibility=='secret'"></div>
+            <div class="library-icon svg-public-library-icon" ng-if="library.visibility=='published'"></div>
+            <div class="library-icon svg-yellow-card-with-globe" ng-if="library.visibility=='discoverable'"></div> <!-- TODO: remove when discoverable libraries are converted -->
             <div class="kf-nav-lib-info">
               <div kf-ellipsis full-text="library.name" max-num-lines=2 class="kf-nav-lib-name"></div>
               <div class="kf-nav-lib-text">
@@ -158,20 +141,18 @@
             <div kf-tooltip position="right" padding="3">
               <div kf-library-mini-card library="library"></div>
             </div>
-          </div>
+          </a>
+          <a ng-if="inUserProfileBeta" href="{{getLibraryOwnerProfileUrl(library)}}">
+            <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+          </a>
+          <img ng-if="!inUserProfileBeta" class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
         </li>
         <li class="kf-nav-lib-separator" ng-if="invitedLibsToShow.length > 0">
           <div class="kf-nav-lib-separator-title">INVITATIONS</div>
         </li>
         <li ng-repeat="library in invitedLibsToShow" class="kf-nav-lib-item" ng-class="{ active: isActive(library.url) }">
-          <div class="kf-nav-link-box" ng-click="redirectTo(library.url)">
-            <div class="library-icon-holder">
-              <div class="library-icon svg-library-card"></div>
-              <a ng-if="inUserProfileBeta" href="{{getLibraryOwnerProfileUrl(library)}}">
-                <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
-              </a>
-              <img ng-if="!inUserProfileBeta" class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
-            </div>
+          <a class="kf-nav-link" ng-href="{{library.url}}">
+            <div class="library-icon svg-library-card"></div>
             <div class="kf-nav-lib-info">
               <div kf-ellipsis full-text="library.name" max-num-lines=2 class="kf-nav-lib-name"></div>
               <div class="kf-nav-lib-text">invitation pending</div>
@@ -179,8 +160,11 @@
             <div kf-tooltip position="right" padding="3">
               <div kf-library-mini-card library="library" invite="true"></div>
             </div>
-          </div>
-
+          </a>
+          <a ng-if="inUserProfileBeta" href="{{getLibraryOwnerProfileUrl(library)}}">
+            <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+          </a>
+          <img ng-if="!inUserProfileBeta" class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
         </li>
       </ul>
     </div>

--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.tpl.html
@@ -145,7 +145,9 @@
           <a ng-if="inUserProfileBeta" href="{{getLibraryOwnerProfileUrl(library)}}">
             <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
           </a>
-          <img ng-if="!inUserProfileBeta" class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+          <a ng-if="!inUserProfileBeta" href="{{library.url}}">
+            <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+          </a>
         </li>
         <li class="kf-nav-lib-separator" ng-if="invitedLibsToShow.length > 0">
           <div class="kf-nav-lib-separator-title">INVITATIONS</div>
@@ -164,7 +166,9 @@
           <a ng-if="inUserProfileBeta" href="{{getLibraryOwnerProfileUrl(library)}}">
             <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
           </a>
-          <img ng-if="!inUserProfileBeta" class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+          <a ng-if="!inUserProfileBeta" href="{{library.url}}">
+            <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+          </a>
         </li>
       </ul>
     </div>

--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/navLibs.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/navLibs.styl
@@ -8,11 +8,15 @@
   padding-top: 3px
 
 .kf-nav-lib-item
+  position: relative
   height: 45px
   width: 230px
   padding-top: 10px
   user-select: none
   font-size: 12px
+
+  & a
+    outline: 0
 
 .kf-create-new-library
   padding: 8px 0 0 0
@@ -42,7 +46,7 @@
 
 .kf-nav-lib-info
   display: inline-block
-  padding-left: 9px
+  padding-left: 12px
 
 .kf-nav-lib-name
   width: 165px
@@ -58,13 +62,6 @@
   font-weight: 200
   color: countGreyColor
 
-.library-icon-holder
-  width: 27px
-  height: 35px
-  display: inline-block
-  vertical-align: top
-  padding-right: 8px
-
 .library-icon
   width: 27px
   height: 35px
@@ -78,12 +75,11 @@
   display: inline-block
 
 .library-icon-owner-img
+  position: absolute
+  top: 32px
+  left: 12px
   width: 23px
   height: 23px
-  position: relative
-  vertical-align: middle
-  left: 13px
-  top: -15px
   z-index: 1
   border-radius: 100%
 


### PR DESCRIPTION
Thanks @yipingliao @2is10 for the suggestions

The links (for profile & library) on the left hand side nav bar are both <a> where the profile link (user image) is `position: absolute`
