### PR TITLE
3.3.57: fixing silent mode to hide the keeper again

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.3.56
+version=3.3.57

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -259,20 +259,22 @@ k.tile = k.tile || function () {  // idempotent for Chrome
       window.removeEventListener('resize', onResize);
       onResize.bound = false;
     }
-    if (tile) {
-      if (trigger) {
-        if (k.keeper) {
-          k.keeper.hide(trigger);
-        }
-        tile.removeAttribute('data-kept');
-      } else {
-        if (tileObserver) tileObserver.disconnect();
-        tileObserver = tileParent = null;
-        tile.remove();
-      }
-    }
-    if (k.pane) {
+    if (k.pane && k.pane.showing()) {
       k.pane.hide();
+    } else if (trigger && k.keeper && k.keeper.showing()) {
+      k.keeper.hide(trigger);
+    }
+    if (trigger) {
+      tile.removeAttribute('data-kept');
+      if (trigger === 'silence') {
+        tile.style.display = 'none';
+      }
+    } else if (tile) {
+      if (tileObserver) {
+        tileObserver.disconnect();
+      }
+      tileObserver = tileParent = null;
+      tile.remove();
     }
   }
 


### PR DESCRIPTION
broken for at least 6 months, it seems, probably since we introduced the round keeper tile
