### PR TITLE
[DO NOT MERGE] Track origin/suborigin of profile page views preliminary

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/originTracking.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/originTracking.js
@@ -1,0 +1,42 @@
+'use strict';
+
+angular.module('kifi')
+
+.factory('originTrackingService', [
+  function () {
+    var pageOrigin = null;
+
+    return {
+      set: function (newOrigin) {
+        pageOrigin = newOrigin;
+      },
+
+      get: function () {
+        var temp = pageOrigin;
+        pageOrigin = null;
+        return temp;
+      }
+    };
+  }
+])
+
+.directive('kfTrackOrigin', [
+  'originTrackingService',
+  function (originTrackingService) {
+    return {
+      restrict: 'A',
+      scope: {
+        origin: '@',
+        subOrigin: '@'
+      },
+      link: function (scope, element /*, attrs*/) {
+        element.on('click', function () {
+          originTrackingService.set({
+            origin: scope.origin,
+            subOrigin: scope.subOrigin
+          });
+        });
+      }
+    };
+  }
+]);

--- a/kifi-backend/modules/shoebox/angular/src/common/originTracking.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/originTracking.js
@@ -8,7 +8,7 @@ angular.module('kifi')
 
     return {
       set: function (newOrigin) {
-        pageOrigin = newOrigin;
+        pageOrigin = _.cloneDeep(newOrigin);
       },
 
       get: function () {

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
@@ -4,9 +4,9 @@ angular.module('kifi')
 
 .controller('UserProfileCtrl', [
   '$scope', '$analytics', '$location', '$rootScope', '$state', '$stateParams', '$window',
-  'env', 'inviteService', 'keepWhoService', 'profileService', 'userProfileActionService',
+  'env', 'inviteService', 'keepWhoService', 'originTrackingService', 'profileService', 'userProfileActionService',
   function ($scope, $analytics, $location, $rootScope, $state, $stateParams, $window,
-            env, inviteService, keepWhoService, profileService, userProfileActionService) {
+            env, inviteService, keepWhoService, originTrackingService, profileService, userProfileActionService) {
 
     //
     // Internal data.
@@ -38,6 +38,8 @@ angular.module('kifi')
         $window.location = '/';
       }
       $rootScope.$emit('libraryUrl', {});
+
+      console.dir(originTrackingService.get());
 
       var username = $stateParams.username;
 

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibrariesList.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibrariesList.tpl.html
@@ -18,7 +18,7 @@
       </div>
     </a>
     <div itemscope itemtype="http://data-vocabulary.org/Person">
-      <a class="kf-upl-card-owner" href="{{lib.ownerProfileUrl}}" ng-click="trackProfileClick()" itemprop="url">
+      <a class="kf-upl-card-owner" href="{{lib.ownerProfileUrl}}" kf-track-origin origin="profile" sub-origin="curator" itemprop="url">
         <img class="kf-upl-card-owner-pic" ng-src="{{lib.ownerPicUrl}}" alt="{{lib.owner.firstName}} {{lib.owner.lastName}}" itemprop="photo" ng-if="libraryType !== 'own'">
         <span class="kf-upl-card-by">by</span>
         <span class="kf-upl-card-by-name" itemprop="name">{{lib.owner.firstName}} {{lib.owner.lastName}}</span>


### PR DESCRIPTION
@2is10 cc @joshm1 

This is what I've come up with for tracking a page view that includes information about where it came from (origin and suborigin). I saw that @joshm1 had previously added a query parameter but I couldn't figure out how to take that off once we land on the new page (Josh doesn't take the query parameter off). Here I am using a service to hold the origin/suborigin data until it's used by tracking. It's a global state, basically, but it's what services are for. I made this into a directive so it can be easily popped into other places.

Please let me know what you think (and if you hate it).

Thanks!
