### PR TITLE
kf-sticky no longer adjusting height of sticky element

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/sticky.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/sticky.js
@@ -38,17 +38,15 @@ angular.module('kifi')
         var isMobile = platformService.isSupportedMobilePlatform();
 
         var marginTop, marginLeft,
-          borderLeftWidth, borderTopWidth, borderRightWidth, borderBottomWidth,
+          borderLeftWidth, borderRightWidth,
           offsetTop, offsetLeft,
-          width, height;
+          width;
 
         function updateProperties() {
           marginLeft = getCssPixelProperty('marginLeft');
           marginTop = getCssPixelProperty('marginTop');
           borderLeftWidth = getCssPixelProperty('borderLeftWidth');
-          borderTopWidth = getCssPixelProperty('borderTopWidth');
           borderRightWidth = getCssPixelProperty('borderRightWidth');
-          borderBottomWidth = getCssPixelProperty('borderBottomWidth');
 
           function update() {
             offsetTop = element.offset().top - marginTop;
@@ -57,7 +55,6 @@ angular.module('kifi')
             if (isWidthCalculated) {
               width = element.width() + borderLeftWidth + borderRightWidth;
             }
-            height = element.height() + borderTopWidth + borderBottomWidth;
           }
 
           // This timeout is needed for mobile Safari.
@@ -102,7 +99,6 @@ angular.module('kifi')
                 position: 'fixed',
                 top: scope.maxTop,
                 left: offsetLeft,
-                height: height,
                 zIndex: 501
               };
               if (isWidthCalculated) {
@@ -134,7 +130,6 @@ angular.module('kifi')
                 top: '',
                 left: '',
                 width: '',
-                height: '',
                 zIndex: ''
               });
 


### PR DESCRIPTION
@yipingliao 
I’m not sure why the height was being measured and set explicitly. Our only current functioning use of `kf-sticky` is the follow button, and it hurts there after #13470, making the button too tall.
