### PR TITLE
Creating traits for LibraryCommander and LibraryInviteCommander

### DIFF
--- a/kifi-backend/modules/shoebox/angular/README.md
+++ b/kifi-backend/modules/shoebox/angular/README.md
@@ -4,7 +4,7 @@
 
 You need to [download](http://nodejs.org/download/) and install node.js.
 
-###1.2. Install node dependencies
+###1.2. Install dev dependencies
 
 After successfully installing node.js, type `npm install` in terminal, and it will start downloading all package depenendencies for development under `node_modules/`.
 
@@ -12,24 +12,18 @@ It will also automatically install [bower](http://bower.io/), the package manage
 
 You can always do this step manually by typing `npm install -g bower` and then `bower install`.
 
+Install Gulp, our frontend build tool. `npm install -g gulp`.
+
 
 #2. Running the app
 
-###2.1. Run `python server.py`
+###1.2. Run Gulp
 
-Run an HTTP Server that serves files on your project directory by typing `python server.py`.
-
-It will, by default, start and run a server listening on port 8080.
-
-###2.2. Run Grunt
-
-Make sure that [grunt-cli](http://gruntjs.com/getting-started) is already installed.
-
-Run Grunt by typing `grunt` on your project directory where `gruntfile.js` is found.
+Run Gulp by typing `gulp` in this directory.
 
 It will run all default tasks and automatically go into watch mode to watch files for changes and run tasks automatically for you.
 
-###2.3. Browse to `dev.ezkeep.com:8080`.
+###2.2. Browse to `dev.ezkeep.com:8080`.
 
 Visit `dev.ezkeep.com:8080` to run the app.
 
@@ -39,6 +33,8 @@ Visit `dev.ezkeep.com:8080` to run the app.
 Edit the code! Your browser will reload changed stylesheets or the entire app, as appropriate, when you save files with changes.
 
 
-#4. Future work
+#4. Things that need more documentation
 
-###4.1. Tests are coming
+##4.1. Testing
+##4.2. High level architecture of the app
+##4.3. How deploys work

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -1,6 +1,6 @@
 package com.keepit.commanders
 
-import com.google.inject.{ Inject, Provider }
+import com.google.inject.{ ImplementedBy, Inject, Provider }
 import com.keepit.abook.ABookServiceClient
 import com.keepit.abook.model.RichContact
 import com.keepit.commanders.emails.{ EmailOptOutCommander, LibraryInviteEmailSender }
@@ -44,7 +44,59 @@ object MarketingSuggestedLibrarySystemValue {
   def systemValueName = Name[SystemValue]("marketing_site_libraries")
 }
 
-class LibraryCommander @Inject() (
+@ImplementedBy(classOf[LibraryCommanderImpl])
+trait LibraryCommander {
+  // todo: For each method here, remove if no one's calling it externally, and set as private in the implementation
+  def getKeeps(libraryId: Id[Library], offset: Int, limit: Int): Future[Seq[Keep]]
+  def getKeepsCount(libraryId: Id[Library]): Future[Int]
+  def updateLastView(userId: Id[User], libraryId: Id[Library]): Unit
+  def getLibraryById(userIdOpt: Option[Id[User]], showPublishedLibraries: Boolean, id: Id[Library], imageSize: ImageSize, viewerId: Option[Id[User]])(implicit context: HeimdalContext): Future[FullLibraryInfo]
+  def getLibrarySummaries(libraryIds: Seq[Id[Library]]): Seq[LibraryInfo]
+  def getLibraryPath(library: Library): String
+  def getBasicLibraryDetails(libraryIds: Set[Id[Library]], idealImageSize: ImageSize, viewerId: Option[Id[User]]): Map[Id[Library], BasicLibraryDetails]
+  def getLibrarySummaryAndMembership(userIdOpt: Option[Id[User]], libraryId: Id[Library]): (LibraryInfo, Option[LibraryMembershipInfo])
+  def getLibraryWithOwnerAndCounts(libraryId: Id[Library], viewerUserId: Id[User]): Either[LibraryFail, (Library, BasicUser, Int, Option[Boolean], Boolean)]
+  def getViewerMembershipInfo(userIdOpt: Option[Id[User]], libraryId: Id[Library]): Option[LibraryMembershipInfo]
+  def sortUsersByImage(users: Seq[BasicUser]): Seq[BasicUser]
+  def createFullLibraryInfos(viewerUserIdOpt: Option[Id[User]], showPublishedLibraries: Boolean, maxMembersShown: Int, maxKeepsShown: Int, idealKeepImageSize: ImageSize, libraries: Seq[Library], idealLibraryImageSize: ImageSize, withKeepTime: Boolean): Future[Seq[(Id[Library], FullLibraryInfo)]]
+  def createFullLibraryInfo(viewerUserIdOpt: Option[Id[User]], showPublishedLibraries: Boolean, library: Library, libImageSize: ImageSize, showKeepCreateTime: Boolean = true): Future[FullLibraryInfo]
+  def getLibraryMembers(libraryId: Id[Library], offset: Int, limit: Int, fillInWithInvites: Boolean): (Seq[LibraryMembership], Seq[LibraryMembership], Seq[(Either[Id[User], EmailAddress], Set[LibraryInvite])], CountWithLibraryIdByAccess)
+  def buildMaybeLibraryMembers(collaborators: Seq[LibraryMembership], followers: Seq[LibraryMembership], inviteesWithInvites: Seq[(Either[Id[User], EmailAddress], Set[LibraryInvite])]): Seq[MaybeLibraryMember]
+  def suggestMembers(userId: Id[User], libraryId: Id[Library], query: Option[String], limit: Option[Int]): Future[Seq[MaybeLibraryMember]]
+  def addLibrary(libAddReq: LibraryAddRequest, ownerId: Id[User])(implicit context: HeimdalContext): Either[LibraryFail, Library]
+  def canModifyLibrary(libraryId: Id[Library], userId: Id[User]): Boolean
+  def getLibrariesWithWriteAccess(userId: Id[User]): Set[Id[Library]]
+  def modifyLibrary(libraryId: Id[Library], userId: Id[User], modifyReq: LibraryModifyRequest)(implicit context: HeimdalContext): Either[LibraryFail, Library]
+  def removeLibrary(libraryId: Id[Library], userId: Id[User])(implicit context: HeimdalContext): Option[LibraryFail]
+  def canViewLibrary(userId: Option[Id[User]], library: Library, authToken: Option[String] = None): Boolean
+  def canViewLibrary(userId: Option[Id[User]], libraryId: Id[Library], accessToken: Option[String]): Boolean
+  def getLibrariesByUser(userId: Id[User]): (Seq[(LibraryMembership, Library)], Seq[(LibraryInvite, Library)])
+  def getLibrariesUserCanKeepTo(userId: Id[User]): Seq[(Library, LibraryMembership, Seq[BasicUser])]
+  def userAccess(userId: Id[User], libraryId: Id[Library], universalLinkOpt: Option[String]): Option[LibraryAccess]
+  def internSystemGeneratedLibraries(userId: Id[User], generateNew: Boolean = true): (Library, Library)
+  def notifyFollowersOfNewKeeps(library: Library, newKeeps: Keep*): Unit
+  def joinLibrary(userId: Id[User], libraryId: Id[Library], authToken: Option[String] = None, subscribed: Option[Boolean] = None)(implicit eventContext: HeimdalContext): Either[LibraryFail, (Library, LibraryMembership)]
+  def leaveLibrary(libraryId: Id[Library], userId: Id[User])(implicit eventContext: HeimdalContext): Either[LibraryFail, Unit]
+  def sortAndSelectLibrariesWithTopGrowthSince(libraryIds: Set[Id[Library]], since: DateTime, totalMemberCount: Id[Library] => Int): Seq[(Id[Library], Seq[LibraryMembership])]
+  def sortAndSelectLibrariesWithTopGrowthSince(libraryMemberCountsSince: Map[Id[Library], Int], since: DateTime, totalMemberCount: Id[Library] => Int): Seq[(Id[Library], Seq[LibraryMembership])]
+  def fixLibraryKeepCount(libIds: Seq[Id[Library]]): Unit
+  def copyKeepsFromCollectionToLibrary(userId: Id[User], libraryId: Id[Library], tagName: Hashtag)(implicit context: HeimdalContext): Either[LibraryFail, (Seq[Keep], Seq[(Keep, LibraryError)])]
+  def moveKeepsFromCollectionToLibrary(userId: Id[User], libraryId: Id[Library], tagName: Hashtag)(implicit context: HeimdalContext): Either[LibraryFail, (Seq[Keep], Seq[(Keep, LibraryError)])]
+  def copyKeeps(userId: Id[User], toLibraryId: Id[Library], keeps: Seq[Keep], withSource: Option[KeepSource])(implicit context: HeimdalContext): (Seq[Keep], Seq[(Keep, LibraryError)])
+  def moveKeeps(userId: Id[User], toLibraryId: Id[Library], keeps: Seq[Keep])(implicit context: HeimdalContext): (Seq[Keep], Seq[(Keep, LibraryError)])
+  def getMainAndSecretLibrariesForUser(userId: Id[User])(implicit session: RWSession): (Library, Library)
+  def getLibraryWithUsernameAndSlug(username: String, slug: LibrarySlug, viewerId: Option[Id[User]])(implicit context: HeimdalContext): Either[LibraryFail, Library]
+  def trackLibraryView(viewerId: Option[Id[User]], library: Library)(implicit context: HeimdalContext): Unit
+  def getLibraryBySlugOrAlias(ownerId: Id[User], slug: LibrarySlug): Option[(Library, Boolean)]
+  def getMarketingSiteSuggestedLibraries(): Future[Seq[LibraryCardInfo]]
+  def createLibraryCardInfos(libs: Seq[Library], owners: Map[Id[User], BasicUser], viewerOpt: Option[User], withFollowing: Boolean, idealSize: ImageSize)(implicit session: RSession): ParSeq[LibraryCardInfo]
+  def createLiteLibraryCardInfos(libs: Seq[Library], viewerId: Id[User])(implicit session: RSession): ParSeq[(LibraryCardInfo, MiniLibraryMembership)]
+  def updateLastEmailSent(userId: Id[User], keeps: Seq[Keep]): Unit
+  def updateSubscribedToLibrary(userId: Id[User], libraryId: Id[Library], subscribedToUpdatesNew: Boolean): Either[LibraryFail, LibraryMembership]
+  def updateLibraryMembershipAccess(requestUserId: Id[User], libraryId: Id[Library], targetUserId: Id[User], newAccess: Option[LibraryAccess]): Either[LibraryFail, LibraryMembership]
+}
+
+class LibraryCommanderImpl @Inject() (
     db: Database,
     libraryRepo: LibraryRepo,
     libraryMembershipRepo: LibraryMembershipRepo,
@@ -84,7 +136,7 @@ class LibraryCommander @Inject() (
     kifiInstallationCommander: KifiInstallationCommander,
     implicit val defaultContext: ExecutionContext,
     implicit val publicIdConfig: PublicIdConfiguration,
-    clock: Clock) extends Logging {
+    clock: Clock) extends LibraryCommander with Logging {
 
   def getKeeps(libraryId: Id[Library], offset: Int, limit: Int): Future[Seq[Keep]] = {
     if (limit > 0) db.readOnlyReplicaAsync { implicit s => keepRepo.getByLibrary(libraryId, offset, limit) }


### PR DESCRIPTION
@yingjieMiao @stkem @leogrim @eishay

You wouldn't believe how much faster this makes compilation.

Traits for large classes are great:
1. They serve as a table of contents for a large classes and form a contract for method signatures.
2. Aid in refactoring. Easy to know what my contracts are if I'm locked into a trait.
3. Speeds up compilation, since signatures are locked and the class constructor doesn't change based on dependency injection changes (one of the downsides of Guice).
4. Make it easier to encapsulate public vs private methods.

If everyone agrees, I will be converting our existing commanders to this pattern over time. If anyone wants to help, this makes it a pretty easy process (leaving cleaning up for later):

``` scala
def genTrait(filename: String) = {
  import scala.io.Source
  val name = filename.drop(filename.lastIndexOf('/')+1).dropRight(6)
  val lines = Source.fromFile(filename).getLines().dropWhile(!_.contains(s"class $name"))
  val methods = lines.filter(_.indexOf("  def ") == 0).map(_.reverse.dropWhile(c => c != '=').drop(1).reverse).mkString("\n")
  val t = s"""
@ImplementedBy(classOf[${name}Impl])
trait $name {
  // todo: For each method here, remove if no one's calling it externally, and set as private in the implementation
$methods
}
  """
  println(t)
}
```
