### PR TITLE
no more "members"!

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
@@ -34,6 +34,8 @@ angular.module('kifi')
         var URL = $window.URL || $window.webkitURL;
         var descWrapEl = element.find('.kf-lh-desc-wrap');
         var descEl = descWrapEl.find('.kf-lh-desc');
+        var smallWindowLimit = 479;
+        var smallWindow = $window.innerWidth <= smallWindowLimit;
 
         //
         // Scope data.
@@ -71,6 +73,13 @@ angular.module('kifi')
           var membersToShow = members.slice(0, numMembersToShow);
           var numMoreMembersText = showPlusMembers ? $filter('num')(numMembers - numMembersToShow) : '';
           return [membersToShow, numMoreMembersText];
+        }
+
+        function setFollowers(hideAll) {
+          var numFollowersToFit = hideAll ? 0 : (scope.onCollabExperiment ? 3 : 5);
+          var res = setMembersToShow(scope.library.followers, scope.library.numFollowers, numFollowersToFit);
+          scope.followersToShow = res[0];
+          scope.numMoreFollowersText = res[1];
         }
 
         //
@@ -623,16 +632,25 @@ angular.module('kifi')
           });
         };
 
+        function onWinResize() {
+          if ($window.innerWidth <= smallWindowLimit && !smallWindow) {
+            smallWindow = true;
+          } else if ($window.innerWidth > smallWindowLimit && smallWindow) {
+            smallWindow = false;
+          }
+          scope.$apply(function() {
+            setFollowers(smallWindow);
+          });
+        }
 
         //
         // Watches and listeners.
         //
 
+        $window.addEventListener('resize', onWinResize);
+
         scope.$watch('library.numFollowers', function() {
-          var numFollowersToFit = scope.onCollabExperiment ? 3 : 5;
-          var res = setMembersToShow(scope.library.followers, scope.library.numFollowers, numFollowersToFit);
-          scope.followersToShow = res[0];
-          scope.numMoreFollowersText = res[1];
+          setFollowers(smallWindow);
         });
 
         scope.$watch('library.numCollaborators', function() {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
@@ -568,7 +568,9 @@ angular.module('kifi')
         scope.showFollowers = function () {
           $rootScope.$emit('trackLibraryEvent', 'click', { action: 'clickedViewFollowers' });
 
-          if (scope.library.owner.id === profileService.me.id) {
+          if (scope.onCollabExperiment) {
+            scope.openMembersModal('followers_only');
+          } else if (scope.library.owner.id === profileService.me.id) {
             $rootScope.$emit('trackLibraryEvent', 'click', { action: 'clickedManageLibrary' });
             modalService.open({
               template: 'libraries/manageLibraryModal.tpl.html',
@@ -597,13 +599,14 @@ angular.module('kifi')
           libraryService.trackEvent('user_clicked_page', scope.library, { action: 'clickedTwitterProfileURL' });
         };
 
-        scope.openMembersModal = function () {
+        scope.openMembersModal = function (filterType) {
           modalService.open({
               template: 'libraries/libraryMembersModal.tpl.html',
               modalData: {
                 library: scope.library,
                 canManageMembers: (scope.isOwner() || (scope.isCollaborating() && scope.collabsCanInvite)),
                 amOwner: scope.isOwner(),
+                filterType: filterType,
                 currentPageOrigin: 'libraryPage'
               }
             });

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.styl
@@ -141,21 +141,6 @@ maxWindowWidthForNarrowKeeps = inviteMaxWidth + 2 * (inviteSidePad + appSidePad1
   top: 0
   right: 0
 
-  &.collab
-    right: 100%
-    width: 8.7em
-
-    @media (max-width: 479px)
-      display: none
-
-  @media (max-width: 479px)
-    font-size: 1.5em
-
-.kf-lh-members-wrapper
-  position: absolute
-  top: 0
-  right: 0
-
   @media (max-width: 479px)
     font-size: 1.5em
 
@@ -174,6 +159,9 @@ followerPicDiam = 2.2em
 
   &:active:hover
     box-shadow: none
+
+  @media (max-width: 479px)
+    display: none
 
 .kf-lh-followers-pic
   height: followerPicDiam

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.styl
@@ -160,9 +160,6 @@ followerPicDiam = 2.2em
   &:active:hover
     box-shadow: none
 
-  @media (max-width: 479px)
-    display: none
-
 .kf-lh-followers-pic
   height: followerPicDiam
   width: followerPicDiam

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
@@ -25,7 +25,7 @@
         <div class="kf-lh-subscribe-msg">Notifications {{library.membership.subscribed ? 'enabled' : 'disabled'}}</div>
       </div>
 
-      <div class="kf-lh-followers" ng-if="!onCollabExperiment">
+      <div class="kf-lh-followers">
         <a class="kf-lh-followers-a" ng-repeat="follower in followersToShow" href="{{follower|profileUrl}}" kf-track-origin="libraryPage/follower">
           <img class="kf-lh-followers-pic" ng-src="{{follower|pic:100}}" alt="{{follower|name}}">
           <span class="kf-lh-followers-name">{{follower.firstName}}</span>
@@ -34,21 +34,6 @@
           <span class="kf-lh-followers-more-text kf-{{numMoreFollowersText.length}}">{{numMoreFollowersText}}</span>
         </button>
       </div>
-
-      <div class="kf-lh-members-wrapper" ng-if="onCollabExperiment && (library.numCollaborators > 0 || library.numFollowers > 0)">
-        <div class="kf-lh-followers collab">
-          <a class="kf-lh-followers-a" ng-repeat="follower in followersToShow" href="{{follower|profileUrl}}" kf-track-origin="libraryPage/follower">
-            <img class="kf-lh-followers-pic" ng-src="{{follower|pic:100}}" alt="{{follower|name}}">
-            <span class="kf-lh-followers-name">{{follower.firstName}}</span>
-          </a>
-        </div>
-        <button class="kf-lh-view-members" ng-click="openMembersModal()">
-          {{(isOwner() || (isCollaborating() && collabsCanInvite)) ? 'Manage ' : 'View '}}
-          {{(library.numFollowers + library.numCollaborators)|num}}
-          <ng-pluralize count="library.numFollowers + library.numCollaborators" when="{'one': ' member', 'other': ' members'}"></ng-pluralize>
-        </button>
-      </div>
-
     </div>
 
     <div class="kf-lh-cover-preview" ng-attr-style="{{imagePreview|shadedBackgroundImage:.2:.6}}" ng-if="imagePreview"></div>
@@ -65,7 +50,7 @@
 
       <div class="kf-lh-stats">
         <span class="kf-lh-stat" ng-pluralize count="library.numKeeps" when="{'one': '1 keep', 'other': '{{library.numKeeps|number}} keeps'}" ng-if="library.numKeeps"></span>
-        <button class="kf-lh-stat" ng-pluralize count="library.numFollowers" when="{'one': '1 follower', 'other': '{{library.numFollowers|num}} followers'}" ng-if="library.numFollowers && onCollabExperiment" ng-click="openMembersModal()"></button>
+        <button class="kf-lh-stat" ng-pluralize count="library.numFollowers" when="{'one': '1 follower', 'other': '{{library.numFollowers|num}} followers'}" ng-if="library.numFollowers && onCollabExperiment" ng-click="openMembersModal('followers_only')"></button>
         <button class="kf-lh-stat" ng-pluralize count="library.numFollowers" when="{one:'1 follower',other:'{{library.numFollowers|num}} followers'}" ng-click="showFollowers()" ng-if="library.numFollowers && !onCollabExperiment"></button>
       </div>
 
@@ -101,7 +86,7 @@
           </a>
           <a class="kf-lh-collab-name" href="{{collab|profileUrl}}" itemprop="name" kf-track-origin="libraryPage/collaborator">{{collab.firstName}}</a>
         </div>
-        <button class="kf-lh-more-collab" ng-click="openMembersModal()" ng-if="numMoreCollaboratorsText" ng-style="{'background-color': library.color}">
+        <button class="kf-lh-more-collab" ng-click="openMembersModal('collaborators_only')" ng-if="numMoreCollaboratorsText" ng-style="{'background-color': library.color}">
           + {{numMoreCollaboratorsText}}
         </button>
         <button class="kf-lh-add-collab-button" ng-if="(isOwner() || (isCollaborating() && library.whoCanInvite == 'collaborator')) && onCollabExperiment" ng-click="openInviteModal('collaborate')" ng-style="{'background-color': library.color}">

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryMembers.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryMembers.js
@@ -49,7 +49,7 @@ angular.module('kifi')
               } else {
                 scope.moreMembers = true;
                 scope.offset += 1;
-                _.remove(members, 'lastInvitedAt');
+                members = filterMembers(members, scope.filterType);
                 scope.memberList.push.apply(scope.memberList, members);
               }
             });
@@ -59,6 +59,15 @@ angular.module('kifi')
         //
         // Internal functions
         //
+        function filterMembers(members, filterType) {
+          if (filterType === 'followers_only') {
+            members = _.filter(members, {membership : 'read_only'});
+          } else if (filterType === 'collaborators_only') {
+            members = _.filter(members, {membership : 'read_write'});
+          }
+          return members;
+        }
+
         function updateMembership(member, access) {
           scope.selectedMember = member;
           return net.updateLibraryMembership(scope.library.id, member.id, {access: access});
@@ -166,6 +175,7 @@ angular.module('kifi')
           scope.canManage = scope.modalData.canManageMembers;
           scope.currentPageOrigin = scope.modalData.currentPageOrigin;
           scope.amOwner = scope.modalData.amOwner;
+          scope.filterType = scope.modalData.filterType;
         }
       }
     };

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryMembers.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryMembers.styl
@@ -39,6 +39,13 @@
 .lmm-member-link
   outline: none
 
+.lmm-member-email
+  display: inline-block
+  width: 30px
+  height: 22px
+  margin: 7px 6px 0 7px
+  background-size: cover
+
 .lmm-member-pic
   display: inline-block
   border-radius: 100%

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryMembers.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryMembers.tpl.html
@@ -10,11 +10,11 @@
       <div class="lmm-stats-box" ng-if="library.numFollowers > 0 || library.numCollaborators > 0">
         <ng-pluralize count="displayNumCollabs()" when="
         {'0' : '', 'one': '1 collaborator', 'other': '{} collaborators'}
-        "></ng-pluralize>
-        <span ng-if="library.numCollaborators > 0 && library.numFollowers > 0">&nbsp;and&nbsp;</span>
+        " ng-hide="filterType === 'followers_only'"></ng-pluralize>
+        <span ng-if="(library.numCollaborators > 0 && library.numFollowers > 0) && !filterType">&nbsp;and&nbsp;</span>
         <ng-pluralize count="library.numFollowers" when="
         {'0' : '', 'one': '1 follower', 'other': '{} followers'}
-        "></ng-pluralize>
+        " ng-hide="filterType === 'collaborators_only'"></ng-pluralize>
       </div>
 
       <div class="lmm-members-content">
@@ -35,14 +35,15 @@
             <!-- Members -->
             <li class="lmm-member-item" ng-repeat="member in memberList">
               <a href="{{member|profileUrl}}" class="lmm-member-link" kf-track-origin="{{currentPageOrigin}}/member" ng-click="close()">
-                <img ng-src="{{member | pic:100}}" alt="{{member|name}}" class="lmm-member-pic">
+                <img ng-src="{{member | pic:100}}" alt="{{member|name}}" class="lmm-member-pic" ng-if="member.id">
+                <div class="lmm-member-email svg-envelope" ng-if="!member.id"></div>
               </a>
               <div class="lmm-member-info-wrapper">
-                <div class="lmm-member-info-name">{{member|name}}</div>
-                <span class="lmm-member-info-icon svg-collaborators-green" ng-if="isCollaborator(member)"></span>
-                <span class="lmm-member-info-state" ng-class="{'collab' : isCollaborator(member)}">{{isCollaborator(member) ? 'Collaborator' : 'Follower'}}</span>
+                <div class="lmm-member-info-name">{{member.firstName ? member.firstName + ' ' + member.lastName : member.email}}</div>
+                <span class="lmm-member-info-icon svg-collaborators-green" ng-if="isCollaborator(member) && !member.lastInvitedAt"></span>
+                <span class="lmm-member-info-state" ng-class="{'collab' : isCollaborator(member) && !member.lastInvitedAt}">{{isCollaborator(member) && !member.lastInvitedAt ? 'Collaborator' : isFollower(member) && !member.lastInvitedAt ? 'Follower' : isCollaborator(member) ? 'Invite to collaborate pending' : 'Invite to follow pending'}}</span>
               </div>
-              <div class="lmm-member-dropdown-parent" kf-hover-menu ng-if="canManage">
+              <div class="lmm-member-dropdown-parent" kf-hover-menu ng-if="canManage && !member.lastInvitedAt">
                 <div class="svg-dropdown-arrow"></div>
                   <menu class="kf-dropdown-menu">
                     <button class="kf-dropdown-menu-item" ng-if="isFollower(member)" ng-click="changeToCollaborator(member)">Make collaborator</button>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -37,6 +37,7 @@ angular.module('kifi')
         scope.showFollowers = false;
         scope.colors = ['#447ab7','#5ab7e7','#4fc49e','#f99457','#dd5c60','#c16c9e','#9166ac'];
         scope.currentPageOrigin = '';
+        scope.onCollabExperiment = (profileService.me.experiments || []).indexOf('collaborative') > -1;
 
         //
         // Scope methods.

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
@@ -9,7 +9,7 @@
       {{modalTitle}}
     </h1>
     <div class="dialog-body">
-      <div ng-if="modifyingExistingLibrary" class="manage-lib-followers-info">
+      <div ng-if="modifyingExistingLibrary && !onCollabExperiment" class="manage-lib-followers-info">
         <p class="manage-lib-followers-stats">
           <span ng-pluralize count="library.numFollowers"
                 when="{'0': '0 people are ', 'one': '1 person is ', 'other': '{} people are '}"></span>


### PR DESCRIPTION
- Have library header filter when you click on "+4 followers" or "+5 collaborators"
- Have invites show up now (to email or to user) in manage members - divides based on whether the invite was `read_only` vs. `read_write`
- remove ability to manage members on edit library (collab experiment only)
