### PR TITLE
increasing scraper assignLock limit to 5 since theoretically we can have...

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ScraperCallbackHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ScraperCallbackHelper.scala
@@ -28,7 +28,7 @@ class ScraperCallbackHelper @Inject() (
     implicit val scraperConfig: ScraperSchedulerConfig,
     integrityHelpers: UriIntegrityHelpers) extends Logging {
 
-  val assignLock = new ReactiveLock(1, Some(3)) // should not be more then number of scrapers!
+  val assignLock = new ReactiveLock(1, Some(5)) // should not be more then number of scrapers x 2!
 
   private[this] var averageNumberOfTasks = 0.0 // an exponential moving average of the number of tasks assigned to a scraper instance
   private[this] val alpha = 0.3


### PR DESCRIPTION
... up to four in practice we hit it often
