### PR TITLE
Updating ng dev dependencies, unbreaking dev for new engineers

### DIFF
--- a/kifi-backend/modules/shoebox/angular/package.json
+++ b/kifi-backend/modules/shoebox/angular/package.json
@@ -10,7 +10,7 @@
   },
   "engines": {
     "node": "0.10.x",
-    "npm": "1.3.x"
+    "npm": "2.10.x"
   },
   "scripts": {
     "postinstall": "node node_modules/bower/bin/bower install && ./node_modules/protractor/bin/webdriver-manager update"
@@ -45,9 +45,9 @@
     "gulp-svgmin": "0.4.6",
     "gulp-uglify": "0.3.1",
     "gulp-util": "3.0.0",
-    "gulp.spritesmith": "1.1.1",
+    "gulp.spritesmith": "3.7.0",
     "jasmine-core": "2.1.3",
-    "jshint-stylish": "0.4.0",
+    "jshint-stylish": "2.0.0",
     "jsonminify": "0.2.3",
     "karma": "0.12.31",
     "karma-chrome-launcher": "0.1.7",

--- a/kifi-backend/modules/shoebox/angular/src/common/platformService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/platformService.js
@@ -60,23 +60,15 @@ angular.module('kifi')
       var isDev = env.dev; // jshint ignore:line
 
       /* jshint ignore:start */
-      // https://github.com/BranchMetrics/Web-SDK#quick-install
-      var config = {
-        app_id: '58363010934112339',
-        debug: env.dev,
-        init_callback: function () {
+      // https://github.com/BranchMetrics/Web-SDK#quick-install-web-sdk
+      (function(b,r,a,n,c,h,_,s,d,k){if(!b[n]||!b[n]._q){for(;s<_.length;)c(h,_[s++]);d=r.createElement(a);d.async=1;d.src="https://cdn.branch.io/branch-v1.5.4.min.js";k=r.getElementsByTagName(a)[0];k.parentNode.insertBefore(d,k);b[n]=h}})(window,document,"script","branch",function(b,r){b[r]=function(){b._q.push([r,arguments])}},{_q:[],_v:1},"init data setIdentity logout track link sendSMS referrals credits redeem banner closeBanner".split(" "),0); // jshint ignore:line
+      window.branch.setDebug(isDev);
+      window.branch.init('58363010934112339', function(err, data) {
+        if (data) {
           Branch = window.branch;
           deferred.resolve(window.branch);
         }
-      };
-      var Branch_Init=function(a){self=this,self.app_id=a.app_id,self.debug=a.debug,self.init_callback=a.init_callback,self
-      .queued=[],this.init=function(){for(var a=["close","logout","track","identify","createLink","showReferrals","showCredits",
-      "redeemCredits","appBanner"],b=0;b<a.length;b++)self[a[b]]=function(a){return function(){self.queued.push([a].concat(Array
-      .prototype.slice.call(arguments,0)))}}(a[b])},self.init();var b=document.createElement("script");b.type="text/javascript",
-      b.async=!0,b.src="https://bnc.lt/_r",document.getElementsByTagName("head")[0].appendChild(b),self._r=function(){if(
-      void 0!==window.browser_fingerprint_id){var a=document.createElement("script");a.type="text/javascript",a.async=!0,a
-      .src="https://s3-us-west-1.amazonaws.com/branch-sdk/branch.min.js",document.getElementsByTagName("head")[0].appendChild(a)
-      }else window.setTimeout("self._r()",100)},self._r()};window.branch=new Branch_Init(config);
+      });
       /* jshint ignore:end */
 
       return deferred.promise;
@@ -85,7 +77,7 @@ angular.module('kifi')
     var createBranchLink = function (data) {
       var deferred = $q.defer();
       branchInit().then(function (branch) {
-        branch.createLink({
+        branch.link({
           data: data
         }, function (url){
           deferred.resolve(url);

--- a/kifi-backend/modules/shoebox/angular/src/common/services/clutch.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/clutch.js
@@ -2,8 +2,8 @@
 
 angular.module('kifi')
 
-.factory('Clutch', ['$q', '$timeout', 'util',
-  function ($q, $timeout, util) {
+.factory('Clutch', ['$q', '$timeout', 'util', '$window',
+  function ($q, $timeout, util, $window) {
 
     var defaultConfig = {
       remoteError: 'ignore',
@@ -88,7 +88,7 @@ angular.module('kifi')
 
     function stringize(args) {
       // todo check if already array
-      return JSON.stringify(Array.prototype.slice.call(args));
+      return $window.JSON.stringify(Array.prototype.slice.call(args));
     }
 
     function isExpired(hitTime, duration) {

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
@@ -139,7 +139,7 @@ angular.module('kifi')
           deferred.notify({'name': 'progress', 'event': e});
         });
         xhr.addEventListener('load', function () {
-          deferred.resolve(JSON.parse(xhr.responseText));
+          deferred.resolve($window.JSON.parse(xhr.responseText));
         });
         xhr.addEventListener('error', function (e) {
           deferred.reject(e);

--- a/kifi-backend/modules/shoebox/angular/src/profile/profileImage.js
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profileImage.js
@@ -120,7 +120,7 @@ angular.module('kifi')
             });
 
             xhr.addEventListener('load', function () {
-              deferred.resolve(JSON.parse(xhr.responseText));
+              deferred.resolve($window.JSON.parse(xhr.responseText));
             });
 
             xhr.addEventListener('loadend', function () {


### PR DESCRIPTION
@2is10 People installing `npm` and `node` now and starting on Angular development were consistently having problems, so this PR should address them.

If you installed `node`/`npm` from homebrew, you may want to remove it and install directly from https://nodejs.org. However, if the following works, then don't worry about it.

For reference, my `npm` version is 2.10.1.

If you're running a very old npm, get a new one: `sudo npm install npm -g`

Run `npm install`. You shouldn't see any striking errors. If you do, grab me and we'll debug it.
