### PR TITLE
Trimming emails that come in.

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/mail/EmailAddress.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/EmailAddress.scala
@@ -47,8 +47,9 @@ object EmailAddress {
   }
 
   def validate(address: String): Try[EmailAddress] = {
-    if (isValid(address)) {
-      Success(EmailAddress(canonicalize(address)))
+    val trimmed = address.trim
+    if (isValid(trimmed)) {
+      Success(EmailAddress(canonicalize(trimmed)))
     } else {
       Failure(new IllegalArgumentException(s"Invalid email address: $address"))
     }


### PR DESCRIPTION
@stkem @thassss @jaredpetker @eishay 

This seems like the easiest place to do it.

The additional logging found that it's quite common for social signups to submit a form with a space at the end of the address. Looks like we've lost a few signups this way (people have tried several times, and can't figure out why their signup isn't working). Fortunately, easy fix.
