### PR TITLE
Perhaps fixing this from breaking in the future?

### DIFF
--- a/kifi-backend/modules/heimdal/test/com/keepit/commanders/HelpRankCommanderTest.scala
+++ b/kifi-backend/modules/heimdal/test/com/keepit/commanders/HelpRankCommanderTest.scala
@@ -404,8 +404,8 @@ class HelpRankCommanderTest extends Specification with HeimdalTestInjector with 
         }
 
         db.readWrite { implicit rw =>
-          (keeps1 ++ keeps2 ++ keeps3 ++ keeps4).foreach { keep =>
-            userBookmarkClicksRepo.save(UserBookmarkClicks(userId = keep.userId, uriId = keep.uriId, selfClicks = 0, otherClicks = 0))
+          (keeps1 ++ keeps2 ++ keeps3 ++ keeps4).groupBy(k => (k.userId, k.uriId)).keySet.foreach { case (userId, uriId) =>
+            userBookmarkClicksRepo.save(UserBookmarkClicks(userId = userId, uriId = uriId, selfClicks = 0, otherClicks = 0))
           }
         }
         val attrCmdr = inject[AttributionCommander]


### PR DESCRIPTION
@stkem @eishay  It fails randomly because of a constraint violation. Could also be caused by two tests running at once, so this may not do anything.
