### PR TITLE
much lower rover task frequency (esp. on scheduling)

### DIFF
--- a/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverArticleFetchingActor.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverArticleFetchingActor.scala
@@ -28,11 +28,9 @@ class RoverArticleFetchingActor @Inject() (
     instanceInfo: AmazonInstanceInfo,
     implicit val executionContext: ExecutionContext) extends ConcurrentTaskProcessingActor[SQSMessage[FetchTask]](airbrake) {
 
-
   private val concurrencyFactor = 25
   protected val maxConcurrentTasks: Int = 1 + instanceInfo.instantTypeInfo.cores * concurrencyFactor
   protected val minConcurrentTasks: Int = 1 + maxConcurrentTasks / 2
-
 
   protected def pullTasks(limit: Int): Future[Seq[SQSMessage[FetchTask]]] = {
     taskQueue.nextBatchWithLock(limit, RoverArticleFetchingActor.lockTimeOut)

--- a/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverArticleFetchingActor.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverArticleFetchingActor.scala
@@ -28,7 +28,7 @@ class RoverArticleFetchingActor @Inject() (
     instanceInfo: AmazonInstanceInfo,
     implicit val executionContext: ExecutionContext) extends ConcurrentTaskProcessingActor[SQSMessage[FetchTask]](airbrake) {
 
-  private val concurrencyFactor = 50
+  private val concurrencyFactor = 25
   protected val maxConcurrentTasks: Int = instanceInfo.instantTypeInfo.cores * concurrencyFactor
   protected val minConcurrentTasks: Int = maxConcurrentTasks / 2
 

--- a/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverArticleImageProcessingActor.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverArticleImageProcessingActor.scala
@@ -32,11 +32,9 @@ class RoverArticleImageProcessingActor @Inject() (
     instanceInfo: AmazonInstanceInfo,
     implicit val executionContext: ExecutionContext) extends ConcurrentTaskProcessingActor[SQSMessage[ArticleImageProcessingTask]](airbrake) {
 
-
   private val concurrencyFactor = 1
   protected val maxConcurrentTasks: Int = 1 + instanceInfo.instantTypeInfo.cores * concurrencyFactor
   protected val minConcurrentTasks: Int = 1 + maxConcurrentTasks / 2
-
 
   protected def pullTasks(limit: Int): Future[Seq[SQSMessage[ArticleImageProcessingTask]]] = {
     taskQueue.nextBatchWithLock(limit, RoverArticleImageProcessingActor.lockTimeOut)

--- a/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverArticleImageProcessingActor.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverArticleImageProcessingActor.scala
@@ -32,7 +32,7 @@ class RoverArticleImageProcessingActor @Inject() (
     instanceInfo: AmazonInstanceInfo,
     implicit val executionContext: ExecutionContext) extends ConcurrentTaskProcessingActor[SQSMessage[ArticleImageProcessingTask]](airbrake) {
 
-  private val concurrencyFactor = 50
+  private val concurrencyFactor = 25
   protected val maxConcurrentTasks: Int = instanceInfo.instantTypeInfo.cores * concurrencyFactor
   protected val minConcurrentTasks: Int = maxConcurrentTasks / 2
 

--- a/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverManagerPlugin.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverManagerPlugin.scala
@@ -27,11 +27,11 @@ class RoverManagerPluginImpl @Inject() (
   val name: String = getClass.toString
 
   override def onStart(): Unit = {
-    scheduleTaskOnOneMachine(ingestionActor.system, 187 seconds, 1 minute, ingestionActor.ref, IfYouCouldJustGoAhead, "NormalizedURI Ingestion")
-    scheduleTaskOnOneMachine(fetchSchedulingActor.system, 200 seconds, 1 minute, fetchSchedulingActor.ref, IfYouCouldJustGoAhead, "Fetch Scheduling")
-    scheduleTaskOnAllMachines(fetchingActor.system, (30 + Random.nextInt(60)) seconds, 1 minute, fetchingActor.ref, IfYouCouldJustGoAhead)
-    scheduleTaskOnOneMachine(imageSchedulingActor.system, 200 seconds, 1 minute, imageSchedulingActor.ref, IfYouCouldJustGoAhead, "ArticleImage Scheduling")
-    scheduleTaskOnAllMachines(imageProcessingActor.system, (30 + Random.nextInt(60)) seconds, 1 minute, imageProcessingActor.ref, IfYouCouldJustGoAhead)
+    scheduleTaskOnOneMachine(ingestionActor.system, 250 seconds, 2 minute, ingestionActor.ref, IfYouCouldJustGoAhead, "NormalizedURI Ingestion")
+    scheduleTaskOnOneMachine(fetchSchedulingActor.system, 250 seconds, 8 minute, fetchSchedulingActor.ref, IfYouCouldJustGoAhead, "Fetch Scheduling")
+    scheduleTaskOnAllMachines(fetchingActor.system, 250 seconds, 5 minute, fetchingActor.ref, IfYouCouldJustGoAhead)
+    scheduleTaskOnOneMachine(imageSchedulingActor.system, 250 seconds, 5 minute, imageSchedulingActor.ref, IfYouCouldJustGoAhead, "ArticleImage Scheduling")
+    scheduleTaskOnAllMachines(imageProcessingActor.system, 300 seconds, 5 minute, imageProcessingActor.ref, IfYouCouldJustGoAhead)
   }
 
   override def onStop(): Unit = {


### PR DESCRIPTION
stop gap. to stop maxing out the db, which I think might be causing a
lot of the problems.
@andrewconner @leogrim 
