### PR TITLE
checking for a specific query parameter more specifically

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -380,8 +380,7 @@ angular.module('kifi')
           defaultAttributes.libraryName = library.name;
         }
 
-        // o=lr shorthand for origin=libraryRec
-        if ($location.url().indexOf('o=lr') > -1) {
+        if ($location.search().o === 'lr') {
           defaultAttributes.origin = 'libraryRec';
         }
 


### PR DESCRIPTION
I think this is the idiomatic way to do it. The `o=lr` is supposed to be in the query string, yes?
@joshm1 
