### PR TITLE
Revert "using red and green library attribution chips in recommendation keep cards for now"

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWho.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWho.styl
@@ -22,15 +22,11 @@
   margin: 4px 4px 0 0
   height: 23px
   border-radius: (23px / 2)
-  background-color: libraryGreen
 
   @media (max-width: 479px)
     margin: 2px 1px 0 0
     height: 18px
     border-radius: 9px
-
-  &.secret
-    background-color: libraryRed
 
 .kf-keep-who-lib
   vertical-align: top

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepWho/keepWhoLib.tpl.html
@@ -1,6 +1,6 @@
 <span ng-if="!library.hidden">
   <span ng-if="!isBot">
-    <span class="kf-keep-who-pic-box" ng-class="{secret: library.visibility === 'secret'}" ng-style="{'background-color': library.color}">
+    <span class="kf-keep-who-pic-box" ng-attr-style="background-color:{{library.color}}">
       <a class="kf-keep-who-pic" href="{{library.keeper||library.owner|profileUrl}}" ng-attr-style="background-image:url({{library.keeper||library.owner|pic:100}})" kf-track-origin="{{currentPageOrigin}}/alsoKeptInLibraryBy"></a>
       <a class="kf-keep-who-lib" href="{{library.absPath||library.url}}" ng-click="onLibraryAttributionClicked()" kf-track-origin="libraryAttributionChip">{{library.name}}</a>
       <span kf-tooltip position="top" padding="10">


### PR DESCRIPTION
This reverts commit 5ce46f13379b845f65d04e04b2799520fad1557d (#14632).

I think recos were the last place we were missing library colors.

cc @leogrim @andrewconner 
