### PR TITLE
not looking up library owner friend status for every user profile library card

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -584,7 +584,7 @@ class LibraryController @Inject() (
               image = info.image,
               slug = info.slug,
               visibility = info.visibility,
-              owner = BasicUserWithFriendStatus.fromWithoutFriendStatus(info.owner),
+              owner = info.owner,
               numKeeps = info.numKeeps,
               numFollowers = info.numFollowers,
               followers = LibraryCardInfo.showable(info.followers),

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
@@ -51,6 +51,7 @@ case class LibraryModifyRequest(
   color: Option[LibraryColor] = None,
   listed: Option[Boolean] = None)
 
+// TODO: move to BasicUser.scala or something
 case class BasicUserWithFriendStatus(
   externalId: ExternalId[User],
   firstName: String,
@@ -181,7 +182,7 @@ case class LibraryCardInfo(
   image: Option[LibraryImageInfo],
   slug: LibrarySlug,
   visibility: LibraryVisibility,
-  owner: BasicUserWithFriendStatus,
+  owner: BasicUser,
   numKeeps: Int,
   numFollowers: Int,
   followers: Seq[BasicUser],

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -522,8 +522,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                     "firstName":"second",
                     "lastName":"user",
                     "pictureName":"alf.jpg",
-                    "username":"seconduser",
-                    "isFriend":false
+                    "username":"seconduser"
                   },
                   "numKeeps":0,
                   "numFollowers":1,


### PR DESCRIPTION
I don’t remember why I added this in #12989 but mobile and website don’t seem to be using it.

@andrewconner cc @eishay 
