### PR TITLE
Safer youtube parsing

### DIFF
--- a/kifi-backend/modules/rover/app/com/keepit/rover/article/fetcher/YoutubeArticleFetcher.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/article/fetcher/YoutubeArticleFetcher.scala
@@ -74,7 +74,7 @@ class YoutubeArticleFetcher @Inject() (
     val description = SafeOpt(doc.doc.select("#watch-description-text .content").text()).getOrElse("")
     val channel = SafeOpt(doc.doc.select("#watch7-user-header .yt-user-name").text()).getOrElse("")
     val tags = SafeOpt(doc.doc.select("#watch-description-extras .content .watch-info-tag-list").map(_.text()).filter(_.nonEmpty)).getOrElse(Seq.empty)
-    val viewCount = SafeOpt(doc.doc.select("#watch7-views-info .watch-view-count").text().replaceAll ("\\D", "").toInt).getOrElse(0)
+    val viewCount = SafeOpt(doc.doc.select("#watch7-views-info .watch-view-count").text().replaceAll("\\D", "").toInt).getOrElse(0)
 
     // todo: Add alerting so we know if youtube breaks these selectors
 


### PR DESCRIPTION
- We don't trust Jsoup to be nice. It returns nulls and throws exceptions.
- YouTube can always break their selectors. We need to know about it, but shouldn't break because of it. Happy to change these defaults if you have a way to represent "failed scrape"
- In this case, YouTube changed their view count format, from something like "2,333" to "2,333 views"
