### PR TITLE
[BE] assign a random library color to all user_created libraries

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -18,6 +18,8 @@ import scala.concurrent.duration.Duration
 import com.keepit.social.BasicUser
 import com.keepit.common.json
 
+import scala.util.Random
+
 case class Library(
     id: Option[Id[Library]] = None,
     createdAt: DateTime = currentDateTime,
@@ -254,4 +256,18 @@ object HexColor {
 
   val regex = "^#[0-9a-f]{6}$".r
   def apply(hex: String): HexColor = new HexColor(hex.toLowerCase)
+
+  val allColors = Seq(
+    HexColor("#C764A2"), // magenta (pink)
+    HexColor("#E35957"), // red
+    HexColor("#FF9430"), // orange (a bit darker)
+    HexColor("#2EC89A"), // indigo (light green)
+    HexColor("#3975BF"), // blue
+    HexColor("#955CB4"), // purple
+    HexColor("#FAB200")) // light orange (more yellow-ish)
+
+  def pickRandomLibraryColor(): HexColor = {
+    val rnd = new Random
+    allColors(rnd.nextInt(allColors.size))
+  }
 }

--- a/kifi-backend/modules/common/test/com/keepit/model/LibraryFactory.scala
+++ b/kifi-backend/modules/common/test/com/keepit/model/LibraryFactory.scala
@@ -28,6 +28,7 @@ object LibraryFactory {
     def withSlug(slug: String) = new PartialLibrary(library.copy(slug = LibrarySlug(slug)))
     def withColor(color: String): PartialLibrary = withColor(HexColor(color))
     def withColor(color: HexColor) = new PartialLibrary(library.copy(color = Some(color)))
+    def withKind(kind: LibraryKind) = new PartialLibrary(library.copy(kind = kind))
     def withState(state: State[Library]) = new PartialLibrary(library.copy(state = state))
     def secret() = new PartialLibrary(library.copy(visibility = SECRET))
     def published() = new PartialLibrary(library.copy(visibility = PUBLISHED))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -368,13 +368,14 @@ class LibraryCommander @Inject() (
           case Some(lib) if lib.slug == validSlug =>
             Left(LibraryFail(BAD_REQUEST, "library_slug_exists"))
           case None =>
+            val newColor = libAddReq.color.orElse(Some(HexColor.pickRandomLibraryColor))
             val newListed = libAddReq.listed.getOrElse(true)
             val library = db.readWrite { implicit s =>
               libraryAliasRepo.reclaim(ownerId, validSlug)
               libraryRepo.getOpt(ownerId, validSlug) match {
                 case None =>
                   val lib = libraryRepo.save(Library(ownerId = ownerId, name = libAddReq.name, description = libAddReq.description,
-                    visibility = libAddReq.visibility, slug = validSlug, color = libAddReq.color, kind = LibraryKind.USER_CREATED, memberCount = 1))
+                    visibility = libAddReq.visibility, slug = validSlug, color = newColor, kind = LibraryKind.USER_CREATED, memberCount = 1))
                   libraryMembershipRepo.save(LibraryMembership(libraryId = lib.id.get, userId = ownerId, access = LibraryAccess.OWNER, listed = newListed))
                   lib
                 case Some(lib) =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -48,28 +48,6 @@ class LibraryController @Inject() (
   implicit val config: PublicIdConfiguration)
     extends UserActions with LibraryAccessActions with ShoeboxServiceController with Logging {
 
-  def colorAllUserLibraries() = UserAction { request =>
-    val pageSize = 500
-    var c = 0
-    var paginator = Paginator(c, pageSize)
-    var libs = db.readOnlyMaster { implicit s =>
-      libraryRepo.pageByKind(LibraryKind.USER_CREATED, paginator)
-    }
-    while (libs.nonEmpty) {
-      db.readWriteBatch(libs) { (session, lib) =>
-        if (lib.color.isEmpty) {
-          libraryRepo.save(lib.copy(color = Some(HexColor.pickRandomLibraryColor)))(session)
-        }
-      }
-      c += 1
-      paginator = Paginator(c, pageSize)
-      libs = db.readOnlyMaster { implicit s =>
-        libraryRepo.pageByKind(LibraryKind.USER_CREATED, paginator)
-      }
-    }
-    NoContent
-  }
-
   def addLibrary() = UserAction.async(parse.tolerantJson) { request =>
     val addRequest = request.body.as[LibraryAddRequest]
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -38,6 +38,7 @@ trait LibraryRepo extends Repo[Library] with SeqNumberFunction[Library] {
   def pagePublished(page: Paginator)(implicit session: RSession): Seq[Library]
   def countPublished(implicit session: RSession): Int
   def filterPublishedByMemberCount(minCount: Int, limit: Int = 100)(implicit session: RSession): Seq[Library]
+  def pageByKind(kind: LibraryKind, page: Paginator)(implicit session: RSession): Seq[Library]
 }
 
 @Singleton
@@ -294,6 +295,12 @@ class LibraryRepoImpl @Inject() (
     (for {
       t <- rows if t.visibility === (LibraryVisibility.PUBLISHED: LibraryVisibility) && t.state === LibraryStates.ACTIVE && t.memberCount >= minCount
     } yield t).sortBy(_.updatedAt.desc).take(limit).list
+  }
+
+  def pageByKind(kind: LibraryKind, page: Paginator)(implicit session: RSession): Seq[Library] = {
+    (for {
+      t <- rows if t.kind === (LibraryKind.USER_CREATED: LibraryKind) && t.state === LibraryStates.ACTIVE
+    } yield t).drop(page.itemsToDrop).take(page.size).list
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -38,7 +38,7 @@ trait LibraryRepo extends Repo[Library] with SeqNumberFunction[Library] {
   def pagePublished(page: Paginator)(implicit session: RSession): Seq[Library]
   def countPublished(implicit session: RSession): Int
   def filterPublishedByMemberCount(minCount: Int, limit: Int = 100)(implicit session: RSession): Seq[Library]
-  def pageByKind(kind: LibraryKind, page: Paginator)(implicit session: RSession): Seq[Library]
+  def pageByKindAndNoColor(kind: LibraryKind, page: Paginator)(implicit session: RSession): Seq[Library]
 }
 
 @Singleton
@@ -297,9 +297,9 @@ class LibraryRepoImpl @Inject() (
     } yield t).sortBy(_.updatedAt.desc).take(limit).list
   }
 
-  def pageByKind(kind: LibraryKind, page: Paginator)(implicit session: RSession): Seq[Library] = {
+  def pageByKindAndNoColor(kind: LibraryKind, page: Paginator)(implicit session: RSession): Seq[Library] = {
     (for {
-      t <- rows if t.kind === (LibraryKind.USER_CREATED: LibraryKind) && t.state === LibraryStates.ACTIVE
+      t <- rows if t.kind === (LibraryKind.USER_CREATED: LibraryKind) && t.state === LibraryStates.ACTIVE && t.color.isNull
     } yield t).drop(page.itemsToDrop).take(page.size).list
   }
 }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -354,6 +354,8 @@ POST    /site/libraries/add         @com.keepit.controllers.website.LibraryContr
 POST    /site/libraries/copy        @com.keepit.controllers.website.LibraryController.copyKeeps()
 POST    /site/libraries/move        @com.keepit.controllers.website.LibraryController.moveKeeps()
 
+POST    /site/libraries/colorAll    @com.keepit.controllers.website.LibraryController.colorAllUserLibraries()
+
 GET     /site/libraries/marketing-suggestions   @com.keepit.controllers.website.LibraryController.marketingSiteSuggestedLibraries()
 
 GET     /site/libraries/:id         @com.keepit.controllers.website.LibraryController.getLibraryById(id: PublicId[Library], showPublishedLibraries: Boolean ?= false, is: Option[String] ?= None)

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -354,8 +354,6 @@ POST    /site/libraries/add         @com.keepit.controllers.website.LibraryContr
 POST    /site/libraries/copy        @com.keepit.controllers.website.LibraryController.copyKeeps()
 POST    /site/libraries/move        @com.keepit.controllers.website.LibraryController.moveKeeps()
 
-POST    /site/libraries/colorAll    @com.keepit.controllers.website.LibraryController.colorAllUserLibraries()
-
 GET     /site/libraries/marketing-suggestions   @com.keepit.controllers.website.LibraryController.marketingSiteSuggestedLibraries()
 
 GET     /site/libraries/:id         @com.keepit.controllers.website.LibraryController.getLibraryById(id: PublicId[Library], showPublishedLibraries: Boolean ?= false, is: Option[String] ?= None)
@@ -670,7 +668,7 @@ POST    /admin/libraries/:id/state/:state   @com.keepit.controllers.admin.AdminL
 POST    /admin/libraries/update             @com.keepit.controllers.admin.AdminLibraryController.updateLibraries
 POST    /admin/libraries/migrateKeepImages  @com.keepit.controllers.ext.ExtKeepImageController.loadPrevImageForKeep(startUserId: Long, endUserId: Long)
 POST    /admin/libraries/updateLibraryOwner @com.keepit.controllers.admin.AdminLibraryController.updateLibraryOwner(libraryId: Id[Library], fromUserId: Id[User], toUserId: Id[User])
-
+POST    /admin/libraries/colorAll           @com.keepit.controllers.admin.AdminLibraryController.colorAllUserLibraries()
 
 GET     /admin/typeahead                    @com.keepit.controllers.admin.TypeaheadAdminController.index
 GET     /admin/typeahead/userSearch         @com.keepit.controllers.admin.TypeaheadAdminController.userSearch(userId:Id[User], query:String ?= "")

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -251,6 +251,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           val allLibs = libraryRepo.all
           allLibs.length === 3
           allLibs.map(_.slug.value) === Seq("avengers", "murica", "science")
+          allLibs.map(_.color.nonEmpty === true)
         }
       }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -13,6 +13,7 @@ import com.keepit.common.social.FakeSocialGraphModule
 import com.keepit.common.store.{ FakeShoeboxStoreModule, ImageSize }
 import com.keepit.common.time._
 import com.keepit.common.time.internalTime.DateTimeJsonLongFormat
+import com.keepit.controllers.admin.AdminLibraryController
 import com.keepit.cortex.FakeCortexServiceClientModule
 import com.keepit.model.KeepFactory._
 import com.keepit.model.KeepFactoryHelper._
@@ -89,9 +90,9 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
           user1
         }
 
-        val libraryController = inject[LibraryController]
+        val libraryController = inject[AdminLibraryController]
         inject[FakeUserActionsHelper].setUser(user1)
-        val request1 = FakeRequest("POST", com.keepit.controllers.website.routes.LibraryController.colorAllUserLibraries().url)
+        val request1 = FakeRequest("POST", "/admin/libraries/colorAll")
         val result1 = libraryController.colorAllUserLibraries()(request1)
         status(result1) must equalTo(NO_CONTENT)
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -21,6 +21,7 @@ import com.keepit.model.LibraryFactory._
 import com.keepit.model.LibraryFactoryHelper._
 import com.keepit.model.LibraryMembershipFactory._
 import com.keepit.model.LibraryMembershipFactoryHelper._
+import com.keepit.model.UserConnectionFactory._
 import com.keepit.model.UserFactory._
 import com.keepit.model.UserFactoryHelper._
 import com.keepit.model._
@@ -64,6 +65,44 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
   }
 
   "LibraryController" should {
+
+    "assign colors to libraries" in {
+      withDb(modules: _*) { implicit injector =>
+        val user1 = db.readWrite { implicit s =>
+          val user1 = user().withName("George", "Washington").withUsername("GDubs").withPictureName("pic1").saved
+          val user2 = user().withName("Abe", "Lincoln").withUsername("abe").saved
+          val user3 = user().withName("Thomas", "Jefferson").withUsername("TJ").saved
+          val user4 = user().withName("John", "Adams").withUsername("jayjayadams").saved
+          val user5 = user().withName("Ben", "Franklin").withUsername("Benji").saved
+
+          library().withUser(user1.id.get).published().withColor(HexColor("#ffffff")).saved
+          libraries(3).map(_.withUser(user2.id.get).published()).saved
+          library().withUser(user3.id.get).secret().saved
+          libraries(2).map(_.withUser(user4.id.get).secret()).saved
+          library().withUser(user5.id.get).withKind(LibraryKind.SYSTEM_MAIN).discoverable().saved
+          library().withUser(user5.id.get).withKind(LibraryKind.SYSTEM_SECRET).secret().saved
+
+          libraryRepo.count === 9
+          val allLibs = libraryRepo.all
+          allLibs.count(_.color.isEmpty) === 8
+          allLibs.count(_.color.nonEmpty) === 1
+          user1
+        }
+
+        val libraryController = inject[LibraryController]
+        inject[FakeUserActionsHelper].setUser(user1)
+        val request1 = FakeRequest("POST", com.keepit.controllers.website.routes.LibraryController.colorAllUserLibraries().url)
+        val result1 = libraryController.colorAllUserLibraries()(request1)
+        status(result1) must equalTo(NO_CONTENT)
+
+        db.readOnlyMaster { implicit s =>
+          val allLibs = libraryRepo.all
+          allLibs.count(_.color.isEmpty) === 2
+          allLibs.count(_.color.nonEmpty) === 7
+        }
+
+      }
+    }
 
     "create library" in {
       withDb(modules: _*) { implicit injector =>


### PR DESCRIPTION
(1) when a library is created, assign a random library color (based on the current color selection on the front-end)
(2) there's also an endpoint to be called that will paginate between all `user_created` libraries and each saving a randomly chosen color. This endpoint will be removed later once all non-system libraries have a color

@andrewconner @2is10 
