### PR TITLE
better error message for urban airship

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/realtime/Device.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/realtime/Device.scala
@@ -25,7 +25,9 @@ case class Device(
 
 object DeviceStates extends States[Device]
 
-sealed abstract class DeviceType(val name: String)
+sealed abstract class DeviceType(val name: String) {
+  override def toString: String = name
+}
 
 object DeviceType {
   case object Android extends DeviceType("android")


### PR DESCRIPTION
the errors we had yesterday night where when we tried to get the status of a device so we'll know not to try to send messages to a "dead" device. they did not effect the actual push notifications. 
with better error messages we should get a better understanding of what's wrong.
