### PR TITLE
Dealing with Curator Memory Issues

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/CuratorTasksPlugin.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/CuratorTasksPlugin.scala
@@ -43,7 +43,7 @@ class CuratorTasksPlugin @Inject() (
     scheduleTaskOnOneMachine(system, 3 minutes, 2 minutes, uriRecommendationPrecomputation) {
       uriRecoGenerationCommander.precomputeRecommendations()
     }
-    scheduleTaskOnOneMachine(system, 10 minutes, 10 minutes, uriRecommendationReaper) {
+    scheduleTaskOnOneMachine(system, 5 minutes, 5 minutes, uriRecommendationReaper) {
       uriRecoCleanupCommander.cleanup()
     }
 

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationCleanupCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationCleanupCommander.scala
@@ -7,19 +7,21 @@ import com.keepit.curator.model.{ PublicFeedRepo, UriRecommendationRepo }
 import org.joda.time.DateTime
 import com.keepit.common.time._
 import scala.util.{ Failure, Random }
+import com.keepit.common.logging.Logging
 
 class RecommendationCleanupCommander @Inject() (
     db: Database,
     uriRecoRepo: UriRecommendationRepo,
-    feedsRepo: PublicFeedRepo) {
+    feedsRepo: PublicFeedRepo) extends Logging {
 
   private val recosTTL = 30 // days (by updateAt)
-  private val defaultLimitNumRecosForUser = 500
+  private val defaultLimitNumRecosForUser = 300
   def cleanup(overrideLimit: Option[Int] = None, overrideTimeCutoff: Option[DateTime] = None): Unit = {
     val userToClean = Random.shuffle(db.readOnlyReplica { implicit session => uriRecoRepo.getUsersWithRecommendations() }.toSeq).take(50)
+    log.info(s"Running Uri Reco Cleanup for $userToClean")
     db.readWriteBatch(userToClean) { (session, userId) =>
       uriRecoRepo.cleanupOldRecos(userId, currentDateTime.minusDays(recosTTL))(session)
-      uriRecoRepo.cleanupLowMasterScoreRecos(userId, overrideLimit.getOrElse(defaultLimitNumRecosForUser), overrideTimeCutoff.getOrElse(currentDateTime.minusDays(4)))(session)
+      uriRecoRepo.cleanupLowMasterScoreRecos(userId, overrideLimit.getOrElse(defaultLimitNumRecosForUser), overrideTimeCutoff.getOrElse(currentDateTime.minusDays(3)))(session)
     }.foreach {
       case (userId, res) =>
         res match {


### PR DESCRIPTION
-More aggressive and more frequent URI recommendation reaper
-Don’t keep previously recommended URI ids (the alwaysInclude variable)
in memory for a given users if it’s going to be a long time before that
users task is up again.

(The problem was all the `alwaysInclude`s being kept around. We were
basically keeping all the URI ids of all recess in memory)

@yingjieMiao cc @ymatsuda @eishay 
