### PR TITLE
fixing a sticky follow button issue

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/sticky.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/sticky.js
@@ -92,10 +92,8 @@ angular.module('kifi')
         // Initialization
         //
 
-        measurePxFromDocTop();
-
         $timeout(function () {  // timeout needed for mobile Safari
-          var onScroll = _.debounce(measurePxFromDocTop, 100);
+          var onScroll = _.throttle(measurePxFromDocTop, 200, {leading: true});
 
           // changes to the page may change the element's position, so measure it periodically
           $win.on('scroll', onScroll);

--- a/kifi-backend/modules/shoebox/angular/src/header/loggedOutHeader.styl
+++ b/kifi-backend/modules/shoebox/angular/src/header/loggedOutHeader.styl
@@ -69,7 +69,7 @@ search-dur = .36s
   box-sizing: border-box
   width: 220px
   height: search-height + 2 * border-width
-  border: border-width solid alpha(defaultBorderColor, .5)
+  border: border-width solid alpha(defaultBorderColor, .6)
   border-radius: 3px
   background-color: transparent
   transition: width search-dur
@@ -213,3 +213,4 @@ input.kf-loh-search-input
 
 .kf-loh-dot
   margin: 0 10px
+  cursor: default


### PR DESCRIPTION
@yipingliao 
Fixes the issue we saw where follow button would sometimes jump to the top before it actually reached it, then jump back down a little too fast when scrolling back up. It happened because 1) we measured the button’s position too early, before templates were rendered, and 2) because we were using `_.debounce` instead of `_.throttle` and without `{leading: true}`, which meant a re-measure of the button’s position would not be triggered until scrolling _stopped_.
