### PR TITLE
Organizations now have base permissions

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationMembership.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationMembership.scala
@@ -20,8 +20,6 @@ case class OrganizationMembership(
   def withId(id: Id[OrganizationMembership]): OrganizationMembership = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime): OrganizationMembership = this.copy(updatedAt = now)
   def withState(newState: State[OrganizationMembership]): OrganizationMembership = this.copy(state = newState)
-  def withRole(newRole: OrganizationRole): OrganizationMembership = this.copy(role = newRole, permissions = OrganizationPermission.defaultPermissions(newRole))
-  def withPermissions(newPermissions: Set[OrganizationPermission]): OrganizationMembership = this.copy(permissions = newPermissions)
 
   def hasPermission(p: OrganizationPermission): Boolean = permissions.contains(p)
 
@@ -41,14 +39,13 @@ object OrganizationMembership {
     (__ \ 'role).format[OrganizationRole] and
     (__ \ 'permissions).format[Set[OrganizationPermission]]
   )(OrganizationMembership.apply, unlift(OrganizationMembership.unapply))
-  def apply(organizationId: Id[Organization], userId: Id[User], role: OrganizationRole): OrganizationMembership =
-    new OrganizationMembership(organizationId = organizationId, userId = userId, role = role, permissions = OrganizationPermission.defaultPermissions(role))
 }
 object OrganizationMembershipStates extends States[OrganizationMembership]
 
 sealed abstract class OrganizationPermission(val value: String)
 
 object OrganizationPermission {
+  case object VIEW_ORGANIZATION extends OrganizationPermission("view_organization")
   case object EDIT_ORGANIZATION extends OrganizationPermission("edit_organization")
   case object INVITE_MEMBERS extends OrganizationPermission("invite_members")
   case object ADD_LIBRARIES extends OrganizationPermission("add_libraries")
@@ -61,6 +58,7 @@ object OrganizationPermission {
 
   def apply(str: String): OrganizationPermission = {
     str match {
+      case VIEW_ORGANIZATION.value => VIEW_ORGANIZATION
       case EDIT_ORGANIZATION.value => EDIT_ORGANIZATION
       case INVITE_MEMBERS.value => INVITE_MEMBERS
       case ADD_LIBRARIES.value => ADD_LIBRARIES
@@ -68,17 +66,6 @@ object OrganizationPermission {
     }
   }
 
-  def defaultPermissions(role: OrganizationRole): Set[OrganizationPermission] = role match {
-    case OrganizationRole.OWNER => Set(
-      OrganizationPermission.EDIT_ORGANIZATION,
-      OrganizationPermission.INVITE_MEMBERS,
-      OrganizationPermission.ADD_LIBRARIES,
-      OrganizationPermission.REMOVE_LIBRARIES
-    )
-    case OrganizationRole.MEMBER => Set(
-      OrganizationPermission.ADD_LIBRARIES
-    )
-  }
 }
 
 sealed abstract class OrganizationRole(val value: String, val priority: Int) extends Ordered[OrganizationRole] {

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/344.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/344.sql
@@ -1,0 +1,10 @@
+# SHOEBOX
+
+# --- !Ups
+
+ALTER TABLE organization
+	ADD COLUMN base_permissions text NOT NULL;
+
+insert into evolutions(name, description) values('344.sql', 'add base permissions to each organization');
+
+# --- !Downs

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -9,7 +9,6 @@ import com.keepit.model._
 @ImplementedBy(classOf[OrganizationCommanderImpl])
 trait OrganizationCommander {
   def get(orgId: Id[Organization]): Organization
-  def canViewOrganization(userIdOpt: Option[Id[User]], orgId: Id[Organization], authToken: Option[String]): Boolean
 }
 
 @Singleton
@@ -18,7 +17,4 @@ class OrganizationCommanderImpl @Inject() (
     orgRepo: OrganizationRepo) extends OrganizationCommander with Logging {
 
   def get(orgId: Id[Organization]): Organization = db.readOnlyReplica { implicit session => orgRepo.get(orgId) }
-
-  // Right now, Organization's are 100% public
-  def canViewOrganization(userIdOpt: Option[Id[User]], orgId: Id[Organization], authToken: Option[String]): Boolean = true
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationMembershipController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationMembershipController.scala
@@ -29,11 +29,8 @@ class MobileOrganizationMembershipController @Inject() (
     } else Organization.decodePublicId(pubId) match {
       case Failure(ex) => BadRequest(Json.obj("error" -> "invalid_organization_id"))
       case Success(orgId) =>
-        val permissionsOpt: Option[Set[OrganizationPermission]] = userIdOpt flatMap { userId => orgMembershipCommander.getMemberPermissions(orgId, userId) }
-        val showInvitees: Boolean = permissionsOpt match {
-          case None => false
-          case Some(permissions) => permissions.contains(OrganizationPermission.INVITE_MEMBERS)
-        }
+        val permissions = orgMembershipCommander.getPermissions(orgId, userIdOpt)
+        val showInvitees = permissions.contains(OrganizationPermission.INVITE_MEMBERS)
         val membersAndMaybeInvitees = orgMembershipCommander.getMembersAndInvitees(orgId, Limit(limit), Offset(offset), includeInvitees = showInvitees)
         Ok(Json.obj("members" -> membersAndMaybeInvitees))
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInviteRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInviteRepo.scala
@@ -12,6 +12,7 @@ import org.joda.time.DateTime
 trait OrganizationInviteRepo extends Repo[OrganizationInvite] {
   def getByOrganization(organizationId: Id[Organization], limit: Limit, offset: Offset, state: State[OrganizationInvite] = OrganizationInviteStates.ACTIVE)(implicit s: RSession): Seq[OrganizationInvite]
   def getByInviter(inviterId: Id[User], state: State[OrganizationInvite] = OrganizationInviteStates.ACTIVE)(implicit s: RSession): Seq[OrganizationInvite]
+  def getByOrgIdAndUserId(organizationId: Id[Organization], userId: Id[User], state: State[OrganizationInvite] = OrganizationInviteStates.ACTIVE)(implicit s: RSession): Seq[OrganizationInvite]
   def getLastSentByOrgIdAndInviterIdAndUserId(organizationId: Id[Organization], inviterId: Id[User], userId: Id[User], includeStates: Set[State[OrganizationInvite]])(implicit s: RSession): Option[OrganizationInvite]
   def getLastSentByOrgIdAndInviterIdAndEmailAddress(organizationId: Id[Organization], inviterId: Id[User], emailAddress: EmailAddress, includeStates: Set[State[OrganizationInvite]])(implicit s: RSession): Option[OrganizationInvite]
 }
@@ -82,6 +83,13 @@ class OrganizationInviteRepoImpl @Inject() (val db: DataBaseComponent, val clock
 
   def getByInviter(inviterId: Id[User], state: State[OrganizationInvite] = OrganizationInviteStates.ACTIVE)(implicit session: RSession): Seq[OrganizationInvite] = {
     getByInviterIdCompiled(inviterId, state).list
+  }
+
+  def getByOrgIdAndUserIdCompiled(organizationId: Column[Id[Organization]], userId: Column[Id[User]], state: State[OrganizationInvite]) = Compiled {
+    for (row <- rows if row.organizationId === organizationId && row.userId === userId && row.state === state) yield row
+  }
+  def getByOrgIdAndUserId(organizationId: Id[Organization], userId: Id[User], state: State[OrganizationInvite] = OrganizationInviteStates.ACTIVE)(implicit s: RSession): Seq[OrganizationInvite] = {
+    getByOrgIdAndUserIdCompiled(organizationId, userId, state).list
   }
 
   def getLastSentByOrgIdAndInviterIdAndUserIdCompiled(organizationId: Column[Id[Organization]], inviterId: Column[Id[User]], userId: Column[Id[User]], includeStates: Set[State[OrganizationInvite]]) = Compiled {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRepo.scala
@@ -6,6 +6,7 @@ import com.keepit.common.db.slick.DBSession.RSession
 import com.keepit.common.db.slick._
 import com.keepit.common.logging.Logging
 import com.keepit.common.time.Clock
+import play.api.libs.json.Json
 
 @ImplementedBy(classOf[OrganizationRepoImpl])
 trait OrganizationRepo extends Repo[Organization] with SeqNumberFunction[Organization] {
@@ -22,14 +23,19 @@ class OrganizationRepoImpl @Inject() (val db: DataBaseComponent, val clock: Cloc
 
   type RepoImpl = OrganizationTable
   class OrganizationTable(tag: Tag) extends RepoTable[Organization](db, tag, "organization") with SeqNumberColumn[Organization] {
+    implicit val basePermissionsMapper = MappedColumnType.base[BasePermissions, String](
+      { basePermissions => Json.stringify(Json.toJson(basePermissions)) },
+      { str => Json.parse(str).as[BasePermissions] }
+    )
 
     def name = column[String]("name", O.NotNull)
     def description = column[Option[String]]("description", O.Nullable)
     def ownerId = column[Id[User]]("owner_id", O.NotNull)
     def organizationHandle = column[Option[OrganizationHandle]]("handle", O.Nullable)
     def normalizedOrganizationHandle = column[Option[OrganizationHandle]]("normalized_handle", O.Nullable)
+    def basePermissions = column[BasePermissions]("base_permissions", O.NotNull)
 
-    def * = (id.?, createdAt, updatedAt, state, seq, name, description, ownerId, organizationHandle, normalizedOrganizationHandle) <> ((Organization.applyFromDbRow _).tupled, Organization.unapplyToDbRow _)
+    def * = (id.?, createdAt, updatedAt, state, seq, name, description, ownerId, organizationHandle, normalizedOrganizationHandle, basePermissions) <> ((Organization.applyFromDbRow _).tupled, Organization.unapplyToDbRow _)
   }
 
   def table(tag: Tag) = new OrganizationTable(tag)

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/controllers/OrganizationAccessActions.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/controllers/OrganizationAccessActions.scala
@@ -25,7 +25,8 @@ trait OrganizationAccessActions {
   private def lookupViewable[A](orgPubId: PublicId[Organization], input: MaybeUserRequest[A]) = {
     parseRequest(orgPubId, input) match {
       case Some((orgId, userIdOpt, authToken)) =>
-        val access = orgCommander.canViewOrganization(userIdOpt, orgId, authToken)
+        // Right now all organizations are publicly visible
+        val access = true // TODO: this ought to be removed when Leo gets to OrganizationAccessAction.byPermission
         if (access) {
           None
         } else {

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -454,7 +454,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           val newLibrary = library().withUser(user).withVisibility(LibraryVisibility.ORGANIZATION).saved
           val organization = orgRepo.save(Organization(name = "Kung Fu Academy", ownerId = orgOwner.id.get, handle = None))
           val otherOrg = orgRepo.save(Organization(name = "Martial Arts", ownerId = orgOwner.id.get, handle = None))
-          orgMemberRepo.save(OrganizationMembership(organizationId = organization.id.get, userId = user.id.get, role = OrganizationRole.OWNER))
+          orgMemberRepo.save(organization.newMembership(userId = user.id.get, role = OrganizationRole.OWNER))
           (user, newLibrary, organization, otherOrg)
         }
 
@@ -500,7 +500,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           val starLabsOrg = orgRepo.save(Organization(name = "Star Labs", ownerId = harrison.id.get, handle = None))
           val starLabsLib = library().withUser(harrison).withVisibility(LibraryVisibility.ORGANIZATION).withOrganization(starLabsOrg.id).saved
 
-          val membership = orgMemberRepo.save(OrganizationMembership(organizationId = starLabsOrg.id.get, userId = barry.id.get, role = OrganizationRole.MEMBER))
+          val membership = orgMemberRepo.save(starLabsOrg.newMembership(userId = barry.id.get, role = OrganizationRole.MEMBER))
 
           starLabsLib.organizationId must equalTo(starLabsOrg.id)
           membership.state must equalTo(OrganizationMembershipStates.ACTIVE)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationInviteCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationInviteCommanderTest.scala
@@ -29,7 +29,7 @@ class OrganizationInviteCommanderTest extends TestKitSupport with SpecificationL
         val owner = UserFactory.user().withName("Kiwi", "Kiwi").withEmailAddress("kiwi-test@kifi.com").saved
         userEmailAddressRepo.save(UserEmailAddress(userId = owner.id.get, address = owner.primaryEmail.get))
         val org = organizationRepo.save(Organization(name = "Kifi", ownerId = owner.id.get, handle = None))
-        val membership = organizationMembershipRepo.save(OrganizationMembership(organizationId = org.id.get, userId = owner.id.get, role = OrganizationRole.OWNER))
+        val membership = organizationMembershipRepo.save(org.newMembership(userId = owner.id.get, role = OrganizationRole.OWNER))
         (org, owner, membership)
       }
     }
@@ -74,7 +74,7 @@ class OrganizationInviteCommanderTest extends TestKitSupport with SpecificationL
           val invitees = Seq[OrganizationMemberInvitation](OrganizationMemberInvitation(Left(owner.id.get), OrganizationRole.MEMBER, Some("I just demoted you from owner")))
           val aMemberThatCannotInvite = db.readWrite { implicit session =>
             val bond = UserFactory.user.withName("James", "Bond").saved
-            val membership: OrganizationMembership = OrganizationMembership(organizationId = org.id.get, userId = bond.id.get, role = OrganizationRole.MEMBER)
+            val membership: OrganizationMembership = org.newMembership(userId = bond.id.get, role = OrganizationRole.MEMBER)
             organizationMembershipRepo.save(membership.copy(permissions = (membership.permissions + OrganizationPermission.INVITE_MEMBERS)))
             bond
           }
@@ -94,7 +94,7 @@ class OrganizationInviteCommanderTest extends TestKitSupport with SpecificationL
           val invitees = Seq[OrganizationMemberInvitation]()
           val aMemberThatCannotInvite = db.readWrite { implicit session =>
             val bond = UserFactory.user.withName("James", "Bond").saved
-            organizationMembershipRepo.save(OrganizationMembership(organizationId = org.id.get, userId = bond.id.get, role = OrganizationRole.MEMBER))
+            organizationMembershipRepo.save(org.newMembership(userId = bond.id.get, role = OrganizationRole.MEMBER))
             bond
           }
           val result = Await.result(orgInviteCommander.inviteUsersToOrganization(org.id.get, aMemberThatCannotInvite.id.get, invitees), new FiniteDuration(3, TimeUnit.SECONDS))

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationMembershipCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationMembershipCommanderTest.scala
@@ -13,41 +13,47 @@ class OrganizationMembershipCommanderTest extends TestKitSupport with Specificat
   "organization membership commander" should {
     "get memberships by organization id" in {
       withDb() { implicit injector =>
-        val orgId = Id[Organization](1)
-        val orgMemberRepo = inject[OrganizationMembershipRepo]
-        db.readWrite { implicit session =>
+        val orgRepo = inject[OrganizationRepo]
+        val orgMembershipRepo = inject[OrganizationMembershipRepo]
+        val org = db.readWrite { implicit session =>
+          val org = orgRepo.save(Organization(ownerId = Id[User](1), name = "Luther Corp.", handle = None))
           for { i <- 1 to 20 } yield {
             val userId = UserFactory.user().withId(Id[User](i)).saved.id.get
-            orgMemberRepo.save(OrganizationMembership(organizationId = orgId, userId = userId, role = OrganizationRole.MEMBER))
+            orgMembershipRepo.save(org.newMembership(userId = userId, role = OrganizationRole.MEMBER))
           }
+          org
         }
 
-        val orgMemberCommander = inject[OrganizationMembershipCommander]
-        orgMemberCommander.getMembersAndInvitees(Id[Organization](0), Limit(10), Offset(0), true).length === 0
-        orgMemberCommander.getMembersAndInvitees(orgId, Limit(50), Offset(0), true).length === 20
+        val orgMembershipCommander = inject[OrganizationMembershipCommander]
+        orgMembershipCommander.getMembersAndInvitees(Id[Organization](0), Limit(10), Offset(0), includeInvitees = true).length === 0
+        orgMembershipCommander.getMembersAndInvitees(org.id.get, Limit(50), Offset(0), includeInvitees = true).length === 20
       }
     }
 
     "and page results" in {
       withDb() { implicit injector =>
-        val orgId = Id[Organization](1)
-        val orgMemberRepo = inject[OrganizationMembershipRepo]
+        val orgRepo = inject[OrganizationRepo]
+        val orgMembershipRepo = inject[OrganizationMembershipRepo]
         val orgInviteRepo = inject[OrganizationInviteRepo]
-        db.readWrite { implicit session =>
+
+        val org = db.readWrite { implicit session =>
+          val org = orgRepo.save(Organization(ownerId = Id[User](1), name = "Luther Corp.", handle = None))
           for { i <- 1 to 20 } yield {
             val userId = UserFactory.user().withId(Id[User](i)).saved.id.get
-            orgMemberRepo.save(OrganizationMembership(organizationId = orgId, userId = userId, role = OrganizationRole.MEMBER))
-            orgInviteRepo.save(OrganizationInvite(organizationId = orgId, inviterId = Id[User](1), role = OrganizationRole.MEMBER, emailAddress = Some(EmailAddress("colin@kifi.com"))))
+            orgMembershipRepo.save(org.newMembership(userId, OrganizationRole.MEMBER))
+            orgInviteRepo.save(OrganizationInvite(organizationId = org.id.get, inviterId = Id[User](1), role = OrganizationRole.MEMBER, emailAddress = Some(EmailAddress("colin@kifi.com"))))
           }
+          org
         }
+        val orgId = org.id.get
 
-        val orgMemberCommander = inject[OrganizationMembershipCommander]
+        val orgMembershipCommander = inject[OrganizationMembershipCommander]
         // limit by count
-        val membersLimitedByCount = orgMemberCommander.getMembersAndInvitees(orgId, Limit(10), Offset(0), true)
+        val membersLimitedByCount = orgMembershipCommander.getMembersAndInvitees(orgId, Limit(10), Offset(0), includeInvitees = true)
         membersLimitedByCount.length === 10
 
         // limit with offset
-        val membersLimitedByOffset = orgMemberCommander.getMembersAndInvitees(orgId, Limit(10), Offset(17), true)
+        val membersLimitedByOffset = orgMembershipCommander.getMembersAndInvitees(orgId, Limit(10), Offset(17), includeInvitees = true)
         membersLimitedByOffset.take(3).foreach(_.member.isLeft === true)
         membersLimitedByOffset.drop(3).take(7).foreach(_.member.isRight === true)
         membersLimitedByOffset.length === 10
@@ -56,84 +62,90 @@ class OrganizationMembershipCommanderTest extends TestKitSupport with Specificat
 
     "add members to org" in {
       withDb() { implicit injector =>
-        val orgMemberRepo = inject[OrganizationMembershipRepo]
+        val orgRepo = inject[OrganizationRepo]
+        val orgMembershipRepo = inject[OrganizationMembershipRepo]
 
-        val orgId = Id[Organization](1)
-
-        db.readWrite { implicit session =>
-          orgMemberRepo.save(OrganizationMembership(organizationId = orgId, userId = Id[User](1), role = OrganizationRole.OWNER))
+        val org = db.readWrite { implicit session =>
+          val org = orgRepo.save(Organization(ownerId = Id[User](1), name = "Luther Corp.", handle = None))
+          orgMembershipRepo.save(org.newMembership(userId = Id[User](1), role = OrganizationRole.OWNER))
+          org
         }
+        val orgId = org.id.get
 
-        val orgMemberCommander = inject[OrganizationMembershipCommander]
+        val orgMembershipCommander = inject[OrganizationMembershipCommander]
 
         val ownerAddUser = OrganizationMembershipAddRequest(orgId, Id[User](1), Id[User](2), OrganizationRole.MEMBER)
-        orgMemberCommander.addMembership(ownerAddUser) === Right(OrganizationMembershipAddResponse(ownerAddUser))
+        orgMembershipCommander.addMembership(ownerAddUser) === Right(OrganizationMembershipAddResponse(ownerAddUser))
 
         val memberAddUser = OrganizationMembershipAddRequest(orgId, Id[User](2), Id[User](3), OrganizationRole.MEMBER)
-        orgMemberCommander.addMembership(memberAddUser) === Right(OrganizationMembershipAddResponse(memberAddUser))
+        orgMembershipCommander.addMembership(memberAddUser) === Right(OrganizationMembershipAddResponse(memberAddUser))
 
         val memberAddUserAsOwner = OrganizationMembershipAddRequest(orgId, Id[User](2), Id[User](5), OrganizationRole.OWNER)
-        orgMemberCommander.addMembership(memberAddUserAsOwner) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
+        orgMembershipCommander.addMembership(memberAddUserAsOwner) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
 
         val noneAddUser = OrganizationMembershipAddRequest(orgId, Id[User](42), Id[User](4), OrganizationRole.MEMBER)
-        orgMemberCommander.addMembership(noneAddUser) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
+        orgMembershipCommander.addMembership(noneAddUser) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
 
         val memberAddMember = OrganizationMembershipAddRequest(orgId, Id[User](3), Id[User](1), OrganizationRole.MEMBER)
-        orgMemberCommander.addMembership(memberAddMember) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS) // TODO: this should fail differently
+        orgMembershipCommander.addMembership(memberAddMember) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS) // TODO: this should fail differently
       }
     }
 
     "modify members in org" in {
       withDb() { implicit injector =>
-        val orgMemberRepo = inject[OrganizationMembershipRepo]
+        val orgRepo = inject[OrganizationRepo]
+        val orgMembershipRepo = inject[OrganizationMembershipRepo]
 
-        val orgId = Id[Organization](1)
-
-        db.readWrite { implicit session =>
-          orgMemberRepo.save(OrganizationMembership(organizationId = orgId, userId = Id[User](1), role = OrganizationRole.OWNER))
-          orgMemberRepo.save(OrganizationMembership(organizationId = orgId, userId = Id[User](2), role = OrganizationRole.MEMBER))
-          orgMemberRepo.save(OrganizationMembership(organizationId = orgId, userId = Id[User](3), role = OrganizationRole.MEMBER))
-          orgMemberRepo.save(OrganizationMembership(organizationId = orgId, userId = Id[User](4), role = OrganizationRole.MEMBER))
+        val org = db.readWrite { implicit session =>
+          val org = orgRepo.save(Organization(ownerId = Id[User](1), name = "Luther Corp.", handle = None))
+          orgMembershipRepo.save(org.newMembership(userId = Id[User](1), role = OrganizationRole.OWNER))
+          orgMembershipRepo.save(org.newMembership(userId = Id[User](2), role = OrganizationRole.MEMBER))
+          orgMembershipRepo.save(org.newMembership(userId = Id[User](3), role = OrganizationRole.MEMBER))
+          orgMembershipRepo.save(org.newMembership(userId = Id[User](4), role = OrganizationRole.MEMBER))
+          org
         }
+        val orgId = org.id.get
 
-        val orgMemberCommander = inject[OrganizationMembershipCommander]
+        val orgMembershipCommander = inject[OrganizationMembershipCommander]
 
         val ownerModMember = OrganizationMembershipModifyRequest(orgId, Id[User](1), Id[User](2), OrganizationRole.OWNER)
-        orgMemberCommander.modifyMembership(ownerModMember) === Right(OrganizationMembershipModifyResponse(ownerModMember))
+        orgMembershipCommander.modifyMembership(ownerModMember) === Right(OrganizationMembershipModifyResponse(ownerModMember))
 
         // 2 is now an OWNER, try to set him back to MEMBER
         val memberModOwner = OrganizationMembershipModifyRequest(orgId, Id[User](3), Id[User](2), OrganizationRole.MEMBER)
-        orgMemberCommander.modifyMembership(memberModOwner) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
+        orgMembershipCommander.modifyMembership(memberModOwner) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
 
         // Try to modify a random user
         val memberModUser = OrganizationMembershipModifyRequest(orgId, Id[User](3), Id[User](42), OrganizationRole.MEMBER)
-        orgMemberCommander.modifyMembership(memberModOwner) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS) // TODO: this should fail differently
+        orgMembershipCommander.modifyMembership(memberModOwner) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS) // TODO: this should fail differently
       }
     }
 
     "remove members from org" in {
       withDb() { implicit injector =>
-        val orgMemberRepo = inject[OrganizationMembershipRepo]
+        val orgRepo = inject[OrganizationRepo]
+        val orgMembershipRepo = inject[OrganizationMembershipRepo]
 
-        val orgId = Id[Organization](1)
-
-        db.readWrite { implicit session =>
-          orgMemberRepo.save(OrganizationMembership(organizationId = orgId, userId = Id[User](1), role = OrganizationRole.OWNER))
-          orgMemberRepo.save(OrganizationMembership(organizationId = orgId, userId = Id[User](2), role = OrganizationRole.MEMBER))
-          orgMemberRepo.save(OrganizationMembership(organizationId = orgId, userId = Id[User](3), role = OrganizationRole.MEMBER))
-          orgMemberRepo.save(OrganizationMembership(organizationId = orgId, userId = Id[User](4), role = OrganizationRole.MEMBER))
+        val org = db.readWrite { implicit session =>
+          val org = orgRepo.save(Organization(ownerId = Id[User](1), name = "Luther Corp.", handle = None))
+          orgMembershipRepo.save(org.newMembership(userId = Id[User](1), role = OrganizationRole.OWNER))
+          orgMembershipRepo.save(org.newMembership(userId = Id[User](2), role = OrganizationRole.MEMBER))
+          orgMembershipRepo.save(org.newMembership(userId = Id[User](3), role = OrganizationRole.MEMBER))
+          orgMembershipRepo.save(org.newMembership(userId = Id[User](4), role = OrganizationRole.MEMBER))
+          org
         }
+        val orgId = org.id.get
 
-        val orgMemberCommander = inject[OrganizationMembershipCommander]
+        val orgMembershipCommander = inject[OrganizationMembershipCommander]
 
         val ownerDelMember = OrganizationMembershipRemoveRequest(orgId, Id[User](1), Id[User](2))
-        orgMemberCommander.removeMembership(ownerDelMember) === Right(OrganizationMembershipRemoveResponse(ownerDelMember))
+        orgMembershipCommander.removeMembership(ownerDelMember) === Right(OrganizationMembershipRemoveResponse(ownerDelMember))
 
         val memberDelOwner = OrganizationMembershipRemoveRequest(orgId, Id[User](3), Id[User](1))
-        orgMemberCommander.removeMembership(memberDelOwner) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
+        orgMembershipCommander.removeMembership(memberDelOwner) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
 
         val memberDelNone = OrganizationMembershipRemoveRequest(orgId, Id[User](3), Id[User](2))
-        orgMemberCommander.removeMembership(memberDelNone) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
+        orgMembershipCommander.removeMembership(memberDelNone) === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
       }
     }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/ShoeboxRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/ShoeboxRepoTest.scala
@@ -43,7 +43,7 @@ class ShoeboxRepoTest extends Specification with ShoeboxApplicationInjector {
         // OrganizationMembershipRepo
         val organizationMembershipRepo = inject[OrganizationMembershipRepo]
         val orgMember = db.readWrite { implicit session =>
-          organizationMembershipRepo.save(OrganizationMembership(organizationId = org.id.get, userId = user.id.get, role = OrganizationRole.OWNER))
+          organizationMembershipRepo.save(org.newMembership(userId = user.id.get, role = OrganizationRole.OWNER))
         }
         orgMember.id must beSome
 


### PR DESCRIPTION
Each organization can configure what permissions each role is entitled to.
This includes permissions for non-members, which should allow us to implement
private organizations.

The base permissions are serialized to JSON and stored in the `organization`
database table.

Changing an OrganizationMembership is now more involved, since you need the
organization itself to tell you what the new role's permissions are. For this
reason we always construct OrganizationMembership via org.newMembership
and modify them via org.modifyMembership.

@leogrim @Colin-Lane @yingjieMiao 
