### PR TITLE
adding keep_count column to library table

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -40,7 +40,8 @@ case class Library(
     kind: LibraryKind = LibraryKind.USER_CREATED,
     universalLink: String = RandomStringUtils.randomAlphanumeric(40),
     memberCount: Int,
-    lastKept: Option[DateTime] = None) extends ModelWithPublicId[Library] with ModelWithState[Library] with ModelWithSeqNumber[Library] {
+    lastKept: Option[DateTime] = None,
+    keepCount: Int) extends ModelWithPublicId[Library] with ModelWithState[Library] with ModelWithSeqNumber[Library] {
 
   def sanitizeForDelete(): Library = copy(
     name = RandomStringUtils.randomAlphanumeric(20),
@@ -83,8 +84,9 @@ object Library extends ModelWithPublicIdCompanion[Library] {
     kind: LibraryKind,
     memberCount: Int,
     universalLink: String,
-    lastKept: Option[DateTime]) = {
-    Library(id, createdAt, updatedAt, getDisplayName(name, kind), ownerId, visibility, description, slug, color, state, seq, kind, universalLink, memberCount, lastKept)
+    lastKept: Option[DateTime],
+    keepCount: Int) = {
+    Library(id, createdAt, updatedAt, getDisplayName(name, kind), ownerId, visibility, description, slug, color, state, seq, kind, universalLink, memberCount, lastKept, keepCount)
   }
 
   def unapplyToDbRow(lib: Library) = {
@@ -103,7 +105,8 @@ object Library extends ModelWithPublicIdCompanion[Library] {
       lib.kind,
       lib.memberCount,
       lib.universalLink,
-      lib.lastKept)
+      lib.lastKept,
+      lib.keepCount)
   }
 
   protected[this] val publicIdPrefix = "l"
@@ -124,7 +127,8 @@ object Library extends ModelWithPublicIdCompanion[Library] {
     (__ \ 'kind).format[LibraryKind] and
     (__ \ 'universalLink).format[String] and
     (__ \ 'memberCount).format[Int] and
-    (__ \ 'lastKept).formatNullable[DateTime]
+    (__ \ 'lastKept).formatNullable[DateTime] and
+    (__ \ 'keepCount).format[Int]
   )(Library.apply, unlift(Library.unapply))
 
   def isValidName(name: String): Boolean = {

--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -41,7 +41,7 @@ case class Library(
     universalLink: String = RandomStringUtils.randomAlphanumeric(40),
     memberCount: Int,
     lastKept: Option[DateTime] = None,
-    keepCount: Int) extends ModelWithPublicId[Library] with ModelWithState[Library] with ModelWithSeqNumber[Library] {
+    keepCount: Int = 0) extends ModelWithPublicId[Library] with ModelWithState[Library] with ModelWithSeqNumber[Library] {
 
   def sanitizeForDelete(): Library = copy(
     name = RandomStringUtils.randomAlphanumeric(20),

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/310.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/310.sql
@@ -1,0 +1,10 @@
+# SHOEBOX
+
+# --- !Ups
+
+alter table library
+    add column keep_count int(11) NOT NULL DEFAULT '0';
+
+insert into evolutions (name, description) values('310.sql', 'add keep count to library table');
+
+# --- !Downs

--- a/kifi-backend/modules/common/test/com/keepit/model/LibraryFactory.scala
+++ b/kifi-backend/modules/common/test/com/keepit/model/LibraryFactory.scala
@@ -12,7 +12,7 @@ object LibraryFactory {
 
   def library(): PartialLibrary = {
     new PartialLibrary(Library(id = Some(Id[Library](idx.incrementAndGet())), name = random(5), slug = LibrarySlug(random(5)),
-      visibility = LibraryVisibility.SECRET, ownerId = Id[User](idx.incrementAndGet()), memberCount = 1))
+      visibility = LibraryVisibility.SECRET, ownerId = Id[User](idx.incrementAndGet()), memberCount = 1, keepCount = 0))
   }
 
   def libraries(count: Int): Seq[PartialLibrary] = List.fill(count)(library())

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -255,6 +255,8 @@ class KeepInterner @Inject() (
       keepToCollectionRepo.getCollectionsForKeep(internedKeep.id.get) foreach { cid => collectionRepo.collectionChanged(cid, inactivateIfEmpty = false) }
     }
 
+    libraryRepo.save(library.copy(keepCount = library.keepCount + 1))
+
     (isNewKeep, wasInactiveKeep, internedKeep)
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -255,7 +255,7 @@ class KeepInterner @Inject() (
       keepToCollectionRepo.getCollectionsForKeep(internedKeep.id.get) foreach { cid => collectionRepo.collectionChanged(cid, inactivateIfEmpty = false) }
     }
 
-    libraryRepo.save(library.copy(keepCount = library.keepCount + 1))
+    libraryRepo.save(library.copy(keepCount = keepRepo.getCountByLibrary(library.id.get)))
 
     (isNewKeep, wasInactiveKeep, internedKeep)
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -376,7 +376,7 @@ class KeepsCommander @Inject() (
     val saved = keepRepo.save(keep withState KeepStates.INACTIVE)
     log.info(s"[unkeep($userId)] deactivated keep=$saved")
     val library = libraryRepo.get(keep.libraryId.get)
-    libraryRepo.save(library.copy(keepCount = library.keepCount - 1))
+    libraryRepo.save(library.copy(keepCount = keepRepo.getCountByLibrary(keep.libraryId.get)))
     keepToCollectionRepo.getCollectionsForKeep(saved.id.get) foreach { cid => collectionRepo.collectionChanged(cid, inactivateIfEmpty = true) }
     saved
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -467,7 +467,7 @@ class LibraryCommander @Inject() (
               libraryRepo.getOpt(ownerId, validSlug) match {
                 case None =>
                   val lib = libraryRepo.save(Library(ownerId = ownerId, name = libAddReq.name, description = libAddReq.description,
-                    visibility = libAddReq.visibility, slug = validSlug, color = newColor, kind = newKind, memberCount = 1))
+                    visibility = libAddReq.visibility, slug = validSlug, color = newColor, kind = newKind, memberCount = 1, keepCount = 0))
                   libraryMembershipRepo.save(LibraryMembership(libraryId = lib.id.get, userId = ownerId, access = LibraryAccess.OWNER, listed = newListed, lastJoinedAt = Some(currentDateTime)))
                   lib
                 case Some(lib) =>
@@ -820,7 +820,7 @@ class LibraryCommander @Inject() (
 
       // If user is missing a system lib, create it
       val mainOpt = if (sysLibs.find(_._2.kind == LibraryKind.SYSTEM_MAIN).isEmpty) {
-        val mainLib = libraryRepo.save(Library(name = "Main Library", ownerId = userId, visibility = LibraryVisibility.DISCOVERABLE, slug = LibrarySlug("main"), kind = LibraryKind.SYSTEM_MAIN, memberCount = 1))
+        val mainLib = libraryRepo.save(Library(name = "Main Library", ownerId = userId, visibility = LibraryVisibility.DISCOVERABLE, slug = LibrarySlug("main"), kind = LibraryKind.SYSTEM_MAIN, memberCount = 1, keepCount = 0))
         libraryMembershipRepo.save(LibraryMembership(libraryId = mainLib.id.get, userId = userId, access = LibraryAccess.OWNER))
         if (!generateNew) {
           airbrake.notify(s"$userId missing main library")
@@ -830,7 +830,7 @@ class LibraryCommander @Inject() (
       } else None
 
       val secretOpt = if (sysLibs.find(_._2.kind == LibraryKind.SYSTEM_SECRET).isEmpty) {
-        val secretLib = libraryRepo.save(Library(name = "Secret Library", ownerId = userId, visibility = LibraryVisibility.SECRET, slug = LibrarySlug("secret"), kind = LibraryKind.SYSTEM_SECRET, memberCount = 1))
+        val secretLib = libraryRepo.save(Library(name = "Secret Library", ownerId = userId, visibility = LibraryVisibility.SECRET, slug = LibrarySlug("secret"), kind = LibraryKind.SYSTEM_SECRET, memberCount = 1, keepCount = 0))
         libraryMembershipRepo.save(LibraryMembership(libraryId = secretLib.id.get, userId = userId, access = LibraryAccess.OWNER))
         if (!generateNew) {
           airbrake.notify(s"$userId missing secret library")
@@ -1026,14 +1026,14 @@ class LibraryCommander @Inject() (
       case None => Right((): Unit)
       case Some(mem) if mem.access == LibraryAccess.OWNER => Left(LibraryFail(BAD_REQUEST, "cannot_leave_own_library"))
       case Some(mem) =>
-        val (keepCount, lib) = db.readWrite { implicit s =>
+        val (numKeeps, lib) = db.readWrite { implicit s =>
           libraryMembershipRepo.save(mem.copy(state = LibraryMembershipStates.INACTIVE))
           val lib = libraryRepo.get(libraryId)
           libraryRepo.save(lib.copy(memberCount = libraryMembershipRepo.countWithLibraryId(libraryId)))
           (keepRepo.getCountByLibrary(libraryId), lib)
         }
         SafeFuture {
-          libraryAnalytics.unfollowLibrary(userId, lib, keepCount, eventContext)
+          libraryAnalytics.unfollowLibrary(userId, lib, numKeeps, eventContext)
           searchClient.updateLibraryIndex()
         }
         Right((): Unit)

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/LibraryChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/LibraryChecker.scala
@@ -60,18 +60,19 @@ class LibraryChecker @Inject() (
 
     libraryMap.map {
       case (libId, lib) =>
+        val currentKeptAt = latestKeptAtMap.get(libId).flatten
         lib.lastKept match {
           case None =>
-            latestKeptAtMap(libId) match {
+            currentKeptAt match {
               case Some(keptAt) =>
                 airbrake.notify(s"Library ${libId} has no last_kept but has active keeps... update last_kept!")
                 db.readWrite { implicit s =>
                   libraryRepo.save(lib.copy(lastKept = Some(keptAt)))
                 }
-              case None =>
+              case _ =>
             }
           case Some(lastKeptDate) =>
-            latestKeptAtMap(libId) match {
+            currentKeptAt match {
               case Some(keptAt) if keptAt != lastKeptDate =>
                 airbrake.notify(s"Library ${libId} has inconsistent last_kept state. Library is last kept at $lastKeptDate but keep is ${keptAt}... making them consistent")
                 db.readWrite { implicit s =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
@@ -480,10 +480,11 @@ class KeepRepoImpl @Inject() (
   }
   def latestKeptAtByLibraryIds(libraryIds: Set[Id[Library]])(implicit session: RSession): Map[Id[Library], Option[DateTime]] = {
     val keepsGroupedByLibrary = (for (r <- rows if r.libraryId.inSet(libraryIds) && r.state === KeepStates.ACTIVE) yield r).groupBy(_.libraryId)
-    keepsGroupedByLibrary.map { case (libraryId, keeps) => (libraryId, keeps.map(k => k.keptAt).max) }.list
+    val map = keepsGroupedByLibrary.map { case (libraryId, keeps) => (libraryId, keeps.map(k => k.keptAt).max) }.list
       .collect {
         case (Some(libraryId), maxKeptAt) =>
           (libraryId, maxKeptAt)
       }.toMap
+    libraryIds.map { libId => libId -> map.getOrElse(libId, None) }.toMap
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -77,8 +77,9 @@ class LibraryRepoImpl @Inject() (
     def universalLink = column[String]("universal_link", O.NotNull)
     def memberCount = column[Int]("member_count", O.NotNull)
     def lastKept = column[Option[DateTime]]("last_kept", O.Nullable)
+    def keepCount = column[Int]("keep_count", O.NotNull)
 
-    def * = (id.?, createdAt, updatedAt, state, name, ownerId, description, visibility, slug, color.?, seq, kind, memberCount, universalLink, lastKept) <> ((Library.applyFromDbRow _).tupled, Library.unapplyToDbRow _)
+    def * = (id.?, createdAt, updatedAt, state, name, ownerId, description, visibility, slug, color.?, seq, kind, memberCount, universalLink, lastKept, keepCount) <> ((Library.applyFromDbRow _).tupled, Library.unapplyToDbRow _)
   }
 
   implicit val getLibraryResult: GetResult[com.keepit.model.Library] = GetResult { r: PositionedResult =>
@@ -97,7 +98,8 @@ class LibraryRepoImpl @Inject() (
       kind = LibraryKind(r.<<[String]),
       memberCount = r.<<[Int],
       universalLink = r.<<[String],
-      lastKept = r.<<[Option[DateTime]]
+      lastKept = r.<<[Option[DateTime]],
+      keepCount = r.<<[Int]
     )
   }
 

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -721,6 +721,8 @@ POST    /admin/libraries/migrateKeepImages  @com.keepit.controllers.ext.ExtKeepI
 POST    /admin/libraries/updateLibraryOwner @com.keepit.controllers.admin.AdminLibraryController.updateLibraryOwner(libraryId: Id[Library], fromUserId: Id[User], toUserId: Id[User])
 POST    /admin/libraries/saveSuggestedSearches    @com.keepit.controllers.admin.AdminLibraryController.saveSuggestedSearches
 
+POST    /admin/libraries/applyNumKeeps  @com.keepit.controllers.admin.AdminLibraryController.applyKeepCountToLibrary
+
 GET     /admin/personas             @com.keepit.controllers.admin.AdminPersonaController.getAllPersonas()
 POST    /admin/personas/add         @com.keepit.controllers.admin.AdminPersonaController.createPersona()
 POST    /admin/personas/:id         @com.keepit.controllers.admin.AdminPersonaController.editPersona(id: Id[Persona])


### PR DESCRIPTION
@andrewconner @yingjieMiao @leogrim @stkem 

doing the `keep_count` stuff in a couple of steps:
This PR: add `num_keep` column, admin endpoint for filling keep counts to libraries, and adding `keepCount` logic to keeping & unkeeping
(2) after applying evolutions, deploy and call admin endpoint. After that, add logic to `LibraryChecker` to make sure keep counts are consistent
(3) Can start using library.keepCount in certain places (instead of looking through DB). 
