### PR TITLE
removing recos affected by uri renormalization

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/AllKeepsSeedIngestionHelper.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/AllKeepsSeedIngestionHelper.scala
@@ -1,7 +1,7 @@
 package com.keepit.curator.commanders
 
 import com.keepit.model.{ SystemValueRepo, Name, Keep, NormalizedURI, KeepStates }
-import com.keepit.curator.model.{ CuratorKeepInfoRepo, RawSeedItemRepo, RawSeedItem, CuratorKeepInfoStates, CuratorKeepInfo }
+import com.keepit.curator.model._
 import com.keepit.common.db.{ SequenceNumber, State }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.db.slick.DBSession.RWSession
@@ -23,6 +23,7 @@ class AllKeepSeedIngestionHelper @Inject() (
     systemValueRepo: SystemValueRepo,
     keepInfoRepo: CuratorKeepInfoRepo,
     rawSeedsRepo: RawSeedItemRepo,
+    uriRecommendationRepo: UriRecommendationRepo,
     db: Database,
     airbrake: AirbrakeNotifier,
     shoebox: ShoeboxServiceClient) extends GlobalSeedIngestionHelper with Logging {
@@ -65,6 +66,7 @@ class AllKeepSeedIngestionHelper @Inject() (
           discoverable = discoverable
         ))
         rawSeedsRepo.delete(seedItem)
+        uriRecommendationRepo.deleteByUriId(seedItem.uriId)
       } getOrElse {
         //no exisitng item for this uriId (and possibly userId). Good to just move over.
         rawSeedsRepo.save(seedItem.copy(

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendationRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecommendationRepo.scala
@@ -29,6 +29,7 @@ trait UriRecommendationRepo extends DbRepo[UriRecommendation] {
   def getUsersWithRecommendations()(implicit session: RSession): Set[Id[User]]
   def getGeneralRecommendationScore(uriId: Id[NormalizedURI], minClickedUsers: Int = 3)(implicit session: RSession): Option[Float]
   def getGeneralRecommendationCandidates(limit: Int, minClickedUsers: Int = 3)(implicit session: RSession): Seq[Id[NormalizedURI]]
+  def deleteByUriId(uriId: Id[NormalizedURI])(implicit session: RWSession): Unit
 }
 
 @Singleton
@@ -175,6 +176,11 @@ class UriRecommendationRepoImpl @Inject() (
       select uri_id from uri_recommendation where uri_id >= 0 and clicked > 0
       group by uri_id having count(*) >= $minClickedUsers limit $limit
     """.as[Id[NormalizedURI]].list
+  }
+
+  def deleteByUriId(uriId: Id[NormalizedURI])(implicit session: RWSession): Unit = {
+    import StaticQuery.interpolation
+    sqlu"""DELETE FROM uri_recommendation WHERE uri_id=$uriId""".first()
   }
 
   def deleteCache(model: UriRecommendation)(implicit session: RSession): Unit = {}


### PR DESCRIPTION
@stkem @yingjieMiao @eishay 
- This adds a logic to remove recommendations when a uri renormalization is propagated to curator
- Those garbage recos already in curator db is not removed. They will be removed by regular clean up process eventually.
