### PR TITLE
Properly validate email addresses in AuthController + use SafeFuture for service calls

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/service/ServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/service/ServiceClient.scala
@@ -119,13 +119,13 @@ trait ServiceClient extends CommonServiceUtilities with Logging {
       }
       if (ignoreFailure) {
         call match {
-          case c@ServiceRoute(GET, _, _*) => httpClient.withTimeout(callTimeouts).getFuture(httpUri, httpClient.ignoreFailure)
-          case c@ServiceRoute(POST, _, _*) => httpClient.withTimeout(callTimeouts).postFuture(httpUri, body, httpClient.ignoreFailure)
+          case c @ ServiceRoute(GET, _, _*) => httpClient.withTimeout(callTimeouts).getFuture(httpUri, httpClient.ignoreFailure)
+          case c @ ServiceRoute(POST, _, _*) => httpClient.withTimeout(callTimeouts).postFuture(httpUri, body, httpClient.ignoreFailure)
         }
       } else {
         call match {
-          case c@ServiceRoute(GET, _, _*) => httpClient.withTimeout(callTimeouts).getFuture(httpUri)
-          case c@ServiceRoute(POST, _, _*) => httpClient.withTimeout(callTimeouts).postFuture(httpUri, body)
+          case c @ ServiceRoute(GET, _, _*) => httpClient.withTimeout(callTimeouts).getFuture(httpUri)
+          case c @ ServiceRoute(POST, _, _*) => httpClient.withTimeout(callTimeouts).postFuture(httpUri, body)
         }
       }
     }

--- a/kifi-backend/modules/common/app/com/keepit/common/service/ServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/service/ServiceClient.scala
@@ -1,5 +1,7 @@
 package com.keepit.common.service
 
+import com.keepit.common.akka.SafeFuture
+
 import scala.collection.mutable.{ SynchronizedSet, HashSet, Set }
 import scala.concurrent.Future
 import scala.util.Random
@@ -106,7 +108,7 @@ trait ServiceClient extends CommonServiceUtilities with Logging {
     respFuture
   }
 
-  protected def callUrl(call: ServiceRoute, httpUri: HttpUri, body: JsValue, ignoreFailure: Boolean = false, callTimeouts: CallTimeouts = CallTimeouts.NoTimeouts): Future[ClientResponse] = {
+  protected def callUrl(call: ServiceRoute, httpUri: HttpUri, body: JsValue, ignoreFailure: Boolean = false, callTimeouts: CallTimeouts = CallTimeouts.NoTimeouts): Future[ClientResponse] = new SafeFuture({
     val url = httpUri.url
     if (url.length > ServiceClient.MaxUrlLength) {
       airbrakeNotifier.notify(AirbrakeError(
@@ -125,7 +127,7 @@ trait ServiceClient extends CommonServiceUtilities with Logging {
         case c @ ServiceRoute(POST, _, _*) => httpClient.withTimeout(callTimeouts).postFuture(httpUri, body)
       }
     }
-  }
+  })
 
   private def logBroadcast(url: ServiceUri, body: JsValue = JsNull): Unit = {
     log.info(s"[broadcast] Sending to $url: ${body.toString.take(120)}")


### PR DESCRIPTION
@andrewconner @eishay @stkem @ymatsuda 
Following Yesterday's issues: 
- Adding proper typing (hence proper validation) for emails in AuthController
- Somehow the call to `getUserIndexable` ends up wrapped in a SafeFuture in `Search`, but was silently failing in `Graph`. Our HTTP client explicitly reports failed service calls, but returns a regular Future so that exceptions further up (e.g. deserialization) may be swallowed => now wrapping all service calls ServiceClient with a `SafeFuture`.
