### PR TITLE
Fix stats formatting on mobile library header.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
@@ -91,6 +91,7 @@
 
         .kf-keep-lib-stats-and-followers
           padding-top: 6px
+          height: 150px
 
         .kf-keep-lib-metrics
           display block
@@ -107,6 +108,9 @@
           .kf-keep-lib-stats-number
             font-size: 35px
             line-height: 42px
+
+        .kf-keep-lib-additional-followers
+          display: none
 
         .kf-keep-lib-follower-preview
           text-align: center


### PR DESCRIPTION
@2is10 Looks like I broke some formatting on the public library header on mobile when I split up the library cards.
