### PR TITLE
Temporarily taking some load out of the db so I can properly test better queries

### DIFF
--- a/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverFetchSchedulingActor.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverFetchSchedulingActor.scala
@@ -30,6 +30,7 @@ class RoverFetchSchedulingActor @Inject() (
   protected def nextBatch: Future[Seq[RoverArticleInfo]] = {
     SafeFuture {
       log.info(s"Queuing up to $maxBatchSize article fetch tasks...")
+      Thread.sleep(2000)
       articleCommander.getRipeForFetching(maxBatchSize, maxQueuedFor)
     }
   }

--- a/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverManagerPlugin.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverManagerPlugin.scala
@@ -28,9 +28,9 @@ class RoverManagerPluginImpl @Inject() (
 
   override def onStart(): Unit = {
     scheduleTaskOnOneMachine(ingestionActor.system, 250 seconds, 2 minute, ingestionActor.ref, IfYouCouldJustGoAhead, "NormalizedURI Ingestion")
-    scheduleTaskOnLeader(fetchSchedulingActor.system, 300 seconds, 8 minute, fetchSchedulingActor.ref, IfYouCouldJustGoAhead)
+    scheduleTaskOnLeader(fetchSchedulingActor.system, 400 seconds, 8 minute, fetchSchedulingActor.ref, IfYouCouldJustGoAhead)
     scheduleTaskOnAllMachines(fetchingActor.system, 250 seconds, 5 minute, fetchingActor.ref, IfYouCouldJustGoAhead)
-    scheduleTaskOnLeader(imageSchedulingActor.system, 300 seconds, 8 minute, imageSchedulingActor.ref, IfYouCouldJustGoAhead)
+    scheduleTaskOnLeader(imageSchedulingActor.system, 400 seconds, 8 minute, imageSchedulingActor.ref, IfYouCouldJustGoAhead)
     scheduleTaskOnAllMachines(imageProcessingActor.system, 300 seconds, 5 minute, imageProcessingActor.ref, IfYouCouldJustGoAhead)
   }
 


### PR DESCRIPTION
The query takes currently about 6 seconds to execute. Adding to 2
seconds to give the DB a breather, so I can test a better query. Hard
to accurately benchmark when the CPU is pegged at 100%. Will revert
this afterwards.

@leogrim @andrewconner 
