### PR TITLE
removing empty keeper attribution above search result from "others" only

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.styl
@@ -1,19 +1,25 @@
-keepRectBorderRadius = 4px
+keepBorderRadius = 8px // from keeps.styl
+keepRectBorderRadius = 4px // inner "page" box
 keepFooterMarginTop = 16px
-eeeTransparentBlack = rgba(0,0,0,.065)  // makes #eee over white
-maxWidthForNarrowKeep = 561px // see derivation in keeps.styl
+eeeOverlay = rgba(0,0,0,.065)  // makes #eee over white
+defaultBorderColorOverlay = rgba(0,0,60,.141)  // makes #dadae2 (defaultBorderColor) over white
+defaultBorderColorOverEee = rgba(0,0,100,.08)  // makes #dadae2 (defaultBorderColor) over #eee
+maxWidthForNarrowKeep = 559px // see derivation in keeps.styl
 minWidthForBoxed = maxWidthForNarrowKeep + 1px
 
 .kf-keep-body
   &.kf-side-by-side
   &.kf-text-only
-    border-top: 1px solid eeeTransparentBlack
+    border-top: 1px solid eeeOverlay
+
+    .kf-keep-top:empty+&
+      border-top: 0
 
   @media (min-width: minWidthForBoxed)
     &.kf-boxed
       border-top: 0
       border-radius: keepRectBorderRadius
-      box-shadow: 0 1px 2px rgba(0,0,0,.05), inset 0 0 0 1px eeeTransparentBlack
+      box-shadow: 0 1px 2px rgba(0,0,0,.05), inset 0 0 0 1px eeeOverlay
 
       &:not(.kf-side-by-side) // increasing top border-radius to ensure box-shadow does not bleed through corners of image/video
         border-radius: (keepRectBorderRadius + 2px) (keepRectBorderRadius + 2px) keepRectBorderRadius keepRectBorderRadius
@@ -24,10 +30,7 @@ minWidthForBoxed = maxWidthForNarrowKeep + 1px
   .kf-side-by-side>&
     overflow: hidden
 
-faintEdgeOverlaysUsingBoxShadow() // provides subtle boundary for white image/video
-  box-shadow: inset 0 0 0 1px eeeTransparentBlack
-
-faintTopAndBottomEdgeOverlaysUsingPseudos() // provides subtle boundary for white image/video
+defaultBorderColorOverlayUsingBefore(borderWidth)  // slightly darkens an image's transparent edge overlays
   position: relative
   &::before
     content: ''
@@ -35,43 +38,45 @@ faintTopAndBottomEdgeOverlaysUsingPseudos() // provides subtle boundary for whit
     top: 0
     left: 0
     right: 0
-    border-top: 1px solid eeeTransparentBlack
-  &::after
-    content: ''
-    position: absolute
-    left: 0
-    right: 0
     bottom: 0
-    border-bottom: 1px solid eeeTransparentBlack
+    border: solid defaultBorderColorOverEee
+    border-width: borderWidth
+    border-radius: '%s' % inherit
 
 .kf-keep-image
   display: block
+  margin: 0 -1px // cover container's 1px side borders
   padding-top: 56.25%  // enforcing 16:9 ratio, like kf-keep-video
   background-size: cover
   background-position: center
+  box-shadow: inset 0 0 0 1px eeeOverlay // provides subtle boundary for white image
 
   :not(.kf-boxed):not(.kf-side-by-side)>&
-    faintTopAndBottomEdgeOverlaysUsingPseudos()
+    defaultBorderColorOverlayUsingBefore(0 1px)
 
-  @media (max-width: (minWidthForBoxed - 1px))
-    faintTopAndBottomEdgeOverlaysUsingPseudos()
+  .kf-boxed:not(.kf-side-by-side)>&
+    @media (max-width: (minWidthForBoxed - 1px))
+      .kf-keep-top:not(:empty)+&  // keeper above
+        defaultBorderColorOverlayUsingBefore(0 1px)
 
-  @media (min-width: minWidthForBoxed)
-    .kf-boxed:not(.kf-side-by-side)>&
+      .kf-keep-top:empty+&  // no keeper above
+        defaultBorderColorOverlayUsingBefore(1px 1px 0)
+        border-radius: keepBorderRadius keepBorderRadius 0 0
+        margin-top: -1px // cover container's 1px top border
+
+    @media (min-width: minWidthForBoxed)
       border-radius: keepRectBorderRadius keepRectBorderRadius 0 0
-
-    .kf-boxed>&
-      faintEdgeOverlaysUsingBoxShadow()
+      margin: 0
 
   .kf-side-by-side>&
     float: left
     margin: 16px 0 keepFooterMarginTop 20px
-    faintEdgeOverlaysUsingBoxShadow()
 
   &.kf-bottom-clip
     background-position: center top
 
 .kf-keep-video
+  margin: 0 -1px // cover container's 1px side borders
   position: relative
 
   &::before
@@ -83,17 +88,35 @@ faintTopAndBottomEdgeOverlaysUsingPseudos() // provides subtle boundary for whit
     content: ''
     position: absolute
     top: 0
-    left: 0
-    right: 0
+    left: 1px // avoiding overlap with side overlays
+    right: 1px
     height: 0
-    border: solid eeeTransparentBlack
+    border: solid eeeOverlay
     border-width: 1px 0 0
+    border-radius: '%s' % inherit
 
-  @media (min-width: minWidthForBoxed)
-    .kf-boxed>&::after
-      height: keepRectBorderRadius
+  .kf-boxed>&
+    @media (max-width: (minWidthForBoxed - 1px))
+      .kf-keep-top:empty+&  // no keeper above
+        margin-top: -1px // cover container's 1px top border
+        border-radius: keepBorderRadius keepBorderRadius 0 0
+
+        &::after
+          left: 0
+          right: 0
+          height: keepBorderRadius
+          border-width: 1px 1px 0
+          border-color: defaultBorderColorOverlay
+
+    @media (min-width: minWidthForBoxed)
       border-radius: keepRectBorderRadius keepRectBorderRadius 0 0
-      border-width: 1px 1px 0
+      margin: 0
+
+      &::after
+        left: 0
+        right: 0
+        height: keepRectBorderRadius
+        border-width: 1px 1px 0
 
 .kf-youtube
   position: absolute
@@ -103,25 +126,43 @@ faintTopAndBottomEdgeOverlaysUsingPseudos() // provides subtle boundary for whit
   bottom: 0
   cursor: pointer
 
-  @media (min-width: minWidthForBoxed)
-    .kf-boxed &
+  .kf-boxed &
+    @media (max-width: (minWidthForBoxed - 1px))
+      .kf-keep-top:empty+&  // no keeper above
+        border-radius: keepBorderRadius keepBorderRadius 0 0
+        overflow: hidden
+
+    @media (min-width: minWidthForBoxed)
       border-radius: keepRectBorderRadius keepRectBorderRadius 0 0
       overflow: hidden
 
-      &::before  // faint left/right border overlays to provide shape to white videos
-      &::after
-        content: ''
-        position: absolute
-        z-index: 1
-        top: keepRectBorderRadius + 1px  // avoiding overlap with top
-        bottom: 1px  // avoiding overlap with bottom
-        width: 0
+  &::before  // faint left/right border overlays to provide shape to white videos
+  &::after
+    content: ''
+    position: absolute
+    z-index: 1
+    top: 0
+    bottom: 0
+    width: 0
+  &::before
+    left: 0
+    border-left: 1px solid defaultBorderColorOverlay
+  &::after
+    right: 0
+    border-right: 1px solid defaultBorderColorOverlay
+
+  .kf-boxed &
+    @media (max-width: (minWidthForBoxed - 1px))
+      .kf-keep-top:empty+&  // no keeper above
+        &::before
+        &::after
+          top: keepBorderRadius + 1px  // avoiding overlap with top
+
+    @media (min-width: minWidthForBoxed)
       &::before
-        left: 0
-        border-left: 1px solid eeeTransparentBlack
       &::after
-        right: 0
-        border-right: 1px solid eeeTransparentBlack
+        top: keepRectBorderRadius + 1px  // avoiding overlap with top
+        border-color: eeeOverlay
 
 .kf-youtube-iframe
   background-color: #000
@@ -132,9 +173,9 @@ faintTopAndBottomEdgeOverlaysUsingPseudos() // provides subtle boundary for whit
 .kf-youtube-bottom-overlay
   position: absolute
   bottom: 0
-  left: 0
-  right: 0
-  border-bottom: 1px solid eeeTransparentBlack
+  left: 1px // avoiding overlap with side overlays
+  right: 1px
+  border-bottom: 1px solid eeeOverlay
 
 .kf-youtube-img
   width: 100%

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.styl
@@ -2,7 +2,7 @@ keepBorderWidth = 1px
 keepBorderRadius = 8px
 keepSidePad = 20px
 keepCardMaxWidth = 496px  // chosen to make youtube videos (16:9 aspect ratio) come out to whole pixels, 496x279
-maxWidthForNarrowKeep = keepCardMaxWidth + 2 * (keepSidePad + keepBorderWidth + appSidePad1) - 1 // = 561px
+maxWidthForNarrowKeep = keepCardMaxWidth + 2 * (keepSidePad + appSidePad1) - 1 // = 559px
 
 .kf-main-keeps
   position: relative
@@ -28,7 +28,7 @@ maxWidthForNarrowKeep = keepCardMaxWidth + 2 * (keepSidePad + keepBorderWidth + 
   background-color: white
 
   @media (max-width: maxWidthForNarrowKeep)
-    max-width: 2 * keepBorderWidth + keepCardMaxWidth
+    max-width: keepCardMaxWidth
 
 .kf-keep-selection-tools
   border-radius: 0 keepBorderRadius keepBorderRadius keepBorderRadius
@@ -89,7 +89,7 @@ maxWidthForNarrowKeep = keepCardMaxWidth + 2 * (keepSidePad + keepBorderWidth + 
 .kf-keep
   position: relative
   border-radius: keepBorderRadius
-  padding: 20px keepSidePad
+  padding: 0 keepSidePad 20px
 
   &.detailed
     background-color: #eff2f7
@@ -115,7 +115,6 @@ maxWidthForNarrowKeep = keepCardMaxWidth + 2 * (keepSidePad + keepBorderWidth + 
     border-top-left-radius: 0
 
   @media (max-width: maxWidthForNarrowKeep)
-    padding-top: 12px
     padding-bottom: 0
 
     &>.kf-keep-body
@@ -145,12 +144,20 @@ maxWidthForNarrowKeep = keepCardMaxWidth + 2 * (keepSidePad + keepBorderWidth + 
 
 .kf-keep-top
   display: table
-  width: 100%
-  margin-bottom: 16px
   table-layout: fixed
+  width: 100%
+  padding-top: 16px
+  margin-bottom: 16px
+
+  &:empty
+    padding-top: 4px
 
   @media (max-width: maxWidthForNarrowKeep)
+    padding-top: 12px
     margin-bottom: 12px
+
+    &:empty
+      display: none
 
 .kf-keep-top-menu-container
   position: absolute

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.tpl.html
@@ -49,8 +49,8 @@
         </menu>
       </div>
       <div class="kf-keep-top">
-        <a class="kf-keep-keeper-pic" ng-href="{{::keep.user|profileUrl}}" ng-attr-style="background-image:url({{::keep.user|pic:100}})"></a>
-        <div class="kf-keep-top-r">
+        <a class="kf-keep-keeper-pic" ng-if="::keep.user" ng-href="{{::keep.user|profileUrl}}" ng-attr-style="background-image:url({{::keep.user|pic:100}})"></a>
+        <div class="kf-keep-top-r" ng-if="::keep.user">
           <a class="kf-keep-keeper-name" ng-href="{{::keep.user|profileUrl}}">{{::keep.user|name}}</a>
           <div class="kf-keep-time">
             <time ng-attr-datetime="{{::keep.createdAt}}" am-time-ago="::keep.createdAt" title="{{::keep.createdAt|localTime}}" ng-if="::keep.createdAt"></time>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/suggestedSearches.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/suggestedSearches.styl
@@ -1,6 +1,6 @@
 .kf-lss
   border-radius: 10px
-  border: 1px solid #dadae2
+  border: defaultBorder
   padding: 10px 16px
   background: #fff
   margin-bottom: 15px

--- a/kifi-backend/modules/shoebox/angular/src/recos/recoLibraryCard.styl
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recoLibraryCard.styl
@@ -1,7 +1,8 @@
 .kf-rcl
   margin-bottom: 10px
 
-rcl-side-pad = 20px
+rclSidePad = 20px
+rclSideBorderWidth = 1px // from defaultBorder
 
 .kf-rcl-color
   height: 3px
@@ -10,12 +11,12 @@ rcl-side-pad = 20px
   &.kf-above-image
     transform: scale(1,2)
     transform-origin: center bottom
-    margin: 0 (-(rcl-side-pad))
+    margin: 0 (-(rclSidePad + rclSideBorderWidth))
 
 .kf-rcl-cover-image
   display: block
   height: 210px
-  margin: 0 (-(rcl-side-pad))
+  margin: 0 (-(rclSidePad + rclSideBorderWidth))
   background-color: #eee
   background-size: cover
 
@@ -26,7 +27,7 @@ rcl-side-pad = 20px
   background-color: #fff
 
   .kf-rcl-body
-    padding: 0 rcl-side-pad
+    padding: 0 rclSidePad
 
   .kf-rcl-name-wrap-2
     padding-top: 4px
@@ -94,7 +95,7 @@ rcl-side-pad = 20px
     display: table
     width: 100%
     height: 72px
-    border-top: 1px solid #dadae2
+    border-top: defaultBorder
 
   .kf-rcl-stats
     display: table-cell

--- a/kifi-backend/modules/shoebox/angular/src/recos/recos.styl
+++ b/kifi-backend/modules/shoebox/angular/src/recos/recos.styl
@@ -1,10 +1,10 @@
 // Note: The responsive two-column structure of this page is similar to the library page and
 //       the general search results page.
 
-leftColWidth = 498px  // chosen so that inner keep card width (youtube video, specifically) comes out to exactly 496px
+leftColWidth = 496px  // ideal keep card width; see keepCardMaxWidth in keeps.styl
 rightColWidth = 256px // chosen to avoid text wrapping
 colGapWidth = 20px
-twoColMinWidth = appSidePad1 + leftColWidth + colGapWidth + rightColWidth + appSidePad1 // = 798px
+twoColMinWidth = appSidePad1 + leftColWidth + colGapWidth + rightColWidth + appSidePad1 // = 796px
 
 .kf-recos-view
   box-sizing: border-box
@@ -232,7 +232,7 @@ twoColMinWidth = appSidePad1 + leftColWidth + colGapWidth + rightColWidth + appS
 
 .kf-reco-get-more-container
   margin-bottom: 20px
-  border: 1px solid #dadae2
+  border: defaultBorder
   border-radius: 10px
   padding: 12px 0
   text-align: center


### PR DESCRIPTION
This pull request may seem a little excessive, but it’s a little tricky to make keep images and videos have rounded top corners, like the keep card, which becomes necessary when there’s nothing above them and the keep card is collapsed (narrow viewports, like mobile).

This change also makes keep images/videos bleed over the outermost keep card side borders in recos view and “boxed” view (wide viewports).
