### PR TITLE
a bit more info

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
@@ -209,7 +209,7 @@ class UriIntegrityActor @Inject() (
     }
 
     val t2 = System.currentTimeMillis()
-    log.info(s"one uri migration takes ${t2 - t1} millis")
+    log.info(s"one uri migration from ${oldUriId} to ${newUriId} takes ${t2 - t1} millis")
   }
 
   /**


### PR DESCRIPTION
@eishay 

I found most memcached errors are from uriRepo.get

And seems not consistent, e.g. some get are fast, some are slow. 

On cache hit, the log indicates time elapse is around 100 millis
On cache exception, the log indicates 2000 ~ 5000 millis second for 1 uri migration.
