### PR TITLE
caching samples instead of density

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/math/Sampler.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/math/Sampler.scala
@@ -1,7 +1,5 @@
 package com.keepit.common.math
 
-import java.util.Arrays
-
 import scala.util.Random
 
 trait Sampler {

--- a/kifi-backend/modules/graph/app/com/keepit/graph/controllers/internal/GraphController.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/controllers/internal/GraphController.scala
@@ -132,13 +132,4 @@ class GraphController @Inject() (
       Ok(Json.toJson(res))
     }
   }
-
-  def enableSampler() = Action {
-    uriWanderingCommander.useSampler = true
-    Ok
-  }
-  def disableSampler() = Action {
-    uriWanderingCommander.useSampler = false
-    Ok
-  }
 }

--- a/kifi-backend/modules/graph/app/com/keepit/graph/wander/DestinationSamples.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/wander/DestinationSamples.scala
@@ -1,0 +1,53 @@
+package com.keepit.graph.wander
+
+import com.keepit.common.math.Sampler
+import com.keepit.graph.model.VertexId
+import scala.util.Random
+
+object DestinationSamples {
+  val random = new Random
+}
+
+class DestinationSamples(destinations: Array[Long], val size: Int, val totalWeight: Double) {
+  private[this] var index = 0
+
+  def hasNext(): Boolean = index < size
+
+  def next(): VertexId = {
+    // randomly retrieve a sample
+    val i = DestinationSamples.random.nextInt(size - index) + index
+    val nextDestination = destinations(i)
+    destinations(i) = destinations(index)
+    index += 1
+    VertexId(nextDestination)
+  }
+}
+
+class DestinationSamplesBuilder(maxSampleSize: Int, totalWeightEstimate: Double) {
+  private[this] var sum = 0.0
+  private[this] val sampler = Sampler(maxSampleSize)
+  private[this] val samples = new Array[Long](maxSampleSize)
+  private[this] var sampleSize = 0
+
+  def add(vertexId: VertexId, weight: Double): Unit = {
+    if (weight > 0.0) {
+      // the estimated total weight is used, instead of the real total weight, to compute probabilities
+      var cnt = sampler.collect(weight / totalWeightEstimate)
+      while (cnt > 0) {
+        cnt -= 1
+        samples(sampleSize) = vertexId.id
+        sampleSize += 1
+      }
+      sum += weight
+    }
+  }
+
+  def build(): DestinationSamples = {
+    if (sum > 0.0) {
+      new DestinationSamples(samples, sampleSize, sum)
+    } else {
+      new DestinationSamples(Array.empty[Long], 0, 0.0)
+    }
+  }
+}
+

--- a/kifi-backend/modules/graph/app/com/keepit/graph/wander/URIWanderingCommander.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/wander/URIWanderingCommander.scala
@@ -4,7 +4,7 @@ import com.google.inject.Inject
 import com.keepit.common.concurrent.ReactiveLock
 import com.keepit.common.db.Id
 import com.keepit.common.logging.Logging
-import com.keepit.common.math.{ Sampler, ProbabilityDensityBuilder, ProbabilityDensity }
+import com.keepit.common.math.Sampler
 import com.keepit.common.time._
 
 import com.keepit.graph.manager.GraphManager
@@ -21,7 +21,6 @@ class URIWanderingCommander @Inject() (
     graph: GraphManager,
     wanderingCommander: WanderingCommander) extends DestinationWeightsQuerier with Logging {
 
-  var useSampler = false
   val uriWanderLock = new ReactiveLock(5)
 
   def wander(user: Id[User], trials: Int): Future[Map[Id[NormalizedURI], Int]] = {
@@ -110,23 +109,12 @@ class URIWanderingCommander @Inject() (
       wanderer.moveTo(source)
 
       val scores = mutable.Map[VertexDataId[D], Int]().withDefaultValue(0)
-      if (useSampler) {
-        val totalWeight = getTotalDestinationWeight(wanderer, scout, Component(component._1, component._2, component._3), resolver)
-        if (totalWeight > 0.0) {
-          val sampler = Sampler(trials)
-          getDestinationWeights(wanderer, scout, Component(component._1, component._2, component._3), edgeResolver) { (vertexId, weight) =>
-            val count = sampler.collect(weight / totalWeight)
-            if (count > 0) scores(vertexId.asId[D]) += count
-          }
-        }
-      } else {
-        val builder = new ProbabilityDensityBuilder[VertexId]
-        getDestinationWeights(wanderer, scout, Component(component._1, component._2, component._3), edgeResolver) { (vertexId, weight) => builder.add(vertexId, weight) }
-        val density = builder.build()
-        var i = 0
-        while (i < trials) {
-          density.sample(Math.random()) foreach { vertex => scores(vertex.asId[D]) += 1 }
-          i += 1
+      val (totalWeight, _) = getTotalDestinationWeightAndCount(wanderer, scout, Component(component._1, component._2, component._3), resolver)
+      if (totalWeight > 0.0) {
+        val sampler = Sampler(trials)
+        getDestinationWeights(wanderer, scout, Component(component._1, component._2, component._3), edgeResolver) { (vertexId, weight) =>
+          val count = sampler.collect(weight / totalWeight)
+          if (count > 0) scores(vertexId.asId[D]) += count
         }
       }
       scores.toMap

--- a/kifi-backend/modules/graph/app/com/keepit/graph/wander/Wanderer.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/wander/Wanderer.scala
@@ -12,20 +12,20 @@ trait Wanderer {
 }
 
 class ScoutingWanderer(wanderer: GlobalVertexReader, scout: GlobalVertexReader) extends DestinationWeightsQuerier with Logging {
-  type TransitionProbabilityCache = mutable.Map[VertexId, mutable.Map[Component, ProbabilityDensity[VertexId]]]
+  type DestinationSampleCache = mutable.Map[VertexId, mutable.Map[Component, DestinationSamples]]
 
   def wander(steps: Int, teleporter: Teleporter, resolver: EdgeResolver, journal: TravelJournal): Unit = {
-    val probabilityCache: TransitionProbabilityCache = mutable.Map()
+    val sampleCache: DestinationSampleCache = mutable.Map()
     teleportTo(teleporter.surely, journal, isStart = true)
     var step = 0
     while (step < steps) {
-      tryAndMove(teleporter, resolver, journal, probabilityCache, 1)
+      tryAndMove(teleporter, resolver, journal, sampleCache, 1)
       step += 1
     }
     journal.onComplete(wanderer)
   }
 
-  private def tryAndMove(teleporter: Teleporter, resolver: EdgeResolver, journal: TravelJournal, cache: TransitionProbabilityCache, retries: Int): Unit = {
+  private def tryAndMove(teleporter: Teleporter, resolver: EdgeResolver, journal: TravelJournal, cache: DestinationSampleCache, retries: Int): Unit = {
     try { move(teleporter, resolver, journal, cache) }
     catch {
       case VertexNotFoundException(id) if retries > 0 =>
@@ -35,7 +35,7 @@ class ScoutingWanderer(wanderer: GlobalVertexReader, scout: GlobalVertexReader) 
     }
   }
 
-  private def move(teleporter: Teleporter, resolver: EdgeResolver, journal: TravelJournal, cache: TransitionProbabilityCache): Unit = {
+  private def move(teleporter: Teleporter, resolver: EdgeResolver, journal: TravelJournal, cache: DestinationSampleCache): Unit = {
     teleporter.maybe(wanderer) match {
       case Some(newStart) => teleportTo(newStart, journal)
       case None => {
@@ -79,15 +79,46 @@ class ScoutingWanderer(wanderer: GlobalVertexReader, scout: GlobalVertexReader) 
     probability.sample(Math.random())
   }
 
-  private def sampleDestination(component: Component, resolver: EdgeResolver, cache: TransitionProbabilityCache): Option[(VertexId, EdgeType)] = {
+  private def sampleDestination(component: Component, resolver: EdgeResolver, cache: DestinationSampleCache): Option[(VertexId, EdgeType)] = {
     val source = wanderer.id
     val localCache = cache.getOrElseUpdate(source, mutable.Map())
-    val probability = localCache.getOrElseUpdate(component, computeDestinationProbability(component, resolver))
-    probability.sample(Math.random()).map { destination => (destination, component._3) }
+
+    val destinationSamples = localCache.get(component) match {
+      case Some(destinationSamples) =>
+        if (destinationSamples.hasNext) destinationSamples
+        else {
+          if (destinationSamples.totalWeight > 0.0) {
+            // double the sample size (and plus 1 in case the old size is zero)
+            // and use the previous totalWeight as the estimated total weight in this iteration
+            computeDestinationSamples(component, resolver, destinationSamples.size * 2 + 1, destinationSamples.totalWeight)
+          } else {
+            destinationSamples
+          }
+        }
+      case None =>
+        val newDestinationSamples = computeDestinationSamples(component, resolver)
+        localCache.put(component, newDestinationSamples)
+        newDestinationSamples
+    }
+
+    if (destinationSamples.hasNext) {
+      Some((destinationSamples.next, component._3))
+    } else {
+      None
+    }
   }
 
-  private def computeDestinationProbability(component: Component, resolver: EdgeResolver): ProbabilityDensity[VertexId] = {
-    val builder = new ProbabilityDensityBuilder[VertexId]
+  private def computeDestinationSamples(component: Component, resolver: EdgeResolver): DestinationSamples = {
+    // use the real total weight for the initial estimated total weight
+    val (totalWeight, destCount) = getTotalDestinationWeightAndCount(wanderer, scout, component, resolver)
+    // the initial sample size is the half of population size or 64 whichever smaller
+    val maxSampleSize = Math.min((destCount + 1) / 2, 64)
+
+    computeDestinationSamples(component, resolver, maxSampleSize, totalWeight)
+  }
+
+  private def computeDestinationSamples(component: Component, resolver: EdgeResolver, maxSampleSize: Int, totalWeight: Double): DestinationSamples = {
+    val builder = new DestinationSamplesBuilder(maxSampleSize, totalWeight)
     getDestinationWeights(wanderer, scout, component, resolver) { (vertexId, weight) => builder.add(vertexId, weight) }
     builder.build
   }
@@ -108,9 +139,13 @@ trait DestinationWeightsQuerier {
     }
   }
 
-  def getTotalDestinationWeight(wanderer: GlobalVertexReader, scout: GlobalVertexReader, component: Component, resolver: EdgeResolver): Double = {
+  def getTotalDestinationWeightAndCount(wanderer: GlobalVertexReader, scout: GlobalVertexReader, component: Component, resolver: EdgeResolver): (Double, Int) = {
     var total = 0.0
-    getDestinationWeights(wanderer, scout, component, resolver) { (_, weight) => total += weight }
-    total
+    var count = 0
+    getDestinationWeights(wanderer, scout, component, resolver) { (_, weight) =>
+      total += weight
+      count += 1
+    }
+    (total, count)
   }
 }

--- a/kifi-backend/modules/graph/conf/graphService.routes
+++ b/kifi-backend/modules/graph/conf/graphService.routes
@@ -9,7 +9,4 @@ GET     /internal/graph/getUserAndScorePairs @com.keepit.graph.controllers.inter
 GET     /internal/graph/getSociallyRelatedEntities  @com.keepit.graph.controllers.internal.GraphController.getSociallyRelatedEntities(userId: Id[User])
 POST    /internal/graph/explainFeed                      @com.keepit.graph.controllers.internal.GraphController.explainFeed
 
-GET     /internal/graph/enableSampler   @com.keepit.graph.controllers.internal.GraphController.enableSampler()
-GET     /internal/graph/disableSampler  @com.keepit.graph.controllers.internal.GraphController.disableSampler()
-
 ->  / commonService.Routes


### PR DESCRIPTION
@leogrim @yingjieMiao @stkem 

another memory saving idea on graph
- caching a batch of samples instead of the probability density of a transition
- the batch are recomputed when cached sample is exhausted
- the batch size is doubled each time recomputation happens
