### PR TITLE
fix automatic library following from user public profile

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
+++ b/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
@@ -88,9 +88,13 @@ angular.module('kifi')
         $rootScope.$emit('trackLibraryEvent', 'view', { type: 'signupLibrary' });
       }
 
-       // twitter signup url with redirect
-      var currentPath = $location.url().split('?')[0]; //remove query params when redirecting back to this page
-      $scope.twitterSignupUrl = '/signup/twitter?redirect=' + $window.encodeURIComponent(currentPath);
+      $scope.twitterSignupUrl = '/signup/twitter?redirect=';
+      if ($scope.userData.redirectPath) {
+        $scope.twitterSignupUrl += $window.encodeURIComponent($scope.userData.redirectPath);
+      } else {
+        var currentPath = $location.url().split('?')[0]; //remove query params when redirecting back to this page
+        $scope.twitterSignupUrl += $window.encodeURIComponent(currentPath);
+      }
       if ($scope.userData.intent === 'follow') {
         $scope.twitterSignupUrl += '&intent=follow';
       }

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
@@ -363,7 +363,7 @@ angular.module('kifi')
         platformService.goToAppOrStore(url + (url.indexOf('?') > 0 ? '&' : '?') + 'follow=true');
         return;
       } else if ($rootScope.userLoggedIn === false) {
-        return signupService.register({libraryId: lib.id, intent: 'follow'});
+        return signupService.register({libraryId: lib.id, intent: 'follow', redirectPath: lib.path});
       }
       $event.target.disabled = true;
       libraryService[lib.following ? 'leaveLibrary' : 'joinLibrary'](lib.id)['catch'](function (resp) {


### PR DESCRIPTION
On public user profile, when you click on Follow on a library card, we want to:
(1) redirect to that library (before it just redirected back to the profile page)
(2) auto-follow that library
@andrewconner 
