### PR TITLE
escaping less in HTML element content context

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/util.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/util.js
@@ -5,15 +5,11 @@ angular.module('util', [])
 .factory('util', [
   '$document', '$window', '$location',
   function ($document, $window, $location) {
-    var HTML_QUOTED_ATTR_ESCAPE_CHARS = /"/g;
-    var HTML_ESCAPE_CHARS = /[&<>"'\/]/g;
-    var HTML_ESCAPES = {
+    var ALL_QUOTES = /"/g;
+    var ALL_HTML_ELEMENT_CONTENT_ESCAPE_CHARS = /[&<]/g; // www.owasp.org/index.php/XSS_Experimental_Minimal_Encoding_Rules
+    var HTML_ESCAPE_REPLACEMENTS = {
       '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      '\'': '&#x27;',
-      '/': '&#x2F;'
+      '<': '&lt;'
     };
     var youtubeVideoUrlRe = /^(?:https?:\/\/)?(?:youtu\.be|(?:www\.)?youtube(?:-nocookie)?\.com)\/(?:|user\/[^\/?#]+)?(?:|.*?[\/=])([a-zA-Z0-9_-]{11})\b/;
     var uriDetectRe = /(?:\b|^)((?:(https?|ftp):\/\/[^\s!"#%&'()*,\/:;?@[\\\]_{}\u00A1\u00A7\u00AB\u00B6\u00B7\u00BB\u00BF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E3B\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]{4,}|(?:(?:[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\.)+(?:a[c-gil-oq-uwxz]|b[abd-jmnoq-tvwyz]|c[acdf-ik-orsu-z]|d[dejkmoz]|e[ceghr-u]|f[ijkmor]|g[abd-ilmnp-uwy]|h[kmnrtu]|i[del-oq-t]|j[emop]|k[eghimnprwyz]|l[abcikr-vy]|m[acdeghk-z]|n[acefgilopruz]|om|p[ae-hk-nrstwy]|qa|r[eosuw]|s[a-eg-or-vxyz]|t[cdfghj-prtvwz]|u[agksyz]|v[aceginu]|w[fs]|y[etu]|z[amrw]|app|bi[doz]|boo|cab|ceo|com|da[dy]|eat|edu|esq|fly|foo|go[pv]|hiv|how|in[gkt]|kim|mil|mo[ev]|ne[tw]|ngo|on[gl]|ooo|org|pro|pub|re[dn]|rip|tax|tel|soy|top|uno|vet|wed|wtf|xxx|xyz|[a-z]{4,20})))(?::[0-9]{1,5})?(?:\/(?:[^\s()<>]*[^\s`!\[\]{};:.'",<>?«»()“”‘’]|\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\))*|\b|$))(?=[\s`!()\[\]{};:.'",<>?«»“”‘’]|$)/;  // jshint ignore:line
@@ -24,16 +20,19 @@ angular.module('util', [])
 
     var queryStringHelper = {$$path: '', $$compose: $location.$$compose};
 
-    function htmlEscape(text) {
-      return text == null ? '' : String(text).replace(HTML_ESCAPE_CHARS, htmlEscapeReplace);
-    }
-
-    function htmlQuotedAttrEscape(text) {
-      return text == null ? '' : String(text).replace(HTML_QUOTED_ATTR_ESCAPE_CHARS, htmlEscapeReplace);
+    function htmlElementContentEscape(text) {
+      return text == null ? '' : String(text).replace(ALL_HTML_ELEMENT_CONTENT_ESCAPE_CHARS, htmlEscapeReplace);
     }
 
     function htmlEscapeReplace(ch) {
-      return HTML_ESCAPES[ch];
+      return HTML_ESCAPE_REPLACEMENTS[ch];
+    }
+
+    function htmlQuotedAttrEscape(text) {
+      // Rule #2 at www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet states
+      // "Properly quoted attributes can only be escaped with the corresponding quote."
+      // Caller must ensure text is safe in its specific attribute context (e.g. href, onload).
+      return text == null ? '' : String(text).replace(ALL_QUOTES, 'quot;');
     }
 
     function processEmailAddressesThen(process, text) {
@@ -41,7 +40,7 @@ angular.module('util', [])
         var parts = text.split(emailAddrDetectRe);
         for (var i = 1; i < parts.length; i += 2) {
           var addr = parts[i];
-          parts[i] = '<a href="mailto:' + htmlQuotedAttrEscape(addr) + '">' + htmlEscape(addr) + '</a>';
+          parts[i] = '<a href="mailto:' + htmlQuotedAttrEscape(addr) + '">' + htmlElementContentEscape(addr) + '</a>';
         }
         for (var j = 0; j < parts.length; j += 2) {
           parts[j] = process(parts[j]);
@@ -66,7 +65,7 @@ angular.module('util', [])
             continue;
           }
         }
-        parts[i] = '<a target="_blank" rel="nofollow" href="' + (scheme ? '' : 'http://') + htmlQuotedAttrEscape(uri) + '">' + htmlEscape(uri);
+        parts[i] = '<a target="_blank" rel="nofollow" href="' + (scheme ? '' : 'http://') + htmlQuotedAttrEscape(uri) + '">' + htmlElementContentEscape(uri);
         parts[i+1] = '</a>';
       }
       for (i = 0; i < parts.length; i += 3) {
@@ -184,7 +183,7 @@ angular.module('util', [])
         var slug = name.toLowerCase().replace(/[^\w\s-]|_/g, '').replace(/(\s|--)+/g, '-').replace(/^-/, '').substr(0, 50).replace(/-$/, '');
         return RESERVED_SLUGS.indexOf(slug) >= 0 ? slug + '-' : slug;
       },
-      linkify: angular.bind(null, processUrlsThen, angular.bind(null, processEmailAddressesThen, htmlEscape)),
+      linkify: angular.bind(null, processUrlsThen, angular.bind(null, processEmailAddressesThen, htmlElementContentEscape)),
       chooseTreatment: function (salt, treatments) {
         // To generate the salt for an experiment:
         // [0,0,0,0,0,0].map(function () { return Math.floor(Math.random() * 32).toString(32) }).join('')

--- a/kifi-backend/modules/shoebox/angular/test/unit/common/util.spec.js
+++ b/kifi-backend/modules/shoebox/angular/test/unit/common/util.spec.js
@@ -82,33 +82,33 @@ describe('util', function () {
       expect(util.linkify('Hello!\nBye.')).toBe('Hello!\nBye.');
       expect(util.linkify('Email me: jo@flo.com')).toBe('Email me: <a href="mailto:jo@flo.com">jo@flo.com</a>');
       expect(util.linkify('I hang out at https://example.com. You?')).toBe(
-        'I hang out at <a target="_blank" rel="nofollow" href="https://example.com">https:&#x2F;&#x2F;example.com</a>. You?');
+        'I hang out at <a target="_blank" rel="nofollow" href="https://example.com">https://example.com</a>. You?');
       expect(util.linkify('a+b@c.com & www.google.com/maps/123+Main/@37.4,-122.7/data=!3m1!1s:0xa\tb@c.d\ntwitter.com/example')).toBe(
         '<a href="mailto:a+b@c.com">a+b@c.com</a>' +
         ' &amp; <a target="_blank" rel="nofollow" href="http://www.google.com/maps/123+Main/@37.4,-122.7/data=!3m1!1s:0xa">' +
-        'www.google.com&#x2F;maps&#x2F;123+Main&#x2F;@37.4,-122.7&#x2F;data=!3m1!1s:0xa</a>' +
+        'www.google.com/maps/123+Main/@37.4,-122.7/data=!3m1!1s:0xa</a>' +
         '\t<a href="mailto:b@c.d">b@c.d</a>' +
-        '\n<a target="_blank" rel="nofollow" href="http://twitter.com/example">twitter.com&#x2F;example</a>');
+        '\n<a target="_blank" rel="nofollow" href="http://twitter.com/example">twitter.com/example</a>');
       expect(util.linkify('Writer.\nEmail: sarahp@techcrunch.com\nhttp://about.me/sarahperez\nArticles I’ve shared')).toBe(
         'Writer.\nEmail: <a href="mailto:sarahp@techcrunch.com">sarahp@techcrunch.com</a>' +
-        '\n<a target="_blank" rel="nofollow" href="http://about.me/sarahperez">http:&#x2F;&#x2F;about.me&#x2F;sarahperez</a>' +
+        '\n<a target="_blank" rel="nofollow" href="http://about.me/sarahperez">http://about.me/sarahperez</a>' +
         '\nArticles I’ve shared');
       expect(util.linkify('about.me/sarahperez')).toBe(
-        '<a target="_blank" rel="nofollow" href="http://about.me/sarahperez">about.me&#x2F;sarahperez</a>');
+        '<a target="_blank" rel="nofollow" href="http://about.me/sarahperez">about.me/sarahperez</a>');
       expect(util.linkify('https://about.me/sarahperez')).toBe(
-        '<a target="_blank" rel="nofollow" href="https://about.me/sarahperez">https:&#x2F;&#x2F;about.me&#x2F;sarahperez</a>');
+        '<a target="_blank" rel="nofollow" href="https://about.me/sarahperez">https://about.me/sarahperez</a>');
       expect(util.linkify('fail.wtf')).toBe(
         '<a target="_blank" rel="nofollow" href="http://fail.wtf">fail.wtf</a>');
       expect(util.linkify('http://fail.wtf/')).toBe(
-        '<a target="_blank" rel="nofollow" href="http://fail.wtf/">http:&#x2F;&#x2F;fail.wtf&#x2F;</a>');
+        '<a target="_blank" rel="nofollow" href="http://fail.wtf/">http://fail.wtf/</a>');
       expect(util.linkify('lung.cancerresearch/news')).toBe(
-        '<a target="_blank" rel="nofollow" href="http://lung.cancerresearch/news">lung.cancerresearch&#x2F;news</a>');
+        '<a target="_blank" rel="nofollow" href="http://lung.cancerresearch/news">lung.cancerresearch/news</a>');
       expect(util.linkify('https://lung.cancerresearch/news/')).toBe(
-        '<a target="_blank" rel="nofollow" href="https://lung.cancerresearch/news/">https:&#x2F;&#x2F;lung.cancerresearch&#x2F;news&#x2F;</a>');  // jshint ignore:line
+        '<a target="_blank" rel="nofollow" href="https://lung.cancerresearch/news/">https://lung.cancerresearch/news/</a>');
       expect(util.linkify('王府半島酒店.中國')).toBe(
         '王府半島酒店.中國');  // being conservative, not detected
       expect(util.linkify('http://王府半島酒店.中國')).toBe(
-        '<a target="_blank" rel="nofollow" href="http://王府半島酒店.中國">http:&#x2F;&#x2F;王府半島酒店.中國</a>');
+        '<a target="_blank" rel="nofollow" href="http://王府半島酒店.中國">http://王府半島酒店.中國</a>');
     });
   });
 


### PR DESCRIPTION
This makes our tests easier to understand and reason about, and I’d love to see any example where HTML entity-encoding only `<` and `&` creates a vulnerability when set using `.innerHTML` on a `<div>`. We’re also using `ng-bind-html` on the output—so Angular claims to have our back.
