### PR TITLE
CanMoveLibrary

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -696,7 +696,7 @@ class LibraryCommander @Inject() (
     library.state == LibraryStates.ACTIVE && canViewLibrary(userId, library, accessToken)
   }
 
-  def canMoveLibrary(userId: Id[User], libId: Id[Library], from: Option[Id[Organization]], to: Option[Id[Organization]]): Boolean = {
+  def canMoveToFromOrg(userId: Id[User], libId: Id[Library], from: Option[Id[Organization]], to: Option[Id[Organization]]): Boolean = {
     // lib.ownerId = userId && userId is in `from` and `to`
     db.readOnlyMaster { implicit s =>
       (libraryRepo.get(libId).ownerId == userId) &&
@@ -705,10 +705,10 @@ class LibraryCommander @Inject() (
             organizationMembershipRepo.getByOrgIdAndUserId(fromOrg, userId).nonEmpty
           case None => true // Can move libraries from Personal space to Organization Space.
         }) && (to match {
-          case Some(toOrg) => // No Need to check access for MVP, if they are part of an Organization they can move libraries to it.
-            organizationMembershipRepo.getByOrgIdAndUserId(toOrg, userId).nonEmpty
-          case None => true // Can move from Organization Space to Personal space.
-        })
+        case Some(toOrg) => // No Need to check access for MVP, if they are part of an Organization they can move libraries to it.
+          organizationMembershipRepo.getByOrgIdAndUserId(toOrg, userId).nonEmpty
+        case None => true // Can move from Organization Space to Personal space.
+      })
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -696,6 +696,25 @@ class LibraryCommander @Inject() (
     library.state == LibraryStates.ACTIVE && canViewLibrary(userId, library, accessToken)
   }
 
+  private def getLibraryById(id: Id[Library]): Library = db.readOnlyReplica { implicit s => libraryRepo.get(id) }
+
+  def canMoveLibrary(userId: Id[User], libId: Id[Library], from: Option[Id[Organization]], to: Option[Id[Organization]]): Boolean = {
+    // lib.ownerId = userId && userId is in `from` and `to`
+    val library = getLibraryById(libId)
+    val ownsLibrary = library.ownerId == userId
+    ownsLibrary && db.readOnlyMaster { implicit s =>
+      (from match {
+        case Some(fromOrg) => // No Need to check access for MVP, if they are part of an Organization they can move libraries from it.
+          organizationMembershipRepo.getByOrgIdAndUserId(fromOrg, userId).nonEmpty
+        case None => true // Can move libraries from Personal space to Organization Space.
+      }) && (to match {
+        case Some(toOrg) => // No Need to check access for MVP, if they are part of an Organization they can move libraries to it.
+          organizationMembershipRepo.getByOrgIdAndUserId(toOrg, userId).nonEmpty
+        case None => true // Can move from Organization Space to Personal space.
+      })
+    }
+  }
+
   def getLibrariesByUser(userId: Id[User]): (Seq[(LibraryMembership, Library)], Seq[(LibraryInvite, Library)]) = {
     db.readOnlyMaster { implicit s =>
       val myLibraries = libraryRepo.getByUser(userId)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -443,7 +443,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
       }
     }
 
-    "can move library" in {
+    "can move a library to and from organization space" in {
       withDb(modules: _*) { implicit injector =>
         val orgRepo = inject[OrganizationRepo]
         val orgMemberRepo = inject[OrganizationMembershipRepo]
@@ -459,28 +459,28 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
         }
 
         // User does not own the library
-        libraryCommander.canMoveLibrary(Id[User](0), newLibrary.id.get, None, organization.id) must equalTo(false)
+        libraryCommander.canMoveToFromOrg(Id[User](0), newLibrary.id.get, None, organization.id) must equalTo(false)
 
         // User owns the library
         // Can move libraries to organizations you are part of.
-        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, None, organization.id) must equalTo(true)
+        libraryCommander.canMoveToFromOrg(user.id.get, newLibrary.id.get, None, organization.id) must equalTo(true)
         // Cannot inject libraries to random organizations.
-        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, None, otherOrg.id) must equalTo(false)
+        libraryCommander.canMoveToFromOrg(user.id.get, newLibrary.id.get, None, otherOrg.id) must equalTo(false)
         // Can move libraries out of organizations you are part of.
-        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, organization.id, None) must equalTo(true)
+        libraryCommander.canMoveToFromOrg(user.id.get, newLibrary.id.get, organization.id, None) must equalTo(true)
         // Cannot inject libraries from an organization you are part of to a random organization.
-        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, organization.id, otherOrg.id) must equalTo(false)
+        libraryCommander.canMoveToFromOrg(user.id.get, newLibrary.id.get, organization.id, otherOrg.id) must equalTo(false)
         // Cannot remove libraries from other organizations you are not part of.
-        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, otherOrg.id, None) must equalTo(false)
+        libraryCommander.canMoveToFromOrg(user.id.get, newLibrary.id.get, otherOrg.id, None) must equalTo(false)
         // Prevent Company Espionage and library stealing!!
-        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, otherOrg.id, organization.id) must equalTo(false)
+        libraryCommander.canMoveToFromOrg(user.id.get, newLibrary.id.get, otherOrg.id, organization.id) must equalTo(false)
         // What about if your library is in an organization and you leave
         db.readWrite { implicit s =>
           val membership = orgMemberRepo.getByOrgIdAndUserId(organization.id.get, user.id.get)
           orgMemberRepo.save(membership.get.copy(state = OrganizationMembershipStates.INACTIVE))
         }
         // You're out of luck.
-        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, organization.id, None) must equalTo(false)
+        libraryCommander.canMoveToFromOrg(user.id.get, newLibrary.id.get, organization.id, None) must equalTo(false)
       }
     }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -1,5 +1,6 @@
 package com.keepit.commanders
 
+import com.keepit.common.db.slick.DBSession.RWSession
 import com.keepit.common.util.Paginator
 import com.keepit.model.UserFactory._
 import com.keepit.model.LibraryFactoryHelper._
@@ -439,6 +440,47 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
         libraryCommander.canViewLibrary(None, libScience) === false
         libraryCommander.canViewLibrary(None, libScience, Some("token-wrong")) === false
         libraryCommander.canViewLibrary(None, libScience, Some("token")) === true
+      }
+    }
+
+    "can move library" in {
+      withDb(modules: _*) { implicit injector =>
+        val orgRepo = inject[OrganizationRepo]
+        val orgMemberRepo = inject[OrganizationMembershipRepo]
+        val libraryCommander = inject[LibraryCommander]
+        val (user, newLibrary, organization, otherOrg) = db.readWrite { implicit s =>
+          val orgOwner = UserFactory.user().withName("Bruce", "Lee").saved
+          val user: User = UserFactory.user().withName("Jackie", "Chan").saved
+          val newLibrary = library().withUser(user).withVisibility(LibraryVisibility.ORGANIZATION).saved
+          val organization = orgRepo.save(Organization(name = "Kung Fu Academy", ownerId = orgOwner.id.get, handle = None))
+          val otherOrg = orgRepo.save(Organization(name = "Martial Arts", ownerId = orgOwner.id.get, handle = None))
+          orgMemberRepo.save(OrganizationMembership(organizationId = organization.id.get, userId = user.id.get, access = OrganizationAccess.READ_WRITE))
+          (user, newLibrary, organization, otherOrg)
+        }
+
+        // User does not own the library
+        libraryCommander.canMoveLibrary(Id[User](0), newLibrary.id.get, None, organization.id) must equalTo(false)
+
+        // User owns the library
+        // Can move libraries to organizations you are part of.
+        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, None, organization.id) must equalTo(true)
+        // Cannot inject libraries to random organizations.
+        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, None, otherOrg.id) must equalTo(false)
+        // Can move libraries out of organizations you are part of.
+        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, organization.id, None) must equalTo(true)
+        // Cannot inject libraries from an organization you are part of to a random organization.
+        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, organization.id, otherOrg.id) must equalTo(false)
+        // Cannot remove libraries from other organizations you are not part of.
+        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, otherOrg.id, None) must equalTo(false)
+        // Prevent Company Espionage and library stealing!!
+        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, otherOrg.id, organization.id) must equalTo(false)
+        // What about if your library is in an organization and you leave
+        db.readWrite { implicit s =>
+          val membership = orgMemberRepo.getByOrgIdAndUserId(organization.id.get, user.id.get)
+          orgMemberRepo.save(membership.get.copy(state = OrganizationMembershipStates.INACTIVE))
+        }
+        // You're out of luck.
+        libraryCommander.canMoveLibrary(user.id.get, newLibrary.id.get, organization.id, None) must equalTo(false)
       }
     }
 


### PR DESCRIPTION
- initial rules for when a user can move a library to/from an
  organization.

@leogrim
