### PR TITLE
Fix refresh-social-networks modal CSS class names

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/friends/friends.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/friends/friends.tpl.html
@@ -5,7 +5,7 @@
       <div class="friends-networks-status">
         <div kf-social-networks-status ng-if="!isRefreshingSocialGraph"></div>
         <div class="import-wrapper" ng-if="isRefreshingSocialGraph">
-          <div class="bouncy-ball">
+          <div class="kf-bouncy-ball">
             <div class="pace pace-active"><div class="pace-progress"></div><div class="pace-activity"></div></div>
           </div> Importing your contacts
         </div>

--- a/kifi-backend/modules/shoebox/angular/src/friends/rotatingConnect.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/friends/rotatingConnect.tpl.html
@@ -1,6 +1,6 @@
 <div>
-  <a ng-show="network === 'Facebook'" href="javascript:" class="social-connect-button facebook" ng-click="connectFacebook()">Connect</a>
-  <a ng-show="network === 'Twitter'" href="javascript:" class="social-connect-button twitter" ng-click="connectTwitter()">Connect</a>
-  <a ng-show="network === 'LinkedIn'" href="javascript:" class="social-connect-button linkedin" ng-click="connectLinkedIn()">Connect</a>
-  <a ng-show="network === 'Gmail'" href="javascript:" class="social-connect-button gmail" ng-click="importGmail()">Connect</a>
+  <a ng-show="network === 'Facebook'" href="javascript:" class="kf-social-connect-button kf-facebook" ng-click="connectFacebook()">Connect</a>
+  <a ng-show="network === 'Twitter'" href="javascript:" class="kf-social-connect-button kf-twitter" ng-click="connectTwitter()">Connect</a>
+  <a ng-show="network === 'LinkedIn'" href="javascript:" class="kf-social-connect-button kf-linkedin" ng-click="connectLinkedIn()">Connect</a>
+  <a ng-show="network === 'Gmail'" href="javascript:" class="kf-social-connect-button kf-gmail" ng-click="importGmail()">Connect</a>
 </div>

--- a/kifi-backend/modules/shoebox/angular/src/invite/invite.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/invite/invite.tpl.html
@@ -4,7 +4,7 @@
       <div kf-friend-request-banner></div>
       <h2 class="invite-title">Find people to invite</h2>
       <div class="import-wrapper" ng-if="isRefreshingSocialGraph">
-        <div class="bouncy-ball">
+        <div class="kf-bouncy-ball">
           <div class="pace pace-active"><div class="pace-progress"></div><div class="pace-activity"></div></div>
         </div> Importing your contacts
       </div>

--- a/kifi-backend/modules/shoebox/angular/src/social/connectNetworks.styl
+++ b/kifi-backend/modules/shoebox/angular/src/social/connectNetworks.styl
@@ -1,41 +1,30 @@
-.social-connect
+.kf-social-connect
   min-width: 430px
   margin: 0 auto
   text-align: center
   width: 0px
 
-.social-connect-title
+.kf-social-connect-title
   font-size: 24px
   font-weight: 300
   font-family: Lato, Arial, sans-serif
   font-style: italic
 
-.social-connect-desc
+.kf-social-connect-desc
   font-size: 16px
   margin: 15px auto 35px
   max-width: 350px
 
-.friends-wrapper, .invite-wrapper
-  .social-connect
-    @media screen and (max-width: 1260px)
-      text-align: left
-      margin: 0 auto
-
-  .social-connect-desc
-    @media screen and (max-width: 1260px)
-      margin: 15px 0 35px
-      text-align: center
-
-a.social-connect-button,
-a.social-connect-button:hover,
-a.social-connect-button:active
+a.kf-social-connect-button,
+a.kf-social-connect-button:hover,
+a.kf-social-connect-button:active
   color: #fff
   text-decoration: none
 
-.social-connect-buttons
+.kf-social-connect-buttons
   text-align: center
 
-.social-connect-button
+.kf-social-connect-button
   padding: 11px
   font-size: 18px
   cursor: pointer
@@ -44,29 +33,29 @@ a.social-connect-button:active
   display: inline-block
   text-align: center
 
-  &.facebook
+  &.kf-facebook
     background-color: #597AB1
 
-  &.linkedin
+  &.kf-linkedin
     background-color: #2786C4
 
-  &.gmail
+  &.kf-gmail
     background-color: #E36767
 
-  &.twitter
+  &.kf-twitter
     background-color: #55acee
 
-.social-connect-row
+.kf-social-connect-row
   margin: 15px auto
 
-.social-more-accounts
+.kf-social-more-accounts
   margin-top: -10px
   font-size: 14px
   color: #486788
   text-decoration: underline
   cursor: pointer
 
-.social-connected-button
+.kf-social-connected-button
   padding: 10px 11px
   font-size: 18px
   width: 215px
@@ -75,47 +64,47 @@ a.social-connect-button:active
   display: inline-block
   text-align: center
 
-  &.facebook
+  &.kf-facebook
     color: #597AB1
     border: 1px solid #597AB1
 
-  &.linkedin
+  &.kf-linkedin
     color: #2786C4
     border: 1px solid #2786C4
 
-  &.gmail
+  &.kf-gmail
     color: #E36767
     border: 1px solid #E36767
 
-  &.twitter
+  &.kf-twitter
     color: #55acee
     border: 1px solid #55acee
 
-  .social-account-name
+  .kf-social-account-name
     font-size: 14px
     color: #999
 
-.social-notice-badge
+.kf-social-notice-badge
   position: relative
   text-align: center
 
-  .notice-message
+  .kf-notice-message
     position: absolute
     width: 200px
     left: 24px
     top: -2px
     text-align: left
 
-    &.import
+    &.kf-import
       color: #40c381
       left: 44px
 
-    &.refresh
+    &.kf-refresh
       color: #486788
       text-decoration: underline
       cursor: pointer
 
-  .notice-button
+  .kf-notice-button
     content: ' '
     position: absolute
     top: -8px
@@ -128,14 +117,14 @@ a.social-connect-button:active
     border: 1px solid #0f0
     user-select: none
 
-    .social-extended &
+    .kf-social-extended &
       top: -16px
 
-    &.good
+    &.kf-good
       background: url(/img/checkmark.png) 7px/18px no-repeat #41C381
       border: 1px solid #41C381
 
-    &.warn
+    &.kf-warn
       border: 1px solid #f59989
       font-size: 30px
       color: #f59989
@@ -144,7 +133,7 @@ a.social-connect-button:active
       font-family: sans-serif
       line-height: 26px
 
-.bouncy-ball
+.kf-bouncy-ball
   transform: scale(.45)
   top: -15px
   left: -30px

--- a/kifi-backend/modules/shoebox/angular/src/social/connectNetworks.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/social/connectNetworks.tpl.html
@@ -1,114 +1,114 @@
 <div class="kf-social-connect">
-  <div class="social-connect-title">Connect your social networks to Kifi</div>
-  <p class="social-connect-desc">Connect your networks to quickly find people you may know already using Kifi.</p>
-  <div class="social-connect-buttons">
+  <div class="kf-social-connect-title">Connect your social networks to Kifi</div>
+  <p class="kf-social-connect-desc">Connect your networks to quickly find people you may know already using Kifi.</p>
+  <div class="kf-social-connect-buttons">
 
     <!-- Facebook -->
-    <div class="social-connect-row">
+    <div class="kf-social-connect-row">
       <div ng-if="facebook.profileUrl">
-        <div class="social-connected-button facebook">Facebook Connected</div>
+        <div class="kf-social-connected-button kf-facebook">Facebook Connected</div>
 
-        <span class="social-notice-badge" ng-if="facebookStatus() === 'good'">
-          <span class="notice-button good"></span>
+        <span class="kf-social-notice-badge" ng-if="facebookStatus() === 'kf-good'">
+          <span class="kf-notice-button kf-good"></span>
         </span>
 
-        <span class="social-notice-badge" ng-if="facebookStatus() === 'refreshing'">
-          <span class="notice-message import">
-            <div class="bouncy-ball">
+        <span class="kf-social-notice-badge" ng-if="facebookStatus() === 'refreshing'">
+          <span class="kf-notice-message kf-import">
+            <div class="kf-bouncy-ball">
               <div class="pace pace-active"><div class="pace-progress"></div><div class="pace-activity"></div></div>
             </div>
             Importing your contacts
           </span>
         </span>
 
-        <span class="social-notice-badge" ng-if="facebookStatus() === 'expired'"  ng-click="connectFacebook()">
-          <span class="notice-button warn">×</span>
-          <span class="notice-message refresh">Refresh connection</span>
+        <span class="kf-social-notice-badge" ng-if="facebookStatus() === 'expired'"  ng-click="connectFacebook()">
+          <span class="kf-notice-button kf-warn">×</span>
+          <span class="kf-notice-message kf-refresh">Refresh connection</span>
         </span>
 
       </div>
       <div ng-if="!facebook.profileUrl">
-        <a class="social-connect-button facebook" href="javascript:" ng-click="connectFacebook()">Connect Facebook</a>
+        <a class="kf-social-connect-button kf-facebook" href="javascript:" ng-click="connectFacebook()">Connect Facebook</a>
       </div>
     </div>
 
     <!-- Twitter -->
-    <div class="social-connect-row" ng-if="onTwitterExperiment">
+    <div class="kf-social-connect-row" ng-if="onTwitterExperiment">
       <div ng-if="twitter.profileUrl">
-        <div class="social-connected-button twitter">Twitter Connected</div>
+        <div class="kf-social-connected-button kf-twitter">Twitter Connected</div>
 
-        <span class="social-notice-badge" ng-if="twitterStatus() === 'good'">
-          <span class="notice-button good"></span>
+        <span class="kf-social-notice-badge" ng-if="twitterStatus() === 'kf-good'">
+          <span class="kf-notice-button kf-good"></span>
         </span>
 
-        <span class="social-notice-badge" ng-if="twitterStatus() === 'refreshing'">
-          <span class="notice-message import">
-            <div class="bouncy-ball">
+        <span class="kf-social-notice-badge" ng-if="twitterStatus() === 'refreshing'">
+          <span class="kf-notice-message kf-import">
+            <div class="kf-bouncy-ball">
               <div class="pace pace-active"><div class="pace-progress"></div><div class="pace-activity"></div></div>
             </div>
             Importing your contacts
           </span>
         </span>
 
-        <span class="social-notice-badge" ng-if="twitterStatus() === 'expired'"  ng-click="connectTwitter()">
-          <span class="notice-button warn">×</span>
-          <span class="notice-message refresh">Refresh connection</span>
+        <span class="kf-social-notice-badge" ng-if="twitterStatus() === 'expired'"  ng-click="connectTwitter()">
+          <span class="kf-notice-button kf-warn">×</span>
+          <span class="kf-notice-message kf-refresh">Refresh connection</span>
         </span>
 
       </div>
       <div ng-if="!twitter.profileUrl">
-        <a class="social-connect-button twitter" href="javascript:" ng-click="connectTwitter()">Connect Twitter</a>
+        <a class="kf-social-connect-button kf-twitter" href="javascript:" ng-click="connectTwitter()">Connect Twitter</a>
       </div>
     </div>
 
     <!-- LinkedIn -->
-    <div class="social-connect-row">
+    <div class="kf-social-connect-row">
       <div ng-if="linkedin.profileUrl">
-        <div class="social-connected-button linkedin">LinkedIn Connected</div>
+        <div class="kf-social-connected-button kf-linkedin">LinkedIn Connected</div>
 
-        <span class="social-notice-badge" ng-if="linkedinStatus() === 'good'">
-          <span class="notice-button good"></span>
+        <span class="kf-social-notice-badge" ng-if="linkedinStatus() === 'kf-good'">
+          <span class="kf-notice-button kf-good"></span>
         </span>
 
-        <span class="social-notice-badge" ng-if="linkedinStatus() === 'refreshing'">
-          <span class="notice-message import">
-            <div class="bouncy-ball">
+        <span class="kf-social-notice-badge" ng-if="linkedinStatus() === 'refreshing'">
+          <span class="kf-notice-message kf-import">
+            <div class="kf-bouncy-ball">
               <div class="pace pace-active"><div class="pace-progress"></div><div class="pace-activity"></div></div>
             </div>
             Importing your contacts
           </span>
         </span>
 
-        <span class="social-notice-badge" ng-if="linkedinStatus() === 'expired'"  ng-click="connectLinkedIn()">
-          <span class="notice-button warn">×</span>
-          <span class="notice-message refresh">Refresh connection</span>
+        <span class="kf-social-notice-badge" ng-if="linkedinStatus() === 'expired'"  ng-click="connectLinkedIn()">
+          <span class="kf-notice-button kf-warn">×</span>
+          <span class="kf-notice-message kf-refresh">Refresh connection</span>
         </span>
 
       </div>
       <div ng-if="!linkedin.profileUrl">
-        <a class="social-connect-button linkedin" href="javascript:" ng-click="connectLinkedIn()">Connect LinkedIn</a>
+        <a class="kf-social-connect-button kf-linkedin" href="javascript:" ng-click="connectLinkedIn()">Connect LinkedIn</a>
       </div>
     </div>
 
 
     <!-- Gmail -->
-    <div class="social-connect-row" ng-if="gmail.length === 0">
-      <a class="social-connect-button gmail" href="javascript:" ng-click="importGmail()">Connect Gmail</a>
+    <div class="kf-social-connect-row" ng-if="gmail.length === 0">
+      <a class="kf-social-connect-button kf-gmail" href="javascript:" ng-click="importGmail()">Connect Gmail</a>
     </div>
 
     <div ng-repeat="account in gmail" ng-if="gmail.length > 0">
-      <div class="social-connect-row social-extended">
-        <div class="social-connected-button gmail">
+      <div class="kf-social-connect-row kf-social-extended">
+        <div class="kf-social-connected-button kf-gmail">
           Gmail Connected
-          <div class="social-account-name">{{account.ownerEmail}}</div>
+          <div class="kf-social-account-name">{{account.ownerEmail}}</div>
         </div>
-        <span class="social-notice-badge">
-          <span class="notice-button good"></span>
+        <span class="kf-social-notice-badge">
+          <span class="kf-notice-button kf-good"></span>
         </span>
       </div>
     </div>
 
-    <div class="social-more-accounts" ng-if="gmail.length > 0" ng-click="importGmail()">Refresh/Add more Gmail accounts</div>
+    <div class="kf-social-more-accounts" ng-if="gmail.length > 0" ng-click="importGmail()">Refresh/Add more Gmail accounts</div>
 
   </div>
 </div>

--- a/kifi-backend/modules/shoebox/angular/src/social/connectNetworks.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/social/connectNetworks.tpl.html
@@ -1,4 +1,4 @@
-<div class="social-connect" ng-show="data.show">
+<div class="kf-social-connect">
   <div class="social-connect-title">Connect your social networks to Kifi</div>
   <p class="social-connect-desc">Connect your networks to quickly find people you may know already using Kifi.</p>
   <div class="social-connect-buttons">

--- a/kifi-backend/modules/shoebox/angular/src/social/social.js
+++ b/kifi-backend/modules/shoebox/angular/src/social/social.js
@@ -11,9 +11,6 @@ angular.module('kifi')
       restrict: 'A',
       templateUrl: 'social/connectNetworks.tpl.html',
       link: function (scope/*, element, attrs*/) {
-        scope.data = scope.data || {};
-        scope.data.show = true;
-
         scope.facebook = socialService.facebook;
         scope.linkedin = socialService.linkedin;
         scope.gmail = socialService.gmail;


### PR DESCRIPTION
@2is10 Leo has found a bug where the modal content was hidden by an ad-blocker extension due to clashing CSS class names.
