### PR TITLE
mobile endpoints for setting notifs read

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
@@ -411,7 +411,17 @@ class NotificationCommander @Inject() (
 
   def setAllNotificationsRead(userId: Id[User]): Unit = {
     log.info(s"Setting all Notifications as read for user $userId.")
-    db.readWrite(attempts = 2) { implicit session => userThreadRepo.markAllRead(userId) }
+    db.readWrite(attempts = 2) { implicit session => userThreadRepo.markAllRead(userId, None) }
+  }
+
+  def setSystemNotificationsRead(userId: Id[User]): Unit = {
+    log.info(s"Setting System Notifications as read for user $userId")
+    db.readWrite(attempts = 2) { implicit session => userThreadRepo.markAllRead(userId, Some(true)) }
+  }
+
+  def setMessageNotificationsRead(userId: Id[User]): Unit = {
+    log.info(s"Setting Messaging Notifications as read for user $userId")
+    db.readWrite(attempts = 2) { implicit session => userThreadRepo.markAllRead(userId, Some(false)) }
   }
 
   def setAllNotificationsReadBefore(user: Id[User], messageId: ExternalId[Message], unreadCount: Int): DateTime = {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
@@ -286,4 +286,16 @@ class MobileMessagingController @Inject() (
     val numUnreadUnmuted = messagingCommander.getUnreadUnmutedThreadCount(request.userId)
     Ok(numUnreadUnmuted.toString)
   }
+
+  def markUnreadNotifications(kind: Option[String] = None) = UserAction { request =>
+    kind match {
+      case Some("system") =>
+        notificationCommander.setSystemNotificationsRead(request.userId) // mark system notifs as read
+      case Some("message") =>
+        notificationCommander.setMessageNotificationsRead(request.userId) // mark message notifs as read
+      case _ =>
+        notificationCommander.setAllNotificationsRead(request.userId) // mark all as read
+    }
+    NoContent
+  }
 }

--- a/kifi-backend/modules/eliza/conf/elizaService.routes
+++ b/kifi-backend/modules/eliza/conf/elizaService.routes
@@ -22,6 +22,7 @@ GET     /m/1/eliza/ws                     @com.keepit.eliza.controllers.shared.S
 GET     /m/1/eliza/notifications          @com.keepit.eliza.controllers.mobile.MobileMessagingController.getNotifications(n: Int, before: Option[String] ?= None)
 GET     /m/1/eliza/notifications/unread          @com.keepit.eliza.controllers.mobile.MobileMessagingController.getUnreadNotifications(n: Int, before: Option[String] ?= None)
 GET     /m/1/eliza/notifications/sent          @com.keepit.eliza.controllers.mobile.MobileMessagingController.getSentNotifications(n: Int, before: Option[String] ?= None)
+POST    /m/1/eliza/notifications/markAsRead @com.keepit.eliza.controllers.mobile.MobileMessagingController.markUnreadNotifications(kind: Option[String] ?= None)
 POST    /m/1/eliza/messages               @com.keepit.eliza.controllers.mobile.MobileMessagingController.sendMessageAction()
 GET     /m/1/eliza/messages/unreadNotificationsCount @com.keepit.eliza.controllers.mobile.MobileMessagingController.getUnreadNotificationsCount()
 POST    /m/1/eliza/messages/:parentId     @com.keepit.eliza.controllers.mobile.MobileMessagingController.sendMessageReplyAction(parentId: ExternalId[MessageThread])


### PR DESCRIPTION
@stkem 
you can use it like so:
`/m/1/eliza/notifications/markAsRead?kind=system` marks only system notifications as read
`/m/1/eliza/notifications/markAsRead?kind=message` marks only message notifs as read
`/m/1/eliza/notifications/markAsRead` marks ALL notifs as read

cc: @jaredpetker @thassss @mrbrown14 @DerekBurch 
