### PR TITLE
Fixed an issue where a user's page showed duplicate install versions

### DIFF
--- a/kifi-backend/modules/shoebox/app/views/admin/user.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/user.scala.html
@@ -14,7 +14,7 @@
 
 @formatKifiInstallations(kifiInstallations: Seq[KifiInstallation]) = {
 <ul>
-    @for(installation <- kifiInstallations) {
+    @for(installation: KifiInstallation <- kifiInstallations.toSet) {
     <li>@{installation.version}; @{installation.userAgent.name} @{installation.userAgent.version}; @{installation.userAgent.operatingSystemName}</li>
     }
 </ul>


### PR DESCRIPTION
Jonathan showed me an issue where a user's page on the admin view could have a
lot of duplicate versions displayed (this is not an issue on the admin view, strangely).
