### PR TITLE
removing unused route for loading info for one user profile connection

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -96,13 +96,6 @@ class UserController @Inject() (
     }
   }
 
-  def fullConnectionByViewer(ownerExternalId: ExternalId[User]) = MaybeUserAction { request =>
-    val owner = db.readOnlyReplica { implicit s => userRepo.get(ownerExternalId) }
-    val ownerId = owner.id.get
-    val viewer = request.userIdOpt
-    Ok(loadFullConnectionUser(ownerId, BasicUser.fromUser(owner), None, viewer))
-  }
-
   def profileConnections(username: Username, limit: Int, userExtIds: String) = MaybeUserAction.async { request =>
     userCommander.userFromUsername(username) match {
       case None =>

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -354,7 +354,6 @@ GET     /site/user/:name/profile    @com.keepit.controllers.website.UserControll
 GET     /site/user/:name/libraries  @com.keepit.controllers.website.LibraryController.getProfileLibraries(name: Username, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")
 GET     /site/user/:name/connections @com.keepit.controllers.website.UserController.profileConnections(name: Username, n: Int ?= 12, ids: String ?= "")
 GET     /site/user/:name/connections/ids @com.keepit.controllers.website.UserController.profileConnectionIds(name: Username, n: Int ?= 480)
-GET     /site/user/connection       @com.keepit.controllers.website.UserController.fullConnectionByViewer(owner: ExternalId[User])
 
 
 GET     /site/libraries             @com.keepit.controllers.website.LibraryController.getLibrarySummariesByUser()


### PR DESCRIPTION
@eishay cc @ahsu1230 

This can also be achieved using:

```
GET  /site/user/:name/connections?ids=:id
```

However, we may want to use a different route for this—one that doesn’t require a user profile to be specified, since which user profile it’s on is irrelevant. I’ll keep this in mind.
