### PR TITLE
hook up

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/RawBookmarkRepresentation.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/RawBookmarkRepresentation.scala
@@ -39,14 +39,6 @@ object RawBookmarkRepresentation {
       JsSuccess(RawBookmarkRepresentation(x.title, x.url, x.isPrivate, x.canonical, x.openGraph, x.keptAt, None))
     }
   }
-
-  // NOTE: No attemp to write the trait SourceAttribution
-  implicit val writes = new Writes[RawBookmarkRepresentation] {
-    def writes(keep: RawBookmarkRepresentation): JsValue = {
-      val tmp = RawBookmarkRepresentationWithoutAttribution(keep.title, keep.url, keep.isPrivate, keep.canonical, keep.openGraph, keep.keptAt)
-      Json.toJson(tmp)
-    }
-  }
 }
 
 @Singleton

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/RawBookmarkRepresentation.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/RawBookmarkRepresentation.scala
@@ -4,10 +4,12 @@ import com.google.inject.{ Singleton, Inject }
 import com.keepit.common.time._
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.healthcheck.AirbrakeNotifier
-import com.keepit.model.{ KeepInfo, Library, Normalization, URLFactory }
+import com.keepit.model._
 import com.kifi.macros.json
-import play.api.libs.json.{ JsArray, JsObject, JsValue }
+import play.api.libs.json._
 import org.joda.time.DateTime
+
+import scala.io.Source
 
 /* RawBookmarkRepresentation is an input (not output) class for parsing JSON requests dealing with keeps.
  * The standard use case is parsing the request JSON, then keeping it.
@@ -16,13 +18,36 @@ import org.joda.time.DateTime
  * Do not trust isPrivate here. It's provided for legacy reasons only. Privacy is the responsibility of the libraryId.
  * LibraryId is purposely not in this, it should be provided separately.
  */
-@json case class RawBookmarkRepresentation(
+case class RawBookmarkRepresentation(
   title: Option[String] = None,
   url: String,
   isPrivate: Option[Boolean],
   canonical: Option[String] = None,
   openGraph: Option[String] = None,
-  keptAt: Option[DateTime] = None)
+  keptAt: Option[DateTime] = None,
+  sourceAttribution: Option[SourceAttribution] = None)
+
+object RawBookmarkRepresentation {
+  case class RawBookmarkRepresentationWithoutAttribution(title: Option[String], url: String, isPrivate: Option[Boolean], canonical: Option[String], openGraph: Option[String], keptAt: Option[DateTime])
+
+  implicit val helperFormat = Json.format[RawBookmarkRepresentationWithoutAttribution]
+
+  // NOTE: No attemp to parse the trait SourceAttribution
+  implicit val reads = new Reads[RawBookmarkRepresentation] {
+    def reads(js: JsValue): JsResult[RawBookmarkRepresentation] = {
+      val x = js.as[RawBookmarkRepresentationWithoutAttribution]
+      JsSuccess(RawBookmarkRepresentation(x.title, x.url, x.isPrivate, x.canonical, x.openGraph, x.keptAt, None))
+    }
+  }
+
+  // NOTE: No attemp to write the trait SourceAttribution
+  implicit val writes = new Writes[RawBookmarkRepresentation] {
+    def writes(keep: RawBookmarkRepresentation): JsValue = {
+      val tmp = RawBookmarkRepresentationWithoutAttribution(keep.title, keep.url, keep.isPrivate, keep.canonical, keep.openGraph, keep.keptAt)
+      Json.toJson(tmp)
+    }
+  }
+}
 
 @Singleton
 class RawBookmarkFactory @Inject() (
@@ -51,6 +76,6 @@ class RawBookmarkFactory @Inject() (
     val isPrivate = (json \ "isPrivate").asOpt[Boolean]
     val canonical = (json \ Normalization.CANONICAL.scheme).asOpt[String]
     val openGraph = (json \ Normalization.OPENGRAPH.scheme).asOpt[String]
-    RawBookmarkRepresentation(title = title, url = url, isPrivate = isPrivate, canonical = canonical, openGraph = openGraph, Some(clock.now))
+    RawBookmarkRepresentation(title = title, url = url, isPrivate = isPrivate, canonical = canonical, openGraph = openGraph, Some(clock.now), None)
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/RawKeepImporterPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/RawKeepImporterPlugin.scala
@@ -94,7 +94,8 @@ private class RawKeepImporterActor @Inject() (
         val rawBookmarks = rawKeepGroup.map { rk =>
           val canonical = rk.originalJson.flatMap(json => (json \ Normalization.CANONICAL.scheme).asOpt[String])
           val openGraph = rk.originalJson.flatMap(json => (json \ Normalization.OPENGRAPH.scheme).asOpt[String])
-          RawBookmarkRepresentation(title = rk.title, url = rk.url, canonical = canonical, openGraph = openGraph, isPrivate = None, keptAt = rk.createdDate)
+          val attribution = RawKeep.extractKeepSourceAttribtuion(rk)
+          RawBookmarkRepresentation(title = rk.title, url = rk.url, canonical = canonical, openGraph = openGraph, isPrivate = None, keptAt = rk.createdDate, sourceAttribution = attribution)
         }
         val library = db.readWrite { implicit s =>
           if (libraryId.isEmpty)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/RawKeep.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/RawKeep.scala
@@ -29,12 +29,12 @@ case class RawKeep(
 }
 
 object RawKeep extends Logging {
-  def extractKeepSourceAttribtuion(keep: RawKeep): Option[KeepSourceAttribution] = {
+  def extractKeepSourceAttribtuion(keep: RawKeep): Option[SourceAttribution] = {
     keep.source match {
       case KeepSource.twitterFileImport | KeepSource.twitterSync =>
         val attrOpt = keep.originalJson.flatMap(js => TwitterAttribution.fromRawTweetJson(js))
         if (attrOpt.isEmpty) log.warn(s"empty KeepSourceAttribtuion extracted. rawKeep id: ${keep.id.get}")
-        attrOpt.map { attr => KeepSourceAttribution(attribution = attr) }
+        attrOpt
       case _ => None
     }
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -23,7 +23,7 @@ import com.keepit.shoebox.FakeShoeboxServiceModule
 import com.keepit.test.ShoeboxTestInjector
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
-import play.api.libs.json.{ JsArray, JsObject, JsString, Json }
+import play.api.libs.json._
 import play.api.test.Helpers._
 import play.api.test._
 
@@ -43,6 +43,18 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
     FakeSocialGraphModule(),
     FakeCuratorServiceClientModule()
   )
+
+  import com.keepit.commanders.RawBookmarkRepresentation._
+
+  implicit val helperFormat = RawBookmarkRepresentation.helperFormat
+
+  // NOTE: No attemp to write the trait SourceAttribution
+  implicit val rawBookmarkRepwrites = new Writes[RawBookmarkRepresentation] {
+    def writes(keep: RawBookmarkRepresentation): JsValue = {
+      val tmp = RawBookmarkRepresentationWithoutAttribution(keep.title, keep.url, keep.isPrivate, keep.canonical, keep.openGraph, keep.keptAt)
+      Json.toJson(tmp)
+    }
+  }
 
   def prenormalize(url: String)(implicit injector: Injector): String = normalizationService.prenormalize(url).get
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -33,7 +33,7 @@ import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
 import play.api.libs.Files.TemporaryFile
-import play.api.libs.json.{ JsArray, JsObject, JsValue, Json }
+import play.api.libs.json._
 import play.api.test.Helpers._
 import play.api.test._
 
@@ -60,6 +60,18 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
     tf.file.deleteOnExit()
     FileUtils.copyFile(new File("test/data/image1.png"), tf.file)
     tf
+  }
+
+  import com.keepit.commanders.RawBookmarkRepresentation._
+
+  implicit val helperFormat = RawBookmarkRepresentation.helperFormat
+
+  // NOTE: No attemp to write the trait SourceAttribution
+  implicit val rawBookmarkRepwrites = new Writes[RawBookmarkRepresentation] {
+    def writes(keep: RawBookmarkRepresentation): JsValue = {
+      val tmp = RawBookmarkRepresentationWithoutAttribution(keep.title, keep.url, keep.isPrivate, keep.canonical, keep.openGraph, keep.keptAt)
+      Json.toJson(tmp)
+    }
   }
 
   "LibraryController" should {

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepSourceAttributionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepSourceAttributionTest.scala
@@ -25,7 +25,7 @@ class KeepSourceAttributionTest extends Specification with ShoeboxTestInjector {
         libraryId = None)
 
       val attr = RawKeep.extractKeepSourceAttribtuion(rawKeep)
-      attr.get.attribution === TwitterAttribution("505809542656303104", "connerdelights")
+      attr.get === TwitterAttribution("505809542656303104", "connerdelights")
 
       val rawKeep2 = rawKeep.copy(originalJson = Some(JsString("{}")))
       RawKeep.extractKeepSourceAttribtuion(rawKeep2) === None


### PR DESCRIPTION
@andrewconner @stkem 

To my surprise, `RawBookmarkRepresentation` is used in a few controllers and need json serialization. The serialization of the trait `SourceAttribution` is a bit annoying and perhaps not really needed. So I ignored that part. 
