### PR TITLE
sending split unread messages and notifications counts to clients

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -541,7 +541,9 @@ class MessagingCommander @Inject() (
     }
     messagingAnalytics.clearedNotification(userId, message, thread, context)
 
-    notificationCommander.notifyRead(userId, thread.externalId, msgExtId, thread.nUrl.getOrElse(""), message.createdAt, getUnreadUnmutedThreadCount(userId))
+    val unreadMessagesCount = getUnreadUnmutedThreadCount(userId, Some(true))
+    val unreadNotificationsCount = getUnreadUnmutedThreadCount(userId, Some(false))
+    notificationCommander.notifyRead(userId, thread.externalId, msgExtId, thread.nUrl.getOrElse(""), message.createdAt, unreadMessagesCount, unreadNotificationsCount)
   }
 
   def setUnread(userId: Id[User], msgExtId: ExternalId[Message]): Unit = {
@@ -553,7 +555,9 @@ class MessagingCommander @Inject() (
       userThreadRepo.markUnread(userId, thread.id.get)
     }
     if (changed) {
-      notificationCommander.notifyUnread(userId, thread.externalId, msgExtId, thread.nUrl.getOrElse(""), message.createdAt, getUnreadUnmutedThreadCount(userId))
+      val unreadMessagesCount = getUnreadUnmutedThreadCount(userId, Some(true))
+      val unreadNotificationsCount = getUnreadUnmutedThreadCount(userId, Some(false))
+      notificationCommander.notifyUnread(userId, thread.externalId, msgExtId, thread.nUrl.getOrElse(""), message.createdAt, unreadMessagesCount, unreadNotificationsCount)
     }
   }
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
@@ -97,8 +97,9 @@ class SharedWsMessagingController @Inject() (
         } // todo(Martin, Jared, Léo): return meaningful error about invalid participants
     },
     "get_unread_notifications_count" -> { _ =>
-      val numUnreadUnmuted = messagingCommander.getUnreadUnmutedThreadCount(socket.userId)
-      socket.channel.push(Json.arr("unread_notifications_count", numUnreadUnmuted))
+      val numUnreadUnmutedMessages = messagingCommander.getUnreadUnmutedThreadCount(socket.userId, Some(true))
+      val numUnreadUnmutedNotifications = messagingCommander.getUnreadUnmutedThreadCount(socket.userId, Some(false))
+      socket.channel.push(Json.arr("unread_notifications_count", numUnreadUnmutedMessages + numUnreadUnmutedNotifications, numUnreadUnmutedMessages, numUnreadUnmutedNotifications))
       // note: "unread_notifications_count" is broadcasted elsewhere too
     },
     // inbox notification/thread handlers
@@ -207,8 +208,9 @@ class SharedWsMessagingController @Inject() (
     "set_all_notifications_visited" -> {
       case JsString(notifId) +: _ =>
         val messageId = ExternalId[Message](notifId)
-        val numUnreadUnmuted = messagingCommander.getUnreadUnmutedThreadCount(socket.userId)
-        val lastModified = notificationCommander.setAllNotificationsReadBefore(socket.userId, messageId, numUnreadUnmuted)
+        val numUnreadUnmutedMessages = messagingCommander.getUnreadUnmutedThreadCount(socket.userId, Some(true))
+        val numUnreadUnmutedNotifications = messagingCommander.getUnreadUnmutedThreadCount(socket.userId, Some(false))
+        val lastModified = notificationCommander.setAllNotificationsReadBefore(socket.userId, messageId, numUnreadUnmutedMessages, numUnreadUnmutedNotifications)
         socket.channel.push(Json.arr("all_notifications_visited", notifId, lastModified))
     },
 


### PR DESCRIPTION
fully backwards compatible, which makes it a bit wet (we are sending two number and their sum to the client) :-/

@andrewconner 
