### PR TITLE
including numFollowedLibraries in user profile responses

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileHeader.js
@@ -13,7 +13,7 @@ angular.module('kifi')
       },
       templateUrl: 'userProfile/userProfileHeader.tpl.html',
       link: function (scope, element) {
-        var navLinks;
+        var navLinks = angular.element();
 
         //
         // Internal Functions

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
@@ -290,9 +290,10 @@ class MobileUserController @Inject() (
     userCommander.profile(Username(username), viewer) match {
       case None => NotFound(s"can't find username $username")
       case Some(profile) =>
-        val (numLibraries, numInvitedLibs) = libraryCommander.countLibraries(profile.userId, viewer.map(_.id.get))
+        val (numLibraries, numFollowedLibs, numInvitedLibs) = libraryCommander.countLibraries(profile.userId, viewer.map(_.id.get))
         val json = Json.toJson(profile.basicUserWithFriendStatus).asInstanceOf[JsObject] ++ Json.obj(
           "numLibraries" -> numLibraries,
+          "numFollowedLibraries" -> numFollowedLibs,
           "numKeeps" -> profile.numKeeps)
 
         numInvitedLibs match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserProfileController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserProfileController.scala
@@ -42,13 +42,14 @@ class UserProfileController @Inject() (
         log.warn(s"can't find username ${username.value}")
         NotFound(s"username ${username.value}")
       case Some(profile) =>
-        val (numLibraries, numInvitedLibs) = libraryCommander.countLibraries(profile.userId, viewer.map(_.id.get))
+        val (numLibraries, numFollowedLibraries, numInvitedLibs) = libraryCommander.countLibraries(profile.userId, viewer.map(_.id.get))
         val numConnections = db.readOnlyMaster { implicit s =>
           userConnectionRepo.getConnectionCount(profile.userId)
         }
 
         val json = Json.toJson(profile.basicUserWithFriendStatus).as[JsObject] ++ Json.obj(
           "numLibraries" -> numLibraries,
+          "numFollowedLibraries" -> numFollowedLibraries,
           "numKeeps" -> profile.numKeeps,
           "numConnections" -> numConnections,
           "numFollowers" -> libraryCommander.countFollowers(profile.userId, viewer.map(_.id.get))

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -34,6 +34,9 @@ trait LibraryRepo extends Repo[Library] with SeqNumberFunction[Library] {
   def getFollowingLibrariesForOtherUser(userId: Id[User], friendId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library]
   def getFollowingLibrariesForSelf(userId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library]
   def getFollowingLibrariesForAnonymous(userId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library]
+  // def countFollowingLibrariesForSelf(userId: Id[User])(implicit session: RSession): Int  // use LibraryMembershipRepo.countWithUserIdAndAccess(userId, READ_ONLY) instead (cached)
+  def countFollowingLibrariesForOtherUser(userId: Id[User], viewerId: Id[User])(implicit session: RSession): Int
+  def countFollowingLibrariesForAnonymous(userId: Id[User])(implicit session: RSession): Int
   def getInvitedLibrariesForSelf(userId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library]
   def getLibrariesForSelf(userId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library]
   def getAllPublishedLibraries()(implicit session: RSession): Seq[Library]
@@ -275,6 +278,26 @@ class LibraryRepoImpl @Inject() (
     import StaticQuery.interpolation
     val query = sql"select lib.* from library_membership lm, library lib where lm.library_id = lib.id and lm.user_id = $userId and lib.state = 'active' and lm.state = 'active' and lm.listed and lib.visibility = 'published' and lm.access != 'owner' order by lib.member_count desc, lib.last_kept desc, lib.id desc limit ${page.itemsToDrop}, ${page.size}"
     query.as[Library].list
+  }
+
+  // TODO: share query logic with getFollowingLibrariesForOtherUser (above)
+  def countFollowingLibrariesForOtherUser(userId: Id[User], viewerId: Id[User])(implicit session: RSession): Int = {
+    import StaticQuery.interpolation
+    val libsFriendFollow = sql"select lib.id from library_membership lm, library lib where lm.library_id = lib.id and lm.user_id = $viewerId and lib.state = 'active' and lm.state = 'active'".as[Id[Library]].list
+    val libVisibility = libsFriendFollow.size match {
+      case 0 => ""
+      case 1 => s"or (lib.id = ${libsFriendFollow.head})"
+      case _ => s"or (lib.id in (${libsFriendFollow mkString ","}))"
+    }
+    val query = sql"select count(lib.*) from library_membership lm, library lib where lm.library_id = lib.id and lm.user_id = $userId and lib.state = 'active' and lm.state = 'active' and lm.access != 'owner' and ((lm.listed and lib.visibility = 'published' and lm.access != 'owner') #$libVisibility)"
+    query.as[Int].first
+  }
+
+  // TODO: share query logic with getFollowingLibrariesForAnonymous (above)
+  def countFollowingLibrariesForAnonymous(userId: Id[User])(implicit session: RSession): Int = {
+    import StaticQuery.interpolation
+    val query = sql"select count(lib.*) from library_membership lm, library lib where lm.library_id = lib.id and lm.user_id = $userId and lib.state = 'active' and lm.state = 'active' and lm.listed and lib.visibility = 'published' and lm.access != 'owner'"
+    query.as[Int].first
   }
 
   def getInvitedLibrariesForSelf(userId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library] = {

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserControllerTest.scala
@@ -207,6 +207,7 @@ class FasterMobileUserControllerTest extends Specification with ShoeboxTestInjec
               "pictureName":"pic1.jpg",
               "username": "GDubs",
               "numLibraries":1,
+              "numFollowedLibraries": 1,
               "numKeeps": 5
             }
           """)
@@ -224,6 +225,7 @@ class FasterMobileUserControllerTest extends Specification with ShoeboxTestInjec
               "pictureName":"pic1.jpg",
               "username": "GDubs",
               "numLibraries":2,
+              "numFollowedLibraries": 1,
               "numKeeps": 5,
               "isFriend": true
             }
@@ -242,6 +244,7 @@ class FasterMobileUserControllerTest extends Specification with ShoeboxTestInjec
               "pictureName":"pic1.jpg",
               "username": "GDubs",
               "numLibraries":4,
+              "numFollowedLibraries": 2,
               "numKeeps": 5,
               "numInvitedLibraries": 0
             }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserProfileControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserProfileControllerTest.scala
@@ -243,6 +243,7 @@ class UserProfileControllerTest extends Specification with ShoeboxTestInjector {
               "pictureName":"pic1.jpg",
               "username": "GDubs",
               "numLibraries": 1,
+              "numFollowedLibraries": 1,
               "numKeeps": 5,
               "numConnections": 3,
               "numFollowers": 2
@@ -263,6 +264,7 @@ class UserProfileControllerTest extends Specification with ShoeboxTestInjector {
               "pictureName":"pic1.jpg",
               "username": "GDubs",
               "numLibraries": 4,
+              "numFollowedLibraries": 2,
               "numKeeps": 5,
               "numConnections": 3,
               "numFollowers": 3,
@@ -285,6 +287,7 @@ class UserProfileControllerTest extends Specification with ShoeboxTestInjector {
               "username": "GDubs",
               "isFriend": true,
               "numLibraries": 2,
+              "numFollowedLibraries": 1,
               "numKeeps": 5,
               "numConnections": 3,
               "numFollowers": 3


### PR DESCRIPTION
@eishay 

This is so that we can quickly decide to show the followed libraries tab instead of the own libraries tab in a user profile if the user owns none but is following some.
https://app.asana.com/0/20849692840229/28604317893859

In the future, we might also decide to display the counts on the tabs.
