### PR TITLE
migrate to hosted statsd

### DIFF
--- a/kifi-backend/modules/common/conf/application-dev.conf
+++ b/kifi-backend/modules/common/conf/application-dev.conf
@@ -183,6 +183,7 @@ elasticache.config.endpoint="localhost:11211"
 # ~~~~~~~~~~~~~~~~~~
 statsd {
   enabled = false
+  # prefix includes the API key for hosted StatsD by Hosted Graphite
   stat.prefix = "29fd6670-4ac9-4c46-8111-d5f80a5f6a57.dev"
   routes.prefix = "routes"
   routes.combined.prefix = "routes.combined"

--- a/kifi-backend/modules/common/conf/prod/abook.conf
+++ b/kifi-backend/modules/common/conf/prod/abook.conf
@@ -9,7 +9,8 @@ application.router=abookService.Routes
 application.name="ABOOK"
 
 statsd {
-  stat.prefix = "abook"
+  # prefix includes the API key for hosted StatsD by Hosted Graphite
+  stat.prefix = "29fd6670-4ac9-4c46-8111-d5f80a5f6a57.abook"
 }
 
 # Database configuration

--- a/kifi-backend/modules/common/conf/prod/c_shoebox.conf
+++ b/kifi-backend/modules/common/conf/prod/c_shoebox.conf
@@ -12,7 +12,8 @@ application.router=shoeboxService.Routes
 application.name="C_SHOEBOX"
 
 statsd {
-  stat.prefix = "c_shoebox"
+  # prefix includes the API key for hosted StatsD by Hosted Graphite
+  stat.prefix = "29fd6670-4ac9-4c46-8111-d5f80a5f6a57.c_shoebox"
 }
 
 # Database configuration

--- a/kifi-backend/modules/common/conf/prod/cortex.conf
+++ b/kifi-backend/modules/common/conf/prod/cortex.conf
@@ -8,7 +8,8 @@ application.router=cortexService.Routes
 application.name="CORTEX"
 
 statsd {
-  stat.prefix = "cortex"
+  # prefix includes the API key for hosted StatsD by Hosted Graphite
+  stat.prefix = "29fd6670-4ac9-4c46-8111-d5f80a5f6a57.cortex"
 }
 
 # ~~~~~~~~~~

--- a/kifi-backend/modules/common/conf/prod/curator.conf
+++ b/kifi-backend/modules/common/conf/prod/curator.conf
@@ -8,7 +8,8 @@ application.router=curatorService.Routes
 application.name="CURATOR"
 
 statsd {
-  stat.prefix = "curator"
+  # prefix includes the API key for hosted StatsD by Hosted Graphite
+  stat.prefix = "29fd6670-4ac9-4c46-8111-d5f80a5f6a57.curator"
 }
 
 # ~~~~~~~~~~

--- a/kifi-backend/modules/common/conf/prod/eliza.conf
+++ b/kifi-backend/modules/common/conf/prod/eliza.conf
@@ -9,7 +9,8 @@ application.router=elizaService.Routes
 application.name="ELIZA"
 
 statsd {
-  stat.prefix = "eliza"
+  # prefix includes the API key for hosted StatsD by Hosted Graphite
+  stat.prefix = "29fd6670-4ac9-4c46-8111-d5f80a5f6a57.eliza"
 }
 
 # Database configuration

--- a/kifi-backend/modules/common/conf/prod/heimdal.conf
+++ b/kifi-backend/modules/common/conf/prod/heimdal.conf
@@ -9,7 +9,8 @@ application.router=heimdalService.Routes
 application.name="HEIMDAL"
 
 statsd {
-  stat.prefix = "heimdal"
+  # prefix includes the API key for hosted StatsD by Hosted Graphite
+  stat.prefix = "29fd6670-4ac9-4c46-8111-d5f80a5f6a57.heimdal"
 }
 
 # Database configuration

--- a/kifi-backend/modules/common/conf/prod/prod.conf
+++ b/kifi-backend/modules/common/conf/prod/prod.conf
@@ -119,7 +119,7 @@ statsd {
   enabled = true
   routes.prefix = "routes"
   routes.combined.prefix = "routes.combined"
-  host = "statsd.keep42.com"
+  host = "statsd.hostedgraphite.com"
   port = 8125
 }
 

--- a/kifi-backend/modules/common/conf/prod/rover.conf
+++ b/kifi-backend/modules/common/conf/prod/rover.conf
@@ -9,7 +9,8 @@ application.router=roverService.Routes
 application.name="ROVER"
 
 statsd {
-  stat.prefix = "rover"
+  # prefix includes the API key for hosted StatsD by Hosted Graphite
+  stat.prefix = "29fd6670-4ac9-4c46-8111-d5f80a5f6a57.rover"
 }
 
 # Database configuration

--- a/kifi-backend/modules/common/conf/prod/scraper.conf
+++ b/kifi-backend/modules/common/conf/prod/scraper.conf
@@ -9,7 +9,8 @@ application.router=scraperService.Routes
 application.name="SCRAPER"
 
 statsd {
-  stat.prefix = "scraper"
+  # prefix includes the API key for hosted StatsD by Hosted Graphite
+  stat.prefix = "29fd6670-4ac9-4c46-8111-d5f80a5f6a57.scraper"
 }
 
 airbrake {

--- a/kifi-backend/modules/common/conf/prod/search.conf
+++ b/kifi-backend/modules/common/conf/prod/search.conf
@@ -9,7 +9,8 @@ application.name="SEARCH"
 application.router=searchService.Routes
 
 statsd {
-  stat.prefix = "search"
+  # prefix includes the API key for hosted StatsD by Hosted Graphite
+  stat.prefix = "29fd6670-4ac9-4c46-8111-d5f80a5f6a57.search"
 }
 
 dbplugin=disabled

--- a/kifi-backend/modules/common/conf/prod/shoebox.conf
+++ b/kifi-backend/modules/common/conf/prod/shoebox.conf
@@ -9,7 +9,8 @@ application.router=shoeboxService.Routes
 application.name="SHOEBOX"
 
 statsd {
-  stat.prefix = "shoebox"
+  # prefix includes the API key for hosted StatsD by Hosted Graphite
+  stat.prefix = "29fd6670-4ac9-4c46-8111-d5f80a5f6a57.shoebox"
 }
 
 # Database configuration


### PR DESCRIPTION
@stkem @andrewconner  from what I understand reading the docs and the source code for the StatsD library (https://github.com/typesafehub/play-plugins/tree/6ac0e80bb35dd21b5f0b1b1e2f00f3675d7a8585/statsd/src/main/scala/play/modules/statsd/api), this is the place to put this. 

there is some risk to this PR because I haven't been able to test it locally. I tried to enable statsd in application-dev.conf but haven't seen any dev-mode stats added (might just be that it didn't execute any code that sent to statsd).

we'd need to keep an eye on graphite to make sure the metrics are flowing in after a deploy
