### PR TITLE
3.3.46: refreshing library list later in guide to avoid race condition

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.3.45
+version=3.3.46

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1402,9 +1402,6 @@ api.port.on({
       api.tabs.emit(tab, 'guide', {step: 0, page: data.keep});
     });
     unsilence(false);
-    // be sure to load any newly created persona libraries
-    storeLibraries([]);
-    ajaxLoadLibraries(api.noop);
   },
   track_guide: function (stepParts) {
     tracker.track('user_viewed_pane', {type: 'guide' + stepParts.join('')});
@@ -1703,6 +1700,10 @@ function awaitDeepLink(link, tabId, retrySec) {
         var page = guideData.keep;
         if (step === 1) {
           page = extend({libraryId: (guideData.library || {id: mySysLibIds[0]}).id}, page);
+          if (guideData.library) {
+            storeLibraries([]);
+            ajaxLoadLibraries(api.noop); // load any newly created persona libraries
+          }
         }
         api.tabs.emit(tab, 'guide', {step: step, page: page}, {queue: 1});
       } else if (loc.indexOf('#compose') >= 0) {


### PR DESCRIPTION
@ahsu1230 

I saw your pull request go by that delays the creation of persona libs until the Done button is clicked, which is right when the guide is triggered and the extension loads the library list. Delaying to avoid a race condition.
