### PR TITLE
temporary to fake-send activity emails to users

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ActivityFeedEmailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ActivityFeedEmailSender.scala
@@ -156,7 +156,7 @@ class ActivityFeedEmailSenderImpl @Inject() (
           subject = subject,
           category = NotificationCategory.System.ADMIN,
           htmlBody = LargeString(body))
-        db.readWrite { implicit rw => postOffice.sendMail(mail) }
+      //        db.readWrite { implicit rw => postOffice.sendMail(mail) }
       case Failure(e) =>
         log.error(s"ActivityEmail.apply failed userIds=${sendTo}", e)
     }
@@ -174,7 +174,8 @@ class ActivityFeedEmailSenderImpl @Inject() (
 
     // TODO remove this filter when we have quality library recos for users w/o keeps
     keepRepo.getCountByUsersAndSource(userIds, Set(KeepSource.keeper, KeepSource.mobile)).collect {
-      case (id, count) if count >= 20 && (id.id <= 3 || id.id > 1215) => id // TODO remove the id < / > condition safter first round of emails sent
+      //case (id, count) if count >= 20 => id
+      case (id, count) if id.id <= 1215 => id // TODO remove after deployed and emails mock-sent once
     }.toSet
   }
 
@@ -261,14 +262,15 @@ class ActivityFeedEmailSenderImpl @Inject() (
             val htmlBody = views.html.email.v3.activityFeed(activityData)
             // trim whitespace at the beginning of each line
             val trimmedHtml = Html(htmlBody.body.trim().replaceAll("(?m)^\\s+", ""))
-            Some(EmailToSend(
-              from = SystemEmailAddress.NOTIFICATIONS,
-              to = toDest,
-              subject = subjectLine,
-              htmlTemplate = trimmedHtml,
-              category = NotificationCategory.User.ACTIVITY,
-              templateOptions = Seq(TemplateOptions.CustomLayout).toMap
-            ))
+            //            Some(EmailToSend(
+            //              from = SystemEmailAddress.NOTIFICATIONS,
+            //              to = toDest,
+            //              subject = subjectLine,
+            //              htmlTemplate = trimmedHtml,
+            //              category = NotificationCategory.User.ACTIVITY,
+            //              templateOptions = Seq(TemplateOptions.CustomLayout).toMap
+            //            ))
+            None
           }
         }
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/ActivityFeedEmailSenderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/ActivityFeedEmailSenderTest.scala
@@ -191,15 +191,16 @@ class ActivityFeedEmailSenderTest extends Specification with ShoeboxTestInjector
         Await.ready(senderF, Duration(5, "seconds"))
 
         val emails = db.readOnlyMaster { implicit s => inject[ElectronicMailRepo].all() }.sortBy(_.to.head.address)
-        val email1 :: email2 :: Nil = emails.filter(_.category == NotificationCategory.toElectronicMailCategory(NotificationCategory.User.ACTIVITY))
+        emails.size === 0
+        //        val email1 :: email2 :: Nil = emails.filter(_.category == NotificationCategory.toElectronicMailCategory(NotificationCategory.User.ACTIVITY))
+        //
+        //        val activityEmails = db.readOnlyMaster { implicit s => inject[ActivityEmailRepo].all }
+        //        activityEmails.size === 2
 
-        val activityEmails = db.readOnlyMaster { implicit s => inject[ActivityEmailRepo].all }
-        activityEmails.size === 2
-
-        val activityEmail1 = activityEmails.find(_.userId == user1.id.get).get
-        activityEmail1.otherFollowedLibraries.get.size === 4
-        activityEmail1.userFollowedLibraries.get.size === 1
-        activityEmail1.libraryRecommendations.get.size === 3
+        //        val activityEmail1 = activityEmails.find(_.userId == user1.id.get).get
+        //        activityEmail1.otherFollowedLibraries.get.size === 4
+        //        activityEmail1.userFollowedLibraries.get.size === 1
+        //        activityEmail1.libraryRecommendations.get.size === 3
 
         // useful for quick-and-dirty testing
         //        val html1: String = email1.htmlBody
@@ -208,8 +209,8 @@ class ActivityFeedEmailSenderTest extends Specification with ShoeboxTestInjector
         //        fw.write(html1)
         //        fw.close()
 
-        email1.to === Seq(EmailAddress("u1@kifi.com"))
-        email2.to === Seq(EmailAddress("u2@kifi.com"))
+        //        email1.to === Seq(EmailAddress("u1@kifi.com"))
+        //        email2.to === Seq(EmailAddress("u2@kifi.com"))
 
       }
     }


### PR DESCRIPTION
@stkem 

going to run the activity email sender once w/o actually sending the email just to populate the activity_emails table with recos these users likely received last Thursday
