### PR TITLE
addedAt field from chrome & firefox should be set for RawKeep.createdDat...

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/RawKeep.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/RawKeep.scala
@@ -46,9 +46,10 @@ class RawKeepFactory @Inject() (airbrake: AirbrakeNotifier) {
     val title = (json \ "title").asOpt[String]
     val url = (json \ "url").asOpt[String].getOrElse(throw new Exception(s"json $json did not have a url"))
     val isPrivate = (json \ "isPrivate").asOpt[Boolean].getOrElse(true)
+    val addedAt = (json \ "addedAt").asOpt[DateTime]
     val canonical = (json \ Normalization.CANONICAL.scheme).asOpt[String]
     val openGraph = (json \ Normalization.OPENGRAPH.scheme).asOpt[String]
-    RawKeep(userId = userId, title = title, url = url, isPrivate = isPrivate, importId = importId, source = source, originalJson = Some(json), installationId = installationId, libraryId = libraryId)
+    RawKeep(userId = userId, title = title, url = url, isPrivate = isPrivate, importId = importId, source = source, originalJson = Some(json), installationId = installationId, libraryId = libraryId, createdDate = addedAt)
   }
 }
 


### PR DESCRIPTION
...e

@andrewconner 
From my understanding, the JSON the Extension is already sending a json with field `addedAt`. We simply look for that field in `RawKeepFactory.toRawKeep`, set it for `createdDate`. `createdDate` gets set for `RawBookmarkRepresentation.keptAt` in `RawKeepImporterPlugin.processBatch`, which eventually translates to `Keep.keptAt`
