### PR TITLE
refactor website client to handle a membership object

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/userTooltip/userTooltip.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/userTooltip/userTooltip.js
@@ -38,7 +38,7 @@ angular.module('kifi')
           }, 50);
           var ready = scope.library ? libraryService.getLibraryInfoById(scope.library.id).then(function (data) {
             scope.library = data.library;
-            scope.isFollowing = data.membership === 'read_only';
+            scope.isFollowing = data.library.membership.access === 'read_only';
             scope.isMine = libraryService.isMyLibrary(data.library);
           }) : timeout;
         }).on('touchstart touchend', function () {

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/userTooltip/userTooltip.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/userTooltip/userTooltip.js
@@ -38,7 +38,7 @@ angular.module('kifi')
           }, 50);
           var ready = scope.library ? libraryService.getLibraryInfoById(scope.library.id).then(function (data) {
             scope.library = data.library;
-            scope.isFollowing = data.library.membership.access === 'read_only';
+            scope.isFollowing = data.library.membership && data.library.membership.access === 'read_only';
             scope.isMine = libraryService.isMyLibrary(data.library);
           }) : timeout;
         }).on('touchstart touchend', function () {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -280,7 +280,7 @@ angular.module('kifi')
 
     $rootScope.$emit('libraryOnPage', library);
 
-    if (!libraryService.isLibraryMainOrSecret(library) && library.access !== 'none') {
+    if (!libraryService.isLibraryMainOrSecret(library) && library.membership) {
       $rootScope.$emit('lastViewedLib', library);
     }
 
@@ -297,7 +297,7 @@ angular.module('kifi')
       if (initParams.getAndClear('install') === '1' && !installService.installedVersion) {
         showInstallModal();
       }
-      if (initParams.getAndClear('intent') === 'follow' && $scope.library.access === 'none') {
+      if (initParams.getAndClear('intent') === 'follow' && !$scope.library.membership) {
         libraryService.joinLibrary($scope.library.id);
       }
     });

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
@@ -507,7 +507,7 @@ angular.module('kifi')
         }
 
         scope.followingLibrary = function () {
-          return scope.library.access === 'read_only';
+          return scope.library.membership && scope.library.membership.access === 'read_only';
         };
 
         scope.followLibrary = function (btnJustClicked) {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
@@ -635,7 +635,6 @@ angular.module('kifi')
           $rootScope.$on('libraryJoined', function (e, libraryId) {
             var lib = scope.library;
             if (lib && libraryId === lib.id && !lib.membership) {
-              (lib.invite || {}).actedOn = true;
               lib.membership = {
                 access: 'read_only',
                 listed: true,

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
@@ -61,8 +61,8 @@ angular.module('kifi')
           lib.absUrl = env.origin + lib.url;
           lib.isSystem = lib.kind.lastIndexOf('system_', 0) === 0;
           scope.hasCollaborators = lib.numCollaborators > 0;
-          scope.amOwner = lib.access === 'owner';
-          scope.amCollab = lib.access === 'read_write';
+          scope.amOwner = lib.membership && lib.membership.access === 'owner';
+          scope.amCollab = lib.membership && lib.membership.access === 'read_write';
           scope.collabsCanEdit = lib.whoCanInvite === 'collaborator';
 
           $timeout(function () {
@@ -104,8 +104,8 @@ angular.module('kifi')
         };
 
         scope.changeSubscription = function () {
-          libraryService.updateSubscriptionToLibrary(scope.library.id, !(scope.library.subscribed)).then(function() {
-            scope.library.subscribed = !(scope.library.subscribed);
+          libraryService.updateSubscriptionToLibrary(scope.library.id, !(scope.library.membership.subscribed)).then(function() {
+            scope.library.membership.subscribed = !(scope.library.membership.subscribed);
           })['catch'](modalService.openGenericErrorModal);
         };
 
@@ -634,9 +634,13 @@ angular.module('kifi')
           }),
           $rootScope.$on('libraryJoined', function (e, libraryId) {
             var lib = scope.library;
-            if (lib && libraryId === lib.id && lib.access === 'none') {
+            if (lib && libraryId === lib.id && !lib.membership) {
               (lib.invite || {}).actedOn = true;
-              lib.access = 'read_only';
+              lib.membership = {
+                access: 'read_only',
+                listed: true,
+                subscribed: false
+              };
               lib.numFollowers++;
               var me = profileService.me;
               if (!_.contains(lib.followers, {id: me.id})) {
@@ -646,8 +650,8 @@ angular.module('kifi')
           }),
           $rootScope.$on('libraryLeft', function (e, libraryId) {
             var lib = scope.library;
-            if (lib && libraryId === lib.id && lib.access !== 'none') {
-              lib.access = 'none';
+            if (lib && libraryId === lib.id && lib.membership) {
+              lib.membership = undefined;
               lib.numFollowers--;
               _.remove(lib.followers, {id: profileService.me.id});
             }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
@@ -27,9 +27,9 @@
       </div>
       <input class="kf-lh-cover-file" type="file" accept="image/jpeg,image/png,image/gif" kf-file-change="onCoverImageFileChosen" ng-if="amOwner && !library.isSystem">
 
-      <div class="kf-lh-subscribe-btn-wrap" ng-if="library.access !== 'none' && (!amOwner || hasCollaborators)" ng-class="{'for-owner' : amOwner}">
-        <button ng-attr-class="kf-lh-subscribe-btn {{library.subscribed ? 'svg-notification-on-white' : 'svg-notification-off-white'}}" ng-click="changeSubscription()"></button>
-        <div class="kf-lh-subscribe-msg">Notifications {{library.subscribed ? 'enabled' : 'disabled'}}</div>
+      <div class="kf-lh-subscribe-btn-wrap" ng-if="library.membership && (!amOwner || hasCollaborators)" ng-class="{'for-owner' : amOwner}">
+        <button ng-attr-class="kf-lh-subscribe-btn {{library.membership.subscribed ? 'svg-notification-on-white' : 'svg-notification-off-white'}}" ng-click="changeSubscription()"></button>
+        <div class="kf-lh-subscribe-msg">Notifications {{library.membership.subscribed ? 'enabled' : 'disabled'}}</div>
       </div>
 
       <div class="kf-lh-followers" ng-if="!onCollabExperiment">
@@ -72,7 +72,7 @@
           <a class="kf-lh-owner-image-a" href="{{library.owner|profileUrl}}" itemprop="url" kf-track-origin="libraryPage/curator">
             <img class="kf-lh-owner-image" ng-src="{{library.owner|pic:200}}" itemprop="image" alt="{{library.owner|name}}">
           </a>
-          <button class="kf-lh-add-collab-button next-to-owner" ng-if="!library.attr.twitter.screenName && library.access === 'owner' && onCollabExperiment" ng-click="openInviteModal('collaborate')">
+          <button class="kf-lh-add-collab-button next-to-owner" ng-if="!library.attr.twitter.screenName && amOwner && onCollabExperiment" ng-click="openInviteModal('collaborate')">
             <div class="kf-lh-add-collab-icon svg-collaborate-white"></div>
             <span class="kf-lh-add-collab-msg">Invite a collaborator</span>
           </button>
@@ -100,7 +100,7 @@
         <button class="kf-lh-more-collab" ng-if="library.numCollaborators - library.collaborators.length > 0">
           +{{library.numCollaborators - library.collaborators.length}}
         </button>
-        <button class="kf-lh-add-collab-button" ng-if="(library.access == 'owner' || (library.access == 'read_write' && library.whoCanInvite == 'collaborator')) && onCollabExperiment" ng-click="openInviteModal('collaborate')">
+        <button class="kf-lh-add-collab-button" ng-if="(amOwner || (amCollab && library.whoCanInvite == 'collaborator')) && onCollabExperiment" ng-click="openInviteModal('collaborate')">
           <div class="kf-lh-add-collab-icon svg-collaborate-white"></div>
           <span class="kf-lh-add-collab-msg">Invite a collaborator</span>
         </button>
@@ -126,8 +126,8 @@
     </div>
     <div class="kf-lh-unfollow-btn-wrap" ng-if="followingLibrary()">
       <button class="kf-button kf-lh-unfollow-btn" ng-class="{'kf-no-unfollow': followBtnJustClicked}" ng-click="unfollowLibrary()" ng-mouseleave="followBtnJustClicked = false"></button><!--
-   --><button ng-attr-class="kf-button kf-lh-subs-btn {{library.subscribed ? 'svg-notification-on-white' : 'svg-notification-off-white'}}" ng-click="changeSubscription()"></button>
-      <div class="kf-lh-subs-msg">Notifications {{library.subscribed ? 'enabled' : 'disabled'}}</div>
+   --><button ng-attr-class="kf-button kf-lh-subs-btn {{library.membership.subscribed ? 'svg-notification-on-white' : 'svg-notification-off-white'}}" ng-click="changeSubscription()"></button>
+      <div class="kf-lh-subs-msg">Notifications {{library.membership.subscribed ? 'enabled' : 'disabled'}}</div>
     </div>
     <div kf-library-share-search library="library" current-page-origin="libraryPage" btn-icon-class="svg-share-arrow-green" ng-if="$root.userLoggedIn && library.visibility === 'published'"></div>
   </div>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -16,9 +16,9 @@ angular.module('kifi')
     function standarizeMembershipInfo(resp) {
       if (!_.isObject(resp.library.membership)) {
         resp.library.membership = {
-          listed: resp.library.listed,
-          access: resp.library.access,
-          subscribed : resp.library.subscribed
+          listed: resp.library.listed || resp.listed,
+          access: resp.library.access || resp.membership,
+          subscribed : resp.library.subscribed || resp.subscribedToUpdates
         };
         if (!resp.library.membership.access || resp.library.membership.access === 'none') {
           resp.library.membership = undefined;
@@ -28,6 +28,7 @@ angular.module('kifi')
       resp.access = undefined;
       resp.listed = undefined;
       resp.subscribed = undefined;
+      resp.subscribedToUpdates = undefined;
       resp.membership = undefined;
       return resp;
     }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -12,6 +12,27 @@ angular.module('kifi')
     };
     var recentIds = [];  // in-memory cache, length limited, most recent first
 
+
+    // make the membership info INSIDE the library object
+    function standarizeMembershipInfo(resp) {
+      if (!_.isObject(resp.library.membership)) {
+        resp.library.membership = {
+          listed: resp.library.listed,
+          access: resp.library.access,
+          subscribed : resp.library.subscribed
+        };
+        if (!resp.library.membership.access || resp.library.membership.access === 'none') {
+          resp.library.membership = undefined;
+        }
+      }
+      resp.library.access = undefined;
+      resp.access = undefined;
+      resp.listed = undefined;
+      resp.subscribed = undefined;
+      resp.membership = undefined;
+      return resp;
+    }
+
     // TODO: flush any non-public cached data when a user logs out.
 
     //
@@ -28,13 +49,13 @@ angular.module('kifi')
 
     var libraryInfoByIdClutch = new Clutch(function (libraryId) {
       return $http.get(routeService.getLibraryInfoById(libraryId)).then(function (res) {
-        return augment(res.data);
+        return standarizeMembershipInfo(augment(res.data));
       });
     });
 
     var libraryByIdClutch = new Clutch(function (libraryId) {
       return $http.get(routeService.getLibraryById(libraryId)).then(function (res) {
-        return res.data;
+        return standarizeMembershipInfo(res.data);
       });
     });
 
@@ -46,6 +67,7 @@ angular.module('kifi')
           res.data.library.listed = res.data.listed;
           res.data.library.suggestedSearches = (res.data.suggestedSearches && res.data.suggestedSearches.terms) || [];
           res.data.library.subscribed = res.data.subscribedToUpdates;
+          res.data = standarizeMembershipInfo(res.data);
           return augment(res.data.library);
         }
         return null;

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -238,8 +238,12 @@ angular.module('kifi')
             'slug': '',
 
             // By default, the create library form selects the 'published' visibility for a new library.
-            'visibility': 'published',
-            'listed': true
+            'visibility': 'published'
+          };
+          scope.library.membership = {
+            access: 'owner',
+            listed: true,
+            subscribed: false
           };
           scope.modalTitle = 'Create a library';
         }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -236,8 +236,6 @@ angular.module('kifi')
             'name': '',
             'description': '',
             'slug': '',
-
-            // By default, the create library form selects the 'published' visibility for a new library.
             'visibility': 'published'
           };
           scope.library.membership = {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -74,13 +74,13 @@ angular.module('kifi')
             description: scope.library.description,
             slug: scope.library.slug,
             visibility: scope.library.visibility,
-            listed: scope.library.listed,
+            listed: scope.library.membership.listed,
             color: colorNames[scope.library.color]
           }, true).then(function (resp) {
             libraryService.fetchLibraryInfos(true);
 
             var newLibrary = resp.data.library;
-            newLibrary.listed = resp.data.listed;
+            newLibrary.listed = resp.data.listed || (resp.data.library.membership && resp.data.library.membership.listed);
 
             scope.$error = {};
             submitting = false;

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
@@ -48,7 +48,7 @@
               <div ng-switch-default class="manage-lib-visibility-description-content">
                 Anyone can see and follow this library
                 <div class="manage-lib-listed-visibility">
-                  <input type="checkbox" id="listed-visibility-checkbox" ng-model="library.listed">
+                  <input type="checkbox" id="listed-visibility-checkbox" ng-model="library.membership.listed">
                   <label for="listed-visibility-checkbox">
                     <span></span>
                     List this library on my public profile

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibraries.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibraries.js
@@ -157,9 +157,8 @@ angular.module('kifi')
           currentPageOrigin: $scope.currentPageOrigin,
           returnAction: function () {
             libraryService.getLibraryById(library.id, true).then(function (data) {
-              _.assign(library, _.pick(data.library, 'name', 'slug', 'description', 'visibility', 'color', 'numFollowers'));
+              _.assign(library, _.pick(data.library, 'name', 'slug', 'description', 'visibility', 'color', 'numFollowers', 'membership'));
               library.path = data.library.url;
-              library.listed = data.listed;
               library.followers = _.take(data.library.followers, 3);
             })['catch'](modalService.openGenericErrorModal);
           }

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibrariesList.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibrariesList.tpl.html
@@ -35,7 +35,7 @@
       </a>
     </div>
     <button ng-class="{'kf-upl-card-follow': true, 'kf-following': lib.following}" ng-if="lib.owner.id !== me.id" ng-click="onFollowButtonClick(lib, $event); trackUplCardClick(lib, 'clickedLibraryFollowButton')"></button>
-    <div class="kf-upl-card-foot" ng-switch="profile.id === me.id && lib.visibility === 'published' && lib.owner.id === me.id && !lib.listed ? 'unlisted' : lib.followers.length ? 'followers' : lib.lastKept ? 'updated' : ''">
+    <div class="kf-upl-card-foot" ng-switch="profile.id === me.id && lib.visibility === 'published' && lib.owner.id === me.id && !(lib.membership && lib.membership.listed) ? 'unlisted' : lib.followers.length ? 'followers' : lib.lastKept ? 'updated' : ''">
       <div class="kf-upl-followers" ng-switch-when="followers">
         <a href="{{user|profileUrl}}" class="kf-upl-follower" ng-repeat="user in lib.followers" kf-track-origin="{{currentPageOrigin}}/follower" ng-click="trackUplCardClick(lib, 'clickedLibraryFollowersFace')"
            ng-attr-style="background-image:url({{user | pic:100}})"></a>


### PR DESCRIPTION
@andrewconner @2is10 

change `getLibrary` (by user/slug or id) to handle a `membership` object inside the `library` object instead of separate sibling fields `membership`, `access`, `subscribed`, `listed`.

If a user does not have access to a library, there should be no `membership` object
