### PR TITLE
rate limit on content check

### DIFF
--- a/kifi-backend/modules/shoebox/test/com/keepit/model/FailedContentCheckTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/FailedContentCheckTest.scala
@@ -1,5 +1,7 @@
 package com.keepit.model
 
+import com.keepit.common.time._
+import org.joda.time.DateTime
 import org.specs2.mutable.Specification
 import com.keepit.test._
 
@@ -18,7 +20,7 @@ class FailedContentCheckTest extends Specification with ShoeboxTestInjector {
         }
 
         db.readOnlyMaster { implicit s =>
-          var r = failedContentCheckRepo.getByUrls(u1, u2)
+          val r = failedContentCheckRepo.getByUrls(u1, u2)
           r.get.counts === 5
           r.get.state === FailedContentCheckStates.ACTIVE
 
@@ -26,6 +28,8 @@ class FailedContentCheckTest extends Specification with ShoeboxTestInjector {
           failedContentCheckRepo.getByUrls(u2, u1)
           r.get.counts === 5
           r.get.state === FailedContentCheckStates.ACTIVE
+          val ancient = new DateTime(2000, 1, 1, 21, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
+          failedContentCheckRepo.getRecentCountByURL(u1, ancient) === 1
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/normalizer/NormalizationServiceTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/normalizer/NormalizationServiceTest.scala
@@ -60,6 +60,7 @@ class NormalizationServiceTest extends TestKitSupport with SpecificationLike wit
 
     "normalize a new http:// url to HTTP" in {
       withDb(modules: _*) { implicit injector =>
+        db.readWrite { implicit s => failedContentCheckRepo.createOrIncrease("abc", "xyz") }
         val httpUri = db.readWrite { implicit session => uriRepo.save(NormalizedURI.withHash("http://vimeo.com/48578814")) }
         httpUri.normalization === None
         updateNormalizationNow(httpUri)
@@ -79,6 +80,7 @@ class NormalizationServiceTest extends TestKitSupport with SpecificationLike wit
     //    }
     "redirect an existing http url to a new https:// url" in {
       withDb(modules: _*) { implicit injector =>
+        db.readWrite { implicit s => failedContentCheckRepo.createOrIncrease("abc", "xyz") }
         db.readWrite { implicit session => uriRepo.save(NormalizedURI.withHash("http://vimeo.com/48578814")) }
         val httpUri = db.readOnlyMaster { implicit session => uriRepo.getByNormalizedUrl("http://vimeo.com/48578814") }.get
 
@@ -95,6 +97,7 @@ class NormalizationServiceTest extends TestKitSupport with SpecificationLike wit
     }
     "redirect a new http://www url to an existing https:// url" in {
       withDb(modules: _*) { implicit injector =>
+        db.readWrite { implicit s => failedContentCheckRepo.createOrIncrease("abc", "xyz") }
         db.readWrite { implicit session => uriRepo.save(NormalizedURI.withHash("https://vimeo.com/48578814")) }
         val httpsUri = db.readOnlyMaster { implicit session => uriRepo.getByNormalizedUrl("https://vimeo.com/48578814") }.get
 
@@ -144,6 +147,7 @@ class NormalizationServiceTest extends TestKitSupport with SpecificationLike wit
     //    }
     "not normalize a LinkedIn private profile to its public url if ids do not match" in {
       withDb(modules: _*) { implicit injector =>
+        db.readWrite { implicit s => failedContentCheckRepo.createOrIncrease("abc", "xyz") }
         val privateUri = db.readWrite { implicit session => uriRepo.save(NormalizedURI.withHash("https://www.linkedin.com/profile/view?id=17558679", normalization = Some(Normalization.HTTPSWWW))) }
         updateNormalizationNow(privateUri, UntrustedCandidate("http://www.linkedin.com/pub/leonard\u002dgrimaldi/12/42/2b3", Normalization.CANONICAL)) === None
       }


### PR DESCRIPTION
@eishay @leogrim @stkem @andrewconner 

To see the problem, see `failed_content_check` table, and query `url1 like %twitter.com%`

This should reduce load both on shoebox and scraper. I think the change is safe.
