### PR TITLE
remove queue size limit

### DIFF
--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/actor/ScrapeProcessorActorImpl.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/actor/ScrapeProcessorActorImpl.scala
@@ -61,7 +61,7 @@ class ScrapeProcessorActorImpl @Inject() (
 
   private[this] def getQueueSize(): Future[Int] = actor.ask(QueueSize).mapTo[Int]
 
-  private[this] val lock = new ReactiveLock(1, Some(100))
+  private[this] val lock = new ReactiveLock(1, None)
 
   override def pull(): Unit = lock.withLockFuture {
     val futureTask: Future[Unit] = getQueueSize() flatMap { qSize =>


### PR DESCRIPTION
@eishay 

when queue size > 100, this throw exception (airbrake) => pagerDuty. 

Will remove this for now. (As I observed, after a while, system becomes idle, but queue size does not decrease)
