### PR TITLE
remove seen items before sorting

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationRetrievalCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationRetrievalCommander.scala
@@ -124,7 +124,8 @@ class RecommendationRetrievalCommander @Inject() (
 
     val (recos, newContext) = db.readOnlyReplica { implicit session =>
       val recosByTopScore = uriRecoRepo.getRecommendableByTopMasterScore(userId, 1000) filter badData map scoreReco //ZZZ
-      val finalSorted = recoSortStrategy.sort(recosByTopScore)
+      val (accepted, _) = idFilter.filter(recosByTopScore, context)((x: UriRecoScore) => x.reco.uriId.id)
+      val finalSorted = recoSortStrategy.sort(accepted)
       idFilter.take(finalSorted, context, limit = 10)((x: UriRecoScore) => x.reco.uriId.id)
     }
 


### PR DESCRIPTION
@stkem 

Old method can cause problem: during sorting, uris are grouped by topicIds, and we apply decay within each topic. If a topic contains several seen items (and they are likely ranked high within the topic), remaining items in the topic will receive big penalty. Those items later will lose any competition with uris from other topics, esp. topics having no seen items).
