### PR TITLE
change FB sign-in from public library/profile page

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .factory('routeService', [
-  '$location', 'env',
-  function ($location, env) {
+  '$location', 'env', '$window',
+  function ($location, env, $window) {
     function route(url) {
       return env.xhrBase + url;
     }
@@ -154,6 +154,14 @@ angular.module('kifi')
       ////////////////////////////
       socialSignup: function (provider) {
         return env.navBase + '/auth/token-signup/' + provider;
+      },
+      socialSignupWithRedirect: function (provider, redirectPath, intent) {
+        var path = '/signup/' + provider + '?redirect=' + $window.encodeURIComponent(redirectPath);
+        if (intent) {
+          path += '&intent=';
+          path += intent;
+        }
+        return path;
       },
       socialFinalize: env.navBase + '/auth/token-finalize',
       emailSignup: env.navBase + '/auth/email-signup',

--- a/kifi-backend/modules/shoebox/angular/src/friends/rightColFriendsView.js
+++ b/kifi-backend/modules/shoebox/angular/src/friends/rightColFriendsView.js
@@ -205,7 +205,7 @@ angular.module('kifi')
         var onTwitterExperiment = _.indexOf(profileService.me.experiments, 'twitter_beta') > -1;
         return _.compact([
           socialService.facebook && socialService.facebook.profileUrl ? null : 'Facebook',
-          onTwitterExperiment && socialService.twitter && socialService.twitter.profileUrl ? null : 'Twitter',
+          !onTwitterExperiment || (socialService.twitter && socialService.twitter.profileUrl) ? null : 'Twitter',
           socialService.linkedin && socialService.linkedin.profileUrl ? null : 'LinkedIn',
           socialService.gmail && socialService.gmail.length ? null : 'Gmail'
         ]).join(',');

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -154,7 +154,7 @@ angular.module('kifi')
           if (initParams.install === '1' && !installService.installedVersion) {
             showInstallModal();
           }
-          if (initParams.intent === 'follow' && $scope.library.access==='none') {
+          if (initParams.intent === 'follow' && $scope.library.access === 'none') {
             libraryService.joinLibrary($scope.library.id);
           }
         });

--- a/kifi-backend/modules/shoebox/angular/src/signup/register.styl
+++ b/kifi-backend/modules/shoebox/angular/src/signup/register.styl
@@ -41,7 +41,7 @@
   font-weight: 300
 
 .register-modal-social-block
-  margin: 31px 0 0
+  margin: 21px 0 0
 
 .register-modal-we-are-nice
   margin-top: 23px

--- a/kifi-backend/modules/shoebox/angular/src/signup/registerModal.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/signup/registerModal.tpl.html
@@ -8,10 +8,10 @@
         <div class="kf-register-header">Join Kifi to get updates to this library</div>
 
         <div class="register-modal-social-block">
-          <a ng-href="{{facebookSignupUrl}}" target="_self">
+          <a ng-href="{{facebookSignupPath}}" target="_self">
             <div class="kf-register-button facebook">Continue with Facebook</div>
           </a>
-          <a ng-href="{{twitterSignupUrl}}" target="_self" ng-if="showTwitter">
+          <a ng-href="{{twitterSignupPath}}" target="_self" ng-if="showTwitter">
             <div class="kf-register-button twitter">Continue with Twitter</div>
           </a>
           <div class="register-modal-we-are-nice">We will never post without your explicit permission.</div>

--- a/kifi-backend/modules/shoebox/angular/src/signup/registerModal.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/signup/registerModal.tpl.html
@@ -8,7 +8,9 @@
         <div class="kf-register-header">Join Kifi to get updates to this library</div>
 
         <div class="register-modal-social-block">
-          <div class="kf-register-button facebook" ng-click="fbAuthFromLibrary()" ng-mouseover="fbInit()">Continue with Facebook</div>
+          <a ng-href="{{facebookSignupUrl}}" target="_self">
+            <div class="kf-register-button facebook">Continue with Facebook</div>
+          </a>
           <a ng-href="{{twitterSignupUrl}}" target="_self" ng-if="showTwitter">
             <div class="kf-register-button twitter">Continue with Twitter</div>
           </a>

--- a/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
+++ b/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
@@ -65,7 +65,38 @@ angular.module('kifi')
       return hasError;
     };
 
+    function createSignupUrl(network) {
+      var base = '/signup/' + network + '?redirect=';
+      var url = base;
+
+      if ($scope.userData.redirectPath) {
+        url += $window.encodeURIComponent($scope.userData.redirectPath);
+      } else {
+        var currentPath = $location.url().split('?')[0]; //remove query params when redirecting back to this page
+        url += $window.encodeURIComponent(currentPath);
+      }
+
+      if ($scope.userData.intent === 'follow') {
+        url += '&intent=follow';
+      }
+      return url;
+    }
+
     // First Register modal
+
+    var registerModal = function () {
+      if ($scope.userData.libraryId) {
+        $rootScope.$emit('trackLibraryEvent', 'view', { type: 'signupLibrary' });
+      }
+
+      $scope.facebookSignupUrl = createSignupUrl('facebook');
+      $scope.twitterSignupUrl = createSignupUrl('twitter');
+
+      setModalScope(modalService.open({
+        template: 'signup/registerModal.tpl.html',
+        scope: $scope
+      }));
+    };
 
     var facebookLogin = function () {
       return $FB.getLoginStatus().then(function (loginStatus) {
@@ -81,28 +112,6 @@ angular.module('kifi')
           });
         }
       });
-    };
-
-    var registerModal = function () {
-      if ($scope.userData.libraryId) {
-        $rootScope.$emit('trackLibraryEvent', 'view', { type: 'signupLibrary' });
-      }
-
-      $scope.twitterSignupUrl = '/signup/twitter?redirect=';
-      if ($scope.userData.redirectPath) {
-        $scope.twitterSignupUrl += $window.encodeURIComponent($scope.userData.redirectPath);
-      } else {
-        var currentPath = $location.url().split('?')[0]; //remove query params when redirecting back to this page
-        $scope.twitterSignupUrl += $window.encodeURIComponent(currentPath);
-      }
-      if ($scope.userData.intent === 'follow') {
-        $scope.twitterSignupUrl += '&intent=follow';
-      }
-
-      setModalScope(modalService.open({
-        template: 'signup/registerModal.tpl.html',
-        scope: $scope
-      }));
     };
 
     $scope.submitEmail = function (form) {

--- a/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
+++ b/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
@@ -65,21 +65,21 @@ angular.module('kifi')
       return hasError;
     };
 
-    function createSignupUrl(network) {
+    function createSignupPath(network) {
       var base = '/signup/' + network + '?redirect=';
-      var url = base;
+      var path = base;
 
       if ($scope.userData.redirectPath) {
-        url += $window.encodeURIComponent($scope.userData.redirectPath);
+        path += $window.encodeURIComponent($scope.userData.redirectPath);
       } else {
         var currentPath = $location.url().split('?')[0]; //remove query params when redirecting back to this page
-        url += $window.encodeURIComponent(currentPath);
+        path += $window.encodeURIComponent(currentPath);
       }
 
       if ($scope.userData.intent === 'follow') {
-        url += '&intent=follow';
+        path += '&intent=follow';
       }
-      return url;
+      return path;
     }
 
     // First Register modal
@@ -89,8 +89,8 @@ angular.module('kifi')
         $rootScope.$emit('trackLibraryEvent', 'view', { type: 'signupLibrary' });
       }
 
-      $scope.facebookSignupUrl = createSignupUrl('facebook');
-      $scope.twitterSignupUrl = createSignupUrl('twitter');
+      $scope.facebookSignupPath = createSignupPath('facebook');
+      $scope.twitterSignupPath = createSignupPath('twitter');
 
       setModalScope(modalService.open({
         template: 'signup/registerModal.tpl.html',

--- a/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
+++ b/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
@@ -41,8 +41,8 @@ angular.module('kifi')
 ])
 
 .controller('SignupCtrl', [
-  '$scope', '$FB', '$twitter', 'modalService', 'registrationService', '$window', 'installService', '$q', '$log', '$rootScope', '$location',
-  function ($scope, $FB, $twitter, modalService, registrationService, $window, installService, $q, $log, $rootScope, $location) {
+  '$scope', '$FB', '$twitter', 'modalService', 'registrationService', '$window', 'installService', '$q', '$log', '$rootScope', '$location', 'routeService',
+  function ($scope, $FB, $twitter, modalService, registrationService, $window, installService, $q, $log, $rootScope, $location, routeService) {
 
     // Shared data across several modals
 
@@ -66,20 +66,11 @@ angular.module('kifi')
     };
 
     function createSignupPath(network) {
-      var base = '/signup/' + network + '?redirect=';
-      var path = base;
-
-      if ($scope.userData.redirectPath) {
-        path += $window.encodeURIComponent($scope.userData.redirectPath);
-      } else {
-        var currentPath = $location.url().split('?')[0]; //remove query params when redirecting back to this page
-        path += $window.encodeURIComponent(currentPath);
-      }
-
-      if ($scope.userData.intent === 'follow') {
-        path += '&intent=follow';
-      }
-      return path;
+      return routeService.socialSignupWithRedirect(
+          network,
+          $scope.userData.redirectPath || $location.url().split('?')[0],
+          $scope.userData.intent
+        );
     }
 
     // First Register modal

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -412,7 +412,8 @@ class AuthController @Inject() (
               if (cookieIntent.isDefined) {
                 initParams ++= s"&intent=${cookieIntent.get.value}"
               }
-              Redirect(s"${redirectPath}${initParams.toString}")
+              val discardedCookies = Seq(cookieRedirect, cookieIntent).flatten.map(c => DiscardingCookie(c.name))
+              Redirect(s"${redirectPath}${initParams.toString}").discardingCookies(discardedCookies: _*)
             } else {
               Redirect(s"${com.keepit.controllers.website.routes.HomeController.home.url}?m=0")
             }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -216,13 +216,14 @@ class AuthHelper @Inject() (
         val cookieRedirect = request.cookies.get("redirect")
         val cookieIntent = request.cookies.get("intent")
         val result = if (cookieRedirect.isDefined) {
-          val redirectUrl = java.net.URLDecoder.decode(cookieRedirect.get.value, "UTF-8")
+          val redirectPath = java.net.URLDecoder.decode(cookieRedirect.get.value, "UTF-8")
           val initParams = new StringBuilder("?install=1") // tell browser to pop-up install modal
           if (cookieIntent.isDefined) {
             initParams ++= s"&intent=${cookieIntent.get.value}"
           }
-          val returnUri = redirectUrl + initParams.toString
-          Ok(Json.obj("uri" -> returnUri))
+          val returnUri = redirectPath + initParams.toString
+          val discardedCookies = Seq(cookieRedirect, cookieIntent).flatten.map(c => DiscardingCookie(c.name))
+          Ok(Json.obj("uri" -> returnUri)).discardingCookies(discardedCookies: _*)
         } else if (isFinalizedImmediately) {
           Redirect(uri)
         } else {


### PR DESCRIPTION
Change FB signup from public profile/library to match the behavior of twitter.
When you click on 'Continue with Facebook', the entire browser will change -> move to /signup/facebook
and use the `?redirect=___&intent=follow` to redirect back to the correct page after signup.

@andrewconner 
