### PR TITLE
avoiding an error dialog on follow/unfollow in some cases

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.js
@@ -23,21 +23,11 @@ angular.module('kifi')
         // Internal helper methods.
         //
         function followLibrary() {
-          libraryService.joinLibrary(scope.library.id).then(function (result) {
-            if (result === 'already_joined') {
-              modalService.openGenericErrorModal({
-                modalData: {
-                  genericErrorMessage: 'You are already following this library!'
-                }
-              });
-
-              return;
+          libraryService.joinLibrary(scope.library.id).then(function () {
+            if ($location.path() === scope.library.url) {
+              $state.reload();
             } else {
-              if ($location.path() === scope.library.url) {
-                $state.reload();
-              } else {
-                $location.path(scope.library.url);
-              }
+              $location.path(scope.library.url);
             }
           })['catch'](modalService.openGenericErrorModal);
         }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -3,9 +3,9 @@
 angular.module('kifi')
 
 .directive('kfManageLibrary', [
-  '$location', '$rootScope', '$state', 'friendService', 'libraryService', 'modalService',
+  '$location', '$state', 'friendService', 'libraryService', 'modalService',
   'profileService', 'routeService', 'userService', 'util',
-  function ($location, $rootScope, $state, friendService, libraryService, modalService,
+  function ($location, $state, friendService, libraryService, modalService,
     profileService, routeService, userService, util) {
     return {
       restrict: 'A',
@@ -129,9 +129,6 @@ angular.module('kifi')
 
           submitting = true;
           libraryService.deleteLibrary(scope.library.id).then(function () {
-            $rootScope.$emit('librarySummariesChanged');
-            $rootScope.$emit('libraryDeleted', scope.library.id);
-
             // If we were on the deleted library's page, return to the homepage.
             if ($state.is('library.keeps') &&
                 ($state.href('library.keeps') === scope.library.url)) {


### PR DESCRIPTION
This pull request breaks up the `libraryUpdated` event into three more specific ones: `libraryJoined`, `libraryLeft`, and `libraryKeepCountChanged`. Each now contains less information. This way we don’t need to load a fresh copy of all information about a library from the server when some of these events occur (which sometimes isn’t possible).

Also showing a more specific error message when the user tries to follow on a library card but the owner has made the library private.

@yipingliao
