### PR TITLE
Fix exception recovery when getting recent article

### DIFF
--- a/kifi-backend/modules/rover/app/com/keepit/rover/article/ArticleCommander.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/article/ArticleCommander.scala
@@ -93,13 +93,13 @@ class ArticleCommander @Inject() (
     getArticleInfoByUrlAndKind(url, kind) match {
       case Some(info) => getOrElseFetchRecentArticle(info, recency, shouldThrottle = false).imap(_.map(_.asExpected[A]))
       case None => { // do not intern the url into a normalized one to make sure it's fetched as it is
-        articleFetcher.fetch(ArticleFetchRequest(kind, url, shouldThrottle = false)).recover {
-          case invalidRequest: InvalidFetchRequestException => None
-          case invalidResponse: InvalidFetchResponseException[_] => None
-          case socketTimeout: SocketTimeoutException => None
-        }
+        articleFetcher.fetch(ArticleFetchRequest(kind, url, shouldThrottle = false))
       }
     }
+  } recover {
+    case invalidRequest: InvalidFetchRequestException => None
+    case invalidResponse: InvalidFetchResponseException[_] => None
+    case socketTimeout: SocketTimeoutException => None
   }
 
   private def isInvalidFetch(failureInfo: String): Boolean = {


### PR DESCRIPTION
@andrewconner @stkem 
I wasn't catching the exceptions of the first `case`, this is why we've kept seeing them. Also got a `SocketTimeoutException` last night that got fixed with a retry, so retrying once on these before throwing.
