### PR TITLE
Greatly simplify number of keeps information in keep cards.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWho.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWho.styl
@@ -8,12 +8,6 @@
   font-size: 12px
   color: #99a3b3
 
-.kf-keep-who-text-prefix
-  padding: 0 3px 0 17px
-  background-size: 10px 9px
-  background-repeat: no-repeat
-  background-position: 0 2px
-
 .kf-keep-who-pic-box
   margin: 3px
   display: inline-block

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoText.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoText.js
@@ -3,63 +3,14 @@
 angular.module('kifi')
 
 .directive('kfKeepWhoText', [
-  'profileService',
-  function (profileService) {
+  function () {
     return {
       restrict: 'A',
       replace: true,
       templateUrl: 'common/directives/keepWho/keepWhoText.tpl.html',
       scope: {
         keep: '='
-      },
-      link: function (scope) {
-        var keep = scope.keep;
-
-        scope.me = profileService.me;
-
-        scope.helprankEnabled = false;
-        scope.$watch(function () {
-          return profileService.me.seqNum;
-        }, function () {
-          scope.helprankEnabled = profileService.me && profileService.me.experiments && profileService.me.experiments.indexOf('helprank') > -1;
-        });
-
-        function librariesTotal() {
-          return keep.librariesTotal || (keep.libraries ? keep.libraries.length : 0);
-        }
-
-        scope.hasKeepers = function () {
-          return keep.keepers && (keep.keepers.length > 0);
-        };
-
-        scope.hasOthers = function () {
-          return keep.others > 0;
-        };
-
-        scope.hasLibraries = function () {
-          return librariesTotal() > 0;
-        };
-
-        scope.getFriendText = function () {
-          var num = keep.keepers ? keep.keepers.length : 0;
-          var text = (num === 1) ? '1 friend' : num + ' friends';
-          return text;
-        };
-
-        scope.getOthersText = function () {
-          var num = keep.others ? keep.others : 0;
-          var text = (num === 1) ? '1 other' : num + ' others';
-          return text;
-        };
-
-        scope.getLibrariesText = function () {
-          var num = librariesTotal();
-          var text = (num === 1) ? '1 library' : num + ' libraries';
-          return text;
-        };
       }
     };
   }
-])
-
-;
+]);

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoText.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoText.tpl.html
@@ -1,8 +1,3 @@
-<div class="kf-keep-who-text">
-  <span class="kf-keep-who-text-prefix svg-button-keep-heart-green">Kept by:</span>
-  <span class="kf-keep-libraries" ng-show="hasLibraries()">{{getLibrariesText()}}</span>
-  <span class="kf-keep-dot" ng-if="hasLibraries() && hasKeepers()">‧</span>
-  <span class="kf-keep-friends" ng-show="hasKeepers()">{{getFriendText()}}</span>
-  <span class="kf-keep-dot" ng-if="hasOthers() && hasKeepers()">‧</span>
-  <span class="kf-keep-others" ng-show="hasOthers()">{{getOthersText()}}</span>
+<div ng-if="keep.keepersTotal" class="kf-keep-who-text">
+  Kept&nbsp;<ng-pluralize count="keep.keepersTotal" when="{'one': '1 time', 'other': '{} times'}"></ng-pluralize>
 </div>

--- a/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
@@ -177,10 +177,6 @@
             font-size: 28px
             margin-left: 10px
 
-            .svg-button-keep-heart-green
-              background-size: 30px 32px
-              padding-left: 45px
-
         .kf-keep-who-libs-and-pics
           padding-top: 20px
 

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepDecoratorService.js
@@ -76,16 +76,6 @@ angular.module('kifi')
         }
       }
 
-      function initializeOthersCount(numTotalKeepers, numFriendKeepers, numOmittedFriendKeepers, numKeptInUserLibraries) {
-        // "others" is the number of Kifi users who kept a keep besides the user and the user's Kifi friends.
-        var others = numTotalKeepers  - numFriendKeepers - numOmittedFriendKeepers;
-        if (numKeptInUserLibraries > 0) {
-          others--;
-        }
-
-        return others;
-      }
-
       // Add new properties to the keep.
       this.titleAttr = this.title || this.url;
       this.titleHtml = this.title || util.formatTitleFromUrl(this.url);
@@ -94,7 +84,6 @@ angular.module('kifi')
       }
       this.readTime = getKeepReadTime(this.summary);
       this.showSocial = this.keepersTotal || (this.keepers && this.keepers.length > 0) || (this.libraries && this.libraries.length > 0);
-      this.others = initializeOthersCount(this.keepersTotal, this.keepers.length, this.keepersOmitted, this.keeps.length);
     }
 
     // Add properties that are specific to a really kept Keep.

--- a/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
@@ -19,12 +19,6 @@ angular.module('kifi')
 
       hit.isPrivate = hit.secret || false;
       hit.isProtected = !hit.isMyBookmark; // will not be hidden if user keeps then unkeeps
-
-      // "others" is the number of Kifi users who kept a keep besides the user and the user's Kifi friends.
-      hit.others = hit.keepersTotal - hit.keepers.length - hit.keepersOmitted;
-      if (hit.keeps.length) {
-        hit.others--;
-      }
     }
 
     function copy(obj) {


### PR DESCRIPTION
@andrewconner 

cc @eishay Note that you can drop the `createdAt` timestamp field on keeps returned from the backend; the front end currently handles that gracefully.
