### PR TITLE
Increase bottom margin on first panel of manage-lib modal

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
@@ -96,6 +96,9 @@
   &.kf-color
     font-size: 0
 
+  &:last-child
+    margin-bottom: 25px
+
 .manage-lib-heading
   display: inline-block
   width: 115px


### PR DESCRIPTION
... to completely cover content from second panel.

Thanks for spotting this, @leogrim !
@2is10 
