### PR TITLE
positioning follow button using CSS only

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -7,38 +7,6 @@ angular.module('kifi')
   'keepDecoratorService', 'libraryService', 'modalService', 'platformService', 'profileService', 'originTrackingService', 'installService',
   function ($scope, $rootScope, $analytics, $location, $state, $stateParams, $timeout, $window, util, initParams, library,
     keepDecoratorService, libraryService, modalService, platformService, profileService, originTrackingService, installService) {
-    //
-    // A/B Tests.
-    //
-    var abTest = {
-      name: 'exp_follow_popup',
-      salt: 'hgg1dv',
-      treatments: [
-        {
-          name: 'none',
-          isControl: true
-        },
-        {
-          name: 'popupLibrary',
-          data: {
-            buttonText: 'Follow',
-            mainText: 'Join Kifi to follow this library.<br/>Discover other libraries,<br/>and build your own!',
-            quote: 'From business to personal, Kifi has been<br/>instrumental in my day-to-day life.',
-            quoteAttribution: 'Remy Weinstein, California'
-          }
-        },
-        {
-          name: 'popupCollection',
-          data: {
-            buttonText: 'Save',
-            mainText: 'Join Kifi to save this collection.<br/>Discover other collections,<br/>and build your own!',
-            quote: 'From business to personal, Kifi has been<br/>instrumental in my day-to-day life.',
-            quoteAttribution: 'Remy Weinstein, California'
-          }
-        }
-      ]
-    };
-
 
     //
     // Internal data.
@@ -305,7 +273,35 @@ angular.module('kifi')
       }
     });
 
-    library.abTest = abTest;
-    library.abTestTreatment = util.chooseTreatment(library.abTest.salt, library.abTest.treatments);
+    if (!$rootScope.userLoggedIn) {
+      library.abTest = {
+        name: 'exp_follow_popup',
+        salt: 'hgg1dv',
+        treatments: [
+          {
+            name: 'none'
+          },
+          {
+            name: 'popupLibrary',
+            data: {
+              buttonText: 'Follow',
+              mainHtml: 'Join Kifi to follow this library.<br/>Discover other libraries,<br/>and build your own!',
+              quoteHtml: 'From business to personal, Kifi has been<br/>instrumental in my day-to-day life.',
+              quoteAttribution: 'Remy Weinstein, California'
+            }
+          },
+          {
+            name: 'popupCollection',
+            data: {
+              buttonText: 'Save',
+              mainHtml: 'Join Kifi to save this collection.<br/>Discover other collections,<br/>and build your own!',
+              quoteHtml: 'From business to personal, Kifi has been<br/>instrumental in my day-to-day life.',
+              quoteAttribution: 'Remy Weinstein, California'
+            }
+          }
+        ]
+      };
+      library.abTestTreatment = util.chooseTreatment(library.abTest.salt, library.abTest.treatments);
+    }
   }
 ]);

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
@@ -35,7 +35,6 @@ angular.module('kifi')
         //
         // Scope data.
         //
-        scope.isUserLoggedOut = $rootScope.userLoggedIn === false;
         scope.clippedDescription = false;
         scope.editKeepsText = 'Edit Keeps';
         scope.search = { 'text': $stateParams.q || '' };
@@ -101,7 +100,7 @@ angular.module('kifi')
           scope.library.followers.forEach(augmentFollower);
 
           var maxLength = 150;
-          if (scope.library.description.length > maxLength && !scope.isUserLoggedOut) {
+          if (scope.library.description.length > maxLength && $rootScope.userLoggedIn) {
             // Try to chop off at a word boundary, using a simple space as the word boundary delimiter.
             var clipLastIndex = maxLength;
             var lastSpaceIndex = scope.library.description.lastIndexOf(' ', maxLength);
@@ -133,10 +132,6 @@ angular.module('kifi')
             scope.coverImageUrl = env.picBase + '/' + image.path;
             scope.coverImagePos = formatCoverImagePos(image);
           }
-
-          scope.library.followButtonText = (scope.isUserLoggedOut && scope.library.abTestTreatment && !scope.library.abTestTreatment.isControl) ?
-            scope.library.abTestTreatment.data.buttonText :
-            'Follow Library';
         }
 
         function augmentFollower(follower) {
@@ -603,7 +598,7 @@ angular.module('kifi')
           // Only user-created (i.e. not Main or Secret) libraries can be shared.
           // Of the user-created libraries, public libraries can be shared by any Kifi user;
           // discoverable/secret libraries can be shared only by the library owner.
-          return !scope.isUserLoggedOut && scope.isUserCreatedLibrary() &&
+          return $rootScope.userLoggedIn && scope.isUserCreatedLibrary() &&
                  (scope.isPublic() || scope.isMyLibrary());
         };
 
@@ -640,7 +635,7 @@ angular.module('kifi')
             var url = $location.absUrl();
             platformService.goToAppOrStore(url + (url.indexOf('?') > 0 ? '&' : '?') + 'follow=true');
             return;
-          } else if ($rootScope.userLoggedIn === false) {
+          } else if (!$rootScope.userLoggedIn) {
             return signupService.register({libraryId: scope.library.id, intent: 'follow'});
           }
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.styl
@@ -441,6 +441,20 @@ a.kf-lh-stat
   .kf-library-share-search
     vertical-align: top
 
+.kf-lh-follow-btn-wrap
+  display: inline-block
+  vertical-align: top
+  line-height: 0
+  z-index: 501
+
+  .kf-logged-out &
+    position: relative
+
+  .kf-loh-right>&
+    position: absolute
+    top: 14px
+    right: 0
+
 follow-unfollow-width = 112px
 
 .kf-lh-follow-btn
@@ -448,16 +462,8 @@ follow-unfollow-width = 112px
   width: follow-unfollow-width
   padding: 0
   background: #008aee
-  color: white
-
-  &.kf-stickable
-    position: relative
-    z-index: 501
-
-  .kf-loh-right>&
-    position: absolute
-    top: 14px
-    right: 0
+  color: #fff
+  position: relative  // to stack in front of its hover callout
 
   &::before  // moves the text slightly right
     content: ''

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
@@ -71,11 +71,10 @@
       <div class="kf-lh-buttons clearfix">
         <div style="float:right">
           <div kf-library-share-search ng-if="canBeShared()" library="library" current-page-origin="libraryPage"></div>
-          <button class="kf-button kf-lh-follow-btn" ng-click="followLibrary()" ng-if="canFollowLibrary()"
-            ng-class="{'kf-stickable': isUserLoggedOut}"
-            kf-sticky sticky-if="isUserLoggedOut" sticky-top="isMobile ? 25 : 14" sticky-toggle="followButtonToggleStuck" sticky-near="followButtonNearlyStuck" sticky-near-px="isMobile ? 90 : 40"
-            kf-library-header-follow-button-cta
-          >{{ library.followButtonText }}</button>
+          <div class="kf-lh-follow-btn-wrap" kf-sticky sticky-if="!$root.userLoggedIn" sticky-top="isMobile ? 25 : 14" sticky-toggle="followButtonToggleStuck" sticky-near="followButtonNearlyStuck" sticky-near-px="isMobile ? 90 : 40" ng-if="canFollowLibrary()">
+            <div kf-library-header-follow-button-cta library="library" ng-if="!isMobile && library.abTest.name === 'exp_follow_popup' && library.abTestTreatment.data"></div>
+            <button class="kf-button kf-lh-follow-btn" ng-click="followLibrary()">{{library.abTestTreatment.data.buttonText || 'Follow Library'}}</button>
+          </div>
           <button class="kf-button kf-lh-unfollow-btn" ng-click="unfollowLibrary()" ng-if="alreadyFollowingLibrary()"></button>
           <button class="kf-button" ng-click="toggleEditKeeps()" ng-if="isMyLibrary() && library.numKeeps > 0">{{editKeepsText}}</button>
           <button class="kf-button kf-button-text-optional" ng-click="manageLibrary()" ng-if="isMyLibrary() && isUserCreatedLibrary()">

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeaderFollowButtonCta.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeaderFollowButtonCta.js
@@ -3,183 +3,192 @@
 angular.module('kifi')
 
 .directive('kfLibraryHeaderFollowButtonCta', [
-  '$compile', '$rootElement', '$rootScope', '$templateCache', '$timeout', '$window', 'libraryService', 'platformService',
-  function ($compile, $rootElement, $rootScope, $templateCache, $timeout, $window, libraryService, platformService) {
+  '$rootScope', '$timeout', '$window', 'libraryService', 'util',
+  function ($rootScope, $timeout, $window, libraryService, util) {
     return {
       restrict: 'A',
-      link: function (scope, element/*, attrs */) {
-        function positionCTA() {
-          var elementTop = element.offset().top;
-          var elementLeft = element.offset().left;
+      scope: {
+        library: '='
+      },
+      templateUrl: 'libraries/libraryHeaderFollowButtonCta.tpl.html',
+      link: function (scope, element) {
 
-          var ctaHeight = cta.outerHeight();
-          var ctaMargin = 15;  // Vertical spacing between CTA and the follow button.
-          var ctaHeightWithMargin = ctaHeight + 15;
+        //
+        // Helper functions
+        //
 
-          // By default, we try to show the CTA above the follow button.
-          var top = elementTop - ctaHeightWithMargin;
-          var ctaOuterArrowTop = ctaHeight - 2;
-          var ctaInnerArrowTop = ctaOuterArrowTop - 1;
-          scope.ctaShownAbove = true;
+        function show(opts) {
+          element
+            .removeClass(opts.below ? 'kf-above' : 'kf-below')
+            .addClass(opts.below ? 'kf-below' : 'kf-above');
 
-          // However, if there is no room between the follow button and the
-          // Kifi header, then we show the CTA beneath the follow button.
-          if (elementTop - ctaHeightWithMargin - angular.element($window).scrollTop() < kfHeaderHeight) {
-            top = elementTop + element.outerHeight() + ctaMargin;
-            ctaOuterArrowTop = -ctaArrowHeight;
-            ctaInnerArrowTop = ctaOuterArrowTop + 1;
-            scope.ctaShownAbove = false;
-          }
+          scope.whyShowing = opts.auto ? 'timer' : 'hover';
+          clearShowTimeout();
+          $window.removeEventListener('visibilitychange', onVisibilityChangeBeforeShow);
 
-          // Center the CTA with respect to the follow button.
-          var left = elementLeft - Math.round((cta.outerWidth() - element.outerWidth()) / 2);
-
-          cta.css({position: 'absolute', top: top + 'px', left: left + 'px'});
-          ctaOuterArrow.css({top: ctaOuterArrowTop + 'px'});
-          ctaInnerArrow.css({top: ctaInnerArrowTop + 'px'});
-        }
-
-        function showCTA(showAutoCTA) {
-          if (cta) {
-            autoCTAShowing = scope.showX = !!showAutoCTA;
-            positionCTA();
-
-            scope.$evalAsync(function () {
-              cta.show();
-              ctaShown = true;
-
-              if (autoShowCTAPromise) {
-                $timeout.cancel(autoShowCTAPromise);
-                autoShowCTAPromise = null;
-              }
-            });
-          }
-        }
-
-        function hideCTA() {
-          if (cta) {
-            cta.hide();
-            autoCTAShowing = false;
-          }
-        }
-
-        function autoShowCTA(timeInMS) {
-          // Show the CTA only if the page is visible and if it hasn't
-          // been shown before.
-          if (autoShowCTAPromise) {
-            $timeout.cancel(autoShowCTAPromise);
-            autoShowCTAPromise = null;
-          }
-
-          autoShowCTAPromise = $timeout(function () {
-            if (!$window.document.hidden && !ctaShown) {
-              showCTA(true);
-              ctaShown = true;
-              trackHover('timer');
-            }
-          }, timeInMS);
-        }
-
-        function autoShowCTAUnlessHidden() {
-          // $document.hidden is undefined; use $window.document to get
-          // around this problem.
-          if (!$window.document.hidden) {
-            autoShowCTA(2000);
-          }
-        }
-
-        function trackHover(trigger) {
           libraryService.trackEvent('visitor_viewed_page', scope.library, {
             type: 'libraryLanding',
             viewType: 'hover',
             subtype: 'hoverFollowButton',
-            trigger: trigger
+            trigger: opts.auto ? 'timer' : 'hover'
           });
         }
 
-        function trackCTAClose() {
-          libraryService.trackEvent('visitor_clicked_page', scope.library, {
-            type: 'libraryLanding',
-            action: 'clickedFollowCTAClose'
-          });
-        }
+        function hide(manually) {
+          scope.whyShowing = hideIfScrollTop = null;
 
-
-        //
-        // Scope methods.
-        //
-        scope.closeCTA = function () {
-          hideCTA();
-          trackCTAClose();
-        };
-
-
-        //
-        // Event listeners.
-        //
-        element.on('mouseenter', function () {
-          showCTA(false);
-          trackHover('hover');
-        });
-        element.on('mouseleave', hideCTA);
-
-        var adjustAutoCTAPosition = function () {
-          if (autoCTAShowing) {
-            positionCTA();
+          if (manually) {
+            libraryService.trackEvent('visitor_clicked_page', scope.library, {
+              type: 'libraryLanding',
+              action: 'clickedFollowCTAClose'
+            });
           }
+        }
+
+        function attemptAutoShowAfter(ms) {
+          clearShowTimeout();
+          showTimeout = $timeout(autoShowAsap, ms);
+        }
+
+        function autoShowAsap() {
+          clearShowTimeout();
+          if (!$window.document.hidden) {
+            var buttonRect = measureButtonRect();
+            var canFit = calcWhereCanFit(buttonRect);
+            if (canFit.above && !(scroll.deltaY > 0 && Date.now() - scroll.time < 100)) {  // if not scrolling up
+              show({auto: true});
+              var lowerBound = scroll.top + buttonRect.top - minSpace;
+              hideIfScrollTop = function (scrollTop) {
+                return scrollTop > lowerBound;
+              };
+            } else if (canFit.below && !canFit.above) {
+              show({auto: true, below: true});
+              var upperBoundPlusWinHeight = scroll.top + buttonRect.bottom + minSpace;
+              hideIfScrollTop = function (scrollTop) {
+                return scrollTop < upperBoundPlusWinHeight - winHeight;
+              };
+            } else {
+              showTimeout = $timeout(autoShowAsap, 500);
+            }
+          }
+        }
+
+        function clearShowTimeout() {
+          if (showTimeout) {
+            $timeout.cancel(showTimeout);
+          }
+          showTimeout = null;
+        }
+
+        function measureButtonRect() {
+          return button[0].getBoundingClientRect();
+        }
+
+        function calcWhereCanFit(buttonRect) {
+          buttonRect = buttonRect || measureButtonRect();
+          var fromBottom = $window.innerHeight - buttonRect.bottom;
+          return {
+            above: buttonRect.top > minSpace && fromBottom > 0,
+            below: fromBottom > minSpace && buttonRect.top > 0
+          };
+        }
+
+
+        //
+        // Scope methods
+        //
+
+        scope.onClickX = function () {
+          hide(true);
         };
-        $window.addEventListener('scroll', adjustAutoCTAPosition);
+
+
+        //
+        // Event handlers
+        //
+
+        function onParentMouseEnter() {
+          if (!scope.whyShowing) {
+            scope.$apply(function () {
+              show({below: !calcWhereCanFit().above});  // prefer showing above
+            });
+          }
+        }
+
+        function onParentMouseLeave() {
+          if (scope.whyShowing === 'hover') {
+            scope.$apply(function () {
+              hide();
+            });
+          }
+        }
+
+        function onScroll() {
+          var top = $window.pageYOffset;
+          scroll.time = Date.now();
+          scroll.deltaY = top - scroll.top;
+          scroll.top = top;
+
+          if (hideIfScrollTop && hideIfScrollTop(top)) {
+            hide();
+          }
+        }
+
+        function onWinResize() {
+          winHeight = $window.innerHeight;
+
+          if (hideIfScrollTop && hideIfScrollTop($window.pageYOffset)) {
+            hide();
+          }
+        }
+
+        function onVisibilityChangeBeforeShow() {
+          if ($window.document.hidden) {
+            clearShowTimeout();
+          } else {
+            attemptAutoShowAfter(2000);
+          }
+        }
+
+
+        //
+        // Initialization
+        //
+
+        var showTimeout;
+        var minSpace = 210;
+        var hideIfScrollTop;
+        var scroll = {top: $window.pageYOffset};
+        var winHeight = $window.innerHeight;
+
+        _.extend(scope, _.pick(scope.library.abTestTreatment.data, 'mainHtml', 'quoteHtml', 'quoteAttribution'));
+
+        if (!$window.document.hidden) {
+          attemptAutoShowAfter(5000);
+        }
+
+        var button = element.next('.kf-lh-follow-btn');
+        button.on('mouseenter', onParentMouseEnter);
+        button.on('mouseleave', onParentMouseLeave);
+        $window.addEventListener('scroll', onScroll);
+        $window.addEventListener('resize', onWinResize);
+        $window.addEventListener('visibilitychange', onVisibilityChangeBeforeShow);
         scope.$on('$destroy', function () {
-          $window.removeEventListener(adjustAutoCTAPosition);
+          button.off('mouseenter', onParentMouseEnter);
+          button.off('mouseleave', onParentMouseLeave);
+          $window.removeEventListener('scroll', onScroll);
+          $window.removeEventListener('resize', onWinResize);
+          $window.removeEventListener('visibilitychange', onVisibilityChangeBeforeShow);
         });
 
-        //
-        // On link.
-        //
-        if (scope.isUserLoggedOut) {
-          var treatment = scope.library.abTestTreatment;
-          if (!treatment || treatment.isControl || platformService.isSupportedMobilePlatform()) {
-            return;
+        scope.$on('$destroy', $rootScope.$on('$stateChangeStart', function () {  // e.g. library search
+          if (scope.whyShowing === 'timer') {
+            hide();
+          } else {
+            clearShowTimeout();
           }
+        }));
 
-          // Create CTA tooltip.
-          var cta = angular.element($templateCache.get('libraries/libraryHeaderFollowButtonCta.tpl.html'));
-          $rootElement.find('html').append(cta);
-          $compile(cta)(scope);
-
-          var ctaOuterArrow = cta.find('.kf-lh-fbc-arrow-outer');
-          var ctaInnerArrow = cta.find('.kf-lh-fbc-arrow-inner');
-          var ctaArrowHeight = 15;
-
-          // The CTA is initially hidden.
-          cta.hide();
-          var autoCTAShowing = false;
-
-          var kfHeaderHeight = angular.element('.kf-header').outerHeight();
-
-          // Populate the CTA content.
-          scope.ctaMainText = treatment.data.mainText;
-          scope.ctaQuote = treatment.data.quote;
-          scope.ctaQuoteAttribution = treatment.data.quoteAttribution;
-
-          // Show the CTA after a certain amount of time.
-          var ctaShown = false;
-          var autoShowCTAPromise = null;
-          autoShowCTA(5000);
-
-          // Show the CTA automatically when the user returns to the library page.
-          $window.addEventListener('visibilitychange', autoShowCTAUnlessHidden);
-          scope.$on('$destroy', function () {
-            $window.removeEventListener('visibilitychange', autoShowCTAUnlessHidden);
-          });
-        }
-
-        var deregisterStateChange = $rootScope.$on('$stateChangeStart', function () {
-          $timeout.cancel(autoShowCTAPromise);
-          autoShowCTAPromise = null;
-          hideCTA();
-        });
-        scope.$on('$destroy', deregisterStateChange);
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeaderFollowButtonCta.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeaderFollowButtonCta.styl
@@ -1,41 +1,81 @@
-kf-lh-fbc-blue = #0081f1
-kf-lh-fbc-gray = #9ea4aa
-kf-lh-fbc-width = 250px
-kf-lh-fbc-arrow-border-width = 15px
-
 .kf-lh-fbc
+  border-color = #0081f1
   position: absolute
-  border: 1px solid kf-lh-fbc-blue
+  margin-left: 50%
+  transform: translate(-50%)
+  border: 1px solid border-color
   border-radius: 12px
   padding: 30px 30px 10px
-  width: kf-lh-fbc-width
+  width: 250px
+  line-height: 1.25
   font-family: Lato, Helvetica, Arial, sans-serif
   font-size: 14px
   text-align: center
   background: #fff
-  z-index: 500
 
-.kf-lh-fbc-arrow-outer
-.kf-lh-fbc-arrow-inner
-  position: absolute
-  left: (kf-lh-fbc-width/2) + kf-lh-fbc-arrow-border-width
-  border-left: kf-lh-fbc-arrow-border-width solid transparent
-  border-right: kf-lh-fbc-arrow-border-width solid transparent
-  width: 0
-  height: 0
-  content: ''
+  &.ng-enter
+    transition: opacity .16s linear, transform .16s
 
-.kf-lh-fbc-arrow-outer.kf-lh-fbc-arrow-bottom
-  border-top: kf-lh-fbc-arrow-border-width solid kf-lh-fbc-blue
+  &.ng-leave
+    transition: opacity .16s, transform .16s
 
-.kf-lh-fbc-arrow-inner.kf-lh-fbc-arrow-bottom
-  border-top: kf-lh-fbc-arrow-border-width solid #fff
+  .kf-above>&
+    bottom: 100%
+    margin-bottom: 20px
+    transform-origin: center bottom
 
-.kf-lh-fbc-arrow-outer.kf-lh-fbc-arrow-top
-  border-bottom: kf-lh-fbc-arrow-border-width solid kf-lh-fbc-blue
+    &.ng-enter:not(.ng-enter-active)
+    &.ng-leave.ng-leave-active
+      opacity: 0
+      transform: translate(-50%,12px) scale(.86)
 
-.kf-lh-fbc-arrow-inner.kf-lh-fbc-arrow-top
-  border-bottom: kf-lh-fbc-arrow-border-width solid #fff
+  .kf-below>&
+    top: 100%
+    margin-top: 20px
+    transform-origin: center top
+
+    &.ng-enter:not(.ng-enter-active)
+    &.ng-leave.ng-leave-active
+      opacity: 0
+      transform: translate(-50%,-12px) scale(.86)
+
+  &::before
+    content: ''
+    position: absolute
+    width: 0
+    height: 0
+    left: 50%
+    margin-left: -15px
+    border-left: 15px solid transparent
+    border-right: 15px solid transparent
+
+  .kf-above>&::before
+    top: 100%
+    border-top: 15px solid border-color
+
+  .kf-below>&::before
+    bottom: 100%
+    border-bottom: 15px solid border-color
+
+  &::after
+    content: ''
+    position: absolute
+    width: 0
+    height: 0
+    left: 50%
+    margin-left: -15px
+    border-left: 15px solid transparent
+    border-right: 15px solid transparent
+
+  .kf-above>&::after
+    top: 100%
+    margin-top: -1px
+    border-top: 15px solid #fff
+
+  .kf-below>&::after
+    bottom: 100%
+    margin-bottom: -1px
+    border-bottom: 15px solid #fff
 
 .kf-lh-fbc-main-text
   font-size: 1.1em
@@ -46,11 +86,10 @@ kf-lh-fbc-arrow-border-width = 15px
   font-style: italic
 
 .kf-lh-fbc-user-quote
-  color: kf-lh-fbc-blue
+  color: border-color
 
 .kf-lh-fbc-user-quote-by
   font-size: 0.9em
   padding: 10px 0 12px
-  color: kf-lh-fbc-gray
+  color: #9ea4aa
   text-align: right
-

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeaderFollowButtonCta.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeaderFollowButtonCta.tpl.html
@@ -1,15 +1,10 @@
-<div class="kf-lh-fbc">
-  <span class="kf-lh-fbc-arrow-outer"
-    ng-class="{'kf-lh-fbc-arrow-bottom': ctaShownAbove, 'kf-lh-fbc-arrow-top': !ctaShownAbove}"></span>
-  <span class="kf-lh-fbc-arrow-inner"
-    ng-class="{'kf-lh-fbc-arrow-bottom': ctaShownAbove, 'kf-lh-fbc-arrow-top': !ctaShownAbove}"></span>
-
-  <a ng-show="showX" class="dialog-x" href="javascript:" ng-click="closeCTA()"></a>
+<div class="kf-lh-fbc" ng-if="whyShowing">
+  <a class="dialog-x" href="javascript:" ng-click="onClickX()" ng-if="whyShowing === 'timer'"></a>
   <div class="kf-lh-fbc-content">
-    <div class="kf-lh-fbc-main-text" ng-bind-html="ctaMainText"></div>
+    <div class="kf-lh-fbc-main-text" ng-bind-html="mainHtml"></div>
     <div class="kf-lh-fbc-user-quote-container">
-      <q class="kf-lh-fbc-user-quote" ng-bind-html="ctaQuote"></q>
-      <footer class="kf-lh-fbc-user-quote-by">{{ ctaQuoteAttribution }}</footer>
+      <q class="kf-lh-fbc-user-quote" ng-bind-html="quoteHtml"></q>
+      <footer class="kf-lh-fbc-user-quote-by">{{quoteAttribution}}</footer>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #13779, which was doing too much DOM reading+writing in a scroll handler and failed to deregister the scroll handler when the user navigated to a different page.

This is an alternative to the #13785 approach, which hid and then re-showed the promotional callout in a different position if it got to where it didn’t fit. Instead, we now anticipate situations where we wouldn’t be able to confidently show the callout very long (due to active scrolling) and slightly delay showing it in those cases.
