### PR TITLE
keep card does not need to be passed all libraries owned by viewer

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keep.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keep.js
@@ -43,7 +43,6 @@ angular.module('kifi')
       scope: {
         keep: '=',
         library: '=',
-        libraries: '=',
         currentPageOrigin: '@',
         editMode: '=',
         editOptions: '&',

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
@@ -40,7 +40,7 @@
   </div>
   <ol class="kf-my-keeps" smart-scroll scroll-distance="scrollDistance" scroll-disabled="isScrollDisabled()" scroll-next="scrollNext()(keeps.length)">
     <div ng-repeat="keep in keeps" kf-keep-card is-selected="!!selection.isSelected(keep)"
-      keep="keep" library="library" me="me" libraries="libraries" current-page-origin="{{currentPageOrigin}}"
+      keep="keep" library="library" me="me" current-page-origin="{{currentPageOrigin}}"
       toggle-select="selection.toggleSelect(keep)" click-callback="keepClickAction(event, keep)"
       drag-keeps="dragKeeps(keep, event, mouseX, mouseY, selection)" stop-dragging-keeps="stopDraggingKeeps()"
       edit-mode="editMode" edit-options="editOptions()"></div>

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.js
@@ -173,12 +173,10 @@ angular.module('kifi')
 
 // For individual recommendation
 .controller('RecoCtrl', [
-  '$scope', 'modalService', 'recoActionService', 'libraryService',
-  function ($scope, modalService, recoActionService, libraryService) {
+  '$scope', 'modalService', 'recoActionService',
+  function ($scope, modalService, recoActionService) {
     $scope.reasons = $scope.reco.recoData.reasons;
     $scope.reasonIndex = 0;
-
-    $scope.libraries = libraryService.fetchLibraryInfos(false);
 
     $scope.hasReason = function () {
       return $scope.reco.recoData.reasons &&

--- a/kifi-backend/modules/shoebox/angular/src/recos/recosView.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recosView.tpl.html
@@ -32,7 +32,7 @@
           </header>
 
           <div ng-if="reco.recoData.kind === 'keep'" kf-keep-card keep="reco.recoKeep" keep-callback="trackRecoKeep(keep)"
-            click-callback="trackRecoClick(reco)" libraries="libraries" current-page-origin="recommendationsPage"></div>
+            click-callback="trackRecoClick(reco)" current-page-origin="recommendationsPage"></div>
           <div ng-if="reco.recoData.kind === 'library'" kf-reco-library-card library="reco.recoLib"
             follow-callback="trackLibraryFollow(reco.recoLib)" click-library-callback="trackRecoClick(reco)"></div>
 


### PR DESCRIPTION
@andrewconner 

I assume this was being done for the keep-to-library widget, but it now gets those libraries directly.
