### PR TITLE
related library. partial update	

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/301.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/301.sql
@@ -1,0 +1,10 @@
+# CORTEX
+
+# --- !Ups
+
+alter table lda_related_library
+    add index lda_related_library_i_version_dest (version, dest_id);
+
+insert into evolutions (name, description) values('301.sql', 'add index in lda_related_library, support look up by dest_id');
+
+# --- !Downs

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/LDARelatedLibraryRepo.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/LDARelatedLibraryRepo.scala
@@ -14,6 +14,7 @@ import com.keepit.model.Library
 @ImplementedBy(classOf[LDARelatedLibraryRepoImpl])
 trait LDARelatedLibraryRepo extends DbRepo[LDARelatedLibrary] {
   def getRelatedLibraries(sourceId: Id[Library], version: ModelVersion[DenseLDA], excludeState: Option[State[LDARelatedLibrary]])(implicit session: RSession): Seq[LDARelatedLibrary]
+  def getIncomingEdges(destId: Id[Library], version: ModelVersion[DenseLDA], excludeState: Option[State[LDARelatedLibrary]])(implicit session: RSession): Seq[LDARelatedLibrary]
   def getNeighborIdsAndWeights(sourceId: Id[Library], version: ModelVersion[DenseLDA])(implicit session: RSession): Seq[(Id[Library], Float)]
   def getTopNeighborIdsAndWeights(sourceId: Id[Library], version: ModelVersion[DenseLDA], limit: Int)(implicit session: RSession): Seq[(Id[Library], Float)]
 }
@@ -44,6 +45,10 @@ class LDARelatedLibraryRepoImpl @Inject() (
 
   def getRelatedLibraries(sourceId: Id[Library], version: ModelVersion[DenseLDA], excludeState: Option[State[LDARelatedLibrary]])(implicit session: RSession): Seq[LDARelatedLibrary] = {
     (for (r <- rows if r.version === version && r.sourceId === sourceId && r.state =!= excludeState.orNull) yield r).list
+  }
+
+  def getIncomingEdges(destId: Id[Library], version: ModelVersion[DenseLDA], excludeState: Option[State[LDARelatedLibrary]])(implicit session: RSession): Seq[LDARelatedLibrary] = {
+    (for (r <- rows if r.version === version && r.destId === destId && r.state =!= excludeState.orNull) yield r).list
   }
 
   def getNeighborIdsAndWeights(sourceId: Id[Library], version: ModelVersion[DenseLDA])(implicit session: RSession): Seq[(Id[Library], Float)] = {

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/LibraryLDATopicRepo.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/LibraryLDATopicRepo.scala
@@ -10,6 +10,7 @@ import com.keepit.cortex.models.lda.{ LDATopic, DenseLDA }
 import com.keepit.cortex.sql.CortexTypeMappers
 import com.keepit.model.{ User, Library }
 import com.keepit.common.db.slick.{ DataBaseComponent, DbRepo }
+import org.joda.time.DateTime
 
 import scala.slick.jdbc.{ GetResult, StaticQuery }
 
@@ -21,6 +22,7 @@ trait LibraryLDATopicRepo extends DbRepo[LibraryLDATopic] {
   def getUserFollowedLibraryFeatures(userId: Id[User], version: ModelVersion[DenseLDA], minEvidence: Int = 5)(implicit session: RSession): Seq[LibraryTopicMean]
   def getLibraryByTopics(firstTopic: LDATopic, secondTopic: Option[LDATopic] = None, thirdTopic: Option[LDATopic] = None, version: ModelVersion[DenseLDA], minKeeps: Int = 5, limit: Int)(implicit session: RSession): Seq[LibraryLDATopic]
   def getAllActiveByVersion(version: ModelVersion[DenseLDA], minEvidence: Int = 5)(implicit session: RSession): Seq[LibraryLDATopic]
+  def getRecentUpdated(version: ModelVersion[DenseLDA], since: DateTime)(implicit session: RSession): Seq[LibraryLDATopic]
 }
 
 @Singleton
@@ -90,5 +92,9 @@ class LibraryLDATopicRepoImpl @Inject() (
 
   def getAllActiveByVersion(version: ModelVersion[DenseLDA], minEvidence: Int = 5)(implicit session: RSession): Seq[LibraryLDATopic] = {
     (for { r <- rows if r.version === version && r.state === LibraryLDATopicStates.ACTIVE && r.numOfEvidence >= minEvidence } yield r).list
+  }
+
+  def getRecentUpdated(version: ModelVersion[DenseLDA], since: DateTime)(implicit session: RSession): Seq[LibraryLDATopic] = {
+    (for { r <- rows if r.version === version && r.updatedAt > since } yield r).list
   }
 }

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDARelatedLibraryCommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/models/lda/LDARelatedLibraryCommander.scala
@@ -14,6 +14,7 @@ import com.keepit.cortex.utils.MatrixUtils._
 import com.keepit.cortex.ModelVersions._
 import com.keepit.model.Library
 import scala.concurrent.duration._
+import com.keepit.common.time._
 
 @ImplementedBy(classOf[LDARelatedLibraryCommanderImpl])
 trait LDARelatedLibraryCommander {
@@ -36,22 +37,58 @@ class LDARelatedLibraryCommanderImpl @Inject() (
   private val TOP_K = 50
   private val MIN_WEIGHT = 0.7f
   private val MIN_EVIDENCE = 2
+  private var hasFullyUpdated = false
+
+  def fullyUpdateMode: Boolean = !hasFullyUpdated
+
+  def update(version: ModelVersion[DenseLDA]): Unit = {
+    if (!hasFullyUpdated) {
+      fullUpdate(version)
+      hasFullyUpdated = true
+    } else {
+      partialUpdate(version)
+    }
+  }
 
   // completely reconstruct an asymetric graph
-  def update(version: ModelVersion[DenseLDA]): Unit = {
+  def fullUpdate(version: ModelVersion[DenseLDA]): Unit = {
     log.info(s"update LDA related library graph for version ${version.version}")
-    var edgeCnt = 0
-
     val libTopics = db.readOnlyReplica { implicit s => libTopicRepo.getAllActiveByVersion(version, MIN_EVIDENCE) }
-    libTopics.foreach { source =>
-      val sourceId = source.libraryId
-      val full = computeFullAdjacencyList(source, libTopics)
-      val sparse = sparsify(full, TOP_K, MIN_WEIGHT)
-      edgeCnt += sparse.size
-      saveAdjacencyList(sourceId, sparse, version)
+    libTopics.foreach { source => computeAndPersistEdges(source, libTopics)(version) }
+    log.info(s"finished updating LDA related library graph for version ${version.version}")
+  }
+
+  private def computeAndPersistEdges(source: LibraryLDATopic, libTopics: Seq[LibraryLDATopic])(implicit version: ModelVersion[DenseLDA]): Unit = {
+    val sourceId = source.libraryId
+    val full = computeFullAdjacencyList(source, libTopics)
+    val sparse = sparsify(full, TOP_K, MIN_WEIGHT)
+    saveAdjacencyList(sourceId, sparse, version)
+  }
+
+  private def deactivateEdges(vertex: Id[Library], version: ModelVersion[DenseLDA]): Unit = {
+    db.readWrite { implicit s =>
+      val outgoing = relatedLibRepo.getRelatedLibraries(vertex, version, excludeState = Some(LDARelatedLibraryStates.INACTIVE))
+      val incoming = relatedLibRepo.getIncomingEdges(vertex, version, excludeState = Some(LDARelatedLibraryStates.INACTIVE))
+      outgoing.foreach { x => relatedLibRepo.save(x.copy(state = LDARelatedLibraryStates.INACTIVE)) }
+      incoming.foreach { x => relatedLibRepo.save(x.copy(state = LDARelatedLibraryStates.INACTIVE)) }
+    }
+  }
+
+  // creates new vertexes, delete inactive ones.
+  def partialUpdate(version: ModelVersion[DenseLDA]): Unit = {
+    log.info(s"begin partial update LDA related library graph for version ${version.version}")
+    val now = currentDateTime
+    val updates = db.readOnlyReplica { implicit s => libTopicRepo.getRecentUpdated(version, since = now.minusHours(3)) }
+    val (active, other) = updates.partition(_.state == LibraryLDATopicStates.ACTIVE)
+    val (newSources, _) = active.partition { x => db.readOnlyReplica { implicit s => relatedLibRepo.getNeighborIdsAndWeights(x.libraryId, version).isEmpty } } // query could be optimized
+
+    if (newSources.size > 0) {
+      val libTopics = db.readOnlyReplica { implicit s => libTopicRepo.getAllActiveByVersion(version, MIN_EVIDENCE) }
+      newSources.foreach { source => computeAndPersistEdges(source, libTopics)(version) }
     }
 
-    log.info(s"finished updating LDA related library graph for version ${version.version}. total edges number = ${edgeCnt}")
+    other.foreach { x => deactivateEdges(x.libraryId, version) }
+    log.info(s"done with partial update LDA related library graph for version ${version.version}")
   }
 
   def cleanFewKeepsLibraries(version: ModelVersion[DenseLDA], readOnly: Boolean): Unit = {
@@ -123,6 +160,7 @@ class LDARelatedLibraryCommanderImpl @Inject() (
 
 trait LDARelatedLibraryMessage
 case object UpdateLDARelatedLibrary extends LDARelatedLibraryMessage
+case object PartialUpdateLDARelatedLibrary extends LDARelatedLibraryMessage
 
 class LDARelatedLibraryActor @Inject() (
     relatedLibCommander: LDARelatedLibraryCommander,

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDARelatedLibraryCommanderTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDARelatedLibraryCommanderTest.scala
@@ -88,11 +88,11 @@ class LDARelatedLibraryCommanderTest extends Specification with CortexTestInject
         db.readOnlyReplica { implicit s =>
 
           checkConnection(Id[Library](1)) === List()
-          checkConnection(Id[Library](2)) === List()              // 2 is deactivated
-          checkConnection(Id[Library](3)) === List()              // 2 is gone
+          checkConnection(Id[Library](2)) === List() // 2 is deactivated
+          checkConnection(Id[Library](3)) === List() // 2 is gone
           checkConnection(Id[Library](4)) === List((5, true))
           checkConnection(Id[Library](5)) === List((4, true))
-          checkConnection(Id[Library](6)).map { x => x._1 }.toSet === Set(4, 5)     // 6 is new
+          checkConnection(Id[Library](6)).map { x => x._1 }.toSet === Set(4, 5) // 6 is new
         }
 
       }

--- a/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDARelatedLibraryCommanderTest.scala
+++ b/kifi-backend/modules/cortex/test/com/keepit/cortex/models/lda/LDARelatedLibraryCommanderTest.scala
@@ -40,6 +40,7 @@ class LDARelatedLibraryCommanderTest extends Specification with CortexTestInject
         }
 
         val commander = new LDARelatedLibraryCommanderImpl(db, libTopicRepo, relatedLibRepo)
+        commander.fullyUpdateMode === true
         commander.update(ModelVersion[DenseLDA](1))
 
         db.readOnlyReplica { implicit s =>
@@ -61,7 +62,8 @@ class LDARelatedLibraryCommanderTest extends Specification with CortexTestInject
           libTopicRepo.save(model.copy(topic = Some(LibraryTopicMean(Array(0f, 0f, 0.1f, 0.9f)))))
         }
 
-        commander.update(ModelVersion[DenseLDA](1))
+        commander.fullyUpdateMode === false
+        commander.fullUpdate(ModelVersion[DenseLDA](1)) // need full update here
 
         db.readOnlyReplica { implicit s =>
 
@@ -71,6 +73,26 @@ class LDARelatedLibraryCommanderTest extends Specification with CortexTestInject
           checkConnection(Id[Library](4)) === List((5, true))
           checkConnection(Id[Library](5)) === List((4, true))
 
+        }
+
+        // make library 2 has inactive feature
+        db.readWrite { implicit s =>
+          val model = libTopicRepo.getActiveByLibraryId(Id[Library](2), ModelVersion[DenseLDA](1)).get
+          libTopicRepo.save(model.copy(state = LibraryLDATopicStates.INACTIVE))
+          val lib6 = lib1.copy(libraryId = Id[Library](6), topic = Some(LibraryTopicMean(Array(0f, 0.9f, 0f, 0.1f))))
+          libTopicRepo.save(lib6)
+        }
+        commander.fullyUpdateMode === false
+        commander.update(ModelVersion[DenseLDA](1)) // partial update
+
+        db.readOnlyReplica { implicit s =>
+
+          checkConnection(Id[Library](1)) === List()
+          checkConnection(Id[Library](2)) === List()              // 2 is deactivated
+          checkConnection(Id[Library](3)) === List()              // 2 is gone
+          checkConnection(Id[Library](4)) === List((5, true))
+          checkConnection(Id[Library](5)) === List((4, true))
+          checkConnection(Id[Library](6)).map { x => x._1 }.toSet === Set(4, 5)     // 6 is new
         }
 
       }


### PR DESCRIPTION
@stkem @eishay 

this avoid the unnecessary full graph computation and persistence every 3 hours. 
the online update part deals with:
- create adjacency list for new library
- remove edges of an inactive library (both directions)
- all other edges and weights remain unchanged
