### PR TITLE
updating gulp-minify-html to fix stripped whitespace issue in prod

### DIFF
--- a/kifi-backend/modules/shoebox/angular/package.json
+++ b/kifi-backend/modules/shoebox/angular/package.json
@@ -35,7 +35,7 @@
     "gulp-ignore": "^1.2.0",
     "gulp-jshint": "~1.8.0",
     "gulp-livereload": "~2.1.0",
-    "gulp-minify-html": "~0.1.4",
+    "gulp-minify-html": "~0.1.8",
     "gulp-ng-html2js": "~0.1.7",
     "gulp-order": "^1.1.1",
     "gulp-protractor": "0.0.11",


### PR DESCRIPTION
@andrewconner @yipingliao 
I already had 0.1.8 locally, but marvin has 0.1.4. This should get everybody onto the latest release with consistent whitespace handling (collapsing to a single space, like the browser).
