### PR TITLE
adapting shoebox cluster size alerts to the new reality

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/service/Service.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/service/Service.scala
@@ -36,6 +36,8 @@ object ServiceType {
       val capabilities = instance.capabilities
       if (capabilities.contains(ServiceStatus.OFFLINE.name)) ServiceStatus.OFFLINE else ServiceStatus.UP
     }
+    override val minInstances = 2
+    override val warnInstances = 3
   }
   case object ELIZA extends ServiceType("ELIZA", "EZ")
   case object HEIMDAL extends ServiceType("HEIMDAL", "HD", loadFactor = 2)


### PR DESCRIPTION
Turns out we lost three out of five shoeboxen this morning! (Likely related to the too many db connections alerts we got this morning) 

The cluster size alerts were still configured for a cluster of 2. I've changed it to reflect the new cluster size.
