### PR TITLE
filter out libraries of fake users in the libraries cards and social tooltips

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -441,10 +441,7 @@ class ShoeboxController @Inject() (
   }
 
   def getAllFakeUsers() = Action { request =>
-    val fakeUsers = db.readOnlyMaster { implicit session =>
-      userExperimentRepo.getByType(ExperimentType.FAKE).map(_.userId).toSet
-    }
-    Ok(Json.toJson(fakeUsers))
+    Ok(Json.toJson(userCommander.getAllFakeUsers()))
   }
 
   def getInvitations(senderId: Id[User]) = Action { request =>


### PR DESCRIPTION
/cc @leogrim @ymatsuda @stkem @andrewconner 
We should make sure the data is of higher quality as @leogrim recommends.
This PR comes to deal with a problem we have now in prod where some fake users which are not trivial to clean and some are used for ongoing testing are looking very bad when appearing in popular library public pages. We filter out the fake users using a cached list so it should be pretty fast.
Note: this does not take care of search results and recommendations, only keep cards on library pages and social tooltips.
