### PR TITLE
Different way of assigning Seq Nums for Raw Seed Items

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/CuratorDbSequencingModule.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/CuratorDbSequencingModule.scala
@@ -2,11 +2,10 @@ package com.keepit.curator
 
 import com.keepit.inject.AppScoped
 import net.codingwell.scalaguice.ScalaModule
-import com.keepit.curator.model.{ CuratorLibraryInfoSequencingPluginImpl, CuratorLibraryInfoSequencingPlugin, RawSeedItemSequencingPluginImpl, RawSeedItemSequencingPlugin }
+import com.keepit.curator.model.{ CuratorLibraryInfoSequencingPluginImpl, CuratorLibraryInfoSequencingPlugin }
 
 case class CuratorDbSequencingModule() extends ScalaModule {
   def configure {
-    bind[RawSeedItemSequencingPlugin].to[RawSeedItemSequencingPluginImpl].in[AppScoped]
     bind[CuratorLibraryInfoSequencingPlugin].to[CuratorLibraryInfoSequencingPluginImpl].in[AppScoped]
   }
 }

--- a/kifi-backend/modules/curator/app/com/keepit/curator/CuratorGlobal.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/CuratorGlobal.scala
@@ -3,7 +3,7 @@ package com.keepit.curator
 import com.keepit.FortyTwoGlobal
 import com.keepit.common.cache.{ FortyTwoCachePlugin, InMemoryCachePlugin }
 import com.keepit.common.healthcheck.HealthcheckPlugin
-import com.keepit.curator.model.{ CuratorLibraryInfoSequencingPlugin, RawSeedItemSequencingPlugin }
+import com.keepit.curator.model.{ CuratorLibraryInfoSequencingPlugin }
 import com.keepit.curator.commanders.CuratorTasksPlugin
 
 import play.api.Application
@@ -26,7 +26,6 @@ trait CuratorServices { self: FortyTwoGlobal =>
     require(injector.instance[HealthcheckPlugin] != null)
     require(injector.instance[FortyTwoCachePlugin] != null)
     require(injector.instance[InMemoryCachePlugin] != null)
-    require(injector.instance[RawSeedItemSequencingPlugin] != null)
     require(injector.instance[CuratorTasksPlugin] != null)
     require(injector.instance[CuratorLibraryInfoSequencingPlugin] != null)
   }

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItemRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/RawSeedItemRepo.scala
@@ -153,19 +153,9 @@ class RawSeedItemRepoImpl @Inject() (
   }
 }
 
-trait RawSeedItemSequencingPlugin extends SequencingPlugin
-
-class RawSeedItemSequencingPluginImpl @Inject() (
-    override val actor: ActorInstance[RawSeedItemSequencingActor],
-    override val scheduling: SchedulingProperties) extends RawSeedItemSequencingPlugin {
-
-  override val interval: FiniteDuration = 60 seconds
-}
-
 @Singleton
 class RawSeedItemSequenceNumberAssigner @Inject() (db: Database, repo: RawSeedItemRepo, airbrake: AirbrakeNotifier)
-  extends DbSequenceAssigner[RawSeedItem](db, repo, airbrake)
+    extends DbSequenceAssigner[RawSeedItem](db, repo, airbrake) {
+  override val batchSize: Int = 500
+}
 
-class RawSeedItemSequencingActor @Inject() (
-  assigner: RawSeedItemSequenceNumberAssigner,
-  airbrake: AirbrakeNotifier) extends SequencingActor(assigner, airbrake)


### PR DESCRIPTION
Instead of being a separate plugins it’s now done synchronously as part
of data ingestions, which is basically the only part that writes to
this table. This should stop the db lock contention issues.
Not a big change, but hopefully the right one.

@yingjieMiao @eishay 
