### PR TITLE
sending ?more=1 instead of just ?more when more is true

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
@@ -117,17 +117,12 @@ angular.module('kifi')
         return route('/recos/adHoc', {n: howMany});
       },
       recos: function (opts) {
-        // todo: fix endpoint to use route()
-        var base = route('/recos/topV2');
-        base += '?more=' + opts.more;
-        base += '&recency=' + opts.recency;
-        if (opts.uriContext) {
-          base += '&uriContext=' + opts.uriContext;
-        }
-        if (opts.libContext) {
-          base += '&libContext=' + opts.libContext;
-        }
-        return base;
+        return route('/recos/topV2', {
+          more: opts.more ? 1 : 0,
+          recency: opts.recency,
+          uriContext: opts.uriContext || [],
+          libContext: opts.libContext || []
+        });
       },
       recosPublic: function () {
         return route('/recos/public');


### PR DESCRIPTION
It turns out the problem #13791 fixed wasn’t with the encoding of the contexts at all. It was a disagreement between Angular and Play about how query parameters with value `true` should be represented.
@ahsu1230 
cc @yingjieMiao 
