### PR TITLE
All social fetching has failed on Twitter

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/common/social/TwitterSocialGraph.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/social/TwitterSocialGraph.scala
@@ -360,8 +360,8 @@ class TwitterSocialGraphImpl @Inject() (
       val call = WS.url(endpoint)
         .sign(OAuthCalculator(providerConfig.key, accessToken))
         .withQueryString(
-          "user_id" -> userId.toString,
-          "cursor" -> cursor.toString,
+          "user_id" -> userId.id.toString,
+          "cursor" -> cursor.id.toString,
           "count" -> count.toString)
         .get()
       call flatMap { resp =>


### PR DESCRIPTION
@eishay @stkem I don't know how long this has failed, but it's broken now. We have received several hundred reports of this, so I assume because of the constant flood of exceptions, we all missed it.

This is the current call:

`https://api.twitter.com/1.1/followers/ids.json?user_id=TwitterId%2878157234%29&cursor=TwitterId%28-1%29&count=5000`

Notice the case class `toString` bug. 
