### PR TITLE
Fix library search clear bug.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/search/search.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/search.js
@@ -58,6 +58,10 @@ angular.module('kifi')
           return library.id;
         });
       } else {
+        if (!query) { // No query or blank query.
+          $state.go('home');
+        }
+
         libraryIdPromise = $q.when('');
         $rootScope.$emit('libraryUrl', {});
       }
@@ -65,9 +69,6 @@ angular.module('kifi')
       libraryIdPromise.then(function (libraryId) {
         library = libraryId;
 
-        if (!query) { // No query or blank query.
-          $location.path('/');
-        }
         lastResult = null;
         selectedCount = 0;
 


### PR DESCRIPTION
@andrewconner cc @ahsu1230 

Ugh, I found this ugly bug about an hour ago. When you clear the search input in a library search or delete all the text in a library search, the page redirects to home! This is the fix for it.
