### PR TITLE
endpoint to fix keep visibility

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
@@ -11,6 +11,7 @@ import com.keepit.common.performance._
 import com.keepit.common.store.S3ImageConfig
 import com.keepit.common.time._
 import com.keepit.heimdal._
+import com.keepit.integrity.LibraryChecker
 import com.keepit.model.{ KeepStates, _ }
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json._
@@ -37,6 +38,7 @@ class AdminBookmarksController @Inject() (
   collectionRepo: CollectionRepo,
   heimdalContextBuilder: HeimdalContextBuilderFactory,
   keepDecorator: KeepDecorator,
+  libraryChecker: LibraryChecker,
   clock: Clock,
   implicit val imageConfig: S3ImageConfig)
     extends AdminUserActions {
@@ -329,6 +331,11 @@ class AdminBookmarksController @Inject() (
       }
     }
     Ok
+  }
+
+  def checkLibraryKeepVisibility(libId: Id[Library]) = UserAction { request =>
+    val numFix = libraryChecker.keepVisibilityCheck(libId)
+    Ok(JsNumber(numFix))
   }
 
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/LibraryChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/LibraryChecker.scala
@@ -144,4 +144,20 @@ class LibraryChecker @Inject() (val airbrake: AirbrakeNotifier,
   private def getIndex(): (Int, Int) = {
     timeSlicer.getSliceAndSize(TimeToSliceInDays.ONE_WEEK, OneSliceInMinutes(DataIntegrityPlugin.EVERY_N_MINUTE))
   }
+
+  def keepVisibilityCheck(libId: Id[Library]): Int = {
+    db.readWrite { implicit s =>
+      val lib = libraryRepo.get(libId)
+      var total = 0
+      var done = false
+      val LIMIT = 500
+      while (!done) {
+        val keepsToFix = keepRepo.getByLibraryIdAndExcludingVisibility(libId, excludeVisibility = Some(lib.visibility), limit = LIMIT)
+        total += keepsToFix.size
+        keepsToFix.foreach { keep => keepRepo.save(keep.copy(visibility = lib.visibility)) }
+        if (keepsToFix.size < LIMIT) done = true
+      }
+      total
+    }
+  }
 }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -552,6 +552,7 @@ GET     /admin/bookmarks/userKeywords @com.keepit.controllers.admin.AdminBookmar
 GET     /admin/bookmarksKeywords/page/:page @com.keepit.controllers.admin.AdminBookmarksController.bookmarksKeywordsPageView(page: Int)
 POST    /admin/bookmarks/populateNotes @com.keepit.controllers.admin.AdminBookmarksController.populateKeepNotesWithTag(page: Int ?= 0, size: Int ?= 500, grouping: Int ?= 500)
 DELETE  /admin/users/:id/tags/:name @com.keepit.controllers.admin.AdminBookmarksController.deleteTag(id: Id[User], name: String)
+POST    /admin/bookmarks/checkLibraryKeepVisibility             @com.keepit.controllers.admin.AdminBookmarksController.checkLibraryKeepVisibility(libId: Id[Library])
 
 GET     /admin/uri/:uriId           @com.keepit.controllers.admin.UrlController.getURIInfo(uriId: Id[NormalizedURI])
 #GET     /admin/uri/article/        @com.keepit.controllers.admin.UrlController.getArticle(uriId: Id[NormalizedURI], kind: ArticleKind[_ <: Article], version: ArticleVersion)

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/LibraryCheckerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/LibraryCheckerTest.scala
@@ -98,5 +98,21 @@ class LibraryCheckerTest extends TestKitSupport with SpecificationLike with Shoe
         seqNum === memberSeqNum
       }
     }
+
+    "check visibility" in {
+      withDb(modules: _*) { implicit injector =>
+        val libraryChecker = inject[LibraryChecker]
+        db.readWrite { implicit session =>
+          LibraryFactory.library().withId(Id[Library](1)).discoverable().saved
+          KeepFactory.keep().withId(Id[Keep](1)).published().withLibrary(Id[Library](1)).saved
+
+          inject[KeepRepo].get(Id[Keep](1)).visibility === LibraryVisibility.PUBLISHED
+        }
+
+        libraryChecker.keepVisibilityCheck(Id[Library](1)) === 1
+
+        db.readOnlyReplica { implicit s => inject[KeepRepo].get(Id[Keep](1)).visibility === LibraryVisibility.DISCOVERABLE }
+      }
+    }
   }
 }


### PR DESCRIPTION
@leogrim 

the endpoint is likely to be temporary. Actual method could be reused later. 
