### PR TITLE
mobile endpoint for editing keep notes

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -159,7 +159,7 @@ class MobileLibraryController @Inject() (
           keepDataList.map { keepData =>
             val keep = keepRepo.get(keepData.id)
             val keepImageUrl = keepImageCommander.getBestImageForKeep(keep.id.get, ScaleImageRequest(MobileLibraryController.defaultKeepImageSize)).flatten.map(keepImageCommander.getUrl)
-            val keepObj = Json.obj("id" -> keep.externalId, "title" -> keep.title, "imageUrl" -> keepImageUrl, "hashtags" -> Json.toJson(collectionRepo.getTagsByKeepId(keep.id.get)))
+            val keepObj = Json.obj("id" -> keep.externalId, "title" -> keep.title, "note" -> keep.note, "imageUrl" -> keepImageUrl, "hashtags" -> Json.toJson(collectionRepo.getTagsByKeepId(keep.id.get)))
             Json.obj("keep" -> keepObj) ++ Json.toJson(keepData).as[JsObject] - ("id")
           }
         }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -279,6 +279,7 @@ POST    /m/1/libraries/recos/feedback      @com.keepit.controllers.website.Libra
 POST    /m/1/content/flagUrl                @com.keepit.controllers.mobile.MobileUriController.flagContent()
 
 GET     /m/1/keeps/:id                      @com.keepit.controllers.mobile.MobileKeepsController.getKeepInfo(id: ExternalId[Keep], withFullInfo: Boolean ?= false, imageWidth: Option[Int] ?= None, imageHeight: Option[Int] ?= None)
+POST    /m/1/keeps/:id                      @com.keepit.controllers.mobile.MobileKeepsController.editKeepInfo(id: ExternalId[Keep])
 GET     /m/1/inviteInfo                     @com.keepit.controllers.website.InviteController.getGeneralInviteInfo()
 
 


### PR DESCRIPTION
@andrewconner @DerekBurch @thassss @mrbrown14 

use `POST    /m/1/keeps/:id` to edit keep info. Send a body with

```
{
   "title" : "new title",
   "note" : "new comment"
}
```

to update the keep. I know title isn't part of the spec, but wouldn't hurt to have it now =)
