### PR TITLE
much longer caching of social scores

### DIFF
--- a/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDACommander.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/commanders/LDACommander.scala
@@ -148,7 +148,7 @@ class LDACommanderImpl @Inject() (
 
     // tweak
     def combineScores(keepInduced: Option[LDAUserURIInterestScore], personaInduced: Option[LDAUserURIInterestScore], userKeeps: Option[Int], personaWeight: Float): Option[LDAUserURIInterestScore] = {
-      val keepWeight = 4.0*Math.tanh(userKeeps.getOrElse(0) / 25)
+      val keepWeight = 4.0 * Math.tanh(userKeeps.getOrElse(0) / 25)
 
       (keepInduced, personaInduced) match {
         case (Some(kscore), Some(pscore)) =>

--- a/kifi-backend/modules/curator/app/com/keepit/common/cache/CuratorCacheModule.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/common/cache/CuratorCacheModule.scala
@@ -152,7 +152,7 @@ case class CuratorCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Singleton
   @Provides
   def userScoreCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new ConnectedUserScoreCache(stats, accessLog, (innerRepo, 10 minute, 20 minute), (outerRepo, 6 hours, 12 hours))
+    new ConnectedUserScoreCache(stats, accessLog, (outerRepo, 40 hours, 60 hours))
 
   @Provides @Singleton
   def allFakeUsersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =

--- a/kifi-backend/modules/graph/app/com/keepit/graph/common/cache/GraphCacheModule.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/common/cache/GraphCacheModule.scala
@@ -157,7 +157,7 @@ case class GraphCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Singleton
   @Provides
   def userScoreCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new ConnectedUserScoreCache(stats, accessLog, (innerRepo, 10 minute, 20 minute), (outerRepo, 6 hours, 12 hours))
+    new ConnectedUserScoreCache(stats, accessLog, (outerRepo, 40 hours, 60 hours))
 
   @Provides @Singleton
   def allFakeUsersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -356,7 +356,7 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Singleton
   @Provides
   def userScoreCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new ConnectedUserScoreCache(stats, accessLog, (innerRepo, 10 minute, 20 minute), (outerRepo, 6 hours, 12 hours))
+    new ConnectedUserScoreCache(stats, accessLog, (innerRepo, 10 minute, 20 minute), (outerRepo, 40 hours, 60 hours))
 
   @Provides @Singleton
   def allFakeUsersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =


### PR DESCRIPTION
cache is useless right now because it takes longer to run through all users once than the cache TTL.
@yingjieMiao 
