### PR TITLE
unit test for new mobile reco endpoint

### DIFF
--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/FakeRecommendationsCommander.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/FakeRecommendationsCommander.scala
@@ -41,12 +41,12 @@ class FakeRecommendationsCommander @Inject() (
   var libRecoInfos: Seq[(Id[Library], FullLibRecoInfo)] = Seq.empty
 
   override def topRecos(userId: Id[User], source: RecommendationSource, subSource: RecommendationSubSource, more: Boolean, recencyWeight: Float, context: Option[String]): Future[FullUriRecoResults] =
-    Future.successful(FullUriRecoResults(uriRecoInfos, ""))
+    Future.successful(FullUriRecoResults(uriRecoInfos, "fake_uri_context"))
 
   override def topPublicRecos(userId: Id[User]) = Future.successful(Seq.empty)
 
   override def topPublicLibraryRecos(userId: Id[User], limit: Int, source: RecommendationSource, subSource: RecommendationSubSource, trackDelivery: Boolean = true, context: Option[String]) = {
     val libs = libRecoInfos take limit
-    Future.successful(FullLibRecoResults(libs, ""))
+    Future.successful(FullLibRecoResults(libs, "fake_lib_context"))
   }
 }


### PR DESCRIPTION
@stkem @jaredpetker @DerekBurch @thassss @mrbrown14 

This PR addresses 'duplicated recos' in one user session. Website is already using this in production. 

Basic idea:
1) initially, mobile sends two empty contexts 
2) backend returns recos with uri_context and library_context
3) If mobile needs more recos, it sends back these two contexts back to BE. 
4) BE filters recos according to these contexts, and send back updated recos and  contexts

mobile team:
please consider testing and using this new endpoint:
/m/3/recos/top

the mobile controller method is : 

```
topRecosV3(recency: Float, uriContext: Option[String] ?= None, libContext: Option[String] ?= None)
```
