### PR TITLE
Support library search filter in the new website import

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/ext/ExtSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/ext/ExtSearchController.scala
@@ -72,7 +72,7 @@ class ExtSearchController @Inject() (
     extVersion: Option[KifiExtVersion],
     debug: Option[String] = None) = UserAction { request =>
 
-    val libraryContextFuture = getLibraryContextFuture(None, None, request)
+    val libraryContextFuture = getLibraryFilterFuture(None, None, request)
     val acceptLangs = getAcceptLangs(request)
     val (userId, experiments) = getUserAndExperiments(request)
     val filterFuture = getUserFilterFuture(filter)

--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/util/SearchControllerUtil.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/util/SearchControllerUtil.scala
@@ -114,10 +114,10 @@ trait SearchControllerUtil {
 
   def getAcceptLangs(requestHeader: RequestHeader): Seq[String] = requestHeader.acceptLanguages.map(_.code)
 
-  def getLibraryContextFuture(library: Option[String], auth: Option[String], requestHeader: RequestHeader)(implicit publicIdConfig: PublicIdConfiguration): Future[LibraryContext] = {
+  def getLibraryFilterFuture(library: Option[PublicId[Library]], auth: Option[String], requestHeader: RequestHeader)(implicit publicIdConfig: PublicIdConfiguration): Future[LibraryContext] = {
     library match {
       case Some(libPublicId) =>
-        Library.decodePublicId(PublicId[Library](libPublicId)) match {
+        Library.decodePublicId(libPublicId) match {
           case Success(libId) =>
             val libraryAccess = requestHeader.session.get("library_access").map { _.split("/") }
             (auth, libraryAccess) match {

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/library/LibraryResultCollector.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/library/LibraryResultCollector.scala
@@ -39,7 +39,7 @@ class LibraryResultCollector(librarySearcher: Searcher, libraryMembershipSearche
         score = ctx.score() * matching
       }
 
-      if (score > 0.0f && isUserCreated(id)) {
+      if (score > 0.0f) {
         val visibility = ctx.visibility
         val relevantQueue = if ((visibility & Visibility.OWNER) != 0) {
           myHits
@@ -55,6 +55,7 @@ class LibraryResultCollector(librarySearcher: Searcher, libraryMembershipSearche
         score = score * popularityBoost
         if ((visibility & (Visibility.OWNER | Visibility.MEMBER)) != 0) { score = score * myLibraryBoost }
         else {
+          //todo(Léo): boost libraries if isUserCreated
           val keepCount = libraryQualityEvaluator.estimateKeepCount(keepSearcher, id)
           val publishedLibraryBoost = libraryQualityEvaluator.getPublishedLibraryBoost(keepCount)
           score = score * publishedLibraryBoost

--- a/kifi-backend/modules/search/app/com/keepit/search/index/IndexerVersion.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/IndexerVersion.scala
@@ -27,7 +27,7 @@ object IndexerVersionProviders {
   case object SearchFriend extends IndexerVersionProvider(0, 0)
   case object Message extends IndexerVersionProvider(0, 0)
   case object Phrase extends IndexerVersionProvider(0, 0)
-  case object Library extends IndexerVersionProvider(8, 8)
+  case object Library extends IndexerVersionProvider(8, 9)
   case object LibraryMembership extends IndexerVersionProvider(1, 1)
   case object Keep extends IndexerVersionProvider(2, 2)
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/index/graph/library/LibraryIndexable.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/graph/library/LibraryIndexable.scala
@@ -107,15 +107,11 @@ class LibraryIndexable(library: DetailedLibraryView) extends Indexable[Library, 
     import LibraryFields._
     val doc = super.buildDocument
 
-    library.kind match {
-      case LibraryKind.SYSTEM_MAIN | LibraryKind.SYSTEM_SECRET | LibraryKind.SYSTEM_PERSONA => // do not index the name of main/private libraries
-      case LibraryKind.USER_CREATED =>
-        val nameLang = LangDetector.detect(library.name)
-        doc.add(buildTextField(nameField, library.name, DefaultAnalyzer.getAnalyzer(nameLang)))
-        doc.add(buildTextField(nameStemmedField, library.name, DefaultAnalyzer.getAnalyzerWithStemmer(nameLang)))
-        doc.add(buildPrefixField(namePrefixField, library.name, maxPrefixLength))
-        doc.add(buildStringDocValuesField(nameValueField, library.name))
-    }
+    val nameLang = LangDetector.detect(library.name)
+    doc.add(buildTextField(nameField, library.name, DefaultAnalyzer.getAnalyzer(nameLang)))
+    doc.add(buildTextField(nameStemmedField, library.name, DefaultAnalyzer.getAnalyzerWithStemmer(nameLang)))
+    doc.add(buildPrefixField(namePrefixField, library.name, maxPrefixLength))
+    doc.add(buildStringDocValuesField(nameValueField, library.name))
 
     library.description.foreach { description =>
       val descriptionLang = LangDetector.detect(description)

--- a/kifi-backend/modules/search/conf/searchService.routes
+++ b/kifi-backend/modules/search/conf/searchService.routes
@@ -44,7 +44,7 @@ GET         /m/2/search       @com.keepit.search.controllers.mobile.MobileSearch
 # Search Website API
 ##########################################
 GET         /site/search2                       @com.keepit.search.controllers.website.WebsiteSearchController.search2(q: String, f: Option[String], l: Option[String], maxHits: Int, lastUUID: Option[String], context: Option[String], auth: Option[String], debug: Option[String])
-GET         /site/search                        @com.keepit.search.controllers.website.WebsiteSearchController.search(q: String, f: Option[String] ?= None, maxUris: Int ?= 0, uriContext: Option[String] ?= None, lastUUIDStr: Option[String] ?= None, maxLibraries: Int ?= 0, libraryContext: Option[String] ?= None, maxUsers: Int ?= 0, userContext: Option[String] ?= None, disablePrefixSearch: Boolean ?= false, debug: Option[String] ?= None)
+GET         /site/search                        @com.keepit.search.controllers.website.WebsiteSearchController.search(q: String, u: Option[String] ?= None, l: Option[String] ?= None, maxUris: Int ?= 0, uriContext: Option[String] ?= None, lastUUIDStr: Option[String] ?= None, maxLibraries: Int ?= 0, libraryContext: Option[String] ?= None, maxUsers: Int ?= 0, userContext: Option[String] ?= None, disablePrefixSearch: Boolean ?= false, debug: Option[String] ?= None)
 GET         /site/search/warmUp                 @com.keepit.search.controllers.website.WebsiteSearchController.warmUp()
 POST        /site/search/events/resultClicked   @com.keepit.search.controllers.website.WebsiteSearchEventController.clickedKifiResult()
 POST        /site/search/events/searched        @com.keepit.search.controllers.website.WebsiteSearchEventController.searched()


### PR DESCRIPTION
@2is10 
Note that I have changed the filter "f" parameter to "u". The reasoning is that our current filter is just about filtering by user, and searching within a library is actually about filtering by library. So this is an attempt to have a more symmetric API where it's just "u"sers and "l"ibrary. I'd like to move towards this more consistently.
