### PR TITLE
Org member validation

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
@@ -94,7 +94,35 @@ class OrganizationMembershipCommanderImpl @Inject() (
   }
 
   private def validRequest(request: OrganizationMembershipRequest)(implicit session: RSession): Boolean = {
-    true
+    val requesterOpt = organizationMembershipRepo.getByOrgIdAndUserId(request.orgId, request.requesterId)
+    val targetOpt = organizationMembershipRepo.getByOrgIdAndUserId(request.orgId, request.targetId)
+
+    if (requesterOpt.isEmpty) return false // a non-member can't request anything
+    val requester = requesterOpt.get
+
+    request match {
+      case OrganizationMembershipAddRequest(_, _, _, newRole) => validAdd(requester, targetOpt, newRole)
+      case OrganizationMembershipModifyRequest(_, _, _, newRole) => validModify(requester, targetOpt, newRole)
+      case OrganizationMembershipRemoveRequest(_, _, _) => validRemove(requester, targetOpt)
+    }
+  }
+  private def validAdd(requester: OrganizationMembership, targetOpt: Option[OrganizationMembership], newRole: OrganizationRole): Boolean = {
+    targetOpt match {
+      case None => newRole <= requester.role
+      case Some(_) => false
+    }
+  }
+  private def validModify(requester: OrganizationMembership, targetOpt: Option[OrganizationMembership], newRole: OrganizationRole): Boolean = {
+    targetOpt match {
+      case None => false
+      case Some(target) => target.role <= requester.role && newRole <= requester.role
+    }
+  }
+  private def validRemove(requester: OrganizationMembership, targetOpt: Option[OrganizationMembership]): Boolean = {
+    targetOpt match {
+      case None => false
+      case Some(target) => target.role <= requester.role
+    }
   }
 
   def addMembership(request: OrganizationMembershipAddRequest): Either[OrganizationFail, OrganizationMembershipAddResponse] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
@@ -97,32 +97,17 @@ class OrganizationMembershipCommanderImpl @Inject() (
     val requesterOpt = organizationMembershipRepo.getByOrgIdAndUserId(request.orgId, request.requesterId)
     val targetOpt = organizationMembershipRepo.getByOrgIdAndUserId(request.orgId, request.targetId)
 
-    requesterOpt match {
-      case None => false // a non-member can't request anything
-      case Some(requester) =>
-        request match {
-          case OrganizationMembershipAddRequest(_, _, _, newRole) => validAdd(requester, targetOpt, newRole)
-          case OrganizationMembershipModifyRequest(_, _, _, newRole) => validModify(requester, targetOpt, newRole)
-          case OrganizationMembershipRemoveRequest(_, _, _) => validRemove(requester, targetOpt)
-        }
-    }
-  }
-  private def validAdd(requester: OrganizationMembership, targetOpt: Option[OrganizationMembership], newRole: OrganizationRole): Boolean = {
-    targetOpt match {
-      case None => requester.role >= newRole
-      case Some(_) => false
-    }
-  }
-  private def validModify(requester: OrganizationMembership, targetOpt: Option[OrganizationMembership], newRole: OrganizationRole): Boolean = {
-    targetOpt match {
-      case None => false
-      case Some(target) => (requester.role >= target.role) && (newRole <= requester.role)
-    }
-  }
-  private def validRemove(requester: OrganizationMembership, targetOpt: Option[OrganizationMembership]): Boolean = {
-    targetOpt match {
-      case None => false
-      case Some(target) => requester.role >= target.role
+    requesterOpt exists { requester =>
+      request match {
+        case OrganizationMembershipAddRequest(_, _, _, newRole) =>
+          targetOpt.isEmpty && (newRole <= requester.role)
+
+        case OrganizationMembershipModifyRequest(_, _, _, newRole) =>
+          targetOpt.exists(_.role < requester.role) && (newRole <= requester.role)
+
+        case OrganizationMembershipRemoveRequest(_, _, _) =>
+          targetOpt.exists(_.role < requester.role)
+      }
     }
   }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationMembershipCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationMembershipCommanderTest.scala
@@ -59,15 +59,14 @@ class OrganizationMembershipCommanderTest extends TestKitSupport with Specificat
         val orgMemberRepo = inject[OrganizationMembershipRepo]
 
         val orgId = Id[Organization](1)
-        val ownerId = Id[User](1)
 
         db.readWrite { implicit session =>
-          orgMemberRepo.save(OrganizationMembership(organizationId = orgId, userId = ownerId, role = OrganizationRole.OWNER))
+          orgMemberRepo.save(OrganizationMembership(organizationId = orgId, userId = Id[User](1), role = OrganizationRole.OWNER))
         }
 
         val orgMemberCommander = inject[OrganizationMembershipCommander]
 
-        val ownerAddUser = OrganizationMembershipAddRequest(orgId, ownerId, Id[User](2), OrganizationRole.MEMBER)
+        val ownerAddUser = OrganizationMembershipAddRequest(orgId, Id[User](1), Id[User](2), OrganizationRole.MEMBER)
         orgMemberCommander.addMembership(ownerAddUser) === Right(OrganizationMembershipAddResponse(ownerAddUser))
 
         val memberAddUser = OrganizationMembershipAddRequest(orgId, Id[User](2), Id[User](3), OrganizationRole.MEMBER)


### PR DESCRIPTION
@leogrim @Colin-Lane 

Relatively clean validation logic and some tests to go along with them.

Take a look specifically at the tests. If that is not the behavior we want, we should fix it
sooner rather than later. To me it seems strange to have multiple owners, but
it is all internally consistent (and we have org.ownerId to identify the "true" original owner, if
for some reason we need that).
