### PR TITLE
set of invalid slugs

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -154,8 +154,10 @@ object LibrarySlug {
     Format(__.read[String].map(LibrarySlug(_)), new Writes[LibrarySlug] { def writes(o: LibrarySlug) = JsString(o.value) })
 
   val MaxLength = 50
+  val invalidSlugSet = Set("libraries", "connections", "followers", "keeps", "tags")
+
   def isValidSlug(slug: String): Boolean = {
-    slug != "" && !slug.contains(' ') && slug.length <= MaxLength
+    slug != "" && !slug.contains(' ') && slug.length <= MaxLength && !invalidSlugSet.contains(slug)
   }
 
   def generateFromName(name: String): String = {

--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -157,7 +157,11 @@ object LibrarySlug {
   val invalidSlugSet = Set("libraries", "connections", "followers", "keeps", "tags", "main", "secret")
 
   def isValidSlug(slug: String): Boolean = {
-    slug != "" && !slug.contains(' ') && slug.length <= MaxLength && !invalidSlugSet.contains(slug)
+    slug != "" && !slug.contains(' ') && slug.length <= MaxLength
+  }
+
+  def isReservedSlug(slug: String): Boolean = {
+    invalidSlugSet.contains(slug)
   }
 
   def generateFromName(name: String): String = {

--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -154,7 +154,7 @@ object LibrarySlug {
     Format(__.read[String].map(LibrarySlug(_)), new Writes[LibrarySlug] { def writes(o: LibrarySlug) = JsString(o.value) })
 
   val MaxLength = 50
-  val invalidSlugSet = Set("libraries", "connections", "followers", "keeps", "tags")
+  val invalidSlugSet = Set("libraries", "connections", "followers", "keeps", "tags", "main", "secret")
 
   def isValidSlug(slug: String): Boolean = {
     slug != "" && !slug.contains(' ') && slug.length <= MaxLength && !invalidSlugSet.contains(slug)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -431,8 +431,11 @@ class LibraryCommander @Inject() (
         log.info(s"[addLibrary] Invalid name ${libAddReq.name} for $ownerId")
         Some("invalid_name")
       } else if (libAddReq.slug.isEmpty || !LibrarySlug.isValidSlug(libAddReq.slug)) {
-        log.info(s"[addLibrary] Invalid slub ${libAddReq.slug} for $ownerId")
+        log.info(s"[addLibrary] Invalid slug ${libAddReq.slug} for $ownerId")
         Some("invalid_slug")
+      } else if (LibrarySlug.isReservedSlug(libAddReq.slug)) {
+        log.info(s"[addLibrary] Attempted reserved slug ${libAddReq.slug} for $ownerId")
+        Some("reserved_slug")
       } else {
         None
       }
@@ -521,6 +524,8 @@ class LibraryCommander @Inject() (
           case Some(slugStr) =>
             if (!LibrarySlug.isValidSlug(slugStr)) {
               Left(LibraryFail(BAD_REQUEST, "invalid_slug"))
+            } else if (LibrarySlug.isReservedSlug(slugStr)) {
+              Left(LibraryFail(BAD_REQUEST, "reserved_slug"))
             } else {
               val slug = LibrarySlug(slugStr)
               db.readOnlyMaster { implicit s =>


### PR DESCRIPTION
@andrewconner @2is10 

This will reject an add library or modify library request by returning a "invalid_slug" error to the FE

I think this would be a decent fix until we decide what to do with auto-generated slugs. Or maybe we'll need better error messages on the FE for all platforms?
