### PR TITLE
if the cluster has at least one offline services, prefer tasks to run on one of them

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/SocialUserInfoRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/SocialUserInfoRepo.scala
@@ -64,7 +64,7 @@ class SocialUserInfoRepoImpl @Inject() (
 
   private val UNPROCESSED_STATES = SocialUserInfoStates.CREATED :: SocialUserInfoStates.FETCHED_USING_FRIEND :: Nil
   private val REFRESHING_STATES = SocialUserInfoStates.FETCHED_USING_SELF :: SocialUserInfoStates.FETCH_FAIL :: Nil
-  private val REFRESH_FREQUENCY = 7
+  private val REFRESH_FREQUENCY = 14
 
   override def save(socialUserInfo: SocialUserInfo)(implicit session: RWSession): SocialUserInfo = {
     val toSave = socialUserInfo.copy(seq = deferredSeqNum())


### PR DESCRIPTION
and reducing social graph refresh to once every two weeks
