### PR TITLE
blocking render to fit the first few library card titles

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/fit.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/fit.js
@@ -158,20 +158,28 @@ angular.module('kifi')
         }
       }
 
+      var block = +attr.block || 0;
       var sizes = {
         1: angular.fromJson(attr[1]).sort(fontSizeAsc),
         2: angular.fromJson(attr[2]).sort(fontSizeDesc),
         3: angular.fromJson(attr[3]).sort(fontSizeDesc)
       };
-      elem.removeAttr('1 2 3').css('visibility', 'hidden');
+      elem.removeAttr('1 2 3 block').css('visibility', 'hidden');
 
       return function postLink(scope, element) {
-        $timeout(function () {  // allowing binding/interpolation to complete
+        function fitAndShow() {
           if (element.attr('kf-fit') !== 'false') {
             fit(element);
           }
           element.css('visibility', '');
-        });
+        }
+
+        if (block > 0) {
+          block--;
+          scope.$evalAsync(fitAndShow);  // blocking on binding/interpolation for first few only
+        } else {
+          $timeout(fitAndShow);
+        }
       };
     }
   };

--- a/kifi-backend/modules/shoebox/angular/src/libraries/smallLibraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/smallLibraryCard.tpl.html
@@ -3,7 +3,7 @@
     <div class="kf-slc-card-cover">
       <div class="kf-slc-card-cover-image" ng-attr-style="background-image:url({{library.imageUrl}});background-position:{{library.image.x}}% {{library.image.y}}%" ng-if="library.image"></div>
     </div>
-    <div class="kf-slc-card-name" kf-fit 1="[[24,29],[28,32]]" 2="[[19,25],[18,24],[17,23],[16,22]]" 3="[[15,19]]">{{library.name}}</div>
+    <div class="kf-slc-card-name" kf-fit 1="[[24,29],[28,32]]" 2="[[19,25],[18,24],[17,23],[16,22]]" 3="[[15,19]]" block="2">{{library.name}}</div>
     <div class="kf-slc-counts">
       <ng-pluralize class="kf-slc-count" count="library.numKeeps" when="{'1':'{} Keep','other':'{} Keeps'}"></ng-pluralize>
       <ng-pluralize class="kf-slc-count" count="library.numFollowers" when="{'1':'{} Follower','other':'{} Followers'}" ng-if="library.numFollowers > 0"></ng-pluralize>

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibrariesList.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibrariesList.tpl.html
@@ -6,7 +6,7 @@
       <div class="kf-upl-card-cover">
         <div class="kf-upl-card-cover-image" ng-attr-style="background-image:url({{lib.imageUrl}});background-position:{{lib.image.x}}% {{lib.image.y}}%" ng-if="lib.image"></div>
       </div>
-      <div class="kf-upl-card-name" ng-attr-kf-fit="{{['system_main','system_secret'].indexOf(lib.kind) < 0}}" 1="[[24,29],[28,32]]" 2="[[19,25],[18,24],[17,23],[16,22]]" 3="[[15,19]]">{{lib.name}}</div>
+      <div class="kf-upl-card-name" ng-attr-kf-fit="{{['system_main','system_secret'].indexOf(lib.kind) < 0}}" 1="[[24,29],[28,32]]" 2="[[19,25],[18,24],[17,23],[16,22]]" 3="[[15,19]]" block="3">{{lib.name}}</div>
       <div class="kf-upl-counts">
         <ng-pluralize class="kf-upl-count" count="lib.numKeeps" when="{'1':'{} Keep','other':'{} Keeps'}"></ng-pluralize>
         <ng-pluralize class="kf-upl-count" count="lib.numFollowers" when="{'1':'{} Follower','other':'{} Followers'}" ng-if="lib.numFollowers > 0"></ng-pluralize>


### PR DESCRIPTION
This way the first few cards already have their title showing at the correct size when they are first drawn. The rest are either off-screen or not the user’s focal point, so it’s okay if their titles appear a bit later—we don’t block on their size calculation.
@ahsu1230 
