### PR TITLE
members endpoint includes owner

### DIFF
--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -279,7 +279,8 @@ POST    /m/1/libraries/:id/invite               @com.keepit.controllers.mobile.M
 POST    /m/1/libraries/:id/subscription @com.keepit.controllers.mobile.MobileLibraryController.setSubscribedToUpdates(id: PublicId[Library], subscribed: Boolean)
 
 
-GET     /m/1/libraries/:id/members              @com.keepit.controllers.mobile.MobileLibraryController.getLibraryMembers(id: PublicId[Library], offset: Int ?= 0, limit: Int ?= 20)
+GET     /m/1/libraries/:id/members              @com.keepit.controllers.mobile.MobileLibraryController.getLibraryMembersV1(id: PublicId[Library], offset: Int ?= 0, limit: Int ?= 20)
+GET     /m/2/libraries/:id/members              @com.keepit.controllers.mobile.MobileLibraryController.getLibraryMembersV2(id: PublicId[Library], offset: Int ?= 0, limit: Int ?= 20)
 GET     /m/1/libraries/:id/members/suggest      @com.keepit.controllers.mobile.MobileLibraryController.suggestMembers(id: PublicId[Library], q: Option[String] ?= None, n: Int ?= 5)
 POST    /m/1/libraries/:id/members/:uId/access  @com.keepit.controllers.mobile.MobileLibraryController.updateLibraryMembership(id: PublicId[Library], uId: ExternalId[User])
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
@@ -635,7 +635,7 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
 
   private def getMembers(user: User, libId: PublicId[Library], offset: Int, limit: Int)(implicit injector: Injector): Future[Result] = {
     inject[FakeUserActionsHelper].setUser(user)
-    controller.getLibraryMembers(libId, offset, limit)(request(routes.MobileLibraryController.getLibraryMembers(libId, offset, limit)))
+    controller.getLibraryMembersV1(libId, offset, limit)(request(routes.MobileLibraryController.getLibraryMembersV1(libId, offset, limit)))
   }
 
   private def keepToLibraryV1(user: User, libId: PublicId[Library], body: JsObject)(implicit injector: Injector): Future[Result] = {


### PR DESCRIPTION
@andrewconner @DerekBurch @jaredpetker @thassss @mrbrown14 

Go ahead and start using 
`GET /m/2/libraries/:id/members` instead of `GET /m/1/libraries/:id/members` so owners (then collaborators, then followers) to show up!
