### PR TITLE
Hot libraries

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
@@ -28,6 +28,7 @@ case class LibraryStatistic(
 
 case class LibraryPageInfo(
   libraryStats: Seq[LibraryStatistic],
+  hotTodayWithStats: Seq[(Double, LibraryStatistic)],
   topDailyFollower: Seq[(Int, LibraryStatistic)],
   topDailyKeeps: Seq[(Int, LibraryStatistic)],
   libraryCount: Int,
@@ -96,7 +97,11 @@ class AdminLibraryController @Inject() (
   def index(page: Int = 0) = AdminUserPage { implicit request =>
     val pageSize = 30
     val topListSize = 15
-    val (stats, topDailyFollower, topDailyKeeps, totalPublishedCount) = db.readOnlyReplica { implicit session =>
+    val (stats, hotTodayWithStats, topDailyFollower, topDailyKeeps, totalPublishedCount) = db.readOnlyReplica { implicit session =>
+      val hotToday = if (page == 0) {
+        libraryMembershipRepo.percentGainSince(clock.now().minusHours(24), totalMoreThan = 0, recentMoreThan = 0, count = topListSize)
+      } else Seq()
+
       val topDailyFollower = if (page == 0) {
         libraryMembershipRepo.mostMembersSince(topListSize, clock.now().minusHours(24))
       } else Seq()
@@ -109,7 +114,7 @@ class AdminLibraryController @Inject() (
 
       val statsByLibraryId = {
         val pagedLibrariesById = pagePublished.map(lib => lib.id.get -> lib).toMap
-        val allLibraryIds = pagedLibrariesById.keySet ++ topDailyFollower.map(_._1) ++ topDailyKeeps.map(_._1)
+        val allLibraryIds = pagedLibrariesById.keySet ++ topDailyFollower.map(_._1) ++ topDailyKeeps.map(_._1) ++ hotToday.map(_._1)
         val librariesById = {
           val missingLibraryIds = allLibraryIds -- pagedLibrariesById.keys
           val missingLibraries = if (missingLibraryIds.nonEmpty) libraryRepo.getLibraries(missingLibraryIds) else Map.empty
@@ -119,13 +124,14 @@ class AdminLibraryController @Inject() (
         librariesById.mapValues(lib => buildLibStatistic(lib, usersById(lib.ownerId)))
       }
 
+      val hotTodayWithStats = hotToday.map { case (libId, _, _, growth) => (growth, statsByLibraryId(libId)) }
       val topDailyFollowerWithStats = topDailyFollower.map { case (libId, count) => (count, statsByLibraryId(libId)) }
       val topDailyKeepsWithStats = topDailyKeeps.map { case (libId, count) => (count, statsByLibraryId(libId)) }
       val pagePublishedWithStats = pagePublished.map { lib => statsByLibraryId(lib.id.get) }
 
-      (pagePublishedWithStats, topDailyFollowerWithStats, topDailyKeepsWithStats, libraryRepo.countPublished)
+      (pagePublishedWithStats, hotTodayWithStats, topDailyFollowerWithStats, topDailyKeepsWithStats, libraryRepo.countPublished)
     }
-    val info = LibraryPageInfo(libraryStats = stats, topDailyFollower = topDailyFollower, topDailyKeeps = topDailyKeeps, libraryCount = totalPublishedCount, page = page, pageSize = pageSize)
+    val info = LibraryPageInfo(libraryStats = stats, hotTodayWithStats = hotTodayWithStats, topDailyFollower = topDailyFollower, topDailyKeeps = topDailyKeeps, libraryCount = totalPublishedCount, page = page, pageSize = pageSize)
     Ok(html.admin.libraries(info))
   }
 

--- a/kifi-backend/modules/shoebox/app/views/admin/libraries.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/libraries.scala.html
@@ -9,24 +9,46 @@
   <h2>Top libraries by followers in past 24 hours</h2>
   <table class="table table-bordered">
     <tr>
-      <th>Cnt</th>
-      <th>#</th>
+      <th>New followers</th>
       <th>Owner</th>
       <th>Name</th>
-      <th>Slug</th>
       <th>Keeps</th>
       <th>Members</th>
       <th>Invites</th>
       <th>Date Created</th>
       <th>Date Updated</th>
     </tr>
-  @for(((count,libStat),i) <- libraryData.topDailyFollower.zipWithIndex) {
+  @for((count,libStat) <- libraryData.topDailyFollower) {
     <tr>
       <td>@count</td>
-      <td>@{i+1}</td>
       <td>@adminHelper.userDisplay(libStat.owner)</td>
-      <td>@adminHelper.libraryDisplay(libStat.library)</td>
-      <td><a href="https://www.kifi.com/@{libStat.owner.username.value}/@{libStat.library.slug.value}">@libStat.library.slug.value</a></td>
+      <td>@adminHelper.libraryDisplay(libStat.library) <b><a href="https://www.kifi.com/@{libStat.owner.username.value}/@{libStat.library.slug.value}">→</a></b></td>
+      <td>@libStat.numKeeps</td>
+      <td>@libStat.numMembers</td>
+      <td>@libStat.numInvites</td>
+      <td>@adminHelper.dateTimeDisplay(libStat.library.createdAt)</td>
+      <td>@adminHelper.dateTimeDisplay(libStat.library.updatedAt)</td>
+    </tr>
+  }
+  </table>
+
+  <h2>Hot libraries in past 24 hours</h2>
+  <table class="table table-bordered">
+    <tr>
+      <th>Growth</th>
+      <th>Owner</th>
+      <th>Name</th>
+      <th>Keeps</th>
+      <th>Members</th>
+      <th>Invites</th>
+      <th>Date Created</th>
+      <th>Date Updated</th>
+    </tr>
+  @for((growth,libStat) <- libraryData.topDailyFollower) {
+    <tr>
+      <td>@{"%.0f%%".format(growth*100)}</td>
+      <td>@adminHelper.userDisplay(libStat.owner)</td>
+      <td>@adminHelper.libraryDisplay(libStat.library) <b><a href="https://www.kifi.com/@{libStat.owner.username.value}/@{libStat.library.slug.value}">→</a></b></td>
       <td>@libStat.numKeeps</td>
       <td>@libStat.numMembers</td>
       <td>@libStat.numInvites</td>
@@ -39,8 +61,7 @@
   <h2>Top libraries by keeps in past 24 hours</h2>
   <table class="table table-bordered">
     <tr>
-      <th>Cnt</th>
-      <th>#</th>
+      <th>New keeps</th>
       <th>Owner</th>
       <th>Name</th>
       <th>Slug</th>
@@ -53,10 +74,8 @@
   @for(((count,libStat),i) <- libraryData.topDailyKeeps.zipWithIndex) {
     <tr>
       <td>@count</td>
-      <td>@{i+1}</td>
       <td>@adminHelper.userDisplay(libStat.owner)</td>
-      <td>@adminHelper.libraryDisplay(libStat.library)</td>
-      <td><a href="https://www.kifi.com/@{libStat.owner.username.value}/@{libStat.library.slug.value}">@libStat.library.slug.value</a></td>
+      <td>@adminHelper.libraryDisplay(libStat.library) <b><a href="https://www.kifi.com/@{libStat.owner.username.value}/@{libStat.library.slug.value}">→</a></b></td>
       <td>@libStat.numKeeps</td>
       <td>@libStat.numMembers</td>
       <td>@libStat.numInvites</td>


### PR DESCRIPTION
@eishay Top libraries is now dominated by the recommended libraries everyone sees. This lets us easily see what libraries are "hot", as determined by % growth in the past 24 hours (where there's over a baseline of followers).

To see the list, try running:

``` sql
SELECT tp.*,
       count(lm2.id) AS total_followers,
       new_followers/count(lm2.id) AS growth
FROM
  (SELECT lm.library_id,
          count(*) AS new_followers
   FROM library_membership lm,
        library l
   WHERE l.id = lm.library_id
     AND l.state='active'
     AND l.visibility='published'
     AND lm.created_at > "2015-02-20"
   GROUP BY lm.library_id
   HAVING new_followers > 10
   ORDER BY new_followers DESC) tp,
                                library_membership lm2
WHERE lm2.library_id = tp.library_id
GROUP BY tp.library_id
HAVING total_followers > 10
ORDER BY growth DESC LIMIT 15;
```
