### PR TITLE
simple push notification hookup for library subscriptions

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -1039,6 +1039,9 @@ class LibraryCommander @Inject() (
             )
           ))
         ).foreach { _ =>
+            if (toBeNotified.size > 100) {
+              airbrake.notify("Warning: Library with lots of subscribers. Time to make the code better!")
+            }
             FutureHelpers.sequentialExec(toBeNotified) { userId =>
               elizaClient.sendLibraryPushNotification(
                 userId,


### PR DESCRIPTION
Note that this is a little naive and when we have libraries with
greater than, say, 5k subscribers, we’ll need to queue these
notifications somewhere so they don’t get lost during deploys and such.

@andrewconner @eishay 
