### PR TITLE
trimming down of libraries and keepers that we need to filter and get me...

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
@@ -183,8 +183,8 @@ class PageCommander @Inject() (
     val augmentFuture = searchClient.augment(
       userId = Some(userId),
       showPublishedLibraries = true,
-      maxKeepersShown = Int.MaxValue, // TODO: reduce to 5 once most users have extension 3.3.28 or later
-      maxLibrariesShown = Int.MaxValue,
+      maxKeepersShown = 5,
+      maxLibrariesShown = 10, //actually its three, but we're trimming them up a bit
       maxTagsShown = 0,
       items = Seq(AugmentableItem(normUri.id.get)))
 


### PR DESCRIPTION
...tadata for.

tracked it down when noticed we're pulling from cache hundreds of entities (like library count) for this call. its overloads the cache
