### PR TITLE
cortex update with new uri format (step 1)

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/330.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/330.sql
@@ -1,0 +1,9 @@
+# CORTEX
+
+# --- !Ups
+
+ALTER TABLE cortex_uri ADD COLUMN should_have_content boolean DEFAULT false;
+
+insert into evolutions (name, description) values('330.sql', 'add should_have_content to cortex_uri');
+
+# --- !Downs

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/article/CortexArticleProvider.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/article/CortexArticleProvider.scala
@@ -9,7 +9,7 @@ import com.keepit.search.ArticleStore
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-@ImplementedBy(classOf[StoreBasedArticleProvider])
+@ImplementedBy(classOf[RoverArticleProvider])
 trait CortexArticleProvider {
   def getArticle(uriId: Id[NormalizedURI]): Option[CortexArticle]
 }

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/CortexDataIngestionPlugin.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/CortexDataIngestionPlugin.scala
@@ -41,7 +41,7 @@ private class CortexDataIngestionPluginImpl @Inject() (
   val name: String = getClass.toString
 
   override def onStart() {
-    scheduleTaskOnOneMachine(actor.system, 55 seconds, 1 minute, actor.ref, UpdateURI, UpdateURI.getClass.getSimpleName)
+    //scheduleTaskOnOneMachine(actor.system, 55 seconds, 1 minute, actor.ref, UpdateURI, UpdateURI.getClass.getSimpleName)
     scheduleTaskOnOneMachine(actor.system, 57 seconds, 1 minute, actor.ref, UpdateKeep, UpdateKeep.getClass.getSimpleName)
     scheduleTaskOnOneMachine(actor.system, 59 seconds, 1 minute, actor.ref, UpdateLibrary, UpdateLibrary.getClass.getSimpleName)
     scheduleTaskOnOneMachine(actor.system, 61 seconds, 1 minute, actor.ref, UpdateLibraryMembership, UpdateLibraryMembership.getClass.getSimpleName)

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/CortexURI.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/CortexURI.scala
@@ -18,7 +18,8 @@ case class CortexURI(
     updatedAt: DateTime = currentDateTime,
     uriId: Id[NormalizedURI],
     state: State[CortexURI],
-    seq: SequenceNumber[CortexURI]) extends ModelWithState[CortexURI] with ModelWithSeqNumber[CortexURI] {
+    seq: SequenceNumber[CortexURI],
+    shouldHaveContent: Boolean = false) extends ModelWithState[CortexURI] with ModelWithSeqNumber[CortexURI] {
   def withId(id: Id[CortexURI]): CortexURI = copy(id = Some(id))
   def withUpdateTime(now: DateTime): CortexURI = copy(updatedAt = now)
 }
@@ -27,14 +28,5 @@ object CortexURI {
   implicit def fromURIState(state: State[NormalizedURI]): State[CortexURI] = State[CortexURI](state.value)
   implicit def fromURISeq(seq: SequenceNumber[NormalizedURI]): SequenceNumber[CortexURI] = SequenceNumber[CortexURI](seq.value)
 
-  implicit def format = (
-    (__ \ 'id).formatNullable(Id.format[CortexURI]) and
-    (__ \ 'createdAt).format(DateTimeJsonFormat) and
-    (__ \ 'updatedAt).format(DateTimeJsonFormat) and
-    (__ \ 'uriId).format(Id.format[NormalizedURI]) and
-    (__ \ 'state).format(State.format[CortexURI]) and
-    (__ \ 'seq).format(SequenceNumber.format[CortexURI])
-  )(CortexURI.apply, unlift(CortexURI.unapply))
-
-  def fromURI(uri: NormalizedURI): CortexURI = CortexURI(uriId = uri.id.get, state = uri.state, seq = uri.seq)
+  def fromURI(uri: NormalizedURI): CortexURI = CortexURI(uriId = uri.id.get, state = uri.state, seq = uri.seq, shouldHaveContent = uri.shouldHaveContent)
 }

--- a/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/CortexURIRepo.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/cortex/dbmodel/CortexURIRepo.scala
@@ -29,7 +29,8 @@ class CortexURIRepoImpl @Inject() (
 
   class CortexURITable(tag: Tag) extends RepoTable[CortexURI](db, tag, "cortex_uri") with SeqNumberColumn[CortexURI] {
     def uriId = column[Id[NormalizedURI]]("uri_id")
-    def * = (id.?, createdAt, updatedAt, uriId, state, seq) <> ((CortexURI.apply _).tupled, CortexURI.unapply _)
+    def shouldHaveContent = column[Boolean]("should_have_content")
+    def * = (id.?, createdAt, updatedAt, uriId, state, seq, shouldHaveContent) <> ((CortexURI.apply _).tupled, CortexURI.unapply _)
   }
 
   def table(tag: Tag) = new CortexURITable(tag)


### PR DESCRIPTION
@leogrim @stkem 

keynote:
- sql table augmentation
- updated `CortexURI`
- tmp disabled URI syncing from shoebox. (plan to reset seqNum and re-enable)
- using rover client as article fetcher
