### PR TITLE
repairing schema.org markup for owner/collaborators for collaborative library

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
@@ -80,13 +80,13 @@
 
       <!--  owner with collaborators -->
       <div class="kf-lh-collabs" ng-if="library.numCollaborators > 0">
-        <div class="kf-lh-collab-image-wrap">
+        <div class="kf-lh-collab-image-wrap" itemprop="creator" itemscope itemtype="http://schema.org/Person">
           <a class="kf-lh-collab-image-a" href="{{library.owner|profileUrl}}" itemprop="url" kf-track-origin="libraryPage/collaborator">
             <img class="kf-lh-collab-image" ng-src="{{library.owner|pic:200}}" itemprop="image" alt="{{library.owner.firstName}}">
           </a>
           <a class="kf-lh-collab-name" href="{{library.owner|profileUrl}}" itemprop="name" kf-track-origin="libraryPage/collaborator">{{library.owner.firstName}}</a>
         </div>
-        <div class="kf-lh-collab-image-wrap" ng-repeat="collab in library.collaborators">
+        <div class="kf-lh-collab-image-wrap" itemprop="contributor" itemscope itemtype="http://schema.org/Person" ng-repeat="collab in library.collaborators">
           <a class="kf-lh-collab-image-a" href="{{collab|profileUrl}}" itemprop="url" kf-track-origin="libraryPage/collaborator">
             <img class="kf-lh-collab-image" ng-src="{{collab|pic:200}}" itemprop="image" alt="{{collab|name}}">
           </a>


### PR DESCRIPTION
@ahsu1230 
Without these scopes, the `itemprop="name"`, `itemprop="url"` and `itemprop="image"` on the owner and collaborator markup would be assumed to describe properties of the library itself.
