### PR TITLE
Use new recommendations endpoint

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLibsAndPics.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLibsAndPics.js
@@ -39,7 +39,7 @@ angular.module('kifi')
           _.each(keeps, function (keep) {
             if (!scope.keep.id &&                      // No scope.keep.id if the keep is not on a library page.
                 scope.keep.url === keep.url &&
-                !libraryService.isSystemLibrary(library) &&     // Do not show system libraries as attributions.
+                !libraryService.isLibraryMainOrSecret(library) &&     // Do not show system libraries as attributions.
                 !_.contains(visibleLibraryIds, library.id)) {
               library.keeperPic = friendService.getPictureUrlForUser(profileService.me);
               scope.visibleKeepLibraries.push(library);
@@ -51,7 +51,7 @@ angular.module('kifi')
         var deregisterKeepRemovedListener = $rootScope.$on('keepRemoved', function (e, removedKeep, library) {
           if (!scope.keep.id &&                        // No scope.keep.id if the keep is not on a library page.
               (scope.keep.url === removedKeep.url) &&
-              (!libraryService.isSystemLibrary(library))) {     // Do not hide system libraries as attributions.
+              (!libraryService.isLibraryMainOrSecret(library))) {     // Do not hide system libraries as attributions.
             _.remove(scope.visibleKeepLibraries, { id: library.id });
           }
         });

--- a/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
@@ -107,7 +107,14 @@ angular.module('kifi')
         return route('/recos/adHoc?n=' + howMany);
       },
       recos: function (opts) {
-        return route('/recos/top?more=' + opts.more + '&recency=' + opts.recency);
+        var routeBase = '/recos/topV2?more=' + opts.more + '&recency=' + opts.recency;
+        if (opts.uriContext) {
+          routeBase += '&uriContext=' + opts.uriContext;
+        }
+        if (opts.libContext) {
+          routeBase += '&libContext=' + opts.libContext;
+        }
+        return route(routeBase);
       },
       recosPublic: function () {
         return route('/recos/public');

--- a/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/libraryMenu/libraryMenu.js
@@ -76,7 +76,7 @@ angular.module('kifi')
         function updateNavLibs() {
           scope.mainLib = _.find(libraryService.librarySummaries, { 'kind' : 'system_main' });
           scope.secretLib = _.find(libraryService.librarySummaries, { 'kind' : 'system_secret' });
-          allUserLibs = _.reject(libraryService.librarySummaries, libraryService.isSystemLibrary);
+          allUserLibs = _.reject(libraryService.librarySummaries, libraryService.isLibraryMainOrSecret);
           librarySummarySearch = new Fuse(allUserLibs, fuseOptions);
           invitedSummarySearch = new Fuse(libraryService.invitedSummaries, fuseOptions);
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -274,7 +274,7 @@ angular.module('kifi')
 
     $rootScope.$emit('libraryOnPage', library);
 
-    if (!libraryService.isSystemLibrary(library) && library.access !== 'none') {
+    if (!libraryService.isLibraryMainOrSecret(library) && library.access !== 'none') {
       $rootScope.$emit('lastViewedLib', library);
     }
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
@@ -592,7 +592,7 @@ angular.module('kifi')
         };
 
         scope.isUserCreatedLibrary = function () {
-          return !libraryService.isSystemLibrary(scope.library);
+          return !libraryService.isLibraryMainOrSecret(scope.library);
         };
 
         scope.isMyLibrary = function () {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -97,7 +97,7 @@ angular.module('kifi')
         library.owner.image = friendService.getPictureUrlForUser(library.owner);
         library.isMine = library.owner.id === profileService.me.id;
       }
-      if (api.isSystemLibrary(library)) {
+      if (api.isLibraryMainOrSecret(library)) {
         library.color = '#808080';
       }
     }
@@ -143,11 +143,11 @@ angular.module('kifi')
       invitedSummaries: invitedSummaries,
       recentLibraries: recentLibraries,
 
-      isSystemLibrary: function (library) {
+      isLibraryMainOrSecret: function (library) {
         return library.kind === 'system_main' || library.kind === 'system_secret';
       },
 
-      isSystemLibraryById: function (libraryId) {
+      isLibraryIdMainOrSecret: function (libraryId) {
         return _.some(librarySummaries, function (libSum) {
           return (libSum.kind === 'system_main' || libSum.kind === 'system_secret') && libSum.id === libraryId;
         });

--- a/kifi-backend/modules/shoebox/angular/src/recos/recoActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recoActionService.js
@@ -7,6 +7,7 @@ angular.module('kifi')
   function ($http, $q, routeService, Clutch) {
     var rawRecos = [];
     var rawPopularRecos = [];
+    var uriContext, libContext;
 
     var clutchParamsRecos = {
       cacheDuration: 2000
@@ -15,15 +16,19 @@ angular.module('kifi')
     var kifiRecommendationService = new Clutch(function (opts) {
       var recoOpts = {
         more: (!opts || opts.more === undefined) ? false : opts.more,
-        recency: opts && angular.isNumber(opts.recency) ? opts.recency : 0.75
+        recency: opts && angular.isNumber(opts.recency) ? opts.recency : 0.75,
+        uriContext: uriContext,
+        libContext: libContext
       };
 
       return $http.get(routeService.recos(recoOpts)).then(function (res) {
         if (res && res.data) {
           // Save recommendation data from the backend so we don't have to
           // fetch them again on Angular route reload of recommendations.
-          rawRecos = res.data;
-          return res.data;
+          rawRecos = res.data.recos;
+          uriContext = res.data.uctx;
+          libContext = res.data.lctx;
+          return res.data.recos;
         }
       });
     }, clutchParamsRecos);

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.styl
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.styl
@@ -301,6 +301,7 @@ col-gap = 20px
   padding: 12px 0
   text-align: center
   background: #fff
+  cursor: pointer
 
 .kf-reco-get-more
 .kf-reco-get-more-loading

--- a/kifi-backend/modules/shoebox/angular/src/search/search.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/search.js
@@ -301,7 +301,7 @@ angular.module('kifi')
       var resultsWithLibs = 0;
       $scope.resultKeeps.forEach( function (keep) {
         // does there exist a library that's not system_created?
-        if (_.some(keep.libraries, function (lib) { return !libraryService.isSystemLibraryById(lib.id); })) {
+        if (_.some(keep.libraries, function (lib) { return !libraryService.isLibraryIdMainOrSecret(lib.id); })) {
           resultsWithLibs++;
         }
       });

--- a/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
@@ -56,7 +56,7 @@ angular.module('kifi')
           lib.keeperName = user.firstName + ' ' + user.lastName;
           lib.owner = user;
 
-          if (!libraryService.isSystemLibraryById(lib.id)) {
+          if (!libraryService.isLibraryIdMainOrSecret(lib.id)) {
             decompressedLibraries.push(lib);
           }
 


### PR DESCRIPTION
Using new recommendations endpoint.
keeps track of a `uriContext` & `libContext` for every call from 'See More'

@2is10 @yipingliao @yingjieMiao @stkem 
