### PR TITLE
removing redundant parameter more from latest recos endpoints

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
@@ -118,7 +118,6 @@ angular.module('kifi')
       },
       recos: function (opts) {
         return route('/recos/topV2', {
-          more: opts.more ? 1 : 0,
           recency: opts.recency,
           uriContext: opts.uriContext || [],
           libContext: opts.libContext || []

--- a/kifi-backend/modules/shoebox/angular/src/recos/recoActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recoActionService.js
@@ -15,11 +15,13 @@ angular.module('kifi')
 
     var kifiRecommendationService = new Clutch(function (opts) {
       var recoOpts = {
-        more: (!opts || opts.more === undefined) ? false : opts.more,
         recency: opts && angular.isNumber(opts.recency) ? opts.recency : 0.75,
-        uriContext: uriContext,
-        libContext: libContext
       };
+
+      if (opts && opts.more) {
+        recoOpts.uriContext = uriContext;
+        recoOpts.libContext = libContext;
+      }
 
       return $http.get(routeService.recos(recoOpts)).then(function (res) {
         if (res && res.data) {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileRecommendationsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileRecommendationsController.scala
@@ -19,7 +19,7 @@ class MobileRecommendationsController @Inject() (
     userExperimentCommander: LocalUserExperimentCommander,
     db: Database) extends UserActions with ShoeboxServiceController {
 
-  def topRecosV2(more: Boolean, recencyWeight: Float) = UserAction.async { request =>
+  def topRecosV2(recencyWeight: Float, more: Boolean) = UserAction.async { request =>
     val uriRecosF = commander.topRecos(request.userId, getRecommendationSource(request), RecommendationSubSource.RecommendationsFeed, more, recencyWeight, None)
     val libRecosF = commander.topPublicLibraryRecos(request.userId, 5, RecommendationSource.Site, RecommendationSubSource.RecommendationsFeed, context = None)
 
@@ -31,8 +31,8 @@ class MobileRecommendationsController @Inject() (
     }
   }
 
-  def topRecosV3(more: Boolean, recencyWeight: Float, uriContext: Option[String], libContext: Option[String]) = UserAction.async { request =>
-    val uriRecosF = commander.topRecos(request.userId, getRecommendationSource(request), RecommendationSubSource.RecommendationsFeed, more, recencyWeight, context = uriContext)
+  def topRecosV3(recencyWeight: Float, uriContext: Option[String], libContext: Option[String]) = UserAction.async { request =>
+    val uriRecosF = commander.topRecos(request.userId, getRecommendationSource(request), RecommendationSubSource.RecommendationsFeed, uriContext.isDefined, recencyWeight, context = uriContext)
     val libRecosF = commander.topPublicLibraryRecos(request.userId, 5, RecommendationSource.Site, RecommendationSubSource.RecommendationsFeed, context = libContext)
 
     for (libs <- libRecosF; uris <- uriRecosF) yield Ok {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/RecommendationsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/RecommendationsController.scala
@@ -25,21 +25,9 @@ class RecommendationsController @Inject() (
     commander.adHocRecos(request.userId, n, scores).map(fkis => Ok(Json.toJson(fkis)))
   }
 
-  def topRecos(more: Boolean, recencyWeight: Float) = UserAction.async { request =>
-    val libRecosF = commander.topPublicLibraryRecos(request.userId, 5, RecommendationSource.Site, RecommendationSubSource.RecommendationsFeed, context = None)
-    val uriRecosF = commander.topRecos(request.userId, RecommendationSource.Site, RecommendationSubSource.RecommendationsFeed, more, recencyWeight, context = None)
-
-    for (libs <- libRecosF; uris <- uriRecosF) yield Ok {
-      val FullUriRecoResults(urisReco, _) = uris
-      val FullLibRecoResults(libsReco, _) = libs
-      val shuffled = util.Random.shuffle(urisReco ++ libsReco.map(_._2))
-      Json.toJson(shuffled)
-    }
-  }
-
-  def topRecosV2(more: Boolean, recencyWeight: Float, uriContext: Option[String], libContext: Option[String]) = UserAction.async { request =>
+  def topRecosV2(recencyWeight: Float, uriContext: Option[String], libContext: Option[String]) = UserAction.async { request =>
     val libRecosF = commander.topPublicLibraryRecos(request.userId, 5, RecommendationSource.Site, RecommendationSubSource.RecommendationsFeed, context = uriContext)
-    val uriRecosF = commander.topRecos(request.userId, RecommendationSource.Site, RecommendationSubSource.RecommendationsFeed, more, recencyWeight, context = libContext)
+    val uriRecosF = commander.topRecos(request.userId, RecommendationSource.Site, RecommendationSubSource.RecommendationsFeed, libContext.isDefined, recencyWeight, context = libContext)
 
     for (libs <- libRecosF; uris <- uriRecosF) yield Ok {
       val FullUriRecoResults(urisReco, newUriContext) = uris

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -236,8 +236,8 @@ POST    /m/1/attribution/appsflyer              @com.keepit.controllers.mobile.M
 
 POST    /m/1/disconnect/:provider               @com.keepit.controllers.mobile.MobileUserController.disconnect(provider)
 
-GET     /m/2/recos/top                          @com.keepit.controllers.mobile.MobileRecommendationsController.topRecosV2(more: Boolean, recency: Float)
-GET     /m/2/recos/topV3                        @com.keepit.controllers.mobile.MobileRecommendationsController.topRecosV3(more: Boolean, recency: Float, uriContext: Option[String] ?= None, libContext: Option[String] ?= None)
+GET     /m/2/recos/top                          @com.keepit.controllers.mobile.MobileRecommendationsController.topRecosV2(recency: Float, more: Boolean ?= false)
+GET     /m/3/recos/top                          @com.keepit.controllers.mobile.MobileRecommendationsController.topRecosV3(recency: Float, uriContext: Option[String] ?= None, libContext: Option[String] ?= None)
 GET     /m/1/recos/public                       @com.keepit.controllers.mobile.MobileRecommendationsController.topPublicRecos()
 POST    /m/1/recos/trash                        @com.keepit.controllers.mobile.MobileRecommendationsController.trash(id: ExternalId[NormalizedURI])
 
@@ -400,8 +400,7 @@ GET     /site/libraries/recos/top           @com.keepit.controllers.website.Libr
 POST    /site/libraries/recos/feedback      @com.keepit.controllers.website.LibraryRecommendationsController.updateLibraryRecommendationFeedback(id: PublicId[Library])
 
 POST    /site/recos/adHoc           @com.keepit.controllers.website.RecommendationsController.adHocRecos(n: Int)
-GET     /site/recos/top             @com.keepit.controllers.website.RecommendationsController.topRecos(more: Boolean, recency: Float)
-GET     /site/recos/topV2           @com.keepit.controllers.website.RecommendationsController.topRecosV2(more: Boolean, recency: Float, uriContext: Option[String] ?= None, libContext: Option[String] ?= None)
+GET     /site/recos/topV2           @com.keepit.controllers.website.RecommendationsController.topRecosV2(recency: Float, uriContext: Option[String] ?= None, libContext: Option[String] ?= None)
 GET     /site/recos/public          @com.keepit.controllers.website.RecommendationsController.topPublicRecos()
 POST    /site/recos/feedback        @com.keepit.controllers.website.RecommendationsController.updateUriRecommendationFeedback(id: ExternalId[NormalizedURI])
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileRecommendationsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileRecommendationsControllerTest.scala
@@ -161,11 +161,11 @@ class MobileRecommendationsControllerTest extends TestKitSupport with Specificat
         withDb(modules: _*) { implicit injector =>
           topRecosSetup()
 
-          val call = com.keepit.controllers.mobile.routes.MobileRecommendationsController.topRecosV2(true, 0.75f)
-          call.url === "/m/2/recos/top?more=true&recency=0.75"
+          val call = routes.MobileRecommendationsController.topRecosV2(0.75f, true)
+          call.url === "/m/2/recos/top?recency=0.75&more=true"
           call.method === "GET"
 
-          val result = runCommonTopRecosTests(call, request => inject[MobileRecommendationsController].topRecosV2(true, 0.75f)(request))
+          val result = runCommonTopRecosTests(call, request => inject[MobileRecommendationsController].topRecosV2(0.75f, true)(request))
           val json = Json.parse(contentAsString(result)).asInstanceOf[JsArray]
           json.value.size == 2
 
@@ -186,12 +186,12 @@ class MobileRecommendationsControllerTest extends TestKitSupport with Specificat
 
         inject[UserActionsHelper].asInstanceOf[FakeUserActionsHelper].setUser(user, Set())
 
-        val route = com.keepit.controllers.mobile.routes.MobileRecommendationsController.topPublicRecos().url
+        val route = routes.MobileRecommendationsController.topPublicRecos().url
         route === "/m/1/recos/public"
 
-        val request = FakeRequest("GET", route)
+        val request = FakeRequest("GET", route).withHeaders(USER_AGENT -> "iKeefee/0.0.0 (Device-Type: NA, OS: iOS NA)")
 
-        val controller = inject[RecommendationsController]
+        val controller = inject[MobileRecommendationsController]
         val result: Future[Result] = controller.topPublicRecos()(request)
         status(result) must equalTo(OK)
         contentType(result) must beSome("application/json")
@@ -220,7 +220,7 @@ class MobileRecommendationsControllerTest extends TestKitSupport with Specificat
           explain = Some("because :-)")))
         inject[RecommendationsCommander].asInstanceOf[FakeRecommendationsCommander].uriRecoInfos = recoInfos
 
-        val result2: Future[Result] = controller.topRecos(true, 0.75f)(request)
+        val result2: Future[Result] = controller.topRecosV2(0.75f, true)(request)
         status(result2) must equalTo(OK)
         contentType(result2) must beSome("application/json")
 


### PR DESCRIPTION
Also removing recos v1 website endpoint and making `more` optional in old mobile endpoint.
@ahsu1230 
cc @yingjieMiao 
