### PR TITLE
retire a json field

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/common/curator/model/RecommendationInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/curator/model/RecommendationInfo.scala
@@ -17,6 +17,7 @@ import play.api.libs.json.{ Json, Writes }
 @json case class RecoMetaData( //WARNING, adding another field here will break clients, due to the way the @json macro behaves with classes with only one field
   attribution: Seq[RecoAttributionInfo])
 
+// Library associated with an URI. Not to be confused with LibraryRecommendation
 @json case class RecoLibraryInfo(owner: BasicUser, id: PublicId[Library], name: String, path: String)
 
 @json case class UriRecoItemInfo(


### PR DESCRIPTION
@stkem 

metaData is not used anymore. We could just remove the field entirely, but would love to sync with mobile guys later.

Removing this just makes the transition clearer. 
