### PR TITLE
Create and transfer library for admins

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
@@ -55,46 +55,51 @@ class AdminLibraryController @Inject() (
     suggestedSearchCommander: LibrarySuggestedSearchCommander,
     implicit val publicIdConfig: PublicIdConfiguration) extends AdminUserActions {
 
-  def updateLibraryOwner(libraryId: Id[Library], fromUserId: Id[User], toUserId: Id[User]) = AdminUserPage { implicit request =>
-    db.readWrite { implicit session =>
-      val lib = libraryRepo.get(libraryId)
-      if (lib.ownerId != fromUserId) throw new Exception(s"orig user $fromUserId is not matching current library owner $lib")
-      libraryAliasRepo.alias(lib.ownerId, lib.slug, lib.id.get)
-      libraryAliasRepo.reclaim(toUserId, lib.slug) // reclaim existing alias to a former library of toUserId with the same slug
-      val newOwnerLib = lib.copy(ownerId = toUserId)
-      libraryRepo.save(newOwnerLib)
-      val currentOwnership = libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, fromUserId).getOrElse(throw new Exception(s"no ownership to lib $lib for user $fromUserId"))
-      libraryMembershipRepo.save(currentOwnership.copy(access = LibraryAccess.READ_ONLY))
-      libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, toUserId) match {
-        case None =>
-          libraryMembershipRepo.save(currentOwnership.copy(id = None, userId = toUserId))
-        case Some(newOwnership) =>
-          libraryMembershipRepo.save(newOwnership.copy(access = LibraryAccess.OWNER, showInSearch = currentOwnership.showInSearch))
-      }
-      var page = 0
-      val pageSize = 100
-      var hasMore = true
-      val keeps = ArrayBuffer[Keep]()
-      while (hasMore) {
-        val from = page * pageSize
-        val chunk: Seq[Keep] = keepRepo.getByLibrary(libraryId, from, from + pageSize, Set.empty) map { keep =>
-          val tags = keepToCollectionRepo.getByKeep(keep.id.get)
-          tags foreach { keepToTag =>
-            val origTag = collectionRepo.get(keepToTag.collectionId)
-            val tag = collectionRepo.getByUserAndName(toUserId, origTag.name, excludeState = None) match {
-              case None => collectionRepo.save(Collection(userId = toUserId, name = origTag.name))
-              case Some(existing) if !existing.isActive => collectionRepo.save(existing.copy(state = CollectionStates.ACTIVE, name = origTag.name))
-              case Some(existing) => existing
-            }
-            keepToCollectionRepo.save(keepToTag.copy(collectionId = tag.id.get))
+  def updateLibraryOwner(libraryId: Id[Library], fromUserId: Id[User]) = AdminUserPage { implicit request =>
+    request.body.asFormUrlEncoded.flatMap(_.get("toUserId").flatMap(_.headOption)).map(s => Id[User](s.toLong)) match {
+      case None => BadRequest("No User Id given")
+      case Some(toUserId) => {
+        db.readWrite { implicit session =>
+          val lib = libraryRepo.get(libraryId)
+          if (lib.ownerId != fromUserId) throw new Exception(s"orig user $fromUserId is not matching current library owner $lib")
+          libraryAliasRepo.alias(lib.ownerId, lib.slug, lib.id.get)
+          libraryAliasRepo.reclaim(toUserId, lib.slug) // reclaim existing alias to a former library of toUserId with the same slug
+          val newOwnerLib = lib.copy(ownerId = toUserId)
+          libraryRepo.save(newOwnerLib)
+          val currentOwnership = libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, fromUserId).getOrElse(throw new Exception(s"no ownership to lib $lib for user $fromUserId"))
+          libraryMembershipRepo.save(currentOwnership.copy(access = LibraryAccess.READ_ONLY))
+          libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, toUserId) match {
+            case None =>
+              libraryMembershipRepo.save(currentOwnership.copy(id = None, userId = toUserId))
+            case Some(newOwnership) =>
+              libraryMembershipRepo.save(newOwnership.copy(access = LibraryAccess.OWNER, showInSearch = currentOwnership.showInSearch))
           }
-          keepRepo.save(keep.copy(userId = toUserId))
+          var page = 0
+          val pageSize = 100
+          var hasMore = true
+          val keeps = ArrayBuffer[Keep]()
+          while (hasMore) {
+            val from = page * pageSize
+            val chunk: Seq[Keep] = keepRepo.getByLibrary(libraryId, from, from + pageSize, Set.empty) map { keep =>
+              val tags = keepToCollectionRepo.getByKeep(keep.id.get)
+              tags foreach { keepToTag =>
+                val origTag = collectionRepo.get(keepToTag.collectionId)
+                val tag = collectionRepo.getByUserAndName(toUserId, origTag.name, excludeState = None) match {
+                  case None => collectionRepo.save(Collection(userId = toUserId, name = origTag.name))
+                  case Some(existing) if !existing.isActive => collectionRepo.save(existing.copy(state = CollectionStates.ACTIVE, name = origTag.name))
+                  case Some(existing) => existing
+                }
+                keepToCollectionRepo.save(keepToTag.copy(collectionId = tag.id.get))
+              }
+              keepRepo.save(keep.copy(userId = toUserId))
+            }
+            hasMore = chunk.size >= pageSize
+            keeps.appendAll(chunk)
+            page += 1
+          }
+          Ok(s"keep count = ${keeps.size} for library: $newOwnerLib")
         }
-        hasMore = chunk.size >= pageSize
-        keeps.appendAll(chunk)
-        page += 1
       }
-      Ok(s"keep count = ${keeps.size} for library: $newOwnerLib")
     }
   }
 
@@ -147,7 +152,7 @@ class AdminLibraryController @Inject() (
     Ok(html.admin.libraries(info))
   }
 
-  def libraryView(libraryId: Id[Library]) = AdminUserPage.async { implicit request =>
+  def libraryView(libraryId: Id[Library], transfer: Boolean = false) = AdminUserPage.async { implicit request =>
     val simLibsFut = cortex.similarLibraries(libraryId, 5).map { libIds =>
       db.readOnlyReplica { implicit s =>
         libIds.map(libraryRepo.get)
@@ -167,7 +172,7 @@ class AdminLibraryController @Inject() (
 
     simLibsFut.map { relatedLibs =>
       val termsStr = suggestedSearches.terms.map { case (t, w) => t + ":" + w.toString }.mkString(", ")
-      Ok(html.admin.library(library, owner, keepCount, contributors, followers, Library.publicId(libraryId), relatedLibs, termsStr))
+      Ok(html.admin.library(library, owner, keepCount, contributors, followers, Library.publicId(libraryId), relatedLibs, termsStr, transfer))
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -412,11 +412,11 @@ class AdminUserController @Inject() (
   }
 
   def createLibrary(userId: Id[User]) = AdminUserPage(parse.tolerantFormUrlEncoded) { implicit request =>
-    val name = request.body.get("name").flatMap(_.headOption)
-    val visibility = request.body.get("visibility").flatMap(_.headOption).map(LibraryVisibility(_))
-    val slug = request.body.get("slug").flatMap(_.headOption)
+    val nameOpt = request.body.get("name").flatMap(_.headOption)
+    val visibilityOpt = request.body.get("visibility").flatMap(_.headOption).map(LibraryVisibility(_))
+    val slugOpt = request.body.get("slug").flatMap(_.headOption)
 
-    (name, visibility, slug) match {
+    (nameOpt, visibilityOpt, slugOpt) match {
       case (Some(name), Some(visibility), Some(slug)) => {
         val libraryAddRequest = LibraryAddRequest(name, visibility, slug)
 

--- a/kifi-backend/modules/shoebox/app/views/admin/library.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/library.scala.html
@@ -28,7 +28,7 @@
       <th>Transfer Ownership</th>
       <td>
         <form action="#" method="POST" class="transfer-ownership">
-          <input type="text" name="toUserId" placeholder="User Id of new Owner">
+          <input id="toUserId" type="text" name="toUserId" placeholder="User Id of new Owner">
           <input type="submit" value="Change Owner">
         </form>
       </td>
@@ -125,12 +125,28 @@
     disableEdit(true)
 
     @if(transfer) {
+      var transferring = false;
       $('.transfer-ownership').on("submit", function() {
-        $.post("@com.keepit.controllers.admin.routes.AdminLibraryController.updateLibraryOwner(library.id.get, library.ownerId)", $('.transfer-ownership').serialize())
+        if (transferring) return false;
+        transferring = true;
+        var value = $('#toUserId').val();
+        $.post('@com.keepit.controllers.admin.routes.AdminLibraryController.updateLibraryOwner(library.id.get, library.ownerId, Id[User](-111L))'.replace('-111', value))
         .done(function(data) {
           alert("Library Owner Updated")
+          transferring = false;
         }).fail(function(data) {
-          alert("Bad Request: " + data.responseText);
+          if (data.status == 408) {
+            // timeout
+            alert("Library transferring in progress");
+          } else if(data.status == 500) {
+            // internal server error
+            alert("An Internal Server Error has occurred - check the dev console for more information");
+            console.log(data);
+            transferring = false;
+          } else {
+            alert(data.responseText);
+            transferring = false;
+          }
         });
         return false;
       });

--- a/kifi-backend/modules/shoebox/app/views/admin/library.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/library.scala.html
@@ -5,7 +5,8 @@
   followers: Seq[User],
   publicId: com.keepit.common.crypto.PublicId[Library],
   relatedLibs: Seq[Library],
-  suggestedSearches: String
+  suggestedSearches: String,
+  transfer: Boolean
 )(implicit request: com.keepit.common.controller.UserRequest[_])
 
 @admin(owner.firstName + " " + owner.lastName + "'s " + library.name, stylesheets = List("admin_library")) {
@@ -22,6 +23,17 @@
     <tr>
       <th>Owner</th><td><img src="@com.keepit.controllers.assets.routes.UserPictureController.get(100, owner.externalId)" height=25 width=25>@adminHelper.userDisplay(owner)</td>
     </tr>
+    @if(transfer) {
+    <tr>
+      <th>Transfer Ownership</th>
+      <td>
+        <form action="#" method="POST" class="transfer-ownership">
+          <input type="text" name="toUserId" placeholder="User Id of new Owner">
+          <input type="submit" value="Change Owner">
+        </form>
+      </td>
+    </tr>
+    }
     <tr>
       <th>Description</th><td>@library.description</td>
     </tr>
@@ -111,6 +123,18 @@
 
     document.getElementById("edit_tc").addEventListener("click", startEdit, true);
     disableEdit(true)
+
+    @if(transfer) {
+      $('.transfer-ownership').on("submit", function() {
+        $.post("@com.keepit.controllers.admin.routes.AdminLibraryController.updateLibraryOwner(library.id.get, library.ownerId)", $('.transfer-ownership').serialize())
+        .done(function(data) {
+          alert("Library Owner Updated")
+        }).fail(function(data) {
+          alert("Bad Request: " + data.responseText);
+        });
+        return false;
+      });
+    }
 
     function disableEdit(disabled){
         if (disabled){

--- a/kifi-backend/modules/shoebox/app/views/admin/userLibraries.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/userLibraries.scala.html
@@ -20,7 +20,6 @@
             <input type="text" name="slug" placeholder="slug">
             <select name="visibility">
                 <option value="published">Published</option>
-                <option value="discoverable">Discoverable</option>
                 <option value="secret">Secret</option>
             </select>
             <input type="submit" value="Create Library">

--- a/kifi-backend/modules/shoebox/app/views/admin/userLibraries.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/userLibraries.scala.html
@@ -13,6 +13,20 @@
       </tr>
     </table>
 
+    <div>
+        <p>Create a Library</p>
+        <form action="#" method="POST" class="create-library">
+            <input type="text" name="name" placeholder="Library Name">
+            <input type="text" name="slug" placeholder="slug">
+            <select name="visibility">
+                <option value="published">Published</option>
+                <option value="discoverable">Discoverable</option>
+                <option value="secret">Secret</option>
+            </select>
+            <input type="submit" value="Create Library">
+        </form>
+    </div>
+
   <h2>Showing @libraryList.size Libraries</h2>
   <form class="navbar-form" action="@com.keepit.controllers.admin.routes.AdminLibraryController.updateLibraries()"
   method="POST">
@@ -56,5 +70,16 @@
   </form>
 
   <script type="text/javascript">
+      $(function() {
+        $('.create-library').on("submit", function() {
+          $.post("@com.keepit.controllers.admin.routes.AdminUserController.createLibrary(user.id.get)", $('.create-library').serialize())
+          .done(function(data) {
+              alert("Library created");
+          }).fail(function(data) {
+              alert(data.responseText);
+          });
+          return false;
+        });
+      });
   </script>
 }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -653,6 +653,7 @@ GET     /admin/user/:id/prefixSearch @com.keepit.controllers.admin.AdminUserCont
 GET     /admin/user/:id/prefixSocialSearch  @com.keepit.controllers.admin.AdminUserController.prefixSocialSearch(id:Id[User], query:String ?= "")
 GET     /admin/user/:id/prefixContactSearch @com.keepit.controllers.admin.AdminUserController.prefixContactSearch(id:Id[User], query:String ?= "")
 POST    /admin/user/:user1/connect  @com.keepit.controllers.admin.AdminUserController.connectUsers(user1: Id[User])
+POST    /admin/user/:id/createLibrary  @com.keepit.controllers.admin.AdminUserController.createLibrary(id: Id[User])
 POST    /admin/user/:id/experiment/:exp  @com.keepit.controllers.admin.AdminUserController.addExperimentAction(id: Id[User], exp: String)
 POST    /admin/user/bookmarks/:id/collections @com.keepit.controllers.admin.AdminUserController.updateCollectionsForBookmark(id: Id[Keep])
 DELETE  /admin/user/:id/experiment/:exp  @com.keepit.controllers.admin.AdminUserController.removeExperimentAction(id: Id[User], exp: String)
@@ -739,7 +740,7 @@ POST    /admin/libraries/internForAllUsers  @com.keepit.controllers.admin.AdminL
 POST    /admin/libraries/:id/state/:state   @com.keepit.controllers.admin.AdminLibraryController.changeState(id: Id[Library], state: String)
 POST    /admin/libraries/update             @com.keepit.controllers.admin.AdminLibraryController.updateLibraries
 POST    /admin/libraries/migrateKeepImages  @com.keepit.controllers.ext.ExtKeepImageController.loadPrevImageForKeep(startUserId: Long, endUserId: Long)
-POST    /admin/libraries/updateLibraryOwner @com.keepit.controllers.admin.AdminLibraryController.updateLibraryOwner(libraryId: Id[Library], fromUserId: Id[User], toUserId: Id[User])
+POST    /admin/libraries/updateLibraryOwner @com.keepit.controllers.admin.AdminLibraryController.updateLibraryOwner(libraryId: Id[Library], fromUserId: Id[User])
 POST    /admin/libraries/saveSuggestedSearches    @com.keepit.controllers.admin.AdminLibraryController.saveSuggestedSearches
 
 GET     /admin/personas             @com.keepit.controllers.admin.AdminPersonaController.getAllPersonas()

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -740,7 +740,7 @@ POST    /admin/libraries/internForAllUsers  @com.keepit.controllers.admin.AdminL
 POST    /admin/libraries/:id/state/:state   @com.keepit.controllers.admin.AdminLibraryController.changeState(id: Id[Library], state: String)
 POST    /admin/libraries/update             @com.keepit.controllers.admin.AdminLibraryController.updateLibraries
 POST    /admin/libraries/migrateKeepImages  @com.keepit.controllers.ext.ExtKeepImageController.loadPrevImageForKeep(startUserId: Long, endUserId: Long)
-POST    /admin/libraries/updateLibraryOwner @com.keepit.controllers.admin.AdminLibraryController.updateLibraryOwner(libraryId: Id[Library], fromUserId: Id[User])
+POST    /admin/libraries/updateLibraryOwner @com.keepit.controllers.admin.AdminLibraryController.updateLibraryOwner(libraryId: Id[Library], fromUserId: Id[User], toUserId: Id[User])
 POST    /admin/libraries/saveSuggestedSearches    @com.keepit.controllers.admin.AdminLibraryController.saveSuggestedSearches
 
 GET     /admin/personas             @com.keepit.controllers.admin.AdminPersonaController.getAllPersonas()

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -732,7 +732,7 @@ POST    /admin/slider/unkillVersion   @com.keepit.controllers.admin.SliderAdminC
 POST    /admin/slider/goldenVersion   @com.keepit.controllers.admin.SliderAdminController.goldenVersion(ver: String)
 
 GET     /admin/libraries                 @com.keepit.controllers.admin.AdminLibraryController.index(page: Int ?= 0)
-GET     /admin/libraries/:id             @com.keepit.controllers.admin.AdminLibraryController.libraryView(id: Id[Library])
+GET     /admin/libraries/:id             @com.keepit.controllers.admin.AdminLibraryController.libraryView(id: Id[Library], transfer: Boolean ?= false)
 GET     /admin/libraries/:id/indexed        @com.keepit.controllers.admin.AdminLibraryController.getLuceneDocument(id: Id[Library])
 GET     /admin/libraries/:id/keeps       @com.keepit.controllers.admin.AdminLibraryController.libraryKeepsView(id: Id[Library], page: Int ?= 0, showPrivates: Boolean ?= false, showInactives: Boolean ?= false)
 POST    /admin/libraries/internForUser   @com.keepit.controllers.admin.AdminLibraryController.internUserSystemLibraries(userId: Id[User])


### PR DESCRIPTION
When viewing a library from admin/libraries/:id if the parameter transfer=true is specified a library’s owner can be changed to a new user with their user id.

When viewing libraries from admin/user/:id/libraries a new library can be created by giving a library name, a slug, and a visibility level.

@stkem @andrewconner 
