### PR TITLE
stringify vertices lazily when persisting

### DIFF
--- a/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraph.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraph.scala
@@ -40,13 +40,13 @@ object SimpleGraph extends Logging {
   implicit val vertexFormat = MutableVertex.lossyFormat
 
   def write(graph: SimpleGraph, graphFile: File): Unit = {
-    val lines: Iterable[String] = graph.vertices.toIterable.map {
+    val lines: Iterable[String] = graph.vertices.iterator.map {
       case (vertexId, vertex) =>
         checkVertexIntegrity(graph.vertices, vertexId, vertex)
         Json.stringify(
           Json.arr(JsNumber(vertexId.id), Json.toJson(vertex))
         )
-    }
+    }.toIterable
     FileUtils.writeLines(graphFile, lines)
   }
 


### PR DESCRIPTION
@leogrim @eishay 

Reducing the peak memory usage during backup by lazily stringify vertices.
We have a backup task every two hours, and graph regularly has a full GC every two hours. This may stop it hopefully.
