### PR TITLE
Wait until social networks are ready before populating PYMK.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/friends/peopleYouMayKnow.js
+++ b/kifi-backend/modules/shoebox/angular/src/friends/peopleYouMayKnow.js
@@ -121,25 +121,20 @@ angular.module('kifi')
 
         function getEligibleNetworksCsv() {
           var onTwitterExperiment = _.indexOf(profileService.me.experiments, 'twitter_beta') > -1;
-          return _.compact([
+          var csv = _.compact([
             socialService.facebook && socialService.facebook.profileUrl ? null : 'fb',
             !onTwitterExperiment || (socialService.twitter && socialService.twitter.profileUrl) ? null : 'tw',
             socialService.linkedin && socialService.linkedin.profileUrl ? null : 'li',
             socialService.gmail && socialService.gmail.length ? null : 'gm'
           ]).join(',');
-        }
 
-        //
-        // Watches and listeners
-        //
-        scope.$watch(getEligibleNetworksCsv, function (csv) {
           scope.network = csv ? _.sample(csv.split(',')) : null;
-        });
+        }
 
         //
         // Initialization
         //
-        socialService.refresh();
+        socialService.refresh().then(getEligibleNetworksCsv);
       }
     };
   }


### PR DESCRIPTION
@2is10 
Previously, the PYMK button was populated once on module load (before the networks are loaded from the backend), and then once again when the networks are updated. Changing it to just populate once, after the networks have been loaded from the backend.

This bug manifested in the UI as a "Facebook flicker" - it actually flickers every time the first selected button is different from the second selected button.
