### PR TITLE
using real link for entire click target

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/smallLibraryCard.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/smallLibraryCard.styl
@@ -2,6 +2,7 @@ desktopBorderRadius = 19px
 mobileBorderRadius = 54px
 
 .kf-small-library-card {
+  display: block;
   position: relative;
   border-radius: desktopBorderRadius desktopBorderRadius;
   z-index: 1;
@@ -11,10 +12,6 @@ mobileBorderRadius = 54px
 
   .kf-mobile & {
     border-radius: mobileBorderRadius mobileBorderRadius;
-  }
-
-  &:hover {
-    cursor: pointer;
   }
 }
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/smallLibraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/smallLibraryCard.tpl.html
@@ -1,6 +1,6 @@
-<div class="kf-small-library-card" ng-attr-style="background-color: {{library.color}}" ng-attr-title="{{library.description}}" ng-click="clickCard($event)">
+<a class="kf-small-library-card" ng-href="{{library.libraryPath}}" ng-attr-style="background-color: {{library.color}}" ng-attr-title="{{library.description}}" ng-click="clickCard($event)">
   <div class="kf-small-library-card-header">
-    <a ng-href="{{library.libraryPath}}" class="kf-small-library-name">{{library.name}}</a>
+    <div class="kf-small-library-name">{{library.name}}</div>
     <div class="kf-small-library-counts-row">
       <span class="kf-small-library-count" ng-if="library.numKeeps > 0">
         <ng-pluralize count="library.numKeeps" when="{'1':'{} Keep','other':'{} Keeps'}"></ng-pluralize>
@@ -29,4 +29,4 @@
   </div>
   <div class="kf-small-library-card-bottom card-1"></div>
   <div class="kf-small-library-card-bottom card-2"></div>
-</div>
+</a>


### PR DESCRIPTION
This is important for usability. Also makes the assumption in `clickCard` that the clicked element is a link correct again.
@joshm1 re: #12993
