### PR TITLE
Exclude fake users from search results and attribution for regular users...

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/engine/library/LibraryFromKeepsScoreVectorSource.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/library/LibraryFromKeepsScoreVectorSource.scala
@@ -16,6 +16,7 @@ class LibraryFromKeepsScoreVectorSource(
     protected val searcher: Searcher,
     protected val userId: Long,
     protected val friendIdsFuture: Future[Set[Long]],
+    protected val restrictedUserIdsFuture: Future[Set[Long]],
     protected val libraryIdsFuture: Future[(Set[Long], Set[Long], Set[Long], Set[Long])],
     filter: SearchFilter,
     protected val config: SearchConfig,

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/library/LibraryFromUserScoreVectorSource.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/library/LibraryFromUserScoreVectorSource.scala
@@ -22,6 +22,7 @@ class LibraryFromUserScoreVectorSource(
     userSearcher: Searcher,
     val userId: Long,
     val friendIdsFuture: Future[Set[Long]],
+    val restrictedUserIdsFuture: Future[Set[Long]],
     val libraryIdsFuture: Future[(Set[Long], Set[Long], Set[Long], Set[Long])],
     filter: SearchFilter,
     config: SearchConfig,

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/library/LibraryScoreVectorSource.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/library/LibraryScoreVectorSource.scala
@@ -16,6 +16,7 @@ class LibraryScoreVectorSource(
     protected val searcher: Searcher,
     protected val userId: Long,
     protected val friendIdsFuture: Future[Set[Long]],
+    protected val restrictedUserIdsFuture: Future[Set[Long]],
     protected val libraryIdsFuture: Future[(Set[Long], Set[Long], Set[Long], Set[Long])],
     filter: SearchFilter,
     protected val config: SearchConfig,

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/library/LibrarySearch.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/library/LibrarySearch.scala
@@ -25,6 +25,7 @@ class LibrarySearch(
     userSearcher: Searcher,
     libraryQualityEvaluator: LibraryQualityEvaluator,
     friendIdsFuture: Future[Set[Long]],
+    restrictedUserIdsFuture: Future[Set[Long]],
     libraryIdsFuture: Future[(Set[Long], Set[Long], Set[Long], Set[Long])],
     monitoredAwait: MonitoredAwait,
     timeLogs: SearchTimeLogs,
@@ -64,9 +65,9 @@ class LibrarySearch(
 
     val collector = new LibraryResultCollector(librarySearcher, keepSearcher, numHitsToReturn * 5, myLibraryBoost, percentMatch / 100.0f, libraryQualityEvaluator, explanation)
 
-    val userScoreSource = new LibraryFromUserScoreVectorSource(librarySearcher, userSearcher, userId.id, friendIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, explanation)
-    val keepScoreSource = new LibraryFromKeepsScoreVectorSource(keepSearcher, userId.id, friendIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, libraryQualityEvaluator, explanation)
-    val libraryScoreSource = new LibraryScoreVectorSource(librarySearcher, userId.id, friendIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, explanation)
+    val userScoreSource = new LibraryFromUserScoreVectorSource(librarySearcher, userSearcher, userId.id, friendIdsFuture, restrictedUserIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, explanation)
+    val keepScoreSource = new LibraryFromKeepsScoreVectorSource(keepSearcher, userId.id, friendIdsFuture, restrictedUserIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, libraryQualityEvaluator, explanation)
+    val libraryScoreSource = new LibraryScoreVectorSource(librarySearcher, userId.id, friendIdsFuture, restrictedUserIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, explanation)
 
     if (debugFlags != 0) {
       engine.debug(this)

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/uri/UriFromKeepsScoreVectorSource.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/uri/UriFromKeepsScoreVectorSource.scala
@@ -17,6 +17,7 @@ class UriFromKeepsScoreVectorSource(
     protected val searcher: Searcher,
     protected val userId: Long,
     protected val friendIdsFuture: Future[Set[Long]],
+    protected val restrictedUserIdsFuture: Future[Set[Long]],
     protected val libraryIdsFuture: Future[(Set[Long], Set[Long], Set[Long], Set[Long])],
     filter: SearchFilter,
     recencyOnly: Boolean,

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/uri/UriSearchImpl.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/uri/UriSearchImpl.scala
@@ -25,6 +25,7 @@ class UriSearchImpl(
     keepSearcher: Searcher,
     librarySearcher: Searcher,
     friendIdsFuture: Future[Set[Long]],
+    restrictedUserIdsFuture: Future[Set[Long]],
     libraryIdsFuture: Future[(Set[Long], Set[Long], Set[Long], Set[Long])],
     clickBoostsFuture: Future[ResultClickBoosts],
     clickHistoryFuture: Future[MultiHashFilter[ClickedURI]],
@@ -59,7 +60,7 @@ class UriSearchImpl(
     }
 
     val libraryScoreSource = new UriFromLibraryScoreVectorSource(librarySearcher, keepSearcher, libraryIdsFuture, filter, config, monitoredAwait, explanation)
-    val keepScoreSource = new UriFromKeepsScoreVectorSource(keepSearcher, userId.id, friendIdsFuture, libraryIdsFuture, filter, engine.recencyOnly, config, monitoredAwait, explanation)
+    val keepScoreSource = new UriFromKeepsScoreVectorSource(keepSearcher, userId.id, friendIdsFuture, restrictedUserIdsFuture, libraryIdsFuture, filter, engine.recencyOnly, config, monitoredAwait, explanation)
     val articleScoreSource = new UriFromArticlesScoreVectorSource(articleSearcher, filter, explanation)
 
     if (debugFlags != 0) {

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/uri/UriSearchNonUserImpl.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/uri/UriSearchNonUserImpl.scala
@@ -20,6 +20,7 @@ class UriSearchNonUserImpl(
     keepSearcher: Searcher,
     librarySearcher: Searcher,
     friendIdsFuture: Future[Set[Long]],
+    restrictedUserIdsFuture: Future[Set[Long]],
     libraryIdsFuture: Future[(Set[Long], Set[Long], Set[Long], Set[Long])],
     monitoredAwait: MonitoredAwait,
     timeLogs: SearchTimeLogs,
@@ -33,7 +34,7 @@ class UriSearchNonUserImpl(
     val collector = new NonUserUriResultCollector(numHitsToReturn, percentMatch / 100.0f, explanation)
 
     val libraryScoreSource = new UriFromLibraryScoreVectorSource(librarySearcher, keepSearcher, libraryIdsFuture, filter, config, monitoredAwait, explanation)
-    val keepScoreSource = new UriFromKeepsScoreVectorSource(keepSearcher, -1L, friendIdsFuture, libraryIdsFuture, filter, engine.recencyOnly, config, monitoredAwait, explanation)
+    val keepScoreSource = new UriFromKeepsScoreVectorSource(keepSearcher, -1L, friendIdsFuture, restrictedUserIdsFuture, libraryIdsFuture, filter, engine.recencyOnly, config, monitoredAwait, explanation)
     val articleScoreSource = new UriFromArticlesScoreVectorSource(articleSearcher, filter, explanation)
 
     if (debugFlags != 0) {

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/user/UserFromKeepsScoreVectorSource.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/user/UserFromKeepsScoreVectorSource.scala
@@ -16,6 +16,7 @@ class UserFromKeepsScoreVectorSource(
     protected val searcher: Searcher,
     protected val userId: Long,
     protected val friendIdsFuture: Future[Set[Long]],
+    protected val restrictedUserIdsFuture: Future[Set[Long]],
     protected val libraryIdsFuture: Future[(Set[Long], Set[Long], Set[Long], Set[Long])],
     filter: SearchFilter,
     protected val config: SearchConfig,

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/user/UserFromLibrariesScoreVectorSource.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/user/UserFromLibrariesScoreVectorSource.scala
@@ -18,6 +18,7 @@ class UserFromLibrariesScoreVectorSource(
     protected val searcher: Searcher,
     protected val userId: Long,
     protected val friendIdsFuture: Future[Set[Long]],
+    protected val restrictedUserIdsFuture: Future[Set[Long]],
     protected val libraryIdsFuture: Future[(Set[Long], Set[Long], Set[Long], Set[Long])],
     filter: SearchFilter,
     protected val config: SearchConfig,

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/user/UserScoreVectorSource.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/user/UserScoreVectorSource.scala
@@ -17,6 +17,7 @@ class UserScoreVectorSource(
     protected val searcher: Searcher,
     protected val userId: Long,
     protected val friendIdsFuture: Future[Set[Long]],
+    protected val restrictedUserIdsFuture: Future[Set[Long]],
     protected val libraryIdsFuture: Future[(Set[Long], Set[Long], Set[Long], Set[Long])],
     filter: SearchFilter,
     protected val config: SearchConfig,

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/user/UserSearch.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/user/UserSearch.scala
@@ -25,6 +25,7 @@ class UserSearch(
     userSearcher: Searcher,
     libraryQualityEvaluator: LibraryQualityEvaluator,
     friendIdsFuture: Future[Set[Long]],
+    restrictedUserIdsFuture: Future[Set[Long]],
     libraryIdsFuture: Future[(Set[Long], Set[Long], Set[Long], Set[Long])],
     monitoredAwait: MonitoredAwait,
     timeLogs: SearchTimeLogs,
@@ -63,9 +64,9 @@ class UserSearch(
 
     val collector = new UserResultCollector(librarySearcher, keepSearcher, numHitsToReturn * 5, myFriendBoost, percentMatch / 100.0f, libraryQualityEvaluator, explanation)
 
-    val userScoreSource = new UserScoreVectorSource(userSearcher, userId.id, friendIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, explanation)
-    val keepScoreSource = new UserFromKeepsScoreVectorSource(keepSearcher, userId.id, friendIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, libraryQualityEvaluator, explanation)
-    val libraryScoreSource = new UserFromLibrariesScoreVectorSource(librarySearcher, userId.id, friendIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, explanation)
+    val userScoreSource = new UserScoreVectorSource(userSearcher, userId.id, friendIdsFuture, restrictedUserIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, explanation)
+    val keepScoreSource = new UserFromKeepsScoreVectorSource(keepSearcher, userId.id, friendIdsFuture, restrictedUserIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, libraryQualityEvaluator, explanation)
+    val libraryScoreSource = new UserFromLibrariesScoreVectorSource(librarySearcher, userId.id, friendIdsFuture, restrictedUserIdsFuture, libraryIdsFuture, filter, config, monitoredAwait, explanation)
 
     if (debugFlags != 0) {
       engine.debug(this)

--- a/kifi-backend/modules/search/test/com/keepit/search/SearchTestHelper.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/SearchTestHelper.scala
@@ -87,6 +87,7 @@ trait SearchTestHelper { self: SearchTestInjector =>
       libraryIndexer,
       userIndexer,
       userGraphsSearcherFactory,
+      inject[ShoeboxServiceClient],
       phraseDetector,
       resultClickTracker,
       inject[ClickHistoryTracker],


### PR DESCRIPTION
... (neither fake or admin)

@eishay @andrewconner @stkem @yingjieMiao 

This is a comprehensive approach to exclude fake users from search results and attribution for regular users. 
Admin and other fake users would still see them, so would a regular user who is _explicitly_ friend with or follower of a fake user. 
