### PR TITLE
Fix styling problems when delighted survey is present.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
@@ -16,9 +16,6 @@ invite-header-orange = #ff7c3c
   margin-bottom: 0
   background-color: #fff
 
-.delighted-visible ~ div .kf-library-card-header
-  margin-top: 10px
-
 .kf-logged-out .kf-main-library-keeps
   width: nonUserAppMaxWidth
   margin: 0 auto

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.styl
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.styl
@@ -142,7 +142,7 @@
   content: '';
   position: absolute;
   left: 50%;
-  bottom: -16px;
+  bottom: -15px;
   height: 0;
   width: 0;
   border: solid;

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.styl
@@ -11,6 +11,9 @@
   margin-top: -15px  // So that the background will extend to the top
   margin-left: 1px   // Otherwise there is a small area jutting out on the top left
 
+.delighted-visible ~ div .kf-user-profile
+  margin-top: 15px  // Push down profile if we're showing the delighted survey.
+
 .kf-user-profile-header
   color: #fff
   background: #3e4954


### PR DESCRIPTION
@andrewconner 

Fixes:
- https://app.asana.com/0/19898402862947/23267996124694/f
- A tiny styling bug where the call to action on featured libraries has an arrow that is not completely attached (see screenshot attached)
- Fix Delighted survey running into user profile page (see screenshot attached). The fix was just to push the user profile header down, but this is ugly. Made a subtask to talk to product about how to style the Delighted survey with the new wide profile header.

![screen shot 2015-01-08 at 11 11 20 am](https://cloud.githubusercontent.com/assets/593801/5668999/f51d5c72-9728-11e4-956a-554cc9d8552f.png)
![screen shot 2015-01-07 at 5 26 33 pm](https://cloud.githubusercontent.com/assets/593801/5669001/f92418ba-9728-11e4-87a0-3e0eec6eae49.png)
