### PR TITLE
Refactor LibraryCommander

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -51,6 +51,7 @@ class LibraryCommander @Inject() (
     libraryAliasRepo: LibraryAliasRepo,
     libraryInviteRepo: LibraryInviteRepo,
     libraryInvitesAbuseMonitor: LibraryInvitesAbuseMonitor,
+    libraryInviteCommander: LibraryInviteCommander,
     libraryImageRepo: LibraryImageRepo,
     userRepo: UserRepo,
     userCommander: Provider[UserCommander],
@@ -321,19 +322,6 @@ class LibraryCommander @Inject() (
         libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, userId)
       } map (LibraryMembershipInfo.fromMembership(_))
     }.flatten
-  }
-
-  def getViewerInviteInfo(userIdOpt: Option[Id[User]], libraryId: Id[Library]): Option[LibraryInviteInfo] = {
-    userIdOpt.flatMap { userId =>
-      db.readOnlyMaster { implicit s =>
-        val inviteOpt = libraryInviteRepo.getLastSentByLibraryIdAndUserId(libraryId, userId, Set(LibraryInviteStates.ACTIVE))
-        val basicUserOpt = inviteOpt map { inv => basicUserRepo.load(inv.inviterId) }
-        (inviteOpt, basicUserOpt)
-      } match {
-        case (Some(invite), Some(inviter)) => Some(LibraryInviteInfo.createInfo(invite, inviter))
-        case (_, _) => None
-      }
-    }
   }
 
   private def getSourceAttribution(libId: Id[Library]): Option[LibrarySourceAttribution] = {
@@ -743,205 +731,6 @@ class LibraryCommander @Inject() (
     }
   }
 
-  def processInvites(invites: Seq[LibraryInvite]): Future[Seq[ElectronicMail]] = {
-    val emailFutures = {
-      invites.groupBy(invite => (invite.inviterId, invite.libraryId, invite.userId, invite.emailAddress))
-        .map { key =>
-          val (inviterId, libId, recipientId, recipientEmail) = key._1
-
-          val (inviter, lib, libOwner, lastInviteOpt) = db.readOnlyMaster { implicit s =>
-            val inviter = userRepo.get(inviterId)
-            val lib = libraryRepo.get(libId)
-            val libOwner = basicUserRepo.load(lib.ownerId)
-            val lastInviteOpt = (recipientId, recipientEmail) match {
-              case (Some(userId), _) =>
-                libraryInviteRepo.getLastSentByLibraryIdAndInviterIdAndUserId(libId, inviterId, userId, Set(LibraryInviteStates.ACTIVE))
-              case (_, Some(email)) =>
-                libraryInviteRepo.getLastSentByLibraryIdAndInviterIdAndEmail(libId, inviterId, email, Set(LibraryInviteStates.ACTIVE))
-              case _ => None
-            }
-            (inviter, lib, libOwner, lastInviteOpt)
-          }
-          val invitesToPersist = key._2.filter { invite =>
-            lastInviteOpt.map { lastInvite =>
-              lastInvite.access != invite.access || lastInvite.createdAt.plusMinutes(5).isBefore(invite.createdAt)
-            }.getOrElse(true)
-          }
-
-          db.readWrite { implicit s =>
-            invitesToPersist.map { inv =>
-              libraryInviteRepo.save(inv)
-            }
-          }
-
-          val userImage = s3ImageStore.avatarUrlByUser(inviter)
-          val libLink = s"""https://www.kifi.com${Library.formatLibraryPath(libOwner.username, lib.slug)}"""
-          val libImageOpt = libraryImageCommander.getBestImageForLibrary(libId, ProcessedImageSize.Medium.idealSize)
-
-          val userInviteesMap = invitesToPersist.collect {
-            case invite if invite.userId.isDefined =>
-              invite.userId.get -> invite
-          }.toMap
-
-          // send notifications to kifi users only
-          if (userInviteesMap.nonEmpty) {
-            notifyInviteeAboutInvitationToJoinLIbrary(inviter, lib, libOwner, userImage, libLink, libImageOpt, userInviteesMap)
-            if (inviterId != lib.ownerId) {
-              notifyLibOwnerAboutInvitationToTheirLibrary(inviter, lib, libOwner, userImage, libImageOpt, userInviteesMap)
-            }
-          }
-          // send emails to both users & non-users
-          invitesToPersist.map { invite =>
-            invite.userId match {
-              case Some(id) =>
-                libraryInvitesAbuseMonitor.inspect(inviterId, Some(id), None, libId, invitesToPersist.length)
-              case _ =>
-                libraryInvitesAbuseMonitor.inspect(inviterId, None, invite.emailAddress, libId, invitesToPersist.length)
-            }
-            libraryInviteSender.get.sendInvite(invite)
-          }
-        }.toSeq.flatten
-    }
-    val emailsF = Future.sequence(emailFutures)
-    emailsF map (_.filter(_.isDefined).map(_.get))
-  }
-
-  def notifyLibOwnerAboutInvitationToTheirLibrary(inviter: User, lib: Library, libOwner: BasicUser, userImage: String, libImageOpt: Option[LibraryImage], inviteeMap: Map[Id[User], LibraryInvite]): Unit = {
-    val (collabInvitees, followInvitees) = inviteeMap.partition { case (userId, invite) => invite.isCollaborator }
-    val collabInviteeSet = collabInvitees.keySet
-    val followInviteeSet = followInvitees.keySet
-    val collabFriendStr = if (collabInviteeSet.size > 1) "friends" else "a friend"
-    val followFriendStr = if (followInviteeSet.size > 1) "friends" else "a friend"
-
-    val collabInvitesF = if (collabInviteeSet.size > 0) {
-      elizaClient.sendGlobalNotification( //push sent
-        userIds = Set(lib.ownerId),
-        title = s"${inviter.firstName} invited someone to contribute to your Library!",
-        body = s"${inviter.fullName} invited $collabFriendStr to contribute to your library, ${lib.name}.",
-        linkText = s"See ${inviter.firstName}’s profile",
-        linkUrl = s"https://www.kifi.com/${inviter.username.value}",
-        imageUrl = userImage,
-        sticky = false,
-        category = NotificationCategory.User.LIBRARY_FOLLOWED,
-        extra = Some(Json.obj(
-          "inviter" -> inviter,
-          "library" -> Json.toJson(LibraryNotificationInfo.fromLibraryAndOwner(lib, libImageOpt, libOwner))
-        ))
-      )
-    } else { Future.successful((): Unit) }
-
-    val followInvitesF = if (followInviteeSet.size > 0) {
-      elizaClient.sendGlobalNotification( //push sent
-        userIds = Set(lib.ownerId),
-        title = s"${inviter.firstName} invited someone to follow your Library!",
-        body = s"${inviter.fullName} invited $followFriendStr to follow your library, ${lib.name}.",
-        linkText = s"See ${inviter.firstName}’s profile",
-        linkUrl = s"https://www.kifi.com/${inviter.username.value}",
-        imageUrl = userImage,
-        sticky = false,
-        category = NotificationCategory.User.LIBRARY_FOLLOWED,
-        extra = Some(Json.obj(
-          "inviter" -> inviter,
-          "library" -> Json.toJson(LibraryNotificationInfo.fromLibraryAndOwner(lib, libImageOpt, libOwner))
-        ))
-      )
-    } else { Future.successful((): Unit) }
-
-    for {
-      collabInvites <- collabInvitesF
-      followInvites <- followInvitesF
-    } yield {
-      val canSendPush = kifiInstallationCommander.isMobileVersionEqualOrGreaterThen(lib.ownerId, KifiAndroidVersion("2.2.4"), KifiIPhoneVersion("2.1.0"))
-      if (canSendPush) {
-        if (collabInviteeSet.size > 0) {
-          elizaClient.sendUserPushNotification(
-            userId = lib.ownerId,
-            message = s"${inviter.firstName} invited $collabFriendStr to contribute to your library ${lib.name}!",
-            recipient = inviter,
-            pushNotificationExperiment = PushNotificationExperiment.Experiment1,
-            category = UserPushNotificationCategory.NewLibraryFollower)
-        }
-        if (followInviteeSet.size > 0) {
-          elizaClient.sendUserPushNotification(
-            userId = lib.ownerId,
-            message = s"${inviter.firstName} invited $followFriendStr to follow your library ${lib.name}!",
-            recipient = inviter,
-            pushNotificationExperiment = PushNotificationExperiment.Experiment1,
-            category = UserPushNotificationCategory.NewLibraryFollower)
-        }
-      }
-    }
-  }
-
-  def notifyInviteeAboutInvitationToJoinLIbrary(inviter: User, lib: Library, libOwner: BasicUser, userImage: String, libLink: String, libImageOpt: Option[LibraryImage], inviteeMap: Map[Id[User], LibraryInvite]): Unit = {
-    val (collabInvitees, followInvitees) = inviteeMap.partition { case (userId, invite) => invite.isCollaborator }
-    val collabInviteeSet = collabInvitees.keySet
-    val followInviteeSet = followInvitees.keySet
-
-    val collabInvitesF = elizaClient.sendGlobalNotification( //push sent
-      userIds = collabInviteeSet,
-      title = s"${inviter.firstName} ${inviter.lastName} invited you to collaborate on a Library!",
-      body = s"Help ${libOwner.firstName} by sharing your knowledge in the library ${lib.name}.",
-      linkText = "Let's do it!",
-      linkUrl = libLink,
-      imageUrl = userImage,
-      sticky = false,
-      category = NotificationCategory.User.LIBRARY_INVITATION,
-      extra = Some(Json.obj(
-        "inviter" -> inviter,
-        "library" -> Json.toJson(LibraryNotificationInfo.fromLibraryAndOwner(lib, libImageOpt, libOwner)),
-        "access" -> LibraryAccess.READ_WRITE
-      ))
-    )
-
-    val followInvitesF = elizaClient.sendGlobalNotification( //push sent
-      userIds = followInviteeSet,
-      title = s"${inviter.firstName} ${inviter.lastName} invited you to follow a Library!",
-      body = s"Browse keeps in ${lib.name} to find some interesting gems kept by ${libOwner.firstName}.",
-      linkText = "Let's take a look!",
-      linkUrl = libLink,
-      imageUrl = userImage,
-      sticky = false,
-      category = NotificationCategory.User.LIBRARY_INVITATION,
-      extra = Some(Json.obj(
-        "inviter" -> inviter,
-        "library" -> Json.toJson(LibraryNotificationInfo.fromLibraryAndOwner(lib, libImageOpt, libOwner)),
-        "access" -> LibraryAccess.READ_ONLY
-      ))
-    )
-
-    for {
-      collabInvites <- collabInvitesF
-      followInvites <- followInvitesF
-    } yield {
-      collabInviteeSet.foreach { userId =>
-        val canSendPush = kifiInstallationCommander.isMobileVersionEqualOrGreaterThen(userId, KifiAndroidVersion("2.2.4"), KifiIPhoneVersion("2.1.0"))
-        if (canSendPush) {
-          elizaClient.sendLibraryPushNotification(
-            userId,
-            s"""${inviter.firstName} ${inviter.lastName} invited you to contribute to: ${lib.name}""",
-            lib.id.get,
-            libLink,
-            PushNotificationExperiment.Experiment1,
-            LibraryPushNotificationCategory.LibraryInvitation)
-        }
-      }
-
-      followInviteeSet.foreach { userId =>
-        val canSendPush = kifiInstallationCommander.isMobileVersionEqualOrGreaterThen(userId, KifiAndroidVersion("2.2.4"), KifiIPhoneVersion("2.1.0"))
-        if (canSendPush) {
-          elizaClient.sendLibraryPushNotification(
-            userId,
-            s"""${inviter.firstName} ${inviter.lastName} invited you to follow: ${lib.name}""",
-            lib.id.get,
-            libLink,
-            PushNotificationExperiment.Experiment1,
-            LibraryPushNotificationCategory.LibraryInvitation)
-        }
-      }
-    }
-  }
-
   def internSystemGeneratedLibraries(userId: Id[User], generateNew: Boolean = true): (Library, Library) = {
     db.readWrite(attempts = 3) { implicit session =>
       val libMem = libraryMembershipRepo.getWithUserId(userId, None)
@@ -1011,140 +800,6 @@ class LibraryCommander @Inject() (
       val mainLib = sysLibs.find(_._2.kind == LibraryKind.SYSTEM_MAIN).map(_._2).orElse(mainOpt).get
       val secretLib = sysLibs.find(_._2.kind == LibraryKind.SYSTEM_SECRET).map(_._2).orElse(secretOpt).get
       (mainLib, secretLib)
-    }
-  }
-
-  def revokeInvitationToLibrary(libraryId: Id[Library], inviterId: Id[User], invitee: Either[ExternalId[User], EmailAddress]): Either[(String, String), String] = {
-    val libraryInvite = invitee match {
-      case Left(externalId) => db.readOnlyMaster { implicit s =>
-        userRepo.getOpt(externalId) match {
-          case Some(userId) => Right(libraryInviteRepo.getLastSentByLibraryIdAndInviterIdAndUserId(libraryId, inviterId, userId.id.get, Set(LibraryInviteStates.ACTIVE)))
-          case None => Left(s"external_id_does_not_exist")
-        }
-      }
-      case Right(email) => db.readOnlyMaster { implicit s =>
-        Right(libraryInviteRepo.getLastSentByLibraryIdAndInviterIdAndEmail(libraryId, inviterId, email, Set(LibraryInviteStates.ACTIVE)))
-      }
-    }
-    libraryInvite match {
-      case Right(Some(toDelete)) => db.readWrite(attempts = 3) { implicit s =>
-        libraryInviteRepo.save(toDelete.copy(state = LibraryInviteStates.INACTIVE)) match {
-          case invite if invite.state == LibraryInviteStates.INACTIVE => Right("library_delete_succeeded")
-          case _ => Left("error" -> "library_invite_delete_failed")
-        }
-      }
-      case Right(None) => Left("error" -> "library_invite_not_found")
-      case Left(error) => Left("error" -> error)
-    }
-  }
-
-  def inviteUsersToLibrary(libraryId: Id[Library], inviterId: Id[User], inviteList: Seq[(Either[Id[User], EmailAddress], LibraryAccess, Option[String])])(implicit eventContext: HeimdalContext): Future[Either[LibraryFail, Seq[(Either[BasicUser, RichContact], LibraryAccess)]]] = {
-    val (lib, inviterMembership) = db.readOnlyMaster { implicit s =>
-      val lib = libraryRepo.get(libraryId)
-      val mem = libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, inviterId)
-      (lib, mem)
-    }
-    val inviterIsOwner = inviterMembership.map(_.isOwner).getOrElse(false)
-    val inviterIsCollab = inviterMembership.map(_.isCollaborator).getOrElse(false)
-    val collabCannotInvite = lib.whoCanInvite == Some(LibraryInvitePermissions.OWNER)
-
-    if (lib.kind == LibraryKind.SYSTEM_MAIN || lib.kind == LibraryKind.SYSTEM_SECRET)
-      Future.successful(Left(LibraryFail(BAD_REQUEST, "cant_invite_to_system_generated_library")))
-    else {
-      // get all invitee contacts by email address
-      val futureInviteeContactsByEmailAddress = {
-        val invitedEmailAddresses = inviteList.collect { case (Right(emailAddress), _, _) => emailAddress }
-        abookClient.internKifiContacts(inviterId, invitedEmailAddresses.map(BasicContact(_)): _*).imap { kifiContacts =>
-          (invitedEmailAddresses zip kifiContacts).toMap
-        }
-      }
-
-      // get all invitee users (mapped userId -> basicuser)
-      val inviteeUserMap = {
-        val invitedUserIds = inviteList.collect { case (Left(userId), _, _) => userId }
-        db.readOnlyMaster { implicit s =>
-          basicUserRepo.loadAll(invitedUserIds.toSet)
-        }
-      }
-
-      futureInviteeContactsByEmailAddress.map { inviteeContactsByEmailAddress => // when email contacts are done fetching... process through inviteList
-        val invitesForInvitees = db.readOnlyMaster { implicit s =>
-          val libMembersMap = libraryMembershipRepo.getWithLibraryId(lib.id.get).map { mem =>
-            mem.userId -> mem
-          }.toMap
-
-          for ((recipient, inviteAccess, msgOpt) <- inviteList) yield {
-            improperInvite(lib, inviterMembership, inviteAccess) match {
-              case Some(fail) =>
-                log.warn(s"[inviteUsersToLibrary] error: user $inviterId attempting to invite $recipient for $inviteAccess access to library (${lib.id.get}, ${lib.name}, ${lib.visibility}, ${lib.whoCanInvite})")
-                None
-              case _ =>
-                recipient match {
-                  case Left(userId) =>
-                    libMembersMap.get(userId) match {
-                      case Some(mem) if mem.isOwner || mem.isCollaborator => // don't persist invite to an owner or collaborator
-                        log.warn(s"[inviteUsersToLibrary] not persisting invite: user $inviterId attempting to invite user $userId when recipient is already owner or collaborator")
-                        None
-                      case Some(mem) if mem.access == inviteAccess => // don't persist invite to a user with same access
-                        log.warn(s"[inviteUsersToLibrary] not persisting invite: user $inviterId attempting to invite user $userId for $inviteAccess access when membership has same access level")
-                        None
-                      case _ =>
-                        val newInvite = LibraryInvite(libraryId = libraryId, inviterId = inviterId, userId = Some(userId), access = inviteAccess, message = msgOpt)
-                        val inviteeInfo = (Left(inviteeUserMap(userId)), inviteAccess)
-                        Some(newInvite, inviteeInfo)
-                    }
-
-                  case Right(email) =>
-                    val newInvite = LibraryInvite(libraryId = libraryId, inviterId = inviterId, emailAddress = Some(email), access = inviteAccess, message = msgOpt)
-                    val inviteeInfo = (Right(inviteeContactsByEmailAddress(email)), inviteAccess)
-                    Some(newInvite, inviteeInfo)
-                }
-            }
-          }
-        }
-        val (invites, inviteesWithAccess) = invitesForInvitees.flatten.unzip
-        processInvites(invites)
-        libraryAnalytics.sendLibraryInvite(inviterId, lib, inviteList.map { _._1 }, eventContext)
-        Right(inviteesWithAccess)
-      }
-    }
-  }
-
-  def inviteAnonymousToLibrary(libraryId: Id[Library], inviterId: Id[User], access: LibraryAccess, message: Option[String])(implicit context: HeimdalContext): Either[LibraryFail, (LibraryInvite, Library)] = {
-    val (library, inviterMembershipOpt) = db.readOnlyMaster { implicit s =>
-      val library = libraryRepo.get(libraryId)
-      val membership = libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, inviterId)
-      (library, membership)
-    }
-
-    val badInvite = improperInvite(library, inviterMembershipOpt, access)
-    if (library.kind == LibraryKind.SYSTEM_MAIN || library.kind == LibraryKind.SYSTEM_SECRET) {
-      Left(LibraryFail(BAD_REQUEST, "cant_invite_to_system_generated_library"))
-    } else if (badInvite.isDefined) {
-      log.warn(s"[inviteAnonymousToLibrary] error: user $inviterId attempting to generate link invite for $access access to library (${library.id.get}, ${library.name}, ${library.visibility}, ${library.whoCanInvite})")
-      Left(badInvite.get)
-    } else {
-      val libInvite = db.readWrite { implicit s =>
-        libraryInviteRepo.save(LibraryInvite(libraryId = libraryId, inviterId = inviterId, userId = None, emailAddress = None, access = access, message = message))
-      }
-      Right((libInvite, library))
-    }
-  }
-
-  private def improperInvite(library: Library, inviterMembership: Option[LibraryMembership], access: LibraryAccess): Option[LibraryFail] = {
-    val inviterIsOwner = inviterMembership.map(_.isOwner).getOrElse(false)
-    val inviterIsCollab = inviterMembership.map(_.isCollaborator).getOrElse(false)
-    val collabCannotInvite = library.whoCanInvite == Some(LibraryInvitePermissions.OWNER)
-    if (access == LibraryAccess.READ_WRITE && !inviterIsOwner && !inviterIsCollab) { // invite to RW, but inviter is not owner or collaborator
-      Some(LibraryFail(BAD_REQUEST, "cant_invite_rw_nonowner_noncollab"))
-    } else if (access == LibraryAccess.READ_WRITE && inviterIsCollab && collabCannotInvite) { // invite to RW, but inviter is collaborator but library does not allow
-      Some(LibraryFail(BAD_REQUEST, "cant_invite_rw_noncollablib"))
-    } else if (access == LibraryAccess.READ_ONLY && library.isSecret && !inviterIsOwner && !inviterIsCollab) { // invite is RO, but library is secret & inviter is not owner or collaborator
-      Some(LibraryFail(BAD_REQUEST, "cant_invite_ro_secretlib__nonowner_noncollab"))
-    } else if (access == LibraryAccess.READ_ONLY && library.isSecret && inviterIsCollab && collabCannotInvite) { // invite is RO, but library is secret & inviter is collaborator but library does not allow
-      Some(LibraryFail(BAD_REQUEST, "cant_invite_ro_secretlib_noncollablib"))
-    } else {
-      None
     }
   }
 
@@ -1277,7 +932,7 @@ class LibraryCommander @Inject() (
         if (invitesToAlert.nonEmpty) {
           val invaitee = userRepo.get(userId)
           val owner = basicUserRepo.load(lib.ownerId)
-          notifyInviterOnLibraryInvitationAcceptance(invitesToAlert, invaitee, lib, owner)
+          libraryInviteCommander.notifyInviterOnLibraryInvitationAcceptance(invitesToAlert, invaitee, lib, owner)
         }
         (updatedLib, updatedMem)
       }
@@ -1286,51 +941,11 @@ class LibraryCommander @Inject() (
     }
   }
 
-  def notifyInviterOnLibraryInvitationAcceptance(invitesToAlert: Seq[LibraryInvite], invaitee: User, lib: Library, owner: BasicUser): Unit = {
-    val invaiteeImage = s3ImageStore.avatarUrlByUser(invaitee)
-    val libImageOpt = libraryImageCommander.getBestImageForLibrary(lib.id.get, ProcessedImageSize.Medium.idealSize)
-    invitesToAlert foreach { invite =>
-      val inviterId = invite.inviterId
-      elizaClient.sendGlobalNotification( //push sent
-        userIds = Set(inviterId),
-        title = s"${invaitee.firstName} is now following ${lib.name}",
-        body = s"You invited ${invaitee.fullName} to follow ${lib.name}.",
-        linkText = s"See ${invaitee.firstName}’s profile",
-        linkUrl = s"https://www.kifi.com/${invaitee.username.value}",
-        imageUrl = invaiteeImage,
-        sticky = false,
-        category = NotificationCategory.User.LIBRARY_FOLLOWED,
-        extra = Some(Json.obj(
-          "follower" -> BasicUser.fromUser(invaitee),
-          "library" -> Json.toJson(LibraryNotificationInfo.fromLibraryAndOwner(lib, libImageOpt, owner))
-        ))
-      ) map { _ =>
-          val message = s"${invaitee.firstName} is now following ${lib.name}"
-          val canSendPush = kifiInstallationCommander.isMobileVersionEqualOrGreaterThen(inviterId, KifiAndroidVersion("2.2.4"), KifiIPhoneVersion("2.1.0"))
-          if (canSendPush) {
-            elizaClient.sendUserPushNotification(
-              userId = inviterId,
-              message = message,
-              recipient = invaitee,
-              pushNotificationExperiment = PushNotificationExperiment.Experiment1,
-              category = UserPushNotificationCategory.NewLibraryFollower)
-          }
-        }
-    }
-  }
-
   private def updateLibraryJoin(userId: Id[User], library: Library, eventContext: HeimdalContext): Future[Unit] = SafeFuture {
     val libraryId = library.id.get
     libraryAnalytics.acceptLibraryInvite(userId, library, eventContext)
     libraryAnalytics.followLibrary(userId, library, eventContext)
     searchClient.updateLibraryIndex()
-  }
-
-  def declineLibrary(userId: Id[User], libraryId: Id[Library]) = {
-    db.readWrite { implicit s =>
-      val listInvites = libraryInviteRepo.getWithLibraryIdAndUserId(libraryId = libraryId, userId = userId)
-      listInvites.map(inv => libraryInviteRepo.save(inv.copy(state = LibraryInviteStates.DECLINED)))
-    }
   }
 
   def leaveLibrary(libraryId: Id[Library], userId: Id[User])(implicit eventContext: HeimdalContext): Either[LibraryFail, Unit] = {
@@ -1757,14 +1372,6 @@ class LibraryCommander @Inject() (
       caption = None,
       modifiedAt = lib.updatedAt,
       kind = lib.kind)
-  }
-
-  def convertPendingInvites(emailAddress: EmailAddress, userId: Id[User]) = {
-    db.readWrite { implicit s =>
-      libraryInviteRepo.getByEmailAddress(emailAddress, Set.empty) foreach { libInv =>
-        libraryInviteRepo.save(libInv.copy(userId = Some(userId)))
-      }
-    }
   }
 
   def updateLastEmailSent(userId: Id[User], keeps: Seq[Keep]): Unit = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInviteCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInviteCommander.scala
@@ -1,0 +1,446 @@
+package com.keepit.commanders
+
+import com.google.inject.{ Inject, Provider }
+import com.keepit.abook.ABookServiceClient
+import com.keepit.abook.model.RichContact
+import com.keepit.commanders.emails.LibraryInviteEmailSender
+import com.keepit.common.core._
+import com.keepit.common.crypto.PublicIdConfiguration
+import com.keepit.common.db.slick.Database
+import com.keepit.common.db.{ ExternalId, Id }
+import com.keepit.common.logging.Logging
+import com.keepit.common.mail.{ BasicContact, ElectronicMail, EmailAddress }
+import com.keepit.common.social.BasicUserRepo
+import com.keepit.common.store.S3ImageStore
+import com.keepit.eliza.{ ElizaServiceClient, LibraryPushNotificationCategory, PushNotificationExperiment, UserPushNotificationCategory }
+import com.keepit.heimdal.{ HeimdalContext, HeimdalServiceClient }
+import com.keepit.model._
+import com.keepit.social.BasicUser
+import play.api.http.Status._
+import play.api.libs.json.Json
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+class LibraryInviteCommander @Inject() (
+    db: Database,
+    libraryRepo: LibraryRepo,
+    libraryMembershipRepo: LibraryMembershipRepo,
+    libraryInviteRepo: LibraryInviteRepo,
+    libraryInvitesAbuseMonitor: LibraryInvitesAbuseMonitor,
+    userRepo: UserRepo,
+    basicUserRepo: BasicUserRepo,
+    s3ImageStore: S3ImageStore,
+    elizaClient: ElizaServiceClient,
+    abookClient: ABookServiceClient,
+    libraryAnalytics: LibraryAnalytics,
+    libraryInviteSender: Provider[LibraryInviteEmailSender],
+    heimdal: HeimdalServiceClient,
+    libraryImageCommander: LibraryImageCommander,
+    kifiInstallationCommander: KifiInstallationCommander,
+    implicit val defaultContext: ExecutionContext,
+    implicit val publicIdConfig: PublicIdConfiguration) extends Logging {
+
+  def convertPendingInvites(emailAddress: EmailAddress, userId: Id[User]): Unit = {
+    db.readWrite { implicit s =>
+      libraryInviteRepo.getByEmailAddress(emailAddress, Set.empty) foreach { libInv =>
+        libraryInviteRepo.save(libInv.copy(userId = Some(userId)))
+      }
+    }
+  }
+
+  def declineLibrary(userId: Id[User], libraryId: Id[Library]) = {
+    db.readWrite { implicit s =>
+      val listInvites = libraryInviteRepo.getWithLibraryIdAndUserId(libraryId = libraryId, userId = userId)
+      listInvites.map(inv => libraryInviteRepo.save(inv.copy(state = LibraryInviteStates.DECLINED)))
+    }
+  }
+
+  def notifyInviterOnLibraryInvitationAcceptance(invitesToAlert: Seq[LibraryInvite], invaitee: User, lib: Library, owner: BasicUser): Unit = {
+    val invaiteeImage = s3ImageStore.avatarUrlByUser(invaitee)
+    val libImageOpt = libraryImageCommander.getBestImageForLibrary(lib.id.get, ProcessedImageSize.Medium.idealSize)
+    invitesToAlert foreach { invite =>
+      val inviterId = invite.inviterId
+      elizaClient.sendGlobalNotification( //push sent
+        userIds = Set(inviterId),
+        title = s"${invaitee.firstName} is now following ${lib.name}",
+        body = s"You invited ${invaitee.fullName} to follow ${lib.name}.",
+        linkText = s"See ${invaitee.firstName}’s profile",
+        linkUrl = s"https://www.kifi.com/${invaitee.username.value}",
+        imageUrl = invaiteeImage,
+        sticky = false,
+        category = NotificationCategory.User.LIBRARY_FOLLOWED,
+        extra = Some(Json.obj(
+          "follower" -> BasicUser.fromUser(invaitee),
+          "library" -> Json.toJson(LibraryNotificationInfo.fromLibraryAndOwner(lib, libImageOpt, owner))
+        ))
+      ) map { _ =>
+          val message = s"${invaitee.firstName} is now following ${lib.name}"
+          val canSendPush = kifiInstallationCommander.isMobileVersionEqualOrGreaterThen(inviterId, KifiAndroidVersion("2.2.4"), KifiIPhoneVersion("2.1.0"))
+          if (canSendPush) {
+            elizaClient.sendUserPushNotification(
+              userId = inviterId,
+              message = message,
+              recipient = invaitee,
+              pushNotificationExperiment = PushNotificationExperiment.Experiment1,
+              category = UserPushNotificationCategory.NewLibraryFollower)
+          }
+        }
+    }
+  }
+
+  def inviteAnonymousToLibrary(libraryId: Id[Library], inviterId: Id[User], access: LibraryAccess, message: Option[String])(implicit context: HeimdalContext): Either[LibraryFail, (LibraryInvite, Library)] = {
+    val (library, inviterMembershipOpt) = db.readOnlyMaster { implicit s =>
+      val library = libraryRepo.get(libraryId)
+      val membership = libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, inviterId)
+      (library, membership)
+    }
+
+    val badInvite = improperInvite(library, inviterMembershipOpt, access)
+    if (library.kind == LibraryKind.SYSTEM_MAIN || library.kind == LibraryKind.SYSTEM_SECRET) {
+      Left(LibraryFail(BAD_REQUEST, "cant_invite_to_system_generated_library"))
+    } else if (badInvite.isDefined) {
+      log.warn(s"[inviteAnonymousToLibrary] error: user $inviterId attempting to generate link invite for $access access to library (${library.id.get}, ${library.name}, ${library.visibility}, ${library.whoCanInvite})")
+      Left(badInvite.get)
+    } else {
+      val libInvite = db.readWrite { implicit s =>
+        libraryInviteRepo.save(LibraryInvite(libraryId = libraryId, inviterId = inviterId, userId = None, emailAddress = None, access = access, message = message))
+      }
+      Right((libInvite, library))
+    }
+  }
+
+  def inviteUsersToLibrary(libraryId: Id[Library], inviterId: Id[User], inviteList: Seq[(Either[Id[User], EmailAddress], LibraryAccess, Option[String])])(implicit eventContext: HeimdalContext): Future[Either[LibraryFail, Seq[(Either[BasicUser, RichContact], LibraryAccess)]]] = {
+    val (lib, inviterMembership) = db.readOnlyMaster { implicit s =>
+      val lib = libraryRepo.get(libraryId)
+      val mem = libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, inviterId)
+      (lib, mem)
+    }
+    val inviterIsOwner = inviterMembership.exists(_.isOwner)
+    val inviterIsCollab = inviterMembership.exists(_.isCollaborator)
+    val collabCannotInvite = lib.whoCanInvite == Some(LibraryInvitePermissions.OWNER)
+
+    if (lib.kind == LibraryKind.SYSTEM_MAIN || lib.kind == LibraryKind.SYSTEM_SECRET)
+      Future.successful(Left(LibraryFail(BAD_REQUEST, "cant_invite_to_system_generated_library")))
+    else {
+      // get all invitee contacts by email address
+      val futureInviteeContactsByEmailAddress = {
+        val invitedEmailAddresses = inviteList.collect { case (Right(emailAddress), _, _) => emailAddress }
+        abookClient.internKifiContacts(inviterId, invitedEmailAddresses.map(BasicContact(_)): _*).imap { kifiContacts =>
+          (invitedEmailAddresses zip kifiContacts).toMap
+        }
+      }
+
+      // get all invitee users (mapped userId -> basicuser)
+      val inviteeUserMap = {
+        val invitedUserIds = inviteList.collect { case (Left(userId), _, _) => userId }
+        db.readOnlyMaster { implicit s =>
+          basicUserRepo.loadAll(invitedUserIds.toSet)
+        }
+      }
+
+      futureInviteeContactsByEmailAddress.map { inviteeContactsByEmailAddress => // when email contacts are done fetching... process through inviteList
+        val invitesForInvitees = db.readOnlyMaster { implicit s =>
+          val libMembersMap = libraryMembershipRepo.getWithLibraryId(lib.id.get).map { mem =>
+            mem.userId -> mem
+          }.toMap
+
+          for ((recipient, inviteAccess, msgOpt) <- inviteList) yield {
+            improperInvite(lib, inviterMembership, inviteAccess) match {
+              case Some(fail) =>
+                log.warn(s"[inviteUsersToLibrary] error: user $inviterId attempting to invite $recipient for $inviteAccess access to library (${lib.id.get}, ${lib.name}, ${lib.visibility}, ${lib.whoCanInvite})")
+                None
+              case _ =>
+                recipient match {
+                  case Left(userId) =>
+                    libMembersMap.get(userId) match {
+                      case Some(mem) if mem.isOwner || mem.isCollaborator => // don't persist invite to an owner or collaborator
+                        log.warn(s"[inviteUsersToLibrary] not persisting invite: user $inviterId attempting to invite user $userId when recipient is already owner or collaborator")
+                        None
+                      case Some(mem) if mem.access == inviteAccess => // don't persist invite to a user with same access
+                        log.warn(s"[inviteUsersToLibrary] not persisting invite: user $inviterId attempting to invite user $userId for $inviteAccess access when membership has same access level")
+                        None
+                      case _ =>
+                        val newInvite = LibraryInvite(libraryId = libraryId, inviterId = inviterId, userId = Some(userId), access = inviteAccess, message = msgOpt)
+                        val inviteeInfo = (Left(inviteeUserMap(userId)), inviteAccess)
+                        Some((newInvite, inviteeInfo))
+                    }
+
+                  case Right(email) =>
+                    val newInvite = LibraryInvite(libraryId = libraryId, inviterId = inviterId, emailAddress = Some(email), access = inviteAccess, message = msgOpt)
+                    val inviteeInfo = (Right(inviteeContactsByEmailAddress(email)), inviteAccess)
+                    Some((newInvite, inviteeInfo))
+                }
+            }
+          }
+        }
+        val (invites, inviteesWithAccess) = invitesForInvitees.flatten.unzip
+        processInvites(invites)
+        libraryAnalytics.sendLibraryInvite(inviterId, lib, inviteList.map {
+          _._1
+        }, eventContext)
+        Right(inviteesWithAccess)
+      }
+    }
+  }
+
+  def improperInvite(library: Library, inviterMembership: Option[LibraryMembership], access: LibraryAccess): Option[LibraryFail] = {
+    val inviterIsOwner = inviterMembership.exists(_.isOwner)
+    val inviterIsCollab = inviterMembership.exists(_.isCollaborator)
+    val collabCannotInvite = library.whoCanInvite == Some(LibraryInvitePermissions.OWNER)
+    if (access == LibraryAccess.READ_WRITE && !inviterIsOwner && !inviterIsCollab) {
+      // invite to RW, but inviter is not owner or collaborator
+      Some(LibraryFail(BAD_REQUEST, "cant_invite_rw_nonowner_noncollab"))
+    } else if (access == LibraryAccess.READ_WRITE && inviterIsCollab && collabCannotInvite) {
+      // invite to RW, but inviter is collaborator but library does not allow
+      Some(LibraryFail(BAD_REQUEST, "cant_invite_rw_noncollablib"))
+    } else if (access == LibraryAccess.READ_ONLY && library.isSecret && !inviterIsOwner && !inviterIsCollab) {
+      // invite is RO, but library is secret & inviter is not owner or collaborator
+      Some(LibraryFail(BAD_REQUEST, "cant_invite_ro_secretlib__nonowner_noncollab"))
+    } else if (access == LibraryAccess.READ_ONLY && library.isSecret && inviterIsCollab && collabCannotInvite) {
+      // invite is RO, but library is secret & inviter is collaborator but library does not allow
+      Some(LibraryFail(BAD_REQUEST, "cant_invite_ro_secretlib_noncollablib"))
+    } else {
+      None
+    }
+  }
+
+  def processInvites(invites: Seq[LibraryInvite]): Future[Seq[ElectronicMail]] = {
+    val emailFutures = {
+      invites.groupBy(invite => (invite.inviterId, invite.libraryId, invite.userId, invite.emailAddress))
+        .map { key =>
+          val (inviterId, libId, recipientId, recipientEmail) = key._1
+
+          val (inviter, lib, libOwner, lastInviteOpt) = db.readOnlyMaster { implicit s =>
+            val inviter = userRepo.get(inviterId)
+            val lib = libraryRepo.get(libId)
+            val libOwner = basicUserRepo.load(lib.ownerId)
+            val lastInviteOpt = (recipientId, recipientEmail) match {
+              case (Some(userId), _) =>
+                libraryInviteRepo.getLastSentByLibraryIdAndInviterIdAndUserId(libId, inviterId, userId, Set(LibraryInviteStates.ACTIVE))
+              case (_, Some(email)) =>
+                libraryInviteRepo.getLastSentByLibraryIdAndInviterIdAndEmail(libId, inviterId, email, Set(LibraryInviteStates.ACTIVE))
+              case _ => None
+            }
+            (inviter, lib, libOwner, lastInviteOpt)
+          }
+          val invitesToPersist = key._2.filter { invite =>
+            lastInviteOpt.map { lastInvite =>
+              lastInvite.access != invite.access || lastInvite.createdAt.plusMinutes(5).isBefore(invite.createdAt)
+            }.getOrElse(true)
+          }
+
+          db.readWrite { implicit s =>
+            invitesToPersist.map { inv =>
+              libraryInviteRepo.save(inv)
+            }
+          }
+
+          val userImage = s3ImageStore.avatarUrlByUser(inviter)
+          val libLink = s"""https://www.kifi.com${Library.formatLibraryPath(libOwner.username, lib.slug)}"""
+          val libImageOpt = libraryImageCommander.getBestImageForLibrary(libId, ProcessedImageSize.Medium.idealSize)
+
+          val userInviteesMap = invitesToPersist.collect {
+            case invite if invite.userId.isDefined =>
+              invite.userId.get -> invite
+          }.toMap
+
+          // send notifications to kifi users only
+          if (userInviteesMap.nonEmpty) {
+            notifyInviteeAboutInvitationToJoinLIbrary(inviter, lib, libOwner, userImage, libLink, libImageOpt, userInviteesMap)
+            if (inviterId != lib.ownerId) {
+              notifyLibOwnerAboutInvitationToTheirLibrary(inviter, lib, libOwner, userImage, libImageOpt, userInviteesMap)
+            }
+          }
+          // send emails to both users & non-users
+          invitesToPersist.map { invite =>
+            invite.userId match {
+              case Some(id) =>
+                libraryInvitesAbuseMonitor.inspect(inviterId, Some(id), None, libId, invitesToPersist.length)
+              case _ =>
+                libraryInvitesAbuseMonitor.inspect(inviterId, None, invite.emailAddress, libId, invitesToPersist.length)
+            }
+            libraryInviteSender.get.sendInvite(invite)
+          }
+        }.toSeq.flatten
+    }
+    val emailsF = Future.sequence(emailFutures)
+    emailsF map (_.filter(_.isDefined).map(_.get))
+  }
+
+  def notifyInviteeAboutInvitationToJoinLIbrary(inviter: User, lib: Library, libOwner: BasicUser, userImage: String, libLink: String, libImageOpt: Option[LibraryImage], inviteeMap: Map[Id[User], LibraryInvite]): Unit = {
+    val (collabInvitees, followInvitees) = inviteeMap.partition { case (userId, invite) => invite.isCollaborator }
+    val collabInviteeSet = collabInvitees.keySet
+    val followInviteeSet = followInvitees.keySet
+
+    val collabInvitesF = elizaClient.sendGlobalNotification( //push sent
+      userIds = collabInviteeSet,
+      title = s"${inviter.firstName} ${inviter.lastName} invited you to collaborate on a Library!",
+      body = s"Help ${libOwner.firstName} by sharing your knowledge in the library ${lib.name}.",
+      linkText = "Let's do it!",
+      linkUrl = libLink,
+      imageUrl = userImage,
+      sticky = false,
+      category = NotificationCategory.User.LIBRARY_INVITATION,
+      extra = Some(Json.obj(
+        "inviter" -> inviter,
+        "library" -> Json.toJson(LibraryNotificationInfo.fromLibraryAndOwner(lib, libImageOpt, libOwner)),
+        "access" -> LibraryAccess.READ_WRITE
+      ))
+    )
+
+    val followInvitesF = elizaClient.sendGlobalNotification( //push sent
+      userIds = followInviteeSet,
+      title = s"${inviter.firstName} ${inviter.lastName} invited you to follow a Library!",
+      body = s"Browse keeps in ${lib.name} to find some interesting gems kept by ${libOwner.firstName}.",
+      linkText = "Let's take a look!",
+      linkUrl = libLink,
+      imageUrl = userImage,
+      sticky = false,
+      category = NotificationCategory.User.LIBRARY_INVITATION,
+      extra = Some(Json.obj(
+        "inviter" -> inviter,
+        "library" -> Json.toJson(LibraryNotificationInfo.fromLibraryAndOwner(lib, libImageOpt, libOwner)),
+        "access" -> LibraryAccess.READ_ONLY
+      ))
+    )
+
+    for {
+      collabInvites <- collabInvitesF
+      followInvites <- followInvitesF
+    } yield {
+      collabInviteeSet.foreach { userId =>
+        val canSendPush = kifiInstallationCommander.isMobileVersionEqualOrGreaterThen(userId, KifiAndroidVersion("2.2.4"), KifiIPhoneVersion("2.1.0"))
+        if (canSendPush) {
+          elizaClient.sendLibraryPushNotification(
+            userId,
+            s"""${inviter.firstName} ${inviter.lastName} invited you to contribute to: ${lib.name}""",
+            lib.id.get,
+            libLink,
+            PushNotificationExperiment.Experiment1,
+            LibraryPushNotificationCategory.LibraryInvitation)
+        }
+      }
+
+      followInviteeSet.foreach { userId =>
+        val canSendPush = kifiInstallationCommander.isMobileVersionEqualOrGreaterThen(userId, KifiAndroidVersion("2.2.4"), KifiIPhoneVersion("2.1.0"))
+        if (canSendPush) {
+          elizaClient.sendLibraryPushNotification(
+            userId,
+            s"""${inviter.firstName} ${inviter.lastName} invited you to follow: ${lib.name}""",
+            lib.id.get,
+            libLink,
+            PushNotificationExperiment.Experiment1,
+            LibraryPushNotificationCategory.LibraryInvitation)
+        }
+      }
+    }
+  }
+
+  def notifyLibOwnerAboutInvitationToTheirLibrary(inviter: User, lib: Library, libOwner: BasicUser, userImage: String, libImageOpt: Option[LibraryImage], inviteeMap: Map[Id[User], LibraryInvite]): Unit = {
+    val (collabInvitees, followInvitees) = inviteeMap.partition { case (userId, invite) => invite.isCollaborator }
+    val collabInviteeSet = collabInvitees.keySet
+    val followInviteeSet = followInvitees.keySet
+    val collabFriendStr = if (collabInviteeSet.size > 1) "friends" else "a friend"
+    val followFriendStr = if (followInviteeSet.size > 1) "friends" else "a friend"
+
+    val collabInvitesF = if (collabInviteeSet.size > 0) {
+      elizaClient.sendGlobalNotification( //push sent
+        userIds = Set(lib.ownerId),
+        title = s"${inviter.firstName} invited someone to contribute to your Library!",
+        body = s"${inviter.fullName} invited $collabFriendStr to contribute to your library, ${lib.name}.",
+        linkText = s"See ${inviter.firstName}’s profile",
+        linkUrl = s"https://www.kifi.com/${inviter.username.value}",
+        imageUrl = userImage,
+        sticky = false,
+        category = NotificationCategory.User.LIBRARY_FOLLOWED,
+        extra = Some(Json.obj(
+          "inviter" -> inviter,
+          "library" -> Json.toJson(LibraryNotificationInfo.fromLibraryAndOwner(lib, libImageOpt, libOwner))
+        ))
+      )
+    } else {
+      Future.successful((): Unit)
+    }
+
+    val followInvitesF = if (followInviteeSet.size > 0) {
+      elizaClient.sendGlobalNotification( //push sent
+        userIds = Set(lib.ownerId),
+        title = s"${inviter.firstName} invited someone to follow your Library!",
+        body = s"${inviter.fullName} invited $followFriendStr to follow your library, ${lib.name}.",
+        linkText = s"See ${inviter.firstName}’s profile",
+        linkUrl = s"https://www.kifi.com/${inviter.username.value}",
+        imageUrl = userImage,
+        sticky = false,
+        category = NotificationCategory.User.LIBRARY_FOLLOWED,
+        extra = Some(Json.obj(
+          "inviter" -> inviter,
+          "library" -> Json.toJson(LibraryNotificationInfo.fromLibraryAndOwner(lib, libImageOpt, libOwner))
+        ))
+      )
+    } else {
+      Future.successful((): Unit)
+    }
+
+    for {
+      collabInvites <- collabInvitesF
+      followInvites <- followInvitesF
+    } yield {
+      val canSendPush = kifiInstallationCommander.isMobileVersionEqualOrGreaterThen(lib.ownerId, KifiAndroidVersion("2.2.4"), KifiIPhoneVersion("2.1.0"))
+      if (canSendPush) {
+        if (collabInviteeSet.size > 0) {
+          elizaClient.sendUserPushNotification(
+            userId = lib.ownerId,
+            message = s"${inviter.firstName} invited $collabFriendStr to contribute to your library ${lib.name}!",
+            recipient = inviter,
+            pushNotificationExperiment = PushNotificationExperiment.Experiment1,
+            category = UserPushNotificationCategory.NewLibraryFollower)
+        }
+        if (followInviteeSet.size > 0) {
+          elizaClient.sendUserPushNotification(
+            userId = lib.ownerId,
+            message = s"${inviter.firstName} invited $followFriendStr to follow your library ${lib.name}!",
+            recipient = inviter,
+            pushNotificationExperiment = PushNotificationExperiment.Experiment1,
+            category = UserPushNotificationCategory.NewLibraryFollower)
+        }
+      }
+    }
+  }
+
+  def revokeInvitationToLibrary(libraryId: Id[Library], inviterId: Id[User], invitee: Either[ExternalId[User], EmailAddress]): Either[(String, String), String] = {
+    val libraryInvite = invitee match {
+      case Left(externalId) => db.readOnlyMaster { implicit s =>
+        userRepo.getOpt(externalId) match {
+          case Some(userId) => Right(libraryInviteRepo.getLastSentByLibraryIdAndInviterIdAndUserId(libraryId, inviterId, userId.id.get, Set(LibraryInviteStates.ACTIVE)))
+          case None => Left(s"external_id_does_not_exist")
+        }
+      }
+      case Right(email) => db.readOnlyMaster { implicit s =>
+        Right(libraryInviteRepo.getLastSentByLibraryIdAndInviterIdAndEmail(libraryId, inviterId, email, Set(LibraryInviteStates.ACTIVE)))
+      }
+    }
+    libraryInvite match {
+      case Right(Some(toDelete)) => db.readWrite(attempts = 3) { implicit s =>
+        libraryInviteRepo.save(toDelete.copy(state = LibraryInviteStates.INACTIVE)) match {
+          case invite if invite.state == LibraryInviteStates.INACTIVE => Right("library_delete_succeeded")
+          case _ => Left("error" -> "library_invite_delete_failed")
+        }
+      }
+      case Right(None) => Left("error" -> "library_invite_not_found")
+      case Left(error) => Left("error" -> error)
+    }
+  }
+
+  def getViewerInviteInfo(userIdOpt: Option[Id[User]], libraryId: Id[Library]): Option[LibraryInviteInfo] = {
+    userIdOpt.flatMap { userId =>
+      db.readOnlyMaster { implicit s =>
+        val inviteOpt = libraryInviteRepo.getLastSentByLibraryIdAndUserId(libraryId, userId, Set(LibraryInviteStates.ACTIVE))
+        val basicUserOpt = inviteOpt map { inv => basicUserRepo.load(inv.inviterId) }
+        (inviteOpt, basicUserOpt)
+      } match {
+        case (Some(invite), Some(inviter)) => Some(LibraryInviteInfo.createInfo(invite, inviter))
+        case (_, _) => None
+      }
+    }
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -69,6 +69,7 @@ class AuthHelper @Inject() (
     postOffice: LocalPostOffice,
     inviteCommander: InviteCommander,
     libraryCommander: LibraryCommander,
+    libraryInviteCommander: LibraryInviteCommander,
     userCommander: UserCommander,
     twitterWaitlistCommander: TwitterWaitlistCommander,
     heimdalContextBuilder: HeimdalContextBuilderFactory,
@@ -218,7 +219,7 @@ class AuthHelper @Inject() (
       } getOrElse "/" // In case the user signs up on a browser that doesn't support the extension
     }
 
-    libraryCommander.convertPendingInvites(emailAddress, user.id.get)
+    libraryInviteCommander.convertPendingInvites(emailAddress, user.id.get)
     libraryPublicId.foreach(authCommander.autoJoinLib(user.id.get, _))
 
     request.session.get("kcid").map(saveKifiCampaignId(user.id.get, _))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -48,6 +48,7 @@ class MobileLibraryController @Inject() (
   heimdalContextBuilder: HeimdalContextBuilderFactory,
   clock: Clock,
   val libraryCommander: LibraryCommander,
+  val libraryInviteCommander: LibraryInviteCommander,
   val userActionsHelper: UserActionsHelper,
   val publicIdConfig: PublicIdConfiguration,
   implicit val config: PublicIdConfiguration)
@@ -124,7 +125,7 @@ class MobileLibraryController @Inject() (
       })
 
       val membershipOpt = libraryCommander.getViewerMembershipInfo(userIdOpt, libraryId)
-      val inviteOpt = libraryCommander.getViewerInviteInfo(userIdOpt, libraryId)
+      val inviteOpt = libraryInviteCommander.getViewerInviteInfo(userIdOpt, libraryId)
       val accessStr = membershipOpt.map(_.access).getOrElse("none")
       val membershipJson = Json.toJson(membershipOpt)
       val inviteJson = Json.toJson(inviteOpt)
@@ -153,7 +154,7 @@ class MobileLibraryController @Inject() (
             })
 
             val membershipOpt = libraryCommander.getViewerMembershipInfo(request.userIdOpt, library.id.get)
-            val inviteOpt = libraryCommander.getViewerInviteInfo(request.userIdOpt, library.id.get)
+            val inviteOpt = libraryInviteCommander.getViewerInviteInfo(request.userIdOpt, library.id.get)
             val accessStr = membershipOpt.map(_.access).getOrElse("none")
             val membershipJson = Json.toJson(membershipOpt)
             val inviteJson = Json.toJson(inviteOpt)
@@ -285,7 +286,7 @@ class MobileLibraryController @Inject() (
       case Success(libraryId) =>
         getUserByIdOrEmail(request.body) match {
           case Right(invitee) =>
-            libraryCommander.revokeInvitationToLibrary(libraryId, request.userId, invitee) match {
+            libraryInviteCommander.revokeInvitationToLibrary(libraryId, request.userId, invitee) match {
               case Right(ok) => Future.successful(NoContent)
               case Left(error) => Future.successful(BadRequest(Json.obj(error._1 -> error._2)))
             }
@@ -315,7 +316,7 @@ class MobileLibraryController @Inject() (
           }
         }
         implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
-        libraryCommander.inviteUsersToLibrary(id, request.userId, validInviteList).map {
+        libraryInviteCommander.inviteUsersToLibrary(id, request.userId, validInviteList).map {
           case Left(fail) => sendFailResponse(fail)
           case Right(inviteesWithAccess) =>
             val result = inviteesWithAccess.map {
@@ -336,7 +337,7 @@ class MobileLibraryController @Inject() (
         val messageOpt = msgOpt.filter(_.nonEmpty)
 
         implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
-        libraryCommander.inviteAnonymousToLibrary(id, request.userId, access, messageOpt) match {
+        libraryInviteCommander.inviteAnonymousToLibrary(id, request.userId, access, messageOpt) match {
           case Left(fail) => sendFailResponse(fail)
           case Right((invite, library)) =>
             val owner = db.readOnlyMaster { implicit s =>
@@ -383,7 +384,7 @@ class MobileLibraryController @Inject() (
       case Failure(ex) =>
         BadRequest(Json.obj("error" -> "invalid_id"))
       case Success(libId) =>
-        libraryCommander.declineLibrary(request.userId, libId)
+        libraryInviteCommander.declineLibrary(request.userId, libId)
         Ok(JsString("success"))
     }
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -524,6 +524,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
         val (userIron, userCaptain, userAgent, userHulk, libShield, libMurica, libScience) = setupLibraries
         val libraryCommander = inject[LibraryCommander]
+        val libraryInviteCommander = inject[LibraryInviteCommander]
 
         db.readOnlyMaster { implicit s =>
           libraryInviteRepo.count === 0
@@ -537,7 +538,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           (Left(userAgent.id.get), LibraryAccess.READ_ONLY, None),
           (Left(userHulk.id.get), LibraryAccess.READ_ONLY, None),
           (Right(thorEmail), LibraryAccess.READ_ONLY, Some("America > Asgard")))
-        val res1 = Await.result(libraryCommander.inviteUsersToLibrary(libMurica.id.get, userCaptain.id.get, inviteList1), Duration(5, "seconds"))
+        val res1 = Await.result(libraryInviteCommander.inviteUsersToLibrary(libMurica.id.get, userCaptain.id.get, inviteList1), Duration(5, "seconds"))
         res1.isRight === true
         res1.right.get === Seq((Left(BasicUser.fromUser(userIron)), LibraryAccess.READ_ONLY),
           (Left(BasicUser.fromUser(userAgent)), LibraryAccess.READ_ONLY),
@@ -554,7 +555,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
         // Tests that users can have multiple invitations multiple times
         // but if invites are sent within 5 Minutes of each other, they do not persist!
-        Await.result(libraryCommander.inviteUsersToLibrary(libMurica.id.get, userCaptain.id.get, inviteList1), Duration(5, "seconds")).isRight === true
+        Await.result(libraryInviteCommander.inviteUsersToLibrary(libMurica.id.get, userCaptain.id.get, inviteList1), Duration(5, "seconds")).isRight === true
         db.readOnlyMaster { implicit s =>
           libraryInviteRepo.count === 4 // 8 invites sent, only 4 persisted from previous call
         }
@@ -570,12 +571,12 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
         val inviteCollab2 = Seq((Right(EmailAddress("hawkeye@shield.gov")), LibraryAccess.READ_WRITE, None))
 
         // Test owner invite to collaborate (invite persists)
-        Await.result(libraryCommander.inviteUsersToLibrary(libMurica.id.get, userCaptain.id.get, inviteCollab1), Duration(5, "seconds")).isRight === true
+        Await.result(libraryInviteCommander.inviteUsersToLibrary(libMurica.id.get, userCaptain.id.get, inviteCollab1), Duration(5, "seconds")).isRight === true
         db.readOnlyMaster { implicit s =>
           libraryInviteRepo.count === 5
         }
         // Test collaborator invite to collaborate (invite persists)
-        Await.result(libraryCommander.inviteUsersToLibrary(libMurica.id.get, userFalcon.id.get, inviteCollab1), Duration(5, "seconds")).isRight === true
+        Await.result(libraryInviteCommander.inviteUsersToLibrary(libMurica.id.get, userFalcon.id.get, inviteCollab1), Duration(5, "seconds")).isRight === true
         db.readOnlyMaster { implicit s =>
           libraryInviteRepo.count === 6
         }
@@ -586,13 +587,13 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
         }
 
         // Test owner invite to collaborate (invite persists)
-        Await.result(libraryCommander.inviteUsersToLibrary(libMurica.id.get, userCaptain.id.get, inviteCollab2), Duration(5, "seconds")).isRight === true
+        Await.result(libraryInviteCommander.inviteUsersToLibrary(libMurica.id.get, userCaptain.id.get, inviteCollab2), Duration(5, "seconds")).isRight === true
         db.readOnlyMaster { implicit s =>
           libraryInviteRepo.count === 7
         }
 
         // Test collaborator invite to collaborate (invite does NOT persist)
-        Await.result(libraryCommander.inviteUsersToLibrary(libMurica.id.get, userFalcon.id.get, inviteCollab2), Duration(5, "seconds")).isRight === true
+        Await.result(libraryInviteCommander.inviteUsersToLibrary(libMurica.id.get, userFalcon.id.get, inviteCollab2), Duration(5, "seconds")).isRight === true
         db.readOnlyMaster { implicit s =>
           libraryInviteRepo.count === 7
         }
@@ -606,6 +607,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
         val (userIron, userCaptain, userAgent, userHulk, libShield, libMurica, libScience) = setupInvites
         val libraryCommander = inject[LibraryCommander]
+        val libraryInviteCommander = inject[LibraryInviteCommander]
 
         val t1 = new DateTime(2014, 8, 1, 3, 0, 0, 0, DEFAULT_DATE_TIME_ZONE)
         db.readWrite { implicit s =>
@@ -627,7 +629,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
         // eliza.inbox(0) === (userCaptain.id.get, NotificationCategory.User.LIBRARY_FOLLOWED, "https://www.kifi.com/ironman", s"http://localhost/users/${userIron.externalId}/pics/200/0.jpg")
 
         libraryCommander.joinLibrary(userAgent.id.get, libMurica.id.get).right.get._1.name === libMurica.name // Agent accepts invite to 'Murica'
-        libraryCommander.declineLibrary(userHulk.id.get, libMurica.id.get) // Hulk declines invite to 'Murica'
+        libraryInviteCommander.declineLibrary(userHulk.id.get, libMurica.id.get) // Hulk declines invite to 'Murica'
         libraryCommander.joinLibrary(userHulk.id.get, libScience.id.get).right.get._1.name === libScience.name // Hulk accepts invite to 'Science' (READ_INSERT) but gets READ_WRITE access
 
         db.readOnlyMaster { implicit s =>
@@ -1137,6 +1139,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
       withDb(modules: _*) { implicit injector =>
         val (userIron, userCaptain, userAgent, userHulk, libShield, libMurica, libScience) = setupInvites
         val libraryCommander = inject[LibraryCommander]
+        val libraryInviteCommander = inject[LibraryInviteCommander]
         val emailRepo = inject[ElectronicMailRepo]
         val eliza = inject[ElizaServiceClient].asInstanceOf[FakeElizaServiceClientImpl]
         eliza.inbox.size === 0
@@ -1149,7 +1152,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           LibraryInvite(libraryId = libScience.id.get, inviterId = userIron.id.get, userId = Some(userHulk.id.get), access = LibraryAccess.READ_INSERT, createdAt = t1)
         )
 
-        Await.result(libraryCommander.processInvites(newInvites), Duration(10, "seconds"))
+        Await.result(libraryInviteCommander.processInvites(newInvites), Duration(10, "seconds"))
         eliza.inbox.size === 4
 
         eliza.inbox.count(t => t._2 == NotificationCategory.User.LIBRARY_FOLLOWED && t._4.endsWith("/0.jpg")) === 0
@@ -1164,7 +1167,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           LibraryInvite(libraryId = libMurica.id.get, inviterId = userCaptain.id.get, userId = Some(userHulk.id.get), access = LibraryAccess.READ_ONLY, createdAt = t2),
           LibraryInvite(libraryId = libScience.id.get, inviterId = userIron.id.get, userId = Some(userHulk.id.get), access = LibraryAccess.READ_INSERT, createdAt = t2)
         )
-        Await.result(libraryCommander.processInvites(newInvitesAgain), Duration(10, "seconds"))
+        Await.result(libraryInviteCommander.processInvites(newInvitesAgain), Duration(10, "seconds"))
         eliza.inbox.size === 4
         db.readOnlyMaster { implicit s => emailRepo.count === 4 }
       }


### PR DESCRIPTION
- pulled out a bunch of methods dealing with invites into
  LibraryInviteCommander (new class)
- modified existing tests for libraryCommander to call relevant methods
  from libraryInviteCommander instead.
- updated all previous references of refactored methods to the new
  class (injected the new class where needed too).

@leogrim @andrewconner 
