### PR TITLE
remove old uri recos

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/CuratorTasksPlugin.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/CuratorTasksPlugin.scala
@@ -33,7 +33,7 @@ class CuratorTasksPlugin @Inject() (
       uriRecoGenerationCommander.precomputeRecommendations()
     }
     scheduleTaskOnLeader(system, 10 minutes, 10 minutes, "recommendation reaper") {
-      uriRecoCleanupCommander.cleanupLowMasterScoreRecos()
+      uriRecoCleanupCommander.cleanup()
     }
 
     scheduleTaskOnLeader(system, 1 hours, 5 hours, "public feed reaper") {


### PR DESCRIPTION
It is annoying to see old recos keep coming back. This change adds a code that remove old uri recos whose update_at is older than 30 days.

@stkem @yingjieMiao @joshm1 
