### PR TITLE
fixing modal signup flow

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryKeeps.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryKeeps.tpl.html
@@ -12,7 +12,7 @@
     <div ng-if="!userIsOwner">
       <p class="public-library-empty-explain">{{library.owner.firstName || 'The curator'}} hasn’t added anything to this library yet.</p>
       <p class="public-library-empty-explain" ng-hide="$root.userLoggedIn">
-        Want to create and share your own libraries? <a href="/signup">Sign up</a> to join the Kifi family.
+        Want to create and share your own libraries? <a href="/signup" target="_self">Sign up</a> to join the Kifi family.
       </p>
     </div>
   </div>

--- a/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
+++ b/kifi-backend/modules/shoebox/angular/src/signup/signupService.js
@@ -20,7 +20,7 @@ angular.module('kifi')
 
         scope.onError = function (reason) {
           (handlers.onError || function (reason) {
-            $window.location.href = (reason && reason.redirect) || 'https://www.kifi.com/signup';
+            $window.location.href = (reason && reason.redirect) || '/signup';
           })(reason);
         };
 
@@ -188,7 +188,7 @@ angular.module('kifi')
         registrationService.socialFinalize(fields).then(function () {
           // todo: do we need to handle the return resp?
           modalService.close();
-          $location.url('/install');
+          $window.location.href = '/install';
         })['catch'](function () {
           // Would love to get logs of this.
           $scope.onError({'code': 'social_finalize_fail', redirect: 'https://www.kifi.com/signup'});
@@ -206,7 +206,7 @@ angular.module('kifi')
           // todo: do we need to handle the return resp?
           modalService.close();
           trackEvent('visitor_clicked_page', 'signup2', 'signup');
-          $location.url('/install');
+          $window.location.href = '/install';
         })['catch'](function (resp) {
           if (resp.data && resp.data.error === 'user_exists_failed_auth') {
             $scope.requestActive = false;


### PR DESCRIPTION
@ahsu1230 

Using `$location.url` or an `<a>` without `target` results in a Whomp! error page because Angular tries to handle the navigation.
