### PR TITLE
keepCommander fixes keep note when keep is tagged by client endpoints

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/HashtagCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/HashtagCommander.scala
@@ -12,6 +12,16 @@ class HashtagCommander {
     } toSet
   }
 
+  def addNewHashtagsToString(str: String, hashtags: Seq[Hashtag]): String = {
+    addNewHashtagNamesToString(str, hashtags.map(_.tag))
+  }
+
+  def addNewHashtagNamesToString(str: String, hashtagNames: Seq[String]): String = {
+    val existingHashtags = findAllHashtagNames(str).map(_.toLowerCase)
+    val tagsToAppend = hashtagNames.filterNot(t => existingHashtags.contains(t.toLowerCase))
+    appendHashtagNamesToString(str, tagsToAppend)
+  }
+
   // append hashtags to the end of a string, separated by spaces
   def appendHashtagsToString(str: String, hashtags: Seq[Hashtag]): String = {
     val hashtagNames = hashtags.map(_.tag)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/HashtagCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/HashtagCommander.scala
@@ -29,8 +29,8 @@ class HashtagCommander {
     HashtagRegex.hashTagRe.replaceAllIn(str, "").trim
   }
 
-  def removeHashtagsFromString(str: String, hashtagNames: Set[Hashtag]): String = {
-    removeHashtagNamesFromString(str, hashtagNames.map(_.tag))
+  def removeHashtagsFromString(str: String, hashtags: Set[Hashtag]): String = {
+    removeHashtagNamesFromString(str, hashtags.map(_.tag))
   }
 
   def removeHashtagNamesFromString(str: String, hashtagNames: Set[String]): String = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/HashtagCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/HashtagCommander.scala
@@ -2,6 +2,8 @@ package com.keepit.commanders
 
 import com.keepit.model.Hashtag
 
+import scala.util.matching.Regex.Match
+
 class HashtagCommander {
 
   def findAllHashtagNames(s: String): Set[String] = {
@@ -23,8 +25,17 @@ class HashtagCommander {
     (str + " " + tagsStr).trim
   }
 
-  def removeHashtagsFromString(str: String): String = {
+  def removeAllHashtagsFromString(str: String): String = {
     HashtagRegex.hashTagRe.replaceAllIn(str, "").trim
+  }
+
+  def removeHashtagsFromString(str: String, hashtagNames: Set[Hashtag]): String = {
+    removeHashtagNamesFromString(str, hashtagNames.map(_.tag))
+  }
+
+  def removeHashtagNamesFromString(str: String, hashtagNames: Set[String]): String = {
+    val mapper = (m: Match) => if (hashtagNames.contains(m.group(1))) Some("") else None
+    HashtagRegex.hashTagRe.replaceSomeIn(str, mapper).trim
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -474,7 +474,7 @@ class KeepsCommander @Inject() (
               } else {
                 hashtagCommander.appendHashtagsToString(noteStr, Seq(collection.name))
               }
-            }
+            } filterNot (_.isEmpty)
             keepRepo.save(targetKeep.copy(note = editedNote)) // notify keep index
             libraryAnalytics.taggedPage(updatedCollection, keepsById(ktc.keepId), context, taggingAt)
           }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -646,10 +646,8 @@ class KeepsCommander @Inject() (
     val noteWithHashtagsAppended = hashtagCommander.appendHashtagNamesToString(noteWithHashtagsRemoved, hashtagsToAppend)
     val finalNote = Some(noteWithHashtagsAppended.trim).filterNot(_.isEmpty)
 
-    if (finalNote != keep.note) {
-      val updatedKeep = keepRepo.save(keep.copy(note = finalNote))
-      libraryAnalytics.updatedKeep(keep, updatedKeep, context)
-    }
+    val updatedKeep = keepRepo.save(keep.copy(note = finalNote))
+    libraryAnalytics.updatedKeep(keep, updatedKeep, context)
   }
 
   private def postSingleKeepReporting(keep: Keep, isNewKeep: Boolean, library: Library, socialShare: SocialShare): Unit = SafeFuture {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -639,8 +639,7 @@ class KeepsCommander @Inject() (
     val hashtagsToRemove = hashtagsInNote.filterNot(hashtagsToPersistSet.contains(_))
     val hashtagsToAppend = selectedTagNames.filterNot(hashtagsInNote.contains(_))
     val noteWithHashtagsRemoved = hashtagCommander.removeHashtagNamesFromString(keepNote, hashtagsToRemove.toSet)
-    val markedNote = keepDecorator.escapeMarkupNotes(noteWithHashtagsRemoved)
-    val noteWithHashtagsAppended = hashtagCommander.appendHashtagNamesToString(markedNote, hashtagsToAppend)
+    val noteWithHashtagsAppended = hashtagCommander.appendHashtagNamesToString(noteWithHashtagsRemoved, hashtagsToAppend)
     val finalNote = Some(noteWithHashtagsAppended.trim).filterNot(_.isEmpty)
 
     keepRepo.save(keep.copy(note = finalNote))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -1289,7 +1289,7 @@ class LibraryCommander @Inject() (
           currentKeepOpt match {
             case None =>
               val newKeep = keepRepo.save(Keep(title = k.title, uriId = k.uriId, url = k.url, urlId = k.urlId, visibility = toLibrary.visibility,
-                userId = userId, source = withSource.getOrElse(k.source), libraryId = Some(toLibraryId), inDisjointLib = toLibrary.isDisjoint))
+                userId = userId, note = k.note, source = withSource.getOrElse(k.source), libraryId = Some(toLibraryId), inDisjointLib = toLibrary.isDisjoint))
               combineTags(k.id.get, newKeep.id.get)
               Right(newKeep)
             case Some(existingKeep) if existingKeep.state == KeepStates.INACTIVE =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
@@ -201,9 +201,9 @@ class MobileKeepsController @Inject() (
         val tagsOpt = (json \ "tags").asOpt[Seq[String]]
 
         val titleToPersist = (titleOpt orElse keep.title) map (_.trim) filterNot (_.isEmpty)
-        val noteToPersist = (noteOpt orElse keep.note).map { note =>
+        val noteToPersist = noteOpt map { note =>
           keepDecorator.escapeMarkupNotes(note).trim
-        }.filter(_.nonEmpty)
+        } orElse keep.note filter (_.nonEmpty)
 
         val tagsToPersist = tagsOpt.getOrElse(
           db.readOnlyMaster { implicit s =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
@@ -200,8 +200,11 @@ class MobileKeepsController @Inject() (
         val noteOpt = (json \ "note").asOpt[String]
         val tagsOpt = (json \ "tags").asOpt[Seq[String]]
 
-        val titleToPersist = titleOpt orElse keep.title map (_.trim) filterNot (_.isEmpty)
-        val noteToPersist = noteOpt orElse keep.note map (_.trim) filterNot (_.isEmpty)
+        val titleToPersist = (titleOpt orElse keep.title) map (_.trim) filterNot (_.isEmpty)
+        val noteToPersist = (noteOpt orElse keep.note).map { note =>
+          keepDecorator.escapeMarkupNotes(note).trim
+        }.filter(_.nonEmpty)
+
         val tagsToPersist = tagsOpt.getOrElse(
           db.readOnlyMaster { implicit s =>
             collectionRepo.getHashtagsByKeepId(keep.id.get).map(_.tag).toSeq

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
@@ -207,15 +207,12 @@ class MobileKeepsController @Inject() (
             collectionRepo.getHashtagsByKeepId(keep.id.get).map(_.tag).toSeq
           }
         )
-
-        val updatedKeep = if (titleToPersist != keep.title || noteToPersist != keep.note) {
-          db.readWrite { implicit s =>
-            keepRepo.save(keep.copy(title = titleToPersist, note = noteToPersist))
-          }
-        } else keep
+        val updatedKeep = keep.copy(title = titleToPersist, note = noteToPersist)
 
         implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
-        keepsCommander.persistHashtagsForKeep(request.userId, updatedKeep, tagsToPersist)
+        db.readWrite { implicit s =>
+          keepsCommander.persistHashtagsForKeep(request.userId, updatedKeep, tagsToPersist)(s, context)
+        }
         NoContent
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -168,7 +168,7 @@ class MobileLibraryController @Inject() (
 
                 // remove hashtags, then turn all '[\#' -> '[#'
                 val editedKeepNote = keep.note.map { note =>
-                  val noteWithoutHashtags = hashtagCommander.removeHashtagsFromString(note)
+                  val noteWithoutHashtags = hashtagCommander.removeAllHashtagsFromString(note)
                   keepDecorator.unescapeMarkupNotes(noteWithoutHashtags).trim
                 }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/HashtagCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/HashtagCommanderTest.scala
@@ -51,20 +51,41 @@ class HashtagCommanderTest extends Specification with ShoeboxTestInjector {
     "remove all hashtags from a string" in {
       withDb(modules: _*) { implicit injector =>
         val commander = inject[HashtagCommander]
-        commander.removeHashtagsFromString("") === ""
-        commander.removeHashtagsFromString("asdf") === "asdf"
-        commander.removeHashtagsFromString("#[asdf]") === "#[asdf]"
-        commander.removeHashtagsFromString("[\\#asdf]") === "[\\#asdf]"
-        commander.removeHashtagsFromString("[#asdf]") === ""
-        commander.removeHashtagsFromString("[#asdf]]") === "]"
-        commander.removeHashtagsFromString("[#asdf\\]]") === ""
-        commander.removeHashtagsFromString("[#asd[f\\]]") === ""
-        commander.removeHashtagsFromString("[##asdf]") === ""
-        commander.removeHashtagsFromString("[[#asdf]]") === "[]"
+        commander.removeAllHashtagsFromString("") === ""
+        commander.removeAllHashtagsFromString("asdf") === "asdf"
+        commander.removeAllHashtagsFromString("#[asdf]") === "#[asdf]"
+        commander.removeAllHashtagsFromString("[\\#asdf]") === "[\\#asdf]"
+        commander.removeAllHashtagsFromString("[#asdf]") === ""
+        commander.removeAllHashtagsFromString("[#asdf]]") === "]"
+        commander.removeAllHashtagsFromString("[#asdf\\]]") === ""
+        commander.removeAllHashtagsFromString("[#asd[f\\]]") === ""
+        commander.removeAllHashtagsFromString("[##asdf]") === ""
+        commander.removeAllHashtagsFromString("[[#asdf]]") === "[]"
 
-        commander.removeHashtagsFromString("[#asdf] [#qwer]") === ""
-        commander.removeHashtagsFromString("[#asdf] a [#qwer]") === "a"
-        commander.removeHashtagsFromString("a [#asdf] b [#qwer] c") === "a  b  c"
+        commander.removeAllHashtagsFromString("[#asdf] [#qwer]") === ""
+        commander.removeAllHashtagsFromString("[#asdf] a [#qwer]") === "a"
+        commander.removeAllHashtagsFromString("a [#asdf] b [#qwer] c") === "a  b  c"
+      }
+    }
+
+    "remove specific hashtags from a string" in {
+      withDb(modules: _*) { implicit injector =>
+        val commander = inject[HashtagCommander]
+        commander.removeHashtagNamesFromString("", Set("asdf")) === ""
+        commander.removeHashtagNamesFromString("asdf", Set("asdf")) === "asdf"
+        commander.removeHashtagNamesFromString("#[asdf]", Set("asdf")) === "#[asdf]"
+        commander.removeHashtagNamesFromString("[\\#asdf]", Set("asdf")) === "[\\#asdf]"
+        commander.removeHashtagNamesFromString("[#asdf]", Set("asdf")) === ""
+        commander.removeHashtagNamesFromString("[#asdf]]", Set("asdf")) === "]"
+        commander.removeHashtagNamesFromString("[#asdf\\]]", Set("asdf")) === "[#asdf\\]]" //'#asdf\]' does not match '#asdf'
+        commander.removeHashtagNamesFromString("[#asd[f\\]]", Set("asdf")) === "[#asd[f\\]]" //'#asd[f\]' does not match '#asdf'
+        commander.removeHashtagNamesFromString("[##asdf]", Set("asdf")) === "[##asdf]"
+        commander.removeHashtagNamesFromString("[[#asdf]]", Set("asdf")) === "[]"
+
+        commander.removeHashtagNamesFromString("[#asdf] [#qwer]", Set("asdf")) === "[#qwer]"
+        commander.removeHashtagNamesFromString("[#asdf] [#qwer]", Set("asdf", "qwer")) === ""
+        commander.removeHashtagNamesFromString("[#asdf] a [#qwer]", Set("asdf", "qwer")) === "a"
+        commander.removeHashtagNamesFromString("a [#asdf] b [#qwer] c", Set("asdf", "qwer")) === "a  b  c"
       }
     }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/HashtagCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/HashtagCommanderTest.scala
@@ -48,6 +48,17 @@ class HashtagCommanderTest extends Specification with ShoeboxTestInjector {
       }
     }
 
+    "add new hashtags to string" in {
+      withDb(modules: _*) { implicit injector =>
+        val commander = inject[HashtagCommander]
+        commander.addNewHashtagNamesToString("", Seq.empty) === ""
+        commander.addNewHashtagNamesToString("a", Seq.empty) === "a"
+        commander.addNewHashtagNamesToString("a", Seq("b")) === "a [#b]"
+        commander.addNewHashtagNamesToString("[#b] a", Seq("b")) === "[#b] a"
+        commander.addNewHashtagNamesToString("[#b] a", Seq("b", "c")) === "[#b] a [#c]"
+      }
+    }
+
     "remove all hashtags from a string" in {
       withDb(modules: _*) { implicit injector =>
         val commander = inject[HashtagCommander]

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -832,22 +832,22 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
 
     "edit note" in {
       withDb(controllerTestModules: _*) { implicit injector =>
-        val (user, keep, oldKeep, keepInactive) = db.readWrite { implicit session =>
+        val (user, keep1, keepWithTags, keepInactive) = db.readWrite { implicit session =>
           val user = userRepo.save(User(firstName = "Eishay", lastName = "Smith", username = Username("test"), normalizedUsername = "test"))
           val lib = library().withUser(user).saved
-          val keep = KeepFactory.keep().withUser(user).withLibrary(lib).withTitle("default").saved
-          val oldKeep = KeepFactory.keep().withUser(user).withLibrary(lib).withTitle("default1").saved
+          val keep1 = KeepFactory.keep().withUser(user).withLibrary(lib).withTitle("default").saved
+          val keep2 = KeepFactory.keep().withUser(user).withLibrary(lib).withTitle("default1").saved
           val keepInactive = KeepFactory.keep().withUser(user).withLibrary(lib).withState(KeepStates.INACTIVE).saved
 
           val tag1 = collectionRepo.save(Collection(userId = user.id.get, name = Hashtag("tag1")))
           val tag2 = collectionRepo.save(Collection(userId = user.id.get, name = Hashtag("tag2")))
-          keepToCollectionRepo.save(KeepToCollection(keepId = oldKeep.id.get, collectionId = tag1.id.get))
-          keepToCollectionRepo.save(KeepToCollection(keepId = oldKeep.id.get, collectionId = tag2.id.get))
+          keepToCollectionRepo.save(KeepToCollection(keepId = keep2.id.get, collectionId = tag1.id.get))
+          keepToCollectionRepo.save(KeepToCollection(keepId = keep2.id.get, collectionId = tag2.id.get))
 
           collectionRepo.count(user.id.get) === 2
           keepToCollectionRepo.count === 2
 
-          (user, keep, oldKeep, keepInactive)
+          (user, keep1, keep2, keepInactive)
         }
 
         def editKeepInfo(user: User, keep: Keep, body: JsObject): Future[Result] = {
@@ -860,87 +860,87 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
         val testInactiveKeep = editKeepInfo(user, keepInactive, Json.obj("title" -> "blahablhablhahbla"))
         status(testInactiveKeep) must equalTo(NOT_FOUND)
 
-        val testEditTitle = editKeepInfo(user, keep, Json.obj("title" -> ""))
+        val testEditTitle = editKeepInfo(user, keep1, Json.obj("title" -> ""))
         status(testEditTitle) must equalTo(NO_CONTENT)
         db.readOnlyMaster { implicit s =>
-          val currentKeep = keepRepo.get(keep.externalId)
+          val currentKeep = keepRepo.get(keep1.externalId)
           currentKeep.title === None
           currentKeep.note === None
         }
 
-        val testEditNote = editKeepInfo(user, keep, Json.obj("note" -> "first comment!"))
+        val testEditNote = editKeepInfo(user, keep1, Json.obj("note" -> "first comment!"))
         status(testEditNote) must equalTo(NO_CONTENT)
         db.readOnlyMaster { implicit s =>
-          val currentKeep = keepRepo.get(keep.externalId)
+          val currentKeep = keepRepo.get(keep1.externalId)
           currentKeep.title === None
           currentKeep.note === Some("first comment!")
         }
 
-        val testEditBoth = editKeepInfo(user, keep, Json.obj("title" -> "a real keep", "note" -> "a real note"))
+        val testEditBoth = editKeepInfo(user, keep1, Json.obj("title" -> "a real keep", "note" -> "a real note"))
         status(testEditBoth) must equalTo(NO_CONTENT)
         db.readOnlyMaster { implicit s =>
-          val currentKeep = keepRepo.get(keep.externalId)
+          val currentKeep = keepRepo.get(keep1.externalId)
           currentKeep.title === Some("a real keep")
           currentKeep.note === Some("a real note")
         }
 
-        val testEditNothing = editKeepInfo(user, keep, Json.obj())
+        val testEditNothing = editKeepInfo(user, keep1, Json.obj())
         status(testEditNothing) must equalTo(NO_CONTENT)
         db.readOnlyMaster { implicit s =>
-          val currentKeep = keepRepo.get(keep.externalId)
+          val currentKeep = keepRepo.get(keep1.externalId)
           currentKeep.title === Some("a real keep")
           currentKeep.note === Some("a real note")
           keepToCollectionRepo.count === 2
         }
 
-        val testEditTags1 = editKeepInfo(user, keep, Json.obj("tags" -> Seq("a", "b", "c")))
+        val testEditTags1 = editKeepInfo(user, keep1, Json.obj("tags" -> Seq("a", "b", "c")))
         status(testEditTags1) must equalTo(NO_CONTENT)
         db.readOnlyMaster { implicit s =>
-          val currentKeep = keepRepo.get(keep.externalId)
+          val currentKeep = keepRepo.get(keep1.externalId)
           currentKeep.title === Some("a real keep")
           currentKeep.note === Some("a real note [#a] [#b] [#c]")
           keepToCollectionRepo.count === 5
           collectionRepo.count(user.id.get) === 5
         }
 
-        val testEditTags2 = editKeepInfo(user, keep, Json.obj("note" -> "a real [#note]", "tags" -> Seq("a", "b", "d", "e")))
+        val testEditTags2 = editKeepInfo(user, keep1, Json.obj("note" -> "a real [#note]", "tags" -> Seq("a", "b", "d", "e")))
         status(testEditTags2) must equalTo(NO_CONTENT)
         db.readOnlyMaster { implicit s =>
-          val currentKeep = keepRepo.get(keep.externalId)
+          val currentKeep = keepRepo.get(keep1.externalId)
           currentKeep.title === Some("a real keep")
           currentKeep.note === Some("a real [\\#note] [#a] [#b] [#d] [#e]")
           keepToCollectionRepo.count === 7
           collectionRepo.count(user.id.get) === 7
         }
 
-        val testEditTags3 = editKeepInfo(user, keep, Json.obj("note" -> "a real [#note] thing"))
+        val testEditTags3 = editKeepInfo(user, keep1, Json.obj("note" -> "a real [#note] thing"))
         status(testEditTags3) must equalTo(NO_CONTENT)
         db.readOnlyMaster { implicit s =>
-          val currentKeep = keepRepo.get(keep.externalId)
+          val currentKeep = keepRepo.get(keep1.externalId)
           currentKeep.title === Some("a real keep")
           currentKeep.note === Some("a real [\\#note] thing [#a] [#b] [#d] [#e]")
         }
 
-        val testEditTags4 = editKeepInfo(user, keep, Json.obj("note" -> "a real [#note] thing", "tags" -> Json.toJson(Seq(): Seq[String])))
+        val testEditTags4 = editKeepInfo(user, keep1, Json.obj("note" -> "a real [#note] thing", "tags" -> Seq.empty[String]))
         status(testEditTags4) must equalTo(NO_CONTENT)
         db.readOnlyMaster { implicit s =>
-          val currentKeep = keepRepo.get(keep.externalId)
+          val currentKeep = keepRepo.get(keep1.externalId)
           currentKeep.title === Some("a real keep")
           currentKeep.note === Some("a real [\\#note] thing")
         }
 
         // test a keep that already has tags persisted
-        val testEditExistingTags1 = editKeepInfo(user, oldKeep, Json.obj("note" -> "this keep already has [#tags]"))
+        val testEditExistingTags1 = editKeepInfo(user, keepWithTags, Json.obj("note" -> "this keep already has [#tags]"))
         status(testEditExistingTags1) must equalTo(NO_CONTENT)
         db.readOnlyMaster { implicit s =>
-          val currentKeep = keepRepo.get(oldKeep.externalId)
+          val currentKeep = keepRepo.get(keepWithTags.externalId)
           currentKeep.title === Some("default1")
           currentKeep.note === Some("this keep already has [\\#tags] [#tag1] [#tag2]")
         }
-        val testEditExistingTags2 = editKeepInfo(user, oldKeep, Json.obj("note" -> "this keep already has [#tags]", "tags" -> JsArray(Seq(JsString("tag1")))))
+        val testEditExistingTags2 = editKeepInfo(user, keepWithTags, Json.obj("note" -> "this keep already has [#tags]", "tags" -> Seq("tag1")))
         status(testEditExistingTags2) must equalTo(NO_CONTENT)
         db.readOnlyMaster { implicit s =>
-          val currentKeep = keepRepo.get(oldKeep.externalId)
+          val currentKeep = keepRepo.get(keepWithTags.externalId)
           currentKeep.title === Some("default1")
           currentKeep.note === Some("this keep already has [\\#tags] [#tag1]")
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -909,6 +909,26 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
           keepToCollectionRepo.count === 5
           collectionRepo.count(user.id.get) === 5
         }
+
+        val testEditTags3 = editKeepInfo(user, keep, Json.obj("note" -> "a real [#note] thing"))
+        status(testEditTags3) must equalTo(NO_CONTENT)
+        db.readOnlyMaster { implicit s =>
+          val currentKeep = keepRepo.get(keep.externalId)
+          currentKeep.title === Some("a real keep")
+          currentKeep.note === Some("a real [\\#note] thing [#a] [#b] [#d] [#e]")
+          keepToCollectionRepo.count === 5
+          collectionRepo.count(user.id.get) === 5
+        }
+
+        val testEditTags4 = editKeepInfo(user, keep, Json.obj("note" -> "a real [#note] thing", "tags" -> Json.toJson(Seq(): Seq[String])))
+        status(testEditTags4) must equalTo(NO_CONTENT)
+        db.readOnlyMaster { implicit s =>
+          val currentKeep = keepRepo.get(keep.externalId)
+          currentKeep.title === Some("a real keep")
+          currentKeep.note === Some("a real [\\#note] thing")
+          keepToCollectionRepo.count === 5
+          collectionRepo.count(user.id.get) === 5
+        }
       }
     }
 


### PR DESCRIPTION
@2is10 @andrewconner 

A couple changes around `KeepCommander` to fix up a keep's notes when tags are involved.
Currently, tagging by clients is used by the following:

`LibraryController.tagKeep`  calls `KeepCommander.addToCollection()`
`LibraryController.untagKeep` -> `KeepCommander.removeFromCollection()`
`KeepsController.tagKeeps` -> `KeepCommander.addToCollection()`

`ExtLibraryController.tagKeep`-> `KeepCommander.addToCollection()`
`ExtLibraryController.untagKeep` -> `KeepCommander.removeFromCollection()`

`MobileLibraryController.keepToLibrary` -> `KeepCommander.keepWithSelectedTags()`
`MobileKeepsController.editKeepInfo` -> `KeepCommander.persistHashtagsForKeep()`

so the places to fix are in KeepCommander are:
- `addToCollection()`
- `removeFromCollection()`
- `keepWithSelectedTags()`
- `persistHashtagsForKeep()`
