### PR TITLE
Drop NormalizedURI.screenshot_updated_at, is_private, add should_have…

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/NormalizedURI.scala
@@ -27,7 +27,6 @@ case class NormalizedURI(
     urlHash: UrlHash,
     state: State[NormalizedURI] = NormalizedURIStates.ACTIVE,
     seq: SequenceNumber[NormalizedURI] = SequenceNumber.ZERO,
-    screenshotUpdatedAt: Option[DateTime] = None,
     restriction: Option[Restriction] = None,
     normalization: Option[Normalization] = None,
     redirect: Option[Id[NormalizedURI]] = None,
@@ -71,7 +70,6 @@ object NormalizedURI {
     (__ \ 'urlHash).format[String].inmap(UrlHash.apply, unlift(UrlHash.unapply)) and
     (__ \ 'state).format(State.format[NormalizedURI]).inmap(handleDeprecatedScrapeWantedState, identity[State[NormalizedURI]]) and
     (__ \ 'seq).format(SequenceNumber.format[NormalizedURI]) and
-    (__ \ 'screenshotUpdatedAt).formatNullable[DateTime] and
     (__ \ 'restriction).formatNullable[Restriction] and
     (__ \ 'normalization).formatNullable[Normalization] and
     (__ \ 'redirect).formatNullable(Id.format[NormalizedURI]) and
@@ -89,7 +87,7 @@ object NormalizedURI {
     state: State[NormalizedURI] = NormalizedURIStates.ACTIVE,
     normalization: Option[Normalization] = None): NormalizedURI = {
     if (normalizedUrl.size > URLFactory.MAX_URL_SIZE) throw new Exception(s"url size is ${normalizedUrl.size} which exceeds ${URLFactory.MAX_URL_SIZE}: $normalizedUrl")
-    NormalizedURI(title = title, url = normalizedUrl, urlHash = hashUrl(normalizedUrl), state = state, screenshotUpdatedAt = None, normalization = normalization)
+    NormalizedURI(title = title, url = normalizedUrl, urlHash = hashUrl(normalizedUrl), state = state, normalization = normalization)
   }
 }
 

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/329.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/329.sql
@@ -1,0 +1,11 @@
+# SHOEBOX
+
+# --- !Ups
+
+ALTER TABLE normalized_uri ADD COLUMN should_have_content boolean DEFAULT false;
+ALTER TABLE normalized_uri DROP COLUMN is_private;
+ALTER TABLE normalized_uri DROP COLUMN screenshot_updated_at;
+
+insert into evolutions (name, description) values('329.sql', 'add should_have_content column to normalized_uri, drop deprecated columns');
+
+# --- !Downs

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -385,8 +385,7 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, impli
       NormalizedURI(
         id = Some(Id[NormalizedURI](url.hashCode)),
         url = url.toString(),
-        urlHash = UrlHash(url.hashCode.toString),
-        screenshotUpdatedAt = None
+        urlHash = UrlHash(url.hashCode.toString)
       )
     }
     Future.successful(uri)

--- a/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeWorker.scala
+++ b/kifi-backend/modules/scraper/app/com/keepit/scraper/ScrapeWorker.scala
@@ -69,12 +69,6 @@ class ScrapeWorkerImpl @Inject() (
     }
   }
 
-  private def shouldUpdateScreenshot(uri: NormalizedURI) = {
-    uri.screenshotUpdatedAt exists { update =>
-      Days.daysBetween(currentDateTime.withTimeAtStartOfDay, update.withTimeAtStartOfDay).getDays >= 5
-    }
-  }
-
   private def needReIndex(latestUri: NormalizedURI, article: Article, signature: Signature, info: ScrapeInfo): Boolean = {
     def titleChanged = latestUri.title != Option(article.title)
     def scrapeFailed = latestUri.state == NormalizedURIStates.SCRAPE_FAILED


### PR DESCRIPTION
…_content
@andrewconner @eishay 
Doing some cleanup on NormalizedURI as I add a new column.
Will also drop `NormalizedURI.domain` (looks like the migration 41 has never been applied)
