### PR TITLE
auto following from redirects

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -65,7 +65,7 @@ angular.module('kifi', [
 .factory('initParams', [
   '$location',
   function ($location) {
-    var params = ['m', 'o', 'friend', 'subtype', 'install'];
+    var params = ['m', 'o', 'friend', 'subtype', 'install', 'intent'];
     var search = $location.search();
     var state = _.pick(search, params);
     if (!_.isEmpty(state)) {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -154,6 +154,9 @@ angular.module('kifi')
           if (initParams.install === '1' && !installService.installedVersion) {
             showInstallModal();
           }
+          if (initParams.intent === 'follow' && !$scope.library.isMine && $scope.library.access==='none') {
+            libraryService.joinLibrary($scope.library.id);
+          }
         });
       }
     });

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -154,7 +154,7 @@ angular.module('kifi')
           if (initParams.install === '1' && !installService.installedVersion) {
             showInstallModal();
           }
-          if (initParams.intent === 'follow' && !$scope.library.isMine && $scope.library.access==='none') {
+          if (initParams.intent === 'follow' && $scope.library.access==='none') {
             libraryService.joinLibrary($scope.library.id);
           }
         });

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryCard.js
@@ -789,7 +789,7 @@ angular.module('kifi')
             platformService.goToAppOrStore(url + (url.indexOf('?') > 0 ? '&' : '?') + 'follow=true');
             return;
           } else if ($rootScope.userLoggedIn === false) {
-            return signupService.register({libraryId: scope.library.id});
+            return signupService.register({libraryId: scope.library.id, intent: 'follow'});
           }
 
           libraryService.joinLibrary(scope.library.id)['catch'](modalService.openGenericErrorModal);

--- a/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
+++ b/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
@@ -49,9 +49,6 @@ angular.module('kifi')
     $scope.userData = $scope.userData || {};
     $scope.showTwitter = _.has($location.search(), 'twitter'); // todo (aaron): remove for twitter launch
 
-    var encodedCurrentPage = $window.encodeURIComponent($location.url().split('?')[0]); //remove query params when redirecting back to this page
-    $scope.twitterSignupUrl = '/signup/twitter?redirect=' + encodedCurrentPage; // twitter signup url with redirect
-
     function setModalScope($modalScope, onClose) {
       $modalScope.close = modalService.close;
       $modalScope.$on('$destroy', function () {
@@ -89,6 +86,13 @@ angular.module('kifi')
     var registerModal = function () {
       if ($scope.userData.libraryId) {
         $rootScope.$emit('trackLibraryEvent', 'view', { type: 'signupLibrary' });
+      }
+
+       // twitter signup url with redirect
+      var currentPath = $location.url().split('?')[0]; //remove query params when redirecting back to this page
+      $scope.twitterSignupUrl = '/signup/twitter?redirect=' + $window.encodeURIComponent(currentPath);
+      if ($scope.userData.intent === 'follow') {
+        $scope.twitterSignupUrl += '&intent=follow';
       }
 
       setModalScope(modalService.open({

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
@@ -363,7 +363,7 @@ angular.module('kifi')
         platformService.goToAppOrStore(url + (url.indexOf('?') > 0 ? '&' : '?') + 'follow=true');
         return;
       } else if ($rootScope.userLoggedIn === false) {
-        return signupService.register({libraryId: lib.id});
+        return signupService.register({libraryId: lib.id, intent: 'follow'});
       }
       $event.target.disabled = true;
       libraryService[lib.following ? 'leaveLibrary' : 'joinLibrary'](lib.id)['catch'](function (resp) {

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -46,7 +46,7 @@ GET     /connect/:provider          @com.keepit.controllers.core.AuthController.
 GET     /connect/:provider/done     @com.keepit.controllers.core.AuthController.popupAfterLinkSocial(provider)
 GET     /link/:provider             @com.keepit.controllers.core.AuthController.link(provider: String, redirect: Option[String] ?= None)
 
-GET     /signup/:provider           @com.keepit.controllers.core.AuthController.signup(provider: String, redirect: Option[String] ?= None)
+GET     /signup/:provider           @com.keepit.controllers.core.AuthController.signup(provider: String, redirect: Option[String] ?= None, intent: Option[String] ?= None)
 
 # do we still use this endpoint?
 POST    /mobileauth/:provider       @com.keepit.controllers.mobile.MobileAuthController.accessTokenLogin(provider)


### PR DESCRIPTION
On a public profile page:
- signup with Header -> send `/signup/twitter?redirect=/a.aron` (not encoded) to BE
- signup with Follow a Library -> `/signup/twitter?redirect=/a.aron/ramen&intent=follow`
  On a public library page:
- signup with Header -> `/signup/twitter?redirect=/a.aron/ramen`
- signup with Follow Library -> `/signup/twitter?redirect=/a.aron/ramen&intent=follow`
- signup with Create your own -> `/signup/twitter?redirect=/a.aron/ramen`

From backend, we first create cookies for `redirect` and `intent`
Then, after social network authentication, we read cookies.
If `intent` was set, we tack on `&intent=follow` after the redirected path

Once redirected to a library page, we check `intent`. 
If it's follow, the browser will call join library

@andrewconner @2is10 
