### PR TITLE
more context if social id is empty on handleSocialFinalizeInfo method

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -54,7 +54,7 @@ object AuthHelper {
 class AuthHelper @Inject() (
     db: Database,
     clock: Clock,
-    airbrakeNotifier: AirbrakeNotifier,
+    airbrake: AirbrakeNotifier,
     oauth1ProviderRegistry: OAuth1ProviderRegistry,
     oauth2ProviderRegistry: OAuth2ProviderRegistry,
     authCommander: AuthCommander,
@@ -186,7 +186,7 @@ class AuthHelper @Inject() (
       userValueRepo.save(UserValue(userId = userId, name = UserValueName.KIFI_CAMPAIGN_ID, value = kcid))
     }
   } catch {
-    case t: Throwable => airbrakeNotifier.notify(s"fail to save Kifi Campaign Id for user $userId where kcid = $kcid", t)
+    case t: Throwable => airbrake.notify(s"fail to save Kifi Campaign Id for user $userId where kcid = $kcid", t)
   }
 
   def finishSignup(user: User, emailAddress: EmailAddress, newIdentity: Identity, emailConfirmedAlready: Boolean, libraryPublicId: Option[PublicId[Library]], isFinalizedImmediately: Boolean)(implicit request: MaybeUserRequest[_]): Result = {
@@ -290,6 +290,9 @@ class AuthHelper @Inject() (
     require(request.identityOpt.isDefined, "A social identity should be available in order to finalize social account")
 
     val identity = request.identityOpt.get
+    if (identity.identityId.userId.trim.isEmpty) {
+      airbrake.notify(AirbrakeError.incoming(request = request, message = s"empty social id for $identity joining library $libraryPublicId with $sfi"))
+    }
     val inviteExtIdOpt: Option[ExternalId[Invitation]] = request.cookies.get("inv").flatMap(v => ExternalId.asOpt[Invitation](v.value))
     implicit val context = heimdalContextBuilder.withRequestInfo(request).build
     val (user, emailPassIdentity) = authCommander.finalizeSocialAccount(sfi, identity, inviteExtIdOpt)
@@ -467,7 +470,7 @@ class AuthHelper @Inject() (
           case Success((token, pictureUrl)) =>
             Ok(Json.obj("token" -> token, "url" -> pictureUrl))
           case Failure(ex) =>
-            airbrakeNotifier.notify("Couldn't upload temporary picture (xhr direct) for $userInfo", ex)
+            airbrake.notify("Couldn't upload temporary picture (xhr direct) for $userInfo", ex)
             BadRequest(JsNumber(0))
         }
       case None => Forbidden(JsNumber(0))
@@ -482,7 +485,7 @@ class AuthHelper @Inject() (
             case Success((token, pictureUrl)) =>
               Ok(Json.obj("token" -> token, "url" -> pictureUrl))
             case Failure(ex) =>
-              airbrakeNotifier.notify(AirbrakeError(ex, Some("Couldn't upload temporary picture (form encoded)")))
+              airbrake.notify(AirbrakeError(ex, Some("Couldn't upload temporary picture (form encoded)")))
               BadRequest(JsNumber(0))
           }
         } getOrElse {
@@ -504,7 +507,7 @@ class AuthHelper @Inject() (
           val filledUser = SecureSocialAdaptor.toSocialUser(profileInfo, AuthenticationMethod.OAuth2)
           val longTermTokenInfoF = provider.exchangeLongTermToken(oauth2InfoOrig) recover {
             case t: Throwable =>
-              airbrakeNotifier.notify(s"[accessTokenSignup($providerName)] Caught Exception($t) during token exchange; token=${oauth2InfoOrig}; Cause:${t.getCause}; StackTrace: ${t.getStackTrace.mkString("", "\n", "\n")}")
+              airbrake.notify(s"[accessTokenSignup($providerName)] Caught Exception($t) during token exchange; token=${oauth2InfoOrig}; Cause:${t.getCause}; StackTrace: ${t.getStackTrace.mkString("", "\n", "\n")}")
               OAuth2TokenInfo.fromOAuth2Info(oauth2InfoOrig)
           }
           longTermTokenInfoF map { oauth2InfoNew =>
@@ -512,7 +515,7 @@ class AuthHelper @Inject() (
           }
         } recover {
           case t: Throwable =>
-            airbrakeNotifier.notify(s"[accessTokenSignup($providerName)] Caught Exception($t) during getUserProfileInfo; token=${oauth2InfoOrig}; Cause:${t.getCause}; StackTrace: ${t.getStackTrace.mkString("", "\n", "\n")}")
+            airbrake.notify(s"[accessTokenSignup($providerName)] Caught Exception($t) during getUserProfileInfo; token=${oauth2InfoOrig}; Cause:${t.getCause}; StackTrace: ${t.getStackTrace.mkString("", "\n", "\n")}")
             BadRequest(Json.obj("error" -> "invalid_token"))
         }
     }
@@ -529,7 +532,7 @@ class AuthHelper @Inject() (
           authCommander.signupWithTrustedSocialUser(providerName, filledUser.copy(oAuth1Info = Some(oauth1Info)), signUpUrl)
         } recover {
           case t: Throwable =>
-            airbrakeNotifier.notify(s"[accessTokenSignup($providerName)] Caught Exception($t) during getUserProfileInfo; token=${oauth1Info}; Cause:${t.getCause}; StackTrace: ${t.getStackTrace.mkString("", "\n", "\n")}")
+            airbrake.notify(s"[accessTokenSignup($providerName)] Caught Exception($t) during getUserProfileInfo; token=${oauth1Info}; Cause:${t.getCause}; StackTrace: ${t.getStackTrace.mkString("", "\n", "\n")}")
             BadRequest(Json.obj("error" -> "invalid_token"))
         }
     }


### PR DESCRIPTION
riding on this exception:

```
empty social id for social user SocialUser(IdentityId(,userpass),Emily,Russell,Emily Russell,Some(),None,AuthenticationMethod(userPassword),None,None,Some(PasswordInfo(bcrypt,$2a$10$yLI/kaa9XcJIJ1rNaprK9eKMTrhwsAC3dmiEAScB86zPnMlvuggd2,None))) userId None and identity SocialUser(IdentityId(,userpass),Emily,Russell,Emily Russell,Some(),None,AuthenticationMethod(userPassword),None,None,Some(PasswordInfo(bcrypt,$2a$10$yLI/kaa9XcJIJ1rNaprK9eKMTrhwsAC3dmiEAScB86zPnMlvuggd2,None))) com.keepit.common.healthcheck.DefaultAirbrakeException: null 
  Cause: [No Cause]

Total Errors since start: 2
Total Errors since last alert: 1
Server: shoebox-demand-6
Server started at: 2015-05-14T18:51:44.313Z
Full Details

2015-05-14T21:52:35.165Z: [a6afb770-fdf3-415c-b64d-f1f3139ccf01]
error message [empty social id for social user SocialUser(IdentityId(,userpass),Emily,Russell,Emily Russell,Some(),None,AuthenticationMethod(userPassword),None,None,Some(PasswordInfo(bcrypt,$2a$10$yLI/kaa9XcJIJ1rNaprK9eKMTrhwsAC3dmiEAScB86zPnMlvuggd2,None))) userId None and identity SocialUser(IdentityId(,userpass),Emily,Russell,Emily Russell,Some(),None,AuthenticationMethod(userPassword),None,None,Some(PasswordInfo(bcrypt,$2a$10$yLI/kaa9XcJIJ1rNaprK9eKMTrhwsAC3dmiEAScB86zPnMlvuggd2,None)))]
Exception stack trace: 
Cause:

com.keepit.common.healthcheck.AirbrakeError$.apply$default$1(AirbrakeError.scala:26) 
com.keepit.common.healthcheck.AirbrakeNotifierImpl.notify(AirbrakeNotifier.scala:197) 
com.keepit.social.SecureSocialUserPluginImpl[a].apply(SecureSocialUserServiceImpl.scala:100) 
com.keepit.social.SecureSocialUserPluginImpl[a].apply(SecureSocialUserServiceImpl.scala:95) 
com.keepit.social.SecureSocialUserPluginImpl.reportExceptions(SecureSocialUserServiceImpl.scala:49) 
com.keepit.social.SecureSocialUserPluginImpl.save(SecureSocialUserServiceImpl.scala:95) 
com.keepit.social.SecureSocialUserService.save(SecureSocialUserService.scala:59) 
com.keepit.social.SecureSocialUserService.save(SecureSocialUserService.scala:48) 
securesocial.core.UserService[a].apply(UserService.scala:169) 
securesocial.core.UserService[a].apply(UserService.scala:169) 
scala.Option.map(Option.scala:146) 
securesocial.core.UserService$.save(UserService.scala:169) 
com.keepit.commanders.AuthCommander.saveUserPasswordIdentity(AuthCommander.scala:148) 
com.keepit.commanders.AuthCommander[a].apply(AuthCommander.scala:205) 
com.keepit.commanders.AuthCommander[a].apply(AuthCommander.scala:197) 
com.keepit.common.performance.package$.timing(package.scala:42) 
com.keepit.commanders.AuthCommander.finalizeSocialAccount(AuthCommander.scala:197) 
com.keepit.controllers.core.AuthHelper.handleSocialFinalizeInfo(AuthHelper.scala:295) 
com.keepit.controllers.core.AuthController.com$keepit$controllers$core$AuthController$$doSignupPage(AuthController.scala:518) 
com.ke
```
