### PR TITLE
default to old title/note if fields are not provided

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
@@ -190,8 +190,8 @@ class MobileKeepsController @Inject() (
         val titleOpt = (json \ "title").asOpt[String]
         val noteOpt = (json \ "note").asOpt[String]
 
-        val newTitle = titleOpt map { _.trim } filterNot { _.isEmpty }
-        val newNote = noteOpt map { _.trim } filterNot { _.isEmpty }
+        val newTitle = titleOpt orElse keep.title map { _.trim } filterNot { _.isEmpty }
+        val newNote = noteOpt orElse keep.note map { _.trim } filterNot { _.isEmpty }
 
         db.readWrite { implicit s =>
           keepRepo.save(keep.copy(title = newTitle, note = newNote))

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -879,6 +879,14 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
           currentKeep.note === Some("a real note")
         }
 
+        val testEditNothing = editKeepInfo(user, keep, Json.obj())
+        status(testEditNothing) must equalTo(NO_CONTENT)
+        db.readOnlyMaster { implicit s =>
+          val currentKeep = keepRepo.get(keep.externalId)
+          currentKeep.title === Some("a real keep")
+          currentKeep.note === Some("a real note")
+        }
+
       }
     }
 


### PR DESCRIPTION
just in case a title or note field is not provided, leave it alone and don't overwrite those fields.

thanks @andrewconner for the catch
@DerekBurch @thassss 
