### PR TITLE
Library and User Index modifications

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/engine/library/LibrarySearch.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/library/LibrarySearch.scala
@@ -60,7 +60,7 @@ class LibrarySearch(
         new LibrarySearchExplanationBuilder(libraryId, (firstLang, secondLang), query, labels)
     }
 
-    val collector = new LibraryResultCollector(numHitsToReturn * 5, myLibraryBoost, percentMatch / 100.0f, explanation)
+    val collector = new LibraryResultCollector(librarySearcher, numHitsToReturn * 5, myLibraryBoost, percentMatch / 100.0f, explanation)
 
     val keepScoreSource = new LibraryFromKeepsScoreVectorSource(keepSearcher, userId.id, friendIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, explanation)
     val libraryScoreSource = new LibraryScoreVectorSource(librarySearcher, userId.id, friendIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, explanation)

--- a/kifi-backend/modules/search/app/com/keepit/search/index/IndexerVersion.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/IndexerVersion.scala
@@ -22,7 +22,7 @@ object IndexerVersionProviders {
   case object Article extends IndexerVersionProvider(1, 1)
   case object URIGraph extends IndexerVersionProvider(0, 0)
   case object Collection extends IndexerVersionProvider(0, 0)
-  case object User extends IndexerVersionProvider(0, 0)
+  case object User extends IndexerVersionProvider(0, 1)
   case object UserGraph extends IndexerVersionProvider(0, 0)
   case object SearchFriend extends IndexerVersionProvider(0, 0)
   case object Message extends IndexerVersionProvider(0, 0)

--- a/kifi-backend/modules/search/app/com/keepit/search/index/IndexerVersion.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/IndexerVersion.scala
@@ -19,7 +19,7 @@ sealed abstract class IndexerVersionProvider(activeVersion: IndexerVersion, back
 }
 
 object IndexerVersionProviders {
-  case object Article extends IndexerVersionProvider(0, 1)
+  case object Article extends IndexerVersionProvider(1, 1)
   case object URIGraph extends IndexerVersionProvider(0, 0)
   case object Collection extends IndexerVersionProvider(0, 0)
   case object User extends IndexerVersionProvider(0, 0)

--- a/kifi-backend/modules/search/app/com/keepit/search/index/IndexerVersion.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/IndexerVersion.scala
@@ -27,6 +27,6 @@ object IndexerVersionProviders {
   case object SearchFriend extends IndexerVersionProvider(0, 0)
   case object Message extends IndexerVersionProvider(0, 0)
   case object Phrase extends IndexerVersionProvider(0, 0)
-  case object Library extends IndexerVersionProvider(2, 2)
+  case object Library extends IndexerVersionProvider(2, 3)
   case object Keep extends IndexerVersionProvider(0, 0)
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/index/user/UserIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/user/UserIndexer.scala
@@ -19,12 +19,12 @@ import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
 
 object UserIndexer {
 
-  val FULLNAME_FIELD = "u_fullname"
-  val EMAILS_FIELD = "u_emails"
-  val BASIC_USER_FIELD = "u_basic_user"
-  val USER_EXPERIMENTS = "u_experiments"
-  val PREFIX_FIELD = "u_prefix"
   val PREFIX_MAX_LEN = 8 // do not change this number unless you do reindexing immediately
+  val nameField = "t"
+  val namePrefixField = "tp"
+  val emailsField = "e"
+  val recordField = "rec"
+  val experimentsField = "exp"
 
   val toBeDeletedStates = Set[State[User]](INACTIVE, PENDING, BLOCKED, INCOMPLETE_SIGNUP)
 }
@@ -167,19 +167,19 @@ class UserIndexer(
     override def buildDocument = {
       val doc = super.buildDocument
 
-      val userNameField = buildTextField(FULLNAME_FIELD, user.firstName + " " + user.lastName, analyzer)
+      val userNameField = buildTextField(nameField, user.firstName + " " + user.lastName, analyzer)
       doc.add(userNameField)
 
-      val emailField = buildIteratorField[String](EMAILS_FIELD, emails.map { _.address.toLowerCase }.toIterator)(x => x)
+      val emailField = buildIteratorField[String](emailsField, emails.map { _.address.toLowerCase }.toIterator)(x => x)
       doc.add(emailField)
 
-      val expField = buildIteratorField[String](USER_EXPERIMENTS, experiments.map { _.value }.toIterator)(x => x)
+      val expField = buildIteratorField[String](experimentsField, experiments.map { _.value }.toIterator)(x => x)
       doc.add(expField)
 
-      val basicUserField = buildBinaryDocValuesField(BASIC_USER_FIELD, BasicUserSerializer.toByteArray(basicUser))
+      val basicUserField = buildBinaryDocValuesField(recordField, BasicUserSerializer.toByteArray(basicUser))
       doc.add(basicUserField)
 
-      val prefixField = buildIteratorField[String](PREFIX_FIELD, genPrefix(user).toIterator)(x => x)
+      val prefixField = buildIteratorField[String](namePrefixField, genPrefix(user).toIterator)(x => x)
       doc.add(prefixField)
 
       doc

--- a/kifi-backend/modules/search/app/com/keepit/search/index/user/UserQueryParser.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/user/UserQueryParser.scala
@@ -46,7 +46,7 @@ class UserQueryParser(
     if (queryText == null) None
     else {
       val bq = new BooleanQuery
-      val tq = new TermQuery(new Term(UserIndexer.EMAILS_FIELD, queryText.toString.toLowerCase))
+      val tq = new TermQuery(new Term(UserIndexer.emailsField, queryText.toString.toLowerCase))
       bq.add(tq, Occur.MUST)
       Some(bq)
     }
@@ -56,14 +56,14 @@ class UserQueryParser(
   private def genNameQuery(queryText: CharSequence): Option[BooleanQuery] = {
 
     val bq = new BooleanQuery
-    val ts = analyzer.tokenStream(UserIndexer.FULLNAME_FIELD, new StringReader(queryText.toString))
+    val ts = analyzer.tokenStream(UserIndexer.nameField, new StringReader(queryText.toString))
     try {
       ts.reset()
 
       val termAttr = ts.getAttribute(classOf[CharTermAttribute])
 
       while (ts.incrementToken) {
-        val tq = new PrefixQuery(new Term(UserIndexer.FULLNAME_FIELD, new String(termAttr.buffer(), 0, termAttr.length())))
+        val tq = new PrefixQuery(new Term(UserIndexer.nameField, new String(termAttr.buffer(), 0, termAttr.length())))
         bq.add(tq, Occur.MUST)
       }
       ts.end()
@@ -77,7 +77,7 @@ class UserQueryParser(
   private def genPrefixNameQuery(queryText: CharSequence): Option[BooleanQuery] = {
     val bq = new BooleanQuery
     PrefixFilter.tokenize(queryText.toString).foreach { q =>
-      val tq = new TermQuery(new Term(UserIndexer.PREFIX_FIELD, q.take(UserIndexer.PREFIX_MAX_LEN)))
+      val tq = new TermQuery(new Term(UserIndexer.namePrefixField, q.take(UserIndexer.PREFIX_MAX_LEN)))
       bq.add(tq, Occur.MUST)
     }
     if (bq.clauses.size > 0) Some(bq) else None
@@ -85,7 +85,7 @@ class UserQueryParser(
 
   private def addUserExperimentConstrains(bq: BooleanQuery, exps: Seq[String]) = {
     exps.foreach { exp =>
-      val tq = new TermQuery(new Term(UserIndexer.USER_EXPERIMENTS, exp))
+      val tq = new TermQuery(new Term(UserIndexer.experimentsField, exp))
       bq.add(tq, Occur.MUST_NOT)
     }
   }

--- a/kifi-backend/modules/search/app/com/keepit/search/index/user/UserSearcher.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/user/UserSearcher.scala
@@ -49,7 +49,7 @@ class UserSearcher(searcher: Searcher) {
     val pq = new ScoredUserHitPQ(queueSize)
 
     searcher.search(query) { (scorer, reader) =>
-      val bv = reader.getBinaryDocValues(UserIndexer.BASIC_USER_FIELD)
+      val bv = reader.getBinaryDocValues(UserIndexer.recordField)
       val mapper = reader.getIdMapper
       var doc = scorer.nextDoc()
       while (doc != NO_MORE_DOCS) {


### PR DESCRIPTION
@ymatsuda @yingjieMiao 
- renaming fields in UserIndex to be consistent with other indices and queries
- adding LibraryKind to LibraryIndex to be able to make explicit exclusions / boosts both in library search and augmentation (e.g. excluding Main and Private from Library search results, per Mark's request) 

@andrewconner @stkem if we can have special library kinds for imports, search can now explicitly filter them out.
