### PR TITLE
Using the default font-weight (400) instead of 100 (hairline) in emails

### DIFF
--- a/kifi-backend/modules/shoebox/app/views/email/helper/kifiTemplate.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/helper/kifiTemplate.scala.html
@@ -321,7 +321,7 @@ img.center {
 body, table.body, h1, h2, h3, h4, h5, h6, p {
   color: #222222;
   font-family: Helvetica,Arial,Geneva,Verdana,sans-serif;
-  font-weight: 100;
+  font-weight: 400;
   padding:0;
   margin: 0;
   text-align: left;
@@ -746,12 +746,12 @@ table.header {
   font-size: 18px !important;
   padding: 15px 0px !important;
   font-family: Helvetica,Arial,Geneva,Verdana,sans-serif !important;
-  font-weight: 100;
+  font-weight: 400;
   white-space: nowrap;
 }
 .main-body p {
   font-size: 18px !important;
-  font-weight: 100 !important;
+  font-weight: 400 !important;
 }
 
 table.green td {
@@ -787,7 +787,7 @@ table.green:active td a {
   font-family: Helvetica,Arial,Geneva,Verdana,sans-serif !important;
   font-size: 10px !important;
   color: #929292 !important;
-  font-weight: 100;
+  font-weight: 400;
 }
 .kifi-footer a {
   color: #929292 !important;

--- a/kifi-backend/modules/shoebox/app/views/email/helper/sampleCompleteEmail.html
+++ b/kifi-backend/modules/shoebox/app/views/email/helper/sampleCompleteEmail.html
@@ -746,7 +746,7 @@ table.header {
 }
 .main-body p {
   font-size: 18px !important;
-  font-weight: 100 !important;
+  font-weight: 400 !important;
 }
 
 table.green td {


### PR DESCRIPTION
@andrewconner @stkem 

It looks like maybe someone thought `100` means “normal” font-weight. These occurrences are on font sizes of 10 and 18, which are too small for a hairline font weight.
