### PR TITLE
Remove unrequired database call in recursive function (!!!)

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationService.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationService.scala
@@ -121,20 +121,18 @@ class NormalizationServiceImpl @Inject() (
           assert(weakerCandidates.isEmpty || weakerCandidates.head.normalization <= strongerCandidate.normalization, s"Normalization candidates ${weakerCandidates.head} and $strongerCandidate have not been sorted properly for $currentReference")
           assert(currentReference.normalization.isEmpty || currentReference.normalization.get <= strongerCandidate.normalization, s"Normalization candidate $strongerCandidate has not been filtered properly for $currentReference")
 
-          db.readOnlyMaster { implicit session =>
-            action(strongerCandidate) match {
-              case Accept => Future.successful((Some(strongerCandidate), weakerCandidates))
-              case Reject => findCandidate(weakerCandidates)
-              case Check(contentCheck) =>
-                if (currentReference.url == strongerCandidate.url) Future.successful(Some(strongerCandidate), weakerCandidates)
-                else for {
-                  contentCheck <- contentCheck(strongerCandidate)
-                  (successful, weaker) <- {
-                    if (contentCheck) Future.successful((Some(strongerCandidate), weakerCandidates))
-                    else findCandidate(weakerCandidates)
-                  }
-                } yield (successful, weaker)
-            }
+          action(strongerCandidate) match {
+            case Accept => Future.successful((Some(strongerCandidate), weakerCandidates))
+            case Reject => findCandidate(weakerCandidates)
+            case Check(contentCheck) =>
+              if (currentReference.url == strongerCandidate.url) Future.successful(Some(strongerCandidate), weakerCandidates)
+              else for {
+                contentCheck <- contentCheck(strongerCandidate)
+                (successful, weaker) <- {
+                  if (contentCheck) Future.successful((Some(strongerCandidate), weakerCandidates))
+                  else findCandidate(weakerCandidates)
+                }
+              } yield (successful, weaker)
           }
       }
     }


### PR DESCRIPTION
@eishay @andrewconner @stkem 
This is messed up, don't know how we lived with this all that time. I guess we never supplied more than one candidate at once, so we were never calling the function recursively but we do now with Rover supplying several scraped candidates at once.
