### PR TITLE
model and repo to support feedback

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/316.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/316.sql
@@ -1,0 +1,24 @@
+# CURATOR
+
+# --- !Ups
+
+create table uri_reco_feedback(
+  id bigint(20) NOT NULL AUTO_INCREMENT,
+  created_at datetime NOT NULL,
+  updated_at datetime NOT NULL,
+  user_id bigint(20) NOT NULL,
+  uri_id bigint(20) NOT NULL,
+  viewed boolean DEFAULT NULL,
+  clicked boolean DEFAULT NULL,
+  kept boolean DEFAULT NULL,
+  liked boolean DEFAULT NULL,
+  state varchar(20) NOT NULL,
+
+  PRIMARY KEY (id),
+  Unique index uri_reco_feedback_i_user_uri (user_id, uri_id)
+
+);
+
+insert into evolutions (name, description) values('316.sql', 'create uri_reco_feedback table');
+
+# --- !Downs

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/316.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/316.sql
@@ -8,15 +8,10 @@ create table uri_reco_feedback(
   updated_at datetime NOT NULL,
   user_id bigint(20) NOT NULL,
   uri_id bigint(20) NOT NULL,
-  viewed boolean DEFAULT NULL,
-  clicked boolean DEFAULT NULL,
-  kept boolean DEFAULT NULL,
-  liked boolean DEFAULT NULL,
+  feedback varchar(32) NOT NULL,
   state varchar(20) NOT NULL,
 
   PRIMARY KEY (id),
-  Unique index uri_reco_feedback_i_user_uri (user_id, uri_id)
-
 );
 
 insert into evolutions (name, description) values('316.sql', 'create uri_reco_feedback table');

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedback.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedback.scala
@@ -11,20 +11,21 @@ case class UriRecoFeedback(
     updatedAt: DateTime = currentDateTime,
     userId: Id[User],
     uriId: Id[NormalizedURI],
-    viewed: Option[Boolean],
-    clicked: Option[Boolean],
-    kept: Option[Boolean],
-    liked: Option[Boolean],
+    feedback: UriRecoFeedbackValue,
     state: State[UriRecoFeedback] = UriRecoFeedbackStates.ACTIVE) extends ModelWithState[UriRecoFeedback] {
 
   def withId(id: Id[UriRecoFeedback]): UriRecoFeedback = this.copy(id = Some(id))
   def withUpdateTime(updateTime: DateTime): UriRecoFeedback = this.copy(updatedAt = updateTime)
-
-  def onView(): UriRecoFeedback = this.copy(viewed = Some(true))
-  def onClick(): UriRecoFeedback = this.copy(clicked = Some(true))
-  def onKeep(): UriRecoFeedback = this.copy(kept = Some(true))
-  def onLike(): UriRecoFeedback = this.copy(liked = Some(true))
-  def onDislike(): UriRecoFeedback = this.copy(liked = Some(false))
 }
 
 object UriRecoFeedbackStates extends States[UriRecoFeedback]
+
+case class UriRecoFeedbackValue(value: String)
+
+object UriRecoFeedbackValue {
+  val VIEWED = UriRecoFeedbackValue("viewed")
+  val CLICKED = UriRecoFeedbackValue("clicked")
+  val KEPT = UriRecoFeedbackValue("kept")
+  val LIKE = UriRecoFeedbackValue("like")
+  val DISLIKE = UriRecoFeedbackValue("dislike")
+}

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedback.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedback.scala
@@ -14,7 +14,7 @@ case class UriRecoFeedback(
     viewed: Option[Boolean],
     clicked: Option[Boolean],
     kept: Option[Boolean],
-    like: Option[Boolean],
+    liked: Option[Boolean],
     state: State[UriRecoFeedback] = UriRecoFeedbackStates.ACTIVE) extends ModelWithState[UriRecoFeedback] {
 
   def withId(id: Id[UriRecoFeedback]): UriRecoFeedback = this.copy(id = Some(id))
@@ -23,8 +23,8 @@ case class UriRecoFeedback(
   def onView(): UriRecoFeedback = this.copy(viewed = Some(true))
   def onClick(): UriRecoFeedback = this.copy(clicked = Some(true))
   def onKeep(): UriRecoFeedback = this.copy(kept = Some(true))
-  def onLike(): UriRecoFeedback = this.copy(like = Some(true))
-  def onDislike(): UriRecoFeedback = this.copy(like = Some(false))
+  def onLike(): UriRecoFeedback = this.copy(liked = Some(true))
+  def onDislike(): UriRecoFeedback = this.copy(liked = Some(false))
 }
 
 object UriRecoFeedbackStates extends States[UriRecoFeedback]

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedback.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedback.scala
@@ -1,0 +1,30 @@
+package com.keepit.curator.model
+
+import com.keepit.common.db.{ States, ModelWithState, State, Id }
+import com.keepit.common.time._
+import com.keepit.model.{ NormalizedURI, User }
+import org.joda.time.DateTime
+
+case class UriRecoFeedback(
+    id: Option[Id[UriRecoFeedback]],
+    createdAt: DateTime = currentDateTime,
+    updatedAt: DateTime = currentDateTime,
+    userId: Id[User],
+    uriId: Id[NormalizedURI],
+    viewed: Option[Boolean],
+    clicked: Option[Boolean],
+    kept: Option[Boolean],
+    like: Option[Boolean],
+    state: State[UriRecoFeedback] = UriRecoFeedbackStates.ACTIVE) extends ModelWithState[UriRecoFeedback] {
+
+  def withId(id: Id[UriRecoFeedback]): UriRecoFeedback = this.copy(id = Some(id))
+  def withUpdateTime(updateTime: DateTime): UriRecoFeedback = this.copy(updatedAt = updateTime)
+
+  def onView(): UriRecoFeedback = this.copy(viewed = Some(true))
+  def onClick(): UriRecoFeedback = this.copy(clicked = Some(true))
+  def onKeep(): UriRecoFeedback = this.copy(kept = Some(true))
+  def onLike(): UriRecoFeedback = this.copy(like = Some(true))
+  def onDislike(): UriRecoFeedback = this.copy(like = Some(false))
+}
+
+object UriRecoFeedbackStates extends States[UriRecoFeedback]

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedbackRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedbackRepo.scala
@@ -1,0 +1,38 @@
+package com.keepit.curator.model
+
+import com.google.inject.Inject
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.DBSession.RSession
+import com.keepit.common.db.slick.{ DataBaseComponent, DbRepo }
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.time.Clock
+import com.keepit.model._
+
+trait UriRecoFeedbackRepo extends DbRepo[UriRecoFeedback]
+
+class UriRecoFeedbackRepoImpl @Inject() (
+    val db: DataBaseComponent,
+    val clock: Clock,
+    airbrake: AirbrakeNotifier) extends DbRepo[UriRecoFeedback] with UriRecoFeedbackRepo {
+
+  import db.Driver.simple._
+
+  type RepoImpl = UriRecoFeedbackTable
+
+  class UriRecoFeedbackTable(tag: Tag) extends RepoTable[UriRecoFeedback](db, tag, "uri_reco_feedback") {
+    def userId = column[Id[User]]("user_id", O.NotNull)
+    def uriId = column[Id[NormalizedURI]]("uri_id", O.NotNull)
+    def viewed = column[Option[Boolean]]("viewed", O.Nullable)
+    def clicked = column[Option[Boolean]]("clicked", O.Nullable)
+    def kept = column[Option[Boolean]]("kept", O.Nullable)
+    def like = column[Option[Boolean]]("like", O.Nullable)
+    def * = (id.?, createdAt, updatedAt, userId, uriId, viewed, clicked, kept, like, state) <> ((UriRecoFeedback.apply _).tupled, UriRecoFeedback.unapply _)
+  }
+
+  def table(tag: Tag) = new UriRecoFeedbackTable(tag)
+  initTable()
+
+  def invalidateCache(model: UriRecoFeedback)(implicit session: RSession): Unit = {}
+
+  def deleteCache(model: UriRecoFeedback)(implicit session: RSession): Unit = {}
+}

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedbackRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedbackRepo.scala
@@ -21,14 +21,16 @@ class UriRecoFeedbackRepoImpl @Inject() (
 
   type RepoImpl = UriRecoFeedbackTable
 
+  implicit def feedbackTypeMapper = MappedColumnType.base[UriRecoFeedbackValue, String](
+    { feedback => feedback.value },
+    { value => UriRecoFeedbackValue(value) }
+  )
+
   class UriRecoFeedbackTable(tag: Tag) extends RepoTable[UriRecoFeedback](db, tag, "uri_reco_feedback") {
     def userId = column[Id[User]]("user_id", O.NotNull)
     def uriId = column[Id[NormalizedURI]]("uri_id", O.NotNull)
-    def viewed = column[Option[Boolean]]("viewed", O.Nullable)
-    def clicked = column[Option[Boolean]]("clicked", O.Nullable)
-    def kept = column[Option[Boolean]]("kept", O.Nullable)
-    def liked = column[Option[Boolean]]("liked", O.Nullable)
-    def * = (id.?, createdAt, updatedAt, userId, uriId, viewed, clicked, kept, liked, state) <> ((UriRecoFeedback.apply _).tupled, UriRecoFeedback.unapply _)
+    def feedback = column[UriRecoFeedbackValue]("feedback", O.NotNull)
+    def * = (id.?, createdAt, updatedAt, userId, uriId, feedback, state) <> ((UriRecoFeedback.apply _).tupled, UriRecoFeedback.unapply _)
   }
 
   def table(tag: Tag) = new UriRecoFeedbackTable(tag)

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedbackRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedbackRepo.scala
@@ -25,8 +25,8 @@ class UriRecoFeedbackRepoImpl @Inject() (
     def viewed = column[Option[Boolean]]("viewed", O.Nullable)
     def clicked = column[Option[Boolean]]("clicked", O.Nullable)
     def kept = column[Option[Boolean]]("kept", O.Nullable)
-    def like = column[Option[Boolean]]("like", O.Nullable)
-    def * = (id.?, createdAt, updatedAt, userId, uriId, viewed, clicked, kept, like, state) <> ((UriRecoFeedback.apply _).tupled, UriRecoFeedback.unapply _)
+    def liked = column[Option[Boolean]]("liked", O.Nullable)
+    def * = (id.?, createdAt, updatedAt, userId, uriId, viewed, clicked, kept, liked, state) <> ((UriRecoFeedback.apply _).tupled, UriRecoFeedback.unapply _)
   }
 
   def table(tag: Tag) = new UriRecoFeedbackTable(tag)

--- a/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedbackRepo.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/model/UriRecoFeedbackRepo.scala
@@ -1,6 +1,6 @@
 package com.keepit.curator.model
 
-import com.google.inject.Inject
+import com.google.inject.{ Singleton, ImplementedBy, Inject }
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.DBSession.RSession
 import com.keepit.common.db.slick.{ DataBaseComponent, DbRepo }
@@ -8,8 +8,10 @@ import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.time.Clock
 import com.keepit.model._
 
+@ImplementedBy(classOf[UriRecoFeedbackRepoImpl])
 trait UriRecoFeedbackRepo extends DbRepo[UriRecoFeedback]
 
+@Singleton
 class UriRecoFeedbackRepoImpl @Inject() (
     val db: DataBaseComponent,
     val clock: Clock,


### PR DESCRIPTION
@stkem 

I took out the topic ids, as they can be queried from Cortex later on (if we want to retrain model). During online update, there is no need to store them. Stored values can be problematic during model transition. 

View data will be persisted as mobile supports that. 
