### PR TITLE
beginning to unwind/simplify KifiSiteRouter

### DIFF
--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -924,4 +924,12 @@ GET     /img/*file                 com.keepit.controllers.website.AngularImgAsse
 
 ->  / commonService.Routes
 
+##########################################
+# Web App
+##########################################
+
+GET     /recommendations           @com.keepit.controllers.website.KifiSiteRouter.redirectUserTo(path = "/")
+GET     /friends/invite            @com.keepit.controllers.website.KifiSiteRouter.redirectUserTo(path = "/invite")
+GET     /me                        @com.keepit.controllers.website.KifiSiteRouter.redirectUserToOwnProfile(subpath = "")
+GET     /me/*subpath               @com.keepit.controllers.website.KifiSiteRouter.redirectUserToOwnProfile(subpath)
 GET     /*wildcard                 @com.keepit.controllers.website.KifiSiteRouter.app(wildcard)

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
@@ -6,7 +6,7 @@ import com.keepit.commanders.{ LibraryCommander, UserCommander }
 import com.keepit.common.concurrent.FakeExecutionContextModule
 import com.keepit.common.controller.{ FakeUserActionsHelper, UserRequest, NonUserRequest }
 import com.keepit.common.crypto.FakeCryptoModule
-
+import com.keepit.common.db.Id
 import com.keepit.common.mail.{ EmailAddress, FakeMailModule }
 import com.keepit.common.social.FakeSocialGraphModule
 import com.keepit.common.store.FakeShoeboxStoreModule
@@ -18,19 +18,20 @@ import com.keepit.model._
 import com.keepit.scraper.{ FakeScrapeSchedulerModule, FakeScraperServiceClientModule }
 import com.keepit.search.FakeSearchServiceClientModule
 import com.keepit.shoebox.FakeKeepImportsModule
-import com.keepit.test.ShoeboxTestInjector
+import com.keepit.test.{ ShoeboxTestInjector, ShoeboxApplication, ShoeboxApplicationInjector }
+
 import org.specs2.mutable.Specification
-import play.api.test.FakeRequest
-import play.api.test.Helpers.{ contentType, OK, status }
-import com.keepit.common.db.Id
+import org.specs2.matcher.{ Matcher, Expectable }
 
-import play.api.test.Helpers._
+import play.api.mvc.Result
 import play.api.test._
+import play.api.test.Helpers._
 
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
+import scala.concurrent.Future
 
-class KifiSiteRouterTest extends Specification with ShoeboxTestInjector {
+import securesocial.core.SecureSocial
+
+class KifiSiteRouterTest extends Specification with ShoeboxApplicationInjector {
 
   val modules = Seq(
     FakeExecutionContextModule(),
@@ -50,24 +51,60 @@ class KifiSiteRouterTest extends Specification with ShoeboxTestInjector {
   "KifiSiteRouter" should {
     implicit val context = HeimdalContext.empty
 
-    "route requests correctly" in {
-      withDb(modules: _*) { implicit injector =>
-        val userCommander = inject[UserCommander]
+    "route correctly" in {
+      running(new ShoeboxApplication(modules: _*)) {
+        // Database population
         val (user1, user2) = db.readWrite { implicit session =>
           val u1 = userRepo.save(User(firstName = "Abe", lastName = "Lincoln", username = Username("abez"), normalizedUsername = "abez"))
           val u2 = userRepo.save(User(firstName = "Léo", lastName = "HasAnAccentInHisName", username = Username("léo1221"), normalizedUsername = "leo"))
           (u1, u2)
         }
 
+        val userCommander = inject[UserCommander]
         userCommander.setUsername(user1.id.get, Username("abez"))
         userCommander.setUsername(user2.id.get, Username("léo1221"))
 
         val router = inject[KifiSiteRouter]
-        val actionsHelper = inject[FakeUserActionsHelper].setUser(user1)
+        val actionsHelper = inject[FakeUserActionsHelper]
 
-        router.route(NonUserRequest(FakeRequest.apply("GET", "/asdf"))) === Error404
+        // Custom matchers, TODO: find better home
+        case class beRedirect(expectedStatus: Int, expectedUrl: String) extends Matcher[Option[Future[Result]]] {
+          def apply[T <: Option[Future[Result]]](x: Expectable[T]) = {
+            x.value map { resultF =>
+              val resStatus = status(resultF)
+              if (resStatus != expectedStatus) {
+                result(false, "", s"expected status $expectedStatus but was $resStatus", x)
+              }
+              redirectLocation(resultF) map { resUrl =>
+                result(resUrl == expectedUrl, "", s"expected redirect to $expectedUrl but was $resUrl", x)
+              } getOrElse result(false, "", "expected redirect to $expectedUrl but was None", x)
+            } getOrElse result(false, "", "request did not match any routes", x)
+          }
+        }
+        case class beLoginRedirect(expectedUrl: String) extends Matcher[Option[Future[Result]]] {
+          def apply[T <: Option[Future[Result]]](x: Expectable[T]) = {
+            x.value map { resultF =>
+              val expectedStatus = 303
+              val resStatus = status(resultF)
+              if (resStatus != expectedStatus) {
+                result(false, "", s"expected status $expectedStatus but was $resStatus", x)
+              }
+              val loginUrl = "/login"
+              redirectLocation(resultF) map { resUrl =>
+                if (resUrl != loginUrl) {
+                  result(false, "", s"expected redirect to $loginUrl but was $resUrl", x)
+                } else {
+                  val destUrl = session(resultF).get(SecureSocial.OriginalUrlKey)
+                  result(destUrl == Some(expectedUrl), "", s"expected destination $expectedUrl in session cookie but was $destUrl", x)
+                }
+              } getOrElse result(false, "", "expected redirect to $expectedUrl but was None", x)
+            } getOrElse result(false, "", "request did not match any routes", x)
+          }
+        }
 
         // Username routing
+        router.route(NonUserRequest(FakeRequest.apply("GET", "/asdf"))) === Error404
+
         router.route(NonUserRequest(FakeRequest.apply("GET", "/abez"))) must beAnInstanceOf[Angular]
         router.route(NonUserRequest(FakeRequest.apply("GET", "/abez/libraries/following"))) must beAnInstanceOf[Angular]
         router.route(NonUserRequest(FakeRequest.apply("GET", "/abez/libraries/invited"))) must beAnInstanceOf[Angular]
@@ -100,19 +137,24 @@ class KifiSiteRouterTest extends Specification with ShoeboxTestInjector {
 
         // Fixed Angular routes
         router.route(NonUserRequest(FakeRequest.apply("GET", "/invite"))) === RedirectToLogin("/invite")
+        actionsHelper.setUser(user1)
         router.route(UserRequest(FakeRequest.apply("GET", "/invite"), user1.id.get, None, actionsHelper)) must beAnInstanceOf[Angular]
 
         // /me
-        router.route(NonUserRequest(FakeRequest.apply("GET", "/me"))) === RedirectToLogin("/me")
-        router.route(NonUserRequest(FakeRequest.apply("GET", "/me/libraries/following"))) === RedirectToLogin("/me/libraries/following")
-        router.route(UserRequest(FakeRequest.apply("GET", "/me"), user1.id.get, None, actionsHelper)) === SeeOtherRoute("/abez")
-        router.route(UserRequest(FakeRequest.apply("GET", "/me/libraries/invited"), user1.id.get, None, actionsHelper)) === SeeOtherRoute("/abez/libraries/invited")
+        actionsHelper.unsetUser
+        route(FakeRequest("GET", "/me")) must beLoginRedirect("/me")
+        route(FakeRequest("GET", "/me/libraries/following")) must beLoginRedirect("/me/libraries/following")
+
+        actionsHelper.setUser(user1)
+        route(FakeRequest("GET", "/me")) must beRedirect(303, "/abez")
+        route(FakeRequest("GET", "/me/libraries/invited")) must beRedirect(303, "/abez/libraries/invited")
 
         // Redirects (logged out)
-        router.route(NonUserRequest(FakeRequest.apply("GET", "/recommendations"))) === RedirectToLogin("/")
+        actionsHelper.unsetUser
+        route(FakeRequest("GET", "/recommendations")) must beLoginRedirect("/")
         router.route(NonUserRequest(FakeRequest.apply("GET", "/connections"))) === RedirectToLogin("/connections")
         router.route(NonUserRequest(FakeRequest.apply("GET", "/friends"))) === RedirectToLogin("/connections")
-        router.route(NonUserRequest(FakeRequest.apply("GET", "/friends/invite"))) === RedirectToLogin("/invite")
+        route(FakeRequest("GET", "/friends/invite")) must beLoginRedirect("/invite")
         router.route(NonUserRequest(FakeRequest.apply("GET", "/friends/requests"))) === RedirectToLogin("/connections")
         router.route(NonUserRequest(FakeRequest.apply("GET", "/friends/requests/email"))) === RedirectToLogin("/connections")
         router.route(NonUserRequest(FakeRequest.apply("GET", "/friends/requests/linkedin"))) === RedirectToLogin("/connections")
@@ -122,10 +164,11 @@ class KifiSiteRouterTest extends Specification with ShoeboxTestInjector {
         router.route(NonUserRequest(FakeRequest.apply("GET", "/invite?friend=" + user2.externalId))) === RedirectToLogin("/l%C3%A9o1221?intent=connect")
 
         // Redirects (logged in)
-        router.route(UserRequest(FakeRequest.apply("GET", "/recommendations"), user1.id.get, None, actionsHelper)) === MovedPermanentlyRoute("/")
+        actionsHelper.setUser(user1)
+        route(FakeRequest("GET", "/recommendations")) must beRedirect(301, "/")
         router.route(UserRequest(FakeRequest.apply("GET", "/connections"), user1.id.get, None, actionsHelper)) === SeeOtherRoute("/abez/connections")
         router.route(UserRequest(FakeRequest.apply("GET", "/friends"), user1.id.get, None, actionsHelper)) === SeeOtherRoute("/abez/connections")
-        router.route(UserRequest(FakeRequest.apply("GET", "/friends/invite"), user1.id.get, None, actionsHelper)) === MovedPermanentlyRoute("/invite")
+        route(FakeRequest("GET", "/friends/invite")) must beRedirect(301, "/invite")
         router.route(UserRequest(FakeRequest.apply("GET", "/friends/requests"), user1.id.get, None, actionsHelper)) === SeeOtherRoute("/abez/connections")
         router.route(UserRequest(FakeRequest.apply("GET", "/friends/requests/email"), user1.id.get, None, actionsHelper)) === SeeOtherRoute("/abez/connections")
         router.route(UserRequest(FakeRequest.apply("GET", "/friends/requests/linkedin"), user1.id.get, None, actionsHelper)) === SeeOtherRoute("/abez/connections")
@@ -133,36 +176,29 @@ class KifiSiteRouterTest extends Specification with ShoeboxTestInjector {
         router.route(UserRequest(FakeRequest.apply("GET", "/friends/requests/refresh"), user1.id.get, None, actionsHelper)) === SeeOtherRoute("/abez/connections")
         router.route(UserRequest(FakeRequest.apply("GET", "/friends?friend=" + user2.externalId), user1.id.get, None, actionsHelper)) === SeeOtherRoute("/l%C3%A9o1221?intent=connect")
         router.route(UserRequest(FakeRequest.apply("GET", "/invite?friend=" + user2.externalId), user1.id.get, None, actionsHelper)) === SeeOtherRoute("/l%C3%A9o1221?intent=connect")
-      }
-    }
 
-    "catching mobile" in {
-      withDb(modules: _*) { implicit injector =>
-        val request = FakeRequest("GET", "/some/path?kma=1").withHeaders("user-agent" -> "Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3")
-        val result = inject[KifiSiteRouter].app("some/path?kma=1")(request)
-        status(result) must equalTo(OK);
-        contentType(result) must beSome("text/html");
-        val resString = contentAsString(result)
-        resString.contains("window.location = 'kifi://some/path?kma=1';") === true
-        resString.contains("var cleanUrl = '/some/path?kma=1") === true
-      }
-    }
+        { // catching mobile
+          val request = FakeRequest("GET", "/some/path?kma=1").withHeaders("user-agent" -> "Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3")
+          val result = inject[KifiSiteRouter].app("some/path?kma=1")(request)
+          status(result) must equalTo(OK)
+          contentType(result) must beSome("text/html")
+          val resString = contentAsString(result)
+          resString.contains("window.location = 'kifi://some/path?kma=1';") === true
+          resString.contains("var cleanUrl = '/some/path?kma=1") === true
+        }
 
-    "ignoring flag with no mobile" in {
-      withDb(modules: _*) { implicit injector =>
-        val request = FakeRequest("GET", "/some/path?kma=1").withHeaders("user-agent" -> "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:20.0) Gecko/20100101 Firefox/20.0")
-        val result = inject[KifiSiteRouter].app("some/path?kma=1")(request)
-        status(result) must equalTo(404);
-      }
-    }
+        { // ignoring flag with no mobile
+          val request = FakeRequest("GET", "/some/path?kma=1").withHeaders("user-agent" -> "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:20.0) Gecko/20100101 Firefox/20.0")
+          val result = inject[KifiSiteRouter].app("some/path?kma=1")(request)
+          status(result) must equalTo(404)
+        }
 
-    "ignoring mobile with no flag" in {
-      withDb(modules: _*) { implicit injector =>
-        val request = FakeRequest("GET", "/some/path").withHeaders("user-agent" -> "Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3")
-        val result = inject[KifiSiteRouter].app("some/path")(request)
-        status(result) must equalTo(404);
+        { // ignoring mobile with no flag
+          val request = FakeRequest("GET", "/some/path").withHeaders("user-agent" -> "Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3")
+          val result = inject[KifiSiteRouter].app("some/path")(request)
+          status(result) must equalTo(404)
+        }
       }
     }
   }
-
 }


### PR DESCRIPTION
@andrewconner 

As `KifiSiteRouter` has become more complex, it strikes me that the Play framework is better at routing clearly and efficiently than we are. Here I’ve factored out some of the redirects into the shoebox routes file and introduced private action filters for cross-cutting concerns.

I intend to remove a bit more of the branching logic and then add a mechanism for handling email links differently for web and mobile.
