### PR TITLE
allow unkeep any keep that is not inactive (active or duplicate)

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -344,7 +344,7 @@ class KeepsCommander @Inject() (
         val (keeps, invalidKeepIds) = db.readWrite { implicit s =>
           val (keeps, invalidKeepIds) = keepIds.map { kId =>
             keepRepo.getByExtIdandLibraryId(kId, libId, excludeState = None) match {
-              case Some(k) if (k.isActive) =>
+              case Some(k) if k.state != KeepStates.INACTIVE =>
                 keepsToFinalize = k +: keepsToFinalize
                 Left(setKeepStateWithSession(k, KeepStates.INACTIVE, userId))
               case Some(k) =>


### PR DESCRIPTION
@andrewconner @stkem 

the simple fix for our duplicates problem. The more complex, we can put in lower priority.
