### PR TITLE
ensuring that the top margin does not animate on initial render

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.styl
@@ -354,7 +354,9 @@ cover-image-adjust-right = 24px
 
   .kf-keep-lib-info
     margin: 30px 40px 0
-    transition: margin-top 0.3s ease
+
+    .kf-loaded &
+      transition: margin-top 0.3s ease
 
   .kf-keep-lib-owner
     white-space: nowrap


### PR DESCRIPTION
@yipingliao 

May rename the `kf-loaded` class for more clarity in the future.
