### PR TITLE
returning invite information with each LibraryCardInfo for Invited tab

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/LibraryInvite.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/LibraryInvite.scala
@@ -47,6 +47,21 @@ object LibraryInvite extends ModelWithPublicIdCompanion[LibraryInvite] {
   protected[this] val publicIdPrefix = "l"
   protected[this] val publicIdIvSpec = new IvParameterSpec(Array(-20, -76, -59, 85, 85, -2, 72, 61, 58, 38, 60, -2, -128, 79, 9, -87))
 
+  def applyFromDbRow(
+    id: Option[Id[LibraryInvite]],
+    libraryId: Id[Library],
+    inviterId: Id[User],
+    userId: Option[Id[User]],
+    emailAddress: Option[EmailAddress],
+    access: LibraryAccess,
+    createdAt: DateTime,
+    updatedAt: DateTime,
+    state: State[LibraryInvite],
+    authToken: String,
+    message: Option[String]) = {
+    LibraryInvite(id, libraryId, inviterId, userId, emailAddress, access, createdAt, updatedAt, state, authToken, message)
+  }
+
   implicit def format = (
     (__ \ 'id).formatNullable(Id.format[LibraryInvite]) and
     (__ \ 'libraryId).format[Id[Library]] and

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserProfileCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserProfileCommander.scala
@@ -116,9 +116,12 @@ class UserProfileCommander @Inject() (
   def getInvitedLibraries(user: User, viewer: Option[User], page: Paginator, idealSize: ImageSize): ParSeq[LibraryCardInfo] = {
     if (viewer.exists(_.id == user.id)) {
       db.readOnlyMaster { implicit session =>
-        val libs = libraryRepo.getInvitedLibrariesForSelf(user.id.get, page)
-        val owners = basicUserRepo.loadAll(libs.map(_.ownerId).toSet)
-        libraryCommander.createLibraryCardInfos(libs, owners, viewer, false, idealSize)
+        val (libs, invites) = libraryRepo.getInvitedLibrariesForSelf(user.id.get, page).unzip
+        val ownersAndInviters = basicUserRepo.loadAll((libs.map(_.ownerId) ++ invites.map(_.inviterId)).toSet)
+        libraryCommander.createLibraryCardInfos(libs, ownersAndInviters, viewer, false, idealSize) zip invites map {
+          case (card, invite) =>
+            card.copy(invite = Some(LibraryInviteInfo.createInfo(invite, ownersAndInviters(invite.inviterId))))
+        }
       }
     } else {
       ParSeq.empty

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryInviteRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryInviteRepo.scala
@@ -10,7 +10,7 @@ import com.keepit.common.time.Clock
 import com.keepit.common.util.Paginator
 import org.joda.time.DateTime
 
-import scala.slick.jdbc.StaticQuery
+import scala.slick.jdbc.{ PositionedResult, GetResult, StaticQuery }
 
 @ImplementedBy(classOf[LibraryInviteRepoImpl])
 trait LibraryInviteRepo extends Repo[LibraryInvite] with RepoWithDelete[LibraryInvite] {
@@ -173,4 +173,5 @@ class LibraryInviteRepoImpl @Inject() (
   def getLastSentByLibraryIdAndUserId(libraryId: Id[Library], userId: Id[User], includeStates: Set[State[LibraryInvite]])(implicit session: RSession): Option[LibraryInvite] = {
     getLastSentByLibraryIdAndUserIdCompiled(libraryId, userId, includeStates).firstOption
   }
+
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -8,6 +8,7 @@ import com.keepit.common.db.slick._
 import com.keepit.common.db._
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
+import com.keepit.common.mail.EmailAddress
 import com.keepit.common.plugin.{ SchedulingProperties, SequencingActor, SequencingPlugin }
 import com.keepit.common.time._
 import com.keepit.common.util.Paginator
@@ -40,7 +41,7 @@ trait LibraryRepo extends Repo[Library] with SeqNumberFunction[Library] {
   def getOwnerLibrariesForAnonymous(ownerId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library]
   def getOwnerLibrariesForOtherUser(userId: Id[User], friendId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library]
   def getOwnerLibrariesForSelf(userId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library]
-  def getInvitedLibrariesForSelf(userId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library]
+  def getInvitedLibrariesForSelf(userId: Id[User], page: Paginator)(implicit session: RSession): Seq[(Library, LibraryInvite)]
 
   def getFollowingLibrariesForAnonymous(userId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library]
   def getFollowingLibrariesForOtherUser(userId: Id[User], friendId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library]
@@ -96,7 +97,7 @@ class LibraryRepoImpl @Inject() (
     def * = (id.?, createdAt, updatedAt, state, name, ownerId, description, visibility, slug, color.?, seq, kind, memberCount, universalLink, lastKept, keepCount, whoCanInvite, orgId) <> ((Library.applyFromDbRow _).tupled, Library.unapplyToDbRow _)
   }
 
-  implicit val getLibraryResult: GetResult[com.keepit.model.Library] = GetResult { r: PositionedResult =>
+  implicit val getLibraryResult: GetResult[Library] = GetResult { r: PositionedResult =>
     Library.applyFromDbRow(
       id = r.<<[Option[Id[Library]]],
       createdAt = r.<<[DateTime],
@@ -117,6 +118,22 @@ class LibraryRepoImpl @Inject() (
       whoCanInvite = r.<<[Option[String]].map(LibraryInvitePermissions(_)),
       organizationId = r.<<[Option[Id[Organization]]]
     )
+  }
+
+  implicit val getLibraryAndLibraryInviteResult: GetResult[(Library, LibraryInvite)] = GetResult { r: PositionedResult =>
+    (getLibraryResult(r), LibraryInvite.applyFromDbRow(
+      id = r.<<[Option[Id[LibraryInvite]]],
+      createdAt = r.<<[DateTime],
+      updatedAt = r.<<[DateTime],
+      state = r.<<[State[LibraryInvite]],
+      libraryId = r.<<[Id[Library]],
+      inviterId = r.<<[Id[User]],
+      userId = r.<<[Option[Id[User]]],
+      access = LibraryAccess(r.<<[String]),
+      emailAddress = r.<<[Option[String]].map(EmailAddress(_)),
+      authToken = r.<<[String],
+      message = r.<<[Option[String]]
+    ))
   }
 
   def table(tag: Tag) = new LibraryTable(tag)
@@ -291,10 +308,14 @@ class LibraryRepoImpl @Inject() (
     query.as[Library].list
   }
 
-  def getInvitedLibrariesForSelf(userId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library] = {
+  def getInvitedLibrariesForSelf(userId: Id[User], page: Paginator)(implicit session: RSession): Seq[(Library, LibraryInvite)] = {
     import com.keepit.common.db.slick.StaticQueryFixed.interpolation
-    val query = sql"select distinct lib.* from library lib, library_invite li where li.user_id=$userId and li.state='active' and lib.id = li.library_id and lib.state='active' order by lib.member_count desc, lib.last_kept desc, lib.id desc limit ${page.itemsToDrop}, ${page.size}"
-    query.as[Library].list
+    // The technique we use below to ensure we get the desired invite for each library (maximum access level) is from:
+    // http://stackoverflow.com/questions/12102200/get-records-with-max-value-for-each-group-of-grouped-sql-results#answer-28090544
+    // It works right now because 'read_write' > 'read_only'. We'll need to modify the query (e.g. use a case expression) if we start
+    // to allow sending invitations with additional access levels where lexicographical ordering does not match ordinal ordering.
+    val query = sql"select lib.*, li.* from library lib, (select v1.* from library_invite v1 left join library_invite v2 on v2.user_id = v1.user_id and v2.library_id = v1.library_id and v2.state = v1.state and (v1.access < v2.access or (v1.access = v2.access and v1.id < v2.id)) where v1.user_id=$userId and v1.state='active' and v2.id is null) li where lib.id = li.library_id and lib.state='active' order by lib.member_count desc, lib.last_kept desc, lib.id desc limit ${page.itemsToDrop}, ${page.size}"
+    query.as[(Library, LibraryInvite)].list
   }
 
   def getFollowingLibrariesForAnonymous(userId: Id[User], page: Paginator)(implicit session: RSession): Seq[Library] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
@@ -166,7 +166,8 @@ case class LibraryCardInfo(
   membership: Option[LibraryMembershipInfo],
   caption: Option[String],
   modifiedAt: DateTime,
-  kind: LibraryKind)
+  kind: LibraryKind,
+  invite: Option[LibraryInviteInfo] = None)
     extends BaseLibraryCardInfo(id, name, description, color, image, slug, owner, numKeeps, numFollowers, followers, numCollaborators, collaborators, lastKept, following, membership, modifiedAt, kind)
 
 object LibraryCardInfo {


### PR DESCRIPTION
@andrewconner 
This is necessary so that we can tell the difference between follow invites and collaborate invites.
