### PR TITLE
use recommendationGenerationLock for throttling

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
@@ -228,7 +228,6 @@ class RecommendationGenerationCommander @Inject() (
         }
         res.map(_ => ())
       } else {
-        recommendationGenerationLock.clear()
         if (serviceDiscovery.myStatus.exists(_ != ServiceStatus.STOPPING)) log.error("Trying to run reco precomputation on non-leader (and it's not a shut down)! Aborting.")
         Future.successful()
       }
@@ -240,7 +239,12 @@ class RecommendationGenerationCommander @Inject() (
     specialCurators().flatMap { boostedKeepersSeq =>
       if (recommendationGenerationLock.waiting < userIds.length + 1) {
         val boostedKeepers = boostedKeepersSeq.toSet
-        Future.sequence(userIds.map(userId => precomputeRecommendationsForUser(userId, boostedKeepers))).map(_ => ())
+        val futSeq = userIds.map { userId =>
+          recommendationGenerationLock.withLockFuture {
+            precomputeRecommendationsForUser(userId, boostedKeepers)
+          }
+        }
+        Future.sequence(futSeq).map(_ => ())
       } else {
         Future.successful()
       }


### PR DESCRIPTION
@yingjieMiao @stkem 

recommendationGenerationLock was not actually used. Now the futures are created using recommendationGenerationLock.
I found the `clear` method of `ReactiveLock` is dangerous. It does not completes `Promise`s (thus `Future`s of them) in the task queue. They will never be completed once the task queue is cleared. I removed the call from `RecommendationGenerationCommander` because I don't think it is essential.
