### PR TITLE
Increase max height of modal to show entire manage-lib modal.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/modal/modal.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/modal/modal.js
@@ -68,13 +68,13 @@ angular.module('kifi')
         });
 
         var wrap = element.find('.dialog-body');
-        var verticalScrollbarCss = {'max-height': $window.innerHeight - 160 + 'px'};
+        var verticalScrollbarCss = {'max-height': $window.innerHeight - 120 + 'px'};
         if (!scope.disableScroll) {
           _.merge(verticalScrollbarCss, {'overflow-y': 'auto', 'overflow-x': 'hidden'});
         }
 
         var resizeWindow = _.debounce(function () {
-          verticalScrollbarCss['max-height'] = $window.innerHeight - 160 + 'px';
+          verticalScrollbarCss['max-height'] = $window.innerHeight - 120 + 'px';
           wrap.css(verticalScrollbarCss);
         }, 100);
         $window.addEventListener('resize', resizeWindow);


### PR DESCRIPTION
@2is10 Enlarging the maximum height of our modals a bit; this allows the entire manage-library modal to show up. After the addition of the color picker, that modal is not showing up entirely on smaller screens (e.g., my MacBook Air) even when the browser window fully occupies the screen.
