### PR TITLE
escaping quoted HTML attributes a little less aggressively

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/util.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/util.js
@@ -5,6 +5,7 @@ angular.module('util', [])
 .factory('util', [
   '$document', '$window', '$location',
   function ($document, $window, $location) {
+    var HTML_QUOTED_ATTR_ESCAPE_CHARS = /"/g;
     var HTML_ESCAPE_CHARS = /[&<>"'\/]/g;
     var HTML_ESCAPES = {
       '&': '&amp;',
@@ -27,6 +28,10 @@ angular.module('util', [])
       return text == null ? '' : String(text).replace(HTML_ESCAPE_CHARS, htmlEscapeReplace);
     }
 
+    function htmlQuotedAttrEscape(text) {
+      return text == null ? '' : String(text).replace(HTML_QUOTED_ATTR_ESCAPE_CHARS, htmlEscapeReplace);
+    }
+
     function htmlEscapeReplace(ch) {
       return HTML_ESCAPES[ch];
     }
@@ -35,8 +40,8 @@ angular.module('util', [])
       if (text.indexOf('@', 1)) {
         var parts = text.split(emailAddrDetectRe);
         for (var i = 1; i < parts.length; i += 2) {
-          var escapedAddr = htmlEscape(parts[i]);
-          parts[i] = '<a href="mailto:' + escapedAddr + '">' + escapedAddr + '</a>';
+          var addr = parts[i];
+          parts[i] = '<a href="mailto:' + htmlQuotedAttrEscape(addr) + '">' + htmlEscape(addr) + '</a>';
         }
         for (var j = 0; j < parts.length; j += 2) {
           parts[j] = process(parts[j]);
@@ -61,9 +66,7 @@ angular.module('util', [])
             continue;
           }
         }
-        var escapedUri = htmlEscape(uri);
-        var escapedUrl = (scheme ? '' : 'http://') + escapedUri;
-        parts[i] = '<a target="_blank" rel="nofollow" href="' + escapedUrl + '">' + escapedUri;
+        parts[i] = '<a target="_blank" rel="nofollow" href="' + (scheme ? '' : 'http://') + htmlQuotedAttrEscape(uri) + '">' + htmlEscape(uri);
         parts[i+1] = '</a>';
       }
       for (i = 0; i < parts.length; i += 3) {
@@ -168,7 +171,6 @@ angular.module('util', [])
         }
         return text;
       },
-      htmlEscape: htmlEscape,
       /**
        * Behaves like $location.search({...}). Keys whose values are an empty array will be omitted entirely.
        * https://docs.angularjs.org/api/ng/service/$location#search

--- a/kifi-backend/modules/shoebox/angular/test/unit/common/util.spec.js
+++ b/kifi-backend/modules/shoebox/angular/test/unit/common/util.spec.js
@@ -82,33 +82,33 @@ describe('util', function () {
       expect(util.linkify('Hello!\nBye.')).toBe('Hello!\nBye.');
       expect(util.linkify('Email me: jo@flo.com')).toBe('Email me: <a href="mailto:jo@flo.com">jo@flo.com</a>');
       expect(util.linkify('I hang out at https://example.com. You?')).toBe(
-        'I hang out at <a target="_blank" rel="nofollow" href="https:&#x2F;&#x2F;example.com">https:&#x2F;&#x2F;example.com</a>. You?');
+        'I hang out at <a target="_blank" rel="nofollow" href="https://example.com">https:&#x2F;&#x2F;example.com</a>. You?');
       expect(util.linkify('a+b@c.com & www.google.com/maps/123+Main/@37.4,-122.7/data=!3m1!1s:0xa\tb@c.d\ntwitter.com/example')).toBe(
         '<a href="mailto:a+b@c.com">a+b@c.com</a>' +
-        ' &amp; <a target="_blank" rel="nofollow" href="http://www.google.com&#x2F;maps&#x2F;123+Main&#x2F;@37.4,-122.7&#x2F;data=!3m1!1s:0xa">' +
+        ' &amp; <a target="_blank" rel="nofollow" href="http://www.google.com/maps/123+Main/@37.4,-122.7/data=!3m1!1s:0xa">' +
         'www.google.com&#x2F;maps&#x2F;123+Main&#x2F;@37.4,-122.7&#x2F;data=!3m1!1s:0xa</a>' +
         '\t<a href="mailto:b@c.d">b@c.d</a>' +
-        '\n<a target="_blank" rel="nofollow" href="http://twitter.com&#x2F;example">twitter.com&#x2F;example</a>');
+        '\n<a target="_blank" rel="nofollow" href="http://twitter.com/example">twitter.com&#x2F;example</a>');
       expect(util.linkify('Writer.\nEmail: sarahp@techcrunch.com\nhttp://about.me/sarahperez\nArticles I’ve shared')).toBe(
         'Writer.\nEmail: <a href="mailto:sarahp@techcrunch.com">sarahp@techcrunch.com</a>' +
-        '\n<a target="_blank" rel="nofollow" href="http:&#x2F;&#x2F;about.me&#x2F;sarahperez">http:&#x2F;&#x2F;about.me&#x2F;sarahperez</a>' +
+        '\n<a target="_blank" rel="nofollow" href="http://about.me/sarahperez">http:&#x2F;&#x2F;about.me&#x2F;sarahperez</a>' +
         '\nArticles I’ve shared');
       expect(util.linkify('about.me/sarahperez')).toBe(
-        '<a target="_blank" rel="nofollow" href="http://about.me&#x2F;sarahperez">about.me&#x2F;sarahperez</a>');
+        '<a target="_blank" rel="nofollow" href="http://about.me/sarahperez">about.me&#x2F;sarahperez</a>');
       expect(util.linkify('https://about.me/sarahperez')).toBe(
-        '<a target="_blank" rel="nofollow" href="https:&#x2F;&#x2F;about.me&#x2F;sarahperez">https:&#x2F;&#x2F;about.me&#x2F;sarahperez</a>');
+        '<a target="_blank" rel="nofollow" href="https://about.me/sarahperez">https:&#x2F;&#x2F;about.me&#x2F;sarahperez</a>');
       expect(util.linkify('fail.wtf')).toBe(
         '<a target="_blank" rel="nofollow" href="http://fail.wtf">fail.wtf</a>');
       expect(util.linkify('http://fail.wtf/')).toBe(
-        '<a target="_blank" rel="nofollow" href="http:&#x2F;&#x2F;fail.wtf&#x2F;">http:&#x2F;&#x2F;fail.wtf&#x2F;</a>');
+        '<a target="_blank" rel="nofollow" href="http://fail.wtf/">http:&#x2F;&#x2F;fail.wtf&#x2F;</a>');
       expect(util.linkify('lung.cancerresearch/news')).toBe(
-        '<a target="_blank" rel="nofollow" href="http://lung.cancerresearch&#x2F;news">lung.cancerresearch&#x2F;news</a>');
+        '<a target="_blank" rel="nofollow" href="http://lung.cancerresearch/news">lung.cancerresearch&#x2F;news</a>');
       expect(util.linkify('https://lung.cancerresearch/news/')).toBe(
-        '<a target="_blank" rel="nofollow" href="https:&#x2F;&#x2F;lung.cancerresearch&#x2F;news&#x2F;">https:&#x2F;&#x2F;lung.cancerresearch&#x2F;news&#x2F;</a>');  // jshint ignore:line
+        '<a target="_blank" rel="nofollow" href="https://lung.cancerresearch/news/">https:&#x2F;&#x2F;lung.cancerresearch&#x2F;news&#x2F;</a>');  // jshint ignore:line
       expect(util.linkify('王府半島酒店.中國')).toBe(
         '王府半島酒店.中國');  // being conservative, not detected
       expect(util.linkify('http://王府半島酒店.中國')).toBe(
-        '<a target="_blank" rel="nofollow" href="http:&#x2F;&#x2F;王府半島酒店.中國">http:&#x2F;&#x2F;王府半島酒店.中國</a>');
+        '<a target="_blank" rel="nofollow" href="http://王府半島酒店.中國">http:&#x2F;&#x2F;王府半島酒店.中國</a>');
     });
   });
 


### PR DESCRIPTION
owasp.org says “Properly quoted attributes can only be escaped with the corresponding quote.”

Plus, Angular double-checks all of this HTML for safety anyway.
