### PR TITLE
a font-smoothing mixin that sets -moz-osx-font-smoothing too

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/app.styl
+++ b/kifi-backend/modules/shoebox/angular/src/app.styl
@@ -37,7 +37,7 @@ menu, ol, ul
   padding: 0
   margin: 0
 
-:link,
+:link
 :visited
   color: linkColor
   text-decoration: none

--- a/kifi-backend/modules/shoebox/angular/src/common/build-css/common.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/build-css/common.styl
@@ -1,6 +1,17 @@
 //
 // Mixins and functions.
 //
+font-smoothing(val)
+  if val == antialiased || val == grayscale
+    -webkit-font-smoothing: antialiased
+    -moz-osx-font-smoothing: grayscale
+  else if val == inherit || val == auto || val == unset
+    -webkit-font-smoothing: val
+    -moz-osx-font-smoothing: val
+  else
+    -webkit-font-smoothing: initial
+    -moz-osx-font-smoothing: initial
+
 long-text()
   white-space: nowrap
   overflow: hidden

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/callout/callout.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/callout/callout.styl
@@ -12,7 +12,7 @@ bg-color = #4dAf7c
   text-align: left
   z-index: 100
   font-size: 15px
-  -webkit-font-smoothing: antialiased
+  font-smoothing: antialiased
 
 .kf-callout-bubble-body
   margin-bottom: 22px

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/main.styl
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/main.styl
@@ -29,7 +29,7 @@
   padding: 10px 0
   font-size: 13px
   line-height: 20px
-  -webkit-font-smoothing: antialiased;
+  font-smoothing: antialiased
 
   .kf-subtitle-text
     color: #999

--- a/kifi-backend/modules/shoebox/angular/src/libraries/smallLibraryCard.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/smallLibraryCard.styl
@@ -142,7 +142,7 @@ owner-pic-diam = 32px
   bottom: 0
   height: 35px
   border-top: 1px solid rgba(255,255,255,.3)
-  -webkit-font-smoothing: antialiased
+  font-smoothing: antialiased
   text-align: center
   color: rgba(255,255,255,.8)
   text-shadow: 0 0 6px rgba(0,0,0,.3)

--- a/kifi-backend/modules/shoebox/angular/src/profile/profile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profile.styl
@@ -579,7 +579,7 @@ input.profile-email-address-add-input
   border: none
   background: transparent
   cursor: pointer
-  -webkit-font-smoothing: antialiased
+  font-smoothing: antialiased
 
 .profile-section
   padding: 20px 0 30px 27px

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileHeader.styl
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileHeader.styl
@@ -267,7 +267,6 @@ uphSmallMaxDim = 736px // for @media max-height and max-width
   line-height: 1.6em
   font-size: 0.9em
   font-smoothing: antialiased
-  -moz-osx-font-smoothing: grayscale;
 
   &:hover
     text-decoration: underline
@@ -279,7 +278,6 @@ uphSmallMaxDim = 736px // for @media max-height and max-width
   line-height: 1.6em
   font-size: 0.9em
   font-smoothing: antialiased
-  -moz-osx-font-smoothing: grayscale;
   word-break: break-word
 
   @media (max-height: uphSmallMaxDim) and (max-width: uphSmallMaxDim)

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibraries.styl
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibraries.styl
@@ -346,7 +346,7 @@ owner-pic-diam = 32px
   bottom: 0
   height: 35px
   border-top: 1px solid rgba(255,255,255,.3)
-  -webkit-font-smoothing: antialiased
+  font-smoothing: antialiased
   cursor: default
 
 follower-pic-diameter = 23px


### PR DESCRIPTION
@ahsu1230 introduced me to this property, added in Firefox 25 just for Macs, not yet documented in MDN.

In most places we were already using an apparently built-in `font-smoothing` mixin that outputs `-webkit-font-smoothing`. Now we have our own mixin that outputs both properties, and we’re using it consistently.

cc @andrewconner @stkem 
