### PR TITLE
internal route: send context as payload

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/curator/CuratorServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/curator/CuratorServiceClient.scala
@@ -97,7 +97,8 @@ class CuratorServiceClientImpl(
   }
 
   def topLibraryRecos(userId: Id[User], limit: Option[Int] = None, context: Option[String]): Future[LibraryRecoResults] = {
-    call(Curator.internal.topLibraryRecos(userId, limit, context)).map { response =>
+    val payload = Json.obj("context" -> JsString(context.getOrElse("")))
+    call(Curator.internal.topLibraryRecos(userId, limit, context), payload).map { response =>
       val js = response.json
       js.validate[LibraryRecoResults] match {
         case res: JsSuccess[LibraryRecoResults] => res.get

--- a/kifi-backend/modules/curator/app/com/keepit/curator/controllers/internal/CuratorController.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/controllers/internal/CuratorController.scala
@@ -126,7 +126,7 @@ class CuratorController @Inject() (
     userExperimentCommander.getExperimentsByUser(userId) map { experiments =>
       val sortStrategy = topScoreLibraryRecoStrategy
       val scoringStrategy = nonlinearLibraryRecoScoringStrategy
-
+      val context = (request.body \ "context").asOpt[String]
       val recoResults = libraryRecoGenCommander.getTopRecommendations(userId, limit, sortStrategy, scoringStrategy, context)
       val libRecoInfos = recoResults.recos
       log.info(s"topLibraryRecos returning userId=$userId resultCount=${libRecoInfos.size}")


### PR DESCRIPTION
@stkem @eishay 

occasionally, the internal route reaches MAX URL length 1000. This is a transition code, sending context both as parameter and context. 

next PR will remove the duplication. 
