### PR TITLE
breaking a selector specificity tie to fix library color bar width on mobile

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/mobile.styl
@@ -41,7 +41,7 @@
       .kf-loh-dot
         font-size: 20px
 
-  .kf-lh-color
+  div.kf-lh-color
     margin: 10px 0 0
 
   .kf-lh-cover-image


### PR DESCRIPTION
@yipingliao 

not sure how long this has been broken

![image](https://cloud.githubusercontent.com/assets/647851/6011615/ccba9b9a-aaf2-11e4-80cb-6aeae0b1272b.png)
