### PR TITLE
version up

### DIFF
--- a/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
@@ -201,7 +201,7 @@ class LDAController @Inject() (
   }
 
   def getSimilarLibraries(libId: Id[Library], limit: Int, version: Option[Int]) = Action { request =>
-    val ver = ModelVersion[DenseLDA](3) // just use this for now.
+    implicit val ver = toVersion(version)
     val libs = statsd.time("ldaController.getSimilarLibraries", 1.0) { _ => lda.getSimilarLibraries(libId, limit)(ver) }
     Ok(Json.toJson(libs))
   }

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/package.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/package.scala
@@ -10,8 +10,8 @@ package object cortex {
 
   // version of feature representers/updaters
   object ModelVersions {
-    val defaultLDAVersion = ModelVersion[DenseLDA](2)
-    val experimentalLDAVersion = List(ModelVersion[DenseLDA](3))
+    val defaultLDAVersion = ModelVersion[DenseLDA](3)
+    val experimentalLDAVersion: List[ModelVersion[DenseLDA]] = List()
     val availableLDAVersions = List(defaultLDAVersion) ++ experimentalLDAVersion
     val word2vecVersion = ModelVersion[Word2Vec](2)
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLDAController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLDAController.scala
@@ -226,7 +226,7 @@ class AdminLDAController @Inject() (
   }
 
   def similarURIs(uriId: Id[NormalizedURI]) = AdminUserPage.async { implicit request =>
-    val ver = ModelVersion[DenseLDA](3)
+    val ver = defaultVersion
     cortex.similarURIs(uriId)(Some(ver)).map { uriIds =>
       val uris = db.readOnlyReplica { implicit s =>
         uriIds.map { id => uriRepo.get(id) }


### PR DESCRIPTION
@stkem 

there is only one left: serves as a guard for version 3 names. We can wait a bit. 
