### PR TITLE
foldLeftWhile => foldLeftUntil

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/concurrent/PimpedFuture.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/concurrent/PimpedFuture.scala
@@ -58,7 +58,7 @@ object FutureHelpers {
         }
         p.future
     }
-    Future.sequence(seq).map(_.toMap)
+    Future.sequence(seq).imap(_.toMap)
   }
 
   def sequentialExec[I, T](items: Iterable[I])(f: I => Future[T])(implicit ec: ScalaExecutionContext): Future[Unit] = {


### PR DESCRIPTION
@stkem @andrewconner @eishay 
1. Reversed the semantic from "while" to "until", which is more consistent with classic loop constructs: indeed, this code always runs at least once. 
2. Changed the method signature, it's more expressive and I think easier to consume and read (see the Twitter case).
