### PR TITLE
Remove hover mini from left

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWho.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWho.styl
@@ -114,7 +114,7 @@
 .tooltip-show-hide.ng-hide-add
 .tooltip-show-hide.ng-hide-remove
   transition: opacity linear, padding-top linear
-  transition-duration: 100ms
+  transition-duration: 50ms
   display:block!important
 
 .tooltip-show-hide.ng-hide-add.ng-hide-add-active

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/whoTooltip.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/whoTooltip.js
@@ -64,7 +64,7 @@ angular.module('kifi')
           timeout = $timeout(function () {
             tooltip.css('visibility', 'visible');
             scope.tooltipEnabled = true;
-          }, 500);
+          });
         };
 
         scope.hideTooltip = function () {

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/tooltip/tooltip.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/tooltip/tooltip.styl
@@ -13,10 +13,10 @@
   visibility: hidden
   z-index: 1999
   opacity: 0
-  transition: opacity 0.3s, visibility 0s 0.3s
+  transition: opacity 0.2s, visibility 0s
 
 
 .kf-tooltipped:hover > .kf-tooltip
-  transition: opacity 0.3s 1.5s
+  transition: opacity 0.2s
   visibility: visible
   opacity: 1

--- a/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/nav/nav.tpl.html
@@ -107,9 +107,6 @@
                                      'other':' {} followers'}"></ng-pluralize>
               </div>
             </div>
-            <div kf-tooltip position="right" padding="3">
-              <div kf-library-mini-card library="library"></div>
-            </div>
           </a>
         </li>
 
@@ -138,9 +135,6 @@
                                      'other':' {} followers'}"></ng-pluralize>
               </div>
             </div>
-            <div kf-tooltip position="right" padding="3">
-              <div kf-library-mini-card library="library"></div>
-            </div>
           </a>
           <a href="{{getLibraryOwnerProfileUrl(library)}}" kf-track-origin origin="libraryList/followed">
             <img class="library-icon-owner-img" ng-if="!library.isMine" ng-src="{{library.owner.image || 'https://www.kifi.com/assets/img/ghost.200.png'}}" title="{{library.owner.firstName + ' ' + library.owner.lastName}}"></img>
@@ -155,9 +149,6 @@
             <div class="kf-nav-lib-info">
               <div kf-ellipsis full-text="library.name" max-num-lines=2 class="kf-nav-lib-name"></div>
               <div class="kf-nav-lib-text">invitation pending</div>
-            </div>
-            <div kf-tooltip position="right" padding="3">
-              <div kf-library-mini-card library="library" invite="true"></div>
             </div>
           </a>
           <a href="{{getLibraryOwnerProfileUrl(library)}}" kf-track-origin origin="libraryList/invited">


### PR DESCRIPTION
@andrewconner This removes the mini hover card from the left nav only. In addition, per Mark's advice, reducing/removing the transition delays for showing the mini hover card. Also, to match the mini hover card, I've reduced the delay for the user picture tooltip as well.
