### PR TITLE
distributing tasks by simple hashing

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/actor/ActorSystemModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/actor/ActorSystemModule.scala
@@ -51,6 +51,7 @@ case class DevActorSystemModule() extends ActorSystemModule {
     new SchedulingProperties {
       def enabled = enabledProp
       def enabledOnlyForLeader = enabledProp
+      def enabledOnlyForOneMachine(taskName: String) = enabledProp
     }
   }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/plugin/SchedulingPlugin.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/plugin/SchedulingPlugin.scala
@@ -18,10 +18,12 @@ trait SchedulingProperties {
   //bad name, can you think of anything else?
   //method returns true if schedualing is enabled and the instance is the leader
   def enabledOnlyForLeader: Boolean
+  def enabledOnlyForOneMachine(taskName: String): Boolean
 }
 
 class SchedulingPropertiesImpl(serviceDiscovery: ServiceDiscovery, val enabled: Boolean = true) extends SchedulingProperties {
   def enabledOnlyForLeader: Boolean = enabled && serviceDiscovery.isLeader()
+  def enabledOnlyForOneMachine(taskName: String): Boolean = enabled && serviceDiscovery.isRunnerFor(taskName)
 }
 
 case class NamedCancellable(underlying: Cancellable, taskName: String) extends Cancellable {
@@ -89,6 +91,21 @@ trait SchedulerPlugin extends Plugin with Logging {
     }
   }
 
+  def scheduleTaskOnOneMachine(system: ActorSystem, initialDelay: FiniteDuration, frequency: FiniteDuration, receiver: ActorRef, message: Any, taskName: String): Unit = {
+    if (scheduling.enabled) {
+      log.info(s"Scheduling $taskName")
+      scheduleTask(system, initialDelay, frequency, taskName) {
+        if (scheduling.enabledOnlyForOneMachine(taskName)) {
+          timing(s"executing scheduled task: $taskName") {
+            receiver ! message
+          }
+        }
+      }
+    } else {
+      log.debug(s"permanently disable scheduling for task: $taskName")
+    }
+  }
+
   def scheduleTaskOnAllMachines(system: ActorSystem, initialDelay: FiniteDuration, frequency: FiniteDuration, receiver: ActorRef, message: Any): Unit = {
     val taskName = s"send message $message to actor $receiver on all machines"
     if (scheduling.enabled) {
@@ -109,6 +126,22 @@ trait SchedulerPlugin extends Plugin with Logging {
       log.info(s"Scheduling $taskName")
       scheduleTask(system, initialDelay, frequency, taskName) {
         if (scheduling.enabledOnlyForLeader) {
+          timing(s"executing scheduled task: $taskName") {
+            f
+          }
+        }
+      }
+    } else {
+      log.debug(s"permanently disable scheduling for task: $taskName")
+    }
+  }
+
+  def scheduleTaskOnOneMachine(system: ActorSystem, initialDelay: FiniteDuration, frequency: FiniteDuration, name: String)(f: => Unit): Unit = {
+    val taskName = s"call task function $name on leader only"
+    if (scheduling.enabled) {
+      log.info(s"Scheduling $taskName")
+      scheduleTask(system, initialDelay, frequency, taskName) {
+        if (scheduling.enabledOnlyForOneMachine(taskName)) {
           timing(s"executing scheduled task: $taskName") {
             f
           }

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/DiscoveryModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/DiscoveryModule.scala
@@ -183,6 +183,7 @@ abstract class LocalDiscoveryModule(serviceType: ServiceType) extends DiscoveryM
       def serviceCluster(serviceType: ServiceType): ServiceCluster = if (availableServices.contains(serviceType)) cluster else throw new UnknownServiceException(s"DiscoveryService is not listening to service $serviceType.")
       def register() = thisInstance.get
       def isLeader() = true
+      def isRunnerFor(taskName: String) = true
       def changeStatus(newStatus: ServiceStatus): Unit = { state = Some(newStatus) }
       def startSelfCheck(): Future[Boolean] = Promise[Boolean].success(true).future
       def forceUpdate(): Unit = {}

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
@@ -158,7 +158,7 @@ class ServiceCluster(val serviceType: ServiceType, airbrake: Provider[AirbrakeNo
   }
 
   private def resetRoutingList() = {
-    routingList = Vector(instances.values.toSeq: _*)
+    routingList = instances.values.toVector.sortBy(_.node.path)
 
     customRouter.foreach { myRouter =>
       try {

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
@@ -24,6 +24,7 @@ trait ServiceDiscovery {
   def register(): ServiceInstance
   def unRegister(): Unit = {}
   def isLeader(): Boolean
+  def isRunnerFor(taskName: String): Boolean
   def myClusterSize: Int = 0
   def startSelfCheck(): Future[Boolean]
   def changeStatus(newStatus: ServiceStatus): Unit
@@ -123,6 +124,18 @@ class ServiceDiscoveryImpl(
         if (logMe) logLeader(s"I'm not the leader since my instance is ${myInstance.get} and I have no idea who the leader is")
         require(myCluster.size == 0)
         return false
+    }
+  }
+
+  def isRunnerFor(taskName: String): Boolean = if (isCanary) false else zkClient.session { zk =>
+    if (!stillRegistered()) {
+      log.warn(s"service did not register itself yet!")
+      return false
+    }
+
+    myInstance.exists { thisInst =>
+      val index = (taskName.hashCode() & 0x7FFFFFFF) % myCluster.allMembers.size
+      myCluster.allMembers(index) == thisInst
     }
   }
 

--- a/kifi-backend/modules/common/test/com/keepit/common/actor/FakeActorSystemModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/actor/FakeActorSystemModule.scala
@@ -28,6 +28,7 @@ case class FakeSchedulerModule() extends ScalaModule {
     new SchedulingProperties {
       def enabled = false
       def enabledOnlyForLeader = false
+      def enabledOnlyForOneMachine(taskName: String) = false
     }
 }
 

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/CuratorTasksPlugin.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/CuratorTasksPlugin.scala
@@ -11,6 +11,15 @@ import us.theatr.akka.quartz.QuartzActor
 
 import scala.concurrent.duration._
 
+object CuratorTasks {
+  val completeDataIngestion = "complete data ingestion"
+  val uriRecommendationPrecomputation = "uri recommendation precomputation"
+  val uriRecommendationReaper = "uri recommendation reaper"
+  val publicFeedReaper = "public feed reaper"
+  val libraryRecommendationPrecomputation = "library recommendation precomputation"
+  val libraryRecommendationReaper = "library recommendation reaper"
+}
+
 @Singleton
 class CuratorTasksPlugin @Inject() (
     ingestionCommander: SeedIngestionCommander,
@@ -24,26 +33,28 @@ class CuratorTasksPlugin @Inject() (
     quartz: ActorInstance[QuartzActor],
     val scheduling: SchedulingProperties) extends SchedulerPlugin {
 
+  import CuratorTasks._
+
   override def onStart() {
     log.info("CuratorTasksPlugin onStart")
-    scheduleTaskOnLeader(system, 5 minutes, 3 minutes, "complete data ingestion") {
+    scheduleTaskOnOneMachine(system, 5 minutes, 3 minutes, completeDataIngestion) {
       ingestionCommander.ingestAll()
     }
-    scheduleTaskOnLeader(system, 3 minutes, 2 minutes, "recommendation precomputation") {
+    scheduleTaskOnOneMachine(system, 3 minutes, 2 minutes, uriRecommendationPrecomputation) {
       uriRecoGenerationCommander.precomputeRecommendations()
     }
-    scheduleTaskOnLeader(system, 10 minutes, 10 minutes, "recommendation reaper") {
+    scheduleTaskOnOneMachine(system, 10 minutes, 10 minutes, uriRecommendationReaper) {
       uriRecoCleanupCommander.cleanup()
     }
 
-    scheduleTaskOnLeader(system, 1 hours, 5 hours, "public feed reaper") {
+    scheduleTaskOnOneMachine(system, 1 hours, 5 hours, publicFeedReaper) {
       feedCommander.cleanup()
     }
 
-    scheduleTaskOnLeader(system, 1 minutes, 3 minutes, "library recommendation precomputation") {
+    scheduleTaskOnOneMachine(system, 1 minutes, 3 minutes, libraryRecommendationPrecomputation) {
       libraryRecoGenerationCommander.precomputeRecommendations()
     }
-    scheduleTaskOnLeader(system, 10 minutes, 10 minutes, "library recommendation reaper") {
+    scheduleTaskOnOneMachine(system, 10 minutes, 10 minutes, libraryRecommendationReaper) {
       libraryRecoCleanupCommander.cleanupLowMasterScoreRecos()
     }
 

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/LibraryRecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/LibraryRecommendationGenerationCommander.scala
@@ -114,7 +114,7 @@ class LibraryRecommendationGenerationCommander @Inject() (
     }
 
     private def precomputeRecommendationsForUser(alwaysInclude: Set[Id[Library]], recoGenState: LibraryRecommendationGenerationState): Future[Unit] = {
-      if (serviceDiscovery.isLeader()) {
+      if (serviceDiscovery.isRunnerFor(CuratorTasks.libraryRecommendationPrecomputation)) {
         log.info(s"precomputeRecommendationsForUser called userId=$userId seq=${recoGenState.seq}")
         val (candidateLibraries, excludedLibraries, newSeqNum) = getCandidateLibrariesForUser(recoGenState)
 

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
@@ -205,7 +205,7 @@ class RecommendationGenerationCommander @Inject() (
 
   private def precomputeRecommendationsForUser(userId: Id[User], boostedKeepers: Set[Id[User]], alwaysIncludeOpt: Option[Set[Id[NormalizedURI]]] = None): Future[Unit] = recommendationGenerationLock.withLockFuture {
     getPerUserGenerationLock(userId).withLockFuture {
-      if (serviceDiscovery.isLeader()) {
+      if (serviceDiscovery.isRunnerFor(CuratorTasks.uriRecommendationPrecomputation)) {
         val alwaysInclude: Set[Id[NormalizedURI]] = alwaysIncludeOpt.getOrElse(db.readOnlyReplica { implicit session => uriRecRepo.getUriIdsForUser(userId) })
         val state: UserRecommendationGenerationState = getStateOfUser(userId)
         val seedsAndSeqFuture: Future[(Seq[SeedItem], SequenceNumber[SeedItem])] = getCandidateSeedsForUser(userId, state)


### PR DESCRIPTION
@eishay 
FYI @stkem @andrewconner 
- allowing distribution of tasks, which are currently executed by a leader, by hashing task names
- using this only in curator for now to see the behavior in prod.
