### PR TITLE
dealing with missing row in shoebox db

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/rover/ShoeboxArticleIngestionActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/rover/ShoeboxArticleIngestionActor.scala
@@ -14,7 +14,7 @@ import com.keepit.rover.RoverServiceClient
 import com.keepit.rover.article.{ ArticleKind, EmbedlyArticle }
 import com.keepit.rover.model.{ ShoeboxArticleUpdate, ArticleInfo, ShoeboxArticleUpdates }
 import scala.concurrent.{ Future, ExecutionContext }
-import scala.util.{ Failure, Success }
+import scala.util.{ Try, Failure, Success }
 import com.keepit.common.core._
 
 object ShoeboxArticleIngestionActor {
@@ -65,6 +65,18 @@ class ShoeboxArticleIngestionActor @Inject() (
     } flatMap { seqNum =>
       rover.getShoeboxUpdates(seqNum, fetchSize).flatMap {
         case Some(ShoeboxArticleUpdates(updates, maxSeq)) =>
+          //checking the normalized uris are valid and in the db
+          val verifiedAtricles = db.readOnlyMaster { implicit s =>
+            updates filter { article =>
+              Try(uriRepo.get(article.uriId)) match {
+                case Success(_) =>
+                  true
+                case Failure(e) =>
+                  airbrake.notify(s"article uri is not in the db: $article", e)
+                  false
+              }
+            }
+          }
           processRedirectsAndNormalizationInfo(updates).map { partiallyProcessedUpdatesByUri =>
             db.readWrite { implicit session =>
               updateActiveUris(partiallyProcessedUpdatesByUri)


### PR DESCRIPTION
Failed to ingest Shoebox Article updates from Rover. java.lang.Exception: failed processing normalization info for uri 6964029, of kind DefaultArticle NormalizationInfo(None,None,Set(),None) : http://tasker.dinglisch.net/guides.html
  Cause: java.util.NoSuchElementException: Invoker.first
  Cause: [No Cause]

Total Errors since start: 387
Total Errors since last alert: 30
Server: shoebox-spot-1
Server started at: 2015-05-24T21:03:27.861Z
Full Details

2015-05-25T03:32:33.926Z: [3a5ff8a3-8dc6-42f8-935b-8c385e5a2fa3]
error message [Failed to ingest Shoebox Article updates from Rover.]
Exception stack trace:
Cause:
java.lang.Exception: failed processing normalization info for uri 6964029, of kind DefaultArticle NormalizationInfo(None,None,Set(),None) : http://tasker.dinglisch.net/guides.html
com.keepit.shoebox.rover.NormalizationInfoIngestionHelper.liftedTree1$1(NormalizationInfoIngestionHelper.scala:35)
com.keepit.shoebox.rover.NormalizationInfoIngestionHelper.processNormalizationInfo(NormalizationInfoIngestionHelper.scala:27)
com.keepit.shoebox.rover.ShoeboxArticleIngestionActor.com$keepit$shoebox$rover$ShoeboxArticleIngestionActor$$processNormalizationInfo(ShoeboxArticleIngestionActor.scala:128)
com.keepit.shoebox.rover.ShoeboxArticleIngestionActor[a].apply(ShoeboxArticleIngestionActor.scala:117)
com.keepit.shoebox.rover.ShoeboxArticleIngestionActor[a].apply(ShoeboxArticleIngestionActor.scala:116)
scala.concurrent.Future[a].apply(Future.scala:251)
scala.concurrent.Future[a].apply(Future.scala:249)
scala.concurrent.impl.CallbackRunnable.run(Promise.scala:32)
akka.dispatch.BatchingExecutor$Batch[a].processBatch$1(BatchingExecutor.scala:67)
akka.dispatch.BatchingExecutor$Batch[a].apply$mcV$sp(BatchingExecutor.scala:82)
akka.dispatch.BatchingExecutor$Batch[a].apply(BatchingExecutor.scala:59)
akka.dispatch.BatchingExecutor$Batch[a].apply(BatchingExecutor.scala:59)
scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:72)
akka.dispatch.BatchingExecutor$Batch.run(BatchingExecutor.scala:58)
akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:41)
akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(AbstractDispatcher.scala:393)
scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
