### PR TITLE
Corrected Urban Airship Error Reporting

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/realtime/UrbanAirshipClient.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/realtime/UrbanAirshipClient.scala
@@ -60,7 +60,7 @@ abstract class UrbanAirshipClientImpl(clock: Clock, config: UrbanAirshipConfig, 
     res.onSuccess {
       case clientRes =>
         println(s"sent! $clientRes")
-        if (clientRes.status != 200) {
+        if (clientRes.status != 200 && clientRes.status != 202) {
           if (trial < MaxTrials) {
             log.info(s"failure to send notification ${notification.id} to device $device on trial $trial: ${clientRes.body}, trying more")
           } else {


### PR DESCRIPTION
@eishay Turns out Urban Airship (at least in some cases) responds with a 202 when everything is supposedly ok, so we were incorrectly logging failures.
I'm pretty sure at this point that the problem is with Urban Airship (or possibly google, since Leor has Cyanogen not official Android). The response we are getting from Urban Airship (with a 202) looks something like this: `{"ok":true,"operation_id":"676bb090-9cd7-11e4-a69e-001b21aceac8","push_ids":["f19e5faf-d622-46d2-8d65-283e37515649"],"message_ids":[],"content_urls":[]}`. Of note is the `"ok":true` part :-)
What further points to them is that is apparently started working again for him without us doing anything. I'll poke around a little more, but will likely file a ticket with them tomorrow. It's very hard for us to tell how pervasive this is.
