### PR TITLE
added AdminUserControllerTest.scala

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -76,8 +76,6 @@ object UserViewTypes {
 }
 import UserViewTypes._
 
-case class SuperAdminAccessDenied() extends Exception
-
 class AdminUserController @Inject() (
     val userActionsHelper: UserActionsHelper,
     db: Database,
@@ -509,18 +507,16 @@ class AdminUserController @Inject() (
   def isAdminExperiment(expType: ExperimentType) = expType == ExperimentType.ADMIN
 
   def addExperimentAction(userId: Id[User], experiment: String) = AdminUserAction { request =>
-    try {
-      addExperiment(request.userId, userId, experiment)
-      Ok(Json.obj(experiment -> true))
-    } catch {
-      case SuperAdminAccessDenied() => Forbidden
+    addExperiment(requesterUserId = request.userId, userId, experiment) match {
+      case Right(expType) => Ok(Json.obj(experiment -> true))
+      case Left(s) => Forbidden
     }
   }
 
-  def addExperiment(requesterUserId: Id[User], userId: Id[User], experiment: String) {
+  def addExperiment(requesterUserId: Id[User], userId: Id[User], experiment: String): Either[String, ExperimentType] = {
     val expType = ExperimentType.get(experiment)
     if (isAdminExperiment(expType) && !isSuperAdmin(requesterUserId)) {
-      throw SuperAdminAccessDenied()
+      Left("Failure")
     } else {
       db.readWrite { implicit session =>
         (userExperimentRepo.get(userId, expType, excludeState = None) match {
@@ -534,6 +530,33 @@ class AdminUserController @Inject() (
         }
         userRepo.save(userRepo.getNoCache(userId)) // update user index sequence number
       }
+      Right(expType)
+    }
+  }
+
+  def removeExperimentAction(userId: Id[User], experiment: String) = AdminUserAction { request =>
+    removeExperiment(requesterUserId = request.userId, userId, experiment) match {
+      case Right(expType) => Ok(Json.obj(experiment -> false))
+      case Left(s) => Forbidden
+    }
+  }
+
+  def removeExperiment(requesterUserId: Id[User], userId: Id[User], experiment: String): Either[String, ExperimentType] = {
+    val expType = ExperimentType(experiment)
+    if (isAdminExperiment(expType) && !isSuperAdmin(requesterUserId)) {
+      Left("Failure")
+    } else {
+      db.readWrite { implicit session =>
+        val ue: Option[UserExperiment] = userExperimentRepo.get(userId, ExperimentType(experiment))
+        ue foreach { ue =>
+          userExperimentRepo.save(ue.withState(UserExperimentStates.INACTIVE))
+          val experiments = userExperimentRepo.getUserExperiments(userId)
+          eliza.sendToUser(userId, Json.arr("experiments", experiments.map(_.value)))
+          heimdal.setUserProperties(userId, "experiments" -> ContextList(experiments.map(exp => ContextStringData(exp.value)).toSeq))
+          userRepo.save(userRepo.getNoCache(userId)) // update user index sequence number
+        }
+      }
+      Right(expType)
     }
   }
 
@@ -601,33 +624,6 @@ class AdminUserController @Inject() (
 
     db.readWrite(implicit s => userRepo.save(userRepo.get(userId).withState(userState)))
     Ok
-  }
-
-  def removeExperimentAction(userId: Id[User], experiment: String) = AdminUserAction { request =>
-    try {
-      removeExperiment(request.userId, userId, experiment)
-      Ok(Json.obj(experiment -> false))
-    } catch {
-      case SuperAdminAccessDenied() => Forbidden
-    }
-  }
-
-  def removeExperiment(requesterUserId: Id[User], userId: Id[User], experiment: String) {
-    val expType = ExperimentType(experiment)
-    if (isAdminExperiment(expType) && !isSuperAdmin(requesterUserId)) {
-      throw SuperAdminAccessDenied()
-    } else {
-      db.readWrite { implicit session =>
-        val ue: Option[UserExperiment] = userExperimentRepo.get(userId, ExperimentType(experiment))
-        ue foreach { ue =>
-          userExperimentRepo.save(ue.withState(UserExperimentStates.INACTIVE))
-          val experiments = userExperimentRepo.getUserExperiments(userId)
-          eliza.sendToUser(userId, Json.arr("experiments", experiments.map(_.value)))
-          heimdal.setUserProperties(userId, "experiments" -> ContextList(experiments.map(exp => ContextStringData(exp.value)).toSeq))
-          userRepo.save(userRepo.getNoCache(userId)) // update user index sequence number
-        }
-      }
-    }
   }
 
   def refreshAllSocialInfo(userId: Id[User]) = AdminUserPage { implicit request =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminUserControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminUserControllerTest.scala
@@ -1,0 +1,93 @@
+package com.keepit.controllers.admin
+
+import com.keepit.abook.FakeABookServiceClientModule
+import com.keepit.common.actor.FakeActorSystemModule
+import com.keepit.common.concurrent.FakeExecutionContextModule
+import com.keepit.common.controller.FakeUserActionsModule
+import com.keepit.common.crypto.FakeCryptoModule
+import com.keepit.common.db.Id
+import com.keepit.common.healthcheck.FakeAirbrakeModule
+import com.keepit.common.mail.FakeMailModule
+import com.keepit.common.social.{ FakeSocialGraphModule, FakeShoeboxAppSecureSocialModule }
+import com.keepit.common.store.FakeShoeboxStoreModule
+import com.keepit.cortex.FakeCortexServiceClientModule
+import com.keepit.curator.FakeCuratorServiceClientModule
+import com.keepit.heimdal.FakeHeimdalServiceClientModule
+import com.keepit.scraper.{ FakeScraperServiceClientModule, FakeScrapeSchedulerModule }
+import com.keepit.search.FakeSearchServiceClientModule
+import com.keepit.shoebox.FakeShoeboxServiceModule
+import org.specs2.mutable.Specification
+import com.keepit.test._
+import com.keepit.model._
+import com.google.inject.Injector
+import com.keepit.common.net.FakeHttpClientModule
+import play.libs.F.Tuple
+
+class AdminUserControllerTest extends Specification with ShoeboxTestInjector {
+
+  def modules = Seq(
+    FakeShoeboxServiceModule(),
+    FakeSocialGraphModule(),
+    FakeScrapeSchedulerModule(),
+    FakeABookServiceClientModule()
+  )
+
+  def setup()(implicit injector: Injector) = {
+
+    val NON_ADMIN_ID = Id[User](87754) // cam's dad's id
+    val ADMIN_ID = Id[User](35713) // cam's id
+    val SUPERADMIN_ID = Id[User](1) // eishay's id
+
+    val userRepo = inject[UserRepo]
+    val userExperimentRepo = inject[UserExperimentRepo]
+    db.readWrite { implicit session =>
+
+      val userSuperAdminOpt: User = userRepo.save(User(
+        firstName = "Clark",
+        lastName = "Kent", username = Username("clark"), normalizedUsername = "clark"
+      ))
+      val userNonAdminOpt = userRepo.save(User(
+        firstName = "Homer",
+        lastName = "Simpson", username = Username("homer"), normalizedUsername = "homer"
+      ))
+      val userAdminOpt = userRepo.save(User(
+        firstName = "Peter",
+        lastName = "Griffin", username = Username("peter"), normalizedUsername = "peter"
+      ))
+
+      userExperimentRepo.save(UserExperiment(userId = userSuperAdminOpt.id.get, experimentType = ExperimentType.ADMIN))
+      userExperimentRepo.save(UserExperiment(userId = userAdminOpt.id.get, experimentType = ExperimentType.ADMIN))
+      userExperimentRepo.save(UserExperiment(userId = userNonAdminOpt.id.get, experimentType = ExperimentType.BYPASS_ABUSE_CHECKS))
+      (userNonAdminOpt, userAdminOpt, userSuperAdminOpt)
+    }
+  }
+
+  "AdminUserController" should {
+    "deny non-superAdmins from adding or removing admins" in {
+
+      withDb(modules: _*) { implicit injector =>
+        val (userNonAdminOpt, userAdminOpt, userSuperAdminOpt) = setup()
+        val adminUserController = inject[AdminUserController]
+        val userExperimentRepo = inject[UserExperimentRepo]
+        val userRepo = inject[UserRepo]
+
+        db.readWrite { implicit session =>
+          
+
+          adminUserController.addExperiment(requesterUserId = userNonAdminOpt.id.get, userId = userNonAdminOpt.id.get, "admin") must throwA[SuperAdminAccessDenied]
+          adminUserController.removeExperiment(requesterUserId = userNonAdminOpt.id.get, userId = userAdminOpt.id.get, "admin") must throwA[SuperAdminAccessDenied]
+
+          adminUserController.addExperiment(requesterUserId = userAdminOpt.id.get, userId = userNonAdminOpt.id.get, "admin") must throwA[SuperAdminAccessDenied]
+          adminUserController.removeExperiment(requesterUserId = userAdminOpt.id.get, userId = userNonAdminOpt.id.get, "admin") must throwA[SuperAdminAccessDenied]
+
+          adminUserController.addExperiment(requesterUserId = userSuperAdminOpt.id.get, userId = userNonAdminOpt.id.get, "admin")
+          userExperimentRepo.getUserExperiments(userNonAdminOpt.id.get).contains(ExperimentType.ADMIN) must equalTo(true)
+
+          adminUserController.removeExperiment(requesterUserId = userSuperAdminOpt.id.get, userId = userAdminOpt.id.get, "admin")
+          userExperimentRepo.getUserExperiments(userAdminOpt.id.get).contains(ExperimentType.ADMIN) must equalTo(false)
+        }
+
+      }
+    }
+  }
+}


### PR DESCRIPTION
test cases assert that only superAdmins can add/remove admins, non-superAdmins cannot add/remove admins

edit:
removed Exception throwing in favor of an Either[String, ExperimentType] return for addExperiment/removeExperiment
