### PR TITLE
Stopgap to help bad migrations

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationService.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationService.scala
@@ -58,10 +58,10 @@ class NormalizationServiceImpl @Inject() (
     val recentFailedChecks = db.readOnlyReplica { implicit s => failedContentCheckRepo.getRecentCountByURL(currentReference.url, now.minusMinutes(5)) }
     val somethingBadIsHappening = {
       // Léo: Please improve/fix this properly
-      log.warn(s"[NormalizationService] Stopping normalization for ${currentReference.uriId}. ${currentReference.url}. Candidates: ${candidates.map(_.url).mkString("  ")}")
       currentReference.url.length >= URLFactory.MAX_URL_SIZE || candidates.exists(_.url.length >= URLFactory.MAX_URL_SIZE)
     }
     if (recentFailedChecks > 10 || somethingBadIsHappening) {
+      log.warn(s"[NormalizationService] Stopping normalization for ${currentReference.uriId}. ${currentReference.url}. Candidates: ${candidates.map(_.url).mkString("  ")}")
       Future.successful(None)
     } else {
       log.debug(s"[processUpdate($currentReference,${candidates.mkString(",")})")

--- a/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationService.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/normalizer/NormalizationService.scala
@@ -56,7 +56,12 @@ class NormalizationServiceImpl @Inject() (
   private def processUpdate(currentReference: NormalizationReference, candidates: Set[NormalizationCandidate]): Future[Option[NormalizationReference]] = timing(s"NormalizationService.processUpdate.${currentReference.url}") {
     val now = currentDateTime
     val recentFailedChecks = db.readOnlyReplica { implicit s => failedContentCheckRepo.getRecentCountByURL(currentReference.url, now.minusMinutes(5)) }
-    if (recentFailedChecks > 10) {
+    val somethingBadIsHappening = {
+      // Léo: Please improve/fix this properly
+      log.warn(s"[NormalizationService] Stopping normalization for ${currentReference.uriId}. ${currentReference.url}. Candidates: ${candidates.map(_.url).mkString("  ")}")
+      currentReference.url.length >= URLFactory.MAX_URL_SIZE || candidates.exists(_.url.length >= URLFactory.MAX_URL_SIZE)
+    }
+    if (recentFailedChecks > 10 || somethingBadIsHappening) {
       Future.successful(None)
     } else {
       log.debug(s"[processUpdate($currentReference,${candidates.mkString(",")})")


### PR DESCRIPTION
@leogrim @eishay @stkem See https://fortytwo.airbrake.io/projects/91268/groups/1426344665598673305/notices/1427551881995501671

Migration appears to have stopped because of a bad URI. Eishay tried adding a rule, didn't help. I tried making the URL more friendly, didn't help:

`update normalized_uri set url = "http://www.flaticon.com/categories/animals", should_have_content=0,seq=-1 where id=6951507 limit 1;`

I hope this doesn't break anything, please review this asap.
