### PR TITLE
Do not show hover tooltip on followers in library header for mobile devices

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/whoTooltip.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/whoTooltip.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .directive('kfWhoTooltip', [
-  '$window', '$timeout', '$rootElement', '$compile', '$templateCache', 'keepWhoService',
-  function ($window, $timeout, $rootElement, $compile, $templateCache, keepWhoService) {
+  '$window', '$timeout', '$rootElement', '$compile', '$templateCache', 'keepWhoService', 'platformService',
+  function ($window, $timeout, $rootElement, $compile, $templateCache, keepWhoService, platformService) {
     return {
       restrict: 'A',
       link: function (scope, element) {
@@ -40,6 +40,10 @@ angular.module('kifi')
         });
 
         scope.showTooltip = function () {
+          if (platformService.isSupportedMobilePlatform()) {
+            return;
+          }
+
           if (!tooltip) {
             // Create tooltip
             tooltip = angular.element($templateCache.get('common/directives/keepWho/friendCard.tpl.html'));

--- a/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
@@ -119,8 +119,8 @@
           height: 80px
 
         .kf-keep-lib-additional-followers-text
-          padding-top: 19px
-          font-size: 2.2em
+          padding-top: 25px
+          font-size: 1.5em
 
         .kf-keep-lib-follower-preview
           text-align: center

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.styl
@@ -396,6 +396,9 @@ owner-pic-diam = 32px
   :hover>&
     text-decoration: underline
 
+  .kf-mobile &
+    text-decoration: none
+
 .kf-upl-counts
   position: absolute
   top: 158px


### PR DESCRIPTION
@andrewconner 
I noticed that on a real phone, when you touch a follower's picture, the tooltip shows up - you have to press twice to get to the follower's profile page. This should fix that.

Another small bug is that on a library card on the user profile page, if you press the curator name and you're already on that curator's profile, an underline will appear. Adding a CSS change to fix that.
