### PR TITLE
smaller batch in fixDuplicateKeeps

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
@@ -306,7 +306,7 @@ class UriIntegrityActor @Inject() (
     log.debug(s"start deduping keeps: fetching tasks from seqNum $seq")
     try {
       var dedupedSuccessCount = 0
-      val keeps = db.readOnlyReplica { implicit s => keepRepo.getBookmarksChanged(seq, 1000) }
+      val keeps = db.readOnlyReplica { implicit s => keepRepo.getBookmarksChanged(seq, 100) }
       if (keeps.nonEmpty) {
         db.readWriteBatch(keeps, 3) { (session, keep) =>
           val newUriOpt = normalizedURIInterner.getByUri(keep.url)(session)


### PR DESCRIPTION
@eishay @andrewconner @leogrim @stkem 

To reduce ridiculously long session duration.
This method runs frequently (every 1 minute). Reduce batch size should still keep things in sync. 
