### PR TITLE
injecting more execution context for more stable (maybe faster?) tests

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeNotifier.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeNotifier.scala
@@ -9,6 +9,8 @@ import com.keepit.common.service.FortyTwoServices
 import com.keepit.model.{ User, NotificationCategory }
 import com.keepit.common.mail.{ SystemEmailAddress, ElectronicMail }
 
+import scala.concurrent.ExecutionContext
+
 import play.api.libs.json.Json
 
 import akka.actor._
@@ -68,9 +70,9 @@ class AirbrakeSender @Inject() (
   healthcheck: HealthcheckPlugin,
   pagerDutySender: PagerDutySender,
   service: FortyTwoServices,
+  implicit val defaultContext: ExecutionContext,
   systemAdminMailSender: SystemAdminMailSender)
     extends Logging {
-  import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
   var firstErrorReported = false
 

--- a/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
@@ -12,9 +12,8 @@ import com.keepit.common.zookeeper.ServiceCluster
 import com.keepit.search.index.message.ThreadContent
 import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
 
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.collection.mutable
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{ ExecutionContext, Future }
 
 import play.api.libs.json.{ JsString, JsValue, JsArray, Json, JsObject }
 
@@ -77,6 +76,7 @@ class ElizaServiceClientImpl @Inject() (
   val airbrakeNotifier: AirbrakeNotifier,
   val httpClient: HttpClient,
   val serviceCluster: ServiceCluster,
+  implicit val defaultContext: ExecutionContext,
   userThreadStatsForUserIdCache: UserThreadStatsForUserIdCache)
     extends ElizaServiceClient with Logging {
 

--- a/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClientModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClientModule.scala
@@ -1,5 +1,6 @@
 package com.keepit.eliza
 
+import scala.concurrent.ExecutionContext
 import com.google.inject.{ Provides, Singleton }
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.net.HttpClient
@@ -21,11 +22,13 @@ case class ProdElizaServiceClientModule() extends ElizaServiceClientModule {
     client: HttpClient,
     serviceDiscovery: ServiceDiscovery,
     airbrakeNotifier: AirbrakeNotifier,
+    defaultContext: ExecutionContext,
     userThreadStatsForUserIdCache: UserThreadStatsForUserIdCache): ElizaServiceClient = {
     new ElizaServiceClientImpl(
       airbrakeNotifier,
       client,
       serviceDiscovery.serviceCluster(ServiceType.ELIZA),
+      defaultContext,
       userThreadStatsForUserIdCache
     )
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
@@ -17,9 +17,8 @@ import com.keepit.model.ImageProcessState.{ ImageLoadedAndHashed, ReadyToPersist
 import com.keepit.model.ProcessImageOperation.Original
 import com.keepit.model._
 import play.api.libs.Files.TemporaryFile
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.DurationInt
 import scala.util.{ Failure, Success, Try }
 
@@ -58,6 +57,7 @@ class KeepImageCommanderImpl @Inject() (
     airbrake: AirbrakeNotifier,
     keepImageRepo: KeepImageRepo,
     photoshop: Photoshop,
+    implicit val defaultContext: ExecutionContext,
     val webService: WebService) extends KeepImageCommander with ProcessedImageHelper with Logging {
 
   def getUrl(keepImage: KeepImage): String = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -23,13 +23,12 @@ import com.keepit.search.SearchServiceClient
 import com.keepit.social.{ SocialId, SocialNetworks, SocialNetworkType, BasicUser }
 
 import play.api.http.Status.{ FORBIDDEN, NOT_FOUND }
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import play.api.mvc.BodyParsers.parse
 
 import scala.collection.mutable
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 import akka.actor.Scheduler
 import com.keepit.eliza.ElizaServiceClient
 import scala.util.{ Success, Failure }
@@ -95,6 +94,7 @@ class KeepsCommander @Inject() (
     keepDecorator: KeepDecorator,
     twitterPublishingCommander: TwitterPublishingCommander,
     facebookPublishingCommander: FacebookPublishingCommander,
+    implicit val defaultContext: ExecutionContext,
     implicit val publicIdConfig: PublicIdConfiguration) extends Logging {
 
   def getKeepsCountFuture(): Future[Int] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -26,7 +26,6 @@ import com.keepit.social.{ BasicNonUser, BasicUser }
 import com.kifi.macros.json
 import org.joda.time.DateTime
 import play.api.http.Status._
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import views.html.admin.{ libraries, library }
@@ -77,6 +76,7 @@ class LibraryCommander @Inject() (
     userValueRepo: UserValueRepo,
     systemValueRepo: SystemValueRepo,
     twitterSyncRepo: TwitterSyncStateRepo,
+    implicit val defaultContext: ExecutionContext,
     implicit val publicIdConfig: PublicIdConfiguration,
     clock: Clock) extends Logging {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LocalUserExperimentCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LocalUserExperimentCommander.scala
@@ -8,10 +8,8 @@ import com.keepit.common.healthcheck.AirbrakeNotifier
 
 import com.google.inject.{ Inject, Singleton }
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import com.keepit.common.db.slick.DBSession.RWSession
 import com.keepit.common.math.ProbabilityDensity
 import com.keepit.common.logging.Logging
 
@@ -20,6 +18,7 @@ class LocalUserExperimentCommander @Inject() (
   userExperimentRepo: UserExperimentRepo,
   db: Database,
   generatorRepo: ProbabilisticExperimentGeneratorRepo,
+  implicit val defaultContext: ExecutionContext,
   protected val generatorCache: ProbabilisticExperimentGeneratorAllCache,
   protected val monitoredAwait: MonitoredAwait,
   protected val airbrake: AirbrakeNotifier)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/RecommendationsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/RecommendationsCommander.scala
@@ -14,10 +14,9 @@ import com.google.inject.Inject
 import com.keepit.normalizer.NormalizedURIInterner
 import com.keepit.search.util.LongSetIdFilter
 
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.{ JsNull, Json }
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Random }
 
 class RecommendationsCommander @Inject() (
@@ -30,6 +29,7 @@ class RecommendationsCommander @Inject() (
     uriSummaryCommander: URISummaryCommander,
     basicUserRepo: BasicUserRepo,
     keepRepo: KeepRepo,
+    implicit val defaultContext: ExecutionContext,
     implicit val publicIdConfig: PublicIdConfiguration,
     userExperimentCommander: LocalUserExperimentCommander) {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateSender.scala
@@ -9,11 +9,10 @@ import com.keepit.common.mail.{ SystemEmailAddress, PostOffice, ElectronicMail, 
 import com.keepit.heimdal.{ HeimdalServiceClient, UserEventTypes, UserEvent, HeimdalContextBuilder }
 import com.keepit.inject.FortyTwoConfig
 import com.keepit.model.{ User, UserEmailAddressRepo, UserValueName, UserValueRepo }
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.twirl.api.Html
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 @ImplementedBy(classOf[EmailTemplateSenderImpl])
 trait EmailTemplateSender {
@@ -28,6 +27,7 @@ class EmailTemplateSenderImpl @Inject() (
     postOffice: LocalPostOffice,
     emailAddrRepo: UserEmailAddressRepo,
     userValueRepo: UserValueRepo,
+    implicit val defaultContext: ExecutionContext,
     config: FortyTwoConfig) extends EmailTemplateSender with Logging {
 
   def send(emailToSend: EmailToSend) = {

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/FakeRecommendationsCommander.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/FakeRecommendationsCommander.scala
@@ -1,5 +1,6 @@
 package com.keepit.commanders
 
+import scala.concurrent.ExecutionContext
 import com.google.inject.{ Inject, Singleton }
 import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.db.Id
@@ -23,6 +24,7 @@ class FakeRecommendationsCommander @Inject() (
   basicUserRepo: BasicUserRepo,
   keepRepo: KeepRepo,
   publicIdConfig: PublicIdConfiguration,
+  defaultContext: ExecutionContext,
   userExperimentCommander: LocalUserExperimentCommander)
     extends RecommendationsCommander(
       curator,
@@ -34,6 +36,7 @@ class FakeRecommendationsCommander @Inject() (
       uriSummaryCommander,
       basicUserRepo,
       keepRepo,
+      defaultContext,
       publicIdConfig,
       userExperimentCommander) {
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/ActivityFeedEmailSenderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/ActivityFeedEmailSenderTest.scala
@@ -2,7 +2,7 @@ package com.keepit.commanders.emails
 
 import com.google.inject.Injector
 import com.keepit.abook.FakeABookServiceClientModule
-import com.keepit.common.concurrent.FakeExecutionContextModule
+import com.keepit.common.concurrent.{ WatchableExecutionContext, FakeExecutionContextModule }
 import com.keepit.common.mail.{ EmailAddress, ElectronicMailRepo, FakeMailModule }
 import com.keepit.common.net.FakeHttpClientModule
 import com.keepit.common.social.FakeSocialGraphModule
@@ -189,6 +189,7 @@ class ActivityFeedEmailSenderTest extends Specification with ShoeboxTestInjector
 
         val senderF = sender(None)
         Await.ready(senderF, Duration(5, "seconds"))
+        inject[WatchableExecutionContext].drain()
 
         val emails = db.readOnlyMaster { implicit s => inject[ElectronicMailRepo].all() }.sortBy(_.to.head.address)
         val email1 :: email2 :: Nil = emails.filter(_.category == NotificationCategory.toElectronicMailCategory(NotificationCategory.User.ACTIVITY))


### PR DESCRIPTION
lets deprecate use of `import play.api.libs.concurrent.Execution.Implicits.defaultContext`
the singleton execution context its one of the reasons our tests are flaky.
