### PR TITLE
Fix internSystemGeneratedLibraries

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -743,6 +743,7 @@ class LibraryCommander @Inject() (
     db.readWrite(attempts = 3) { implicit session =>
       val libMem = libraryMembershipRepo.getWithUserId(userId, None)
       val allLibs = libraryRepo.getByUser(userId, None)
+      val user = userRepo.get(userId)
 
       // Get all current system libraries, for main/secret, make sure only one is active.
       // This corrects any issues with previously created libraries / memberships
@@ -754,27 +755,33 @@ class LibraryCommander @Inject() (
           case (kind, libs) =>
             val (slug, name, visibility) = if (kind == LibraryKind.SYSTEM_MAIN) ("main", "Main Library", LibraryVisibility.DISCOVERABLE) else ("secret", "Secret Library", LibraryVisibility.SECRET)
 
-            val activeLib = libs.head._2.copy(state = LibraryStates.ACTIVE, slug = LibrarySlug(slug), name = name, visibility = visibility, memberCount = 1)
-            val membership = libMem.find(m => m.libraryId == activeLib.id.get && m.access == LibraryAccess.OWNER)
-            if (membership.isEmpty) airbrake.notify(s"user $userId - non-existing ownership of library kind $kind (id: ${activeLib.id.get})")
-            val activeMembership = membership.getOrElse(LibraryMembership(libraryId = activeLib.id.get, userId = userId, access = LibraryAccess.OWNER)).copy(state = LibraryMembershipStates.ACTIVE)
-            val active = (activeMembership, activeLib)
-            if (libs.tail.length > 0) airbrake.notify(s"user $userId - duplicate active ownership of library kind $kind (ids: ${libs.tail.map(_._2.id.get)})")
-            val otherLibs = libs.tail.map {
-              case (a, l) =>
-                val inactMem = libMem.find(_.libraryId == l.id.get)
-                  .getOrElse(LibraryMembership(libraryId = activeLib.id.get, userId = userId, access = LibraryAccess.OWNER))
-                  .copy(state = LibraryMembershipStates.INACTIVE)
-                (inactMem, l.copy(state = LibraryStates.INACTIVE))
+            if (user.state == UserStates.ACTIVE) {
+              val activeLib = libs.head._2.copy(state = LibraryStates.ACTIVE, slug = LibrarySlug(slug), name = name, visibility = visibility, memberCount = 1)
+              val membership = libMem.find(m => m.libraryId == activeLib.id.get && m.access == LibraryAccess.OWNER)
+              if (membership.isEmpty) airbrake.notify(s"user $userId - non-existing ownership of library kind $kind (id: ${activeLib.id.get})")
+              val activeMembership = membership.getOrElse(LibraryMembership(libraryId = activeLib.id.get, userId = userId, access = LibraryAccess.OWNER)).copy(state = LibraryMembershipStates.ACTIVE)
+              val active = (activeMembership, activeLib)
+              if (libs.tail.length > 0) airbrake.notify(s"user $userId - duplicate active ownership of library kind $kind (ids: ${libs.tail.map(_._2.id.get)})")
+              val otherLibs = libs.tail.map {
+                case (a, l) =>
+                  val inactMem = libMem.find(_.libraryId == l.id.get)
+                    .getOrElse(LibraryMembership(libraryId = activeLib.id.get, userId = userId, access = LibraryAccess.OWNER))
+                    .copy(state = LibraryMembershipStates.INACTIVE)
+                  (inactMem, l.copy(state = LibraryStates.INACTIVE))
+              }
+              active +: otherLibs
+            } else { // do not reactivate libraries / memberships for nonactive users
+              libs
             }
-            active +: otherLibs
         }.flatten.toList // force eval
 
-      // Save changes
-      sysLibs.map {
-        case (mem, lib) =>
-          libraryRepo.save(lib)
-          libraryMembershipRepo.save(mem)
+      // save changes for active users only
+      if (sysLibs.nonEmpty && user.state == UserStates.ACTIVE) {
+        sysLibs.map {
+          case (mem, lib) =>
+            libraryRepo.save(lib)
+            libraryMembershipRepo.save(mem)
+        }
       }
 
       // If user is missing a system lib, create it

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/email/EmailRecosController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/email/EmailRecosController.scala
@@ -37,7 +37,6 @@ class EmailRecosController @Inject() (
   }
 
   def keepReco(uriId: ExternalId[NormalizedURI]) = UserAction { request =>
-    println(s"keepReco: uriId=$uriId userId=${request.userId}")
     db.readOnlyReplica(uriRepo.getOpt(uriId)(_)) map { uri =>
       val source = KeepSource.emailReco
       val hcb = heimdalContextBuilder.withRequestInfoAndSource(request, source)

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/LibraryChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/LibraryChecker.scala
@@ -26,11 +26,11 @@ class LibraryChecker @Inject() (
     val currentTime = DateTime.now()
     val hourInd = currentTime.hourOfDay().get
     val minuteInd = currentTime.minuteOfHour().get / 10
+    val index = hourInd * 6 + minuteInd // hour * 6 + minute / 10 (int div)
 
     db.readOnlyMaster { implicit s =>
-      val index = hourInd * 6 + minuteInd // hour * 6 + minute / 10 (int div)
-      val pageSize = userRepo.count / 144 // 144 = 24 (hours per day) * 6 (10 minute intervals per hour)
-      userRepo.page(index, pageSize)
+      val pageSize = userRepo.countIncluding(UserStates.ACTIVE) / 144 // 144 = 24 (hours per day) * 6 (10 minute intervals per hour)
+      userRepo.pageIncluding(UserStates.ACTIVE)(index, pageSize)
     }.map { u =>
       // libraryCommander.internSystemGeneratedLibraries does the following...
       // takes the earliest MAIN & SECRET Library created for a user

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -5,6 +5,7 @@ import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.commanders._
 import com.keepit.common.actor.FakeActorSystemModule
 import com.keepit.common.controller._
+import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.db._
 
 import com.keepit.common.healthcheck.FakeAirbrakeModule
@@ -55,7 +56,6 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
 
       val (user, bookmark1, bookmark2, collections) = db.readWrite { implicit s =>
         val user1 = userRepo.save(User(firstName = "Andrew", lastName = "C", createdAt = t1, username = Username("test"), normalizedUsername = "test"))
-        libCommander.internSystemGeneratedLibraries(user1.id.get)
         val uri1 = uriRepo.save(NormalizedURI.withHash(prenormalize("http://www.google.com/"), Some("Google")))
         val uri2 = uriRepo.save(NormalizedURI.withHash(prenormalize("http://www.amazon.com/"), Some("Amazon")))
 
@@ -122,7 +122,6 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
 
       val (user, bookmark1, bookmark2, collections) = db.readWrite { implicit s =>
         val user1 = userRepo.save(User(firstName = "Andrew", lastName = "C", createdAt = t1, username = Username("test2"), normalizedUsername = "test2"))
-        libCommander.internSystemGeneratedLibraries(user1.id.get)
 
         uriRepo.count === 0
         val uri1 = uriRepo.save(NormalizedURI.withHash(prenormalize("http://www.google.com/"), Some("Google")))
@@ -191,7 +190,6 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
 
       val (user, collections) = db.readWrite { implicit s =>
         val user1 = userRepo.save(User(firstName = "Andrew", lastName = "C", createdAt = t1, username = Username("test3"), normalizedUsername = "test3"))
-        libCommander.internSystemGeneratedLibraries(user1.id.get)
         uriRepo.count === 0
 
         val collections = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("myCollaction1"))) ::
@@ -243,13 +241,9 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
       val keeper = KeepSource.keeper
       val initLoad = KeepSource.bookmarkImport
 
-      val libCommander = inject[LibraryCommander]
-
-      val (user1, user2, bookmark1, bookmark2, bookmark3) = db.readWrite { implicit s =>
+      val (user1, user2, bookmark1, bookmark2, bookmark3, lib1) = db.readWrite { implicit s =>
         val user1 = userRepo.save(User(firstName = "Andrew", lastName = "C", createdAt = t1, username = Username("test1"), normalizedUsername = "test1"))
         val user2 = userRepo.save(User(firstName = "Eishay", lastName = "S", createdAt = t2, username = Username("test"), normalizedUsername = "test"))
-        libCommander.internSystemGeneratedLibraries(user1.id.get)
-        libCommander.internSystemGeneratedLibraries(user2.id.get)
 
         uriRepo.count === 0
         val uri1 = uriRepo.save(NormalizedURI.withHash("http://www.google.com/", Some("Google")))
@@ -271,9 +265,9 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
           uriId = uri1.id.get, source = initLoad, createdAt = t2.plusDays(1), keptAt = t2.plusDays(1), state = KeepStates.ACTIVE,
           visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get), inDisjointLib = lib1.isDisjoint))
 
-        (user1, user2, bookmark1, bookmark2, bookmark3)
+        (user1, user2, bookmark1, bookmark2, bookmark3, lib1)
       }
-
+      val pubLibId1 = Library.publicId(lib1.id.get)(inject[PublicIdConfiguration])
       val keeps = db.readWrite { implicit s =>
         keepRepo.getByUser(user1.id.get, None, None, 100)
       }
@@ -309,7 +303,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
             "isPrivate":false,
             "createdAt":"${bookmark2.keptAt.toStandardTimeString}",
             "others":1,
-            "keeps":[{"id":"${bookmark2.externalId}", "mine":true, "removable":true, "visibility":"${bookmark2.visibility.value}","libraryId":"lzmfsKLJyou6"}],
+            "keeps":[{"id":"${bookmark2.externalId}", "mine":true, "removable":true, "visibility":"${bookmark2.visibility.value}","libraryId":"${pubLibId1.id}"}],
             "keepers":[{"id":"${user2.externalId.toString}","firstName":"Eishay","lastName":"S","pictureName":"0.jpg", "username":"test"}],
             "keepersOmitted": 0,
             "keepersTotal": 3,
@@ -321,7 +315,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
             "hashtags":[],
             "summary":{},
             "siteName":"Amazon",
-            "libraryId":"lzmfsKLJyou6"},
+            "libraryId":"${pubLibId1.id}"},
           {
             "id":"${bookmark1.externalId.toString}",
             "title":"G1",
@@ -329,7 +323,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
             "isPrivate":false,
             "createdAt":"${bookmark1.keptAt.toStandardTimeString}",
             "others":0,
-            "keeps":[{"id":"${bookmark1.externalId}", "mine":true, "removable":true, "visibility":"${bookmark1.visibility.value}", "libraryId":"lzmfsKLJyou6"}],
+            "keeps":[{"id":"${bookmark1.externalId}", "mine":true, "removable":true, "visibility":"${bookmark1.visibility.value}", "libraryId":"${pubLibId1.id}"}],
             "keepers":[],
             "keepersOmitted": 0,
             "keepersTotal": 1,
@@ -341,7 +335,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
             "hashtags":[],
             "summary":{},
             "siteName":"Google",
-            "libraryId":"lzmfsKLJyou6"}
+            "libraryId":"${pubLibId1.id}"}
         ]}
       """)
       Json.parse(contentAsString(result)) must equalTo(expected)
@@ -504,14 +498,9 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
       val keeper = KeepSource.keeper
       val initLoad = KeepSource.bookmarkImport
 
-      val libCommander = inject[LibraryCommander]
-
-      val (user, bookmark1, bookmark2, bookmark3) = db.readWrite { implicit s =>
+      val (user, bookmark1, bookmark2, bookmark3, lib1) = db.readWrite { implicit s =>
         val user1 = userRepo.save(User(firstName = "Andrew", lastName = "C", createdAt = t1, username = Username("test1"), normalizedUsername = "test1"))
         val user2 = userRepo.save(User(firstName = "Eishay", lastName = "S", createdAt = t2, username = Username("test"), normalizedUsername = "test"))
-
-        libCommander.internSystemGeneratedLibraries(user1.id.get)
-        libCommander.internSystemGeneratedLibraries(user2.id.get)
 
         uriRepo.count === 0
         val uri1 = uriRepo.save(NormalizedURI.withHash("http://www.google.com/", Some("Google")))
@@ -533,8 +522,10 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
           uriId = uri1.id.get, source = initLoad, createdAt = t2.plusDays(1), keptAt = t2.plusDays(1), state = KeepStates.ACTIVE,
           visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(lib1.id.get), inDisjointLib = lib1.isDisjoint))
 
-        (user1, bookmark1, bookmark2, bookmark3)
+        (user1, bookmark1, bookmark2, bookmark3, lib1)
       }
+
+      val pubLibId1 = Library.publicId(lib1.id.get)(inject[PublicIdConfiguration])
 
       val keeps = db.readWrite { implicit s =>
         keepRepo.getByUser(user.id.get, None, None, 100)
@@ -569,7 +560,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
                 "isPrivate":false,
                 "createdAt":"2013-02-16T23:59:00.000Z",
                 "others":0,
-                "keeps":[{"id":"${bookmark2.externalId}", "mine":true, "removable":true, "visibility":"${bookmark2.visibility.value}","libraryId":"lzmfsKLJyou6"}],
+                "keeps":[{"id":"${bookmark2.externalId}", "mine":true, "removable":true, "visibility":"${bookmark2.visibility.value}","libraryId":"${pubLibId1.id}"}],
                 "keepers":[],
                 "keepersOmitted": 0,
                 "keepersTotal": 1,
@@ -581,7 +572,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
                 "hashtags":[],
                 "summary":{},
                 "siteName":"Amazon",
-                "libraryId":"lzmfsKLJyou6"
+                "libraryId":"${pubLibId1.id}"
               }
             ]
           }
@@ -595,8 +586,6 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
       val user = db.readWrite { implicit session =>
         userRepo.save(User(firstName = "Eishay", lastName = "Smith", username = Username("test"), normalizedUsername = "test"))
       }
-
-      inject[LibraryCommander].internSystemGeneratedLibraries(user.id.get)
 
       val path = com.keepit.controllers.mobile.routes.MobileKeepsController.saveCollection().url
       path === "/m/1/collections/create"
@@ -626,7 +615,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
       withDb(controllerTestModules: _*) { implicit injector =>
         val (user, collections) = db.readWrite { implicit session =>
           val user = userRepo.save(User(firstName = "Eishay", lastName = "Smith", username = Username("test"), normalizedUsername = "test"))
-          inject[LibraryCommander].internSystemGeneratedLibraries(user.id.get)
+
           val collectionRepo = inject[CollectionRepo]
           val collections = collectionRepo.save(Collection(userId = user.id.get, name = Hashtag("myCollaction1"))) ::
             collectionRepo.save(Collection(userId = user.id.get, name = Hashtag("myCollaction2"))) ::


### PR DESCRIPTION
@eishay @andrewconner @yingjieMiao 
- have `LibraryChecker` only page through active users
- have an extra safety layer for `internSystemGeneratedLibraries()` to also check for active user state

The second change caused a bunch of tests to fail (from nested readWrite operations) and bug out, so would be nice if there was another pair of eyes to check the tests aren't changed significantly. Some calls to `internSystem()` were not used at all either, so removed those from the tests as well.
