### PR TITLE
undoing previous concurrency increase

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationGenerationCommander.scala
@@ -49,7 +49,7 @@ class RecommendationGenerationCommander @Inject() (
     shardingCommander: ShardingCommander) extends Logging {
 
   val defaultScore = 0.0f
-  val recommendationGenerationLock = new ReactiveLock(16)
+  val recommendationGenerationLock = new ReactiveLock(10)
   val perUserRecommendationGenerationLocks = TrieMap[Id[User], ReactiveLock]()
   val candidateURILock = new ReactiveLock(4)
 


### PR DESCRIPTION
it actually ended up slower overall, likely due to database contention

@eishay 
