### PR TITLE
removing old redundant "secret" key from libraries in website search results

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/website/WebsiteSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/website/WebsiteSearchController.scala
@@ -58,7 +58,7 @@ class WebsiteSearchController @Inject() (
       getWebsiteUriSearchResults(userId, uriSearchResult).imap {
         case (hits, users, libraries) =>
           val librariesJson = libraries.map { library =>
-            Json.obj("id" -> library.id, "name" -> library.name, "path" -> library.path, "visibility" -> library.visibility, "secret" -> library.isSecret) //todo(Léo): remove secret field
+            Json.obj("id" -> library.id, "name" -> library.name, "path" -> library.path, "visibility" -> library.visibility)
           }
           val result = Json.obj(
             "uuid" -> uriSearchResult.uuid,


### PR DESCRIPTION
@leogrim 
cc @yipingliao 

We also need to add the library color. I would have, but it didn’t appear to be readily available. We should probably add it to `BasicLibrary` since the color will soon be displayed everywhere a library is.

I’ve verified that the website isn’t using the `"secret"` key. It’s only using `"visibility"`.
