### PR TITLE
slack UX and bug-fix

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -93,6 +93,10 @@ angular.module('kifi')
 
           scope.library.subscriptions.forEach(function(sub) {
 
+            if (sub.name === '' && sub.info.url === '') {
+              return;
+            }
+
             if (sub.name) { // slack channels can't have uppercase letters
               sub.name = sub.name.toLowerCase();
             }
@@ -127,6 +131,10 @@ angular.module('kifi')
 
           submitting = true;
 
+          var nonEmptySubscriptions = _.filter(scope.library.subscriptions, function(sub){
+            return sub.name !== '' && sub.info.url !== '';
+          });
+
           libraryService[scope.modifyingExistingLibrary && scope.library.id ? 'modifyLibrary' : 'createLibrary']({
             id: scope.library.id,
             name: scope.library.name,
@@ -135,7 +143,7 @@ angular.module('kifi')
             visibility: scope.library.visibility,
             listed: scope.library.membership.listed,
             color: colorNames[scope.library.color],
-            subscriptions: scope.library.subscriptions
+            subscriptions: nonEmptySubscriptions
           }, true).then(function (resp) {
             libraryService.fetchLibraryInfos(true);
 
@@ -145,6 +153,8 @@ angular.module('kifi')
             scope.$error = {};
             submitting = false;
             scope.close();
+
+            scope.library.subscriptions = nonEmptySubscriptions;
 
             if (!returnAction) {
               $location.url(newLibrary.url);

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -640,7 +640,7 @@ class LibraryCommanderImpl @Inject() (
         }
       }
 
-      val newSubKeysOpt = modifyReq.subscriptions.filter(sub => sub == LibrarySubscriptionKey("", SlackInfo("")))
+      val newSubKeysOpt = modifyReq.subscriptions
 
       val result = for {
         newName <- validName(modifyReq.name).right


### PR DESCRIPTION
@andrewconner when a user provides blank inputs, we should remove them before making the API call. But, this manipulates the DOM-binding right before closing the modal, leading to an uncomfortable experience.

My (buggy and) inaccurate solution was to send blank inputs to the backend and filter them there. This new solution filters on the front-end without manipulating the DOM.
