### PR TITLE
update library membership endpoint (site & mobile)

### DIFF
--- a/kifi-backend/modules/common/test/com/keepit/model/LibraryMembershipFactory.scala
+++ b/kifi-backend/modules/common/test/com/keepit/model/LibraryMembershipFactory.scala
@@ -23,6 +23,8 @@ object LibraryMembershipFactory {
     def withLibraryFollower(lib: Library, userId: Id[User]) = new PartialLibraryMembership(membership.copy(userId = userId, libraryId = lib.id.get, access = LibraryAccess.READ_ONLY))
     def withLibraryFollower(lib: Id[Library], userId: Id[User]) = new PartialLibraryMembership(membership.copy(userId = userId, libraryId = lib, access = LibraryAccess.READ_ONLY))
     def withLibraryFollower(lib: Library, user: User) = new PartialLibraryMembership(membership.copy(userId = user.id.get, libraryId = lib.id.get, access = LibraryAccess.READ_ONLY))
+    def withLibraryCollaborator(libId: Id[Library], userId: Id[User], access: LibraryAccess) = new PartialLibraryMembership(membership.copy(userId = userId, libraryId = libId, access = access))
+    def withLibraryCollaborator(lib: Library, user: User, access: LibraryAccess) = new PartialLibraryMembership(membership.copy(userId = user.id.get, libraryId = lib.id.get, access = access))
     def withUser(id: Int) = new PartialLibraryMembership(membership.copy(userId = Id[User](id)))
     def withUser(id: Id[User]) = new PartialLibraryMembership(membership.copy(userId = id))
     def withUser(user: User) = new PartialLibraryMembership(membership.copy(userId = user.id.get))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -1682,4 +1682,35 @@ class LibraryCommander @Inject() (
     }
   }
 
+  ///////////////////
+  // Collaborators!
+  ///////////////////
+
+  def updateLibraryMembershipAccess(libraryId: Id[Library], targetUserId: Id[User], newAccess: Option[LibraryAccess]): Either[LibraryFail, LibraryMembership] = {
+    if (newAccess.isDefined && newAccess.get == LibraryAccess.OWNER) {
+      Left(LibraryFail(BAD_REQUEST, "cannot_change_access_to_owner"))
+    } else {
+      db.readOnlyMaster { implicit s =>
+        libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, targetUserId)
+      } match {
+        case None =>
+          Left(LibraryFail(NOT_FOUND, "membership_not_found"))
+        case Some(targetMembership) =>
+          if (targetMembership.access == LibraryAccess.OWNER) {
+            Left(LibraryFail(BAD_REQUEST, "cannot_change_owner_access"))
+          } else {
+            val updatedMembership = db.readWrite { implicit s =>
+              newAccess match {
+                case None =>
+                  libraryMembershipRepo.save(targetMembership.copy(state = LibraryMembershipStates.INACTIVE))
+                case Some(access) =>
+                  libraryMembershipRepo.save(targetMembership.copy(access = access))
+              }
+            }
+            Right(updatedMembership)
+          }
+      }
+    }
+  }
+
 }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -269,13 +269,15 @@ GET     /m/2/libraries/:id/keeps                @com.keepit.controllers.mobile.M
 POST    /m/1/libraries/:id/keeps                @com.keepit.controllers.mobile.MobileLibraryController.keepToLibrary(id: PublicId[Library])
 DELETE  /m/1/libraries/:id/keeps/:kId           @com.keepit.controllers.mobile.MobileLibraryController.unkeepFromLibrary(id: PublicId[Library], kId: ExternalId[Keep])
 POST    /m/1/libraries/:id/invite               @com.keepit.controllers.mobile.MobileLibraryController.inviteUsersToLibrary(id: PublicId[Library])
+
 GET     /m/1/libraries/:id/members              @com.keepit.controllers.mobile.MobileLibraryController.getLibraryMembers(id: PublicId[Library], offset: Int ?= 0, limit: Int ?= 20)
 GET     /m/1/libraries/:id/members/suggest      @com.keepit.controllers.mobile.MobileLibraryController.suggestMembers(id: PublicId[Library], q: Option[String] ?= None, n: Int ?= 5)
+POST    /m/1/libraries/:id/members/:uId/access/:access @com.keepit.controllers.mobile.MobileLibraryController.updateLibraryMembership(id: PublicId[Library], uId: ExternalId[User], access: String)
+
 GET     /m/1/libraries/:id/inviteInfo           @com.keepit.controllers.website.InviteController.getLibraryInviteInfo(id: PublicId[Library])
 POST    /m/1/libraries/recos/feedback      @com.keepit.controllers.website.LibraryRecommendationsController.updateLibraryRecommendationFeedback(id: PublicId[Library])
 
 POST    /m/1/content/flagUrl                @com.keepit.controllers.mobile.MobileUriController.flagContent()
-
 GET     /m/1/inviteInfo                     @com.keepit.controllers.website.InviteController.getGeneralInviteInfo()
 
 
@@ -398,19 +400,22 @@ POST    /site/libraries/:id/invite  @com.keepit.controllers.website.LibraryContr
 POST    /site/libraries/:id/join    @com.keepit.controllers.website.LibraryController.joinLibrary(id: PublicId[Library], authToken: Option[String] ?= None)
 POST    /site/libraries/:id/decline @com.keepit.controllers.website.LibraryController.declineLibrary(id: PublicId[Library])
 POST    /site/libraries/:id/leave   @com.keepit.controllers.website.LibraryController.leaveLibrary(id: PublicId[Library])
+
 GET     /site/libraries/:id/keeps   @com.keepit.controllers.website.LibraryController.getKeeps(id: PublicId[Library], offset: Int ?= 0, limit: Int ?= 10, showPublishedLibraries: Boolean ?= false)
 POST    /site/libraries/:id/keeps   @com.keepit.controllers.website.LibraryController.addKeeps(id: PublicId[Library])
-GET     /site/libraries/:id/members @com.keepit.controllers.website.LibraryController.getLibraryMembers(id: PublicId[Library], offset: Int ?= 0, limit: Int ?= 10)
-GET     /site/libraries/:id/members/suggest  @com.keepit.controllers.website.LibraryController.suggestMembers(id: PublicId[Library], q: Option[String] ?= None, n: Int ?= 5)
 POST    /site/libraries/:id/keeps/delete   @com.keepit.controllers.website.LibraryController.removeKeeps(id: PublicId[Library])
 DELETE  /site/libraries/:id/keeps/:k   @com.keepit.controllers.website.LibraryController.removeKeep(id: PublicId[Library], k: ExternalId[Keep])
 GET     /site/libraries/:id/keeps/:k/tags/suggest  @com.keepit.controllers.website.LibraryController.suggestTags(id: PublicId[Library], k: ExternalId[Keep], q: Option[String] ?= None, n: Int ?= 5)
-GET     /site/libraries/:id/related                @com.keepit.controllers.website.LibraryController.relatedLibraries(id: PublicId[Library])
-
 POST    /site/libraries/:id/keeps/:k/update       @com.keepit.controllers.website.LibraryController.updateKeep(id:PublicId[Library], k: ExternalId[Keep])
 POST    /site/libraries/:id/keeps/:k/tags/:tag    @com.keepit.controllers.website.LibraryController.tagKeep(id: PublicId[Library], k: ExternalId[Keep], tag: String)
 DELETE  /site/libraries/:id/keeps/:k/tags/:tag    @com.keepit.controllers.website.LibraryController.untagKeep(id: PublicId[Library], k: ExternalId[Keep], tag: String)
 POST    /site/libraries/:id/keeps/:k/note         @com.keepit.controllers.website.LibraryController.editKeepNote(id: PublicId[Library], k: ExternalId[Keep])
+
+GET     /site/libraries/:id/related                @com.keepit.controllers.website.LibraryController.relatedLibraries(id: PublicId[Library])
+
+POST    /site/libraries/:id/members/:uId/access/:access @com.keepit.controllers.website.LibraryController.updateLibraryMembership(id: PublicId[Library], uId: ExternalId[User], access: String)
+GET     /site/libraries/:id/members @com.keepit.controllers.website.LibraryController.getLibraryMembers(id: PublicId[Library], offset: Int ?= 0, limit: Int ?= 10)
+GET     /site/libraries/:id/members/suggest  @com.keepit.controllers.website.LibraryController.suggestMembers(id: PublicId[Library], q: Option[String] ?= None, n: Int ?= 5)
 
 POST    /site/libraries/:id/importTag   @com.keepit.controllers.website.LibraryController.copyKeepsFromCollectionToLibrary(id: PublicId[Library], tag: String)
 POST    /site/libraries/:id/moveTag     @com.keepit.controllers.website.LibraryController.moveKeepsFromCollectionToLibrary(id: PublicId[Library], tag: String)

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -413,9 +413,9 @@ POST    /site/libraries/:id/keeps/:k/note         @com.keepit.controllers.websit
 
 GET     /site/libraries/:id/related                @com.keepit.controllers.website.LibraryController.relatedLibraries(id: PublicId[Library])
 
-POST    /site/libraries/:id/members/:uId/access/:access @com.keepit.controllers.website.LibraryController.updateLibraryMembership(id: PublicId[Library], uId: ExternalId[User], access: String)
 GET     /site/libraries/:id/members @com.keepit.controllers.website.LibraryController.getLibraryMembers(id: PublicId[Library], offset: Int ?= 0, limit: Int ?= 10)
 GET     /site/libraries/:id/members/suggest  @com.keepit.controllers.website.LibraryController.suggestMembers(id: PublicId[Library], q: Option[String] ?= None, n: Int ?= 5)
+POST    /site/libraries/:id/members/:uId/access/:access @com.keepit.controllers.website.LibraryController.updateLibraryMembership(id: PublicId[Library], uId: ExternalId[User], access: String)
 
 POST    /site/libraries/:id/importTag   @com.keepit.controllers.website.LibraryController.copyKeepsFromCollectionToLibrary(id: PublicId[Library], tag: String)
 POST    /site/libraries/:id/moveTag     @com.keepit.controllers.website.LibraryController.moveKeepsFromCollectionToLibrary(id: PublicId[Library], tag: String)

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
@@ -11,8 +11,6 @@ import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.db.ExternalId
 import com.keepit.common.db.slick.DBSession.RWSession
 
-import com.keepit.model.LibraryFactory._
-import com.keepit.model.LibraryFactoryHelper._
 import com.keepit.common.healthcheck.FakeAirbrakeModule
 import com.keepit.common.mail.EmailAddress
 import com.keepit.common.social.FakeSocialGraphModule
@@ -21,6 +19,12 @@ import com.keepit.common.time._
 import com.keepit.cortex.FakeCortexServiceClientModule
 import com.keepit.curator.FakeCuratorServiceClientModule
 import com.keepit.heimdal.{ FakeHeimdalServiceClientModule, HeimdalContext }
+import com.keepit.model.UserFactory._
+import com.keepit.model.UserFactoryHelper._
+import com.keepit.model.LibraryFactory._
+import com.keepit.model.LibraryFactoryHelper._
+import com.keepit.model.LibraryMembershipFactory._
+import com.keepit.model.LibraryMembershipFactoryHelper._
 import com.keepit.model._
 import com.keepit.scraper.{ FakeScrapeSchedulerModule, FakeScraperServiceClientModule }
 import com.keepit.search.FakeSearchServiceClientModule
@@ -479,6 +483,35 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
       }
     }
 
+    "update library membership" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val (user1, user2, user3, lib1) = db.readWrite { implicit s =>
+          val user1 = user().withUsername("nickfury").saved
+          val user2 = user().withUsername("quicksilver").saved
+          val user3 = user().withUsername("scarletwitch").saved
+          val lib1 = library().withUser(user1).saved // user1 owns lib1
+          membership().withLibraryFollower(lib1, user2).saved // user2 follows lib1 (has read_only access)
+
+          libraryMembershipRepo.getWithLibraryIdAndUserId(lib1.id.get, user1.id.get).get.access === LibraryAccess.OWNER
+          libraryMembershipRepo.getWithLibraryIdAndUserId(lib1.id.get, user2.id.get).get.access === LibraryAccess.READ_ONLY
+          (user1, user2, user3, lib1)
+        }
+        val pubLibId1 = Library.publicId(lib1.id.get)(inject[PublicIdConfiguration])
+
+        // test invalid library write access
+        status(updateLibraryMembership(user2, user2, pubLibId1, "owner")) must equalTo(FORBIDDEN)
+
+        // test change membership access
+        status(updateLibraryMembership(user1, user2, pubLibId1, "read_write")) must equalTo(NO_CONTENT)
+
+        // test deactivate membership
+        status(updateLibraryMembership(user1, user2, pubLibId1, "none")) must equalTo(NO_CONTENT)
+
+        // test membership not found
+        status(updateLibraryMembership(user1, user2, pubLibId1, "read_only")) must equalTo(NOT_FOUND)
+      }
+    }
+
   }
 
   private def createLibrary(user: User, body: JsObject)(implicit injector: Injector): Future[Result] = {
@@ -534,6 +567,11 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
   private def getWriteableLibraries(user: User, body: JsObject)(implicit injector: Injector): Future[Result] = {
     inject[FakeUserActionsHelper].setUser(user)
     controller.getWriteableLibrariesWithUrlV1()(request(routes.MobileLibraryController.getWriteableLibrariesWithUrlV1()).withBody(body))
+  }
+
+  private def updateLibraryMembership(user: User, targetUser: User, libId: PublicId[Library], access: String)(implicit injector: Injector): Future[Result] = {
+    inject[FakeUserActionsHelper].setUser(user)
+    controller.updateLibraryMembership(libId, targetUser.externalId, access)(request(routes.MobileLibraryController.updateLibraryMembership(libId, targetUser.externalId, access)))
   }
 
   // User 'Spongebob' has one library called "Krabby Patty" (secret)

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -1440,6 +1440,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
         def updateLibraryMembership(user: User, targetUser: User, lib: Library, access: String) = {
           val libraryController = inject[LibraryController]
           val pubLibId = Library.publicId(lib.id.get)(inject[PublicIdConfiguration])
+          inject[FakeUserActionsHelper].setUser(user)
           val testPath = com.keepit.controllers.website.routes.LibraryController.updateLibraryMembership(pubLibId, targetUser.externalId, access).url
           libraryController.updateLibraryMembership(pubLibId, targetUser.externalId, access)(FakeRequest("POST", testPath))
         }


### PR DESCRIPTION
@andrewconner 

front-enders: @2is10 @mrbrown14 @thassss @jaredpetker @DerekBurch 
You can edit library memberships now using this:

```
POST    /m/1/libraries/:id/members/:uId/access/:access
POST    /site/libraries/:id/members/:uId/access/:access
:id is libraryId
:uId is userId
:access is a string for what access you would like to persist
```

For `access`, you can have the following: `read_write`, `read_insert`, `read_only`, and `none`
If access is none, the membership is deactivated.
You cannot change owners nor can you go from owner to a follower/collaborator.
