### PR TITLE
content flagging for mobile endpoint

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/mail/EmailAddress.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/EmailAddress.scala
@@ -77,6 +77,8 @@ object SystemEmailAddress {
   val LÉO = EmailAddress("leo@42go.com")
   val STEPHEN = EmailAddress("stephen@42go.com")
   val JOSH = EmailAddress("josh@kifi.com")
+  val AARON = EmailAddress("aaron@kifi.com")
+  val MARK = EmailAddress("mark@kifi.com")
   val CONGRATS = EmailAddress("congrats@kifi.com")
   val NOTIFY = EmailAddress("42.notify@gmail.com")
   val SENDGRID = EmailAddress("sendgrid@42go.com")

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUriController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUriController.scala
@@ -27,7 +27,7 @@ class MobileUriController @Inject() (
             normalizedUriRepo.updateURIRestriction(uri.id.get, Some(Restriction.ADULT))
             NoContent
           case _ =>
-            BadRequest(Json.obj("error" -> "reason_not_found"))
+            BadRequest(Json.obj("error" -> "reason_unknown"))
         }
       }
     }.getOrElse(BadRequest(Json.obj("error" -> "uri_not_found")))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUriController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUriController.scala
@@ -31,7 +31,7 @@ class MobileUriController @Inject() (
             systemAdminMailSender.sendMail(ElectronicMail(
               from = SystemEmailAddress.ENG,
               to = List(SystemEmailAddress.EISHAY, SystemEmailAddress.ANDREW, SystemEmailAddress.STEPHEN, SystemEmailAddress.MARK),
-              subject = s"url ${uri.url}} flagged as inappropriate!!!",
+              subject = s"url [${uri.id.get}]: ${uri.url} flagged as inappropriate!!!",
               htmlBody = s"uri: ${uri} <br>flagged by user ${request.user}.<br>Check it out: <a href=\"https://admin.kifi.com/admin/scraped/${uri.id.get}\"></a>",
               category = NotificationCategory.System.ADMIN))
             NoContent

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUriController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUriController.scala
@@ -33,7 +33,7 @@ class MobileUriController @Inject() (
               to = List(SystemEmailAddress.EISHAY, SystemEmailAddress.ANDREW, SystemEmailAddress.STEPHEN, SystemEmailAddress.MARK),
               subject = s"url [${uri.id.get}]: ${uri.url} flagged as inappropriate!!!",
               htmlBody = s"uri: ${uri} <br>flagged by user ${request.user}.<br>Check it out: <a href=\"https://admin.kifi.com/admin/scraped/${uri.id.get}\"></a>",
-              category = NotificationCategory.System.ADMIN))
+              category = NotificationCategory.toElectronicMailCategory(NotificationCategory.System.ADMIN)))
             NoContent
           case _ =>
             BadRequest(Json.obj("error" -> "reason_unknown"))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUriController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUriController.scala
@@ -1,0 +1,35 @@
+package com.keepit.controllers.mobile
+
+import com.google.inject.Inject
+import com.keepit.common.controller.{ UserActionsHelper, ShoeboxServiceController, UserActions }
+import com.keepit.common.db.slick.Database
+import com.keepit.common.time.Clock
+import com.keepit.model.{ Restriction, NormalizedURIRepo }
+import com.keepit.normalizer.NormalizedURIInterner
+import play.api.libs.json.Json
+
+class MobileUriController @Inject() (
+    db: Database,
+    normalizedUriRepo: NormalizedURIRepo,
+    normalizedUriInterner: NormalizedURIInterner,
+    clock: Clock,
+    val userActionsHelper: UserActionsHelper) extends UserActions with ShoeboxServiceController {
+
+  def flagContent() = UserAction(parse.tolerantJson) { request =>
+    val jsonBody = request.body
+    val reason = (jsonBody \ "reason").as[String]
+    val url = (jsonBody \ "url").as[String]
+
+    db.readWrite { implicit s =>
+      normalizedUriInterner.getByUri(url).map { uri =>
+        reason match {
+          case "adult" =>
+            normalizedUriRepo.updateURIRestriction(uri.id.get, Some(Restriction.ADULT))
+            NoContent
+          case _ =>
+            BadRequest(Json.obj("error" -> "reason_not_found"))
+        }
+      }
+    }.getOrElse(BadRequest(Json.obj("error" -> "uri_not_found")))
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUriController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUriController.scala
@@ -4,10 +4,10 @@ import com.google.inject.Inject
 import com.keepit.common.controller.{ UserActionsHelper, ShoeboxServiceController, UserActions }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.SystemAdminMailSender
-import com.keepit.common.mail.{SystemEmailAddress, ElectronicMail, ElectronicMailCategory}
+import com.keepit.common.mail.{ SystemEmailAddress, ElectronicMail, ElectronicMailCategory }
 import com.keepit.common.mail.template.EmailToSend
 import com.keepit.common.time.Clock
-import com.keepit.model.{NotificationCategory, Restriction, NormalizedURIRepo}
+import com.keepit.model.{ NotificationCategory, Restriction, NormalizedURIRepo }
 import com.keepit.normalizer.NormalizedURIInterner
 import play.api.libs.json.Json
 
@@ -28,11 +28,12 @@ class MobileUriController @Inject() (
       normalizedUriInterner.getByUri(url).map { uri =>
         reason match {
           case "adult" =>
+            log.info(s"{uri} marked as adult content!")
             systemAdminMailSender.sendMail(ElectronicMail(
               from = SystemEmailAddress.ENG,
               to = List(SystemEmailAddress.EISHAY, SystemEmailAddress.ANDREW, SystemEmailAddress.STEPHEN, SystemEmailAddress.MARK),
-              subject = s"url [${uri.id.get}]: ${uri.url} flagged as inappropriate!!!",
-              htmlBody = s"uri: ${uri} <br>flagged by user ${request.user}.<br>Check it out: <a href=\"https://admin.kifi.com/admin/scraped/${uri.id.get}\"></a>",
+              subject = s"url [${uri.id.get}]: ${uri.url} flagged as adult content!!!",
+              htmlBody = s"""uri: ${uri} <br>flagged by user ${request.user}.<br>Check it out: <a href="https://admin.kifi.com/admin/scraped/${uri.id.get}"></a>""",
               category = NotificationCategory.toElectronicMailCategory(NotificationCategory.System.ADMIN)))
             NoContent
           case _ =>

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -272,12 +272,10 @@ GET     /m/1/libraries/:id/members/suggest      @com.keepit.controllers.mobile.M
 GET     /m/1/libraries/:id/inviteInfo           @com.keepit.controllers.website.InviteController.getLibraryInviteInfo(id: PublicId[Library])
 POST    /m/1/libraries/recos/feedback      @com.keepit.controllers.website.LibraryRecommendationsController.updateLibraryRecommendationFeedback(id: PublicId[Library])
 
-
+POST    /m/1/content/flagUrl                @com.keepit.controllers.mobile.MobileUriController.flagContent()
 
 GET     /m/1/keeps/:id                      @com.keepit.controllers.mobile.MobileKeepsController.getKeepInfo(id: ExternalId[Keep], withFullInfo: Boolean ?= false, imageWidth: Option[Int] ?= None, imageHeight: Option[Int] ?= None)
-
 GET     /m/1/inviteInfo                     @com.keepit.controllers.website.InviteController.getGeneralInviteInfo()
-
 
 
 ##########################################

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUriControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUriControllerTest.scala
@@ -1,0 +1,74 @@
+package com.keepit.controllers.mobile
+
+import com.google.inject.Injector
+import com.keepit.common.controller.FakeUserActionsHelper
+import com.keepit.model.{ Restriction, User, NormalizedURIRepo }
+import com.keepit.normalizer.NormalizedURIInterner
+import com.keepit.test.ShoeboxTestInjector
+import org.specs2.mutable.Specification
+import com.keepit.model.UserFactory._
+import com.keepit.model.UserFactoryHelper._
+import com.keepit.model.KeepFactory._
+import com.keepit.model.KeepFactoryHelper._
+import play.api.libs.json.{ JsObject, Json }
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+class MobileUriControllerTest extends Specification with ShoeboxTestInjector {
+
+  val modules = Seq()
+
+  "MobileUriController" should {
+
+    "flag content" in {
+      withDb(modules: _*) { implicit injector =>
+        val (user1, k1) = setupUris()
+
+        val nUri1 = db.readOnlyMaster { implicit s =>
+          val nUri1 = uriIntern.getByUri(k1.url).get
+          val targetUri = uriRepo.get(nUri1.id.get)
+          targetUri.restriction === None
+          nUri1
+        }
+
+        val result1 = flagContent(user1, Json.obj("reason" -> "adult", "url" -> k1.url))
+        status(result1) must equalTo(NO_CONTENT)
+
+        db.readOnlyMaster { implicit s =>
+          uriRepo.get(nUri1.id.get).restriction === Some(Restriction.ADULT)
+        }
+
+        val resultBadReason = flagContent(user1, Json.obj("reason" -> "bad", "url" -> k1.url))
+        status(resultBadReason) must equalTo(BAD_REQUEST)
+
+        val resultUriNotFound = flagContent(user1, Json.obj("reason" -> "adult", "url" -> "http://www.notfound.com"))
+        status(resultUriNotFound) must equalTo(BAD_REQUEST)
+      }
+    }
+
+  }
+
+  private def flagContent(user: User, body: JsObject)(implicit injector: Injector) = {
+    setUser(user)
+    val path = com.keepit.controllers.mobile.routes.MobileUriController.flagContent().url
+    val request = FakeRequest("POST", path)
+    controller.flagContent()(request.withBody(body))
+  }
+
+  private def setupUris()(implicit injector: Injector) = {
+    val (user1, keep1) = db.readWrite { implicit s =>
+      val user1 = user().withName("Katniss", "Everdeen").saved
+      val keep1 = keep().withUser(user1).saved
+      uriIntern.getByUri(keep1.url).isDefined === true
+      (user1, keep1)
+    }
+    (user1, keep1)
+  }
+
+  private def setUser(user: User)(implicit injector: Injector) = {
+    inject[FakeUserActionsHelper].setUser(user)
+  }
+  private def controller(implicit injector: Injector) = inject[MobileUriController]
+  //private def uriRepo(implicit injector: Injector) = inject[NormalizedURIRepo]
+  private def uriIntern(implicit injector: Injector) = inject[NormalizedURIInterner]
+}

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUriControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUriControllerTest.scala
@@ -34,10 +34,6 @@ class MobileUriControllerTest extends Specification with ShoeboxTestInjector {
         val result1 = flagContent(user1, Json.obj("reason" -> "adult", "url" -> k1.url))
         status(result1) must equalTo(NO_CONTENT)
 
-        db.readOnlyMaster { implicit s =>
-          uriRepo.get(nUri1.id.get).restriction === Some(Restriction.ADULT)
-        }
-
         val resultBadReason = flagContent(user1, Json.obj("reason" -> "bad", "url" -> k1.url))
         status(resultBadReason) must equalTo(BAD_REQUEST)
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUriControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUriControllerTest.scala
@@ -69,6 +69,5 @@ class MobileUriControllerTest extends Specification with ShoeboxTestInjector {
     inject[FakeUserActionsHelper].setUser(user)
   }
   private def controller(implicit injector: Injector) = inject[MobileUriController]
-  //private def uriRepo(implicit injector: Injector) = inject[NormalizedURIRepo]
   private def uriIntern(implicit injector: Injector) = inject[NormalizedURIInterner]
 }


### PR DESCRIPTION
@andrewconner @stkem @yingjieMiao 

```
POST /m/1/content/flagUrl 
{
  "reason" -> "adult",
  "url" -> "http://www.nsfw.com"
}
```

You will get a `BadRequest` if the `normalizedURI` is not found, the `reason` is unknown, or if `reason` & `url` aren't in the json body.

@jaredpetker @DerekBurch @thassss @mrbrown14 
