### PR TITLE
libraryInviteRepo.getWithLibraryIdAndUserId

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -696,7 +696,7 @@ class LibraryCommander @Inject() (
         userId match {
           case Some(id) =>
             libraryMembershipRepo.getWithLibraryIdAndUserId(library.id.get, id).nonEmpty ||
-              libraryInviteRepo.getWithLibraryIdAndUserId(userId = id, libraryId = library.id.get, excludeState = Some(LibraryInviteStates.INACTIVE)).nonEmpty ||
+              libraryInviteRepo.getWithLibraryIdAndUserId(userId = id, libraryId = library.id.get).nonEmpty ||
               getValidLibInvitesFromAuthToken(library.id.get, authToken).nonEmpty
           case None =>
             getValidLibInvitesFromAuthToken(library.id.get, authToken).nonEmpty

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryInviteRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryInviteRepo.scala
@@ -15,7 +15,7 @@ import scala.slick.jdbc.StaticQuery
 @ImplementedBy(classOf[LibraryInviteRepoImpl])
 trait LibraryInviteRepo extends Repo[LibraryInvite] with RepoWithDelete[LibraryInvite] {
   def getWithLibraryId(libraryId: Id[Library], excludeState: Option[State[LibraryInvite]] = Some(LibraryInviteStates.INACTIVE))(implicit session: RSession): Seq[LibraryInvite]
-  def getWithLibraryIdAndUserId(libraryId: Id[Library], userId: Id[User], excludeState: Option[State[LibraryInvite]] = Some(LibraryInviteStates.INACTIVE))(implicit session: RSession): Seq[LibraryInvite]
+  def getWithLibraryIdAndUserId(libraryId: Id[Library], userId: Id[User], includeSet: Set[State[LibraryInvite]] = Set(LibraryInviteStates.ACTIVE))(implicit session: RSession): Seq[LibraryInvite]
   def countWithLibraryIdAndUserId(libraryId: Id[Library], userId: Id[User], excludeSet: Set[State[LibraryInvite]] = Set(LibraryInviteStates.INACTIVE))(implicit session: RSession): Int
   def countWithLibraryIdAndEmail(libraryId: Id[Library], email: EmailAddress, excludeSet: Set[State[LibraryInvite]] = Set(LibraryInviteStates.INACTIVE))(implicit session: RSession): Int
   def countDistinctWithUserId(userId: Id[User])(implicit session: RSession): Int
@@ -70,11 +70,8 @@ class LibraryInviteRepoImpl @Inject() (
     getWithLibraryIdCompiled(libraryId, excludeState).list
   }
 
-  private def getWithLibraryIdAndUserIdCompiled(libraryId: Column[Id[Library]], userId: Column[Id[User]], excludeState: Option[State[LibraryInvite]]) = Compiled {
-    (for (b <- rows if b.libraryId === libraryId && b.userId === userId && b.state =!= excludeState.orNull) yield b).sortBy(_.createdAt)
-  }
-  def getWithLibraryIdAndUserId(libraryId: Id[Library], userId: Id[User], excludeState: Option[State[LibraryInvite]] = Some(LibraryInviteStates.INACTIVE))(implicit session: RSession): Seq[LibraryInvite] = {
-    getWithLibraryIdAndUserIdCompiled(libraryId, userId, excludeState).list
+  def getWithLibraryIdAndUserId(libraryId: Id[Library], userId: Id[User], includeSet: Set[State[LibraryInvite]] = Set(LibraryInviteStates.INACTIVE))(implicit session: RSession): Seq[LibraryInvite] = {
+    (for (b <- rows if b.libraryId === libraryId && b.userId === userId && b.state.inSet(includeSet)) yield b).sortBy(_.createdAt).list
   }
 
   def countWithLibraryIdAndUserId(libraryId: Id[Library], userId: Id[User], excludeSet: Set[State[LibraryInvite]] = Set(LibraryInviteStates.INACTIVE))(implicit session: RSession): Int = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryInviteRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryInviteRepo.scala
@@ -70,7 +70,7 @@ class LibraryInviteRepoImpl @Inject() (
     getWithLibraryIdCompiled(libraryId, excludeState).list
   }
 
-  def getWithLibraryIdAndUserId(libraryId: Id[Library], userId: Id[User], includeSet: Set[State[LibraryInvite]] = Set(LibraryInviteStates.INACTIVE))(implicit session: RSession): Seq[LibraryInvite] = {
+  def getWithLibraryIdAndUserId(libraryId: Id[Library], userId: Id[User], includeSet: Set[State[LibraryInvite]] = Set(LibraryInviteStates.ACTIVE))(implicit session: RSession): Seq[LibraryInvite] = {
     (for (b <- rows if b.libraryId === libraryId && b.userId === userId && b.state.inSet(includeSet)) yield b).sortBy(_.createdAt).list
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/cron/GratificationEmailCron.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/cron/GratificationEmailCron.scala
@@ -28,7 +28,7 @@ class GratificationEmailCronPluginImpl @Inject() (
     val utcHourForNoonEasternTime = 12 + -offsetHoursToUtc
     val utcHourFor8pmEasternTime = 8 + -offsetHoursToUtc
 
-    val cronTimeEveryday = s"0 0 ${utcHourForNoonEasternTime+2} ? * *" // scheduled to send to QA
+    val cronTimeEveryday = s"0 0 ${utcHourForNoonEasternTime + 2} ? * *" // scheduled to send to QA
     cronTaskOnLeader(quartz, actor.ref, cronTimeEveryday, GratificationEmailMessage.SendEmails)
 
     val cronTimeFriday = s"0 0 $utcHourForNoonEasternTime ? * FRI"


### PR DESCRIPTION
@andrewconner @2is10 

@2is10 found a bug where you can still see a private library even though you declined all library invites (no active invites).
Before, `getWithLibraryIdAndUserId()` only excluded `LibraryInviteStates.INACTIVE`. This change has it look only for active library invites (so exclude inactive, accepted, and declined invites)
