### PR TITLE
Follow button cta follow up

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeaderFollowButtonCta.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeaderFollowButtonCta.js
@@ -34,10 +34,18 @@ angular.module('kifi')
               scope.ctaShownAbove = false;
             }
 
+            // If the follow button is "sticky" (i.e., its position is fixed),
+            // similarly fix the CTA's position so that it won't move upon scroll.
+            var position = 'absolute';
+            if (element.css('position') === 'fixed') {
+              position = 'fixed';
+              top = top - angular.element($window).scrollTop();
+            }
+
             // Center the CTA with respect to the follow button.
             var left = elementLeft - Math.round((cta.outerWidth() - element.outerWidth()) / 2);
 
-            cta.css({top: top + 'px', left: left + 'px'});
+            cta.css({position: position, top: top + 'px', left: left + 'px'});
             ctaOuterArrow.css({top: ctaOuterArrowTop + 'px'});
             ctaInnerArrow.css({top: ctaInnerArrowTop + 'px'});
 
@@ -92,12 +100,6 @@ angular.module('kifi')
           trackHover('hover');
         });
         element.on('mouseleave', hideCTA);
-
-        // TODO: make follow CTA sticky when follow button is sticky.
-        $window.addEventListener('scroll', hideCTA);
-        scope.$on('$destroy', function () {
-          $window.removeEventListener('scroll', hideCTA);
-        });
 
 
         //

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeaderFollowButtonCta.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeaderFollowButtonCta.js
@@ -89,6 +89,10 @@ angular.module('kifi')
           }
         }
 
+        function autoShowCTAQuickly() {
+          autoShowCTA(2000);
+        }
+
         function trackHover(trigger) {
           libraryService.trackEvent('visitor_viewed_page', scope.library, {
             type: 'libraryLanding',
@@ -124,15 +128,6 @@ angular.module('kifi')
         });
         element.on('mouseleave', hideCTA);
 
-        // Show the CTA automatically when the user returns to the library page.
-        function autoShowCTAQuickly() {
-          autoShowCTA(2000);
-        }
-        document.addEventListener('visibilitychange', autoShowCTAQuickly);
-        scope.$on('$destroy', function () {
-          $window.removeEventListener('visibilitychange', autoShowCTAQuickly);
-        });
-
 
         //
         // On link.
@@ -166,6 +161,12 @@ angular.module('kifi')
           var ctaShown = false;
           var autoShowCTAPromise = null;
           autoShowCTA(5000);
+
+          // Show the CTA automatically when the user returns to the library page.
+          document.addEventListener('visibilitychange', autoShowCTAQuickly);
+          scope.$on('$destroy', function () {
+            $window.removeEventListener('visibilitychange', autoShowCTAQuickly);
+          });
         }
       }
     };


### PR DESCRIPTION
@2is10 Here are a couple of UI things for the follow button hover CTA that I didn't have time to get to yesterday:
- When the follow button is stuck to the top header, the CTA should also stick. Previously, the CTA will scroll off on scroll and the bandaid I used is to hide the CTA on scroll. Now the CTA will remain visible even on scroll if the follow button is itself stuck
- Handle better the case when the user has navigated away from the library page tab. Show the CTA automatically only if the tab is visible. When the user returns to the tab, set another timer to show the CTA automatically again.
