### PR TITLE
3.3.65: hiding broken look-here link dialog on scroll away from page

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.3.64
+version=3.3.65

--- a/packrat/scripts/compose.js
+++ b/packrat/scripts/compose.js
@@ -411,6 +411,7 @@ k.compose = k.compose || (function() {
         if ($to.length) {
           $to.tokenInput('destroy');
         }
+        editor.$el.handleLookClicks(false);
         if (!$forms.length) {
           k.snap.disable();
         }

--- a/packrat/scripts/look.js
+++ b/packrat/scripts/look.js
@@ -5,12 +5,19 @@
 
 $.fn.handleLookClicks = $.fn.handleLookClicks || (function () {
   'use strict';
+  var hide;
   return function (containerName) {
-    return this
-      .on('mousedown', 'a[href^="x-kifi-sel:"]', $.proxy(lookMouseDown, null, containerName))
-      .on('click', 'a[href^="x-kifi-sel:"]', function (e) {
-        e.preventDefault();
-      });
+    if (containerName) {
+      this
+        .on('mousedown', 'a[href^="x-kifi-sel:"]', $.proxy(lookMouseDown, null, containerName))
+        .on('click', 'a[href^="x-kifi-sel:"]', function (e) {
+          e.preventDefault();
+        });
+    } else if (hide) {
+      hide();
+      hide = null;
+    }
+    return this;
   };
 
   function lookMouseDown(containerName, e) {
@@ -148,7 +155,7 @@ $.fn.handleLookClicks = $.fn.handleLookClicks || (function () {
     })[0];
     var self = this;
     api.require('scripts/look_link_broken.js', function () {
-      showBrokenLookLinkDialog.call(self, a, authorName, eventOrSelector);
+      hide = showBrokenLookLinkDialog.call(self, a, authorName, eventOrSelector);
     });
   }
 }());

--- a/packrat/scripts/look_link_broken.js
+++ b/packrat/scripts/look_link_broken.js
@@ -42,6 +42,7 @@ var showBrokenLookLinkDialog = (function () {
       .mousedown(onMouseDown);
     $(document).data('esc').add(hide);
     api.onEnd.push(hide);
+    return hide;
   };
 
   function hide(e) {


### PR DESCRIPTION
(e.g. on qz.com)
https://trello.com/c/7Z4zewab/
