### PR TITLE
Sampling

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/math/Sampler.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/math/Sampler.scala
@@ -43,14 +43,18 @@ private[math] class SimpleSampler(val sampleSize: Int) extends Sampler {
   private[this] var cumulative: Double = 0.0
 
   def collect(probability: Double): Int = {
-    cumulative += probability
-    val lastCount = sampledCount
+    if (probability >= 0.0) {
+      cumulative += probability
+      val lastCount = sampledCount
 
-    while (sampledCount < sampleSize && cumulative > rnd(sampledCount)) {
-      sampledCount += 1
+      while (sampledCount < sampleSize && cumulative > rnd(sampledCount)) {
+        sampledCount += 1
+      }
+
+      sampledCount - lastCount
+    } else {
+      throw new IllegalArgumentException(s"probability must be zero or positive: $probability")
     }
-
-    sampledCount - lastCount
   }
 }
 
@@ -97,19 +101,23 @@ private[math] class SegmentedSampler(numSegments: Int) extends Sampler {
   private[this] var cumulative: Double = 0.0
 
   def collect(probability: Double): Int = {
-    cumulative += probability
-    val lastCount = sampledCount
+    if (probability >= 0.0) {
+      cumulative += probability
+      val lastCount = sampledCount
 
-    while (segNo < numSegments && cumulative > rnd(segSampledCount)) {
-      sampledCount += 1
-      segSampledCount += 1
-      if (segSampledCount % segmentSize == 0) {
-        segNo += 1
-        segSampledCount = 0
-        if (segNo < numSegments) randomize(rnd, segWidth * segNo, segWidth * (segNo + 1))
+      while (segNo < numSegments && cumulative > rnd(segSampledCount)) {
+        sampledCount += 1
+        segSampledCount += 1
+        if (segSampledCount % segmentSize == 0) {
+          segNo += 1
+          segSampledCount = 0
+          if (segNo < numSegments) randomize(rnd, segWidth * segNo, segWidth * (segNo + 1))
+        }
       }
-    }
 
-    sampledCount - lastCount
+      sampledCount - lastCount
+    } else {
+      throw new IllegalArgumentException(s"probability must be zero or positive: $probability")
+    }
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/math/Sampler.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/math/Sampler.scala
@@ -20,12 +20,12 @@ trait Sampler {
 
 object Sampler {
 
-  val segmentSize: Int = 2000
+  val stratumSize: Int = 2000
 
   def apply(sampleSize: Int) = {
     require(sampleSize > 0, "the sample size must be greater than 0")
 
-    if (sampleSize <= segmentSize) new SimpleSampler(sampleSize)
+    if (sampleSize <= stratumSize) new SimpleSampler(sampleSize)
     else new CombinedSampler(sampleSize)
   }
 }
@@ -59,40 +59,40 @@ private[math] class SimpleSampler(val sampleSize: Int) extends Sampler {
 }
 
 private[this] class CombinedSampler(val sampleSize: Int) extends Sampler {
-  import Sampler.segmentSize
+  import Sampler.stratumSize
 
   require(sampleSize > 0, "the sample size must be greater than 0")
 
   private[this] var sampledCount: Int = 0
 
-  private[this] val numSegments = (sampleSize - 1) / segmentSize
+  private[this] val numStratum = (sampleSize - 1) / stratumSize
 
-  private[this] val segmentedSampler = new SegmentedSampler(numSegments)
-  private[this] val simpleSampler = new SimpleSampler(sampleSize - segmentedSampler.sampleSize)
+  private[this] val stratifiedSampler = new StratifiedSampler(numStratum)
+  private[this] val simpleSampler = new SimpleSampler(sampleSize - stratifiedSampler.sampleSize)
 
-  require(simpleSampler.sampleSize <= segmentSize, "the sample size for SimpleSampler is too big")
+  require(simpleSampler.sampleSize <= stratumSize, "the sample size for SimpleSampler is too big")
 
   def collect(probability: Double): Int = {
     val lastCount = sampledCount
 
     sampledCount += simpleSampler.collect(probability)
-    sampledCount += segmentedSampler.collect(probability)
+    sampledCount += stratifiedSampler.collect(probability)
 
     sampledCount - lastCount
   }
 }
 
-private[math] class SegmentedSampler(numSegments: Int) extends Sampler {
-  import Sampler.segmentSize
+private[math] class StratifiedSampler(numStrata: Int) extends Sampler {
+  import Sampler.stratumSize
 
-  require(numSegments > 0, "the number of segments must be greater than 0")
+  require(numStrata > 0, "the number of strata must be greater than 0")
 
-  val sampleSize = segmentSize * numSegments
+  val sampleSize = stratumSize * numStrata
 
   private[this] var sampledCount: Int = 0
 
-  private[this] val rnd: Array[Double] = new Array[Double](segmentSize)
-  private[this] val segWidth = 1.0 / numSegments
+  private[this] val rnd: Array[Double] = new Array[Double](stratumSize)
+  private[this] val segWidth = 1.0 / numStrata
   private[this] var segSampledCount: Int = 0
   private[this] var segNo = 0
 
@@ -105,13 +105,13 @@ private[math] class SegmentedSampler(numSegments: Int) extends Sampler {
       cumulative += probability
       val lastCount = sampledCount
 
-      while (segNo < numSegments && cumulative > rnd(segSampledCount)) {
+      while (segNo < numStrata && cumulative > rnd(segSampledCount)) {
         sampledCount += 1
         segSampledCount += 1
-        if (segSampledCount % segmentSize == 0) {
+        if (segSampledCount % stratumSize == 0) {
           segNo += 1
           segSampledCount = 0
-          if (segNo < numSegments) randomize(rnd, segWidth * segNo, segWidth * (segNo + 1))
+          if (segNo < numStrata) randomize(rnd, segWidth * segNo, segWidth * (segNo + 1))
         }
       }
 

--- a/kifi-backend/modules/common/test/com/keepit/common/math/SamplerTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/math/SamplerTest.scala
@@ -4,7 +4,7 @@ import org.specs2.mutable.Specification
 import scala.math.sqrt
 
 class SamplerTest extends Specification {
-  private val sampleSize = (Sampler.segmentSize.toDouble * 2.111).toInt
+  private val sampleSize = (Sampler.stratumSize.toDouble * 2.111).toInt
   private val repeat = 100
 
   "Sampler" should {

--- a/kifi-backend/modules/common/test/com/keepit/common/math/SamplerTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/math/SamplerTest.scala
@@ -59,5 +59,13 @@ class SamplerTest extends Specification {
 
       stddev must beLessThan(avg * 0.01)
     }
+
+    "throw an exception when the probability is not zero or positive" in {
+      val sampler = Sampler(sampleSize)
+
+      sampler.collect(0.0) === 0
+      sampler.collect(Double.NaN) must throwA[IllegalArgumentException]
+      sampler.collect(-.01) must throwA[IllegalArgumentException]
+    }
   }
 }

--- a/kifi-backend/modules/graph/app/com/keepit/graph/controllers/internal/GraphController.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/controllers/internal/GraphController.scala
@@ -132,4 +132,13 @@ class GraphController @Inject() (
       Ok(Json.toJson(res))
     }
   }
+
+  def enableSampler() = Action {
+    uriWanderingCommander.useSampler = true
+    Ok
+  }
+  def disableSampler() = Action {
+    uriWanderingCommander.useSampler = false
+    Ok
+  }
 }

--- a/kifi-backend/modules/graph/conf/graphService.routes
+++ b/kifi-backend/modules/graph/conf/graphService.routes
@@ -9,4 +9,7 @@ GET     /internal/graph/getUserAndScorePairs @com.keepit.graph.controllers.inter
 GET     /internal/graph/getSociallyRelatedEntities  @com.keepit.graph.controllers.internal.GraphController.getSociallyRelatedEntities(userId: Id[User])
 POST    /internal/graph/explainFeed                      @com.keepit.graph.controllers.internal.GraphController.explainFeed
 
+GET     /internal/graph/enableSampler   @com.keepit.graph.controllers.internal.GraphController.enableSampler()
+GET     /internal/graph/disableSampler  @com.keepit.graph.controllers.internal.GraphController.disableSampler()
+
 ->  / commonService.Routes


### PR DESCRIPTION
@yingjieMiao @leogrim @stkem @eishay 
- I think I fixed a bug which caused high CPU
- added a switch to enable the sampler (the default is using ProbabilityDensity)
- renamed SegmentedSampler to StratifiedSampler

If it is ok to use a stratified sampling with a single sample per stratum, we don't need to allocate `Array[Double]` at all (and simplifies the code a lot).
What do you think? Shall we go extreme?
