### PR TITLE
More work on the library menu in new site layout

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.js
@@ -92,7 +92,7 @@ angular.module('kifi')
           var libItems = antiscrollLibList.find('.kf-nav-lib-item');
           libItemHeight = libItems.eq(0).outerHeight(true);
 
-          antiscrollLibList.find('.kf-nav-lib-users').css('padding-top', '25px');
+          antiscrollLibList.find('.kf-nav-lib-users').css('padding-top', '35px');
 
           // set limits based on number of items in myLibs, userLibs or invitedLibs
           var firstLimit, firstLimitOverlay, secondLimit, secondLimitOverlay;

--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.js
@@ -120,7 +120,7 @@ angular.module('kifi')
         }
 
         function fixSeparators(offset, firstLimit, firstLimitOverlay, secondLimit, secondLimitOverlay, separatorHeight) {
-          var stickToMaxTop = 264;
+          var stickToMaxTop = 225;
           // all 3 separators properties need to be set because this function is debounced and a user might scroll too fast
           if (offset <= firstLimit) {
             setPositioning(separators[0], 'fixed', stickToMaxTop);

--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.js
@@ -19,6 +19,7 @@ angular.module('kifi')
         var scrollableLibList = element.find('.kf-scrollable-libs');
         var antiscrollLibList = scrollableLibList.find('.antiscroll-inner');
         var separators = antiscrollLibList.find('.kf-nav-lib-separator');
+        var elementCache = {};
 
         //
         // Scope data.
@@ -39,13 +40,11 @@ angular.module('kifi')
         // Internal methods.
         //
         function getElement(selector) {
-          var cache = {};
-
-          if (!cache[selector] || !cache[selector].length) {
-            cache[selector] = angular.element(selector);
+          if (!elementCache[selector] || !elementCache[selector].length) {
+            elementCache[selector] = angular.element(selector);
           }
 
-          return cache[selector];
+          return elementCache[selector];
         }
 
         function positionMenu() {

--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.js
@@ -176,10 +176,8 @@ angular.module('kifi')
           profileService.savePrefs(save);
         };
 
-        scope.addLibrary = function () {
-          modalService.open({
-            template: 'libraries/manageLibraryModal.tpl.html'
-          });
+        scope.closeMenu = function () {
+          scope.libraryMenu.visible = false;
         };
 
         scope.isActive = function (path) {

--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.styl
@@ -16,6 +16,9 @@
 .kf-nav-link
   display: block
 
+  .active &
+    cursor: default
+
 .kf-nav-name
 .kf-nav-count
   line-height: 26px
@@ -119,7 +122,7 @@
   .active &
     font-weight: bold
 
-.kf-nav-lib-item:hover
+.kf-nav-lib-item:hover:not(.active)
   .kf-nav-lib-name
     color: #71c885
 
@@ -128,12 +131,28 @@
   font-weight: 200
   color: countGreyColor
 
-.library-icon
+.kf-lm-library-card
+  display: inline-block
+  border-radius: 4px
   width: 27px
   height: 35px
-  display: inline-block
   vertical-align: top
-  background-repeat: no-repeat
+  box-shadow: 0 1px #f5f5f5, 0 3px #c9ccc0
+
+.kf-lm-lock-icon
+.kf-lm-star-icon
+  display: block
+  margin: 8px auto 0
+  background-size: 100%
+  background-repeat: none
+
+.kf-lm-lock-icon
+  width: 14px
+  height: 18px
+
+.kf-lm-star-icon
+  width: 18px
+  height: 18px
 
 .reco-icon
   width: 26px

--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.styl
@@ -49,7 +49,7 @@
 
 .kf-nav-group
   padding-top: 10px
-  height: 100%
+  height: calc(100% - 55px)
 
 .kf-nav-group-name
   margin: 0 40px 0 20px
@@ -66,7 +66,7 @@
   font-size: 13px
 
 .kf-lm-libraries
-  height: 100%
+  height: calc(100% - 5px)
 
 .kf-nav-lib-system
   border-bottom: 1px solid separatorColor
@@ -176,7 +176,7 @@
 .kf-scrollable-libs
   position: relative
   width: calc(100% + 15px)
-  height: calc(100% - 175px)
+  height: calc(100% - 160px)
 
   // This is a hack to hide the scrollbar
   // (cf. comments in scrollbar.js)
@@ -324,3 +324,15 @@
     background-color: #fff
     cursor: default
 
+.kf-lm-footer
+  border-top: 1px solid #e8e8e8
+  padding-top: 5px
+  font-size: 12px
+
+.kf-lm-footer-link
+  display: inline-block
+  margin: 0 4px
+
+  &:hover
+  &:active
+    text-decoration: underline

--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.styl
@@ -64,7 +64,7 @@
   font-size: 13px
 
 .kf-lm-libraries
-  height: calc(100% - 45px)
+  height: 100%
 
 .kf-nav-lib-system
   border-bottom: 1px solid separatorColor

--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.styl
@@ -13,9 +13,8 @@
   user-select: none
   margin-top: 10px
 
-.kf-nav-link-box
-  display: inline-block
-  cursor: pointer
+.kf-nav-link
+  display: block
 
 .kf-nav-name
 .kf-nav-count
@@ -113,12 +112,16 @@
 
 .kf-nav-lib-name
   width: 165px
-  font-size: 12px
+  font-size: 13px
   font-weight: 400
   color: textDarkColor
 
   .active &
     font-weight: bold
+
+.kf-nav-lib-item:hover
+  .kf-nav-lib-name
+    color: #71c885
 
 .kf-nav-lib-text
   font-size: 11px

--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.styl
@@ -67,7 +67,6 @@
 
 .kf-nav-lib-system
   border-bottom: 1px solid separatorColor
-  padding-top: 3px
 
 .kf-nav-lib-item
   position: relative
@@ -92,15 +91,16 @@
   margin-top: 5px
   line-height: 30px
   width: 216px
-  border-radius: 4px
-  background-color: #e8e8e8
+  background-color: #fff
   z-index: 3
 
 .kf-nav-lib-separator-title
+  border-radius: 4px
   padding-left: 45px
   font-size: 11px
   text-transform: uppercase
   color: #5d5d5d
+  background-color: #e8e8e8
 
 ////////////////////////////
 ////// Library Icons ///////

--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.tpl.html
@@ -1,12 +1,5 @@
 <div class="kf-library-menu">
   <div class="kf-nav-group">
-    <div class="kf-nav-lib-recos" ng-class="{ active: isActive('/') }">
-      <a class="kf-nav-link" href="/">
-        <span class="reco-icon svg-reco-icon"></span>
-        <span class="kf-nav-name">Recommendations</span>
-      </a>
-    </div>
-
     <div class="kf-lm-libraries">
       <div kf-callout class="kf-callout-bubble-right" ng-if="showCallout()">
           <div>Your main and private libraries hold all of your existing keeps. You can create additional libraries if you wish.</div>

--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.tpl.html
@@ -152,4 +152,13 @@
       </div>
     </div>
   </div>
+  <footer class="kf-lm-footer">
+    <a class="kf-lm-footer-link" target="_top" href="https://www.kifi.com/how_it_works">How it works</a> &middot;
+    <a class="kf-lm-footer-link" target="_top" href="http://support.kifi.com">Support</a> &middot;
+    <a class="kf-lm-footer-link" target="_top" href="https://www.kifi.com/about">About</a> <br>
+
+    <a class="kf-lm-footer-link" target="_top" href="http://blog.kifi.com">Blog</a> &middot;
+    <a class="kf-lm-footer-link" target="_top" href="https://www.kifi.com/privacy">Privacy</a> &middot;
+    <a class="kf-lm-footer-link" target="_top" href="https://www.kifi.com/terms">Terms</a>
+  </footer>
 </div>

--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.tpl.html
@@ -9,7 +9,7 @@
       </div>
       <ul class="kf-nav-lib-system">
         <li class="kf-nav-lib-item" ng-class="{ active: isActive(mainLib.url) }">
-          <a class="kf-nav-link" ng-href="{{mainLib.url}}">
+          <a class="kf-nav-link" ng-href="{{mainLib.url}}" ng-click="closeMenu()">
             <div class="library-icon svg-main-library-icon"></div>
             <div class="kf-nav-lib-info">
               <div class="kf-nav-lib-name">My Main Library</div>
@@ -24,7 +24,7 @@
           </a>
         </li>
         <li class="kf-nav-lib-item" ng-class="{ active: isActive(secretLib.url) }">
-          <a class="kf-nav-link" ng-href="{{secretLib.url}}">
+          <a class="kf-nav-link" ng-href="{{secretLib.url}}" ng-click="closeMenu()">
             <div class="library-icon svg-secret-library-icon"></div>
             <div class="kf-nav-lib-info">
               <div class="kf-nav-lib-name">My Private Library</div>
@@ -77,7 +77,7 @@
           </li>
 
           <li ng-show="sortingMenu.myLibsFirst" ng-repeat="library in myLibsToShow" class="kf-nav-lib-item" ng-class="{ active: isActive(library.url) }">
-            <a class="kf-nav-link" ng-href="{{library.url}}">
+            <a class="kf-nav-link" ng-href="{{library.url}}" ng-click="closeMenu()">
               <div class="library-icon svg-private-library-icon" ng-if="library.visibility=='secret'"></div>
               <div class="library-icon svg-public-library-icon" ng-if="library.visibility=='published'"></div>
               <div class="library-icon svg-yellow-card-with-globe" ng-if="library.visibility=='discoverable'"></div> <!-- TODO: remove when discoverable libraries are converted -->
@@ -105,7 +105,7 @@
             <div class="kf-nav-lib-separator-title">LIBRARIES YOU FOLLOW</div>
           </li>
           <li ng-repeat="library in userLibsToShow" class="kf-nav-lib-item" ng-class="{ active: isActive(library.url) }">
-            <a class="kf-nav-link" ng-href="{{library.url}}">
+            <a class="kf-nav-link" ng-href="{{library.url}}" ng-click="closeMenu()">
               <div class="library-icon svg-private-library-icon" ng-if="library.visibility=='secret'"></div>
               <div class="library-icon svg-public-library-icon" ng-if="library.visibility=='published'"></div>
               <div class="library-icon svg-yellow-card-with-globe" ng-if="library.visibility=='discoverable'"></div> <!-- TODO: remove when discoverable libraries are converted -->
@@ -131,7 +131,7 @@
             <div class="kf-nav-lib-separator-title">INVITATIONS</div>
           </li>
           <li ng-repeat="library in invitedLibsToShow" class="kf-nav-lib-item" ng-class="{ active: isActive(library.url) }">
-            <a class="kf-nav-link" ng-href="{{library.url}}">
+            <a class="kf-nav-link" ng-href="{{library.url}}" ng-click="closeMenu()">
               <div class="library-icon svg-library-card"></div>
               <div class="kf-nav-lib-info">
                 <div kf-ellipsis full-text="library.name" max-num-lines=2 class="kf-nav-lib-name"></div>

--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.tpl.html
@@ -10,7 +10,9 @@
       <ul class="kf-nav-lib-system">
         <li class="kf-nav-lib-item" ng-class="{ active: isActive(mainLib.url) }">
           <a class="kf-nav-link" ng-href="{{mainLib.url}}" ng-click="closeMenu()">
-            <div class="library-icon svg-main-library-icon"></div>
+            <div class="kf-lm-library-card" ng-style="{'background-color': mainLib.color}">
+              <div class="kf-lm-star-icon svg-card-star"></div>
+            </div>
             <div class="kf-nav-lib-info">
               <div class="kf-nav-lib-name">My Main Library</div>
               <div class="kf-nav-lib-text" ng-class="{ empty: !mainLib.numKeeps }">
@@ -25,7 +27,9 @@
         </li>
         <li class="kf-nav-lib-item" ng-class="{ active: isActive(secretLib.url) }">
           <a class="kf-nav-link" ng-href="{{secretLib.url}}" ng-click="closeMenu()">
-            <div class="library-icon svg-secret-library-icon"></div>
+            <div class="kf-lm-library-card" ng-style="{'background-color': secretLib.color}">
+              <div class="kf-lm-lock-icon svg-card-lock"></div>
+            </div>
             <div class="kf-nav-lib-info">
               <div class="kf-nav-lib-name">My Private Library</div>
               <div class="kf-nav-lib-text" ng-class="{ empty: !secretLib.numKeeps }">
@@ -78,9 +82,9 @@
 
           <li ng-show="sortingMenu.myLibsFirst" ng-repeat="library in myLibsToShow" class="kf-nav-lib-item" ng-class="{ active: isActive(library.url) }">
             <a class="kf-nav-link" ng-href="{{library.url}}" ng-click="closeMenu()">
-              <div class="library-icon svg-private-library-icon" ng-if="library.visibility=='secret'"></div>
-              <div class="library-icon svg-public-library-icon" ng-if="library.visibility=='published'"></div>
-              <div class="library-icon svg-yellow-card-with-globe" ng-if="library.visibility=='discoverable'"></div> <!-- TODO: remove when discoverable libraries are converted -->
+              <div class="kf-lm-library-card" ng-style="{'background-color': library.color}">
+                <div ng-if="library.visibility === 'secret'" class="kf-lm-lock-icon svg-card-lock"></div>
+              </div>
               <div class="kf-nav-lib-info">
                 <div kf-ellipsis full-text="library.name" max-num-lines=2 class="kf-nav-lib-name"></div>
                 <div class="kf-nav-lib-text">
@@ -106,9 +110,9 @@
           </li>
           <li ng-repeat="library in userLibsToShow" class="kf-nav-lib-item" ng-class="{ active: isActive(library.url) }">
             <a class="kf-nav-link" ng-href="{{library.url}}" ng-click="closeMenu()">
-              <div class="library-icon svg-private-library-icon" ng-if="library.visibility=='secret'"></div>
-              <div class="library-icon svg-public-library-icon" ng-if="library.visibility=='published'"></div>
-              <div class="library-icon svg-yellow-card-with-globe" ng-if="library.visibility=='discoverable'"></div> <!-- TODO: remove when discoverable libraries are converted -->
+              <div class="kf-lm-library-card" ng-style="{'background-color': library.color}">
+                <div ng-if="library.visibility === 'secret'" class="kf-lm-lock-icon svg-card-lock"></div>
+              </div>
               <div class="kf-nav-lib-info">
                 <div kf-ellipsis full-text="library.name" max-num-lines=2 class="kf-nav-lib-name"></div>
                 <div class="kf-nav-lib-text">
@@ -132,7 +136,9 @@
           </li>
           <li ng-repeat="library in invitedLibsToShow" class="kf-nav-lib-item" ng-class="{ active: isActive(library.url) }">
             <a class="kf-nav-link" ng-href="{{library.url}}" ng-click="closeMenu()">
-              <div class="library-icon svg-library-card"></div>
+              <div class="kf-lm-library-card" ng-style="{'background-color': library.color}">
+                <div ng-if="library.visibility === 'secret'" class="kf-lm-lock-icon svg-card-lock"></div>
+              </div>
               <div class="kf-nav-lib-info">
                 <div kf-ellipsis full-text="library.name" max-num-lines=2 class="kf-nav-lib-name"></div>
                 <div class="kf-nav-lib-text">invitation pending</div>


### PR DESCRIPTION
@2is10 I am going to merge this so you can see it and hopefully spot some bugs while you're using it. Will address PR comments and the comments from the previous pull in another pull, along with lots of clean-up/renaming work. 

Known issue: height of menu is static (at 90% of `window.innerHeight`) - this should be less if we're displaying only a few libraries (e.g., when the search filter is being used).

Please see commit messages for the changes being added.
