### PR TITLE
fix library ordering from profiles endpoint

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -182,13 +182,15 @@ object LibraryVisibility {
   }
 }
 
-sealed abstract class LibraryKind(val value: String)
+sealed abstract class LibraryKind(val value: String, val priority: Int) {
+  def compare(other: LibraryKind): Int = this.priority compare other.priority
+}
 
 object LibraryKind {
-  case object SYSTEM_MAIN extends LibraryKind("system_main")
-  case object SYSTEM_SECRET extends LibraryKind("system_secret")
-  case object SYSTEM_PERSONA extends LibraryKind("system_persona")
-  case object USER_CREATED extends LibraryKind("user_created")
+  case object SYSTEM_MAIN extends LibraryKind("system_main", 0)
+  case object SYSTEM_SECRET extends LibraryKind("system_secret", 1)
+  case object SYSTEM_PERSONA extends LibraryKind("system_persona", 2)
+  case object USER_CREATED extends LibraryKind("user_created", 2)
 
   implicit def format[T]: Format[LibraryKind] =
     Format(__.read[String].map(LibraryKind(_)), new Writes[LibraryKind] { def writes(o: LibraryKind) = JsString(o.value) })

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -52,7 +52,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
   private val profileLibraryOrdering = new Ordering[Library] {
     def compare(self: Library, that: Library): Int =
-      (self.kind.value compare that.kind.value) match {
+      (self.kind compare that.kind) match {
         case 0 =>
           (self.memberCount compare that.memberCount) match {
             case 0 => -(self.id.get.id compare that.id.get.id)


### PR DESCRIPTION
With the introduction of `LibraryKind.System_Persona`, those persona libraries show up before `System_Secret`because of alphabetical ordering lol.
Here's a fix that treats `User_Created` & `System_Persona` the same priority when it comes to `LibraryKind` ordering

@2is10 @andrewconner @stkem 
