### PR TITLE
preloading FB and Twitter APIs less eagerly since FB API affects tile

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
@@ -102,15 +102,6 @@ angular.module('kifi')
           };
         }
 
-        function preloadSocial() {
-          if (!$FB.failedToLoad && !$FB.loaded) {
-            $FB.init();
-          }
-          if (!$twitter.failedToLoad && !$twitter.loaded) {
-            $twitter.load();
-          }
-        }
-
 
         //
         // Scope methods.
@@ -562,12 +553,20 @@ angular.module('kifi')
           return scope.library.visibility === 'published';
         };
 
+        scope.preloadFB = function () {
+          $FB.init();
+        };
+
         scope.shareFB = function () {
           trackShareEvent('clickedShareFacebook');
           $FB.ui({
             method: 'share',
             href: scope.library.shareFbUrl
           });
+        };
+
+        scope.preloadTwitter = function () {
+          $twitter.load();
         };
 
         scope.shareTwitter = function () {
@@ -732,8 +731,6 @@ angular.module('kifi')
         augmentData();
 
         updateInvite();
-
-        scope.$evalAsync(preloadSocial);
 
         $timeout(function () {
           element.addClass('kf-loaded');  // enables transitions/animations

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
@@ -85,12 +85,12 @@
             <span class="kf-button-icon svg-pen"></span> Manage Library
           </button>
         </div>
-        <a ng-if="isPublic()" class="kf-button kf-button-text-optional kf-lh-share-external" ng-click="shareTwitter()" ng-href="https://twitter.com/intent/tweet?original_referer={{library.shareUrl}}&text={{library.shareText}}&tw_p=tweetbutton&url={{library.shareTwitterUrl}}">
+        <a ng-if="isPublic()" class="kf-button kf-button-text-optional kf-lh-share-external" ng-focus="preloadTwitter()" ng-mouseenter="preloadTwitter()" ng-click="shareTwitter()" ng-href="https://twitter.com/intent/tweet?original_referer={{library.shareUrl}}&text={{library.shareText}}&tw_p=tweetbutton&url={{library.shareTwitterUrl}}">
           <span class="kf-button-icon svg-twitter"></span>
           <span class="kf-button-icon svg-twitter-white"></span><!-- for non-logged-in users -->
           Tweet
         </a>
-        <button ng-if="isPublic()" class="kf-button kf-button-text-optional kf-lh-share-external" ng-click="shareFB()">
+        <button ng-if="isPublic()" class="kf-button kf-button-text-optional kf-lh-share-external" ng-focus="preloadFB()" ng-mouseenter="preloadFB()" ng-click="shareFB()">
           <span class="kf-button-icon svg-facebook"></span>
           <span class="kf-button-icon svg-facebook-white"></span><!-- for non-logged-in users -->
           Post

--- a/kifi-backend/modules/shoebox/angular/src/recos/recoLibraryCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recoLibraryCard.js
@@ -68,15 +68,6 @@ angular.module('kifi')
           }
         }
 
-        function preloadSocial() {
-          if (!$FB.failedToLoad && !$FB.loaded) {
-            $FB.init();
-          }
-          if (!$twitter.failedToLoad && !$twitter.loaded) {
-            $twitter.load();
-          }
-        }
-
 
         //
         // Scope methods.
@@ -86,12 +77,20 @@ angular.module('kifi')
           scope.clippedDescription = false;
         };
 
+        scope.preloadFB = function () {
+          $FB.init();
+        };
+
         scope.shareFB = function () {
           trackShareEvent('clickedShareFacebook');
           $FB.ui({
             method: 'share',
             href: scope.library.shareFbUrl
           });
+        };
+
+        scope.preloadTwitter = function () {
+          $twitter.load();
         };
 
         scope.shareTwitter = function () {
@@ -168,8 +167,6 @@ angular.module('kifi')
         scope.clippedDescription = false;
 
         augmentData();
-
-        $timeout(preloadSocial);
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/recos/recoLibraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recoLibraryCard.tpl.html
@@ -49,10 +49,10 @@
           <button class="kf-button kf-rcl-unfollow-btn" ng-if="alreadyFollowingLibrary()" ng-click="unfollowLibrary()"></button>
           <button class="kf-button kf-rcl-follow-btn" ng-if="!alreadyFollowingLibrary()" ng-click="followLibrary()">Follow Library</button>
         </div>
-        <a class="kf-button kf-button-text-optional" ng-click="shareTwitter()" ng-href="https://twitter.com/intent/tweet?original_referer={{library.shareUrl}}&text={{library.shareText}}&tw_p=tweetbutton&url={{library.shareTwitterUrl}}">
+        <a class="kf-button kf-button-text-optional" ng-focus="preloadTwitter()" ng-mouseenter="preloadTwitter()" ng-click="shareTwitter()" ng-href="https://twitter.com/intent/tweet?original_referer={{library.shareUrl}}&text={{library.shareText}}&tw_p=tweetbutton&url={{library.shareTwitterUrl}}">
           <span class="kf-button-icon svg-twitter"></span> Tweet
         </a>
-        <button class="kf-button kf-button-text-optional" ng-click="shareFB()">
+        <button class="kf-button kf-button-text-optional" ng-focus="preloadFB()" ng-mouseenter="preloadFB()" ng-click="shareFB()">
           <span class="kf-button-icon svg-facebook"></span> Post
         </button>
       </div>


### PR DESCRIPTION
Preloading the FB api on the recos page results in an `fb_root` div being appended to the page body—sometimes immediately after the guide has begun. As a result, the tile would move forward to the front of the stacking order, in front of both the facebook div and the guide. But we want it to stay behind the guide, hence this change.
cc @ahsu1230 
