### PR TITLE
Prototype hack involving default pictures for users with no picture

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/common/store/S3ImageStore.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/store/S3ImageStore.scala
@@ -66,7 +66,7 @@ trait S3ImageStore {
   }
 
   def tempPath(token: String): String = {
-    val pic = if (token.endsWith(".jpg")) token else s"token.jpg"
+    val pic = if (token.endsWith(".jpg")) token else s"$token.jpg"
     s"temp/user/pics/$pic"
   }
 }


### PR DESCRIPTION
@stkem @leogrim 

Getting user picture closer to a state where we can use the existing `ProcessedImages` pipeline. A roadblock is `pictureName` being a bad API. We'd like to move to using real, absolute URLs for pictures. This is testing that we don't break clients if I put in a backwards compatibility hack.

Shouldn't affect anyone but me, Eishay, and three test users.
