### PR TITLE
making env a constant

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -28,44 +28,37 @@ angular.module('kifi', [
   appKey: 'r11loldy9zlg'
 })
 
+.constant('env', (function () {
+  var location = window.location;
+  var host = location.hostname;
+  var port = location.port;
+  var prod = host === 'www.kifi.com';
+  var local = !prod && port === '9000';
+  var origin = location.protocol + '//' + host  + (port ? ':' + port : '');
+  var navOrigin = local ? origin : 'https://www.kifi.com';
+
+  return {
+    local: local,
+    dev: !prod,
+    production: prod,
+    origin: origin,
+    navBase: navOrigin,
+    xhrBase: navOrigin + '/site',
+    xhrBaseEliza: navOrigin.replace('www', 'eliza') + '/eliza/site',
+    xhrBaseSearch: navOrigin.replace('www', 'search'),
+    picBase: (local ? '//d1scct5mnc9d9m' : '//djty7jcqog9qu') + '.cloudfront.net'
+  };
+}()))
+
 .config([
-  '$FBProvider',
-  function ($FBProvider) {
-    // We cannot inject `env` here since factories are not yet available in config blocks
-    // We can make `env` a constant if we want to remove duplicate codes, but
-    // then we cannot use $location inside `env` initialization
-    /* global window */
-    var host = window.location.host || window.location.hostname,
-      dev = /^dev\.ezkeep\.com|localhost$/.test(host);
+  '$FBProvider', 'env',
+  function ($FBProvider, env) {
     $FBProvider
-      .appId(dev ? '530357056981814' : '104629159695560')
+      .appId(env.dev ? '530357056981814' : '104629159695560')
       // https://developers.facebook.com/docs/facebook-login/permissions
       .scope('public_profile,user_friends,email')
       .cookie(true)
       .logging(false);
-  }
-])
-
-.factory('env', [
-  '$location',
-  function ($location) {
-    var host = $location.host();
-    var dev = /^dev\.ezkeep\.com|localhost|^protractor\.kifi\.com$/.test(host);
-    var origin = $location.protocol() + '://' + host  + (dev ? ':' + $location.port() : '');
-    var local = $location.port() === 9000;
-    var navOrigin = dev && !local ? 'https://www.kifi.com' : origin;
-
-    return {
-      local: local,
-      dev: dev,
-      production: !dev,
-      origin: origin,
-      navBase: navOrigin,
-      xhrBase: navOrigin + '/site',
-      xhrBaseEliza: navOrigin.replace('www', 'eliza') + '/eliza/site',
-      xhrBaseSearch: navOrigin.replace('www', 'search'),
-      picBase: (local ? '//d1scct5mnc9d9m' : '//djty7jcqog9qu') + '.cloudfront.net'
-    };
   }
 ])
 

--- a/kifi-backend/modules/shoebox/angular/test/unit/tags/hashtagService.spec.js
+++ b/kifi-backend/modules/shoebox/angular/test/unit/tags/hashtagService.spec.js
@@ -2,7 +2,7 @@
 
 describe('kifi.hashtagService', function () {
 
-  var hashtagService, $httpBackend, $q, $rootScope, keepDecoratorService;
+  var hashtagService, routeService, $httpBackend, $q, $rootScope, keepDecoratorService;
 
   var libraryId = 'l6XWQOhPGRgg',
       keepId = '42b043aa-e389-45f2-ab37-b7809990ee7e';
@@ -24,8 +24,9 @@ describe('kifi.hashtagService', function () {
 
   beforeEach(module('kifi'));
 
-  beforeEach(inject(function (_hashtagService_, _$httpBackend_, _$q_, _$rootScope_, _keepDecoratorService_) {
+  beforeEach(inject(function (_hashtagService_, _routeService_, _$httpBackend_, _$q_, _$rootScope_, _keepDecoratorService_) {
     hashtagService = _hashtagService_;
+    routeService = _routeService_;
     $httpBackend = _$httpBackend_;
     $q = _$q_;
     $rootScope = _$rootScope_;
@@ -45,10 +46,9 @@ describe('kifi.hashtagService', function () {
         expect(data).toEqual([{'tag':'Scala','matches':[[0,5]]},{'tag':'Learn Scala','matches':[[6,5]]}]);
       });
 
-      $httpBackend.expectGET('http://server/ext/libraries/l6XWQOhPGRgg/keeps/42b043aa-e389-45f2-ab37-b7809990ee7e/tags/suggest?q=scala')
+      $httpBackend.expectGET(routeService.suggestTags('l6XWQOhPGRgg', '42b043aa-e389-45f2-ab37-b7809990ee7e', 'scala'))
         .respond(200, '[{"tag":"Scala","matches":[[0,5]]},{"tag":"Learn Scala","matches":[[6,5]]}]');
       $httpBackend.flush();
-
     });
 
     it('tagKeep adds tag to keep', function () {
@@ -59,7 +59,7 @@ describe('kifi.hashtagService', function () {
         expect(data).toEqual({'tag':'Scala'});
         expect(keep.hashtags).toEqual(['foo', 'bar', 'Scala']);
       });
-      $httpBackend.expectPOST('http://server/site/libraries/'+ libraryId +'/keeps/' + keepId + '/tags/Scala').respond(200, '{"tag":"Scala"}');
+      $httpBackend.expectPOST(routeService.tagKeep(libraryId, keepId, 'Scala')).respond(200, '{"tag":"Scala"}');
       $httpBackend.flush();
     });
 
@@ -73,7 +73,7 @@ describe('kifi.hashtagService', function () {
         expect(keep1.hashtags).toEqual(['bar', 'Scala']);
         expect(keep2.hashtags).toEqual(['baz', 'Scala']);
       });
-      $httpBackend.expectPOST('http://server/site/tags/Scala', { 'keepIds':
+      $httpBackend.expectPOST(routeService.tagKeeps('Scala'), { 'keepIds':
         [keep0.id, keep1.id, keep2.id] }).respond(200, '{}');
       $httpBackend.flush();
     });
@@ -86,7 +86,7 @@ describe('kifi.hashtagService', function () {
         expect(data).toBeUndefined();
         expect(keep.hashtags).toEqual(['bar']);
       });
-      $httpBackend.expectDELETE('http://server/site/libraries/'+ libraryId +'/keeps/' + keepId + '/tags/foo').respond(204);
+      $httpBackend.expectDELETE(routeService.untagKeep(libraryId, keepId, 'foo')).respond(204);
       $httpBackend.flush();
     });
 


### PR DESCRIPTION
This makes the `$FBProvider` config block simpler and cleaner, avoiding duplication of logic.
@yipingliao 
