### PR TITLE
on graph serialization, persisting smaller chunks of the graph straight ...

### DIFF
--- a/kifi-backend/modules/graph/app/com/keepit/graph/simple/MutableVertex.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/simple/MutableVertex.scala
@@ -41,7 +41,7 @@ class MutableVertex(var data: VertexDataReader, val outgoingEdges: MutableOutgoi
    */
   def write(out: ObjectOutputStream): Unit = {
     out.writeUTF(VertexDataReader.writes.writes(data).toString)
-    out.writeInt(outgoingEdges.edges.foldLeft(0)((_, edges) => edges._2.size))
+    out.writeInt(outgoingEdges.edges.foldLeft(0)((count, edges) => count + edges._2.size))
     outgoingEdges.edges foreach {
       case (component, edges) =>
         edges foreach {

--- a/kifi-backend/modules/graph/app/com/keepit/graph/simple/MutableVertex.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/simple/MutableVertex.scala
@@ -1,5 +1,7 @@
 package com.keepit.graph.simple
 
+import java.io.{ ObjectInputStream, ObjectOutputStream }
+
 import com.keepit.graph.model._
 import scala.collection.mutable.{ Map => MutableMap, Set => MutableSet }
 import com.keepit.graph.model.EdgeKind.EdgeType
@@ -33,10 +35,42 @@ class MutableVertex(var data: VertexDataReader, val outgoingEdges: MutableOutgoi
     incomingEdges.edges(component) -= sourceId
     if (incomingEdges.edges(component).isEmpty) { incomingEdges.edges -= component }
   }
+
+  /**
+   * UTF, Int, (Long, UTF)
+   */
+  def write(out: ObjectOutputStream): Unit = {
+    out.writeUTF(VertexDataReader.writes.writes(data).toString)
+    out.writeInt(outgoingEdges.edges.foldLeft(0)((_, edges) => edges._2.size))
+    outgoingEdges.edges foreach {
+      case (component, edges) =>
+        edges foreach {
+          case (destinationId, edgeDataReader) =>
+            out.writeLong(destinationId.id)
+            out.writeUTF(EdgeDataReader.writes.writes(edgeDataReader).toString())
+        }
+    }
+  }
 }
 
 object MutableVertex {
   def apply(data: VertexDataReader): MutableVertex = new MutableVertex(data, MutableOutgoingEdges(), MutableIncomingEdges())
+
+  def reads(in: ObjectInputStream): MutableVertex = {
+    val dataJson = in.readUTF()
+    VertexDataReader.readsAsVertexData.reads(Json.parse(dataJson)) match {
+      case JsError(error) => throw new Exception(s"error parsing $dataJson: $error")
+      case JsSuccess(data, _) =>
+        val newVertex = MutableVertex(data.asReader)
+        val outgoingEdgesSize = in.readInt()
+        for (i <- 0 until outgoingEdgesSize) {
+          val destinationId = VertexId(in.readLong())
+          val edgeData = EdgeDataReader.readsAsEdgeData.reads(Json.parse(in.readUTF())).get.asReader
+          newVertex.saveOutgoingEdge(destinationId, edgeData)
+        }
+        newVertex
+    }
+  }
 
   // This "lossy" formatter ignores the vertex's incoming edges, which have to be recovered globally (see initializeIncomingEdges method)
   val lossyFormat = new Format[MutableVertex] {

--- a/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraph.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/simple/SimpleGraph.scala
@@ -5,7 +5,7 @@ import scala.collection.Map
 import com.keepit.graph.model._
 import play.api.libs.json._
 import com.keepit.graph.manager.GraphStatistics
-import java.io.File
+import java.io._
 import org.apache.commons.io.{ LineIterator, FileUtils }
 import scala.collection.JavaConversions._
 import com.keepit.common.logging.Logging
@@ -39,7 +39,57 @@ case class SimpleGraph(vertices: ConcurrentMap[VertexId, MutableVertex] = TrieMa
 object SimpleGraph extends Logging {
   implicit val vertexFormat = MutableVertex.lossyFormat
 
+  val SerializationVersionId = 1
+
+  /**
+   * Int, Int (Long, VRTX)
+   */
   def write(graph: SimpleGraph, graphFile: File): Unit = {
+    val out = new ObjectOutputStream(new FileOutputStream(graphFile))
+    try {
+      out.writeInt(SerializationVersionId)
+      out.writeInt(graph.vertices.size)
+      graph.vertices foreach {
+        case (vertexId, vertex) =>
+          checkVertexIntegrity(graph.vertices, vertexId, vertex)
+          out.writeLong(vertexId.id)
+          vertex.write(out)
+      }
+    } finally {
+      out.flush()
+      out.close()
+    }
+  }
+
+  /**
+   * Int, Int (Long, VRTX)
+   */
+  def read(graphFile: File): SimpleGraph = {
+    val vertices = TrieMap[VertexId, MutableVertex]()
+    val in = new ObjectInputStream(new FileInputStream(graphFile))
+    val graphOpt: Option[SimpleGraph] = try {
+      val version = in.readInt()
+      if (version != SerializationVersionId) None
+      else {
+        val graphSize = in.readInt()
+        for (i <- 0 until graphSize) {
+          val vertexId = VertexId(in.readLong())
+          val vertex = MutableVertex.reads(in)
+          vertices += (vertexId -> vertex)
+        }
+        MutableVertex.initializeIncomingEdges(vertices)
+        Some(SimpleGraph(vertices))
+      }
+    } finally {
+      in.close()
+    }
+    graphOpt match {
+      case None => readJson(graphFile)
+      case Some(graph) => graph
+    }
+  }
+
+  def writeJson(graph: SimpleGraph, graphFile: File): Unit = {
     val lines: Iterable[String] = graph.vertices.iterator.map {
       case (vertexId, vertex) =>
         checkVertexIntegrity(graph.vertices, vertexId, vertex)
@@ -50,7 +100,7 @@ object SimpleGraph extends Logging {
     FileUtils.writeLines(graphFile, lines)
   }
 
-  def read(graphFile: File): SimpleGraph = {
+  def readJson(graphFile: File): SimpleGraph = {
     val vertices = TrieMap[VertexId, MutableVertex]()
     val lineIterator = FileUtils.lineIterator(graphFile)
     try {


### PR DESCRIPTION
...to disk without needing to allocate large string representation of the set of edges.

note that the serialization format had changed and the reader is backward compatible.
