### PR TITLE
Move out code that was unnecessarily dependent on fetch-library-summary promise resolutions

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.js
@@ -448,9 +448,10 @@ angular.module('kifi')
             libraryService.fetchLibrarySummaries(true).then(function () {
               scope.$evalAsync(function () {
                 invokeWidgetCallbacks(_.find(libraryService.librarySummaries, { 'name': library.name }));
-                removeWidget();
               });
             });
+
+            removeWidget();
           })['catch'](function (err) {
             var error = err.data && err.data.error;
             switch (error) {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -74,19 +74,17 @@ angular.module('kifi')
           }
 
           promise.then(function (resp) {
+            libraryService.fetchLibrarySummaries(true);
+
             scope.$error = {};
-
             submitting = false;
+            scope.close();
 
-            libraryService.fetchLibrarySummaries(true).then(function () {
-              scope.close();
-
-              if (!returnAction) {
-                $location.path(resp.data.url);
-              } else {
-                returnAction();
-              }
-            });
+            if (!returnAction) {
+              $location.path(resp.data.url);
+            } else {
+              returnAction();
+            }
           })['catch'](function (err) {
             submitting = false;
 


### PR DESCRIPTION
@andrewconner cc @eishay 

Thanks to @eishay's pointers, found two instances where we are waiting for `fetchLibrarySummaries` to return before moving ahead with UI changes that were actually unnecessary. Note that we have to wait for `fetchLibrarySummaries` to return before we can follow a library because we need the most current information about whether the user is already following the library.
