### PR TITLE
fixing numbers in people cards on user profile connections tab

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileConnections.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileConnections.tpl.html
@@ -15,8 +15,8 @@
         </button>
       </div>
       <div>
-        <button class="kf-upc-count" data-n="{{user.mlibs|num}}">
-          <ng-pluralize count="user.mlibs" when="{'one': 'library in common', 'other': 'libraries in common'}"></ng-pluralize>
+        <button class="kf-upc-count" data-n="{{user.mLibraries|num}}">
+          <ng-pluralize count="user.mLibraries" when="{'one': 'library in common', 'other': 'libraries in common'}"></ng-pluralize>
         </button>
       </div>
       <button class="kf-upc-connect">Connect</button>

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
@@ -114,7 +114,7 @@ class UserCommander @Inject() (
     userFromUsername(username) map { user =>
       val basicUserWithFriendStatus = viewer.filter(_.id != user.id) map { viewer =>
         db.readOnlyMaster { implicit session =>
-          friendStatusCommander.augmentWithFriendStatus(viewer.id.get, user.id.get, BasicUser.fromUser(user))
+          friendStatusCommander.augmentUser(viewer.id.get, user.id.get, BasicUser.fromUser(user))
         }
       } getOrElse BasicUserWithFriendStatus.fromWithoutFriendStatus(user)
       db.readOnlyReplica { implicit session =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -51,6 +51,7 @@ class UserController @Inject() (
     networkInfoLoader: NetworkInfoLoader,
     val userActionsHelper: UserActionsHelper,
     friendRequestRepo: FriendRequestRepo,
+    friendStatusCommander: FriendStatusCommander,
     postOffice: LocalPostOffice,
     userConnectionsCommander: UserConnectionsCommander,
     userCommander: UserCommander,
@@ -71,28 +72,26 @@ class UserController @Inject() (
     fortytwoConfig: FortyTwoConfig) extends UserActions with ShoeboxServiceController {
 
   //todo(eishay): caching work!
-  def loadFullConnectionUser(ownerId: Id[User], owner: BasicUser, connectedOpt: Option[Boolean], viewer: Option[Id[User]]): JsValue = {
-    val json = Json.toJson(owner).as[JsObject]
+  def loadFullConnectionUser(userId: Id[User], user: BasicUserWithFriendStatus, viewerIdOpt: Option[Id[User]]): JsValue = {
     db.readOnlyMaster { implicit t =>
-      //global or mutual
-      val libCount = viewer.map(u => libraryRepo.countLibrariesForOtherUser(ownerId, u)).getOrElse(libraryRepo.countLibrariesOfUserFromAnonymous(ownerId)) //not cached
+      val json = Json.toJson(user).as[JsObject]
+      //global or personalized
+      val libCount = viewerIdOpt.map(viewerId => libraryRepo.countLibrariesForOtherUser(userId, viewerId)).getOrElse(libraryRepo.countLibrariesOfUserFromAnonymous(userId)) //not cached
       //global
-      val followersCount = libraryMembershipRepo.countFollowersWithOwnerId(ownerId) //cached
-      val connectionCount = userConnectionRepo.getConnectionCount(ownerId) //cached
+      val followersCount = libraryMembershipRepo.countFollowersWithOwnerId(userId) //cached
+      val connectionCount = userConnectionRepo.getConnectionCount(userId) //cached
       val jsonWithGlobalCounts = json +
-        ("libs" -> JsNumber(libCount)) +
+        ("libraries" -> JsNumber(libCount)) +
         ("followers" -> JsNumber(followersCount)) +
         ("connections" -> JsNumber(connectionCount))
       //mutual
-      viewer.map { u =>
-        val connected = connectedOpt.getOrElse(userConnectionRepo.getConnectionOpt(ownerId, u).exists(_.state == UserConnectionStates.ACTIVE)) //not cached
-        val followingLibCount = libraryRepo.countLibrariesOfOwnerUserFollow(ownerId, u) //not cached
-        val mutualConnectionCount = userConnectionRepo.getMutualConnectionCount(ownerId, u) //cached
+      viewerIdOpt.map { viewerId =>
+        val followingLibCount = libraryRepo.countLibrariesOfOwnerUserFollow(userId, viewerId) //not cached
+        val mutualConnectionCount = userConnectionRepo.getMutualConnectionCount(userId, viewerId) //cached
         jsonWithGlobalCounts +
-          ("connected" -> JsBoolean(connected)) +
-          ("mlibs" -> JsNumber(followingLibCount)) +
-          ("mConnections" -> JsNumber(mutualConnectionCount))
-      }.getOrElse(jsonWithGlobalCounts)
+          ("mConnections" -> JsNumber(mutualConnectionCount)) +
+          ("mLibraries" -> JsNumber(followingLibCount))
+      } getOrElse jsonWithGlobalCounts
     }
   }
 
@@ -103,25 +102,40 @@ class UserController @Inject() (
         Future.successful(NotFound(s"username ${username.value}"))
       case Some(owner) =>
         val ownerId = owner.id.get
-        val viewer = request.userIdOpt.getOrElse(ownerId)
+        val viewerIdOpt = request.userIdOpt
         if (userExtIds.isEmpty) {
-          userConnectionsCommander.getConnectionsSortedByRelationship(viewer, ownerId) map { connections =>
+          userConnectionsCommander.getConnectionsSortedByRelationship(viewerIdOpt.getOrElse(ownerId), ownerId) map { connections =>
             val head = connections.take(limit)
-            val userMap = db.readOnlyMaster { implicit s => basicUserRepo.loadAll(head.map(_.userId).toSet) }
-            val users = head.map(u => userMap(u.userId) -> u.connected)
-            val usersJson = users.map(u => loadFullConnectionUser(ownerId, u._1, Some(u._2), request.userIdOpt))
+            val headFriendIdSet = head.filter(_.connected).map(_.userId).toSet
+            val usersWFS = db.readOnlyMaster { implicit s =>
+              val userMap = basicUserRepo.loadAll(head.map(_.userId).toSet)
+              viewerIdOpt.map { viewerId =>
+                friendStatusCommander.augmentUsers(viewerId, userMap, headFriendIdSet)
+              } getOrElse userMap.mapValues(BasicUserWithFriendStatus.fromWithoutFriendStatus)
+            }
+            val usersJson = usersWFS.map {
+              case (userId, userWFS) =>
+                loadFullConnectionUser(userId, userWFS, viewerIdOpt)
+            }
             Ok(Json.obj("users" -> usersJson, "count" -> connections.size))
           }
         } else {
           Try(userExtIds.split(',').map(ExternalId[User])) match {
             case Success(userIds) =>
-              val users = db.readOnlyMaster { implicit s =>
-                userIds.map(userRepo.getOpt).flatten
+              val usersWFS = db.readOnlyMaster { implicit s =>
+                val userMap = userRepo.getAllUsersByExternalId(userIds).map {
+                  case (extId, user) =>
+                    user.id.get -> BasicUser.fromUser(user)
+                }
+                viewerIdOpt.map { viewerId =>
+                  friendStatusCommander.augmentUsers(viewerId, userMap)
+                } getOrElse userMap.mapValues(BasicUserWithFriendStatus.fromWithoutFriendStatus)
               }
-              val jsons = users.map { user =>
-                loadFullConnectionUser(ownerId, BasicUser.fromUser(user), None, request.userIdOpt)
+              val usersJson = usersWFS.map {
+                case (userId, userWFS) =>
+                  loadFullConnectionUser(userId, userWFS, viewerIdOpt)
               }
-              Future.successful(Ok(Json.obj("users" -> JsArray(jsons))))
+              Future.successful(Ok(Json.obj("users" -> usersJson)))
             case _ =>
               Future.successful(BadRequest("ids invalid"))
           }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/FriendStatusCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/FriendStatusCommanderTest.scala
@@ -22,12 +22,12 @@ class FriendStatusCommanderTest extends Specification with ShoeboxTestInjector {
         val commander = inject[FriendStatusCommander]
 
         db.readOnlyMaster { implicit s =>
-          val u2 = commander.augmentWithFriendStatus(user1.id.get, user2.id.get, BasicUser.fromUser(user2))
+          val u2 = commander.augmentUser(user1.id.get, user2.id.get, BasicUser.fromUser(user2))
           u2.isFriend === Some(true)
           u2.friendRequestSentAt === None
           u2.friendRequestReceivedAt === None
 
-          val u4 = commander.augmentWithFriendStatus(user1.id.get, user4.id.get, BasicUser.fromUser(user4))
+          val u4 = commander.augmentUser(user1.id.get, user4.id.get, BasicUser.fromUser(user4))
           u4.isFriend === Some(false)
           u4.friendRequestSentAt === None
           u4.friendRequestReceivedAt === None
@@ -37,7 +37,7 @@ class FriendStatusCommanderTest extends Specification with ShoeboxTestInjector {
           inject[FriendRequestRepo].save(FriendRequest(senderId = user1.id.get, recipientId = user4.id.get, messageHandle = None))
         }
         db.readOnlyMaster { implicit s =>
-          val u4 = commander.augmentWithFriendStatus(user1.id.get, user4.id.get, BasicUser.fromUser(user4))
+          val u4 = commander.augmentUser(user1.id.get, user4.id.get, BasicUser.fromUser(user4))
           u4.isFriend === Some(false)
           u4.friendRequestSentAt === Some(req1to4.createdAt)
           u4.friendRequestReceivedAt === None
@@ -58,7 +58,7 @@ class FriendStatusCommanderTest extends Specification with ShoeboxTestInjector {
           frRepo.save(FriendRequest(senderId = user4.id.get, recipientId = user1.id.get, messageHandle = None))
         }
         db.readOnlyMaster { implicit s =>
-          val map = commander.augmentWithFriendStatus(user1.id.get, Map(
+          val map = commander.augmentUsers(user1.id.get, Map(
             user2.id.get -> BasicUser.fromUser(user2),
             user3.id.get -> BasicUser.fromUser(user3),
             user4.id.get -> BasicUser.fromUser(user4)))

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserControllerTest.scala
@@ -1,6 +1,6 @@
 package com.keepit.controllers.website
 
-import com.keepit.commanders.UserConnectionsCommander
+import com.keepit.commanders.{ FriendStatusCommander, UserConnectionsCommander }
 import com.keepit.common.time._
 import com.keepit.model.KeepFactoryHelper._
 import com.keepit.model.KeepFactory._
@@ -16,7 +16,7 @@ import com.keepit.model.LibraryMembershipFactory._
 import com.keepit.model.LibraryMembershipFactoryHelper._
 import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.common.controller._
-import com.keepit.common.db.ExternalId
+import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.db.slick.Database
 
 import com.keepit.common.mail.{ EmailAddress, FakeMailModule }
@@ -30,6 +30,7 @@ import com.keepit.model._
 import com.keepit.scraper.FakeScrapeSchedulerModule
 import com.keepit.search.FakeSearchServiceClientModule
 import com.keepit.shoebox.FakeShoeboxServiceModule
+import com.keepit.social.BasicUser
 import com.keepit.test.ShoeboxTestInjector
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
@@ -336,37 +337,49 @@ class UserControllerTest extends Specification with ShoeboxTestInjector {
           (user1, user2, user3, user4, user5, user1lib)
         }
         val controller = inject[UserController]
-        controller.loadFullConnectionUser(user1.id.get, db.readOnlyMaster { implicit s => basicUserRepo.load(user1.id.get) }, None, Some(user2.id.get)) === Json.obj(
+        def basicUserWFS(user: User, viewerIdOpt: Option[Id[User]]): BasicUserWithFriendStatus = {
+          val basicUser = BasicUser.fromUser(user)
+          viewerIdOpt map { viewerId =>
+            db.readOnlyMaster { implicit s =>
+              inject[FriendStatusCommander].augmentUser(viewerId, user.id.get, basicUser)
+            }
+          } getOrElse BasicUserWithFriendStatus.fromWithoutFriendStatus(basicUser)
+        }
+        controller.loadFullConnectionUser(user1.id.get, basicUserWFS(user1, user2.id), user2.id) === Json.obj(
           "id" -> user1.externalId,
           "firstName" -> user1.firstName,
           "lastName" -> user1.lastName,
           "pictureName" -> "pic1.jpg",
           "username" -> user1.username.value,
-          "libs" -> 2, "followers" -> 3, "connections" -> 3, "connected" -> true, "mlibs" -> 0, "mConnections" -> 1
+          "isFriend" -> true,
+          "libraries" -> 2, "connections" -> 3, "followers" -> 4,
+          "mLibraries" -> 0, "mConnections" -> 1
         )
-        controller.loadFullConnectionUser(user1.id.get, db.readOnlyMaster { implicit s => basicUserRepo.load(user1.id.get) }, None, None) === Json.obj(
+        controller.loadFullConnectionUser(user1.id.get, basicUserWFS(user1, None), None) === Json.obj(
           "id" -> user1.externalId,
           "firstName" -> user1.firstName,
           "lastName" -> user1.lastName,
           "pictureName" -> "pic1.jpg",
           "username" -> user1.username.value,
-          "libs" -> 1, "followers" -> 3, "connections" -> 3
+          "libraries" -> 1, "connections" -> 3, "followers" -> 4
         )
-        controller.loadFullConnectionUser(user2.id.get, db.readOnlyMaster { implicit s => basicUserRepo.load(user2.id.get) }, None, Some(user3.id.get)) === Json.obj(
+        controller.loadFullConnectionUser(user2.id.get, basicUserWFS(user2, user3.id), user3.id) === Json.obj(
           "id" -> user2.externalId,
           "firstName" -> user2.firstName,
           "lastName" -> user2.lastName,
           "pictureName" -> "0.jpg",
           "username" -> user2.username.value,
-          "libs" -> 0, "followers" -> 0, "connections" -> 2, "connected" -> true, "mlibs" -> 1, "mConnections" -> 1
+          "isFriend" -> true,
+          "libraries" -> 0, "connections" -> 2, "followers" -> 0,
+          "mLibraries" -> 1, "mConnections" -> 1
         )
-        controller.loadFullConnectionUser(user2.id.get, db.readOnlyMaster { implicit s => basicUserRepo.load(user2.id.get) }, None, None) === Json.obj(
+        controller.loadFullConnectionUser(user2.id.get, basicUserWFS(user2, None), None) === Json.obj(
           "id" -> user2.externalId,
           "firstName" -> user2.firstName,
           "lastName" -> user2.lastName,
           "pictureName" -> "0.jpg",
           "username" -> user2.username.value,
-          "libs" -> 0, "followers" -> 0, "connections" -> 2
+          "libraries" -> 0, "connections" -> 2, "followers" -> 0
         )
       }
     }


### PR DESCRIPTION
@eishay cc @ahsu1230 

Also switched to using `BasicUserWithFriendStatus` for a consistent and more complete representation of the friend status (e.g. whether a request has been sent or received).
