### PR TITLE
removing selection filtering, a concept not currently in use

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
@@ -20,7 +20,6 @@ angular.module('kifi')
         editOptions: '&',
         toggleEdit: '=',
         updateSelectedCount: '&',
-        selectedKeepsFilter: '&',
         currentPageOrigin: '@'
       },
       templateUrl: 'keeps/keeps.tpl.html',
@@ -62,12 +61,6 @@ angular.module('kifi')
             lastSizedAt = $window.innerWidth;
             sizeKeeps();
           }
-        }
-
-        function getSelectedKeeps() {
-          var selectedKeeps = scope.selection.getSelected(scope.availableKeeps);
-          var filter = scope.selectedKeepsFilter();
-          return _.isFunction(filter) ? filter(selectedKeeps) : selectedKeeps;
         }
 
 
@@ -199,7 +192,7 @@ angular.module('kifi')
 
         scope.onWidgetCopyLibraryClicked = function (clickedLibrary) {
           // Copies the keeps that are selected into the library that is selected.
-          var selectedKeeps = getSelectedKeeps();
+          var selectedKeeps = scope.selection.getSelected(scope.availableKeeps);
 
           keepActionService.copyToLibrary(_.pluck(selectedKeeps, 'id'), clickedLibrary.id).then(function (data) {
             var addedKeeps = data.successes;

--- a/kifi-backend/modules/shoebox/angular/src/search/search.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/search.js
@@ -125,29 +125,6 @@ angular.module('kifi')
     // Scope methods.
     //
 
-    /*
-     * returns an array of the user's `keep` objects fetched from the keep
-     * cards that are selected. Each keep card (hit) is basically a URL. Each
-     * hit has a `keeps` array that contains information about all keeps the
-     * user has related to the URL.
-     *
-     * example input:
-     *   [ {url: 'foo.com', keeps: [{id: 1}, {id: 2}]},
-     *     {url: 'bar.com', keeps: [{id: 3}]} ]
-     * example output:
-     *   [ {url: 'foo.com', id: 1},
-     *     {url: 'foo.com', id: 2},
-     *     {url: 'bar.com', id: 3} ]
-     */
-    $scope.selectedKeepsFilter = function (hits) {
-      return _.flatten(_.map(hits, function (hit) {
-        return _.map(hit.keeps, function (keep) {
-          var ret = { 'url': hit.url };
-          return _.merge(ret, keep);
-        });
-      }));
-    };
-
     $scope.getNextKeeps = function (resetExistingResults) {
       if ($scope.loading || query === '') {
         return;

--- a/kifi-backend/modules/shoebox/angular/src/search/search.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/search/search.tpl.html
@@ -24,7 +24,6 @@
     keep-click="analyticsTrack"
     edit-mode="editMode"
     edit-options="editOptions"
-    selected-keeps-filter="selectedKeepsFilter"
     toggle-edit="toggleEdit"
     update-selected-count="updateSelectedCount(numSelected)"
     current-page-origin="searchResultsPage"


### PR DESCRIPTION
Oddly, filtering is only requested by SearchCtrl, but is only performed during the copy-to-library operation, which is not available for search results. We only offer the _keep_-to-library operation for search results.
