### PR TITLE
Handling signup redirecting & auto-follow libraries

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -787,7 +787,7 @@ angular.module('kifi')
             platformService.goToAppOrStore(url + (url.indexOf('?') > 0 ? '&' : '?') + 'follow=true');
             return;
           } else if ($rootScope.userLoggedIn === false) {
-            return signupService.register({libraryId: scope.library.id});
+            return signupService.register({libraryId: scope.library.id, autoFollow: true});
           }
 
           libraryService.joinLibrary(scope.library.id)['catch'](modalService.openGenericErrorModal);

--- a/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
+++ b/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
@@ -49,9 +49,6 @@ angular.module('kifi')
     $scope.userData = $scope.userData || {};
     $scope.showTwitter = _.has($location.search(), 'twitter'); // todo (aaron): remove for twitter launch
 
-    var encodedCurrentPage = $window.encodeURIComponent($location.url().split('?')[0]); //remove query params when redirecting back to this page
-    $scope.twitterSignupUrl = '/signup/twitter?redirect=' + encodedCurrentPage; // twitter signup url with redirect
-
     function setModalScope($modalScope, onClose) {
       $modalScope.close = modalService.close;
       $modalScope.$on('$destroy', function () {
@@ -89,6 +86,13 @@ angular.module('kifi')
     var registerModal = function () {
       if ($scope.userData.libraryId) {
         $rootScope.$emit('trackLibraryEvent', 'view', { type: 'signupLibrary' });
+        $scope.twitterSignupUrl = '/signup/twitter?redirect=' + $window.encodeURIComponent('l/' + $scope.userData.libraryId);
+        if ($scope.userData.autoFollow) {
+          $scope.twitterSignupUrl += '&follow=1';
+        }
+      } else {
+        var currentPath = $location.url().split('?')[0]; //remove query params when redirecting back to this page
+        $scope.twitterSignupUrl = '/signup/twitter?redirect=' + $window.encodeURIComponent(currentPath);
       }
 
       setModalScope(modalService.open({

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
@@ -363,7 +363,7 @@ angular.module('kifi')
         platformService.goToAppOrStore(url + (url.indexOf('?') > 0 ? '&' : '?') + 'follow=true');
         return;
       } else if ($rootScope.userLoggedIn === false) {
-        return signupService.register({libraryId: lib.id});
+        return signupService.register({libraryId: lib.id, autoFollow: true});
       }
       $event.target.disabled = true;
       libraryService[lib.following ? 'leaveLibrary' : 'joinLibrary'](lib.id)['catch'](function (resp) {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
@@ -113,6 +113,7 @@ class AuthCommander @Inject() (
     postOffice: LocalPostOffice,
     inviteCommander: InviteCommander,
     libraryCommander: LibraryCommander,
+    libraryRepo: LibraryRepo,
     implicit val publicIdConfig: PublicIdConfiguration,
     userExperimentCommander: LocalUserExperimentCommander,
     userCommander: UserCommander,
@@ -409,15 +410,38 @@ class AuthCommander @Inject() (
     }
   }
 
-  def autoJoinLib(userId: Id[User], libPubId: PublicId[Library]): Unit = {
-    Library.decodePublicId(libPubId) map { libId =>
-      implicit val context = HeimdalContext(Map())
-      libraryCommander.joinLibrary(userId, libId).fold(
-        libFail =>
-          airbrakeNotifier.notify(s"[finishSignup] auto-join failed. $libFail"),
-        library =>
-          log.info(s"[finishSignup] user(id=$userId) has successfully joined library $library")
-      )
+  def autoJoinPubLib(userId: Id[User], libPubId: PublicId[Library]) = {
+    Library.decodePublicId(libPubId) match {
+      case Success(libId) => Right(autoJoinLib(userId, libId))
+      case _ => Left("invalid_library_id")
+    }
+  }
+
+  def autoJoinLib(userId: Id[User], libId: Id[Library]): Unit = {
+    implicit val context = HeimdalContext(Map())
+    libraryCommander.joinLibrary(userId, libId).fold(
+      libFail => airbrakeNotifier.notify(s"[finishSignup] auto-join failed. $libFail"),
+      library => log.info(s"[finishSignup] user(id=$userId) has successfully joined library $library")
+    )
+  }
+
+  def parseRedirectCookie(path: String): Either[String, (String, Option[Id[Library]])] = {
+    val decodedPath = java.net.URLDecoder.decode(path, "UTF-8")
+    if (decodedPath.startsWith("l/")) { // is a libraryId
+      val idString = decodedPath.substring(2)
+      val libPubId: PublicId[Library] = PublicId[Library](idString)
+      Library.decodePublicId(libPubId) match {
+        case Success(libId) =>
+          val (owner, library) = db.readOnlyMaster { implicit s =>
+            val library = libraryRepo.get(libId)
+            (userRepo.get(library.ownerId), library)
+          }
+          Right((Library.formatLibraryPath(owner.username, library.slug), library.id))
+        case _ =>
+          Left("invalid_library_id")
+      }
+    } else {
+      Right((decodedPath, None))
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
@@ -410,7 +410,7 @@ class AuthCommander @Inject() (
     }
   }
 
-  def autoJoinPubLib(userId: Id[User], libPubId: PublicId[Library]) = {
+  def autoJoinPubLib(userId: Id[User], libPubId: PublicId[Library]): Either[String, Unit] = {
     Library.decodePublicId(libPubId) match {
       case Success(libId) => Right(autoJoinLib(userId, libId))
       case _ => Left("invalid_library_id")
@@ -438,6 +438,7 @@ class AuthCommander @Inject() (
           }
           Right((Library.formatLibraryPath(owner.username, library.slug), library.id))
         case _ =>
+          log.error(s"[parseRedirectCookie] invalid library id in $path")
           Left("invalid_library_id")
       }
     } else {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
@@ -438,7 +438,7 @@ class AuthCommander @Inject() (
           }
           Right((Library.formatLibraryPath(owner.username, library.slug), library.id))
         case _ =>
-          log.error(s"[parseRedirectCookie] invalid library id in $path")
+          airbrakeNotifier.notify(s"[parseRedirectCookie] invalid library id in $decodedPath (decoded from $path)")
           Left("invalid_library_id")
       }
     } else {

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -46,7 +46,7 @@ GET     /connect/:provider          @com.keepit.controllers.core.AuthController.
 GET     /connect/:provider/done     @com.keepit.controllers.core.AuthController.popupAfterLinkSocial(provider)
 GET     /link/:provider             @com.keepit.controllers.core.AuthController.link(provider: String, redirect: Option[String] ?= None)
 
-GET     /signup/:provider           @com.keepit.controllers.core.AuthController.signup(provider: String, redirect: Option[String] ?= None)
+GET     /signup/:provider           @com.keepit.controllers.core.AuthController.signup(provider: String, redirect: Option[String] ?= None, follow: Option[String]?=None)
 
 # do we still use this endpoint?
 POST    /mobileauth/:provider       @com.keepit.controllers.mobile.MobileAuthController.accessTokenLogin(provider)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/AuthCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/AuthCommanderTest.scala
@@ -1,5 +1,6 @@
 package com.keepit.commanders
 
+import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.model.UserFactoryHelper._
 import com.keepit.model.UserFactory._
 import com.keepit.abook.FakeABookServiceClientModule
@@ -21,6 +22,11 @@ import com.keepit.search.FakeSearchServiceClientModule
 import com.keepit.shoebox.{ KeepImportsModule, FakeShoeboxServiceModule }
 import com.keepit.social.{ SocialNetworks, SocialId }
 import com.keepit.test.{ ShoeboxApplicationInjector, ShoeboxApplication }
+import com.keepit.model.LibraryFactory._
+import com.keepit.model.LibraryFactoryHelper._
+import com.keepit.model.LibraryMembershipFactory._
+import com.keepit.model.LibraryMembershipFactoryHelper._
+import com.keepit.model.UserFactoryHelper._
 import org.specs2.mutable.Specification
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -87,6 +93,36 @@ class AuthCommanderTest extends Specification with ShoeboxApplicationInjector {
         res1.header.status === OK
         res1.session.getUserId.isDefined === true
         res1.session.getUserId.get === user.id.get
+      }
+    }
+
+    "parse redirect cookies" in {
+      running(new ShoeboxApplication(modules: _*)) {
+        implicit val config = inject[PublicIdConfiguration]
+        val authCommander = inject[AuthCommander]
+
+        val (user1, user2, library1) = db.readWrite { implicit s =>
+          val user1 = user().withName("first", "user").withUsername("firstuser").saved
+          val user2 = user().withName("second", "user").withUsername("seconduser").saved
+          val library1 = library().withName("lib1").withUser(user1).published.withSlug("lib1").saved
+          (user1, user2, library1)
+        }
+        val libPubId1 = Library.publicId(library1.id.get)
+
+        // return redirect url to library page
+        val redirectLib = authCommander.parseRedirectCookie(s"l/${libPubId1.id}")
+        redirectLib.right.get === ("/firstuser/lib1", Some(library1.id.get))
+
+        // return redirect url encoded
+        val redirectEncoded = authCommander.parseRedirectCookie(s"l%2F${libPubId1.id}")
+        redirectEncoded.right.get === ("/firstuser/lib1", Some(library1.id.get))
+
+        // return redirect url to profile page (username)
+        val redirectProfile = authCommander.parseRedirectCookie(s"/firstuser")
+        redirectProfile.right.get === ("/firstuser", None)
+
+        // incorrect library id
+        authCommander.parseRedirectCookie(s"l/asdfqwer").isRight === false
       }
     }
   }


### PR DESCRIPTION
@andrewconner 

Only applies to the twitter case, for now...

Case 1: Public Profile Page Signup
- click on `Sign up` on header -> should send `?redirect=a.aron`
- click on `Follow` on a library -> should send `?redirect=l/pubId&follow=1`

Case 2: Public Library Page Signup
- click on `Sign up` on header -> should send `?redirect=l/pubId`
- click on `Follow Library` on library card -> `?redirect=l/pubId&follow=1`
- click on `Create your own` on related cards -> `?redirect=l/pubId`

On backend,
on `/signup` we look for two parameters `redirect` & `follow`
If redirect exists and/or follow exists, set cookies

after authentication with social network,
we should read cookies for `redirect`
if `redirect` begins with `l/`... we know it's a libraryId. We take that libraryId to grab the librarypath, and if `follow` cookie is set, we auto follow.
Otherwise (does not begin with `l/`, simply redirect to the path.
