### PR TITLE
allowing functions to be defined below where they are used

### DIFF
--- a/kifi-backend/modules/shoebox/angular/.jshintrc
+++ b/kifi-backend/modules/shoebox/angular/.jshintrc
@@ -10,7 +10,7 @@
   "forin": true,
   "immed": true,
   "indent": 2,
-  "latedef": true,
+  "latedef": "nofunc",
   "newcap": true,
   "noarg": true,
   "noempty": true,


### PR DESCRIPTION
I find it useful to sometimes declare “private” helper functions lower in a scope, so they can be motivated by some higher-level code that calls them before the reader encounters them and (perhaps) feels compelled to read them.

@andrewconner @stkem @ahsu1230 
