### PR TITLE
mobile controller for user personas

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserPersonaController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserPersonaController.scala
@@ -1,0 +1,56 @@
+package com.keepit.controllers.mobile
+
+import com.google.inject.Inject
+import com.keepit.commanders.UserPersonaCommander
+import com.keepit.common.controller.{ UserActionsHelper, UserActions, ShoeboxServiceController }
+import com.keepit.common.db.slick.Database
+import com.keepit.common.logging.Logging
+import com.keepit.common.time.Clock
+import com.keepit.heimdal.{ HeimdalContextBuilderFactory }
+import com.keepit.model._
+import play.api.libs.json.Json
+
+class MobileUserPersonaController @Inject() (
+  db: Database,
+  userPersonaCommander: UserPersonaCommander,
+  personaRepo: PersonaRepo,
+  userPersonaRepo: UserPersonaRepo,
+  val userActionsHelper: UserActionsHelper,
+  heimdalContextFactory: HeimdalContextBuilderFactory,
+  clock: Clock)
+    extends UserActions with ShoeboxServiceController with Logging {
+
+  def getAllPersonas() = MaybeUserAction { request =>
+    val (allPersonas, userPersonas) = db.readOnlyMaster { implicit s =>
+      val allPersonas = personaRepo.getByState(PersonaStates.ACTIVE)
+      val userPersonas = request.userIdOpt.map { userId =>
+        userPersonaRepo.getPersonasForUser(userId)
+      }.getOrElse(Seq.empty)
+      (allPersonas, userPersonas)
+    }
+
+    val personaMap = allPersonas.map { persona =>
+      (persona.name.value, userPersonas.contains(persona))
+    }.toMap
+    Ok(Json.obj("personas" -> Json.toJson(personaMap)))
+  }
+
+  def selectPersonas() = UserAction(parse.tolerantJson) { request =>
+    implicit val context = heimdalContextFactory.withRequestInfoAndSource(request, KeepSource.mobile).build
+    val persistPersonaNames = (request.body \ "personas").as[Seq[PersonaName]]
+    val currentPersonaNames = db.readOnlyMaster { implicit s =>
+      userPersonaRepo.getPersonasForUser(request.userId)
+    }.map(_.name)
+
+    val personasToAdd = persistPersonaNames diff currentPersonaNames
+    val personasToRemove = currentPersonaNames diff persistPersonaNames
+
+    val added = userPersonaCommander.addPersonasForUser(request.userId, personasToAdd.toSet)
+    val removed = userPersonaCommander.removePersonasForUser(request.userId, personasToRemove.toSet)
+
+    Ok(Json.obj(
+      "added" -> added.keys.map(_.name).toSeq,
+      "removed" -> removed.map(_.name).toSeq
+    ))
+  }
+}

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -223,6 +223,8 @@ POST    /m/1/user/:id/include                   @com.keepit.controllers.mobile.M
 POST    /m/1/user/:id/exclude                   @com.keepit.controllers.mobile.MobileUserController.excludeFriend(id: ExternalId[User])
 GET     /m/1/user/settings                      @com.keepit.controllers.mobile.MobileUserController.getSettings()
 POST    /m/1/user/settings                      @com.keepit.controllers.mobile.MobileUserController.setSettings()
+GET     /m/1/user/personas                      @com.keepit.controllers.mobile.MobileUserPersonaController.getAllPersonas()
+POST    /m/1/user/personas                      @com.keepit.controllers.mobile.MobileUserPersonaController.selectPersonas()
 
 POST    /m/1/attribution/appsflyer              @com.keepit.controllers.mobile.MobileUserController.setAppsflyerAttribution()
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserPersonaControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserPersonaControllerTest.scala
@@ -1,0 +1,144 @@
+package com.keepit.controllers.mobile
+
+import com.google.inject.Injector
+import com.keepit.abook.FakeABookServiceClientModule
+import com.keepit.common.concurrent.FakeExecutionContextModule
+import com.keepit.common.controller.FakeUserActionsHelper
+import com.keepit.common.crypto.FakeCryptoModule
+import com.keepit.common.mail.FakeMailModule
+import com.keepit.common.social.FakeSocialGraphModule
+import com.keepit.common.store.FakeShoeboxStoreModule
+import com.keepit.controllers.mobile.MobileUserPersonaController
+import com.keepit.eliza.FakeElizaServiceClientModule
+import com.keepit.heimdal.{ FakeHeimdalServiceClientModule, HeimdalContext }
+import com.keepit.model.{ PersonaName, UserPersona, Persona }
+import com.keepit.scraper.FakeScrapeSchedulerModule
+import com.keepit.search.FakeSearchServiceClientModule
+import com.keepit.test.ShoeboxTestInjector
+import com.keepit.model.UserFactoryHelper._
+import com.keepit.model.UserFactory._
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+class MobileUserPersonaControllerTest extends Specification with ShoeboxTestInjector {
+
+  implicit val context = HeimdalContext.empty
+  def controllerTestModules = Seq(
+    FakeExecutionContextModule(),
+    FakeScrapeSchedulerModule(),
+    FakeSearchServiceClientModule(),
+    FakeMailModule(),
+    FakeShoeboxStoreModule(),
+    FakeCryptoModule(),
+    FakeSocialGraphModule(),
+    FakeABookServiceClientModule(),
+    FakeElizaServiceClientModule(),
+    FakeHeimdalServiceClientModule()
+  )
+
+  "MobileUserPersonaController" should {
+
+    "get all personas" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val (user1, allPersonas) = setupUserPersona
+        val controller = inject[MobileUserPersonaController]
+        inject[FakeUserActionsHelper].setUser(user1)
+
+        val testPath = com.keepit.controllers.mobile.routes.MobileUserPersonaController.getAllPersonas().url
+        val request = FakeRequest("GET", testPath)
+        val result1 = controller.getAllPersonas()(request)
+        status(result1) must equalTo(OK)
+        contentType(result1) must beSome("application/json")
+        contentAsJson(result1) === Json.parse(
+          s"""{
+              "personas":{
+                  "parent": false,
+                  "techie": false,
+                  "designer": false,
+                  "photographer": false,
+                  "student": true,
+                  "artist": false,
+                  "foodie": false,
+                  "athlete": false,
+                  "gamer": false,
+                  "adventurer": true
+                }
+              }"""
+        )
+
+        // view as anonymous user (all personas should be unset)
+        inject[FakeUserActionsHelper].unsetUser()
+        val result2 = controller.getAllPersonas()(request)
+        status(result2) must equalTo(OK)
+        contentType(result2) must beSome("application/json")
+        contentAsJson(result2) === Json.parse(
+          s"""{
+              "personas":{
+                  "parent": false,
+                  "techie": false,
+                  "designer": false,
+                  "photographer": false,
+                  "student": false,
+                  "artist": false,
+                  "foodie": false,
+                  "athlete": false,
+                  "gamer": false,
+                  "adventurer": false
+                }
+              }"""
+        )
+      }
+    }
+
+    "select user persona" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val (user1, allPersonas) = setupUserPersona
+        val controller = inject[MobileUserPersonaController]
+        inject[FakeUserActionsHelper].setUser(user1)
+
+        db.readOnlyMaster { implicit s =>
+          userPersonaRepo.getPersonasForUser(user1.id.get).map(_.name) === Seq(PersonaName.ADVENTURER, PersonaName.STUDENT)
+        }
+
+        val testPath = com.keepit.controllers.mobile.routes.MobileUserPersonaController.selectPersonas().url
+        val request = FakeRequest("POST", testPath)
+
+        // add new persona "photographer", remove "student"
+        val result1 = controller.selectPersonas()(request.withBody(Json.obj("personas" -> Seq("adventurer", "photographer"))))
+        status(result1) must equalTo(OK)
+        val resultJson1 = contentAsJson(result1)
+        (resultJson1 \ "added").as[Seq[String]] === Seq("photographer")
+        (resultJson1 \ "removed").as[Seq[String]] === Seq("student")
+
+        db.readOnlyMaster { implicit s =>
+          userPersonaRepo.getPersonasForUser(user1.id.get).map(_.name) === Seq(PersonaName.ADVENTURER, PersonaName.PHOTOGRAPHER)
+        }
+
+      }
+    }
+
+  }
+
+  // sets up a Map of [String, Persona]
+  private def setupPersonas()(implicit injector: Injector) = {
+    val availablePersonas = PersonaName.allPersonas
+    db.readWrite { implicit s =>
+      availablePersonas.map { pName =>
+        (pName -> personaRepo.save(Persona(name = pName)))
+      }
+    }.toMap
+  }
+
+  private def setupUserPersona()(implicit injector: Injector) = {
+    val allPersonas = setupPersonas
+    val user1 = db.readWrite { implicit s =>
+      val user1 = user().withName("Peter", "Parker").withUsername("peterparker").withEmailAddress("peterparker@gmail.com").saved
+      userPersonaRepo.save(UserPersona(userId = user1.id.get, personaId = allPersonas(PersonaName.ADVENTURER).id.get))
+      userPersonaRepo.save(UserPersona(userId = user1.id.get, personaId = allPersonas(PersonaName.STUDENT).id.get))
+      user1
+    }
+    (user1, allPersonas)
+  }
+}


### PR DESCRIPTION
@andrewconner @yingjieMiao @stkem 
cc: @jaredpetker @DerekBurch @thassss @mrbrown14 

two endpoints:
`GET     /m/1/user/personas` (can be called by a user or non-user)
response comes back with a name -> boolean which indicates whether persona is activated for that user or not. If non-user, all fields will be false

```
  personas: {
    "parent" : true
    "student" : false
    ...
  }
```

`POST    /m/1/user/personas` must be user & takes in:
`{ personas : [parent, adventurer, student]}`

which will persist all personas in that list. Any existing personas not in list will be removed.
responds with which personas have been added or removed

```
{
    added : [ "adventurer", "photographer" ]
    removed : ["student"]
}
```

Note: Backend has a safety guard as to which Persona you can add (kind of like library colors) - you can only add whatever the backend acknowledges is a valid persona
