### PR TITLE
admin flow for twitter sync

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminTwitterWaitlistController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminTwitterWaitlistController.scala
@@ -1,0 +1,41 @@
+package com.keepit.controllers.admin
+
+import com.google.inject.Inject
+import com.keepit.commanders.TwitterWaitlistCommander
+import com.keepit.common.controller.{ AdminUserActions, UserActionsHelper }
+import com.keepit.common.crypto.PublicIdConfiguration
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.Database
+import com.keepit.common.mail.EmailAddress
+import com.keepit.model._
+import play.twirl.api.Html
+import views.html
+
+class AdminTwitterWaitlistController @Inject() (
+    val userActionsHelper: UserActionsHelper,
+    twitterWaitlistCommander: TwitterWaitlistCommander,
+    db: Database,
+    userRepo: UserRepo,
+    libraryRepo: LibraryRepo,
+    twitterSyncStateRepo: TwitterSyncStateRepo,
+    implicit val publicIdConfig: PublicIdConfiguration) extends AdminUserActions {
+
+  def getWaitlist() = AdminUserPage { implicit request =>
+    val entriesList = twitterWaitlistCommander.getWaitlist
+    Ok(html.admin.twitterWaitlist(entriesList))
+  }
+
+  def acceptUser(userId: Id[User], handle: String) = AdminUserPage { implicit request =>
+    val result = twitterWaitlistCommander.acceptUser(userId, handle).right.map { syncState =>
+      val (lib, owner) = db.readOnlyMaster { implicit s =>
+        val lib = libraryRepo.get(syncState.libraryId)
+        val owner = userRepo.get(lib.ownerId)
+        (lib, owner)
+      }
+      val libraryPath = Library.formatLibraryPath(owner.username, lib.slug)
+      (syncState, libraryPath, owner.primaryEmail)
+    }
+    Ok(html.admin.twitterWaitlistAccept(result))
+  }
+
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterWaitlistCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterWaitlistCommander.scala
@@ -118,7 +118,7 @@ class TwitterWaitlistCommanderImpl @Inject() (
         })
       case _ =>
         // invalid
-        Left(s"Couldn't accept $userId. $entryOpt, $suiOpt, $syncOpt")
+        Left(s"Couldn't accept User $userId. Entry: $entryOpt, SocialUserInfo: $suiOpt, SyncState: $syncOpt")
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/TwitterWaitlistController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/TwitterWaitlistController.scala
@@ -177,29 +177,4 @@ class TwitterWaitlistController @Inject() (
     }
   }
 
-  // Admin actions
-  def getWaitlist = UserAction { request => // todo: admin
-    val body = commander.getWaitlist.zipWithIndex.map {
-      case (t, idx) =>
-        s"""
-          |<tr>
-          |  <td>$idx</td>
-          |  <td><a href="https://twitter.com/${t.twitterHandle}">${t.twitterHandle}</a></td>
-          |  <td><a href="/admin/user/${t.userId.id}">user</a></td>
-          |  <td><a href="/admin/twitter/accept?handle=${t.twitterHandle}&userId=${t.userId.id}">Accept</a></td>
-          |</tr>
-        """.stripMargin
-    }.foldRight("")(_ ++ _)
-    Ok(Html(s"""
-        |<table>
-        | <tr><td>#</td><td>Handle</td><td>User</td><td></td></tr>
-        | $body
-        | </table>
-      """.stripMargin))
-  }
-
-  def acceptUser(userId: Id[User], handle: String) = UserAction { request => // todo: admin
-    Ok(commander.acceptUser(userId, handle).toString)
-  }
-
 }

--- a/kifi-backend/modules/shoebox/app/views/admin/twitterWaitlist.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/twitterWaitlist.scala.html
@@ -1,0 +1,29 @@
+@(entriesList: Seq[TwitterWaitlistEntry]
+)(implicit request: com.keepit.common.controller.UserRequest[_])
+
+
+@admin("Twitter Waitlist", stylesheets = List("admin_user")) {
+    <br>
+
+    <h2>Showing All @{entriesList.length} Twitter Waitlist Entries</h2>
+
+    <table class="table table-bordered">
+        <tr>
+            <th>idx</th>
+            <th>Twitter Handle</th>
+            <th>User Id</th>
+            <th>Accept to Waitlist</th>
+        </tr>
+        @for((entry, i) <- entriesList.zipWithIndex) {
+            <tr>
+                <td>@{i+1}</td>
+                <td><a href="https://twitter.com/@{entry.twitterHandle}">@{entry.twitterHandle}</a></td>
+                <td><a href="/admin/user/@{entry.userId.id}">user</a></td>
+                <td><a href="/admin/twitter/accept?handle=@{entry.twitterHandle}&userId=@{entry.userId.id}">Accept</a></td>
+            </tr>
+        }
+    </table>
+}
+
+<script type="text/javascript">
+</script>

--- a/kifi-backend/modules/shoebox/app/views/admin/twitterWaitlistAccept.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/twitterWaitlistAccept.scala.html
@@ -1,0 +1,38 @@
+@(result: Either[String, (TwitterSyncState, String, Option[EmailAddress])]
+)(implicit request: com.keepit.common.controller.UserRequest[_])
+
+@admin("Twitter Waitlist Accepting User...", stylesheets = List("admin_user")) {
+    <br>
+
+        @result match {
+            case Left(error) => {
+                <h2>Error accepting twitter handle!</h2>
+                <p>@{result.left.get}</p>
+            }
+            case Right((syncState, libraryPath, primaryEmail)) => {
+                <h2>Twitter Handle @{syncState.twitterHandle} successfully accepted!</h2>
+                <table class="table table-bordered">
+                    <tr>
+                        <th>Twitter Page</th>
+                        <th>User Admin Page</th>
+                        <th>User Primary Email</th>
+                        <th>LibraryId</th>
+                        <th>Library Admin Page</th>
+                        <th>Library Kifi Page</th>
+                    </tr>
+                    <tr>
+                        <td><a href="https://twitter.com/@{syncState.twitterHandle}">@{syncState.twitterHandle}</a></td>
+                        <td>@if(syncState.userId.isDefined){<a href="/admin/user/@{syncState.userId.get.id}">UserId @{syncState.userId.get.id}</a>}</td>
+                        <td>@if(primaryEmail.isDefined){@{primaryEmail.get}}</td>
+                        <td>@{syncState.libraryId.id}</td>
+                        <td><a href="/admin/libraries/@{syncState.libraryId.id}">Admin</a></td>
+                        <td><a href="https://www.kifi.com/@{libraryPath}">Kifi</a></td>
+                    </tr>
+                </table>
+            }
+        }
+
+}
+
+<script type="text/javascript">
+</script>

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -801,8 +801,8 @@ POST    /admin/graph/wander                                @com.keepit.controlle
 GET     /admin/graph/discover                              @com.keepit.controllers.admin.WanderingAdminController.fromParisWithLove()
 GET     /admin/graph/uriWandering                          @com.keepit.controllers.admin.WanderingAdminController.uriWandering(steps: Int ?= 20000)
 
-GET     /admin/twitter                                     @com.keepit.controllers.website.TwitterWaitlistController.getWaitlist()
-GET     /admin/twitter/accept                              @com.keepit.controllers.website.TwitterWaitlistController.acceptUser(userId: Id[User], handle: String)
+GET     /admin/twitter                                     @com.keepit.controllers.admin.AdminTwitterWaitlistController.getWaitlist()
+GET     /admin/twitter/accept                              @com.keepit.controllers.admin.AdminTwitterWaitlistController.acceptUser(userId: Id[User], handle: String)
 
 ##########################################
 # Common Healthcheck / service routes


### PR DESCRIPTION
@andrewconner 

few things
- switched admin twitter stuff out of the website controller and into an admin controller
- both the waitlist and the acceptUser have an admin page
- admin page has userId, libraryId, user email, twitter handle, link to both admin library page and real kifi library page
- has an error message

future work: better error messages. Maybe actions to do when you see an error message?
