### PR TITLE
Introduce HandleCommander

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/335.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/335.sql
@@ -11,8 +11,8 @@ CREATE TABLE organization (
 	name varchar(256) NOT NULL,
 	description text DEFAULT NULL,
 	owner_id bigint(20) NOT NULL,
-	organization_handle varchar(64) DEFAULT NULL,
-	normalized_organization_handle varchar(64) DEFAULT NULL,
+	handle varchar(64) DEFAULT NULL,
+	normalized_handle varchar(64) DEFAULT NULL,
 
 	PRIMARY KEY(id),
 	UNIQUE KEY `organization_u_organization_handle` (`organization_handle`),

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/335.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/335.sql
@@ -15,8 +15,8 @@ CREATE TABLE organization (
 	normalized_handle varchar(64) DEFAULT NULL,
 
 	PRIMARY KEY(id),
-	UNIQUE KEY `organization_u_organization_handle` (`organization_handle`),
-	UNIQUE KEY `organization_u_normalized_organization_handle` (`normalized_organization_handle`),
+	UNIQUE KEY `organization_u_handle` (`handle`),
+	UNIQUE KEY `organization_u_normalized_handle` (`normalized_handle`),
 	INDEX `organization_i_seq` (`seq`),
 	CONSTRAINT `organization_f_user` FOREIGN KEY (`owner_id`) REFERENCES user(`id`)
 );

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/HandleCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/HandleCommander.scala
@@ -1,0 +1,91 @@
+package com.keepit.commanders
+
+import com.google.inject.{ Inject, Singleton }
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.logging.Logging
+import com.keepit.common.time.Clock
+import com.keepit.model.HandleOwnershipStates._
+import com.keepit.model._
+import com.keepit.common.core._
+import com.keepit.common.time._
+
+import scala.util.{ Failure, Success, Try }
+
+object HandleCommander {
+
+  case class InvalidHandleException(handle: Handle) extends Exception(s"Handle $handle is invalid.")
+
+  sealed abstract class UnavailableHandleException(ownership: HandleOwnership, reason: String)
+    extends Exception(s"Handle ${ownership.handle} is owned by ${ownership.prettyOwner} ($reason).")
+
+  case class LockedHandleException(ownership: HandleOwnership) extends UnavailableHandleException(ownership, "locked")
+
+  case class ProtectedHandleException(ownership: HandleOwnership) extends UnavailableHandleException(ownership, "protected")
+
+  case class PrimaryHandleException(ownership: HandleOwnership) extends UnavailableHandleException(ownership, "primary")
+
+}
+
+@Singleton
+class HandleCommander @Inject() (
+    db: Database,
+    handleRepo: HandleOwnershipRepo,
+    userRepo: UserRepo,
+    usernameCache: UsernameCache,
+    organizationRepo: OrganizationRepo,
+    airbrake: AirbrakeNotifier,
+    clock: Clock) extends Logging {
+
+  import HandleCommander._
+
+  def setUsername(username: Username, user: User, lock: Boolean = false, overrideProtection: Boolean = false, overrideValidityCheck: Boolean = false)(implicit session: RWSession): Try[User] = {
+    claimUsername(username, user.id.get, lock, overrideProtection, overrideValidityCheck).map { normalizedUsername =>
+      val primaryUsername = PrimaryUsername(original = username, normalized = normalizedUsername)
+      val updatedUser = userRepo.save(user.copy(primaryUsername = Some(primaryUsername)))
+      //we have to do cache invalidation now, the repo does not have the old username for that
+      user.primaryUsername.foreach(oldUsername => usernameCache.remove(UsernameKey(oldUsername.original)))
+      updatedUser
+    }
+  }
+
+  def claimUsername(username: Username, userId: Id[User], lock: Boolean = false, overrideProtection: Boolean = false, overrideValidityCheck: Boolean = false)(implicit session: RWSession): Try[Username] = {
+    claimHandle(username, Some(Right(userId)), lock, overrideProtection, overrideValidityCheck).map { ownership =>
+      Username(ownership.handle.value)
+    }
+  }
+
+  private[commanders] def claimHandle(handle: Handle, ownerId: Option[Either[Id[Organization], Id[User]]], lock: Boolean = false, overrideProtection: Boolean = false, overrideValidityCheck: Boolean = false)(implicit session: RWSession): Try[HandleOwnership] = {
+    if (overrideValidityCheck || HandleOps.isValid(handle.value)) setHandleOwnership(handle, ownerId, lock, overrideProtection)
+    else Failure(InvalidHandleException(handle))
+  } tap {
+    case Failure(error) => log.info(s"Failed to claim handle $handle for ${HandleOwnership.prettyOwner(ownerId)}", error)
+    case Success(updatedOwnership) => log.info(s"Handle $handle (${updatedOwnership.handle}) is now owned by ${updatedOwnership.prettyOwner}: $updatedOwnership")
+  }
+
+  private def setHandleOwnership(handle: Handle, ownerId: Option[Either[Id[Organization], Id[User]]], lock: Boolean = false, overrideProtection: Boolean = false)(implicit session: RWSession): Try[HandleOwnership] = {
+    val ownershipMaybe = {
+      val normalizedHandle = Handle.normalize(handle)
+      handleRepo.getByNormalizedHandle(normalizedHandle, excludeState = None) match {
+        case Some(ownership) if ownership.belongsTo(ownerId) => Success(ownership)
+        case Some(ownership) if ownership.isLocked => Failure(LockedHandleException(ownership))
+        case Some(ownership) if ownership.isProtected && !overrideProtection => Failure(ProtectedHandleException(ownership))
+        case Some(ownership) if isPrimary(ownership) => Failure(PrimaryHandleException(ownership))
+        case Some(availableOwnership) => Success(availableOwnership.copy(state = ACTIVE, locked = false, ownerId = ownerId))
+        case None => Success(HandleOwnership(handle = normalizedHandle, ownerId = ownerId))
+      }
+    }
+    ownershipMaybe.map { ownership =>
+      handleRepo.save(ownership.copy(lastClaimedAt = clock.now, locked = ownership.locked || lock))
+    }
+  }
+
+  private def isPrimary(ownership: HandleOwnership)(implicit session: RSession): Boolean = {
+    ownership.ownerId.exists {
+      case Left(organizationId) => organizationRepo.get(organizationId).handle.exists(_.normalized.value == ownership.handle.value)
+      case Right(userId) => userRepo.get(userId).primaryUsername.exists(_.normalized.value == ownership.handle.value)
+    }
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/HandleOwnership.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/HandleOwnership.scala
@@ -33,7 +33,7 @@ case class HandleOwnership(
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def isActive = (state == HandleOwnershipStates.ACTIVE)
   def isLocked = isActive && locked
-  def isProtected = (isActive && !isLocked && (currentDateTime isBefore (lastClaimedAt plusSeconds HandleOwnership.gracePeriod.toSeconds.toInt)))
+  def isProtected = isActive && !isLocked && (currentDateTime isBefore (lastClaimedAt plusSeconds HandleOwnership.gracePeriod.toSeconds.toInt))
   def belongsToOrg(orgId: Id[Organization]) = belongsTo(Some(Left(orgId)))
   def belongsToUser(userId: Id[User]) = belongsTo(Some(Right(userId)))
   def belongsToSystem = belongsTo(None)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/HandleOwnership.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/HandleOwnership.scala
@@ -10,22 +10,15 @@ import com.keepit.common.time._
 import org.joda.time.DateTime
 import scala.concurrent.duration._
 
-import scala.util.{ Failure, Success, Try }
-
-case class Handle(value: String) {
+case class Handle(value: String) extends AnyVal {
   override def toString() = value
 }
 
 object Handle {
   implicit def fromUsername(username: Username) = Handle(username.value)
   implicit def fromOrganizationHandle(organizationHandle: OrganizationHandle) = Handle(organizationHandle.value)
+  def normalize(handle: Handle): Handle = Handle(HandleOps.normalize(handle.value))
 }
-
-case class LockedHandleException(ownership: HandleOwnership)
-  extends Exception(s"Handle ${ownership.handle} is locked, owned by ${ownership.prettyOwner}.")
-
-case class ProtectedHandleException(ownership: HandleOwnership)
-  extends Exception(s"Handle ${ownership.handle} is protected, owned by ${ownership.prettyOwner}.")
 
 case class HandleOwnership(
     id: Option[Id[HandleOwnership]] = None,
@@ -39,21 +32,23 @@ case class HandleOwnership(
   def withId(id: Id[HandleOwnership]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
   def isActive = (state == HandleOwnershipStates.ACTIVE)
-  def isLocked = locked
+  def isLocked = isActive && locked
   def isProtected = (isActive && !isLocked && (currentDateTime isBefore (lastClaimedAt plusSeconds HandleOwnership.gracePeriod.toSeconds.toInt)))
   def belongsToOrg(orgId: Id[Organization]) = belongsTo(Some(Left(orgId)))
   def belongsToUser(userId: Id[User]) = belongsTo(Some(Right(userId)))
   def belongsToSystem = belongsTo(None)
-  def belongsTo(thatOwnerId: Option[Either[Id[Organization], Id[User]]]) = (ownerId == thatOwnerId)
-  def prettyOwner: String = ownerId match {
-    case Some(Left(orgId)) => s"organization $orgId"
-    case Some(Right(userId)) => s"user $userId"
-    case None => "system"
-  }
+  def belongsTo(thatOwnerId: Option[Either[Id[Organization], Id[User]]]) = isActive && (ownerId == thatOwnerId)
+  def prettyOwner = HandleOwnership.prettyOwner(ownerId)
 }
 
 object HandleOwnership {
   private[HandleOwnership] val gracePeriod = 7 days // an active handle should be protected for this period of time after it was last claimed
+
+  def prettyOwner(ownerId: Option[Either[Id[Organization], Id[User]]]): String = ownerId match {
+    case Some(Left(orgId)) => s"organization $orgId"
+    case Some(Right(userId)) => s"user $userId"
+    case None => "system"
+  }
 
   def applyFromDbRow(id: Option[Id[HandleOwnership]],
     createdAt: DateTime,
@@ -86,10 +81,8 @@ object HandleOwnershipStates extends States[HandleOwnership]
 @ImplementedBy(classOf[HandleOwnershipRepoImpl])
 trait HandleOwnershipRepo extends Repo[HandleOwnership] {
   def getByHandle(handle: Handle, excludeState: Option[State[HandleOwnership]] = Some(HandleOwnershipStates.INACTIVE))(implicit session: RSession): Option[HandleOwnership]
+  def getByNormalizedHandle(normalizedHandle: Handle, excludeState: Option[State[HandleOwnership]])(implicit session: RSession): Option[HandleOwnership]
   def getByOwnerId(ownerId: Either[Id[Organization], Id[User]])(implicit session: RSession): Seq[HandleOwnership]
-  def setOrganizationOwnership(handle: Handle, organizationId: Id[Organization], lock: Boolean = false, overrideProtection: Boolean = false)(implicit session: RWSession): Try[HandleOwnership]
-  def setUserOwnership(handle: Handle, userId: Id[User], lock: Boolean = false, overrideProtection: Boolean = false)(implicit session: RWSession): Try[HandleOwnership]
-  def setSystemOwnership(handle: Handle, lock: Boolean = false, overrideProtection: Boolean = false)(implicit session: RWSession): Try[HandleOwnership]
   def unlock(handle: Handle)(implicit session: RWSession): Boolean
 }
 
@@ -128,7 +121,7 @@ class HandleOwnershipRepoImpl @Inject() (
     for (row <- rows if row.handle === normalizedHandle && row.state =!= excludedState) yield row
   }
 
-  private def getByNormalizedHandle(normalizedHandle: Handle, excludeState: Option[State[HandleOwnership]])(implicit session: RSession) = {
+  def getByNormalizedHandle(normalizedHandle: Handle, excludeState: Option[State[HandleOwnership]])(implicit session: RSession): Option[HandleOwnership] = {
     val q = excludeState match {
       case Some(state) => compiledGetByNormalizedHandleAndExcludedState(normalizedHandle, state)
       case None => compiledGetByNormalizedHandle(normalizedHandle)
@@ -136,12 +129,8 @@ class HandleOwnershipRepoImpl @Inject() (
     q.firstOption
   }
 
-  private def normalize(handle: Handle): Handle = {
-    Handle(HandleOps.normalize(handle.value))
-  }
-
   def getByHandle(handle: Handle, excludeState: Option[State[HandleOwnership]] = Some(INACTIVE))(implicit session: RSession): Option[HandleOwnership] = {
-    getByNormalizedHandle(normalize(handle), excludeState)
+    getByNormalizedHandle(Handle.normalize(handle), excludeState)
   }
 
   private val compiledGetByUserId = Compiled { (userId: Column[Id[User]]) =>
@@ -160,29 +149,6 @@ class HandleOwnershipRepoImpl @Inject() (
     q.list
   }
 
-  private def setOwner(handle: Handle, ownerId: Option[Either[Id[Organization], Id[User]]], lock: Boolean = false, overrideProtection: Boolean = false)(implicit session: RWSession): Try[HandleOwnership] = {
-    val ownershipMaybe = {
-      val normalizedHandle = normalize(handle)
-      getByNormalizedHandle(normalizedHandle, excludeState = None) match { // locked handles must be explicitly released
-        case Some(ownership) if ownership.isLocked => if (ownership.belongsTo(ownerId)) Success(ownership) else Failure(LockedHandleException(ownership))
-        case Some(ownership) if ownership.isProtected && !overrideProtection => if (ownership.belongsTo(ownerId)) Success(ownership) else Failure(ProtectedHandleException(ownership))
-        case Some(availableOwnership) => Success(availableOwnership.copy(state = ACTIVE, ownerId = ownerId))
-        case None => Success(HandleOwnership(handle = normalizedHandle, ownerId = ownerId))
-      }
-    }
-    ownershipMaybe.map(ownership => save(ownership.copy(lastClaimedAt = clock.now, locked = ownership.locked || lock)))
-  }
-
-  def setOrganizationOwnership(handle: Handle, organizationId: Id[Organization], lock: Boolean = false, overrideProtection: Boolean = false)(implicit session: RWSession): Try[HandleOwnership] = {
-    setOwner(handle, Some(Left(organizationId)), lock, overrideProtection)
-  }
-  def setUserOwnership(handle: Handle, userId: Id[User], lock: Boolean = false, overrideProtection: Boolean = false)(implicit session: RWSession): Try[HandleOwnership] = {
-    setOwner(handle, Some(Right(userId)), lock, overrideProtection)
-  }
-  def setSystemOwnership(handle: Handle, lock: Boolean = false, overrideProtection: Boolean = false)(implicit session: RWSession): Try[HandleOwnership] = {
-    setOwner(handle, None, lock, overrideProtection)
-  }
-
   def unlock(handle: Handle)(implicit session: RWSession): Boolean = {
     getByHandle(handle).exists { ownership =>
       val wasLocked = ownership.isLocked
@@ -191,4 +157,3 @@ class HandleOwnershipRepoImpl @Inject() (
     }
   }
 }
-

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRepo.scala
@@ -26,8 +26,8 @@ class OrganizationRepoImpl @Inject() (val db: DataBaseComponent, val clock: Cloc
     def name = column[String]("name", O.NotNull)
     def description = column[Option[String]]("description", O.Nullable)
     def ownerId = column[Id[User]]("owner_id", O.NotNull)
-    def organizationHandle = column[Option[OrganizationHandle]]("organization_handle", O.Nullable)
-    def normalizedOrganizationHandle = column[Option[OrganizationHandle]]("normalized_organization_handle", O.Nullable)
+    def organizationHandle = column[Option[OrganizationHandle]]("handle", O.Nullable)
+    def normalizedOrganizationHandle = column[Option[OrganizationHandle]]("normalized_handle", O.Nullable)
 
     def * = (id.?, createdAt, updatedAt, state, seq, name, description, ownerId, organizationHandle, normalizedOrganizationHandle) <> ((Organization.applyFromDbRow _).tupled, Organization.unapplyToDbRow _)
   }


### PR DESCRIPTION
@Colin-Lane @andrewconner 

Next steps:
1. Create `Organization` table (`OrganizationRepo` is instantiated by `HandleCommander`)
2. Deploy, so that `HandleOwnership` starts to get populated.
3. Migrate existing data i.e. from username ownership defined by `UsernameAlias` and `User`
4. Introduce foreign key constraints
5. Clean up
- Rely on `HandleOwnership` instead of `UsernameAlias` and kill the latter 
- Factor out `UserCommander.autosetUsername` out to work with `Handle`

Then I can get started on `OrganizationCommander`
