### PR TITLE
Add library count, mutual friend count to user search results

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -169,7 +169,6 @@ object Shoebox extends Service {
     def getLibraryMembershipsChanged(seqNum: SequenceNumber[LibraryMembership], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getLibraryMembershipsChanged", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def canViewLibrary() = ServiceRoute(POST, "/internal/shoebox/libraries/canView")
     def newKeepsInLibraryForEmail(userId: Id[User], max: Int) = ServiceRoute(GET, "/internal/shoebox/database/newKeepsInLibraryForEmail", Param("userId", userId), Param("max", max))
-    def getMutualFriends(user1Id: Id[User], user2Id: Id[User]) = ServiceRoute(GET, "/internal/shoebox/database/getMutualFriends", Param("user1Id", user1Id), Param("user2Id", user2Id))
     def getBasicKeeps(userId: Id[User]) = ServiceRoute(POST, "/internal/shoebox/database/getBasicKeeps", Param("userId", userId))
     def getBasicLibraryStatistics() = ServiceRoute(POST, "/internal/shoebox/database/getBasicLibraryStatistics")
   }

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -118,7 +118,6 @@ trait ShoeboxServiceClient extends ServiceClient {
   def getLibraryMembershipsChanged(seqNum: SequenceNumber[LibraryMembership], fetchSize: Int): Future[Seq[LibraryMembershipView]]
   def canViewLibrary(libraryId: Id[Library], userId: Option[Id[User]], authToken: Option[String], hashedPassPhrase: Option[HashedPassPhrase]): Future[Boolean]
   def newKeepsInLibraryForEmail(userId: Id[User], max: Int): Future[Seq[Keep]]
-  def getMutualFriends(user1Id: Id[User], user2Id: Id[User]): Future[Set[Id[User]]]
   def getBasicKeeps(userId: Id[User], uriIds: Set[Id[NormalizedURI]]): Future[Map[Id[NormalizedURI], Set[BasicKeep]]]
   def getBasicLibraryStatistics(libraryIds: Set[Id[Library]]): Future[Map[Id[Library], BasicLibraryStatistics]]
 }
@@ -739,9 +738,6 @@ class ShoeboxServiceClientImpl @Inject() (
   def newKeepsInLibraryForEmail(userId: Id[User], max: Int): Future[Seq[Keep]] = {
     call(Shoebox.internal.newKeepsInLibraryForEmail(userId, max)).map(_.json.as[Seq[Keep]])
   }
-
-  def getMutualFriends(user1Id: Id[User], user2Id: Id[User]) =
-    call(Shoebox.internal.getMutualFriends(user1Id, user2Id)).map(_.json.as[Set[Id[User]]])
 
   def getBasicKeeps(userId: Id[User], uriIds: Set[Id[NormalizedURI]]): Future[Map[Id[NormalizedURI], Set[BasicKeep]]] = {
     if (uriIds.isEmpty) Future.successful(Map.empty[Id[NormalizedURI], Set[BasicKeep]]) else {

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -752,8 +752,6 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, impli
   def newKeepsInLibraryForEmail(userId: Id[User], max: Int): Future[Seq[Keep]] =
     Future.successful(newKeepsInLibrariesExpectation(userId).take(max))
 
-  def getMutualFriends(user1Id: Id[User], user2Id: Id[User]) = Future.successful(Set.empty)
-
   def getBasicKeeps(userId: Id[User], uriIds: Set[Id[NormalizedURI]]): Future[Map[Id[NormalizedURI], Set[BasicKeep]]] = Future.successful {
     (allUserBookmarks(userId).map(allBookmarks(_)).groupBy(_.uriId) -- uriIds).mapValues(_.map { keep =>
       BasicKeep(

--- a/kifi-backend/modules/search/app/com/keepit/search/UriSearchCommander.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/UriSearchCommander.scala
@@ -232,7 +232,7 @@ class UriSearchCommanderImpl @Inject() (
       context,
       predefinedConfig,
       debug)
-    val friendIdsFuture = searchFactory.getFriendIdsFuture(userId)
+    val friendIdsFuture = searchFactory.getSearchFriends(userId)
 
     val result = monitoredAwait.result(future, 3 seconds, "getting result")
     val friendIds = monitoredAwait.result(friendIdsFuture, 3 seconds, "getting friend ids")

--- a/kifi-backend/modules/search/app/com/keepit/search/UriSearchCommander.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/UriSearchCommander.scala
@@ -370,7 +370,7 @@ class UriSearchCommanderImpl @Inject() (
 
     val searches = if (userId.id < 0 || (debugOption.debugFlags & DebugOption.AsNonUser.flag) != 0) {
       try {
-        searchFactory.getKifiNonUserSearch(localShards, query, firstLang, secondLang, maxHits, searchFilter, config)
+        searchFactory.getNonUserUriSearches(localShards, query, firstLang, secondLang, maxHits, searchFilter, config)
       } catch {
         case e: Exception =>
           log.error("unable to create KifiNonUserSearch", e)
@@ -378,7 +378,7 @@ class UriSearchCommanderImpl @Inject() (
       }
     } else {
       // logged in user
-      searchFactory.getKifiSearch(localShards, userId, query, firstLang, secondLang, maxHits, searchFilter, config)
+      searchFactory.getUriSearches(localShards, userId, query, firstLang, secondLang, maxHits, searchFilter, config)
     }
 
     Future.traverse(searches) { search =>
@@ -408,14 +408,14 @@ class UriSearchCommanderImpl @Inject() (
         findShard(uriId).flatMap { shard =>
           val searchOpt = if (userId.id < 0) {
             try {
-              searchFactory.getKifiNonUserSearch(Set(shard), query, firstLang, secondLang, 0, SearchFilter.default(), config).headOption
+              searchFactory.getNonUserUriSearches(Set(shard), query, firstLang, secondLang, 0, SearchFilter.default(), config).headOption
             } catch {
               case e: Exception =>
                 log.error("unable to create KifiNonUserSearch", e)
                 None
             }
           } else {
-            searchFactory.getKifiSearch(Set(shard), userId, query, firstLang, secondLang, 0, SearchFilter.default(), config).headOption
+            searchFactory.getUriSearches(Set(shard), userId, query, firstLang, secondLang, 0, SearchFilter.default(), config).headOption
           }
           searchOpt.map { search =>
             debug.map(search.debug(_))

--- a/kifi-backend/modules/search/app/com/keepit/search/augmentation/AugmentationCommander.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/augmentation/AugmentationCommander.scala
@@ -46,7 +46,7 @@ class AugmentationCommanderImpl @Inject() (
   def getAugmentedItems(itemAugmentationRequest: ItemAugmentationRequest): Future[Map[AugmentableItem, AugmentedItem]] = {
     val futureAugmentationResponse = augmentation(itemAugmentationRequest)
     val userId = itemAugmentationRequest.context.userId
-    val futureFriends = searchFactory.getFriendIdsFuture(userId).imap(_.map(Id[User](_)))
+    val futureFriends = searchFactory.getSearchFriends(userId).imap(_.map(Id[User](_)))
     val futureLibraries = searchFactory.getLibraryIdsFuture(userId, LibraryContext.None).imap(_._2.map(Id[Library](_)))
     for {
       augmentationResponse <- futureAugmentationResponse
@@ -92,7 +92,7 @@ class AugmentationCommanderImpl @Inject() (
         case (_, followedLibraries, _, _) => followedLibraries.map(Id[Library](_))
       }
 
-      val futureUserFilter = searchFactory.getFriendIdsFuture(context.userId).imap(_.map(Id[User](_)) + context.userId)
+      val futureUserFilter = searchFactory.getSearchFriends(context.userId).imap(_.map(Id[User](_)) + context.userId)
 
       for {
         libraryFilter <- futureLibraryFilter

--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/util/SearchControllerUtil.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/util/SearchControllerUtil.scala
@@ -148,7 +148,7 @@ trait SearchControllerUtil {
     for {
       libId <- libraryIds
       record <- LibraryIndexable.getRecord(librarySearcher, libId)
-      visibility <- LibraryIndexable.getVisibility(librarySearcher, libId)
+      visibility <- LibraryIndexable.getVisibility(librarySearcher, libId.id)
     } yield {
       libId -> (record, visibility)
     }

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/SearchFactory.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/SearchFactory.scala
@@ -46,7 +46,7 @@ class SearchFactory @Inject() (
   private[this] val libraryIdsReqConsolidator = new RequestConsolidator[Id[User], (Set[Long], Set[Long])](3 seconds)
   private[this] val configReqConsolidator = new RequestConsolidator[(Id[User]), (SearchConfig, Option[Id[SearchConfigExperiment]])](10 seconds)
 
-  def getKifiSearch(
+  def getUriSearches(
     shards: Set[Shard[NormalizedURI]],
     userId: Id[User],
     queryString: String,
@@ -147,7 +147,7 @@ class SearchFactory @Inject() (
     future.map { case (myOwnLibIds, memberLibIds) => (myOwnLibIds, memberLibIds, trustedPublishedLibIds, authorizedLibIds) }(immediate)
   }
 
-  def getKifiNonUserSearch(
+  def getNonUserUriSearches(
     shards: Set[Shard[NormalizedURI]],
     queryString: String,
     lang1: Lang,

--- a/kifi-backend/modules/search/app/com/keepit/search/index/graph/user/UserGraphsSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/graph/user/UserGraphsSearcher.scala
@@ -43,14 +43,6 @@ class UserGraphsSearcher(
     Future { new SearchFriendSearcher(searchFriendGraph.getSearcher).getUnfriended(userId) }
   }
 
-  def getConnectedUsers(): Set[Long] = {
-    Await.result(getConnectedUsersFuture(), 5 seconds)
-  }
-
-  def getUnfriended(): Set[Long] = {
-    Await.result(getUnfriendedFuture(), 5 seconds)
-  }
-
   def getSearchFriendsFuture(): Future[Set[Long]] = {
     (getUnfriendedFuture() zip getConnectedUsersFuture()).map {
       case (unfriends, friends) =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -486,11 +486,6 @@ class ShoeboxController @Inject() (
     Ok(Json.toJson(keeps))
   }
 
-  def getMutualFriends(user1Id: Id[User], user2Id: Id[User]) = Action { request =>
-    val mutualFriendIds = userConnectionsCommander.getMutualFriends(user1Id, user2Id)
-    Ok(Json.toJson(mutualFriendIds))
-  }
-
   def getBasicKeeps(userId: Id[User]) = Action(parse.tolerantJson) { request =>
     val uriIds = request.body.as[Set[Id[NormalizedURI]]]
     val keepDataByUriId = keepsCommander.getBasicKeeps(userId, uriIds)

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -818,7 +818,6 @@ GET     /internal/shoebox/database/socialUserInfosByUserId @com.keepit.controlle
 GET     /internal/shoebox/database/sessionViewByExternalId @com.keepit.controllers.internal.ShoeboxController.getSessionViewByExternalId(sessionId: UserSessionExternalId)
 GET     /internal/shoebox/database/searchFriends @com.keepit.controllers.internal.ShoeboxController.searchFriends(userId: Id[User])
 GET     /internal/shoebox/database/unfriends     @com.keepit.controllers.internal.ShoeboxController.getUnfriends(userId: Id[User])
-GET     /internal/shoebox/database/getMutualFriends   @com.keepit.controllers.internal.ShoeboxController.getMutualFriends(user1Id: Id[User], user2Id: Id[User])
 
 
 POST    /internal/shoebox/logEvent                    @com.keepit.controllers.ext.ExtEventController.logEvent()

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserControllerTest.scala
@@ -23,7 +23,7 @@ import com.keepit.common.mail.FakeMailModule
 import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.common.social._
 import com.keepit.common.store.FakeShoeboxStoreModule
-import com.keepit.controllers.website.{ routes, UserController }
+import com.keepit.controllers.website.UserController
 import com.keepit.cortex.FakeCortexServiceClientModule
 import com.keepit.curator.FakeCuratorServiceClientModule
 import com.keepit.model.KeepFactory._


### PR DESCRIPTION
@stkem @andrewconner 
Missing a user's keep count, I guess we need it for profiles anyway, it will be easy to piggy back on that when it's ready. It needs proper definition anyway:
- in terms of ownership: keeps a user made? keeps from the libraries a user owns? keeps from the libraries a user follows? 
- in terms of visibility: global published keep count vs personalized keep count depending on viewer's access?)
