### PR TITLE
decouple ScrapeInfoRepo from NormalizedURIRepoImpl

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/DataIntegrityModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/DataIntegrityModule.scala
@@ -8,5 +8,6 @@ case class DataIntegrityModule() extends ScalaModule {
   def configure {
     bind[DataIntegrityPlugin].to[DataIntegrityPluginImpl].in[AppScoped]
     bind[UriIntegrityPlugin].to[UriIntegrityPluginImpl].in[AppScoped]
+    bind[ScrapeInfoIntegrityPlugin].to[ScrapeInfoIntegrityPluginImpl].in[AppScoped]
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/OrphanCleaner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/OrphanCleaner.scala
@@ -23,7 +23,7 @@ class OrphanCleaner @Inject() (
     libraryRepo: LibraryRepo,
     bookmarkInterner: KeepInterner,
     centralConfig: CentralConfig,
-    val airbrake: AirbrakeNotifier) extends ScrapeInfoIntegrityChecker {
+    val airbrake: AirbrakeNotifier) extends UriIntegrityChecker {
 
   case class OrphanCleanerSequenceNumberKey[T](seqKey: String) extends SequenceNumberCentralConfigKey[T] {
     val longKey = new LongCentralConfigKey {
@@ -191,7 +191,7 @@ class OrphanCleaner @Inject() (
   }
 }
 
-trait ScrapeInfoIntegrityChecker extends Logging {
+trait UriIntegrityChecker extends Logging {
   val db: Database
   val normUriRepo: NormalizedURIRepo
   val scrapeInfoRepo: ScrapeInfoRepo

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/ScrapeInfoIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/ScrapeInfoIntegrityPlugin.scala
@@ -83,7 +83,7 @@ class ScrapeInfoIntegrityChecker @Inject() (
   val normalizedURISeqKey = NormalizedUriSequenceNumberKey()
 
   private def getSequenceNumber(key: NormalizedUriSequenceNumberKey): SequenceNumber[NormalizedURI] = {
-    centralConfig(key) getOrElse (SequenceNumber.MinValue[NormalizedURI])
+    centralConfig(key) getOrElse (SequenceNumber[NormalizedURI](64935824L)) // starting from a safe known sequence number
   }
 
   def checkIntegrity(): Future[Unit] = SafeFuture {

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/ScrapeInfoIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/ScrapeInfoIntegrityPlugin.scala
@@ -1,0 +1,136 @@
+package com.keepit.integrity
+
+import com.keepit.common.db._
+import com.keepit.common.db.slick._
+import com.keepit.model.NormalizedURIStates._
+import com.keepit.model._
+import com.google.inject.{ ImplementedBy, Inject, Singleton }
+import com.keepit.common.time._
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.logging.Logging
+import com.keepit.common.akka.{ SafeFuture, FortyTwoActor, UnsupportedActorMessage }
+import com.keepit.common.actor.ActorInstance
+import com.keepit.scraper.ScrapeScheduler
+import scala.concurrent.duration._
+import com.keepit.common.zookeeper.{ LongCentralConfigKey, SequenceNumberCentralConfigKey, CentralConfig }
+import com.keepit.common.plugin.SchedulerPlugin
+import com.keepit.common.plugin.SchedulingProperties
+import com.keepit.common.db.slick.DBSession.RWSession
+import akka.pattern.{ ask, pipe }
+import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits._
+import com.keepit.normalizer.NormalizedURIInterner
+import com.keepit.common.core._
+
+case object SyncScrapeInfo
+
+class ScrapeInfoIntegrityActor @Inject() (
+    scrapeInfoIntegrityChecker: ScrapeInfoIntegrityChecker,
+    airbrake: AirbrakeNotifier) extends FortyTwoActor(airbrake) with Logging {
+
+  @volatile private[this] var running = false
+
+  case object Done
+
+  def receive = {
+    case SyncScrapeInfo =>
+      if (!running) {
+        running = true
+        scrapeInfoIntegrityChecker.checkIntegrity().onComplete { case _ => self ! Done }
+      }
+    case Done =>
+      running = false
+    case m => throw new UnsupportedActorMessage(m)
+  }
+}
+
+trait ScrapeInfoIntegrityPlugin extends SchedulerPlugin {
+  def checkScrapeInfo(): Unit
+}
+
+class ScrapeInfoIntegrityPluginImpl @Inject() (
+    actor: ActorInstance[UriIntegrityActor],
+    db: Database,
+    uriRepo: NormalizedURIRepo,
+    centralConfig: CentralConfig,
+    val scheduling: SchedulingProperties) extends ScrapeInfoIntegrityPlugin with Logging {
+  override def enabled = true
+  override def onStart() {
+    scheduleTaskOnOneMachine(actor.system, 60 seconds, 6 seconds, actor.ref, SyncScrapeInfo, this.getClass.getSimpleName)
+  }
+
+  def checkScrapeInfo(): Unit = {
+    actor.ref ! SyncScrapeInfo
+  }
+}
+
+class ScrapeInfoIntegrityChecker @Inject() (
+    val db: Database,
+    val scrapeInfoRepo: ScrapeInfoRepo,
+    val scraper: ScrapeScheduler,
+    clock: Clock,
+    val normUriRepo: NormalizedURIRepo,
+    val centralConfig: CentralConfig,
+    val airbrake: AirbrakeNotifier) extends Logging {
+
+  case class NormalizedUriSequenceNumberKey() extends SequenceNumberCentralConfigKey[NormalizedURI] {
+    val longKey = new LongCentralConfigKey {
+      def key: String = "NormalizedURISeq"
+      val namespace: String = "ScrapeInfoIntegrityChecker"
+    }
+  }
+
+  val normalizedURISeqKey = NormalizedUriSequenceNumberKey()
+
+  private def getSequenceNumber(key: NormalizedUriSequenceNumberKey): SequenceNumber[NormalizedURI] = {
+    centralConfig(key) getOrElse (SequenceNumber.MinValue[NormalizedURI])
+  }
+
+  def checkIntegrity(): Future[Unit] = SafeFuture {
+    var numProcessed = 0
+    var numScrapeInfoCreated = 0
+    var seq = getSequenceNumber(normalizedURISeqKey)
+    var done = false
+
+    log.info("start processing NormalizedURIs")
+    while (!done) {
+      val normalizedURIs = db.readOnlyReplica { implicit s => normUriRepo.getIndexable(seq, 20) }
+      done = normalizedURIs.isEmpty
+
+      def collector(uri: NormalizedURI, fixedScrapeInfo: Boolean): Unit = {
+        if (fixedScrapeInfo) numScrapeInfoCreated += 1
+        numProcessed += 1
+        seq = uri.seq
+      }
+
+      db.readWriteSeq(normalizedURIs, collector) { (s, uri) => checkIntegrity(uri)(s) }
+
+      if (!done) centralConfig.update(normalizedURISeqKey, seq) // update high watermark
+    }
+    log.info(s"done: ${numProcessed} NormalizedURIs processed. Created ${numScrapeInfoCreated} ScrapeInfos")
+  }
+
+  private def checkIntegrity(uri: NormalizedURI)(implicit session: RWSession): Boolean = {
+    uri.state match {
+      case e: State[NormalizedURI] if DO_NOT_SCRAPE.contains(e) => // ensure no ACTIVE scrapeInfo records
+        scrapeInfoRepo.getByUriId(uri.id.get) match {
+          case Some(scrapeInfo) if scrapeInfo.state != ScrapeInfoStates.INACTIVE =>
+            val savedSI = scrapeInfoRepo.save(scrapeInfo.withStateAndNextScrape(ScrapeInfoStates.INACTIVE))
+            log.info(s"[save(${uri.toShortString})] mark scrapeInfo as INACTIVE; si=$savedSI")
+            true
+          case _ => false // do nothing
+        }
+      case SCRAPE_FAILED | SCRAPED =>
+        scrapeInfoRepo.getByUriId(uri.id.get) match { // do NOT use saveStateAndNextScrape
+          case Some(scrapeInfo) if scrapeInfo.state == ScrapeInfoStates.INACTIVE =>
+            val savedSI = scrapeInfoRepo.save(scrapeInfo.withState(ScrapeInfoStates.ACTIVE))
+            log.info(s"[save(${uri.toShortString})] mark scrapeInfo as ACTIVE; si=$savedSI")
+            true
+          case _ => false // do nothing
+        }
+      case ACTIVE => false // do nothing
+      case _ =>
+        throw new IllegalStateException(s"Unhandled state=${uri.state}; uri=$uri")
+    }
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/ScrapeInfoIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/ScrapeInfoIntegrityPlugin.scala
@@ -86,6 +86,8 @@ class ScrapeInfoIntegrityChecker @Inject() (
     centralConfig(key) getOrElse (SequenceNumber[NormalizedURI](64935824L)) // starting from a safe known sequence number
   }
 
+  def forceSeqNum(seq: SequenceNumber[NormalizedURI]): Unit = centralConfig.update(normalizedURISeqKey, seq)
+
   def checkIntegrity(): Future[Unit] = SafeFuture {
     var numProcessed = 0
     var numScrapeInfoCreated = 0

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
@@ -44,7 +44,7 @@ class UriIntegrityActor @Inject() (
     renormRepo: RenormalizedURLRepo,
     centralConfig: CentralConfig,
     val airbrake: AirbrakeNotifier,
-    keepUriUserCache: KeepUriUserCache) extends FortyTwoActor(airbrake) with ScrapeInfoIntegrityChecker with Logging {
+    keepUriUserCache: KeepUriUserCache) extends FortyTwoActor(airbrake) with UriIntegrityChecker with Logging {
 
   /** tricky point: make sure (library, uri) pair is unique.  */
   private def handleBookmarks(oldBookmarks: Seq[Keep])(implicit session: RWSession): Unit = {

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/OrphanCleanerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/OrphanCleanerTest.scala
@@ -2,7 +2,7 @@ package com.keepit.integrity
 
 import com.google.inject.Module
 import com.keepit.abook.FakeABookServiceClientModule
-import com.keepit.common.db.{ ModelWithSeqNumber, Model }
+import com.keepit.common.db.SequenceNumber
 import com.keepit.common.db.slick._
 import com.keepit.common.social.FakeSocialGraphModule
 import com.keepit.model._
@@ -11,6 +11,8 @@ import com.keepit.shoebox.FakeKeepImportsModule
 import com.keepit.test.ShoeboxTestInjector
 import org.specs2.mutable.Specification
 import com.keepit.common.core._
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 class OrphanCleanerTest extends Specification with ShoeboxTestInjector {
 
@@ -149,6 +151,8 @@ class OrphanCleanerTest extends Specification with ShoeboxTestInjector {
         val keepRepo = inject[KeepRepo]
         val cleaner = inject[OrphanCleaner]
         val scrapeInfoIntegrityChecker = inject[ScrapeInfoIntegrityChecker]
+
+        scrapeInfoIntegrityChecker.forceSeqNum(SequenceNumber[NormalizedURI](0L))
 
         @inline def doAssign[T](f: => T): T = {
           f tap { _ => assignSeqNums(db)(uriRepo, keepRepo) }
@@ -312,7 +316,7 @@ class OrphanCleanerTest extends Specification with ShoeboxTestInjector {
             )
           }
         }
-        scrapeInfoIntegrityChecker.checkIntegrity() // sync scrape info
+        Await.result(scrapeInfoIntegrityChecker.checkIntegrity(), Duration("10 seconds")) // sync scrape info
 
         doAssign { cleaner.clean(readOnly = false) }
         db.readOnlyMaster { implicit s =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/OrphanCleanerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/OrphanCleanerTest.scala
@@ -148,6 +148,7 @@ class OrphanCleanerTest extends Specification with ShoeboxTestInjector {
         val uriRepo = inject[NormalizedURIRepo]
         val keepRepo = inject[KeepRepo]
         val cleaner = inject[OrphanCleaner]
+        val scrapeInfoIntegrityChecker = inject[ScrapeInfoIntegrityChecker]
 
         @inline def doAssign[T](f: => T): T = {
           f tap { _ => assignSeqNums(db)(uriRepo, keepRepo) }
@@ -311,6 +312,8 @@ class OrphanCleanerTest extends Specification with ShoeboxTestInjector {
             )
           }
         }
+        scrapeInfoIntegrityChecker.checkIntegrity() // sync scrape info
+
         doAssign { cleaner.clean(readOnly = false) }
         db.readOnlyMaster { implicit s =>
           uriRepo.get(uris(0).id.get).state === NormalizedURIStates.SCRAPED


### PR DESCRIPTION
@eishay @andrewconner @yingjieMiao 

ScrapeInfo is populated asynchronously using NormalizedURI sequence number rather than transactionally.
This will make it lighter to save NormalizedURI.

next to do: decouple ScrapeInfoRepo from OrphanCleaner and UriIntegrityActor
