### PR TITLE
remove deprecated fields

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
@@ -111,8 +111,6 @@ class KeepDecorator @Inject() (
               hashtags = Some(collsForKeep.toSet.map { c: BasicCollection => Hashtag(c.name) }),
               summary = Some(pageInfoForKeep),
               siteName = DomainToNameMapper.getNameFromUrl(keep.url),
-              clickCount = None,
-              rekeepCount = None,
               libraryId = keep.libraryId.map(l => Library.publicId(l))
             )
         }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -224,13 +224,7 @@ class KeepsCommander @Inject() (
     keepsF.flatMap {
       case keepsWithHelpRankCounts =>
         val (keeps, clickCounts, rkCounts) = keepsWithHelpRankCounts.unzip3
-
-        keepDecorator.decorateKeepsIntoKeepInfos(Some(userId), false, keeps, ProcessedImageSize.Large.idealSize, withKeepTime = true).map { keepInfos =>
-          (keepInfos, clickCounts, rkCounts).zipped.map {
-            case (keepInfo, clickCount, rkCount) =>
-              keepInfo.copy(clickCount = clickCount, rekeepCount = rkCount)
-          }
-        }
+        keepDecorator.decorateKeepsIntoKeepInfos(Some(userId), false, keeps, ProcessedImageSize.Large.idealSize, withKeepTime = true)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepInfo.scala
@@ -7,7 +7,7 @@ import com.keepit.common.db.ExternalId
 import com.keepit.common.json.TupleFormat
 import com.keepit.social.BasicUser
 import org.joda.time.DateTime
-import play.api.libs.json.{ Json, Writes }
+import play.api.libs.json.{ JsNull, Json, Writes }
 
 case class KeepInfo(
   id: Option[ExternalId[Keep]] = None,
@@ -28,8 +28,6 @@ case class KeepInfo(
   hashtags: Option[Set[Hashtag]] = None,
   summary: Option[URISummary] = None,
   siteName: Option[String] = None,
-  clickCount: Option[Int] = None, // deprecated
-  rekeepCount: Option[Int] = None, // deprecated
   libraryId: Option[PublicId[Library]] = None)
 
 object KeepInfo {

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -403,14 +403,11 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
                       "libraries":[],
                       "librariesOmitted": 0,
                       "librariesTotal": 0,
-                      "clickCount":1,
                       "collections":[],
                       "tags":[],
                       "hashtags":[],
                       "summary":{},
                       "siteName":"kifi.com",
-                      "clickCount":1,
-                      "rekeepCount":1,
                       "libraryId":"l7jlKlnA36Su"
                     },
                     {
@@ -431,7 +428,6 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
                       "hashtags":[],
                       "summary":{},
                       "siteName":"FortyTwo",
-                      "clickCount":1,
                       "libraryId":"l7jlKlnA36Su"
                     }
                   ],
@@ -490,7 +486,6 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
                       "hashtags":[],
                       "summary":{},
                       "siteName":"FortyTwo",
-                      "clickCount":1,
                       "libraryId":"l7jlKlnA36Su"
                     }
                   ],

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepsControllerTest.scala
@@ -319,14 +319,11 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
                       "libraries":[],
                       "librariesOmitted": 0,
                       "librariesTotal": 0,
-                      "clickCount":1,
                       "collections":[],
                       "tags":[],
                       "hashtags":[],
                       "summary":{},
                       "siteName":"kifi.com",
-                      "clickCount":1,
-                      "rekeepCount":1,
                       "libraryId":"l7jlKlnA36Su"
                     },
                     {
@@ -347,7 +344,6 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
                       "hashtags":[],
                       "summary":{},
                       "siteName":"FortyTwo",
-                      "clickCount":1,
                       "libraryId":"l7jlKlnA36Su"
                     }
                   ],
@@ -409,7 +405,6 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
                       "hashtags":[],
                       "summary":{},
                       "siteName":"FortyTwo",
-                      "clickCount":1,
                       "libraryId":"l7jlKlnA36Su"
                     }
                   ],
@@ -469,7 +464,6 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
                                       "hashtags":[],
                                       "summary":{},
                                       "siteName":"Facebook",
-                                      "clickCount":1,
                                       "libraryId":"lzmfsKLJyou6"
                                     },
                                     {
@@ -490,8 +484,6 @@ class KeepsControllerTest extends Specification with ShoeboxTestInjector with He
                                       "hashtags":[],
                                       "summary":{},
                                       "siteName":"kifi.com",
-                                      "clickCount":1,
-                                      "rekeepCount":1,
                                       "libraryId":"lzmfsKLJyou6"
                                     }
                                   ],


### PR DESCRIPTION
@andrewconner @eishay @stkem 

`KeepInfo` has too many fields and Play Json macro has problem with it if I add one more field. 
