### PR TITLE
perturbation for special libraries

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/persona/PersonaRecommendationPool.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/persona/PersonaRecommendationPool.scala
@@ -15,7 +15,7 @@ trait FixedSetPersonaRecoPool[T, R] extends PersonaRecommendationPool[R] {
   protected val specialBoostScore: Float
 
   def perturbation(hasSpecialBoost: Boolean): Float = {
-    if (hasSpecialBoost) specialBoostScore else util.Random.nextFloat()
+    if (hasSpecialBoost) specialBoostScore + util.Random.nextFloat() else util.Random.nextFloat()
   }
 
   def getRecoIdsByPersona(pid: Id[Persona]): Seq[Id[T]] = fixedRecos.getOrElse(pid, Seq())


### PR DESCRIPTION
@stkem @ahsu1230 

Make sure libraries have unique scores. I am worrying any Map or groupBy operation will shadow the libraries with same score. 
