### PR TITLE
Dropping NormalizedURI from ScraperURISummaryCommanderImpl

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/store/S3URIImageStore.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/S3URIImageStore.scala
@@ -2,6 +2,7 @@ package com.keepit.common.store
 
 import java.io.{ ByteArrayOutputStream, ByteArrayInputStream }
 import com.amazonaws.services.s3.AmazonS3
+import com.keepit.common.db.ExternalId
 import com.keepit.common.logging.Logging
 import java.awt.image.BufferedImage
 import javax.imageio.ImageIO
@@ -11,32 +12,24 @@ import com.keepit.common.net.URI
 import com.keepit.common.healthcheck.AirbrakeNotifier
 
 trait S3URIImageStore {
-  def storeImage(info: ImageInfo, rawImage: BufferedImage, nUri: NormalizedURI): Try[(String, Int)]
-  def getDefaultScreenshotURL(nUri: NormalizedURI): Option[String]
-  def getImageURL(imageInfo: ImageInfo, nUri: NormalizedURI): Option[String]
+  def storeImage(info: ImageInfo, rawImage: BufferedImage, extNormUriId: ExternalId[NormalizedURI]): Try[(String, Int)]
+  def getImageURL(imageInfo: ImageInfo, extNormUriId: ExternalId[NormalizedURI]): Option[String]
 }
 
 class S3URIImageStoreImpl(override val s3Client: AmazonS3, config: S3ImageConfig, airbrake: AirbrakeNotifier) extends S3URIImageStore with S3Helper with Logging {
 
-  def storeImage(info: ImageInfo, rawImage: BufferedImage, nUri: NormalizedURI): Try[(String, Int)] = {
+  def storeImage(info: ImageInfo, rawImage: BufferedImage, extNormUriId: ExternalId[NormalizedURI]): Try[(String, Int)] = {
     val os = new ByteArrayOutputStream()
     ImageIO.write(rawImage, "jpg", os)
     os.flush
     val bytes = os.toByteArray
     os.close
-    val key = getImageKey(info, nUri)
-    log.info(s"Uploading screenshot of ${nUri.url} to S3 key $key")
+    val key = getImageKey(info, extNormUriId)
+    log.info(s"Uploading screenshot of ${extNormUriId} to S3 key $key")
     streamUpload(config.bucketName, key, new ByteArrayInputStream(bytes), "public, max-age=1800", bytes.length) flatMap { _ =>
       // Return the url of the image in S3
-      Try { (getImageURL(info, nUri).get, bytes.length) }
+      Try { (getImageURL(info, extNormUriId).get, bytes.length) }
     }
-  }
-
-  /**
-   * Builds generic screenshot URL for given normalized URI. No check if the screenshot actually exists.
-   */
-  def getDefaultScreenshotURL(nUri: NormalizedURI): Option[String] = {
-    urlFromKey(getScreenshotKey(nUri, None))
   }
 
   private def urlFromKey(key: String): Option[String] = {
@@ -49,16 +42,16 @@ class S3URIImageStoreImpl(override val s3Client: AmazonS3, config: S3ImageConfig
     }
   }
 
-  def getImageURL(imageInfo: ImageInfo, nUri: NormalizedURI): Option[String] = {
-    if (config.isLocal || (imageInfo.provider == ImageProvider.PAGEPEEKER && nUri.screenshotUpdatedAt.isEmpty)) return None
-    urlFromKey(getImageKey(imageInfo, nUri))
+  def getImageURL(imageInfo: ImageInfo, extNormUriId: ExternalId[NormalizedURI]): Option[String] = {
+    if (config.isLocal || imageInfo.provider == ImageProvider.PAGEPEEKER) return None
+    urlFromKey(getImageKey(imageInfo, extNormUriId))
   }
 
-  private def getImageKey(imageInfo: ImageInfo, nUri: NormalizedURI): String = {
+  private def getImageKey(imageInfo: ImageInfo, extNormUriId: ExternalId[NormalizedURI]): String = {
     val provider = imageInfo.provider.getOrElse(ImageProvider.EMBEDLY) // Use Embedly as default provider (backwards compatibility)
     provider match {
-      case ImageProvider.EMBEDLY => s"images/${nUri.externalId}/${ImageProvider.getProviderIndex(imageInfo.provider)}/${imageInfo.name}.${imageInfo.getFormatSuffix}"
-      case ImageProvider.PAGEPEEKER => getScreenshotKey(nUri, imageInfo.getImageSize)
+      case ImageProvider.EMBEDLY => s"images/${extNormUriId}/${ImageProvider.getProviderIndex(imageInfo.provider)}/${imageInfo.name}.${imageInfo.getFormatSuffix}"
+      case ImageProvider.PAGEPEEKER => getScreenshotKey(extNormUriId, imageInfo.getImageSize)
       case _ => {
         airbrake.notify(s"Unsupported image provider: ${imageInfo.provider}")
         ""
@@ -68,8 +61,8 @@ class S3URIImageStoreImpl(override val s3Client: AmazonS3, config: S3ImageConfig
 
   private val screenshotFormat = ImageFormat.JPG
   private val defaultSize = ImageSize(500, 280)
-  private def getScreenshotKey(nUri: NormalizedURI, imageSizeOpt: Option[ImageSize]): String = {
+  private def getScreenshotKey(extNormUriId: ExternalId[NormalizedURI], imageSizeOpt: Option[ImageSize]): String = {
     val size = imageSizeOpt getOrElse defaultSize
-    s"screenshot/${nUri.externalId}/${size.width}x${size.height}.${screenshotFormat.value}"
+    s"screenshot/${extNormUriId}/${size.width}x${size.height}.${screenshotFormat.value}"
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/scraper/ScraperServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/scraper/ScraperServiceClient.scala
@@ -15,7 +15,6 @@ import com.keepit.common.service.{ RequestConsolidator, ServiceClient, ServiceTy
 import com.keepit.common.store.ImageSize
 import com.keepit.common.zookeeper.ServiceCluster
 import com.keepit.model._
-import com.keepit.scraper.embedly.EmbedlyInfo
 import com.keepit.scraper.extractor.ExtractorProviderType
 import com.keepit.search.Article
 import org.joda.time.DateTime
@@ -131,7 +130,6 @@ trait ScraperServiceClient extends ServiceClient {
   def detectPorn(query: String): Future[Map[String, Float]]
   def whitelist(words: String): Future[String]
   def getEmbedlyImageInfos(uriId: Id[NormalizedURI], url: String): Future[Seq[ImageInfo]]
-  def getEmbedlyInfo(url: String): Future[Option[EmbedlyInfo]]
   def getURISummaryFromEmbedly(uri: NormalizedURI, minSize: ImageSize, descriptionOnly: Boolean): Future[Option[URISummary]]
   def getURIWordCount(uriId: Id[NormalizedURI], url: Option[String]): Future[Int]
   def getURIWordCountOpt(uriId: Id[NormalizedURI], url: Option[String]): Option[Int]
@@ -209,13 +207,6 @@ class ScraperServiceClientImpl @Inject() (
     val payload = Json.obj("uriId" -> uriId.id, "url" -> url)
     call(Scraper.internal.getEmbedlyImageInfos, payload).map { r =>
       Json.fromJson[Seq[ImageInfo]](r.json).get
-    }
-  }
-
-  def getEmbedlyInfo(url: String): Future[Option[EmbedlyInfo]] = {
-    val payload = Json.obj("url" -> url)
-    call(Scraper.internal.getEmbedlyInfo, payload, callTimeouts = superExtraLongTimeoutJustForEmbedly).map { r =>
-      Json.fromJson[Option[EmbedlyInfo]](r.json).get
     }
   }
 

--- a/kifi-backend/modules/common/app/com/keepit/scraper/ScraperServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/scraper/ScraperServiceClient.scala
@@ -211,6 +211,7 @@ class ScraperServiceClientImpl @Inject() (
   }
 
   def getURISummaryFromEmbedly(uri: NormalizedURI, minSize: ImageSize, descriptionOnly: Boolean): Future[Option[URISummary]] = {
+    // todo: Bad API, NormalizedURI isn't needed anymore. Just JSON with id, uri, and externalId. Fix soon?
     val payload = Json.obj("uri" -> uri, "minSize" -> minSize, "descriptionOnly" -> descriptionOnly)
     call(Scraper.internal.getURISummaryFromEmbedly, payload, callTimeouts = superExtraLongTimeoutJustForEmbedly).map { r =>
       r.json.as[Option[URISummary]]

--- a/kifi-backend/modules/common/test/com/keepit/common/store/FakeS3URIImageStore.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/store/FakeS3URIImageStore.scala
@@ -6,9 +6,8 @@ import scala.util.{ Success, Try }
 import com.keepit.common.db.ExternalId
 
 case class FakeS3URIImageStore() extends S3URIImageStore {
-  def storeImage(info: ImageInfo, rawImage: BufferedImage, nUri: NormalizedURI): Try[(String, Int)] = Success((FakeS3URIImageStore.placeholderImageURL, FakeS3URIImageStore.placeholderSize))
-  def getDefaultScreenshotURL(nUri: NormalizedURI): Option[String] = None
-  def getImageURL(imageInfo: ImageInfo, nUri: NormalizedURI): Option[String] = None
+  def storeImage(info: ImageInfo, rawImage: BufferedImage, extNormUriId: ExternalId[NormalizedURI]): Try[(String, Int)] = Success((FakeS3URIImageStore.placeholderImageURL, FakeS3URIImageStore.placeholderSize))
+  def getImageURL(imageInfo: ImageInfo, extNormUriId: ExternalId[NormalizedURI]): Option[String] = None
 }
 
 object FakeS3URIImageStore {

--- a/kifi-backend/modules/common/test/com/keepit/scraper/FakeScraperServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/scraper/FakeScraperServiceClientImpl.scala
@@ -36,8 +36,6 @@ class FakeScraperServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, sched
 
   def getEmbedlyImageInfos(uriId: Id[NormalizedURI], url: String): Future[Seq[ImageInfo]] = ???
 
-  def getEmbedlyInfo(url: String): Future[Option[EmbedlyInfo]] = ???
-
   def getURISummaryFromEmbedly(uri: NormalizedURI, minSize: ImageSize, descriptionOnly: Boolean): Future[Option[URISummary]] = Future.successful(None)
 
   def getURIWordCount(uriId: Id[NormalizedURI], url: Option[String]): Future[Int] = Future.successful(0)

--- a/kifi-backend/modules/scraper/app/com/keepit/controllers/scraper/URISummaryController.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/controllers/scraper/URISummaryController.scala
@@ -1,11 +1,12 @@
 package com.keepit.controllers.scraper
 
 import com.google.inject.Inject
-import com.keepit.commanders.{ ScraperURISummaryCommander, WordCountCommander }
+import com.keepit.commanders.{ NormalizedURIRef, ScraperURISummaryCommander, WordCountCommander }
 import com.keepit.common.controller.ScraperServiceController
 import com.keepit.common.db.Id
 import com.keepit.common.store.ImageSize
 import com.keepit.model.NormalizedURI
+import com.kifi.macros.json
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
 import play.api.mvc.Action
@@ -16,7 +17,7 @@ class URISummaryController @Inject() (
 
   def getURISummaryFromEmbedly() = Action.async(parse.tolerantJson) { request =>
     val js = request.body
-    val uri = (js \ "uri").as[NormalizedURI]
+    val uri = (js \ "uri").as[NormalizedURIRef]
     val minSize = (js \ "minSize").as[ImageSize]
     val descOnly = (js \ "descriptionOnly").as[Boolean]
     summaryCmdr.fetchFromEmbedly(uri, minSize, descOnly).map { res =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
@@ -90,7 +90,7 @@ class KeepImageCommanderImpl @Inject() (
   def getExistingImageUrlForKeepUri(nUriId: Id[NormalizedURI])(implicit session: RSession): Option[String] = {
     imageInfoRepo.getLargestByUriWithPriority(nUriId).flatMap { imageInfo =>
       val nuri = normalizedUriRepo.get(nUriId)
-      s3UriImageStore.getImageURL(imageInfo, nuri)
+      s3UriImageStore.getImageURL(imageInfo, nuri.externalId)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/URISummaryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/URISummaryCommander.scala
@@ -191,7 +191,7 @@ class URISummaryCommander @Inject() (
   /**
    * Get S3 url for image info
    */
-  private def getS3URL(info: ImageInfo, nUri: NormalizedURI): Option[String] = uriImageStore.getImageURL(info, nUri)
+  private def getS3URL(info: ImageInfo, nUri: NormalizedURI): Option[String] = uriImageStore.getImageURL(info, nUri.externalId)
 
   def getStoredEmbedlyKeywords(id: Id[NormalizedURI]): Seq[EmbedlyKeyword] = {
     embedlyStore.get(id) match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -436,6 +436,13 @@ class AuthController @Inject() (
               ))
             } else {
               // No user exists, has social network identity, must finalize
+
+              // Check if request.identityOpt.get.identityId.providerId == "twitter"
+              // if so, do signup2 page below (need to get email)
+              // else, finalize
+
+              // This is where we will finalize and redirect to home? install? (Aaron!!)
+
               Ok(views.html.auth.authGrey(
                 view = "signup2Social",
                 firstName = User.sanitizeName(identity.firstName),

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -254,6 +254,9 @@ class AuthHelper @Inject() (
 
   def handleSocialFinalizeInfo(sfi: SocialFinalizeInfo, libraryPublicId: Option[PublicId[Library]])(implicit request: MaybeUserRequest[JsValue]): Result = {
     require(request.identityOpt.isDefined, "A social identity should be available in order to finalize social account")
+
+    // The below logic needs to happen for password-less social signups (Aaron!!)
+
     val identity = request.identityOpt.get
     val inviteExtIdOpt: Option[ExternalId[Invitation]] = request.cookies.get("inv").flatMap(v => ExternalId.asOpt[Invitation](v.value))
     implicit val context = heimdalContextBuilder.withRequestInfo(request).build


### PR DESCRIPTION
`ScraperURISummaryCommander` uses NormalizedURI a ton, only needing `id`, `externalId`, and `url`. Since these parts are a bit hairy, doing them separately.

The risk here is if a client is ever currently sending a NormalizedURI without an id. We'll get serialization issues if that happens.

@stkem 
