### PR TITLE
increase update frequency

### DIFF
--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDARelatedLibraryCommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDARelatedLibraryCommander.scala
@@ -126,6 +126,6 @@ class LDARelatedLibraryPluginImpl @Inject() (
   override def enabled = true
 
   override def onStart() {
-    scheduleTaskOnOneMachine(actor.system, 10 minutes, 12 hours, actor.ref, UpdateLDARelatedLibrary, UpdateLDARelatedLibrary.getClass.getSimpleName)
+    scheduleTaskOnOneMachine(actor.system, 10 minutes, 3 hours, actor.ref, UpdateLDARelatedLibrary, UpdateLDARelatedLibrary.getClass.getSimpleName)
   }
 }


### PR DESCRIPTION
@eishay @stkem 

make the global library-library similarity graph update more frequently. Should not burn cortex. 

In the future, it's not hard to update the graph in an online fashion. 
