### PR TITLE
Increase timeout on ScraperServiceClient.getSignature, let it go when it...

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/scraper/ScraperServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/scraper/ScraperServiceClient.scala
@@ -191,9 +191,9 @@ class ScraperServiceClientImpl @Inject() (
   def getSignature(url: String, proxy: Option[HttpProxy], extractorProviderType: Option[ExtractorProviderType]): Future[Option[Signature]] = consolidateGetSignatureReq(url) { url =>
     val key = UrlSignatureKey(NormalizedURI.hashUrl(url), extractorProviderType)
     cacheProvider.signatureCache.getOrElseFuture(key) {
-      call(Scraper.internal.getSignature, Json.obj("url" -> url, "proxy" -> Json.toJson(proxy), "extractorProviderType" -> extractorProviderType.map(_.name)), callTimeouts = longTimeout).map { r =>
+      call(Scraper.internal.getSignature, Json.obj("url" -> url, "proxy" -> Json.toJson(proxy), "extractorProviderType" -> extractorProviderType.map(_.name)), callTimeouts = superExtraLongTimeoutJustForEmbedly).map { r =>
         r.json.asOpt[String].map(Signature(_))
-      }
+      } recover { case _: java.util.concurrent.TimeoutException => None }
     }
   }
 


### PR DESCRIPTION
... fails
