### PR TITLE
fixing library attribution hovercards

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
@@ -4,7 +4,7 @@
       <a class="kf-keep-who-pic" href="{{library.keeper||library.owner|profileUrl}}" ng-attr-style="background-image:url({{library.keeper||library.owner|pic:100}})" kf-track-origin="{{currentPageOrigin}}/alsoKeptInLibraryBy"></a>
       <a class="kf-keep-who-lib" href="{{library.absPath||library.url}}" ng-click="onLibraryAttributionClicked()" kf-track-origin="libraryAttributionChip">{{library.name}}</a>
       <span kf-tooltip position="top" padding="10">
-        <span kf-library-mini-card library="library"></span>
+        <span kf-library-mini-card></span>
       </span>
     </span>
   </span>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryMiniCard.js
@@ -8,15 +8,8 @@ angular.module('kifi')
     return {
       restrict: 'A',
       replace: true,
-      scope: {
-        refLibrary: '&library',
-        invite: '='
-      },
       templateUrl: 'libraries/libraryMiniCard.tpl.html',
       link: function (scope) {
-        scope.library = _.cloneDeep(scope.refLibrary());
-        scope.showMiniCard = true;
-
 
         //
         // Internal helper methods.
@@ -53,7 +46,7 @@ angular.module('kifi')
         };
 
         scope.following = function () {
-          return !scope.invite && !scope.isMyLibrary() && scope.isFollowing;
+          return !scope.isMyLibrary() && scope.isFollowing;
         };
 
         scope.toggleFollow = function () {
@@ -74,8 +67,9 @@ angular.module('kifi')
         //
 
         libraryService.getLibraryInfoById(scope.library.id).then(function (data) {
-          _.assign(scope.library, data.library);
+          scope.library = data.library;
           scope.isFollowing = data.membership === 'read_only';
+          scope.showMiniCard = true;
         })['catch'](function () {
           scope.showMiniCard = false;
         });


### PR DESCRIPTION
@andrewconner 

Apparently the problem had something to do with using an isolate scope in a transcluded directive. I don’t fully understand, but this seems to work around it.
