### PR TITLE
Airbrake upgrade

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeModule.scala
@@ -23,6 +23,12 @@ case class ProdAirbrakeModule() extends AirbrakeModule {
   }
 
   @Provides
+  def jsonFormatter(playMode: Mode, service: FortyTwoServices, serviceDiscovery: ServiceDiscovery): JsonAirbrakeFormatter = {
+    val apiKey = Play.current.configuration.getString("airbrake.key").get
+    new JsonAirbrakeFormatter(apiKey, playMode, service, serviceDiscovery)
+  }
+
+  @Provides
   def airbrakeProvider(actor: ActorInstance[AirbrakeNotifierActor]): AirbrakeNotifier = {
     new AirbrakeNotifierImpl(actor, DiscoveryModule.isCanary)
   }
@@ -35,6 +41,11 @@ case class DevAirbrakeModule() extends AirbrakeModule {
   @Provides
   def formatter(playMode: Mode, service: FortyTwoServices, serviceDiscovery: ServiceDiscovery): AirbrakeFormatter = {
     new AirbrakeFormatter("fakeApiKey", playMode, service, serviceDiscovery)
+  }
+
+  @Provides
+  def jsonFormatter(playMode: Mode, service: FortyTwoServices, serviceDiscovery: ServiceDiscovery): JsonAirbrakeFormatter = {
+    new JsonAirbrakeFormatter("fakeApiKey", playMode, service, serviceDiscovery)
   }
 
   @Provides

--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeNotifier.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeNotifier.scala
@@ -8,6 +8,7 @@ import com.keepit.common.net._
 import com.keepit.common.service.FortyTwoServices
 import com.keepit.model.{ User, NotificationCategory }
 import com.keepit.common.mail.{ SystemEmailAddress, ElectronicMail }
+import play.api.Play
 
 import scala.concurrent.ExecutionContext
 
@@ -74,9 +75,8 @@ class AirbrakeSender @Inject() (
   systemAdminMailSender: SystemAdminMailSender)
     extends Logging {
 
-  // Where are these injected from?
-  val apiKey = "701215c3c9029a56df52250ce2c5750f"
-  val projectId = "91268"
+  val apiKey = Play.current.configuration.getString("airbrake.key").get
+  val projectId = Play.current.configuration.getString("airbrake.id").get
 
   var firstErrorReported = false
 

--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeNotifier.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeNotifier.scala
@@ -11,7 +11,7 @@ import com.keepit.common.mail.{ SystemEmailAddress, ElectronicMail }
 
 import scala.concurrent.ExecutionContext
 
-import play.api.libs.json.Json
+import play.api.libs.json.{ JsValue, JsObject, Json }
 
 import akka.actor._
 
@@ -24,7 +24,7 @@ object AirbrakeDeploymentNotice
 private[healthcheck] class AirbrakeNotifierActor @Inject() (
   airbrakeSender: AirbrakeSender,
   healthcheck: HealthcheckPlugin,
-  formatter: AirbrakeFormatter,
+  formatter: JsonAirbrakeFormatter,
   pagerDutySender: PagerDutySender)
     extends AlertingActor with Logging {
 
@@ -39,8 +39,8 @@ private[healthcheck] class AirbrakeNotifierActor @Inject() (
       try {
         if (error.panic) pagerDutySender.openIncident(error.message.getOrElse(error.exception.toString), error.exception, Some(error.signature.value))
         if (!error.aggregateOnly) {
-          val xml = formatter.format(error)
-          airbrakeSender.sendError(xml)
+          val json: JsValue = formatter.format(error)
+          airbrakeSender.sendError(json)
           val toLog = error.message.getOrElse(error.exception.toString)
           println(s"[airbrake] $toLog")
           log.error(s"[airbrake] $toLog")
@@ -74,6 +74,10 @@ class AirbrakeSender @Inject() (
   systemAdminMailSender: SystemAdminMailSender)
     extends Logging {
 
+  // Where are these injected from?
+  val apiKey = "701215c3c9029a56df52250ce2c5750f"
+  val projectId = "91268"
+
   var firstErrorReported = false
 
   val defaultFailureHandler: Request => PartialFunction[Throwable, Unit] = { url =>
@@ -101,6 +105,35 @@ class AirbrakeSender @Inject() (
       withTimeout(CallTimeouts(responseTimeout = Some(60000))).
       withHeaders("Content-type" -> "application/x-www-form-urlencoded").
       postTextFuture(DirectUrl("http://api.airbrake.io/deploys.txt"), payload, httpClient.ignoreFailure)
+  }
+
+  def sendError(json: JsValue): Unit = {
+    val futureResult = httpClient
+      .withHeaders("Content-Type" -> "application/json")
+      .withTimeout(CallTimeouts(responseTimeout = Some(60000)))
+      .postFuture(DirectUrl(s"https://airbrake.io/api/v3/projects/$projectId/notices?key=$apiKey"), json, defaultFailureHandler)
+    futureResult.onSuccess {
+      case res: ClientResponse =>
+        try {
+          val jsonRes = res.json
+          val id = (jsonRes \ "id").as[String]
+          val url = (jsonRes \ "url").as[String]
+          log.info(s"sent airbrake error $id, more info at $url: $json")
+          println(s"sent airbrake error $id, more info at $url: $json")
+        } catch {
+          case t: Throwable => {
+            pagerDutySender.openIncident("Airbrake Response Deserialization Error!", t, moreInfo = Some(res.body.take(1000)))
+            throw t
+          }
+        }
+    }
+
+    futureResult.onFailure {
+      case exception =>
+        log.info(s"error sending airbrake json: $json", exception)
+        exception.printStackTrace()
+        println(s"error sending airbrake json: $json")
+    }
   }
 
   def sendError(xml: NodeSeq): Unit = {

--- a/kifi-backend/modules/common/conf/application-dev.conf
+++ b/kifi-backend/modules/common/conf/application-dev.conf
@@ -222,6 +222,7 @@ include classpath("dev-akka-sync.conf")
 
 #its not used by default since we use a mock airbrake module in dev
 airbrake {
+  id = "91632"
   key = "72bef131737b4a9b2987f81735fa024b"
 }
 

--- a/kifi-backend/modules/common/conf/prod/abook.conf
+++ b/kifi-backend/modules/common/conf/prod/abook.conf
@@ -35,5 +35,6 @@ db.shoebox {
 }
 
 airbrake {
+  id = "92150"
   key = "9a0b8d722a37b844f6b514d9f121d879"
 }

--- a/kifi-backend/modules/common/conf/prod/c_shoebox.conf
+++ b/kifi-backend/modules/common/conf/prod/c_shoebox.conf
@@ -73,6 +73,7 @@ urban-airship {
 }
 
 airbrake {
+  id = "95271"
   key = "7bd46555f18444c907121c8f2fbac006"
 }
 

--- a/kifi-backend/modules/common/conf/prod/cortex.conf
+++ b/kifi-backend/modules/common/conf/prod/cortex.conf
@@ -39,5 +39,6 @@ db.shoebox {
 mixpanel.token = "cff752ff16ee39eda30ae01bb6fa3bd6"
 
 airbrake {
+  id = "97775"
   key = "385adca1bdfec1e0e97c7bbb72b1deb9"
 }

--- a/kifi-backend/modules/common/conf/prod/curator.conf
+++ b/kifi-backend/modules/common/conf/prod/curator.conf
@@ -55,5 +55,6 @@ db.shoeboxslave {
 mixpanel.token = "cff752ff16ee39eda30ae01bb6fa3bd6"
 
 airbrake {
+  id = "99522"
   key = "d1f2922ffc5e1cf0871d9f63e73cc81a"
 }

--- a/kifi-backend/modules/common/conf/prod/eliza.conf
+++ b/kifi-backend/modules/common/conf/prod/eliza.conf
@@ -56,5 +56,6 @@ mail-notifications {
 
 
 airbrake {
+  id = "91270"
   key = "b903a091b834929686b95673c23fcb0d"
 }

--- a/kifi-backend/modules/common/conf/prod/graph.conf
+++ b/kifi-backend/modules/common/conf/prod/graph.conf
@@ -24,5 +24,6 @@ graph {
 amazon.s3.graph.bucket = "graph-b-prod"
 
 airbrake {
+  id = "97986"
   key = "640761a2e98c83abb33d939b87479b24"
 }

--- a/kifi-backend/modules/common/conf/prod/heimdal.conf
+++ b/kifi-backend/modules/common/conf/prod/heimdal.conf
@@ -46,6 +46,7 @@ mongodb {
 mixpanel.token = "cff752ff16ee39eda30ae01bb6fa3bd6"
 
 airbrake {
+  id = "91826"
   key = "59fdb07051772d1278615aa2ae0df968"
 }
 

--- a/kifi-backend/modules/common/conf/prod/rover.conf
+++ b/kifi-backend/modules/common/conf/prod/rover.conf
@@ -43,6 +43,7 @@ amazon.s3.rover.bucket = "article-b-prod"
 # ~~~~~
 
 airbrake {
+  id = "109561"
   key = "4dda89c34b5b677bf145676ea3ae65fa"
 }
 

--- a/kifi-backend/modules/common/conf/prod/scraper.conf
+++ b/kifi-backend/modules/common/conf/prod/scraper.conf
@@ -13,6 +13,7 @@ statsd {
 }
 
 airbrake {
+  id = "93498"
   key = "51802b68d8c10ec2e806ed37bce4c429" 
 }
 

--- a/kifi-backend/modules/common/conf/prod/search.conf
+++ b/kifi-backend/modules/common/conf/prod/search.conf
@@ -37,5 +37,6 @@ index {
 search.temporary.directory = "../../search/temp"
 
 airbrake {
+  id = "91269"
   key = "2b96f538e70463004bdbb6077fd42fc1"
 }

--- a/kifi-backend/modules/common/conf/prod/shoebox.conf
+++ b/kifi-backend/modules/common/conf/prod/shoebox.conf
@@ -71,6 +71,7 @@ urban-airship {
 }
 
 airbrake {
+  id = "91268"
   key = "701215c3c9029a56df52250ce2c5750f"
 }
 

--- a/kifi-backend/modules/common/test/com/keepit/common/healthcheck/FakeAirbrakeModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/healthcheck/FakeAirbrakeModule.scala
@@ -23,6 +23,11 @@ case class FakeAirbrakeModule() extends AirbrakeModule {
   def formatter(playMode: Mode, service: FortyTwoServices, serviceDiscovery: ServiceDiscovery): AirbrakeFormatter = {
     new AirbrakeFormatter("fakeApiKey", Mode.Test, service, serviceDiscovery)
   }
+
+  @Provides
+  def jsonFormatter(playMode: Mode, service: FortyTwoServices, serviceDiscovery: ServiceDiscovery): JsonAirbrakeFormatter = {
+    new JsonAirbrakeFormatter("fakeApiKey", Mode.Test, service, serviceDiscovery)
+  }
 }
 
 @Singleton

--- a/kifi-backend/modules/common/test/com/keepit/common/healthcheck/JsonAirbrakeTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/healthcheck/JsonAirbrakeTest.scala
@@ -1,0 +1,97 @@
+package com.keepit.common.healthcheck
+
+import com.keepit.common.db.{ Id, ExternalId }
+import com.keepit.common.controller.ReportedException
+import com.keepit.common.time._
+import com.keepit.common.zookeeper._
+import com.keepit.test._
+import com.keepit.inject.FakeFortyTwoModule
+import com.keepit.common.actor._
+import org.joda.time.DateTime
+import org.specs2.mutable.Specification
+
+import javax.xml.transform.stream.StreamSource
+import javax.xml.validation.SchemaFactory
+import javax.xml.validation.{ Validator => JValidator }
+import java.io.StringReader
+
+import play.api.libs.json.{ JsArray, Json, JsValue }
+
+import scala.xml._
+import com.keepit.model.User
+
+class JsonAirbrakeTest extends Specification with CommonTestInjector {
+  "Json Airbrake Formatter" should {
+    val modules = Seq(FakeFortyTwoModule(), FakeDiscoveryModule())
+
+    "format to json" in {
+      withInjector(modules: _*) { implicit injector =>
+        val formatter = inject[JsonAirbrakeFormatter]
+        val error = new IllegalArgumentException("hi there", new Exception("middle thing", new IllegalStateException("its me")))
+        val json: JsValue = formatter.format(error)
+        (json \ "notifier" \ "name").as[String] === "S42"
+      }
+    }
+
+    "have an environment" in {
+      withInjector(modules: _*) { implicit injector =>
+        val formatter = inject[JsonAirbrakeFormatter]
+        val json = formatter.format(new Exception("There's an Error!"))
+        Option(json \ "environment") !== None
+      }
+    }
+
+    "have a context" in {
+      withInjector(modules: _*) { implicit injector =>
+        val formatter = inject[JsonAirbrakeFormatter]
+        val json = formatter.format(AirbrakeError(new Exception("There's an Error!"), userName = Some("test")))
+        Option(json \ "context") !== None
+      }
+    }
+
+    "populate fields for json correctly" in {
+      withInjector(modules: _*) { implicit injector =>
+        val error = AirbrakeError(exception = new Exception("There's an Error!"), message = Some("Message"),
+          userId = Some(Id[User](1234)), userName = Some("username"),
+          url = Some("url"), params = Map(), method = Some("GET"), headers = Map(),
+          id = ExternalId[AirbrakeError], createdAt = DateTime.now(), panic = false, aggregateOnly = false)
+
+        val formatter = inject[JsonAirbrakeFormatter]
+        val json = formatter.format(error)
+
+        val notifier = json \ "notifier"
+        (notifier \ "name").asOpt[String] === Some("S42")
+        (notifier \ "version").asOpt[String] === Some("0.0.2")
+        (notifier \ "url").asOpt[String] === Some("https://admin.kifi.com/admin")
+
+        val errors = json \ "errors"
+        errors must haveClass[JsArray]
+
+        val context = json \ "context"
+        (context \ "userName").asOpt[String] === Some("username")
+        (context \ "userId").asOpt[String] === Some("1234")
+        (context \ "userEmail").asOpt[String] === None
+      }
+    }
+
+    "json formatter does not change message" in {
+      withInjector(modules: _*) { implicit injector =>
+        val error = AirbrakeError(exception = new Exception("There's an Error!"), message = Some("Message"))
+
+        val formatter = inject[JsonAirbrakeFormatter]
+        val json = formatter.format(error)
+        ((json \ "errors")(0) \ "message").asOpt[String] === Some("[0L]Message java.lang.Exception: There's an Error!")
+      }
+    }
+
+    "clean json formatter" in {
+      withInjector(modules: _*) { implicit injector =>
+        val formatter = inject[JsonAirbrakeFormatter]
+        val error = AirbrakeError(message = Some("Execution exception in null:null"), exception = new IllegalArgumentException("hi there"))
+        val json = formatter.format(error)
+        ((json \ "errors")(0) \ "message").asOpt[String] === Some("[0L] java.lang.IllegalArgumentException: hi there")
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Updates airbrake to version 3

I tried to keep the functionality the same as the previous version, just upgrading from the deprecated v2 xml notifier to a more current json notifier.

I wasn't quite sure where to inject the apiKey and projectId from as I couldn't find the module that was declaring the AirbrakeSender (so I just hardcoded those two fields :( )

I went with using case classes and Json.format[T] to build my objects and have a rigidly defined structure according to the airbrake v3 docs.

@stkem @andrewconner
