### PR TITLE
queue activity emails to SQS

### DIFF
--- a/kifi-backend/modules/common/test/com/keepit/common/queue/FakeQueue.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/queue/FakeQueue.scala
@@ -1,0 +1,61 @@
+package com.keepit.common.queue
+
+import java.util.UUID
+
+import com.kifi.franz.{ FakeSQSQueue, MessageId, SQSMessage }
+
+import scala.collection.mutable
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.duration.FiniteDuration
+
+class FakeQueue[T] extends FakeSQSQueue[T] {
+
+  // mutable objects are public so test cases can check the state of the fake queue
+  val messages = mutable.Queue[SQSMessage[T]]()
+  val lockedMessages = mutable.Map[MessageId, SQSMessage[T]]()
+  val consumedMessages = mutable.Map[MessageId, SQSMessage[T]]()
+
+  def unlockAll(): Int = synchronized {
+    lockedMessages.keys.map { msgId =>
+      messages.enqueue(lockedMessages.remove(msgId).get)
+    }.size
+  }
+
+  override def nextWithLock(lockTimeout: FiniteDuration)(implicit ec: ExecutionContext) = synchronized {
+    Future.successful {
+      if (messages.nonEmpty) {
+        val msg = messages.dequeue()
+        lockedMessages(msg.id) = msg
+        Some(msg)
+      } else None
+    }
+  }
+
+  override def nextBatchWithLock(maxBatchSize: Int, lockTimeout: FiniteDuration)(implicit ec: ExecutionContext) = synchronized {
+    Future.successful(for (i <- 1 to maxBatchSize if messages.nonEmpty) yield {
+      val msg = messages.dequeue()
+      lockedMessages(msg.id) = msg
+      msg
+    })
+  }
+
+  override def send(msg: T): Future[MessageId] = synchronized {
+    val msgId = MessageId(UUID.randomUUID().toString)
+    val sqsMsg = SQSMessage(id = msgId, body = msg, consume = consume(msgId), attributes = Map.empty)
+    messages.enqueue(sqsMsg)
+    Future.successful(msgId)
+  }
+
+  private def consume(msgId: MessageId)(): Unit = synchronized {
+    if (consumedMessages.isDefinedAt(msgId))
+      throw new IllegalStateException(s"cannot consume message that's already been consumed $msgId")
+
+    val msgOpt = lockedMessages.remove(msgId)
+    msgOpt.foreach { msg => consumedMessages(msgId) = msg }
+  }
+
+  override def toString() = {
+    s"FakeQueue(messages=$messages consumedMessages=$consumedMessages lockedMessages=$lockedMessages)"
+  }
+
+}

--- a/kifi-backend/modules/curator/test/com/keepit/curator/queue/FakeFeedDigestEmailQueueModule.scala
+++ b/kifi-backend/modules/curator/test/com/keepit/curator/queue/FakeFeedDigestEmailQueueModule.scala
@@ -1,61 +1,11 @@
 package com.keepit.curator.queue
 
-import java.util.UUID
-
 import com.google.inject.{ Provides, Singleton }
 import com.keepit.common.logging.Logging
-import com.kifi.franz.{ SQSMessage, MessageId, FakeSQSQueue, SQSQueue }
-import collection.mutable
+import com.keepit.common.queue.FakeQueue
+import com.kifi.franz.SQSQueue
 
-import scala.concurrent.{ ExecutionContext, Future }
-import scala.concurrent.duration.FiniteDuration
-
-class FakeFeedDigestEmailQueue extends FakeSQSQueue[SendFeedDigestToUserMessage] {
-
-  // mutable objects are public so test cases can check the state of the fake queue
-  val messages = mutable.Queue[SQSMessage[SendFeedDigestToUserMessage]]()
-  val lockedMessages = mutable.Map[MessageId, SQSMessage[SendFeedDigestToUserMessage]]()
-  val consumedMessages = mutable.Map[MessageId, SQSMessage[SendFeedDigestToUserMessage]]()
-
-  def unlockAll(): Int = synchronized {
-    lockedMessages.keys.map { msgId =>
-      messages.enqueue(lockedMessages.remove(msgId).get)
-    }.size
-  }
-
-  override def nextWithLock(lockTimeout: FiniteDuration)(implicit ec: ExecutionContext) = synchronized {
-    Future.successful {
-      if (messages.nonEmpty) {
-        val msg = messages.dequeue()
-        lockedMessages(msg.id) = msg
-        Some(msg)
-      } else None
-    }
-  }
-
-  override def nextBatchWithLock(maxBatchSize: Int, lockTimeout: FiniteDuration)(implicit ec: ExecutionContext) = synchronized {
-    Future.successful(for (i <- 1 to maxBatchSize if messages.nonEmpty) yield {
-      val msg = messages.dequeue()
-      lockedMessages(msg.id) = msg
-      msg
-    })
-  }
-
-  override def send(msg: SendFeedDigestToUserMessage): Future[MessageId] = synchronized {
-    val msgId = MessageId(UUID.randomUUID().toString)
-    val sqsMsg = SQSMessage(id = msgId, body = msg, consume = consume(msgId), attributes = Map.empty)
-    messages.enqueue(sqsMsg)
-    Future.successful(msgId)
-  }
-
-  private def consume(msgId: MessageId)(): Unit = synchronized {
-    if (consumedMessages.isDefinedAt(msgId))
-      throw new IllegalStateException(s"cannot consume message that's already been consumed $msgId")
-
-    val msgOpt = lockedMessages.remove(msgId)
-    msgOpt.foreach { msg => consumedMessages(msgId) = msg }
-  }
-
+class FakeFeedDigestEmailQueue extends FakeQueue[SendFeedDigestToUserMessage] {
 }
 
 case class FakeFeedDigestEmailQueueModule() extends FeedDigestEmailQueueModule with Logging {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/activity/ActivityEmailActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/activity/ActivityEmailActor.scala
@@ -1,0 +1,148 @@
+package com.keepit.commanders.emails.activity
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.regions.Regions
+import com.google.inject.{ Provides, Inject, Singleton }
+import com.keepit.commanders.emails.ActivityFeedEmailSender
+import com.keepit.common.akka.FortyTwoActor
+import com.keepit.common.concurrent.{ FutureHelpers, ReactiveLock }
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.logging.Logging
+import com.keepit.common.zookeeper.ServiceDiscovery
+import com.keepit.model.User
+import com.keepit.common.db.Id
+import com.kifi.franz.{ SimpleSQSClient, QueueName, SQSQueue, FakeSQSQueue }
+import net.codingwell.scalaguice.ScalaModule
+import play.api.libs.json.{ Json, Format, Writes }
+import scala.concurrent.duration._
+
+import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+class ActivityEmailActor @Inject() (
+    serviceDiscovery: ServiceDiscovery,
+    activityEmailQueueHelper: ActivityFeedEmailQueueHelper,
+    protected val airbrake: AirbrakeNotifier) extends FortyTwoActor(airbrake) with Logging {
+
+  import ActivityEmailMessage._
+
+  val isRunning = new AtomicBoolean(false)
+
+  def receive: PartialFunction[Any, Unit] = {
+    case QueueEmails => {
+      log.info("[Queue] calling ActivityEmailSender.send()")
+      if (serviceDiscovery.isLeader()) {
+        activityEmailQueueHelper.addToQueue().foreach(_ => {
+          log.info("[Queue] all emails queued; sending emails..")
+          self ! SendEmails
+        })
+      } else {
+        airbrake.notify("ActivityEmailSender.send() should not be called by non-leader!")
+        Future.successful(Unit)
+      }
+    }
+    case SendEmails => {
+      if (isRunning.compareAndSet(false, true)) {
+        activityEmailQueueHelper.processQueue().onComplete(_ => isRunning.set(false))
+      } else {
+        log.info("[Send] skipping; already running")
+        Future.successful(Unit)
+      }
+    }
+  }
+}
+
+class ActivityFeedEmailQueueHelper @Inject() (
+    activityEmailSender: ActivityFeedEmailSender,
+    queue: SQSQueue[SendActivityEmailToUserMessage],
+    protected val airbrake: AirbrakeNotifier) extends Logging {
+  private val queueLock = new ReactiveLock(10)
+
+  def addToQueue(): Future[Unit] = {
+    val usersIdsToSendTo: Set[Id[User]] = activityEmailSender.usersToSendEmailTo()
+
+    val seqF = usersIdsToSendTo.map { userId =>
+      queueLock.withLockFuture { queue.send(SendActivityEmailToUserMessage(userId)) }
+    }
+
+    Future.sequence(seqF) map (_ -> Unit)
+  }
+
+  def processQueue(): Future[Unit] = {
+    def fetchFromQueue(): Future[Boolean] = {
+      log.info(s"[processQueue] fetching message from queue ${queue.queue.name}")
+      queue.nextWithLock(1 minute).flatMap { messageOpt =>
+        messageOpt map { message =>
+          try {
+            val emailF = activityEmailSender.sendToUser(message.body.userId)
+            emailF map { emailToSend =>
+              log.info(s"[processQueue] consumed activity email to=${emailToSend.to}")
+              message.consume()
+            } recover {
+              case e =>
+                airbrake.notify(s"error sending activity email to ${message.body.userId}", e)
+            } map (_ => true)
+          } catch {
+            case e: Exception =>
+              airbrake.notify(s"error sending activity email to ${message.body.userId} before future", e)
+              Future.successful(true)
+          }
+        } getOrElse Future.successful(false)
+      }
+    }
+
+    val doneF: Future[Unit] = FutureHelpers.whilef(fetchFromQueue())(Unit)
+    doneF.onFailure {
+      case e => airbrake.notify(s"SQS queue(${queue.queue.name}) nextWithLock failed", e)
+    }
+
+    doneF
+  }
+
+}
+
+case class SendActivityEmailToUserMessage(userId: Id[User])
+
+object ActivityEmailMessage {
+  object QueueEmails
+  object SendEmails
+}
+
+object SendActivityEmailToUserMessage {
+  import play.api.libs.json.__
+  implicit val format = Format(
+    __.read[Id[User]].map(SendActivityEmailToUserMessage.apply),
+    new Writes[SendActivityEmailToUserMessage] { def writes(o: SendActivityEmailToUserMessage) = Json.toJson(o.userId) }
+  )
+}
+
+trait ActivityEmailQueueModule extends ScalaModule {
+  val queueName: String
+
+  override def configure(): Unit = {}
+}
+
+@Singleton
+case class ProdActivityEmailQueueModule() extends ActivityEmailQueueModule with Logging {
+  val queueName = "prod-shoebox-activity-email"
+
+  @Singleton
+  @Provides
+  def activityEmailQueue(basicAWSCreds: BasicAWSCredentials): SQSQueue[SendActivityEmailToUserMessage] = {
+    val client = SimpleSQSClient(basicAWSCreds, Regions.US_WEST_1, buffered = false)
+    client.formatted[SendActivityEmailToUserMessage](QueueName(queueName))
+  }
+}
+
+@Singleton
+case class DevActivityEmailQueueModule() extends ActivityEmailQueueModule with Logging {
+  val queueName = "dev-shoebox-activity-email"
+
+  @Singleton
+  @Provides
+  def activityEmailQueue(basicAWSCreds: BasicAWSCredentials): SQSQueue[SendActivityEmailToUserMessage] = {
+    new FakeSQSQueue[SendActivityEmailToUserMessage] {}
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/dev/ShoeboxDevModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/dev/ShoeboxDevModule.scala
@@ -1,5 +1,6 @@
 package com.keepit.dev
 
+import com.keepit.commanders.emails.activity.DevActivityEmailQueueModule
 import com.keepit.controllers.internal.DevDataPipelineExecutorModule
 import com.keepit.abook.ProdABookServiceClientModule
 import com.keepit.common.controller.ProdShoeboxUserActionsModule
@@ -35,6 +36,7 @@ case class ShoeboxDevModule() extends ShoeboxModule with CommonDevModule {
   val storeModule = ShoeboxDevStoreModule()
   val sqsModule = DevSimpleQueueModule()
   val normalizationQueueModule = DevNormalizationUpdateJobQueueModule()
+  val activityEmailActorModule = DevActivityEmailQueueModule()
 
   // Shoebox Functional Modules
   val analyticsModule = DevAnalyticsModule()

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxModule.scala
@@ -1,5 +1,6 @@
 package com.keepit.shoebox
 
+import com.keepit.commanders.emails.activity.{ ActivityEmailQueueModule, ProdActivityEmailQueueModule, DevActivityEmailQueueModule }
 import com.keepit.common.controller.UserActionsModule
 import com.keepit.common.seo.SiteMapGeneratorModule
 import com.keepit.controllers.internal.DataPipelineExecutorModule
@@ -54,6 +55,7 @@ trait ShoeboxModule extends ConfigurationModule with CommonServiceModule {
   val fjMonitorModule: ForkJoinContextMonitorModule
   val twilioCredentialsModule: TwilioCredentialsModule
   val dataPipelineExecutorModule: DataPipelineExecutorModule
+  val activityEmailActorModule: ActivityEmailQueueModule
 
   //these are modules that are provided here (but can be overriden by inheriting modules)
   // Service clients

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxProdModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/ShoeboxProdModule.scala
@@ -1,6 +1,7 @@
 package com.keepit.shoebox
 
 import com.keepit.abook.ProdABookServiceClientModule
+import com.keepit.commanders.emails.activity.ProdActivityEmailQueueModule
 import com.keepit.common.cache.{ EhCacheCacheModule, MemcachedCacheModule, ShoeboxCacheModule }
 import com.keepit.common.controller.ProdShoeboxUserActionsModule
 import com.keepit.common.seo.{ ProdSiteMapGeneratorModule }
@@ -33,6 +34,7 @@ case class ShoeboxProdModule() extends ShoeboxModule with CommonProdModule {
   val storeModule = ShoeboxProdStoreModule()
   val sqsModule = ProdSimpleQueueModule()
   val normalizationQueueModule = ProdNormalizationUpdateJobQueueModule()
+  val activityEmailActorModule = ProdActivityEmailQueueModule()
 
   // Shoebox Functional Modules
   val analyticsModule = ProdAnalyticsModule()

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/cron/ActivityEmailCronPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/cron/ActivityEmailCronPlugin.scala
@@ -2,6 +2,7 @@ package com.keepit.shoebox.cron
 
 import com.google.inject.{ Singleton, Inject }
 import com.keepit.commanders.emails.ActivityFeedEmailSender
+import com.keepit.commanders.emails.activity.{ ActivityEmailMessage, ActivityEmailActor }
 import com.keepit.common.actor.ActorInstance
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.healthcheck.AirbrakeNotifier
@@ -12,23 +13,6 @@ import us.theatr.akka.quartz.QuartzActor
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 import scala.util.{ Failure, Success }
-
-private[cron] object SendActivityEmail
-
-class ActivityEmailActor @Inject() (
-    airbrake: AirbrakeNotifier,
-    activityEmailSender: ActivityFeedEmailSender) extends FortyTwoActor(airbrake) with Logging {
-
-  def receive() = {
-    case SendActivityEmail =>
-      log.info("ActivityEmailActor sending...")
-      val doneF = activityEmailSender.apply(None)
-      doneF.onComplete {
-        case Success(x) => log.info("ActivityEmailActor success")
-        case Failure(e) => log.error("ActivityEmailActor failed", e)
-      }
-  }
-}
 
 trait ActivityEmailCronPlugin extends SchedulerPlugin
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/cron/ActivityEmailCronPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/cron/ActivityEmailCronPlugin.scala
@@ -1,18 +1,12 @@
 package com.keepit.shoebox.cron
 
 import com.google.inject.{ Singleton, Inject }
-import com.keepit.commanders.emails.ActivityFeedEmailSender
 import com.keepit.commanders.emails.activity.{ ActivityEmailMessage, ActivityEmailActor }
 import com.keepit.common.actor.ActorInstance
-import com.keepit.common.akka.FortyTwoActor
-import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.common.plugin.{ SchedulerPlugin, SchedulingProperties }
 import com.keepit.common.time._
 import us.theatr.akka.quartz.QuartzActor
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
-import scala.util.{ Failure, Success }
 
 trait ActivityEmailCronPlugin extends SchedulerPlugin
 
@@ -32,7 +26,7 @@ class ActivityEmailCronPluginImpl @Inject() (
     val utcHourFor9amEasternTime = 9 + -offsetHoursToUtc
 
     // <sec> <min> <hr> <day of mo> <mo> <day of wk> <yr>
-    // val cronTime = s"0 0 $utcHourFor9amEasternTime ? * 5" // 1pm UTC - send Thursday at 9am ET / 6am PT
-    // cronTaskOnLeader(quartz, actor.ref, cronTime, SendActivityEmail)
+    //    val cronTime = s"0 0 $utcHourFor9amEasternTime ? * 5" // 1pm UTC - send Thursday at 9am ET / 6am PT
+    //    cronTaskOnLeader(quartz, actor.ref, cronTime, ActivityEmailMessage.QueueEmails)
   }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/FakeActivityFeedEmailQueueModule.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/FakeActivityFeedEmailQueueModule.scala
@@ -1,0 +1,22 @@
+package com.keepit.commanders.emails
+
+import com.google.inject.{ Provides, Singleton }
+import com.keepit.commanders.emails.activity.{ ActivityEmailQueueModule, SendActivityEmailToUserMessage }
+import com.keepit.common.logging.Logging
+import com.keepit.common.queue.FakeQueue
+import com.kifi.franz.SQSQueue
+
+class FakeActivityEmailQueue extends FakeQueue[SendActivityEmailToUserMessage] {
+}
+
+case class FakeActivityFeedEmailQueueModule() extends ActivityEmailQueueModule with Logging {
+
+  // this SQS queue doesn't actually exist
+  val queueName = "test-activity-feed-email"
+
+  @Singleton
+  @Provides
+  def activityEmailQueue(): SQSQueue[SendActivityEmailToUserMessage] = new FakeActivityEmailQueue
+
+}
+

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/ActivityEmailRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/ActivityEmailRepoTest.scala
@@ -1,6 +1,8 @@
 package com.keepit.model
 
 import com.keepit.common.db.Id
+import com.keepit.model.UserFactory._
+import com.keepit.model.UserFactoryHelper._
 import com.keepit.test.ShoeboxTestInjector
 import org.specs2.mutable.Specification
 
@@ -9,19 +11,21 @@ class ActivityEmailRepoTest extends Specification with ShoeboxTestInjector {
   "ActivityEmailRepo" should {
     "save model" in {
       withDb() { implicit injector =>
-        val unsavedActivityEmail = ActivityEmail(
-          userId = Id[User](42),
-          state = ActivityEmailStates.PENDING,
-          otherFollowedLibraries = Some(Id[Library](2) :: Id[Library](4) :: Nil),
-          userFollowedLibraries = Some(Id[Library](1) :: Id[Library](3) :: Nil),
-          libraryRecommendations = Some(Id[Library](33) :: Nil)
-        )
-        val activityEmail = db.readWrite { implicit rw =>
-          inject[ActivityEmailRepo].save(unsavedActivityEmail)
+        val (activityEmail, user1) = db.readWrite { implicit rw =>
+          val u1 = user().withName("Kifi", "User1").withEmailAddress("u1@kifi.com").saved
+          val unsavedActivityEmail = ActivityEmail(
+            userId = u1.id.get,
+            state = ActivityEmailStates.PENDING,
+            otherFollowedLibraries = Some(Id[Library](2) :: Id[Library](4) :: Nil),
+            userFollowedLibraries = Some(Id[Library](1) :: Id[Library](3) :: Nil),
+            libraryRecommendations = Some(Id[Library](33) :: Nil)
+          )
+
+          (inject[ActivityEmailRepo].save(unsavedActivityEmail), u1)
         }
 
         activityEmail.id must beSome
-        activityEmail.userId === Id[User](42)
+        activityEmail.userId === user1.id.get
         activityEmail.libraryRecommendations must beSome(Id[Library](33) :: Nil)
         activityEmail.otherFollowedLibraries must beSome(Id[Library](2) :: Id[Library](4) :: Nil)
         activityEmail.userFollowedLibraries must beSome(Id[Library](1) :: Id[Library](3) :: Nil)


### PR DESCRIPTION
the motivation of using SQS instead of the existing implementation is to prevent pending emails from getting dropped if the server goes down (or is restarted) while there is an in-memory queue of emails to process and send

@stkem should we do a fake run of this to internal emails (like we did with this email originally) before it's live? The only risk I can imagine is if there's a production-environment bug that would halt either queuing or dequeuing messages to SQS and prevent emails from being sent. I included a test that ensures the correct # of emails (messages) get queued and consumed in `ActivityFeedEmailQueueHelper` and changed the existing test to use those methods
