### PR TITLE
User profiles misc bugs

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/layout/header/header.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/header/header.tpl.html
@@ -11,7 +11,10 @@
       <div class="kf-query-lib-container" ng-class="{empty: isEmpty()}">
         <div class="kf-query-lib-icon" ng-class="{'focused': isFocused}"></div>
 
-        <img class="kf-search-bar-lib-owner-img" ng-show="search.showName" ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+        <a ng-if="inUserProfileBeta" href="{{userProfileUrl}}">
+          <img class="kf-search-bar-lib-owner-img" ng-show="search.showName" ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
+        </a>
+        <img ng-if="!inUserProfileBeta" class="kf-search-bar-lib-owner-img" ng-show="search.showName" ng-src="{{library.owner.picUrl || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
 
         <div class="kf-search-bar-lib-name" ng-show="search.showName" ng-class="library.kind != 'user_created' ? 'system-created' : library.visibility == 'secret' ? 'secret' : 'published'"> {{library.name}} </div>
         <div class="kf-search-bar-lib-name-clear" ng-show="search.showName" ng-class="library.kind != 'user_created' ? 'system-created' : library.visibility == 'secret' ? 'secret' : 'published'" ng-click="clearLibraryName()">&times;</div>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -3,9 +3,9 @@
 angular.module('kifi')
 
 .directive('kfManageLibrary', [
-  '$location', '$window', '$rootScope', 'friendService', 'libraryService', 'modalService',
+  '$location', '$rootScope', '$state', 'friendService', 'libraryService', 'modalService',
   'profileService', 'routeService', 'userService', 'util',
-  function ($location, $window, $rootScope, friendService, libraryService, modalService,
+  function ($location, $rootScope, $state, friendService, libraryService, modalService,
     profileService, routeService, userService, util) {
     return {
       restrict: 'A',
@@ -124,8 +124,13 @@ angular.module('kifi')
           submitting = true;
           libraryService.deleteLibrary(scope.library.id).then(function () {
             $rootScope.$emit('librarySummariesChanged');
+            $rootScope.$emit('libraryDeleted', scope.library.id);
             scope.close();
-            $location.path('/');
+
+            // If we were on the deleted library's page, return to the homepage.
+            if ($state.is('library.keeps')) {
+              $location.path('/');
+            }
           })['catch'](modalService.openGenericErrorModal)['finally'](function () {
             submitting = false;
           });

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
@@ -169,6 +169,10 @@ angular.module('kifi')
     $scope.libraryType = $state.current.data.libraryType;
     $scope.libraries = null;
 
+    function removeDeletedLibrary(event, libraryId) {
+      _.remove($scope.libraries, { id: libraryId });
+    }
+
     var deregister$stateChangeSuccess = $rootScope.$on('$stateChangeSuccess', function (event, toState) {
       if (/^userProfile\.libraries\./.test(toState.name)) {
         $scope.libraryType = toState.data.libraryType;
@@ -176,6 +180,9 @@ angular.module('kifi')
       }
     });
     $scope.$on('$destroy', deregister$stateChangeSuccess);
+
+    var deregisterLibraryDeleted = $rootScope.$on('libraryDeleted', removeDeletedLibrary);
+    $scope.$on('$destroy', deregisterLibraryDeleted);
 
     $scope.fetchLibraries = function () {
       if (loading) {


### PR DESCRIPTION
@ahsu1230 @2is10 

Fixes two issues:
- Curator images in library search chips are now clickable
- When a user deletes a library from the manage-library modal she opened on the user profiles page, the page will stay on the user profile page (it previously redirected to home) and the deleted library is removed from the view.
