### PR TITLE
Add `extra` field to Global notifications

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
@@ -32,7 +32,7 @@ trait ElizaServiceClient extends ServiceClient {
 
   def connectedClientCount: Future[Seq[Int]]
 
-  def sendGlobalNotification(userIds: Set[Id[User]], title: String, body: String, linkText: String, linkUrl: String, imageUrl: String, sticky: Boolean, category: NotificationCategory): Future[Id[MessageHandle]]
+  def sendGlobalNotification(userIds: Set[Id[User]], title: String, body: String, linkText: String, linkUrl: String, imageUrl: String, sticky: Boolean, category: NotificationCategory, extra: Option[JsObject] = None): Future[Id[MessageHandle]]
 
   def unsendNotification(messageHandle: Id[MessageHandle]): Unit
 
@@ -83,7 +83,7 @@ class ElizaServiceClientImpl @Inject() (
     }
   }
 
-  def sendGlobalNotification(userIds: Set[Id[User]], title: String, body: String, linkText: String, linkUrl: String, imageUrl: String, sticky: Boolean, category: NotificationCategory): Future[Id[MessageHandle]] = {
+  def sendGlobalNotification(userIds: Set[Id[User]], title: String, body: String, linkText: String, linkUrl: String, imageUrl: String, sticky: Boolean, category: NotificationCategory, extra: Option[JsObject]): Future[Id[MessageHandle]] = {
     implicit val userFormatter = Id.format[User]
     val payload = Json.obj(
       "userIds" -> userIds.toSeq,
@@ -93,7 +93,8 @@ class ElizaServiceClientImpl @Inject() (
       "linkUrl" -> linkUrl,
       "imageUrl" -> imageUrl,
       "sticky" -> sticky,
-      "category" -> category
+      "category" -> category,
+      "extra" -> extra
     )
     call(Eliza.internal.sendGlobalNotification, payload).map { response =>
       Id[MessageHandle](response.body.toLong)
@@ -171,7 +172,7 @@ class FakeElizaServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, schedul
     p.future
   }
 
-  def sendGlobalNotification(userIds: Set[Id[User]], title: String, body: String, linkText: String, linkUrl: String, imageUrl: String, sticky: Boolean, category: NotificationCategory): Future[Id[MessageHandle]] = {
+  def sendGlobalNotification(userIds: Set[Id[User]], title: String, body: String, linkText: String, linkUrl: String, imageUrl: String, sticky: Boolean, category: NotificationCategory, extra: Option[JsObject]): Future[Id[MessageHandle]] = {
     userIds.map { id =>
       inbox = (id, category, linkUrl, imageUrl) +: inbox
     }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
@@ -170,7 +170,7 @@ class NotificationCommander @Inject() (
   def sendToUser(userId: Id[User], data: JsArray): Unit =
     notificationRouter.sendToUser(userId, data)
 
-  def createGlobalNotification(userIds: Set[Id[User]], title: String, body: String, linkText: String, linkUrl: String, imageUrl: String, sticky: Boolean, category: NotificationCategory) = {
+  def createGlobalNotification(userIds: Set[Id[User]], title: String, body: String, linkText: String, linkUrl: String, imageUrl: String, sticky: Boolean, category: NotificationCategory, extra: Option[JsObject]) = {
     val (message, thread) = db.readWrite { implicit session =>
       val mtps = MessageThreadParticipants(userIds)
       val thread = threadRepo.save(MessageThread(
@@ -213,7 +213,8 @@ class NotificationCommander @Inject() (
             "linkText" -> linkText,
             "url" -> linkUrl,
             "isSticky" -> sticky,
-            "image" -> imageUrl
+            "image" -> imageUrl,
+            "extra" -> extra
           )
           notificationRouter.sendToUser(userId, Json.arr("notification", notifJson))
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/MessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/MessagingController.scala
@@ -61,8 +61,9 @@ class MessagingController @Inject() (
     val imageUrl: String = (data \ "imageUrl").as[String]
     val sticky: Boolean = (data \ "sticky").as[Boolean]
     val category: NotificationCategory = (data \ "category").as[NotificationCategory]
+    val extra = (data \ "extra").asOpt[JsObject]
 
-    Ok(notificationCommander.createGlobalNotification(userIds, title, body, linkText, linkUrl, imageUrl, sticky, category).id.toString)
+    Ok(notificationCommander.createGlobalNotification(userIds, title, body, linkText, linkUrl, imageUrl, sticky, category, extra).id.toString)
 
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -764,7 +764,8 @@ class LibraryCommander @Inject() (
       linkUrl = "https://www.kifi.com" + Library.formatLibraryPath(owner.username, lib.slug),
       imageUrl = s3ImageStore.avatarUrlByUser(follower),
       sticky = false,
-      category = NotificationCategory.User.LIBRARY_FOLLOWED
+      category = NotificationCategory.User.LIBRARY_FOLLOWED,
+      extra = Some(Json.obj("follower" -> BasicUser.fromUser(follower)))
     )
   }
 


### PR DESCRIPTION
This is for information useful to mobile clients who are not going to `linkUrl`. Immediately, this will enable tapping on new followers to go to their profile (and not the user's own library).

@stkem: Obviously the current API is driven 100% by the extension's needs. Perhaps we should re-evaluate a good intra-service API for notifications soon?

@mrbrown14 
