### PR TITLE
Disabling Topic and Library-You-Follow attribution

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/AttributionHelper.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/AttributionHelper.scala
@@ -23,17 +23,18 @@ class SeedAttributionHelper @Inject() (
     val timer = new NamedStatsdTimer("SeedAttributionHelper.getAttributions")
     val userAttrFut = getUserAttribution(seeds)
     val keepAttrFut = getKeepAttribution(seeds)
-    val topicAttrFut = getTopicAttribution(seeds)
-    val libraryAttrFut = getLibraryAttribution(seeds)
+    //these are currently disabled for performance reasons. Likely to be removed entirely soon.
+    //val topicAttrFut = getTopicAttribution(seeds)
+    //val libraryAttrFut = getLibraryAttribution(seeds)
     for {
       userAttr <- userAttrFut
       keepAttr <- keepAttrFut
-      topicAttr <- topicAttrFut
-      libraryAttr <- libraryAttrFut
+      //topicAttr <- topicAttrFut
+      //libraryAttr <- libraryAttrFut
     } yield {
       timer.stopAndReport()
       (0 until seeds.size).map { i =>
-        val attr = SeedAttribution(userAttr(i), keepAttr(i), topicAttr(i), libraryAttr(i))
+        val attr = SeedAttribution(userAttr(i), keepAttr(i))
         ScoredSeedItemWithAttribution(seeds(i).userId, seeds(i).uriId, seeds(i).uriScores, attr,
           seeds(i).topic1, seeds(i).topic2)
       }

--- a/kifi-backend/modules/curator/test/com/keepit/curator/SeedAttributionHelperTest.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/SeedAttributionHelperTest.scala
@@ -91,11 +91,11 @@ class SeedAttributionHelperTest extends Specification with CuratorTestInjector {
         val attrHelper = new SeedAttributionHelper(db, repo, fakeCortex, fakeSearch, inject[CuratorLibraryMembershipInfoRepo])
 
         val itemsWithAttr = Await.result(attrHelper.getAttributions(scoredItems), Duration(5, "seconds"))
-        itemsWithAttr(0).attribution.topic.get.topicName === "topic_1"
+        //itemsWithAttr(0).attribution.topic.get.topicName === "topic_1"
         itemsWithAttr(0).attribution.user === None
         itemsWithAttr(0).attribution.keep === None
-        itemsWithAttr(0).topic1 === topic1
-        itemsWithAttr(0).topic2 === topic2
+        //itemsWithAttr(0).topic1 === topic1
+        //itemsWithAttr(0).topic2 === topic2
 
         itemsWithAttr(1).attribution.user.get.friends.map { _.id } === List(1, 2)
         itemsWithAttr(1).attribution.user.get.friendsLib.get.map { case (userId, libId) => (userId.id, libId.id) }.toMap === Map(1 -> 1)
@@ -110,10 +110,10 @@ class SeedAttributionHelperTest extends Specification with CuratorTestInjector {
         itemsWithAttr(3).topic2 === topic2
 
         itemsWithAttr(4).attribution.user === None
-        itemsWithAttr(4).attribution.topic.get.topicName === "topic_4"
+        //itemsWithAttr(4).attribution.topic.get.topicName === "topic_4"
         itemsWithAttr(4).attribution.keep.get.keeps.map { _.id }.toList === List(4)
-        itemsWithAttr(4).topic1 === topic1
-        itemsWithAttr(4).topic2 must beNone
+        //itemsWithAttr(4).topic1 === topic1
+        //itemsWithAttr(4).topic2 must beNone
       }
     }
   }


### PR DESCRIPTION
Topic attribution is already not shown to the user and
library-you-follow attribution is extremely rarely shown, not
justifying the computation cost at this time.

@yingjieMiao 
