### PR TITLE
mobile recos reminder preference

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/UserNotifyPreference.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserNotifyPreference.scala
@@ -19,3 +19,13 @@ case class UserNotifyPreference(
 
 object UserNotifyPreferenceStates extends States[UserNotifyPreference]
 
+abstract class NotifyPreference(val name: String)
+object NotifyPreference {
+  case object RECOS_REMINDER extends NotifyPreference("recos_reminder")
+
+  def apply(name: String): NotifyPreference = {
+    name match {
+      case RECOS_REMINDER.name => NotifyPreference.RECOS_REMINDER
+    }
+  }
+}

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/URICommander.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/URICommander.scala
@@ -24,7 +24,7 @@ class URICommander @Inject() (
       Future.successful(true)
   }
 
-  def isUnscrapable(url: String, destinationUrl: Option[String]): Future[Boolean]  = try {
+  def isUnscrapable(url: String, destinationUrl: Option[String]): Future[Boolean] = try {
     shoeboxScraperClient.getAllURLPatterns() map { rules =>
       rules.isUnscrapable(url) || destinationUrl.exists(rules.isUnscrapable)
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobilePreferenceController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobilePreferenceController.scala
@@ -1,0 +1,23 @@
+package com.keepit.controllers.mobile
+
+import com.google.inject.Inject
+import com.keepit.common.controller.{ UserActionsHelper, ShoeboxServiceController, UserActions }
+import com.keepit.common.db.slick.Database
+import com.keepit.model.{ NotifyPreference, UserNotifyPreferenceRepo }
+
+class MobilePreferenceController @Inject() (
+    val userActionsHelper: UserActionsHelper,
+    db: Database,
+    notifyPreferenceRepo: UserNotifyPreferenceRepo) extends UserActions with ShoeboxServiceController {
+
+  def setNotifyPreferences = UserAction(parse.tolerantJson) { request =>
+    val recosReminderOpt = (request.body \ "recos_reminder").asOpt[Boolean]
+    recosReminderOpt.map { recosReminderSend =>
+      db.readWrite { implicit s =>
+        notifyPreferenceRepo.setNotifyPreference(request.user.id.get, NotifyPreference.RECOS_REMINDER, recosReminderSend)
+      }
+    }
+    NoContent
+  }
+
+}

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -189,6 +189,7 @@ GET     /m/1/collections/all                @com.keepit.controllers.mobile.Mobil
 GET     /m/1/user/me                        @com.keepit.controllers.mobile.MobileUserController.currentUser()
 POST    /m/1/user/me                        @com.keepit.controllers.mobile.MobileUserController.updateCurrentUser()
 GET     /m/1/user/prefs                     @com.keepit.controllers.mobile.MobileUserController.getPrefs()
+POST    /m/1/user/notifyPrefs               @com.keepit.controllers.mobile.MobilePreferenceController.setNotifyPreferences()
 POST    /m/1/user/pic/upload                @com.keepit.controllers.mobile.MobileUserController.uploadBinaryUserPicture()
 GET     /m/1/keeps/all                      @com.keepit.controllers.mobile.MobileKeepsController.allKeeps(before: Option[String], after: Option[String], collection: Option[String], helprank: Option[String], count: Int ?= Integer.MAX_VALUE, withPageInfo: Boolean ?= false)
 POST    /m/1/tags/:id/addToKeep             @com.keepit.controllers.mobile.MobileKeepsController.addTag(id: ExternalId[Collection])

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobilePreferenceControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobilePreferenceControllerTest.scala
@@ -1,0 +1,54 @@
+package com.keepit.controllers.mobile
+
+import com.google.inject.Injector
+import com.keepit.common.controller.FakeUserActionsHelper
+import com.keepit.test.ShoeboxTestInjector
+import org.specs2.mutable.Specification
+import com.keepit.model.{ NotifyPreference, UserNotifyPreferenceRepo, User }
+import com.keepit.model.UserFactory._
+import com.keepit.model.UserFactoryHelper._
+import play.api.libs.json.{ Json, JsObject }
+import play.api.mvc.{ Result, Call }
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+import scala.concurrent.Future
+
+class MobilePreferenceControllerTest extends Specification with ShoeboxTestInjector {
+
+  val mobileControllerTestModules = Seq()
+
+  "MobileController" should {
+
+    "change recos reminder notifications" in {
+      withDb(mobileControllerTestModules: _*) { implicit injector =>
+        val notifyPreferenceRepo = inject[UserNotifyPreferenceRepo]
+        val user1 = db.readWrite { implicit s =>
+          val user1 = user().withName("Lebron", "James").saved
+          notifyPreferenceRepo.canNotify(user1.id.get, NotifyPreference.RECOS_REMINDER) === true
+          user1
+        }
+
+        val result1 = setRecosReminder(user1, Json.obj("recos_reminder" -> false))
+        status(result1) must equalTo(NO_CONTENT)
+        db.readOnlyMaster { implicit s =>
+          notifyPreferenceRepo.canNotify(user1.id.get, NotifyPreference.RECOS_REMINDER) === false
+        }
+
+        val result2 = setRecosReminder(user1, Json.obj("recos_reminder" -> true))
+        status(result2) must equalTo(NO_CONTENT)
+        db.readOnlyMaster { implicit s =>
+          notifyPreferenceRepo.canNotify(user1.id.get, NotifyPreference.RECOS_REMINDER) === true
+        }
+
+      }
+    }
+
+  }
+  private def setRecosReminder(user: User, body: JsObject)(implicit injector: Injector): Future[Result] = {
+    inject[FakeUserActionsHelper].setUser(user)
+    controller.setNotifyPreferences()(request(routes.MobilePreferenceController.setNotifyPreferences()).withBody(body))
+  }
+  private def controller(implicit injector: Injector) = inject[MobilePreferenceController]
+  private def request(route: Call) = FakeRequest(route.method, route.url)
+}


### PR DESCRIPTION
@andrewconner @stkem @jaredpetker @thassss 

You can use this endpoint by:

```
POST /m/1/user/notifyPrefs 
```

It takes in a Json object in which you can send the preference like this: `{"recos_reminder" : true}`
You'll see the update in `GET     /m/1/user/prefs`

In the future, we can just add to this object

```
{
 "recos_reminder" : true,
 "leave_me_alone": true,
 "shut_up": false
}
```
