### PR TITLE
remove password step from FB signin on public library/profile page

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
+++ b/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
@@ -209,7 +209,8 @@ angular.module('kifi')
       $scope.registerFinalizeSubmitted = true;
       $scope.requestActive = true;
       var fields;
-      if (!form.$valid) {
+
+      if (form && !form.$valid) {
         $scope.requestActive = false;
         return false;
       } else if ($scope.userData.method === 'social') {

--- a/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
+++ b/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
@@ -166,9 +166,13 @@ angular.module('kifi')
               $scope.onSuccess();
             } else if (resp.code && resp.code === 'continue_signup') {
               // todo: handle case when emails match, so backend auto-logs in user - andrew
-              modalService.close();
+
               $scope.userData.method = 'social';
-              registerFinalizeModal();
+
+              // skip password setting (set randomly)
+              $scope.userData.password = Math.random().toString(36).substring(8);
+              $scope.registerFinalizeSubmit();
+
             } else if (resp.code && resp.code === 'connect_option') {
               // todo, figure out what this could be, handle errors - andrew
               $scope.onError({'code': 'connect_option', redirect: resp.uri});

--- a/kifi-backend/modules/shoebox/public/css/auth2.css
+++ b/kifi-backend/modules/shoebox/public/css/auth2.css
@@ -363,7 +363,8 @@ a.video-frame {
 }
 .twitter > .form-network-icon:empty:before {
   background-image: url(../img/twitter-icon.svg);
-  width: 37px;
+  width: 28px;
+  height: 24px;
   background-size: cover;
   background-repeat: no-repeat;
 }


### PR DESCRIPTION
Go to a public library/profile page
click on Follow or Sign In
click on Continue with Facebook

After authenticating, you normally would be brought to a finalize modal (You're almost there! Enter in a password phase)
We want to skip this step and just go straight to "Thanks for Registering" install extension modal.

@andrewconner 
