### PR TITLE
Three very small tweaks

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminIDController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminIDController.scala
@@ -23,11 +23,11 @@ class AdminIDController @Inject() (
   }
 
   def byId(name: String, id: Long) = AdminUserPage { implicit request =>
-    val pubId = PublicIdRegistry.registry.find(_._1.toLowerCase.contains(name.toLowerCase)).map {
+    val pubIds = PublicIdRegistry.registry.filter(_._1.toLowerCase.contains(name.toLowerCase)).map {
       case (clazz, accessor) =>
         clazz + " " + accessor.toPubId(id)
-    }.getOrElse("Couldn't find class")
-    Ok(pubId)
+    }.mkString("\n")
+    Ok(pubIds)
   }
 
   def byPublicId(name: String, publicId: String) = AdminUserPage { implicit request =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
@@ -410,7 +410,7 @@ class TypeaheadCommander @Inject() (
           case (users, contacts) =>
             val userOrder = users.zipWithIndex.map(u => u._1._1 -> u._2).toMap
             val contactOrder = contacts.zipWithIndex.toMap
-            (userOrder.withDefaultValue(limit.getOrElse(100)), contactOrder.withDefaultValue(limit.getOrElse(100)))
+            (userOrder.withDefaultValue(limit.getOrElse(500)), contactOrder.withDefaultValue(limit.getOrElse(500)))
         }
 
         log.info(s"[searchForContacts] Ordering results for $userId took ${System.currentTimeMillis() - startTime}ms")

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
@@ -451,7 +451,7 @@ class KeepRepoImpl @Inject() (
   // Make compiled in Slick 2.1
 
   def getByLibrary(libraryId: Id[Library], offset: Int, limit: Int, excludeSet: Set[State[Keep]])(implicit session: RSession): Seq[Keep] = {
-    (for (b <- rows if b.libraryId === libraryId && !b.state.inSet(excludeSet)) yield b).sortBy(_.keptAt desc).drop(offset).take(limit).list
+    (for (b <- rows if b.libraryId === libraryId && !b.state.inSet(excludeSet)) yield b).sortBy(r => (r.keptAt desc, r.id desc)).drop(offset).take(limit).list
   }
 
   def getCountByLibrary(libraryId: Id[Library])(implicit session: RSession): Int = {


### PR DESCRIPTION
1) PublicId admin page now shows all classes that match the search string. Helps with LibraryInvite vs Library.
2) Higher (lower is better) scoring for typeahead search of users with no interactions
3) Fixing a test that had a race due to sorting by a time.

@Colin-Lane @leogrim  
