### PR TITLE
Increase image processing throughput

### DIFF
--- a/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverArticleImageProcessingActor.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverArticleImageProcessingActor.scala
@@ -30,7 +30,7 @@ class RoverArticleImageProcessingActor @Inject() (
     instanceInfo: AmazonInstanceInfo,
     implicit val executionContext: ExecutionContext) extends ConcurrentTaskProcessingActor[SQSMessage[ArticleImageProcessingTask]](airbrake) {
 
-  private val concurrencyFactor = 1
+  private val concurrencyFactor = 5
   protected val maxConcurrentTasks: Int = 1 + instanceInfo.instantTypeInfo.cores * concurrencyFactor
   protected val minConcurrentTasks: Int = 1 + maxConcurrentTasks / 2
 


### PR DESCRIPTION
@andrewconner @stkem CPU on Rover machines is currently at ~5% so this should be safe.
