### PR TITLE
3.3.51: sending folder names along when importing bookmarks

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.3.50
+version=3.3.51


### PR DESCRIPTION
Only implemented for Chrome right now. I’ll add it for Firefox tomorrow.
@ahsu1230 

Format is `path: ["JavaScript", "Tutorials"]` and `path` will be absent if empty.

(Publishing a Firefox extension triggers a bug. I want to fix it before publishing another one.)
