### PR TITLE
faster logged-out page loads (one less roundtrip—for a 403)

### DIFF
--- a/kifi-backend/modules/shoebox/angular/dev.html
+++ b/kifi-backend/modules/shoebox/angular/dev.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" type="text/css" href="/dist/kifi.css">
 <link rel="stylesheet" type="text/css" href="/dist/svg.css">
 
-<!-- HEADER_PLACEHOLDER -->
+<title id="kf-authenticated">Kifi</title><!-- remove the id attribute for logged-out experience -->
 
 <div class="kf-app ng-cloak" ng-controller="AppCtrl">
   <div ng-if="$root.userLoggedIn != null" ng-include="'layout/body.tpl.html'"></div>

--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -94,14 +94,18 @@ angular.module('kifi', [
       if (platformService.isSupportedMobilePlatform()) {
         $rootElement.find('html').addClass('kf-mobile');
       }
-      $timeout(function () {
-        profileService.fetchMe().then(function () {
-          if ($rootScope.userLoggedIn) {
-            profileService.fetchPrefs();
-            libraryService.fetchLibraryInfos(true);
-          }
+      if ($rootElement.find('#kf-authenticated').removeAttr('id').length) {
+        $timeout(function () {
+          profileService.fetchMe().then(function () {
+            if ($rootScope.userLoggedIn) {
+              profileService.fetchPrefs();
+              libraryService.fetchLibraryInfos(true);
+            }
+          });
         });
-      });
+      } else {
+        profileService.initLoggedOut();
+      }
 
       $rootScope.$on('$stateChangeSuccess', function (event, toState, toParams, fromState, fromParams) {
         $scope.errorStatus = $scope.errorParams = null;

--- a/kifi-backend/modules/shoebox/angular/src/profile/profileService.js
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profileService.js
@@ -278,6 +278,9 @@ angular.module('kifi')
     }
 
     return {
+      initLoggedOut: function () {
+        updateLoginState(false);
+      },
       userLoggedIn: getUserLoggedIn,
       me: me,
       getSettings: getSettings,

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
@@ -130,6 +130,23 @@ class KifiSiteRouterTest extends Specification with ShoeboxApplicationInjector {
           }
         }
 
+        // Site root
+        actionsHelper.unsetUser
+
+        {
+          val Some(resF) = route(FakeRequest("GET", "/"))
+          status(resF) === 200
+          Some(resF) must not(beWebApp)
+        }
+
+        actionsHelper.setUser(user1)
+
+        {
+          val Some(resF) = route(FakeRequest("GET", "/"))
+          Some(resF) must beWebApp
+          contentAsString(resF) must contain("""<title id="kf-authenticated">Kifi</title>""")
+        }
+
         // User profiles
         actionsHelper.unsetUser
         route(FakeRequest("GET", "/asdf")) must be404


### PR DESCRIPTION
@andrewconner 

This is another baby step towards including data in the page. The first data I’d like to include is basic information about the logged-in user. Confusingly, we’ll need to make the app continue to load the information via XHR in the dev environment.
