### PR TITLE
refactoring user profile connections/followers for fewer requests, shared code

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
@@ -242,14 +242,11 @@ angular.module('kifi')
           size: _.isUndefined(opt_size) ? [] : opt_size
         });
       },
-      getUserConnections: function (username, limit) {
-        return route('/user/' + username + '/connections', {n: limit || []});
+      getProfileConnections: function (username, limit) {
+        return route('/users/' + username + '/connections', {n: limit || []});
       },
-      getUserConnectionsById: function (username, ids) {
-        return route('/user/' + username + '/connections', {ids: ids.join(',')});
-      },
-      getUserConnectionIds: function (username, limit) {
-        return route('/user/' + username + '/connections/ids', {n: limit || []});
+      getProfileUsers: function (username, ids) {
+        return route('/users/' + ids.join('.'));
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileActionService.js
@@ -22,23 +22,16 @@ angular.module('kifi')
     }, clutchParams);
 
     var connectionsClutch = new Clutch(function (username, limit) {
-      return $http.get(routeService.getUserConnections(username, limit)).then(getData);
+      return $http.get(routeService.getProfileConnections(username, limit)).then(getData);
     }, clutchParams);
 
-    var connectionIdsClutch = new Clutch(function (username, limit) {
-      return $http.get(routeService.getUserConnectionIds(username, limit)).then(getData);
-    }, clutchParams);
-
-    var api = {
+    return {
       getProfile: angular.bind(profileClutch, profileClutch.get),
       getLibraries: angular.bind(librariesClutch, librariesClutch.get),
       getConnections: angular.bind(connectionsClutch, connectionsClutch.get),
-      getConnectionsById: function (username, ids) {
-        return $http.get(routeService.getUserConnectionsById(username, ids)).then(getData);
-      },
-      getConnectionIds: angular.bind(connectionIdsClutch, connectionIdsClutch.get)
+      getUsers: function (ids) {
+        return $http.get(routeService.getProfileUsers(ids)).then(getData);
+      }
     };
-
-    return api;
   }
 ]);

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileConnections.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileConnections.js
@@ -7,7 +7,7 @@ angular.module('kifi')
   function ($scope, $stateParams, $q, userProfileActionService, modalService) {
     var users;
     var remainingUserIds;
-    var fetchPageSize = 6;
+    var fetchPageSize = 9;
     var loading = true;
 
     function getId(o) {
@@ -21,7 +21,7 @@ angular.module('kifi')
       loading = true;
 
       var requestedIds = remainingUserIds.slice(0, fetchPageSize);
-      userProfileActionService.getConnectionsById($stateParams.username, requestedIds).then(function (data) {
+      userProfileActionService.getUsers(requestedIds).then(function (data) {
         users.push.apply(users, data.users);
         remainingUserIds = _.difference(remainingUserIds, requestedIds);
         loading = false;
@@ -44,14 +44,8 @@ angular.module('kifi')
 
     userProfileActionService.getConnections($stateParams.username, fetchPageSize).then(function (data) {
       $scope.users = users = data.users;
-      if (remainingUserIds) {
-        remainingUserIds = _.difference(remainingUserIds, users.map(getId));
-      }
+      remainingUserIds = data.ids;
       loading = false;
-    });
-
-    userProfileActionService.getConnectionIds($stateParams.username).then(function (data) {
-      remainingUserIds = users ? _.difference(data, users.map(getId)) : data.ids;
     });
   }
 ]);

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -352,10 +352,9 @@ POST    /site/users/:userStr/libraries/:slug/auth    @com.keepit.controllers.web
 # Profile pages
 GET     /site/user/:name/profile    @com.keepit.controllers.website.UserController.profile(name: Username)
 GET     /site/user/:name/libraries  @com.keepit.controllers.website.LibraryController.getProfileLibraries(name: Username, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")
-GET     /site/user/:name/connections @com.keepit.controllers.website.UserController.profileConnections(name: Username, n: Int ?= 12, ids: String ?= "")
-GET     /site/user/:name/connections/ids @com.keepit.controllers.website.UserController.profileConnectionIds(name: Username, n: Int ?= 480)
-GET     /site/user/:name/followers      @com.keepit.controllers.website.UserController.profileFollowers(name: Username, n: Int ?= 12, ids: String ?= "")
-GET     /site/user/:name/followers/ids  @com.keepit.controllers.website.UserController.profileFollowerIds(name: Username, n: Int ?= 480)
+GET     /site/users/:name/connections @com.keepit.controllers.website.UserController.getProfileConnections(name: Username, n: Int ?= 12)
+GET     /site/users/:name/followers  @com.keepit.controllers.website.UserController.getProfileFollowers(name: Username, n: Int ?= 12)
+GET     /site/users/:ids            @com.keepit.controllers.website.UserController.getProfileUsers(ids)
 
 GET     /site/libraries             @com.keepit.controllers.website.LibraryController.getLibrarySummariesByUser()
 POST    /site/libraries/add         @com.keepit.controllers.website.LibraryController.addLibrary()


### PR DESCRIPTION
This puts the list of ids in the original response for the first page of connections/followers.
It also combines the endpoints for loading more connections or followers by ID.
@ahsu1230 
