### PR TITLE
3.3.60: quasi-fixing arrow, backspace, and delete keys in PDFs in Chrome

### DIFF
--- a/packrat/adapters/chrome/scripts/repair_inputs.js
+++ b/packrat/adapters/chrome/scripts/repair_inputs.js
@@ -1,0 +1,73 @@
+$.fn.repairInputs = function () {  // crbug.com/484291
+  'use strict';
+  if ($(document.body.firstChild).is('embed[type=application/pdf]')) {
+    this.on('keydown', 'input,textarea', function (e) {
+      var s, i, j, d;
+      switch (e.keyCode) {
+        case 8: // BKSP
+          s = this.value, i = this.selectionStart, j = this.selectionEnd;
+          if (i === j) {
+            if (i > 0) {
+              this.value = s.slice(0, i - 1) + s.slice(i);
+              this.setSelectionRange(i - 1, i - 1);
+              $(this).trigger('input');
+              e.preventDefault();
+            }
+          } else {
+            this.value = s.slice(0, i) + s.slice(j);
+            this.setSelectionRange(i, i);
+            $(this).trigger('input');
+            e.preventDefault();
+          }
+          break;
+        case 46: // DEL
+          s = this.value, i = this.selectionStart, j = this.selectionEnd;
+          if (i === j) {
+            if (i < s.length) {
+              this.value = s.slice(0, i) + s.slice(i + 1);
+              this.setSelectionRange(i, i);
+              $(this).trigger('input');
+              e.preventDefault();
+            }
+          } else {
+            this.value = s.slice(0, i) + s.slice(j);
+            this.setSelectionRange(i, i);
+            $(this).trigger('input');
+            e.preventDefault();
+          }
+          break;
+        case 37: // LEFT
+          i = this.selectionStart, j = this.selectionEnd, d = this.selectionDirection;
+          if (i === j || d === 'backward') {
+            if (i > 0) {
+              this.setSelectionRange(i - 1, e.shiftKey ? j : i - 1, i === j && e.shiftKey ? 'backward' : d);
+              e.preventDefault();
+            } else if (i < j && !e.shiftKey) {
+              this.setSelectionRange(0, 0);
+              e.preventDefault();
+            }
+          } else {
+            this.setSelectionRange(e.shiftKey ? i : j - 1, j - 1, d);
+            e.preventDefault();
+          }
+          break;
+        case 39: // RIGHT
+          s = this.value, i = this.selectionStart, j = this.selectionEnd, d = this.selectionDirection;
+          if (i === j || d !== 'backward') {
+            if (j < s.length) {
+              this.setSelectionRange(e.shiftKey ? i : j + 1, j + 1, i === j && e.shiftKey ? 'forward' : d);
+              e.preventDefault();
+            } else if (i < j && !e.shiftKey) {
+              this.setSelectionRange(j, j);
+              e.preventDefault();
+            }
+          } else {
+            this.setSelectionRange(i + 1, e.shiftKey ? j : i + 1, d);
+            e.preventDefault();
+          }
+          break;
+      }
+    });
+  }
+  return this;
+};

--- a/packrat/adapters/firefox/data/scripts/repair_inputs.js
+++ b/packrat/adapters/firefox/data/scripts/repair_inputs.js
@@ -1,0 +1,4 @@
+$.fn.repairInputs = function () {
+  'use strict';
+  return this;
+};

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.3.59
+version=3.3.60

--- a/packrat/scripts/friend_search.js
+++ b/packrat/scripts/friend_search.js
@@ -1,6 +1,7 @@
 // @require scripts/lib/jquery-tokeninput.js
 // @require scripts/lib/mustache.js
 // @require scripts/render.js
+// @require scripts/repair_inputs.js
 
 var initFriendSearch = (function () {
 
@@ -16,6 +17,7 @@ var initFriendSearch = (function () {
       onSelect: onSelect.bind(null, source),
       onRemove: onRemove
     }, options));
+    $in.prev().find('.kifi-ti-token-for-input').repairInputs();
   };
 
   function search(participantIds, includeSelf, ids, query, withResults) {

--- a/packrat/scripts/keep_box.js
+++ b/packrat/scripts/keep_box.js
@@ -381,6 +381,10 @@ k.keepBox = k.keepBox || (function () {
       saveKeepTitleIfChanged($view);
       saveKeepImageIfChanged($view);
     });
+
+    api.require('scripts/repair_inputs.js', function () {
+      $view.repairInputs();
+    });
   }
 
   function addCreateLibraryBindings($view) {


### PR DESCRIPTION
This specifically helps the keep title field, keep tags, compose-to, and add-to-thread inputs. It doesn’t help the compose editor (a `[contenteditable]` or `textarea`).

cc @yingjieMiao 
