### PR TITLE
Limit width upl logged out

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
@@ -285,9 +285,7 @@ angular.module('kifi')
     };
 
     $scope.showInvitedLibraries = function () {
-      // TODO: modify the profile endpoint to return number of invited libraries instead of relying
-      // on libraryService.invitedSummaries.length.
-      return $scope.viewingOwnProfile && libraryService.invitedSummaries.length;
+      return $scope.profile && $scope.profile.numInvitedLibraries && $scope.viewingOwnProfile;
     };
 
     $scope.getUserProfileUrl = function (user) {

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.styl
@@ -77,11 +77,13 @@
   text-align: center
 
 .kf-upl-card-list
-  margin-bottom: 40px
+  max-width: 800px
+  margin: 0 auto 40px
 
 .kf-upl-nav
   display: table
   width: 75%
+  max-width: 600px
   margin: 0 auto
   border-radius: 6px
   background: #cbcbcb


### PR DESCRIPTION
@2is10 cc @ahsu1230 
- Limit width of user profile library cards to 3 cards per row, per Mark
- Switch to using `numInvitedLibraries` on profile endpoint that @ahsu1230 just pushed
