### PR TITLE
inactivate urban airship rows (only with same signature)

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/realtime/AppBoy.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/realtime/AppBoy.scala
@@ -36,7 +36,7 @@ class AppBoyImpl @Inject() (
 
     val updatedDevice = db.readWrite { implicit s =>
 
-      // inactivate devices (if has non-appboy signature, is urbanairship, inactivate!)
+      // inactivate devices that have non-appboy signature
       deviceRepo.getByUserIdAndDeviceTypeAndSignature(userId, deviceType, signature) match {
         case Some(d) => // probably urbanairship, inactivate
           deviceRepo.save(d.copy(state = DeviceStates.INACTIVE))

--- a/kifi-backend/modules/eliza/app/com/keepit/realtime/AppBoy.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/realtime/AppBoy.scala
@@ -32,15 +32,24 @@ class AppBoyImpl @Inject() (
   def registerDevice(userId: Id[User], deviceType: DeviceType, isDev: Boolean, signature: String): Device = {
     log.info(s"[AppBoy] Registering device: $deviceType:(no token) for (user $userId, signature $signature)")
 
+    val appBoySign = "ab_" + signature
+
     val updatedDevice = db.readWrite { implicit s =>
-      deviceRepo.getByUserIdAndDeviceTypeAndSignature(userId, deviceType, signature, None) match {
+
+      // inactivate devices (if has non-appboy signature, is urbanairship, inactivate!)
+      deviceRepo.getByUserIdAndDeviceTypeAndSignature(userId, deviceType, signature) match {
+        case Some(d) => // probably urbanairship, inactivate
+          deviceRepo.save(d.copy(state = DeviceStates.INACTIVE))
+        case _ =>
+      }
+
+      deviceRepo.getByUserIdAndDeviceTypeAndSignature(userId, deviceType, appBoySign, None) match {
         case Some(d) => // update or reactivate an existing device
           deviceRepo.save(d.copy(token = None, isDev = isDev, state = DeviceStates.ACTIVE))
         case None => // new device for user! save new device!
-          deviceRepo.save(Device(userId = userId, token = None, deviceType = deviceType, isDev = isDev, signature = Some(signature)))
+          deviceRepo.save(Device(userId = userId, token = None, deviceType = deviceType, isDev = isDev, signature = Some(appBoySign)))
       }
     }
-    // inactivate any devices?
 
     updatedDevice
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/realtime/MobilePushNotifier.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/realtime/MobilePushNotifier.scala
@@ -48,7 +48,7 @@ class MobilePushDelegator @Inject() (
   def registerDevice(userId: Id[User], token: Option[String], deviceType: DeviceType, isDev: Boolean, signature: Option[String]): Either[String, Device] = {
     token match {
       case Some(tokenStr) => Right(urbanAirship.get.registerDevice(userId, tokenStr, deviceType, isDev, signature))
-      case None if signature.isDefined => Right(appBoy.get.registerDevice(userId, deviceType, isDev, "ab_" + signature.get))
+      case None if signature.isDefined => Right(appBoy.get.registerDevice(userId, deviceType, isDev, signature.get))
       case _ => Left("invalid_params")
     }
   }

--- a/kifi-backend/modules/rover/app/com/keepit/rover/article/GithubArticleFetcher.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/article/GithubArticleFetcher.scala
@@ -3,7 +3,7 @@ package com.keepit.rover.article
 import com.google.inject.Inject
 import com.keepit.common.logging.Logging
 import com.keepit.rover.article.content.GithubContent
-import com.keepit.rover.document.{RoverDocumentFetcher, JsoupDocument}
+import com.keepit.rover.document.{ RoverDocumentFetcher, JsoupDocument }
 import com.keepit.rover.fetcher.FetchResult
 import com.keepit.common.time._
 import com.keepit.rover.store.{ RoverArticleStore, RoverUnderlyingArticleStore }

--- a/kifi-backend/modules/rover/app/com/keepit/rover/article/LinkedInProfileArticleFetcher.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/article/LinkedInProfileArticleFetcher.scala
@@ -3,7 +3,7 @@ package com.keepit.rover.article
 import com.google.inject.Inject
 import com.keepit.common.logging.Logging
 import com.keepit.rover.article.content.{ LinkedInProfile, LinkedInProfileContent }
-import com.keepit.rover.document.{RoverDocumentFetcher, JsoupDocument}
+import com.keepit.rover.document.{ RoverDocumentFetcher, JsoupDocument }
 import com.keepit.rover.fetcher.FetchResult
 import com.keepit.common.time._
 import com.keepit.rover.store.RoverArticleStore

--- a/kifi-backend/modules/rover/app/com/keepit/rover/article/YoutubeArticleFetcher.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/article/YoutubeArticleFetcher.scala
@@ -7,7 +7,7 @@ import com.keepit.common.logging.Logging
 import com.keepit.common.net._
 import com.keepit.common.time.Clock
 import com.keepit.rover.article.content.{ YoutubeVideo, YoutubeTrack, YoutubeTrackInfo, YoutubeContent }
-import com.keepit.rover.document.{RoverDocumentFetcher, JsoupDocument}
+import com.keepit.rover.document.{ RoverDocumentFetcher, JsoupDocument }
 import com.keepit.rover.fetcher.FetchResult
 import com.keepit.rover.store.RoverArticleStore
 import com.keepit.search.Lang

--- a/kifi-backend/modules/rover/app/com/keepit/rover/document/RoverDocumentFetcher.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/document/RoverDocumentFetcher.scala
@@ -1,12 +1,12 @@
 package com.keepit.rover.document
 
-import com.google.inject.{Inject, Singleton}
+import com.google.inject.{ Inject, Singleton }
 import com.keepit.rover.document.tika.TikaDocument
-import com.keepit.rover.fetcher.{FetchRequest, FetchResult, HttpFetcher, HttpInputStream}
+import com.keepit.rover.fetcher.{ FetchRequest, FetchResult, HttpFetcher, HttpInputStream }
 import org.apache.http.HttpStatus
 import org.joda.time.DateTime
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 @Singleton
 class RoverDocumentFetcher @Inject() (httpFetcher: HttpFetcher) {


### PR DESCRIPTION
prevents double pushes + tests!

@andrewconner @eishay 
