### PR TITLE
Backfilling Twitter sync

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/Implicits.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/Implicits.scala
@@ -46,3 +46,4 @@ trait Implicits {
   implicit def funcExtensionOps[A](x: => A): FuncExtensionOpts[A] = new FuncExtensionOpts[A](x)
   implicit def futureExtensionOps[A](x: => Future[A]): FutureExtensionOps[A] = new FutureExtensionOps[A](x)
 }
+

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/316.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/316.sql
@@ -1,0 +1,9 @@
+# SHOEBOX
+
+# --- !Ups
+
+ALTER TABLE twitter_sync_state ADD COLUMN min_tweet_id_seen bigint(20) NULL;
+
+INSERT INTO evolutions (name, description) VALUES ('316.sql', 'add min_tweet_id_seen to twitter_sync_state');
+
+# --- !Downs

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterSyncCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterSyncCommander.scala
@@ -1,6 +1,7 @@
 package com.keepit.commanders
 
 import com.google.inject.{ Inject, Singleton }
+import com.keepit.common.core
 
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.db.slick.Database
@@ -44,26 +45,69 @@ class TwitterSyncCommander @Inject() (
         case Some(notActive) =>
           syncStateRepo.save(notActive.copy(state = TwitterSyncStateStates.ACTIVE))
         case None => //create one!
-          val sync = TwitterSyncState(userId = userTokenToUse, twitterHandle = handle, state = TwitterSyncStateStates.ACTIVE, libraryId = libraryId, maxTweetIdSeen = None, lastFetchedAt = None)
+          val sync = TwitterSyncState(userId = userTokenToUse, twitterHandle = handle, state = TwitterSyncStateStates.ACTIVE, libraryId = libraryId, lastFetchedAt = None, minTweetIdSeen = None, maxTweetIdSeen = None)
           syncStateRepo.save(sync)
       }
     }
   }
 
   def syncOne(socialUserInfo: Option[SocialUserInfo], state: TwitterSyncState, libraryOwner: Id[User]): Unit = throttle.withLockFuture {
-    twitter.fetchTweets(socialUserInfo, state.twitterHandle, state.maxTweetIdSeen.getOrElse(0L)).map { tweets =>
-      log.info(s"[TweetSync] Got ${tweets.length} tweets from ${state.twitterHandle}")
-      if (tweets.nonEmpty) {
-        val urls = tweets.map(_ \\ "expanded_url").map(_.toString())
-        log.info(s"[TweetSync] Got urls: $urls")
-        val newMaxTweetId = tweets.map(tweet => (tweet \ "id").as[Long]).max
-        storeTweets(libraryOwner, state.libraryId, tweets)
-        val newState = state.copy(lastFetchedAt = Some(currentDateTime), maxTweetIdSeen = Some(newMaxTweetId))
-        db.readWrite { implicit session =>
-          syncStateRepo.save(newState)
-        }
-        syncOne(socialUserInfo, newState, libraryOwner)
+
+    def fetchAllNewerThanState(syncState: TwitterSyncState, upperBound: Option[Long]): Future[TwitterSyncState] = {
+      (syncState.maxTweetIdSeen, upperBound) match {
+        case (Some(max), Some(batchUb)) if batchUb <= max => // Batch upper bound less than existing max id
+          Future.successful(syncState)
+        case _ =>
+          twitter.fetchTweets(socialUserInfo, syncState.twitterHandle, syncState.maxTweetIdSeen, upperBound).map(persistTweets(syncState, libraryOwner, _)).flatMap {
+            case (newSyncState, Some(batchMin), _) =>
+              fetchAllNewerThanState(newSyncState, Some(batchMin))
+            case (newSyncState, _, _) =>
+              Future.successful(newSyncState)
+          }
       }
+    }
+
+    def fetchAllOlderThanState(syncState: TwitterSyncState, upperBound: Option[Long]): Future[TwitterSyncState] = {
+      (syncState.minTweetIdSeen, upperBound) match {
+        case (Some(min), Some(batchUb)) if batchUb > min => // Batch upper bound greater than existing min id
+          Future.successful(syncState)
+        case _ =>
+          twitter.fetchTweets(socialUserInfo, syncState.twitterHandle, None, upperBound).map(persistTweets(syncState, libraryOwner, _)).flatMap {
+            case (newSyncState, Some(batchMin), _) =>
+              fetchAllOlderThanState(newSyncState, Some(batchMin))
+            case (newSyncState, _, _) =>
+              Future.successful(newSyncState)
+          }
+      }
+    }
+
+    fetchAllNewerThanState(state, None).flatMap { newState =>
+      fetchAllOlderThanState(newState, newState.minTweetIdSeen)
+    }
+  }
+
+  private def persistTweets(syncState: TwitterSyncState, libraryOwner: Id[User], tweets: Seq[JsObject]) = {
+    log.info(s"[TweetSync] Got ${tweets.length} tweets from ${syncState.twitterHandle}")
+    if (tweets.nonEmpty) {
+
+      importer.processDirectTwitterData(libraryOwner, syncState.libraryId, tweets)
+
+      val tweetIds = tweets.map(tweet => (tweet \ "id").as[Long])
+      val batchMinTweetId = tweetIds.min
+      val batchMaxTweetId = tweetIds.max
+
+      val newMin = syncState.minTweetIdSeen.map(Math.min(_, batchMinTweetId)).getOrElse(batchMinTweetId)
+      val newMax = syncState.maxTweetIdSeen.map(Math.max(_, batchMaxTweetId)).getOrElse(batchMaxTweetId)
+
+      val newState = db.readWrite { implicit session =>
+        syncStateRepo.save(syncState.copy(lastFetchedAt = Some(clock.now), maxTweetIdSeen = Some(newMax), minTweetIdSeen = Some(newMin)))
+      }
+      (newState, Some(batchMinTweetId), Some(batchMaxTweetId))
+    } else {
+      val newState = db.readWrite { implicit session =>
+        syncStateRepo.save(syncState.copy(lastFetchedAt = Some(clock.now)))
+      }
+      (newState, None, None)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/TwitterSyncState.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/TwitterSyncState.scala
@@ -18,7 +18,8 @@ case class TwitterSyncState(
     twitterHandle: String,
     lastFetchedAt: Option[DateTime],
     libraryId: Id[Library],
-    maxTweetIdSeen: Option[Long]) extends ModelWithState[TwitterSyncState] {
+    maxTweetIdSeen: Option[Long],
+    minTweetIdSeen: Option[Long]) extends ModelWithState[TwitterSyncState] {
   def withId(id: Id[TwitterSyncState]): TwitterSyncState = this.copy(id = Some(id))
   def withUpdateTime(updateTime: DateTime) = this.copy(updatedAt = updateTime)
 }
@@ -26,7 +27,7 @@ case class TwitterSyncState(
 object TwitterSyncStateStates extends States[TwitterSyncState]
 
 case class TwitterHandleLibraryIdKey(val id: Id[Library]) extends Key[String] {
-  override val version = 1
+  override val version = 2
   val namespace = "twitter_handle_library_id"
   def toKey(): String = id.id.toString
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/TwitterSyncStateRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/TwitterSyncStateRepo.scala
@@ -34,7 +34,9 @@ class TwitterSyncStateRepoImpl @Inject() (
     def lastFetchedAt = column[Option[DateTime]]("last_fetched_at", O.Nullable)
     def libraryId = column[Id[Library]]("library_id", O.NotNull)
     def maxTweetIdSeen = column[Option[Long]]("max_tweet_id_seen", O.Nullable)
-    def * = (id.?, createdAt, updatedAt, state, userId.?, twitterHandle, lastFetchedAt, libraryId, maxTweetIdSeen) <> ((TwitterSyncState.apply _).tupled, TwitterSyncState.unapply)
+    def minTweetIdSeen = column[Option[Long]]("min_tweet_id_seen", O.Nullable)
+
+    def * = (id.?, createdAt, updatedAt, state, userId.?, twitterHandle, lastFetchedAt, libraryId, maxTweetIdSeen, minTweetIdSeen) <> ((TwitterSyncState.apply _).tupled, TwitterSyncState.unapply)
   }
 
   def table(tag: Tag) = new TwitterSyncStateTable(tag)


### PR DESCRIPTION
@stkem 

Strategy is:
1. Given `syncState: TwitterSyncState`, fetch all until the current max. This is typically just one batch. With no previous fetches, this is always one batch.
2. Fetch before `syncState`, by setting the fetch upper bound to existing lower bound. Recurse.

Infinite loops could potentially occur in two ways:
1. We fetch the same or similar batches over and over, and don't progress.
2. We don't stop when twitter returns no tweets.

Could you verify both of these?

Seems to work, I fetched 245 links over 500+ tweets from my account.
