### PR TITLE
Make entire text re followers in upl card footer clickable.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibrariesList.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibrariesList.tpl.html
@@ -39,10 +39,12 @@
         <a href="{{user.profileUrl}}" class="kf-upl-follower" ng-repeat="user in lib.followers" kf-track-origin origin="{{currentPageOrigin}}/follower" ng-click="trackProfileClick()"
            ng-attr-style="background-image:url({{user.picUrl}})"></a>
         <span ng-if="lib.numFollowers === lib.followers.length">
-          <ng-pluralize class="kf-upl-all-followers" count="lib.numFollowers" when="{'1':'follows this library','other':'are following'}"></ng-pluralize>
+          <a href="javascript:" ng-click="openFollowersList(lib)" class="kf-upl-followers-number">
+            <ng-pluralize class="kf-upl-all-followers" count="lib.numFollowers" when="{'1':'follows this library','other':'are following'}"></ng-pluralize>
+          </a>
         </span>
         <span ng-if="lib.numFollowers > lib.followers.length">
-          <a href="javascript:" ng-click="openFollowersList(lib)" class="kf-upl-followers-number">+ {{lib.numFollowers - lib.followers.length}}</a> are following
+          <a href="javascript:" ng-click="openFollowersList(lib)" class="kf-upl-followers-number">+ {{lib.numFollowers - lib.followers.length}} are following</a>
         </span>
       </div>
       <div class="kf-upl-updated" ng-switch-when="updated">


### PR DESCRIPTION
@2is10 Currently only the "+25" section is clickable; this pull makes the whole follower text clickable.
