### PR TITLE
making search filters work properly

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/search/search.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/search.js
@@ -223,7 +223,7 @@ angular.module('kifi')
     };
 
     $scope.onClickSearchFilter = function (newSearchFilter) {
-      $location.search({f: newSearchFilter});
+      $location.search('f', newSearchFilter);
     };
 
 


### PR DESCRIPTION
@andrewconner 

There’s going to need to be server-side work done to get `f=f` to stop returning searcher’s own keeps.
