### PR TITLE
a read-once API for initParams

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -64,13 +64,22 @@ angular.module('kifi', [
 .factory('initParams', [
   '$location',
   function ($location) {
-    var params = ['m', 'o', 'friend', 'subtype', 'install', 'intent'];
+    var names = ['m', 'o', 'friend', 'subtype', 'install', 'intent'];
     var search = $location.search();
-    var state = _.pick(search, params);
-    if (!_.isEmpty(state)) {
-      $location.search(_.omit(search, params)).replace();
+    var params = _.pick(search, names);
+    if (!_.isEmpty(params)) {
+      $location.search(_.omit(search, names)).replace();
     }
-    return state;
+    return {
+      getAndClear: function (name) {
+        var value;
+        if (name in params) {
+          value = params[name];
+          delete params[name];
+        }
+        return value;
+      }
+    };
   }
 ])
 

--- a/kifi-backend/modules/shoebox/angular/src/common/originTracking.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/originTracking.js
@@ -19,10 +19,7 @@ angular.module('kifi')
 
       applyAndClear: function (obj) {
         if (!pageOrigin) {
-          pageOrigin = pageOrigins[initParams.o];
-          if (pageOrigin) {
-            delete initParams.o;
-          }
+          pageOrigin = pageOrigins[initParams.getAndClear('o')];
         }
         if (pageOrigin) {
           var parts = pageOrigin.split('/');

--- a/kifi-backend/modules/shoebox/angular/src/invite/invite.js
+++ b/kifi-backend/modules/shoebox/angular/src/invite/invite.js
@@ -280,8 +280,6 @@ angular.module('kifi')
 
     function setupShowFriendRequestBanner(scope, externalId, eventSubtype) {
       function closeBanner() {
-        delete initParams.friend;
-        delete initParams.subtype;
         scope.hidden = true;
       }
 
@@ -327,11 +325,11 @@ angular.module('kifi')
     function link(scope) {
       scope.hidden = true;
 
-      var externalId = initParams.friend;
+      var externalId = initParams.getAndClear('friend');
       if (externalId && /^[a-f0-9-]{36}$/.test(externalId)) {
         scope.friendRequestBannerHeader = 'Send a friend request';
         scope.showFriendRequestBanner = true;
-        setupShowFriendRequestBanner(scope, externalId, initParams.subtype || 'contactJoined');
+        setupShowFriendRequestBanner(scope, externalId, initParams.getAndClear('subtype') || 'contactJoined');
       }
     }
 

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
@@ -23,14 +23,16 @@ angular.module('kifi')
 
     $scope.undo = undoService;
 
-    if (initParams.m === '1') {
-      $scope.showEmailVerifiedModal = true;
-    } else if (initParams.m in tooltipMessages) { // show small tooltip
-      $scope.tooltipMessage = tooltipMessages[initParams.m];
-      $timeout(function () {
-        delete $scope.tooltipMessage;
-      }, 5000);
-    }
+    (function (m) {
+      if (m === '1') {
+        $scope.showEmailVerifiedModal = true;
+      } else if (m in tooltipMessages) { // show small tooltip
+        $scope.tooltipMessage = tooltipMessages[m];
+        $timeout(function () {
+          $scope.tooltipMessage = null;
+        }, 5000);
+      }
+    }(initParams.getAndClear('m')));
 
     //
     // For importing bookmarks

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -264,10 +264,10 @@ angular.module('kifi')
     libraryService.getRelatedLibraries(library.id).then(function (libraries) {
       trackPageView({libraryRecCount: libraries.length});
       $scope.relatedLibraries = libraries;
-      if (initParams.install === '1' && !installService.installedVersion) {
+      if (initParams.getAndClear('install') === '1' && !installService.installedVersion) {
         showInstallModal();
       }
-      if (initParams.intent === 'follow' && $scope.library.access === 'none') {
+      if (initParams.getAndClear('intent') === 'follow' && $scope.library.access === 'none') {
         libraryService.joinLibrary($scope.library.id);
       }
     });

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
@@ -101,7 +101,7 @@ angular.module('kifi')
     trackPageView();
     setCurrentPageOrigin();
 
-    if (initParams.install === '1' && !installService.installedVersion) {
+    if (initParams.getAndClear('install') === '1' && !installService.installedVersion) {
       showInstallModal();
     }
   }

--- a/kifi-backend/modules/shoebox/angular/test/unit/invite/invite.spec.js
+++ b/kifi-backend/modules/shoebox/angular/test/unit/invite/invite.spec.js
@@ -108,7 +108,7 @@ describe('kifi.invite', function () {
     var friendRequestUrl, basicUserInfoUrl, profileUrl;
 
     beforeEach(function () {
-      initParams.friend = fakeSocialId;
+      spyOn(initParams, 'getAndClear').and.returnValue(fakeSocialId);
       elem = angular.element('<div kf-friend-request-banner></div>');
       friendRequestUrl = routeService.friendRequest(fakeSocialId);
       basicUserInfoUrl = routeService.basicUserInfo(fakeSocialId, true);


### PR DESCRIPTION
cc @andrewconner @ahsu1230 

The goal here is to make it harder to accidentally reuse initial query parameters (after the initial page view).
