### PR TITLE
make the tmp file prefix and suffix more predictable.

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/store/S3AsyncHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/S3AsyncHelper.scala
@@ -41,7 +41,8 @@ trait S3AsyncHelper {
 
   def asyncDownload(bucketName: String, key: String)(implicit tm: TransferManager): Future[TemporaryFile] = {
     val p = Promise[TemporaryFile]()
-    val tf = TemporaryFile(prefix = bucketName, suffix = key)
+    //from javadoc, the prefix "must be at least three characters long"
+    val tf = TemporaryFile(prefix = "s3downloads", suffix = ".tmp")
     tf.file.deleteOnExit()
     val transfer = Try {
       val download = tm.download(bucketName, key, tf.file)


### PR DESCRIPTION
prev naming (or something else) resulted in "java.io.IOException: No such file or directory"
