### PR TITLE
Admin Cache fix

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminCacheController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminCacheController.scala
@@ -29,7 +29,7 @@ class AdminCacheController @Inject() (
 
   def getCacheEntry(key: String) = AdminUserAction { implicit request =>
     memcachedCache.get(key) match {
-      case Some(value) => Ok(Json.obj(key -> value.toString))
+      case Some(value) => Ok(value.toString)
       case _ => NoContent
     }
   }

--- a/kifi-backend/modules/shoebox/app/views/admin/modifyCache.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/modifyCache.scala.html
@@ -47,7 +47,7 @@
       $.get('@com.keepit.controllers.admin.routes.AdminCacheController.getCacheEntry("__")'.replace("__", getKeyInput.val()))
       .done(function(data, textStatus, xhr) {
         if (xhr.status == 200) {
-          getCacheResult.text(getKeyInput.val() + "->" + data.key);
+          getCacheResult.text(getKeyInput.val() + "->" + data);
           deleteCacheResult.text("");
           setCacheResult.text("");
         } else if (xhr.status == 204) {


### PR DESCRIPTION
We currently return {key : value} as a json object, the key being
whatever the actual key is. We were getting undefined for data.key from the admin cache page.
Since we already know what the key is, just return the value.

@stkem @andrewconner 
