### PR TITLE
client be backward compatible

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/curator/CuratorServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/curator/CuratorServiceClient.scala
@@ -52,8 +52,8 @@ class CuratorServiceClientImpl(
     call(Curator.internal.topRecos(userId), body = payload).map { response =>
       val js = response.json
       js.validate[URIRecoResults] match {
-        case JsSuccess(res) => res
-        case JsError(_) =>
+        case res: JsSuccess[URIRecoResults] => res.get
+        case err: JsError =>
           val recos = js.as[Seq[RecoInfo]]
           URIRecoResults(recos, "")
       }
@@ -98,8 +98,8 @@ class CuratorServiceClientImpl(
     call(Curator.internal.topLibraryRecos(userId, limit)).map { response =>
       val js = response.json
       js.validate[LibraryRecoResults] match {
-        case JsSuccess(res) => res
-        case JsError(_) =>
+        case res: JsSuccess[LibraryRecoResults] => res.get
+        case err: JsError =>
           val recos = js.as[Seq[LibraryRecoInfo]]
           LibraryRecoResults(recos, "")
       }

--- a/kifi-backend/modules/common/app/com/keepit/curator/CuratorServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/curator/CuratorServiceClient.scala
@@ -7,7 +7,7 @@ import com.keepit.common.net.{ HttpClient, CallTimeouts }
 import com.keepit.common.routes.Curator
 import com.keepit.common.db.Id
 import com.keepit.model._
-import com.keepit.curator.model.{ RecommendationSubSource, LibraryRecoSelectionParams, LibraryRecoInfo, RecoInfo, RecommendationSource }
+import com.keepit.curator.model._
 
 import scala.concurrent.Future
 import play.api.libs.json._
@@ -17,14 +17,14 @@ trait CuratorServiceClient extends ServiceClient {
   final val serviceType = ServiceType.CURATOR
 
   def adHocRecos(userId: Id[User], n: Int, scoreCoefficientsUpdate: UriRecommendationScores): Future[Seq[RecoInfo]]
-  def topRecos(userId: Id[User], source: RecommendationSource, subSource: RecommendationSubSource, more: Boolean, recencyWeight: Float): Future[Seq[RecoInfo]]
+  def topRecos(userId: Id[User], source: RecommendationSource, subSource: RecommendationSubSource, more: Boolean, recencyWeight: Float): Future[URIRecoResults]
   def topPublicRecos(userId: Option[Id[User]]): Future[Seq[RecoInfo]]
   def generalRecos(): Future[Seq[RecoInfo]]
   def updateUriRecommendationFeedback(userId: Id[User], uriId: Id[NormalizedURI], feedback: UriRecommendationFeedback): Future[Boolean]
   def updateLibraryRecommendationFeedback(userId: Id[User], libraryId: Id[Library], feedback: LibraryRecommendationFeedback): Future[Boolean]
   def triggerEmailToUser(code: String, userId: Id[User]): Future[String]
   def refreshUserRecos(userId: Id[User]): Future[Unit]
-  def topLibraryRecos(userId: Id[User], limit: Option[Int] = None): Future[Seq[LibraryRecoInfo]]
+  def topLibraryRecos(userId: Id[User], limit: Option[Int] = None): Future[LibraryRecoResults]
   def refreshLibraryRecos(userId: Id[User], await: Boolean = false, selectionParams: Option[LibraryRecoSelectionParams] = None): Future[Unit]
   def notifyLibraryRecosDelivered(userId: Id[User], libraryIds: Set[Id[Library]], source: RecommendationSource, subSource: RecommendationSubSource): Future[Unit]
 }
@@ -42,7 +42,7 @@ class CuratorServiceClientImpl(
     }
   }
 
-  def topRecos(userId: Id[User], source: RecommendationSource, subSource: RecommendationSubSource, more: Boolean, recencyWeight: Float): Future[Seq[RecoInfo]] = {
+  def topRecos(userId: Id[User], source: RecommendationSource, subSource: RecommendationSubSource, more: Boolean, recencyWeight: Float): Future[URIRecoResults] = {
     val payload = Json.obj(
       "source" -> source,
       "subSource" -> subSource,
@@ -50,7 +50,13 @@ class CuratorServiceClientImpl(
       "recencyWeight" -> recencyWeight
     )
     call(Curator.internal.topRecos(userId), body = payload).map { response =>
-      response.json.as[Seq[RecoInfo]]
+      val js = response.json
+      js.validate[URIRecoResults] match {
+        case JsSuccess(res) => res
+        case JsError(_) =>
+          val recos = js.as[Seq[RecoInfo]]
+          URIRecoResults(recos, "")
+      }
     }
   }
 
@@ -88,8 +94,16 @@ class CuratorServiceClientImpl(
     callLeader(Curator.internal.refreshUserRecos(userId), callTimeouts = longTimeout).map { x => }
   }
 
-  def topLibraryRecos(userId: Id[User], limit: Option[Int] = None): Future[Seq[LibraryRecoInfo]] = {
-    call(Curator.internal.topLibraryRecos(userId, limit)).map { response => response.json.as[Seq[LibraryRecoInfo]] }
+  def topLibraryRecos(userId: Id[User], limit: Option[Int] = None): Future[LibraryRecoResults] = {
+    call(Curator.internal.topLibraryRecos(userId, limit)).map { response =>
+      val js = response.json
+      js.validate[LibraryRecoResults] match {
+        case JsSuccess(res) => res
+        case JsError(_) =>
+          val recos = js.as[Seq[LibraryRecoInfo]]
+          LibraryRecoResults(recos, "")
+      }
+    }
   }
 
   def refreshLibraryRecos(userId: Id[User], await: Boolean = false, selectionParams: Option[LibraryRecoSelectionParams] = None) = {

--- a/kifi-backend/modules/common/test/com/keepit/curator/FakeCuratorServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/curator/FakeCuratorServiceClientImpl.scala
@@ -9,7 +9,7 @@ import com.keepit.common.service.ServiceType
 import com.google.inject.util.Providers
 import com.keepit.common.actor.FakeScheduler
 import com.keepit.common.db.Id
-import com.keepit.curator.model.{ RecommendationSubSource, LibraryRecoSelectionParams, LibraryRecoInfo, RecoInfo, RecommendationSource }
+import com.keepit.curator.model._
 import collection.mutable.ListBuffer
 
 class FakeCuratorServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) extends CuratorServiceClient {
@@ -20,8 +20,11 @@ class FakeCuratorServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
 
   var fakeTopRecos: Map[Id[User], Seq[RecoInfo]] = Map.empty
 
-  def topRecos(userId: Id[User], source: RecommendationSource, subSource: RecommendationSubSource, more: Boolean, recencyWeight: Float): Future[Seq[RecoInfo]] =
-    Future.successful(fakeTopRecos.getOrElse(userId, Seq[RecoInfo]()))
+  def topRecos(userId: Id[User], source: RecommendationSource, subSource: RecommendationSubSource, more: Boolean, recencyWeight: Float): Future[URIRecoResults] =
+    Future.successful {
+      val recos = fakeTopRecos.getOrElse(userId, Seq[RecoInfo]())
+      URIRecoResults(recos, "")
+    }
 
   def topPublicRecos(userId: Option[Id[User]]): Future[Seq[RecoInfo]] = Future.successful(Seq.empty)
 
@@ -41,8 +44,11 @@ class FakeCuratorServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
 
   def refreshUserRecos(userId: Id[User]): Future[Unit] = { Future.successful() }
 
-  def topLibraryRecos(userId: Id[User], limit: Option[Int] = None): Future[Seq[LibraryRecoInfo]] =
-    Future.successful(topLibraryRecosExpectations(userId))
+  def topLibraryRecos(userId: Id[User], limit: Option[Int] = None): Future[LibraryRecoResults] =
+    Future.successful {
+      val recos = topLibraryRecosExpectations(userId)
+      LibraryRecoResults(recos, "")
+    }
 
   def refreshLibraryRecos(userId: Id[User], await: Boolean = false, selectionParams: Option[LibraryRecoSelectionParams] = None): Future[Unit] = {
     Future.successful()

--- a/kifi-backend/modules/curator/app/com/keepit/curator/controllers/internal/CuratorController.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/controllers/internal/CuratorController.scala
@@ -60,6 +60,7 @@ class CuratorController @Inject() (
     val subSource = (request.body \ "subSource").as[RecommendationSubSource]
     val more = (request.body \ "more").as[Boolean]
     val recencyWeight = (request.body \ "recencyWeight").as[Float]
+    val context = (request.body \ "context").asOpt[String]
 
     userExperimentCommander.getExperimentsByUser(userId) map { experiments =>
       val sortStrategy =
@@ -67,9 +68,9 @@ class CuratorController @Inject() (
         else topScoreRecoStrategy
       val scoringStrategy = nonlinearRecoScoringStrategy
 
-      val recoResults = recoRetrievalCommander.topRecos(userId, more, recencyWeight, source, subSource, sortStrategy, scoringStrategy)
+      val recoResults = recoRetrievalCommander.topRecos(userId, more, recencyWeight, source, subSource, sortStrategy, scoringStrategy, context)
 
-      Ok(Json.toJson(recoResults.recos))
+      Ok(Json.toJson(recoResults))
     }
   }
 
@@ -118,17 +119,17 @@ class CuratorController @Inject() (
     Ok
   }
 
-  def topLibraryRecos(userId: Id[User], limit: Int) = Action.async(parse.tolerantJson) { request =>
+  def topLibraryRecos(userId: Id[User], limit: Int, context: Option[String]) = Action.async(parse.tolerantJson) { request =>
     log.info(s"topLibraryRecos called userId=$userId limit=$limit")
 
     userExperimentCommander.getExperimentsByUser(userId) map { experiments =>
       val sortStrategy = topScoreLibraryRecoStrategy
       val scoringStrategy = nonlinearLibraryRecoScoringStrategy
 
-      val recoResults = libraryRecoGenCommander.getTopRecommendations(userId, limit, sortStrategy, scoringStrategy)
+      val recoResults = libraryRecoGenCommander.getTopRecommendations(userId, limit, sortStrategy, scoringStrategy, context)
       val libRecoInfos = recoResults.recos
       log.info(s"topLibraryRecos returning userId=$userId resultCount=${libRecoInfos.size}")
-      Ok(Json.toJson(libRecoInfos))
+      Ok(Json.toJson(recoResults))
     }
   }
 

--- a/kifi-backend/modules/curator/conf/curatorService.routes
+++ b/kifi-backend/modules/curator/conf/curatorService.routes
@@ -18,7 +18,7 @@ POST   /internal/curator/updateLibraryRecommendationFeedback @com.keepit.curator
 POST   /internal/curator/triggerEmailToUser 	@com.keepit.curator.controllers.internal.CuratorController.triggerEmailToUser(code: String, userId: Id[User])
 POST   /internal/curator/refreshUserRecos @com.keepit.curator.controllers.internal.CuratorController.refreshUserRecos(userId: Id[User])
 
-POST   /internal/curator/topLibraryRecos  @com.keepit.curator.controllers.internal.CuratorController.topLibraryRecos(userId: Id[User], limit: Int ?= 100)
+POST   /internal/curator/topLibraryRecos  @com.keepit.curator.controllers.internal.CuratorController.topLibraryRecos(userId: Id[User], limit: Int ?= 100, context: Option[String] ?= None)
 POST   /internal/curator/refreshLibraryRecos  @com.keepit.curator.controllers.internal.CuratorController.refreshLibraryRecos(userId: Id[User], await: Boolean ?= false)
 
 POST   /internal/curator/notifyLibraryRecosDelivered  @com.keepit.curator.controllers.internal.CuratorController.notifyLibraryRecosDelivered(userId: Id[User])

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryRecommendationsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryRecommendationsController.scala
@@ -28,7 +28,8 @@ class AdminLibraryRecommendationsController @Inject() (
   def view() = AdminUserAction.async { implicit request =>
     val userId = request.request.getQueryString("userId")
       .filter(_.nonEmpty) map (s => Id[User](s.toInt)) getOrElse request.userId
-    val recosF = curator.topLibraryRecos(userId, Some(100)) map { libRecos =>
+    val recosF = curator.topLibraryRecos(userId, Some(100)) map { recoResults =>
+      val libRecos = recoResults.recos
       val libIds = libRecos.map(_.libraryId)
       val libInfos = (libIds zip libCommander.getLibrarySummaries(libIds)).toMap
 


### PR DESCRIPTION
@stkem 

main changes:
- `CuratorController` changes return format
- `CuratorClient` handles Json with backward support
- Route changes in curator side with default parameters

Deploy order: 1) shoebox 2) curator.

Next PR: call new internal routes within CuratorClient
