### PR TITLE
updating google site verification for webmaster tools

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
@@ -95,6 +95,10 @@ class HomeController @Inject() (
       """.stripMargin)
   }
 
+  def googleWebmasterToolsSiteVerification = Action {
+    Ok(Html("google-site-verification: google6de4ad16957106ef.html"))
+  }
+
   def getKeepsCount = Action.async {
     keepsCommander.getKeepsCountFuture() imap { count =>
       Ok(count.toString)

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -263,6 +263,7 @@ GET     /m/1/keeps/:id                      @com.keepit.controllers.mobile.Mobil
 
 GET     /                           @com.keepit.controllers.website.HomeController.home
 GET     /robots.txt                 @com.keepit.controllers.website.HomeController.robots
+GET     /google6de4ad16957106ef.html @com.keepit.controllers.website.HomeController.googleWebmasterToolsSiteVerification
 GET     /blog                       @com.keepit.controllers.website.HomeController.moved(uri = "http://blog.kifi.com")
 GET     /blog/                      @com.keepit.controllers.website.HomeController.moved(uri = "http://blog.kifi.com")
 GET     /about                      @com.keepit.controllers.website.HomeController.route(path = "about")

--- a/tools/etc/nginx/conf.d/shoebox.conf
+++ b/tools/etc/nginx/conf.d/shoebox.conf
@@ -173,8 +173,8 @@ server {
     return 200 '<!doctype html>';
   }
 
-  location = /googled7d06970b48cdafa.html {
-    return 200 'google-site-verification: googled7d06970b48cdafa.html';
+  location = /google6de4ad16957106ef.html {
+    return 200 'google-site-verification: google6de4ad16957106ef.html';
   }
 }
 


### PR DESCRIPTION
@stkem @eishay 

I’m not sure why the filename changed. Hopefully this fixes it and doesn’t break anything else.

One reason we may need to do this in nginx going forward is that Google may expect us to serve the file of each subdomain without any redirects.

http://kifi.com/google6de4ad16957106ef.html
https://kifi.com/google6de4ad16957106ef.html
http://www.kifi.com/google6de4ad16957106ef.html
https://www.kifi.com/google6de4ad16957106ef.html
