### PR TITLE
Context Bankruptcy. Alternate POST endpoint.

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/310.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/310.sql
@@ -1,0 +1,13 @@
+# SHOEBOX
+
+# --- !Ups
+
+alter table activity_push_task
+    add column next_push datetime NULL;
+
+alter table activity_push_task
+    add column backoff bigint(20) NULL;
+
+insert into evolutions (name, description) values('310.sql', 'add next_push and backoff to activity_push_task table');
+
+# --- !Downs

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/ActivityPushTask.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/ActivityPushTask.scala
@@ -4,6 +4,8 @@ import org.joda.time.{ LocalTime, DateTime }
 import com.keepit.common.db._
 import com.keepit.common.time._
 
+import scala.concurrent.duration.Duration
+
 case class ActivityPushTask(
     id: Option[Id[ActivityPushTask]] = None,
     createdAt: DateTime = currentDateTime,
@@ -12,7 +14,10 @@ case class ActivityPushTask(
     state: State[ActivityPushTask] = ActivityPushTaskStates.ACTIVE,
     lastPush: Option[DateTime] = None,
     lastActiveTime: LocalTime,
-    lastActiveDate: DateTime) extends Model[ActivityPushTask] {
+    lastActiveDate: DateTime, // when was user active last? open app, keep, user creation, etc
+    nextPush: Option[DateTime], // when we should push next?
+    backoff: Option[Duration] // how long did we previously wait?
+    ) extends Model[ActivityPushTask] {
 
   def withId(id: Id[ActivityPushTask]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/ActivityPushTaskRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/ActivityPushTaskRepo.scala
@@ -5,15 +5,18 @@ import com.keepit.common.db.Id
 import com.keepit.common.db.slick.DBSession.RSession
 import com.keepit.common.db.slick._
 import com.keepit.common.logging.Logging
-import com.keepit.common.time.Clock
+import com.keepit.common.time._
 import org.joda.time.{ LocalTime, DateTime }
+import scala.concurrent.duration._
+import scala.concurrent.duration.Duration._
 
+import scala.concurrent.duration.Duration
 import scala.slick.jdbc.StaticQuery
 
 @ImplementedBy(classOf[ActivityPushTaskRepoImpl])
 trait ActivityPushTaskRepo extends Repo[ActivityPushTask] {
   def getByUser(userId: Id[User])(implicit session: RSession): Option[ActivityPushTask]
-  def getByPushAndActivity(pushTimeBefore: DateTime, lastActivityAfter: LocalTime, limit: Int)(implicit session: RSession): Seq[Id[ActivityPushTask]]
+  def getByPushAndActivity(limit: Int)(implicit session: RSession): Seq[Id[ActivityPushTask]]
   def getUsersWithoutActivityPushTask(limit: Int)(implicit session: RSession): Seq[Id[User]]
 }
 
@@ -33,7 +36,10 @@ class ActivityPushTaskRepoImpl @Inject() (
     def lastPush = column[Option[DateTime]]("last_push", O.Nullable)
     def lastActiveTime = column[LocalTime]("last_active_time", O.NotNull)
     def lastActiveDate = column[DateTime]("last_active_date", O.NotNull)
-    def * = (id.?, createdAt, updatedAt, userId, state, lastPush, lastActiveTime, lastActiveDate) <> ((ActivityPushTask.apply _).tupled, ActivityPushTask.unapply)
+    def nextPush = column[Option[DateTime]]("next_push", O.Nullable)
+    def backoff = column[Option[Duration]]("backoff", O.Nullable)
+
+    def * = (id.?, createdAt, updatedAt, userId, state, lastPush, lastActiveTime, lastActiveDate, nextPush, backoff) <> ((ActivityPushTask.apply _).tupled, ActivityPushTask.unapply)
   }
 
   def table(tag: Tag) = new ActivityPushTable(tag)
@@ -48,9 +54,10 @@ class ActivityPushTaskRepoImpl @Inject() (
     (for (b <- rows if b.userId === id) yield b).firstOption
   }
 
-  def getByPushAndActivity(pushTimeBefore: DateTime, activeTimeAfter: LocalTime, limit: Int)(implicit session: RSession): Seq[Id[ActivityPushTask]] = {
+  def getByPushAndActivity(limit: Int)(implicit session: RSession): Seq[Id[ActivityPushTask]] = {
     import com.keepit.common.db.slick.StaticQueryFixed.interpolation
-    sql"select id from activity_push_task where state = 'active' and ((last_push is null) or (last_push < $pushTimeBefore)) and last_active_time < $activeTimeAfter limit $limit".as[Id[ActivityPushTask]].list
+    val now = clock.now
+    sql"select id from activity_push_task where state = 'active' and ((last_push is null) or (next_push > $now)) limit $limit".as[Id[ActivityPushTask]].list
   }
 
   def getUsersWithoutActivityPushTask(limit: Int)(implicit session: RSession): Seq[Id[User]] = {

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -251,6 +251,7 @@ POST    /m/1/disconnect/:provider               @com.keepit.controllers.mobile.M
 
 GET     /m/2/recos/top                          @com.keepit.controllers.mobile.MobileRecommendationsController.topRecosV2(recency: Float, more: Boolean ?= false)
 GET     /m/3/recos/top                          @com.keepit.controllers.mobile.MobileRecommendationsController.topRecosV3(recency: Float, uriContext: Option[String] ?= None, libContext: Option[String] ?= None, uctx: Option[String] ?= None, lctx: Option[String] ?= None)
+POST     /m/3/recos/top                          @com.keepit.controllers.mobile.MobileRecommendationsController.topRecosV3Post()
 GET     /m/1/recos/public                       @com.keepit.controllers.mobile.MobileRecommendationsController.topPublicRecos()
 POST    /m/1/recos/trash                        @com.keepit.controllers.mobile.MobileRecommendationsController.trash(id: ExternalId[NormalizedURI])
 POST    /m/1/recos/feedback                     @com.keepit.controllers.website.RecommendationsController.updateUriRecommendationFeedback(id: ExternalId[NormalizedURI])


### PR DESCRIPTION
@stkem @mrbrown14 @jaredpetker 

https://www.youtube.com/watch?v=ydID4hKCMD8

For context bankruptcy, you won't need to do anything. However, the preferred format is now using a POST. No query params, send all of them in a request JSON object.

``` javascript
{
  'recency': Float,
  'uriContext': Option[String]
  'libContext': Option[String]
}
```
