### PR TITLE
explicit lower bound on scrape interval

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/ScrapeInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/ScrapeInfo.scala
@@ -50,7 +50,7 @@ case class ScrapeInfo(
 
   def withFailure()(implicit config: ScraperSchedulerConfig) = {
     val backoff = min(config.intervalConfig.maxBackoff, config.intervalConfig.initialBackoff * (1 << failures).toDouble)
-    val newInterval = min(config.intervalConfig.maxInterval, interval + config.intervalConfig.intervalIncrement)
+    val newInterval = min(config.intervalConfig.maxInterval, interval + config.intervalConfig.intervalIncrement) max config.intervalConfig.minInterval
     val now = currentDateTime
     copy(nextScrape = now.plusSeconds(hoursToSeconds(backoff) + config.randomDelay),
       interval = newInterval,
@@ -58,7 +58,7 @@ case class ScrapeInfo(
   }
 
   def withDocumentUnchanged()(implicit config: ScraperSchedulerConfig) = {
-    val newInterval = min(config.intervalConfig.maxInterval, interval + config.intervalConfig.intervalIncrement)
+    val newInterval = min(config.intervalConfig.maxInterval, interval + config.intervalConfig.intervalIncrement) max config.intervalConfig.minInterval
     val now = currentDateTime
     copy(nextScrape = now.plusSeconds(hoursToSeconds(newInterval) + config.randomDelay),
       interval = newInterval,


### PR DESCRIPTION
@eishay @stkem @andrewconner 

In `prod.conf`, there is a configuration of min scrape interval, set to 4 weeks. 
50% items (over 1 million) in the scrape_info table actually have much smaller scrape intervals. 

I put the cap explicitly in the code. (The old code only works if we can assume every existing scrape_interval is already above min value)

If we think 4 weeks is an overkill, we can tweak it shorter. The point is to make sure the configuration really in effect. 
