### PR TITLE
deprecating routeService, introducing net

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -39,8 +39,7 @@ angular.module('kifi', [
     origin: origin,
     navBase: navOrigin,
     xhrBase: navOrigin + '/site',
-    xhrBaseEliza: navOrigin.replace('www', 'eliza') + '/eliza/site',
-    xhrBaseSearch: navOrigin.replace('www', 'search'),
+    xhrBaseSearch: navOrigin.replace('www', 'search') + '/site',
     picBase: (local ? '//d1scct5mnc9d9m' : '//djty7jcqog9qu') + '.cloudfront.net'
   };
 }()))

--- a/kifi-backend/modules/shoebox/angular/src/common/services/mixpanelService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/mixpanelService.js
@@ -17,17 +17,16 @@
       $analyticsProvider.settings.pageTracking.autoTrackVirtualPages = false;
     }
   ])
-  .run(['$window', '$log', 'profileService', '$http', 'env',
-    function (_$window_, _$log_, _profileService_, _$http_, _env_) {
+  .run(['$window', '$log', 'profileService', 'net',
+    function (_$window_, _$log_, _profileService_, _net_) {
       $window = _$window_;
       $log = _$log_;
       profileService = _profileService_;
-      $http = _$http_;
-      env = _env_;
+      net = _net_;
     }
   ]);
 
-  var $window, $log, profileService, $http, env;  // injected before any code below runs
+  var $window, $log, profileService, net;  // injected before any code below runs
   var identifiedViewEventQueue = [];
   var userId;
 
@@ -39,7 +38,7 @@
   };
 
   function trackEventThroughProxy(event, properties)  {
-    return $http.post(env.xhrBase + '/events', [{
+    return net.event([{
       'event': event,
       'properties': properties
     }]);

--- a/kifi-backend/modules/shoebox/angular/src/common/services/net.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/net.js
@@ -1,0 +1,60 @@
+'use strict';
+
+angular.module('kifi')
+
+.factory('net', [
+  'env', '$http',
+  function (env, $http) {
+    var shoebox = env.xhrBase;
+    var search = env.xhrBaseSearch;
+    var pathParamRe = /(:\w+)/;
+
+    var get = angular.bind(null, http, 'GET');    // caller should pass any path params and then, optionally, a query params object
+    var post = angular.bind(null, http, 'POST');  // caller should pass any path params, optional post data (JSON), and an optional query params object
+    var del = angular.bind(null, http, 'DELETE'); // caller should pass any path params and then, optionally, a query params object
+
+    return {
+      event: post(shoebox, '/events'),
+
+      getKeep: get(shoebox, '/keeps/:id'),
+      addKeepsToLibrary: post(shoebox, '/libraries/:id/keeps'),
+      copyKeepsToLibrary: post(shoebox, '/libraries/copy'),
+      moveKeepsToLibrary: post(shoebox, '/libraries/move'),
+      removeKeepFromLibrary: del(shoebox, '/libraries/:id/keeps/:keepId'),
+      removeManyKeepsFromLibrary: post(shoebox, '/libraries/:id/keeps/delete'),
+
+      search: {
+        search: get(search, '/search'),
+        searched: post(search, '/search/events/searched'),
+        resultClicked: post(search, '/search/events/resultClicked')
+      }
+    };
+
+    function http(method, base, pathSpec) {
+      var pathParts = pathSpec.split(pathParamRe);
+      return function () {
+        var path = constructPath(pathParts, arguments);
+        var i = (pathParts.length - 1) / 2;
+        var data = method === 'POST' ? arguments[i++] : undefined;
+        var params = arguments[i++];
+        return $http({
+          method: method,
+          url: base + path,
+          params: params,
+          data: data
+        });
+      };
+    }
+
+    function constructPath(pathParts, args) {
+      if (pathParts.length === 1) {
+        return pathParts[0];
+      }
+      var parts = pathParts.slice();
+      for (var i = 1; i < pathParts.length; i += 2) {
+        parts[i] = args[(i - 1) / 2];
+      }
+      return parts.join('');
+    }
+  }
+]);

--- a/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/routeService.js
@@ -2,15 +2,13 @@
 
 angular.module('kifi')
 
+// DEPRECATED. Use the 'net' service instead.
+
 .factory('routeService', [
   'env', 'URI',
   function (env, URI) {
     function route(path, params) {
       return env.xhrBase + path + (params ? URI.formatQueryString(params) : '');
-    }
-
-    function searchRoute(path, params) {
-      return env.xhrBaseSearch + path + (params ? URI.formatQueryString(params) : '');
     }
 
     function navRoute(path, params) {
@@ -43,9 +41,6 @@ angular.module('kifi')
       userBiography: route('/user/me/biography'),
       formatPicUrl: function (userId, pictureName, size) {
         return env.picBase + '/users/' + userId + '/pics/' + (size || 200) + '/' + pictureName;
-      },
-      getKeep: function (keepId) {
-        return route('/keeps/' + keepId);
       },
 
       ////////////////////////////
@@ -82,12 +77,6 @@ angular.module('kifi')
       hideUserRecommendation: function (id) {
         return route('/user/' + id + '/hide');
       },
-      search: function (params) {
-        return searchRoute('/site/search', params);
-      },
-      searchResultClicked: searchRoute('/site/search/events/resultClicked'),
-      searchedAnalytics: searchRoute('/site/search/events/searched'),
-      searchResultClickedAnalytics: searchRoute('/site/search/events/resultClicked'),
       socialSearch: function (name, limit) {
         return route('/user/connections/all/search', {
           query: name,
@@ -124,21 +113,6 @@ angular.module('kifi')
       },
       basicUserInfo: function (id, friendCount) {
         return route('/user/' + id, {friendCount: friendCount ? 1 : []});
-      },
-      addKeepsToLibrary: function (libraryId) {
-        return route('/libraries/' + libraryId + '/keeps');
-      },
-      copyKeepsToLibrary: function () {
-        return route('/libraries/copy');
-      },
-      moveKeepsToLibrary: function () {
-        return route('/libraries/move');
-      },
-      removeKeepFromLibrary: function (libraryId, keepId) {
-        return route('/libraries/' + libraryId + '/keeps/' + keepId);
-      },
-      removeManyKeepsFromLibrary: function (libraryId) {
-        return route('/libraries/' + libraryId + '/keeps/delete');
       },
       saveKeepNote: function (libraryId, keepId) {
         return route('/libraries/' + libraryId + '/keeps/' + keepId + '/note');

--- a/kifi-backend/modules/shoebox/angular/src/header/searchSuggest.js
+++ b/kifi-backend/modules/shoebox/angular/src/header/searchSuggest.js
@@ -196,15 +196,15 @@ angular.module('kifi')
 ])
 
 .factory('searchSuggestService', [
-  'Clutch', '$http', 'routeService',
-  function (Clutch, $http, routeService) {
+  'Clutch', 'net',
+  function (Clutch, net) {
     function getData(res) {
       return res.data;
     }
 
     var clutch = new Clutch(function (q, libraryId) {
       var params = {q: q, l: libraryId || [], maxUsers: 3, maxLibraries: 3, maxUris: 3, is: '88x72'};
-      return $http.get(routeService.search(params)).then(getData);
+      return net.search.search(params).then(getData);
     }, {cacheDuration: 15000});
 
     return {

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keepActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keepActionService.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .factory('keepActionService', [
-  '$analytics', '$http', '$location', 'libraryService', 'routeService',
-  function ($analytics, $http, $location, libraryService, routeService) {
+  '$analytics', '$location', 'net', 'libraryService',
+  function ($analytics, $location, net, libraryService) {
 
     function sanitizeUrl(url) {
       var regex = /^[a-zA-Z]+:\/\//;
@@ -31,8 +31,7 @@ angular.module('kifi')
         })
       };
 
-      var url = routeService.addKeepsToLibrary(libraryId);
-      return $http.post(url, data, {}).then(function (res) {
+      return net.addKeepsToLibrary(libraryId, data).then(function (res) {
         libraryService.rememberRecentId(libraryId);
 
         _.uniq(res.data.keeps, function (keep) {
@@ -56,8 +55,7 @@ angular.module('kifi')
         keeps: keepIds
       };
 
-      var url = routeService.copyKeepsToLibrary();
-      return $http.post(url, data, {}).then(function (res) {
+      return net.copyKeepsToLibrary(data).then(function (res) {
         libraryService.rememberRecentId(libraryId);
 
         _.uniq(res.data.keeps, function (keep) {
@@ -81,8 +79,7 @@ angular.module('kifi')
         keeps: keepIds
       };
 
-      var url = routeService.moveKeepsToLibrary();
-      return $http.post(url, data, {}).then(function (res) {
+      return net.moveKeepsToLibrary(data).then(function (res) {
         libraryService.rememberRecentId(libraryId);
 
         _.uniq(res.data.keeps, function (keep) {
@@ -97,29 +94,22 @@ angular.module('kifi')
     // keep information we need to display it. This function fetches that
     // information.
     function fetchFullKeepInfo(keep) {
-      var url = routeService.getKeep(keep.id);
-      var config = {
-        params: { withFullInfo: true }
-      };
-
-      return $http.get(url, config).then(function (result) {
+      return net.getKeep(keep.id, {withFullInfo: true}).then(function (result) {
         return _.assign(keep, result.data);
       });
     }
 
     function unkeepFromLibrary(libraryId, keepId) {
       libraryService.expireKeepsInLibraries();
-      var url = routeService.removeKeepFromLibrary(libraryId, keepId);
-      return $http.delete(url);  // jshint ignore:line
+      return net.removeKeepFromLibrary(libraryId, keepId);
     }
 
     function unkeepManyFromLibrary(libraryId, keeps) {
       libraryService.expireKeepsInLibraries();
-      var url = routeService.removeManyKeepsFromLibrary(libraryId);
       var data = {
         'ids': _.pluck(keeps, 'id')
       };
-      return $http.post(url, data);
+      return net.removeManyKeepsFromLibrary(libraryId, data);
     }
 
     var api = {

--- a/kifi-backend/modules/shoebox/angular/test/unit/common/services/net.spec.js
+++ b/kifi-backend/modules/shoebox/angular/test/unit/common/services/net.spec.js
@@ -1,0 +1,54 @@
+'use strict';
+
+describe('net', function () {
+
+  beforeEach(module('kifi'));
+  beforeEach(module(function ($provide) {
+    $provide.value('$http', function (o) { return o; });
+  }));
+
+  var net, env;
+  beforeEach(inject(function (_net_, _env_) {
+    net = _net_;
+    env = _env_;
+  }));
+
+  describe('net.event', function () {
+    it('issues a POST request', function () {
+      var eventData = {type: 'foo', a: 0, b: true};
+      expect(net.event(eventData)).toEqual({
+        method: 'POST',
+        url: env.xhrBase + '/events',
+        params: undefined,
+        data: eventData
+      });
+    });
+  });
+
+  describe('net.removeKeepFromLibrary', function () {
+    it('issues a DELETE request', function () {
+      var libraryId = 'l5B4wZ0GoRWb';
+      var keepId = '8bcca8c5-d1a7-47d0-9f69-f8f58305779f';
+      expect(net.removeKeepFromLibrary(libraryId, keepId)).toEqual({
+        method: 'DELETE',
+        url: env.xhrBase + '/libraries/' + libraryId + '/keeps/' + keepId,
+        params: undefined,
+        data: undefined
+      });
+    });
+  });
+
+  describe('net.search.search', function () {
+    it('issues a GET request', function () {
+      // Note: Angular omits a parameter from the query string if its value is [] (an empty array)
+      var params = {q: 'dogfood', l: [], maxUsers: 3, maxLibraries: 3, maxUris: 3, is: '88x72'};
+      expect(net.search.search(params)).toEqual({
+        method: 'GET',
+        url: env.xhrBaseSearch + '/search',
+        params: params,
+        data: undefined
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
cc @andrewconner @ahsu1230 @stkem 

The way we’ve been doing things with `routeService` is cumbersome:
1. While URLs are specified in routeService, their HTTP methods are specified elsewhere.
2. Users of `routeService` have to inject `$http` too.

Hence this new `net` service.
