### PR TITLE
higher read timeout for library image uploads

### DIFF
--- a/tools/etc/nginx/conf.d/shoebox.conf
+++ b/tools/etc/nginx/conf.d/shoebox.conf
@@ -126,7 +126,7 @@ server {
   }
 
   location / {
-    if ($http_origin ~* (https?://[^/]*\.(ezkeep|kifi)\.com(:[0-9]+)?)) {
+    if ($http_origin ~* ^https?://[^/]*\.(ezkeep|kifi)\.com(:[0-9]+)?$) {
         set $cors "true";
     }
     if ($request_method = 'OPTIONS') {
@@ -144,14 +144,38 @@ server {
         add_header 'Access-Control-Max-Age' 1728000;
         add_header 'Access-Control-Allow-Methods' 'GET,OPTIONS,POST,PUT,DELETE';
         add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept,Origin,User-Agent,DNT,Cache-Control,X-Mx-ReqToken,Keep-Alive,X-Requested-With,If-Modified-Since';
-        add_header 'Content-Length' 0;
-        add_header 'Content-Type' 'text/plain charset=UTF-8';
         return 204;
     }
 
     proxy_pass http://shoebox;
     proxy_set_header Host $host;
     proxy_read_timeout 20s;
+    proxy_connect_timeout 5s;
+
+    allow 10.0.0.0/8;
+    allow 127.0.0.1;
+    deny all;
+  }
+
+  location /site/libraries/l\w+/image/upload {
+    if ($http_origin ~* ^https?://[^/]*\.(ezkeep|kifi)\.com(:[0-9]+)?$) {
+        set $cors "true";
+    }
+    if ($request_method = 'OPTIONS') {
+        set $cors "${cors}options";
+    }
+    if ($cors = "trueoptions") {
+        add_header 'Access-Control-Allow-Origin' "$http_origin";
+        add_header 'Access-Control-Allow-Credentials' 'true';
+        add_header 'Access-Control-Max-Age' 1728000;
+        add_header 'Access-Control-Allow-Methods' 'OPTIONS,POST';
+        add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept,Origin,User-Agent,DNT,Cache-Control,X-Mx-ReqToken,Keep-Alive,X-Requested-With,If-Modified-Since';
+        return 204;
+    }
+
+    proxy_pass http://shoebox;
+    proxy_set_header Host $host;
+    proxy_read_timeout 3m;
     proxy_connect_timeout 5s;
 
     allow 10.0.0.0/8;

--- a/tools/etc/nginx/conf.d/shoebox.conf
+++ b/tools/etc/nginx/conf.d/shoebox.conf
@@ -126,26 +126,18 @@ server {
   }
 
   location / {
-
-    if ($http_origin ~* (https?://[^/]*\.kifi\.com(:[0-9]+)?)) {
+    if ($http_origin ~* (https?://[^/]*\.(ezkeep|kifi)\.com(:[0-9]+)?)) {
         set $cors "true";
     }
-
-    if ($http_origin ~* (https?://[^/]*\.ezkeep\.com(:[0-9]+)?)) {
-        set $cors "true";
-    }
-
     if ($request_method = 'OPTIONS') {
         set $cors "${cors}options";
     }
-
     if ($request_method = 'GET') {
         set $cors "${cors}get";
     }
     if ($request_method = 'POST') {
         set $cors "${cors}post";
     }
-
     if ($cors = "trueoptions") {
         add_header 'Access-Control-Allow-Origin' "$http_origin";
         add_header 'Access-Control-Allow-Credentials' 'true';


### PR DESCRIPTION
@andrewconner I’m not sure this solves [the problem](https://twitter.com/UnsungHero97/status/595343005105541120) the guy on Twitter had, but it’s my best first stab at fixing it.

He said he was uploading a 2.4MB file. I suspect he was on a slower connection than ours. Nginx [describes](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout) `proxy_read_timeout` this way:

> Defines a timeout for reading a response from the proxied server. The timeout is set only between two successive read operations, not for the transmission of the whole response. If the proxied server does not transmit anything within this time, the connection is closed.

I’m not sure how the mechanics of uploads work between nginx and Play. Do you think nginx waits until the entire file is uploaded (written to temp file?) before passing the request on to Play? If so, that should rule out connection speed as a potential culprit, and would suggest image processing time as the culprit. If nginx streams bytes on to Play as they arrive, and Play writes to a temp file, then we may need to determine whether Play initiates the response 1) before the upload is complete or 2) as soon as the upload is complete and before processing or 3) after processing is done. Or maybe the `proxy_read_timeout` also applies to the first byte of the response, in which case the total upload time + image processing time counts.

Regardless of the specifics, I raised the value for this endpoint from 20 sec to 3 min. I guess we could check the nginx access logs for uploads—specifically long ones—to see if this makes any difference.
