### PR TITLE
changed Sendgrid username/password (now uses API key)

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
@@ -94,7 +94,7 @@ class EmailTemplateProcessorImpl @Inject() (
     templatesF.flatMap[ProcessedEmailResult] { templates =>
       val (htmlBody, textBody) = loadLayout(emailToSend, templates)
 
-      val personalEmailCategories = Seq(NotificationCategory.User.WELCOME, NotificationCategory.User.LIBRARY_INVITATION)
+      val personalEmailCategories = Seq(NotificationCategory.User.WELCOME, NotificationCategory.User.LIBRARY_INVITATION, NotificationCategory.NonUser.LIBRARY_INVITATION)
 
       val viaKifiSuffix = if (personalEmailCategories contains emailToSend.category) "" else " (via Kifi)"
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/mail/SendgridMailProvider.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/mail/SendgridMailProvider.scala
@@ -34,8 +34,8 @@ class SendgridMailProvider @Inject() (
 
   private class SMTPAuthenticator extends Authenticator {
     override def getPasswordAuthentication: PasswordAuthentication = {
-      val username = "fortytwo" //load from conf
-      val password = "keepemailsrunning"
+      val username = "apikey" //load from conf
+      val password = "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"
       new PasswordAuthentication(username, password)
     }
   }


### PR DESCRIPTION
@stkem also a minor patch to lib invites for non-users

tested in dev mode, sending welcome + reset password emails properly.
