### PR TITLE
Sending images to resized S3

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/BaseImage.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/BaseImage.scala
@@ -44,7 +44,9 @@ sealed trait ImageProcessDone extends ImageProcessState
 
 sealed trait ImageProcessSuccess extends ImageProcessDone
 sealed abstract class ImageStoreFailure(val reason: String) extends ImageProcessState with ImageProcessDone
-sealed abstract class ImageStoreFailureWithException(ex: Throwable, reason: String) extends ImageStoreFailure(reason)
+sealed abstract class ImageStoreFailureWithException(ex: Throwable, reason: String) extends ImageStoreFailure(reason) {
+  def getCause: Throwable = ex
+}
 
 object ImageProcessState {
   // In-progress

--- a/kifi-backend/modules/common/app/com/keepit/scraper/ScraperServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/scraper/ScraperServiceClient.scala
@@ -121,7 +121,7 @@ case class ScraperThreadInstanceInfo(info: AmazonInstanceInfo, jobInfo: Either[S
 
 @json case class NormalizedURIRef(id: Id[NormalizedURI], url: String, externalId: ExternalId[NormalizedURI])
 
-@json case class PersistedImageVersion(width: Int, height: Int, imageUrl: String)
+@json case class PersistedImageVersion(width: Int, height: Int, path: String)
 @json case class PersistedImageRef(sizes: Seq[PersistedImageVersion], caption: Option[String])
 @json case class URIPreviewFetchResult(
   pageUrl: String,

--- a/kifi-backend/modules/common/test/com/keepit/graph/FakeGraphServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/graph/FakeGraphServiceClientImpl.scala
@@ -4,7 +4,7 @@ import com.keepit.common.db.{ Id }
 import com.keepit.model._
 
 import scala.concurrent.Future
-import com.keepit.common.amazon.{AmazonInstanceInfo, AmazonInstanceId}
+import com.keepit.common.amazon.{ AmazonInstanceInfo, AmazonInstanceId }
 import com.keepit.graph.manager.{ PrettyGraphState, PrettyGraphStatistics }
 import com.keepit.common.zookeeper.ServiceCluster
 import com.keepit.common.net.HttpClient

--- a/kifi-backend/modules/scraper/app/com/keepit/controllers/scraper/URISummaryController.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/controllers/scraper/URISummaryController.scala
@@ -19,8 +19,7 @@ class URISummaryController @Inject() (
   def getURISummaryFromEmbedly() = Action.async(parse.tolerantJson) { request =>
     val js = request.body
     val uri = (js \ "uri").as[NormalizedURIRef]
-    val descOnly = (js \ "descriptionOnly").as[Boolean]
-    summaryCmdr.fetchFromEmbedly(uri, descOnly).map { res =>
+    summaryCmdr.fetchFromEmbedly(uri).map { res =>
       Ok(Json.toJson(res))
     }
   }


### PR DESCRIPTION
Plugging up new resized images to S3. Skipping the old pipeline (blocking image uploads).

Next step: shoebox using new API, data migration.
