### PR TITLE
Can modify cache as admin

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminCacheController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminCacheController.scala
@@ -7,7 +7,8 @@ import com.keepit.common.service.{ FortyTwoServices, ServiceType, ServiceClient 
 import com.keepit.common.net.HttpClient
 import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.api.libs.json.{ JsBoolean, JsNumber, JsArray, JsObject }
+import play.api.libs.json.{ JsBoolean, JsNumber, JsArray, JsObject, JsString }
+import play.api.libs.json._
 import com.keepit.common.zookeeper.ServiceDiscovery
 import com.keepit.common.cache.InMemoryCachePlugin
 
@@ -19,6 +20,23 @@ class AdminCacheController @Inject() (
     serviceDiscovery: ServiceDiscovery) extends AdminUserActions {
   def serviceView = AdminUserPage { implicit request =>
     Ok(html.admin.cacheOverview())
+  }
+
+  def getCacheEntry(key: String) = AdminUserAction { implicit request =>
+    localCache.get(key) match {
+      case Some(value) => Ok(Json.obj(key -> value.toString))
+      case _ => NoContent
+    }
+  }
+
+  def deleteCacheEntry(key: String) = AdminUserAction { implicit request =>
+    localCache.remove(key)
+    Ok
+  }
+
+  def setCacheEntry(key: String, value: String) = AdminUserAction { implicit request =>
+    localCache.set(key, value)
+    Ok
   }
 
   def clearLocalCaches(service: String, prefix: String) = AdminUserAction.async { implicit request =>

--- a/kifi-backend/modules/shoebox/app/views/admin/admin.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/admin.scala.html
@@ -118,6 +118,7 @@
                   <li><a href="@com.keepit.controllers.admin.routes.AdminIndexInfoController.all">Index</a>
                   <li><a href="@com.keepit.controllers.admin.routes.AdminIndexInfoController.viewIndexGrowth">Index Growth</a>
                   <li><a href="@com.keepit.controllers.admin.routes.AdminSearchPerformanceController.viewSearchPerformance">Search Performance</a>
+                  <li><a href="@com.keepit.controllers.admin.routes.AdminCacheController.modifyCache">Modify Cache</a>
                   <li><a href="@com.keepit.controllers.admin.routes.AdminCacheController.serviceView">Cache Overview</a>
                   <li><a href="@com.keepit.controllers.admin.routes.AdminWebSocketController.serviceView">WebSocket Performance</a>
                   <li><a href="@com.keepit.controllers.admin.routes.AdminClusterController.clustersView">Clusters Overview</a>

--- a/kifi-backend/modules/shoebox/app/views/admin/cacheOverview.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/cacheOverview.scala.html
@@ -5,39 +5,6 @@
 
 @admin("Cache Overview", scripts = List("graphite")) {
 
-<div>
-  <div class="row-fluid span10">
-    <span class="span6">
-      <form class="form-horizontal get-cache-form" action="#">
-        <input id="get-cache-key-input" type="text" placeholder="cache key" class="form-control span8">
-        <input type="submit" value="Get cache value" class="btn btn-default span4">
-      </form>
-    </span>
-    <p class="span6" id="get-cache-result"></p>
-  </div>
-
-  <div class="row-fluid span10">
-    <span class="span6">
-      <form class="form-horizontal delete-cache-form" action="#">
-        <input class="form-control span8" id="delete-cache-key-input" type="text" placeholder="cache key">
-        <input class = "btn btn-default span4" type="submit" value="Delete key from cache">
-      </form>
-    </span>
-    <p class="span6" id="delete-cache-result"></p>
-  </div>
-
-  <div class="row-fluid span10">
-    <span class="span6">
-      <form class="form-horizontal set-cache-form" action="#">
-        <input class="form-control span4" id="set-cache-key-input" type="text" placeholder="cache key">
-        <input class="form-control span4" id="set-cache-value-input" type="text" placeholder="cache value">
-        <input class="btn btn-default span4" type="submit" value="Set cache key-value pair">
-      </form>
-    </span>
-    <p class="span6" id="set-cache-result"></p>
-  </div>
-</div>
-
 <h3>Invalidation</h3>
 <div>
   <form class="form-horizontal" action="@com.keepit.controllers.admin.routes.AdminCacheController.clearLocalCaches()" method="GET">
@@ -75,61 +42,6 @@
 </p>
 
 <script>
-
-  (function() {
-    var getCacheResult = $('#get-cache-result');
-    var deleteCacheResult = $('#delete-cache-result');
-    var setCacheResult = $('#set-cache-result');
-
-    var getKeyInput = $('#get-cache-key-input');
-    $('.get-cache-form').on("submit", function() {
-      getCacheResult.text("Processing Request");
-      $.get('@com.keepit.controllers.admin.routes.AdminCacheController.getCacheEntry("__")'.replace("__", getKeyInput.val()))
-      .done(function(data, textStatus, xhr) {
-        if (xhr.status == 200) {
-          getCacheResult.text(getKeyInput.val() + "->" + data.key);
-          deleteCacheResult.text("");
-          setCacheResult.text("");
-        } else if (xhr.status == 204) {
-          // No Content (Cache entry does not exist)
-          getCacheResult.text("Cache key "+ getKeyInput.val() +" does not exist.");
-          deleteCacheResult.text("");
-          setCacheResult.text("");
-        }
-      });
-      return false;
-    });
-
-    var deleteKeyInput = $('#delete-cache-key-input');
-    $('.delete-cache-form').on('submit', function() {
-      $.ajax({
-        url: '@com.keepit.controllers.admin.routes.AdminCacheController.deleteCacheEntry("__")'.replace('__', deleteKeyInput.val()),
-        type: 'delete'
-      })
-      .done(function(data) {
-        getCacheResult.text("");
-        deleteCacheResult.text("Deleted: " + deleteKeyInput.val());
-        setCacheResult.text("");
-      })
-      return false;
-    });
-    var setCacheKey = $('#set-cache-key-input');
-    var setCacheValue = $('#set-cache-value-input');
-    $('.set-cache-form').on('submit', function() {
-      $.ajax({
-        url: '@com.keepit.controllers.admin.routes.AdminCacheController.setCacheEntry("__", "___")'.replace('__', setCacheKey.val()).replace('___', setCacheValue.val()),
-        type: 'put'
-      })
-      .done(function(data) {
-        getCacheResult.text("");
-        deleteCacheResult.text("");
-        setCacheResult.text("Set Cache Entry: " +setCacheKey.val() + "->" + setCacheValue.val());
-      });
-      return false;
-    });
-  })();
-
-
 
   var plugins = {
   "All Plugins": "Cache",

--- a/kifi-backend/modules/shoebox/app/views/admin/cacheOverview.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/cacheOverview.scala.html
@@ -5,6 +5,39 @@
 
 @admin("Cache Overview", scripts = List("graphite")) {
 
+<div>
+  <div class="row-fluid span10">
+    <span class="span6">
+      <form class="form-horizontal get-cache-form" action="#">
+        <input id="get-cache-key-input" type="text" placeholder="cache key" class="form-control span8">
+        <input type="submit" value="Get cache value" class="btn btn-default span4">
+      </form>
+    </span>
+    <p class="span6" id="get-cache-result"></p>
+  </div>
+
+  <div class="row-fluid span10">
+    <span class="span6">
+      <form class="form-horizontal delete-cache-form" action="#">
+        <input class="form-control span8" id="delete-cache-key-input" type="text" placeholder="cache key">
+        <input class = "btn btn-default span4" type="submit" value="Delete key from cache">
+      </form>
+    </span>
+    <p class="span6" id="delete-cache-result"></p>
+  </div>
+
+  <div class="row-fluid span10">
+    <span class="span6">
+      <form class="form-horizontal set-cache-form" action="#">
+        <input class="form-control span4" id="set-cache-key-input" type="text" placeholder="cache key">
+        <input class="form-control span4" id="set-cache-value-input" type="text" placeholder="cache value">
+        <input class="btn btn-default span4" type="submit" value="Set cache key-value pair">
+      </form>
+    </span>
+    <p class="span6" id="set-cache-result"></p>
+  </div>
+</div>
+
 <h3>Invalidation</h3>
 <div>
   <form class="form-horizontal" action="@com.keepit.controllers.admin.routes.AdminCacheController.clearLocalCaches()" method="GET">
@@ -42,6 +75,61 @@
 </p>
 
 <script>
+
+  (function() {
+    var getCacheResult = $('#get-cache-result');
+    var deleteCacheResult = $('#delete-cache-result');
+    var setCacheResult = $('#set-cache-result');
+
+    var getKeyInput = $('#get-cache-key-input');
+    $('.get-cache-form').on("submit", function() {
+      getCacheResult.text("Processing Request");
+      $.get('@com.keepit.controllers.admin.routes.AdminCacheController.getCacheEntry("__")'.replace("__", getKeyInput.val()))
+      .done(function(data, textStatus, xhr) {
+        if (xhr.status == 200) {
+          getCacheResult.text(getKeyInput.val() + "->" + data.key);
+          deleteCacheResult.text("");
+          setCacheResult.text("");
+        } else if (xhr.status == 204) {
+          // No Content (Cache entry does not exist)
+          getCacheResult.text("Cache key "+ getKeyInput.val() +" does not exist.");
+          deleteCacheResult.text("");
+          setCacheResult.text("");
+        }
+      });
+      return false;
+    });
+
+    var deleteKeyInput = $('#delete-cache-key-input');
+    $('.delete-cache-form').on('submit', function() {
+      $.ajax({
+        url: '@com.keepit.controllers.admin.routes.AdminCacheController.deleteCacheEntry("__")'.replace('__', deleteKeyInput.val()),
+        type: 'delete'
+      })
+      .done(function(data) {
+        getCacheResult.text("");
+        deleteCacheResult.text("Deleted: " + deleteKeyInput.val());
+        setCacheResult.text("");
+      })
+      return false;
+    });
+    var setCacheKey = $('#set-cache-key-input');
+    var setCacheValue = $('#set-cache-value-input');
+    $('.set-cache-form').on('submit', function() {
+      $.ajax({
+        url: '@com.keepit.controllers.admin.routes.AdminCacheController.setCacheEntry("__", "___")'.replace('__', setCacheKey.val()).replace('___', setCacheValue.val()),
+        type: 'put'
+      })
+      .done(function(data) {
+        getCacheResult.text("");
+        deleteCacheResult.text("");
+        setCacheResult.text("Set Cache Entry: " +setCacheKey.val() + "->" + setCacheValue.val());
+      });
+      return false;
+    });
+  })();
+
+
 
   var plugins = {
   "All Plugins": "Cache",

--- a/kifi-backend/modules/shoebox/app/views/admin/modifyCache.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/modifyCache.scala.html
@@ -1,0 +1,96 @@
+@()(implicit request: com.keepit.common.controller.UserRequest[_])
+
+@admin("Cache") {
+<div>
+    <div class="row-fluid span10">
+    <span class="span8">
+      <form class="form-horizontal get-cache-form" action="#">
+          <input id="get-cache-key-input" type="text" placeholder="cache key" class="form-control span8">
+          <input type="submit" value="Get cache value" class="btn btn-default span4">
+      </form>
+    </span>
+        <p class="span4" id="get-cache-result"></p>
+    </div>
+
+    <div class="row-fluid span10">
+    <span class="span8">
+      <form class="form-horizontal delete-cache-form" action="#">
+          <input class="form-control span8" id="delete-cache-key-input" type="text" placeholder="cache key">
+          <input class = "btn btn-default span4" type="submit" value="Delete key from cache">
+      </form>
+    </span>
+        <p class="span4" id="delete-cache-result"></p>
+    </div>
+
+    <div class="row-fluid span10">
+    <span class="span8">
+      <form class="form-horizontal set-cache-form" action="#">
+          <input class="form-control span3" id="set-cache-key-input" type="text" placeholder="cache key">
+          <input class="form-control span3" id="set-cache-value-input" type="text" placeholder="cache value">
+          <input class="form-control span3" id="set-cache-expiration-input" type="number" placeholder="expiration (s)">
+          <input class="btn btn-default span3" type="submit" value="Set cache key-value pair">
+      </form>
+    </span>
+        <p class="span4" id="set-cache-result"></p>
+    </div>
+</div>
+
+<script>
+      (function() {
+    var getCacheResult = $('#get-cache-result');
+    var deleteCacheResult = $('#delete-cache-result');
+    var setCacheResult = $('#set-cache-result');
+
+    var getKeyInput = $('#get-cache-key-input');
+    $('.get-cache-form').on("submit", function() {
+      getCacheResult.text("Processing Request");
+      $.get('@com.keepit.controllers.admin.routes.AdminCacheController.getCacheEntry("__")'.replace("__", getKeyInput.val()))
+      .done(function(data, textStatus, xhr) {
+        if (xhr.status == 200) {
+          getCacheResult.text(getKeyInput.val() + "->" + data.key);
+          deleteCacheResult.text("");
+          setCacheResult.text("");
+        } else if (xhr.status == 204) {
+          // No Content (Cache entry does not exist)
+          getCacheResult.text("Cache key "+ getKeyInput.val() +" does not exist.");
+          deleteCacheResult.text("");
+          setCacheResult.text("");
+        }
+      });
+      return false;
+    });
+
+    var deleteKeyInput = $('#delete-cache-key-input');
+    $('.delete-cache-form').on('submit', function() {
+      $.ajax({
+        url: '@com.keepit.controllers.admin.routes.AdminCacheController.deleteCacheEntry("__")'.replace('__', deleteKeyInput.val()),
+        type: 'delete'
+      })
+      .done(function(data) {
+        getCacheResult.text("");
+        deleteCacheResult.text("Deleted: " + deleteKeyInput.val());
+        setCacheResult.text("");
+      })
+      return false;
+    });
+    var setCacheKey = $('#set-cache-key-input');
+    var setCacheValue = $('#set-cache-value-input');
+    var setCacheExpiration = $('#set-cache-expiration-input');
+    $('.set-cache-form').on('submit', function() {
+      $.ajax({
+        url: '@com.keepit.controllers.admin.routes.AdminCacheController.setCacheEntry("__", "___", 11)'
+                .replace('__', setCacheKey.val())
+                .replace('___', setCacheValue.val())
+                .replace('11', setCacheExpiration.val()),
+        type: 'put'
+      })
+      .done(function(data) {
+        getCacheResult.text("");
+        deleteCacheResult.text("");
+        setCacheResult.text("Set Cache Entry: " +setCacheKey.val() + "->" + setCacheValue.val());
+      });
+      return false;
+    });
+  })();
+</script>
+}

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -697,9 +697,10 @@ GET     /admin/wti/triggerPush @com.keepit.controllers.admin.AdminWTIController.
 
 GET     /admin/ec2-instance         @com.keepit.controllers.admin.AmazonInstanceController.instanceInfo()
 GET     /admin/cache                @com.keepit.controllers.admin.AdminCacheController.serviceView
-GET     /admin/cache/entry  @com.keepit.controllers.admin.AdminCacheController.getCacheEntry(key: String)
-DELETE  /admin/cache/entry  @com.keepit.controllers.admin.AdminCacheController.deleteCacheEntry(key: String)
-PUT     /admin/cache/entry  @com.keepit.controllers.admin.AdminCacheController.setCacheEntry(key: String, value: String)
+GET     /admin/cache/modify     @com.keepit.controllers.admin.AdminCacheController.modifyCache
+GET     /admin/cache/modify/entry  @com.keepit.controllers.admin.AdminCacheController.getCacheEntry(key: String)
+DELETE  /admin/cache/modify/entry  @com.keepit.controllers.admin.AdminCacheController.deleteCacheEntry(key: String)
+PUT     /admin/cache/modify/entry  @com.keepit.controllers.admin.AdminCacheController.setCacheEntry(key: String, value: String, duration: Int)
 
 GET     /admin/cache/clearLocalCaches          @com.keepit.controllers.admin.AdminCacheController.clearLocalCaches(service: String ?= "all", prefix: String ?= "")
 GET     /admin/websocket            @com.keepit.controllers.admin.AdminWebSocketController.serviceView

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -697,6 +697,10 @@ GET     /admin/wti/triggerPush @com.keepit.controllers.admin.AdminWTIController.
 
 GET     /admin/ec2-instance         @com.keepit.controllers.admin.AmazonInstanceController.instanceInfo()
 GET     /admin/cache                @com.keepit.controllers.admin.AdminCacheController.serviceView
+GET     /admin/cache/entry  @com.keepit.controllers.admin.AdminCacheController.getCacheEntry(key: String)
+DELETE  /admin/cache/entry  @com.keepit.controllers.admin.AdminCacheController.deleteCacheEntry(key: String)
+PUT     /admin/cache/entry  @com.keepit.controllers.admin.AdminCacheController.setCacheEntry(key: String, value: String)
+
 GET     /admin/cache/clearLocalCaches          @com.keepit.controllers.admin.AdminCacheController.clearLocalCaches(service: String ?= "all", prefix: String ?= "")
 GET     /admin/websocket            @com.keepit.controllers.admin.AdminWebSocketController.serviceView
 


### PR DESCRIPTION
on page /admin/cache
- added 3 new forms to allow for get/delete/set key/value pairs in
  the cache

Looks like remove and set from the cache return Unit, so they only have success scenarios.
I also didn't think limiting the user to one request at a time was necessary as all of these operations should be immediate when done on a cache.

The only drawback to putting these forms on the cache overview page is that the cache overview page takes a while to load the graphs. It might be better to place them on their own page.

@stkem @andrewconner 
