### PR TITLE
profile endpoint includes number of distinct libraries you're invited to

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -247,24 +247,33 @@ object BasicLibraryStatistics {
   implicit val format = Json.format[BasicLibraryStatistics]
 }
 
-class HexColor private (val hex: String) {
-  require(HexColor.regex.findFirstIn(hex).isDefined, "hex color must be in format '#aaaaaa'")
-}
+sealed abstract class HexColor(val hex: String)
 object HexColor {
+
   implicit def format[T]: Format[HexColor] =
     Format(__.read[String].map(HexColor(_)), new Writes[HexColor] { def writes(o: HexColor) = JsString(o.hex) })
 
-  val regex = "^#[0-9a-f]{6}$".r
-  def apply(hex: String): HexColor = new HexColor(hex.toLowerCase)
+  case object MAGENTA extends HexColor("#c764a2")
+  case object RED extends HexColor("#e35957")
+  case object ORANGE extends HexColor("#ff9430")
+  case object ORANGE_YELLOW extends HexColor("#fab200")
+  case object INDIGO extends HexColor("#2ec89a")
+  case object BLUE extends HexColor("#3975bf")
+  case object PURPLE extends HexColor("#955cb4")
 
-  val allColors = Seq(
-    HexColor("#C764A2"), // magenta (pink)
-    HexColor("#E35957"), // red
-    HexColor("#FF9430"), // orange (a bit darker)
-    HexColor("#2EC89A"), // indigo (light green)
-    HexColor("#3975BF"), // blue
-    HexColor("#955CB4"), // purple
-    HexColor("#FAB200")) // light orange (more yellow-ish)
+  def apply(str: String) = {
+    str.toLowerCase match {
+      case MAGENTA.hex => MAGENTA
+      case RED.hex => RED
+      case ORANGE.hex => ORANGE
+      case ORANGE_YELLOW.hex => ORANGE_YELLOW
+      case INDIGO.hex => INDIGO
+      case BLUE.hex => BLUE
+      case PURPLE.hex => PURPLE
+    }
+  }
+
+  val allColors = Seq(MAGENTA, RED, ORANGE, ORANGE_YELLOW, INDIGO, BLUE, PURPLE)
 
   def pickRandomLibraryColor(): HexColor = {
     val rnd = new Random

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
@@ -242,25 +242,5 @@ class AdminLibraryController @Inject() (
     Redirect(request.request.referer)
   }
 
-  def colorAllUserLibraries() = UserAction { request =>
-    val pageSize = 500
-    var c = 0
-    var paginator = Paginator(c, pageSize)
-    var libs = db.readOnlyMaster { implicit s =>
-      libraryRepo.pageByKindAndNoColor(LibraryKind.USER_CREATED, paginator)
-    }
-    while (libs.nonEmpty) {
-      db.readWriteBatch(libs) { (session, lib) =>
-        libraryRepo.save(lib.copy(color = Some(HexColor.pickRandomLibraryColor)))(session)
-      }
-      c += 1
-      paginator = Paginator(c, pageSize)
-      libs = db.readOnlyMaster { implicit s =>
-        libraryRepo.pageByKindAndNoColor(LibraryKind.USER_CREATED, paginator)
-      }
-    }
-    NoContent
-  }
-
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
@@ -289,11 +289,16 @@ class MobileUserController @Inject() (
       case None => NotFound(s"can't find username $username")
       case Some(profile) =>
         val (numLibraries, numInvitedLibs) = libraryCommander.countLibraries(profile.userId, viewer.map(_.id.get))
-        Ok(Json.toJson(profile.basicUserWithFriendStatus).asInstanceOf[JsObject] ++ Json.obj(
+        val json = Json.toJson(profile.basicUserWithFriendStatus).asInstanceOf[JsObject] ++ Json.obj(
           "numLibraries" -> numLibraries,
-          "numInvitedLibraries" -> numInvitedLibs,
           "numKeeps" -> profile.numKeeps)
-        )
+
+        numInvitedLibs match {
+          case Some(numInvited) =>
+            Ok(json ++ Json.obj("numInvitedLibraries" -> numInvited))
+          case _ =>
+            Ok(json)
+        }
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
@@ -288,11 +288,12 @@ class MobileUserController @Inject() (
     userCommander.profile(Username(username), viewer) match {
       case None => NotFound(s"can't find username $username")
       case Some(profile) =>
-        val numLibraries = libraryCommander.countLibraries(profile.userId, viewer.map(_.id.get))
+        val (numLibraries, numInvitedLibs) = libraryCommander.countLibraries(profile.userId, viewer.map(_.id.get))
         Ok(Json.toJson(profile.basicUserWithFriendStatus).asInstanceOf[JsObject] ++ Json.obj(
           "numLibraries" -> numLibraries,
-          "numKeeps" -> profile.numKeeps
-        ))
+          "numInvitedLibraries" -> numInvitedLibs,
+          "numKeeps" -> profile.numKeeps)
+        )
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -38,7 +38,6 @@ trait LibraryRepo extends Repo[Library] with SeqNumberFunction[Library] {
   def pagePublished(page: Paginator)(implicit session: RSession): Seq[Library]
   def countPublished(implicit session: RSession): Int
   def filterPublishedByMemberCount(minCount: Int, limit: Int = 100)(implicit session: RSession): Seq[Library]
-  def pageByKindAndNoColor(kind: LibraryKind, page: Paginator)(implicit session: RSession): Seq[Library]
 }
 
 @Singleton
@@ -295,12 +294,6 @@ class LibraryRepoImpl @Inject() (
     (for {
       t <- rows if t.visibility === (LibraryVisibility.PUBLISHED: LibraryVisibility) && t.state === LibraryStates.ACTIVE && t.memberCount >= minCount
     } yield t).sortBy(_.updatedAt.desc).take(limit).list
-  }
-
-  def pageByKindAndNoColor(kind: LibraryKind, page: Paginator)(implicit session: RSession): Seq[Library] = {
-    (for {
-      t <- rows if t.kind === (LibraryKind.USER_CREATED: LibraryKind) && t.state === LibraryStates.ACTIVE && t.color.isNull
-    } yield t).drop(page.itemsToDrop).take(page.size).list
   }
 }
 

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -669,7 +669,6 @@ POST    /admin/libraries/:id/state/:state   @com.keepit.controllers.admin.AdminL
 POST    /admin/libraries/update             @com.keepit.controllers.admin.AdminLibraryController.updateLibraries
 POST    /admin/libraries/migrateKeepImages  @com.keepit.controllers.ext.ExtKeepImageController.loadPrevImageForKeep(startUserId: Long, endUserId: Long)
 POST    /admin/libraries/updateLibraryOwner @com.keepit.controllers.admin.AdminLibraryController.updateLibraryOwner(libraryId: Id[Library], fromUserId: Id[User], toUserId: Id[User])
-POST    /admin/libraries/colorAll           @com.keepit.controllers.admin.AdminLibraryController.colorAllUserLibraries()
 
 GET     /admin/typeahead                    @com.keepit.controllers.admin.TypeaheadAdminController.index
 GET     /admin/typeahead/userSearch         @com.keepit.controllers.admin.TypeaheadAdminController.userSearch(userId:Id[User], query:String ?= "")

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
@@ -70,7 +70,7 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
         }
 
         // add new library
-        val jsBody1 = Json.obj("name" -> "Drones stuff", "visibility" -> "published", "color" -> "#BBBbbb")
+        val jsBody1 = Json.obj("name" -> "Drones stuff", "visibility" -> "published", "color" -> HexColor.PURPLE.hex)
         val result1 = createLibrary(user, jsBody1)
         status(result1) must equalTo(OK)
         contentType(result1) must beSome("application/json")
@@ -79,7 +79,7 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
         (resultJson \ "visibility").as[LibraryVisibility] === LibraryVisibility.PUBLISHED
         (resultJson \ "owner").as[BasicUser].firstName === "R2"
         (resultJson \ "url").as[String] === "/r2d2/drones-stuff"
-        (resultJson \ "color").asOpt[HexColor].get.hex === "#bbbbbb"
+        (resultJson \ "color").asOpt[HexColor].get === HexColor.PURPLE
 
         // add library with same title
         val jsBody2 = Json.obj("name" -> "Drones stuff", "visibility" -> "secret")
@@ -105,7 +105,7 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
         lib1.color must beEmpty
 
         // change fields (to something different)
-        val jsBody1 = Json.obj("newName" -> "Feed Gary", "newDescription" -> "qwer", "newVisibility" -> "secret", "newSlug" -> "feed-gary", "newColor" -> "#BBbbbb")
+        val jsBody1 = Json.obj("newName" -> "Feed Gary", "newDescription" -> "qwer", "newVisibility" -> "secret", "newSlug" -> "feed-gary", "newColor" -> HexColor.ORANGE.hex)
         val result1 = modifyLibrary(user, pubLib1, jsBody1)
         status(result1) must equalTo(OK)
         contentType(result1) must beSome("application/json")
@@ -114,7 +114,7 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
         (resultJson \ "shortDescription").asOpt[String] === Some("qwer")
         (resultJson \ "visibility").as[LibraryVisibility] === LibraryVisibility.SECRET
         (resultJson \ "url").as[String] === "/spongebob/feed-gary"
-        (resultJson \ "color").asOpt[HexColor].get.hex === "#bbbbbb"
+        (resultJson \ "color").asOpt[HexColor].get === HexColor.ORANGE
 
         // change a library title to an existing library's title
         val result2 = modifyLibrary(user, pubLib1, Json.obj("newName" -> lib2.name))

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserControllerTest.scala
@@ -210,23 +210,6 @@ class FasterMobileUserControllerTest extends Specification with ShoeboxTestInjec
             }
           """)
 
-        //seeing a profile of my own
-        val selfViewer = call(Some(user1), user1.username)
-        status(selfViewer) must equalTo(OK)
-        contentType(selfViewer) must beSome("application/json")
-        contentAsJson(selfViewer) === Json.parse(
-          s"""
-            {
-              "id":"${user1.externalId.id}",
-              "firstName":"George",
-              "lastName":"Washington",
-              "pictureName":"pic1.jpg",
-              "username": "GDubs",
-              "numLibraries":4,
-              "numKeeps": 5
-            }
-          """)
-
         //seeing a profile from another user (friend)
         val friendViewer = call(Some(user2), user1.username)
         status(friendViewer) must equalTo(OK)
@@ -242,6 +225,24 @@ class FasterMobileUserControllerTest extends Specification with ShoeboxTestInjec
               "numLibraries":2,
               "numKeeps": 5,
               "isFriend": true
+            }
+          """)
+
+        //seeing a profile of my own
+        val selfViewer = call(Some(user1), user1.username)
+        status(selfViewer) must equalTo(OK)
+        contentType(selfViewer) must beSome("application/json")
+        contentAsJson(selfViewer) === Json.parse(
+          s"""
+            {
+              "id":"${user1.externalId.id}",
+              "firstName":"George",
+              "lastName":"Washington",
+              "pictureName":"pic1.jpg",
+              "username": "GDubs",
+              "numLibraries":4,
+              "numKeeps": 5,
+              "numInvitedLibraries": 0
             }
           """)
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -13,7 +13,6 @@ import com.keepit.common.social.FakeSocialGraphModule
 import com.keepit.common.store.{ FakeShoeboxStoreModule, ImageSize }
 import com.keepit.common.time._
 import com.keepit.common.time.internalTime.DateTimeJsonLongFormat
-import com.keepit.controllers.admin.AdminLibraryController
 import com.keepit.cortex.FakeCortexServiceClientModule
 import com.keepit.model.KeepFactory._
 import com.keepit.model.KeepFactoryHelper._
@@ -22,7 +21,6 @@ import com.keepit.model.LibraryFactory._
 import com.keepit.model.LibraryFactoryHelper._
 import com.keepit.model.LibraryMembershipFactory._
 import com.keepit.model.LibraryMembershipFactoryHelper._
-import com.keepit.model.UserConnectionFactory._
 import com.keepit.model.UserFactory._
 import com.keepit.model.UserFactoryHelper._
 import com.keepit.model._

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserControllerTest.scala
@@ -2,6 +2,8 @@ package com.keepit.controllers.website
 
 import com.keepit.model.KeepFactoryHelper._
 import com.keepit.model.KeepFactory._
+import com.keepit.model.LibraryInviteFactory._
+import com.keepit.model.LibraryInviteFactoryHelper._
 import com.keepit.model.UserFactoryHelper._
 import com.keepit.model.UserFactory._
 import com.keepit.model.UserConnectionFactoryHelper._
@@ -318,6 +320,10 @@ class UserControllerTest extends Specification with ShoeboxTestInjector {
           val user5lib = library().withUser(user5).published().saved.savedFollowerMembership(user1)
           membership().withLibraryFollower(library().withUser(user5).published().saved, user1).unlisted().saved
 
+          invite().fromLibraryOwner(user3lib).toUser(user1.id.get).withState(LibraryInviteStates.ACTIVE).saved
+          invite().fromLibraryOwner(user3lib).toUser(user1.id.get).withState(LibraryInviteStates.ACTIVE).saved // duplicate library invite
+          invite().fromLibraryOwner(user5lib).toUser(user1.id.get).withState(LibraryInviteStates.ACCEPTED).saved
+
           keeps(2).map(_.withLibrary(user1secretLib)).saved
           keeps(3).map(_.withLibrary(user1lib)).saved
           keep().withLibrary(user3lib).saved
@@ -396,7 +402,8 @@ class UserControllerTest extends Specification with ShoeboxTestInjector {
               "pictureName":"pic1.jpg",
               "username": "GDubs",
               "numLibraries": 4,
-              "numKeeps": 5
+              "numKeeps": 5,
+              "numInvitedLibraries": 1
             }
           """)
 


### PR DESCRIPTION
The Json field `numInvitedLibraries` only returns when you're viewing your own profile
The number is distinct libraries you're invited to

and set library colors are in, so removing admin endpoint that sets all the library colors

@2is10 cc: @yipingliao 
