### PR TITLE
Fix keep titles in Orphan cleaner

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/OrphanCleaner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/OrphanCleaner.scala
@@ -17,7 +17,8 @@ class OrphanCleaner @Inject() (
     val normUriRepo: NormalizedURIRepo,
     libraryRepo: LibraryRepo,
     centralConfig: CentralConfig,
-    val airbrake: AirbrakeNotifier) extends UriIntegrityChecker {
+    val airbrake: AirbrakeNotifier,
+    uriIntegrityHelpers: UriIntegrityHelpers) extends UriIntegrityChecker {
 
   case class OrphanCleanerSequenceNumberKey[T](seqKey: String) extends SequenceNumberCentralConfigKey[T] {
     val longKey = new LongCentralConfigKey {
@@ -115,20 +116,27 @@ class OrphanCleaner @Inject() (
       }
 
       db.readWriteSeq(bookmarks, collector) { (s, bookmark) =>
-        bookmark.libraryId match {
-          case Some(libId) =>
-            val library = libraryRepo.get(libId)(s)
-            if (library.visibility != bookmark.visibility) {
-              log.error(s"Bookmark ${bookmark.id.get} has inconsistent visibility with library ${library.id.get}. Expected: ${bookmark.visibility} Actual: ${library.visibility}")
-              keepRepo.save(bookmark.copy(visibility = library.visibility))(s)
-            }
-          case _ =>
+        implicit val session = s
+        val hasUpdatedUri = bookmark.state match {
+          case KeepStates.ACTIVE => checkIntegrity(bookmark.uriId, readOnly, hasKnownKeep = true)
+          case KeepStates.INACTIVE => checkIntegrity(bookmark.uriId, readOnly)
+          case KeepStates.DUPLICATE => checkIntegrity(bookmark.uriId, readOnly)
         }
-        bookmark.state match {
-          case KeepStates.ACTIVE => checkIntegrity(bookmark.uriId, readOnly, hasKnownKeep = true)(s)
-          case KeepStates.INACTIVE => checkIntegrity(bookmark.uriId, readOnly)(s)
-          case KeepStates.DUPLICATE => checkIntegrity(bookmark.uriId, readOnly)(s)
+
+        val improvedBookmark = {
+          val uri = normUriRepo.get(bookmark.uriId)
+          uriIntegrityHelpers.improveKeepSafely(uri, bookmark)
         }
+
+        val correctVisibility = bookmark.libraryId.map(libraryRepo.get(_).visibility) getOrElse bookmark.visibility
+        if (correctVisibility != bookmark.visibility) {
+          log.error(s"Keep ${bookmark.id.get} has inconsistent visibility with its library ${bookmark.libraryId}. Expected: ${bookmark.visibility} Actual: ${correctVisibility}")
+        }
+
+        val updatedBookmark = improvedBookmark.copy(visibility = correctVisibility)
+        if (bookmark != updatedBookmark) { keepRepo.save(updatedBookmark) }
+
+        hasUpdatedUri
       }
       if (!done && !readOnly) centralConfig.update(bookmarkSeqKey, seq) // update high watermark
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/rover/ShoeboxArticleIngestionActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/rover/ShoeboxArticleIngestionActor.scala
@@ -162,7 +162,7 @@ class ShoeboxArticleIngestionActor @Inject() (
       }
     }
 
-    val updatedUri = uriRepo.save(uri.withTitle(preferredTitle)copy(restriction = restriction)) // always save to increment sequence numbers for other services
+    val updatedUri = uriRepo.save(uri.withTitle(preferredTitle) copy (restriction = restriction)) // always save to increment sequence numbers for other services
 
     updatedUri tap uriIntegrityHelpers.improveKeepsSafely
   }


### PR DESCRIPTION
@andrewconner once this is deployed, I'll wipe out keep's titles when they're equal to their url. This should then pick it up.
