### PR TITLE
falling back to Library.createdAt if .lastKept is missing (for cards)

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -1136,38 +1136,33 @@ class LibraryCommander @Inject() (
       ).zipWithIndex.map { case (value, idx) => value.id -> (value, idx) }.toMap
 
       val libIds = systemValueLibraries.keySet
-      val libIdsMap = db.readOnlyReplica { implicit s => libraryRepo.getLibraries(libIds) } filter {
-        case (_, lib) => lib.visibility == LibraryVisibility.PUBLISHED
+      val libs = db.readOnlyReplica { implicit s =>
+        libraryRepo.getLibraries(libIds).values.toSeq.filter(_.visibility == LibraryVisibility.PUBLISHED)
+      }
+      val infos: ParSeq[LibraryCardInfo] = db.readOnlyMaster { implicit s =>
+        val owners = basicUserRepo.loadAll(libs.map(_.ownerId).toSet)
+        createLibraryCardInfos(libs, owners, None, false, ProcessedImageSize.Medium.idealSize)
       }
 
-      val fullLibInfosF = createFullLibraryInfos(viewerUserIdOpt = None,
-        showPublishedLibraries = true,
-        maxMembersShown = 0,
-        maxKeepsShown = 0,
-        idealKeepImageSize = ProcessedImageSize.Medium.idealSize,
-        libraries = libIdsMap.values.toSeq,
-        idealLibraryImageSize = ProcessedImageSize.Medium.idealSize, withKeepTime = true)
-
-      fullLibInfosF map { libInfos =>
-        libInfos map {
-          case (libId, info) =>
-            val (extraInfo, idx) = systemValueLibraries(libId)
-            val card = LibraryCardInfo(
+      SafeFuture {
+        (infos.zip(libs).map {
+          case (info, lib) =>
+            val (extraInfo, idx) = systemValueLibraries(lib.id.get)
+            idx -> LibraryCardInfo(
               id = info.id,
               name = info.name,
               description = None, // not currently used
               color = info.color,
               image = info.image,
               slug = info.slug,
-              owner = BasicUserWithFriendStatus.fromWithoutFriendStatus(info.owner),
+              owner = info.owner,
               numKeeps = info.numKeeps,
               numFollowers = info.numFollowers,
               followers = Seq.empty,
               lastKept = info.lastKept,
               following = None,
               caption = extraInfo.caption)
-            card -> idx
-        } sortBy (_._2) map (_._1)
+        }).seq.sortBy(_._1).map(_._2)
       }
     } getOrElse Future.successful(Seq.empty)
   }
@@ -1218,7 +1213,7 @@ class LibraryCommander @Inject() (
       val libraryIds = libs.map(_.id.get).toSet
       val owners = Map(user.id.get -> BasicUser.fromUser(user))
       val memberships = libraryMembershipRepo.getWithLibraryIdsAndUserId(libraryIds, user.id.get)
-      val libraryInfos = createLibraryCardInfos(libs, owners, user, Some(user), idealSize) zip libs
+      val libraryInfos = createLibraryCardInfos(libs, owners, Some(user), false, idealSize) zip libs
       (libraryInfos, memberships)
     }
     libraryInfos map {
@@ -1235,7 +1230,7 @@ class LibraryCommander @Inject() (
           numKeeps = info.numKeeps,
           numFollowers = info.numFollowers,
           followers = info.followers,
-          lastKept = lib.lastKept,
+          lastKept = lib.lastKept.getOrElse(lib.createdAt),
           listed = memberships(lib.id.get).listed)
     }
   }
@@ -1249,7 +1244,7 @@ class LibraryCommander @Inject() (
           libraryRepo.getOwnedLibrariesForOtherUser(user.id.get, other.id.get, page)
       }
       val owners = Map(user.id.get -> BasicUser.fromUser(user))
-      createLibraryCardInfos(libs, owners, user, viewer, idealSize)
+      createLibraryCardInfos(libs, owners, viewer, viewer.exists(_.id != user.id), idealSize)
     }
   }
 
@@ -1270,7 +1265,7 @@ class LibraryCommander @Inject() (
           } else Seq.empty
       }
       val owners = basicUserRepo.loadAll(libs.map(_.ownerId).toSet)
-      createLibraryCardInfos(libs, owners, user, viewer, idealSize)
+      createLibraryCardInfos(libs, owners, viewer, viewer.exists(_.id != user.id), idealSize)
     }
   }
 
@@ -1279,23 +1274,19 @@ class LibraryCommander @Inject() (
       db.readOnlyMaster { implicit session =>
         val libs = libraryRepo.getInvitedLibrariesOfSelf(user.id.get, page)
         val owners = basicUserRepo.loadAll(libs.map(_.ownerId).toSet)
-        createLibraryCardInfos(libs, owners, user, viewer, idealSize)
+        createLibraryCardInfos(libs, owners, viewer, false, idealSize)
       }
     } else {
       ParSeq.empty
     }
   }
 
-  private def createLibraryCardInfos(libs: Seq[Library], owners: Map[Id[User], BasicUser], profileUser: User, viewer: Option[User], idealSize: ImageSize)(implicit session: RSession): ParSeq[LibraryCardInfo] = {
+  private def createLibraryCardInfos(libs: Seq[Library], owners: Map[Id[User], BasicUser], viewer: Option[User], withFollowing: Boolean, idealSize: ImageSize)(implicit session: RSession): ParSeq[LibraryCardInfo] = {
     val ownersWFS = if (viewer.isDefined && owners.keySet.exists(_ != viewer.get.id.get)) {
       friendStatusCommander.augmentWithFriendStatus(viewer.get.id.get, owners)
     } else {
       owners mapValues BasicUserWithFriendStatus.fromWithoutFriendStatus
     }
-
-    val isUserViewingOtherProfile = viewer.map { v =>
-      v.id.get != profileUser.id.get
-    }.getOrElse(false)
 
     libs.par map { lib => // may want to optimize queries below into bulk queries
       val image = ProcessedImageSize.pickBestImage(idealSize, libraryImageRepo.getForLibraryId(lib.id.get))
@@ -1309,12 +1300,13 @@ class LibraryCommander @Inject() (
         (0, Seq.empty)
       }
 
-      val isFollowing = if (isUserViewingOtherProfile) {
+      val ownerWFS = ownersWFS(lib.ownerId)
+      val isFollowing = if (withFollowing && viewer.isDefined && viewer.get.externalId != ownerWFS.externalId) {
         Some(libraryMembershipRepo.getWithLibraryIdAndUserId(lib.id.get, viewer.get.id.get).isDefined)
       } else {
         None
       }
-      createLibraryCardInfo(lib, image, ownersWFS(lib.ownerId), numKeeps, numFollowers, followersSample, isFollowing)
+      createLibraryCardInfo(lib, image, ownerWFS, numKeeps, numFollowers, followersSample, isFollowing)
     }
   }
 
@@ -1331,7 +1323,7 @@ class LibraryCommander @Inject() (
       numKeeps = numKeeps,
       numFollowers = numFollowers,
       followers = LibraryCardInfo.showable(followers),
-      lastKept = lib.lastKept,
+      lastKept = lib.lastKept.getOrElse(lib.createdAt),
       following = isFollowing,
       caption = None)
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -20,6 +20,9 @@ import com.keepit.heimdal.HeimdalContextBuilderFactory
 import com.keepit.inject.FortyTwoConfig
 import com.keepit.model._
 import com.keepit.shoebox.controllers.LibraryAccessActions
+
+import org.joda.time.DateTime
+
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
 import play.api.mvc.Action
@@ -557,7 +560,7 @@ class LibraryController @Inject() (
               numKeeps = info.numKeeps,
               numFollowers = info.numFollowers,
               followers = LibraryCardInfo.showable(info.followers),
-              lastKept = info.lastKept,
+              lastKept = info.lastKept.getOrElse(new DateTime(0)),
               following = None,
               caption = None)
           }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
@@ -146,9 +146,8 @@ private[model] abstract class BaseLibraryCardInfo(
   numKeeps: Int,
   numFollowers: Int,
   followers: Seq[BasicUser],
-  lastKept: Option[DateTime],
-  following: Option[Boolean] // is viewer following this library? Set to None if viewing anonymously or viewing own profile
-  )
+  lastKept: DateTime,
+  following: Option[Boolean]) // is viewer following this library? Set to None if viewing anonymously or viewing own profile
 
 @json
 case class OwnLibraryCardInfo( // when viewing own created libraries
@@ -163,7 +162,7 @@ case class OwnLibraryCardInfo( // when viewing own created libraries
   numKeeps: Int,
   numFollowers: Int,
   followers: Seq[BasicUser],
-  lastKept: Option[DateTime],
+  lastKept: DateTime,
   following: Option[Boolean] = None,
   listed: Boolean)
     extends BaseLibraryCardInfo(id, name, description, color, image, slug, numKeeps, numFollowers, followers, lastKept, following)
@@ -180,7 +179,7 @@ case class LibraryCardInfo(
   numKeeps: Int,
   numFollowers: Int,
   followers: Seq[BasicUser],
-  lastKept: Option[DateTime],
+  lastKept: DateTime,
   following: Option[Boolean],
   caption: Option[String])
     extends BaseLibraryCardInfo(id, name, description, color, image, slug, numKeeps, numFollowers, followers, lastKept, following)

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
@@ -480,6 +480,7 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
                   "numKeeps" : 0,
                   "numFollowers" : 0,
                   "followers": [],
+                  "lastKept": ${lib2.createdAt.getMillis},
                   "listed": true
                 },
                 {
@@ -494,6 +495,7 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
                   "numKeeps" : 0,
                   "numFollowers" : 0,
                   "followers": [],
+                  "lastKept": ${lib1.createdAt.getMillis},
                   "listed": true
                 }
               ]

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -494,6 +494,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                       "pictureName": "alf.jpg",
                       "username": "seconduser"
                     }],
+                  "lastKept":${lib1.createdAt.getMillis},
                   "listed": true
                 }
                ]
@@ -523,7 +524,8 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                   },
                   "numKeeps":0,
                   "numFollowers":1,
-                  "followers":[]
+                  "followers":[],
+                  "lastKept":${lib3.createdAt.getMillis}
                 }
               ]
             }
@@ -534,13 +536,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
         val result3 = libraryController.getProfileLibraries(user1.username, 0, 10, "invited")(request3)
         status(result3) must equalTo(OK)
         contentType(result3) must beSome("application/json")
-        Json.parse(contentAsString(result3)) must equalTo(Json.parse(
-          s"""
-            {
-              "invited": []
-            }
-          """
-        ))
+        Json.parse(contentAsString(result3)) === Json.parse("""{"invited":[]}""")
 
         val request4 = FakeRequest("GET", testPath)
         val result4 = libraryController.getProfileLibraries(user1.username, 0, 10, "all")(request4)
@@ -558,7 +554,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
         val result5Json = (contentAsJson(result5) \ "following").as[Seq[JsObject]]
         (result5Json.head \ "name").as[String] === "lib1"
         (result5Json.head \ "numFollowers").as[Int] === 1
-        (result5Json.head \ "following").as[Boolean] === true
+        (result5Json.head \ "following").asOpt[Boolean] === None
       }
     }
 
@@ -1375,8 +1371,8 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
             val user1 = user().withName("John", "Doe").saved
             val user2 = user().withName("Joe", "Blow").saved
             val user3 = user().withName("Jack", "Black").saved
-            val lib1 = library().withName("Scala").withUser(user1).published().saved
-            val lib2 = library().withName("Java").withUser(user1).published().saved
+            val lib1 = library().withName("Scala").withUser(user1).published().withMemberCount(3).saved
+            val lib2 = library().withName("Java").withUser(user1).published().withMemberCount(2).saved
 
             // test that private libraries are not returned in the response
             val lib3 = library().withName("Private").withUser(user1).saved


### PR DESCRIPTION
Also fixing an issue where `"following": true` was being returned for viewer’s own libraries when viewed on someone else’s profile.

@ahsu1230 
