### PR TITLE
having /ext/guide response include the library path too

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtUserController.scala
@@ -36,11 +36,9 @@ class ExtUserController @Inject() (
 
   def getGuideInfo() = UserAction { request =>
     val (personaKeep, libOpt) = userPersonaCommander.getPersonaKeepAndLibrary(request.userId)
-    val libObj = libOpt.map { lib =>
-      Json.obj("library" ->
-        Json.obj("id" -> Library.publicId(lib.id.get), "name" -> lib.name, "color" -> lib.color)
-      )
-    }.getOrElse(Json.obj())
-    Ok(Json.obj("keep" -> Json.toJson(personaKeep)) ++ libObj)
+    Ok(Json.obj(
+      "keep" -> personaKeep,
+      "libraryId" -> libOpt.map(lib => Library.publicId(lib.id.get))
+    ))
   }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtUserControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtUserControllerTest.scala
@@ -59,7 +59,8 @@ class ExtUserControllerTest extends Specification with ShoeboxTestInjector with 
                 "query":"steve+jobs",
                 "title":"Steve Jobs: How to live before you die | Talk Video | TED.com",
                 "matches":{"title":[[0,5],[6,4]],"url":[[25,5],[31,4]]},"track":"steveJobsSpeech"
-              }
+              },
+              "libraryId":null
             }
            """)
 
@@ -84,11 +85,7 @@ class ExtUserControllerTest extends Specification with ShoeboxTestInjector with 
                 "title":"Steve Jobs: How to live before you die | Talk Video | TED.com",
                 "matches":{"title":[[0,5],[6,4]],"url":[[25,5],[31,4]]},"track":"steveJobsSpeech"
               },
-              "library":{
-                "id":"${Library.publicId(personaLibOpt.get.id.get).id}",
-                "name":"Techie Picks",
-                "color":"${personaLibOpt.get.color.get.hex}"
-              }
+              "libraryId":"${Library.publicId(personaLibOpt.get.id.get).id}"
             }
            """)
       }


### PR DESCRIPTION
just for clarity, so that it won’t feel weird on the receiving end that the other fields aren’t used

@ahsu1230 
