### PR TITLE
Cache IPs and notifications for new clusters

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/service/IpAddress.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/service/IpAddress.scala
@@ -1,7 +1,10 @@
 package com.keepit.common.service
 
+import play.api.libs.json._
+
 object IpAddress {
   val ipPattern = """^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"""
+  implicit val format: Format[IpAddress] = Format(__.read[String].map(IpAddress(_)), Writes(ip => JsString(ip.ip)))
 }
 
 case class IpAddress(ip: String) {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserIpAddressCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserIpAddressCommander.scala
@@ -6,17 +6,23 @@ import com.keepit.common.controller.UserRequest
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
-import com.keepit.common.net.UserAgent
+import com.keepit.common.net.{ DirectUrl, HttpClient, UserAgent }
 import com.keepit.common.service.IpAddress
-import com.keepit.model.{ User, UserIpAddress, UserIpAddressRepo, UserIpAddressStates }
-import org.joda.time.DateTime
+import com.keepit.model._
+import org.joda.time.{ DateTime, Period }
+import play.api.libs.json.Json
 
-import scala.concurrent.{ Future, ExecutionContext }
+import scala.concurrent.{ ExecutionContext, Future }
 
 class UserIpAddressCommander @Inject() (
     db: Database,
     implicit val defaultContext: ExecutionContext,
-    userIpAddressRepo: UserIpAddressRepo) extends Logging {
+    httpClient: HttpClient,
+    userIpAddressRepo: UserIpAddressRepo,
+    userRepo: UserRepo) extends Logging {
+
+  private val ipClusterSlackChannelUrl = "https://hooks.slack.com/services/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"
+  private val clusterMemoryTime = Period.weeks(10) // How long back do we look and still consider a user to be part of a cluster
 
   def simplifyUserAgent(userAgent: UserAgent): String = {
     val agentType = userAgent.typeName.toUpperCase()
@@ -33,7 +39,16 @@ class UserIpAddressCommander @Inject() (
       log.info("[RPB] Could not parse an agent type out of: " + userAgent)
     }
     val model = UserIpAddress(None, now, now, UserIpAddressStates.ACTIVE, userId, ip, agentType)
-    db.readWrite { implicit session => userIpAddressRepo.save(model) }
+
+    val oldCluster = db.readWrite { implicit session =>
+      val currentCluster = userIpAddressRepo.getUsersFromIpAddressSince(ip, now.minus(clusterMemoryTime))
+      userIpAddressRepo.saveIfNew(model)
+      currentCluster
+    }
+
+    if (!oldCluster.isEmpty && !oldCluster.contains(userId)) {
+      notifySlackChannelAboutCluster(ip)
+    }
   }
 
   def logUserByRequest[T](request: UserRequest[T]): Unit = {
@@ -42,6 +57,20 @@ class UserIpAddressCommander @Inject() (
     val raw_ip_string = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
     val ip = IpAddress(raw_ip_string.split(",").head)
     logUser(userId, ip, userAgent)
+  }
+
+  def formatCluster(ip: IpAddress, users: Seq[User]): BasicSlackMessage = {
+    val userDeclarations = (for { u <- users } yield s"<http://admin.kifi.com/admin/user/${u.id.get}|${u.fullName}>").toList
+    BasicSlackMessage((s"Found a cluster of ${users.length} at $ip" :: userDeclarations).mkString("\n"))
+  }
+
+  def notifySlackChannelAboutCluster(clusterIp: IpAddress): Unit = {
+    val usersFromCluster = db.readOnlyReplica { implicit session =>
+      val userIds = userIpAddressRepo.getUsersFromIpAddressSince(clusterIp, DateTime.now.minus(clusterMemoryTime))
+      userRepo.getUsers(userIds).values.toSeq
+    }
+    val msg = formatCluster(clusterIp, usersFromCluster)
+    httpClient.post(DirectUrl(ipClusterSlackChannelUrl), Json.toJson(msg))
   }
 
   def totalNumberOfLogs(): Int = {
@@ -55,6 +84,10 @@ class UserIpAddressCommander @Inject() (
     db.readOnlyReplica { implicit session => userIpAddressRepo.getByUser(userId, limit) }
   }
 
+  def getUsersByIpAddressSince(ip: IpAddress, time: DateTime): Seq[Id[User]] = {
+    db.readOnlyReplica { implicit session => userIpAddressRepo.getUsersFromIpAddressSince(ip, time) }
+  }
+
   def kvPairsToMap[A, B](kvs: Seq[(A, B)]): Map[A, Seq[B]] = {
     kvs.groupBy(_._1).mapValues(_.map(_._2))
   }
@@ -64,7 +97,7 @@ class UserIpAddressCommander @Inject() (
     }
     kvPairsToMap(sharedIps)
   }
-  def findIpClustersSince(time: DateTime, limit: Int): Seq[(IpAddress, Int, Id[User])] = {
+  def findIpClustersSince(time: DateTime, limit: Int): Seq[IpAddress] = {
     db.readOnlyReplica { implicit session =>
       userIpAddressRepo.findIpClustersSince(time, limit)
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserIpAddressCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserIpAddressCommander.scala
@@ -29,14 +29,14 @@ class UserIpAddressCommander @Inject() (
     if (agentType.isEmpty) "NONE" else agentType
   }
 
-  def logUser(userId: Id[User], ip: IpAddress, userAgent: UserAgent): Future[Unit] = SafeFuture {
+  def logUser(userId: Id[User], ip: IpAddress, userAgent: UserAgent, reportNewClusters: Boolean = true): Future[Unit] = SafeFuture {
     if (ip.ip.toString.startsWith("10.")) {
       throw new IllegalArgumentException("IP Addresses of the form 10.x.x.x are internal ec2 addresses and should not be logged")
     }
     val now = DateTime.now()
     val agentType = simplifyUserAgent(userAgent)
     if (agentType == "NONE") {
-      log.info("[RPB] Could not parse an agent type out of: " + userAgent)
+      log.info("[IPTRACK AGENT] Could not parse an agent type out of: " + userAgent)
     }
     val model = UserIpAddress(None, now, now, UserIpAddressStates.ACTIVE, userId, ip, agentType)
 
@@ -46,7 +46,7 @@ class UserIpAddressCommander @Inject() (
       currentCluster
     }
 
-    if (!oldCluster.isEmpty && !oldCluster.contains(userId)) {
+    if (reportNewClusters && !oldCluster.isEmpty && !oldCluster.contains(userId)) {
       notifySlackChannelAboutCluster(ip)
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -390,4 +390,8 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Provides @Singleton
   def keepImagesCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new KeepImagesCache(stats, accessLog, (outerRepo, 30 days))
+
+  @Provides @Singleton
+  def userIpAddressCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserIpAddressCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 1 days))
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserIpAddressRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserIpAddressRepo.scala
@@ -89,15 +89,15 @@ class UserIpAddressRepoImpl @Inject() (
     result.as[(IpAddress, Id[User])].list
   }
 
-  implicit val getIpClusterResult = GetResult(r => (IpAddress(r.<<), r.<< : Int))
+  implicit val getIpAddressResult = GetResult(r => (IpAddress(r.<<)))
   def findIpClustersSince(time: DateTime, limit: Int)(implicit session: RSession): Seq[IpAddress] = {
     import com.keepit.common.db.slick.StaticQueryFixed.interpolation
-    val result = sql"""select ip_address, count(distinct user_id) as cnt
+    val result = sql"""select ip_address
                        from user_ip_addresses
                        where created_at > $time
                        group by ip_address
-                       order by cnt desc
+                       order by count(distinct user_id) desc
                        limit $limit;"""
-    result.as[(IpAddress, Int)].list.map(_._1)
+    result.as[IpAddress].list
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserIpAddressRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserIpAddressRepo.scala
@@ -2,7 +2,7 @@ package com.keepit.model
 
 import com.google.inject.{ ImplementedBy, Inject, Singleton }
 import com.keepit.common.db._
-import com.keepit.common.db.slick.DBSession.RSession
+import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
 import com.keepit.common.db.slick._
 import com.keepit.common.logging.Logging
 import com.keepit.common.service.IpAddress
@@ -13,15 +13,18 @@ import scala.slick.jdbc.GetResult
 
 @ImplementedBy(classOf[UserIpAddressRepoImpl])
 trait UserIpAddressRepo extends Repo[UserIpAddress] {
+  def saveIfNew(model: UserIpAddress)(implicit session: RWSession): UserIpAddress
   def countByUser(userId: Id[User])(implicit session: RSession): Int
   def getByUser(userId: Id[User], limit: Int)(implicit session: RSession): Seq[UserIpAddress]
+  def getUsersFromIpAddressSince(ip: IpAddress, time: DateTime)(implicit session: RSession): Seq[Id[User]]
   def findSharedIpsByUser(userId: Id[User], limit: Int)(implicit session: RSession): Seq[(IpAddress, Id[User])]
-  def findIpClustersSince(time: DateTime, limit: Int)(implicit session: RSession): Seq[(IpAddress, Int, Id[User])]
+  def findIpClustersSince(time: DateTime, limit: Int)(implicit session: RSession): Seq[IpAddress]
 }
 
 @Singleton
 class UserIpAddressRepoImpl @Inject() (
   val db: DataBaseComponent,
+  userIpAddressCache: UserIpAddressCache,
   val clock: Clock)
     extends DbRepo[UserIpAddress] with UserIpAddressRepo with Logging {
 
@@ -40,8 +43,25 @@ class UserIpAddressRepoImpl @Inject() (
   def table(tag: Tag) = new UserIpAddressTable(tag)
   initTable()
 
-  def invalidateCache(model: UserIpAddress)(implicit session: RSession): Unit = {}
-  def deleteCache(model: UserIpAddress)(implicit session: RSession): Unit = {}
+  override def deleteCache(model: UserIpAddress)(implicit session: RSession): Unit = {
+    userIpAddressCache.remove(UserIpAddressKey(model.userId))
+  }
+
+  override def invalidateCache(model: UserIpAddress)(implicit session: RSession) = {
+    userIpAddressCache.set(UserIpAddressKey(model.userId), model)
+  }
+
+  def saveIfNew(model: UserIpAddress)(implicit session: RWSession): UserIpAddress = {
+    userIpAddressCache.get(UserIpAddressKey(model.userId)) match {
+      case None => save(model)
+      case Some(oldModel) =>
+        if (model.createdAt.minusMinutes(30).isBefore(oldModel.createdAt)) {
+          oldModel // within 30 minutes of old model, ignore
+        } else {
+          save(model)
+        }
+    }
+  }
 
   def getByUser(ownerId: Id[User], limit: Int)(implicit session: RSession): Seq[UserIpAddress] = {
     (for { row <- rows if row.userId === ownerId } yield row).sortBy(_.createdAt.desc).take(limit).list
@@ -49,6 +69,14 @@ class UserIpAddressRepoImpl @Inject() (
 
   def countByUser(userId: Id[User])(implicit session: RSession): Int = {
     Query((for (r <- rows if r.userId === userId) yield r).length).first
+  }
+
+  def getUsersFromIpAddressSince(ip: IpAddress, time: DateTime)(implicit session: RSession): Seq[Id[User]] = {
+    import com.keepit.common.db.slick.StaticQueryFixed.interpolation
+    val result = sql"""select distinct user_id
+                       from user_ip_addresses
+                       where created_at > $time and ip_address = ${ip.ip}"""
+    result.as[Id[User]].list
   }
 
   implicit val getSharedIpResult = GetResult(r => (IpAddress(r.<<), r.<< : Id[User]))
@@ -61,15 +89,15 @@ class UserIpAddressRepoImpl @Inject() (
     result.as[(IpAddress, Id[User])].list
   }
 
-  implicit val getIpClusterResult = GetResult(r => (IpAddress(r.<<), r.<< : Int, r.<< : Id[User]))
-  def findIpClustersSince(time: DateTime, limit: Int)(implicit session: RSession): Seq[(IpAddress, Int, Id[User])] = {
+  implicit val getIpClusterResult = GetResult(r => (IpAddress(r.<<), r.<< : Int))
+  def findIpClustersSince(time: DateTime, limit: Int)(implicit session: RSession): Seq[IpAddress] = {
     import com.keepit.common.db.slick.StaticQueryFixed.interpolation
-    val result = sql"""select ip_address, count(distinct user_id) as cnt, min(user_id)
+    val result = sql"""select ip_address, count(distinct user_id) as cnt
                        from user_ip_addresses
                        where created_at > $time
                        group by ip_address
                        order by cnt desc
                        limit $limit;"""
-    result.as[(IpAddress, Int, Id[User])].list
+    result.as[(IpAddress, Int)].list.map(_._1)
   }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/UserIpAddressCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/UserIpAddressCommanderTest.scala
@@ -6,6 +6,7 @@ import com.keepit.common.net.UserAgent
 import com.keepit.common.service.IpAddress
 import com.keepit.model._
 import com.keepit.test.ShoeboxTestInjector
+import org.joda.time.DateTime
 import org.specs2.mutable.Specification
 
 import scala.concurrent.Await
@@ -43,5 +44,43 @@ class UserIpAddressCommanderTest extends Specification with ShoeboxTestInjector 
         commander.totalNumberOfLogs() === 1
       }
     }
+
+    "ignore rapidly repeating visits" in {
+      withDb() { implicit injector =>
+        val commander = inject[UserIpAddressCommander]
+
+        val n = 10
+        val ips = for (ipOff <- 1 to n) yield { IpAddress((100 + ipOff).toString + ".0.0.1") }
+        for (uid <- 1 to n; i <- 1 to n) {
+          val res = commander.logUser(Id[User](uid), ips(i - 1), UserAgent(""), reportNewClusters = false)
+          Await.result(res, Duration.Inf)
+        }
+
+        commander.totalNumberOfLogs() === n
+      }
+    }
+
+    "find ip clusters" in {
+      withDb() { implicit injector =>
+        val commander = inject[UserIpAddressCommander]
+
+        val n = 5
+        val ips = for (i <- 1 to n) yield {
+          IpAddress((100 + i).toString + ".0.0.1")
+        }
+        val uids = for (i <- 1 to n) yield (10 * i to 10 * i + i - 1) // ip(i-1) has i user ids going to it
+        for (i <- 1 to n) {
+          for (uid <- uids(i - 1)) {
+            val res = commander.logUser(Id[User](uid), ips(i - 1), UserAgent(""), reportNewClusters = false)
+            Await.result(res, Duration.Inf)
+          }
+        }
+
+        commander.totalNumberOfLogs() === n * (n + 1) / 2
+        val clusterIps = commander.findIpClustersSince(DateTime.now.minusHours(1), n)
+        clusterIps === ips.reverse
+      }
+    }
+
   }
 }


### PR DESCRIPTION
Added a cache to the userIpAddressRepo and logic that prevents a user
from being logged if they are still in the cache. Also, upon adding
a user we check to see if they share an ip with any other people. If
this is a new discovery, we report it to the Slack channel #userclusters

@eishay @stkem
