### PR TITLE
clean related lib graph. remove trivial library

### DIFF
--- a/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/controllers/cortex/LDAController.scala
@@ -25,6 +25,7 @@ class LDAController @Inject() (
   versionCommander: CortexVersionCommander,
   representer: LDARepresenterCommander,
   infoCommander: LDAInfoCommander,
+  relatedLibCommander: LDARelatedLibraryCommander,
   personaCommander: LDAPersonaCommander)
     extends CortexServiceController with Logging {
 
@@ -204,6 +205,11 @@ class LDAController @Inject() (
     implicit val ver = toVersion(version)
     val libs = statsd.time("ldaController.getSimilarLibraries", 1.0) { _ => lda.getSimilarLibraries(libId, limit)(ver) }
     Ok(Json.toJson(libs))
+  }
+
+  def cleanRelatedLibraries(version: Int, readOnly: Boolean) = Action { request =>
+    relatedLibCommander.cleanFewKeepsLibraries(ModelVersion[DenseLDA](version), readOnly)
+    Ok
   }
 
   def uploadPMIScores(version: ModelVersion[DenseLDA]) = Action(parse.tolerantJson) { request =>

--- a/kifi-backend/modules/cortex/conf/cortexService.routes
+++ b/kifi-backend/modules/cortex/conf/cortexService.routes
@@ -41,6 +41,7 @@ POST    /internal/cortex/lda/userLibrariesScores                                
 GET     /internal/cortex/lda/dumpFeature                                            @com.keepit.controllers.cortex.LDAController.dumpFeature(dataType: String, id: Long, version: Option[Int] ?= None)
 GET     /internal/cortex/lda/similarURIs                                            @com.keepit.controllers.cortex.LDAController.getSimilarURIs(uriId: Id[NormalizedURI], version: Option[Int] ?= None)
 GET     /internal/cortex/lda/similarLibraries                                       @com.keepit.controllers.cortex.LDAController.getSimilarLibraries(libId: Id[Library], limit: Int, version: Option[Int] ?= None)
+POST    /internal/cortex/lda/cleanRelatedLibraries                                  @com.keepit.controllers.cortex.LDAController.cleanRelatedLibraries(version: Int, readOnly: Boolean ?= true)
 POST    /internal/cortex/lda/uploadPMIScores                                        @com.keepit.controllers.cortex.LDAController.uploadPMIScores(version: ModelVersion[DenseLDA])
 GET     /internal/cortex/lda/getExistingPersonaFeature                              @com.keepit.controllers.cortex.LDAController.getExistingPersonaFeature(personaId: Id[Persona], version: ModelVersion[DenseLDA])
 POST    /internal/cortex/lda/generatePersonaFeature                                 @com.keepit.controllers.cortex.LDAController.generatePersonaFeature(version: ModelVersion[DenseLDA])


### PR DESCRIPTION
@stkem FYI

destination sets is refreshed regularly, so they are up-to-date. 
the problem was with sources. These sources are no longer picked up by the update process.

This should do the trick. 
