### PR TITLE
Org avatars 2

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -165,9 +165,9 @@ trait ProcessedImageHelper {
 
   // Returns Set of bounding box sizes
   protected def calcSizesForImage(imageSize: ImageSize, scaleCandidates: Seq[ScaledImageSize], cropCandidates: Seq[CroppedImageSize]): Set[ProcessImageRequest] = {
-    val scaleSizes = scaleCandidates.map { size =>
+    val scaleSizes = scaleCandidates.flatMap { size =>
       calcResizeBoundingBox(imageSize, size.idealSize)
-    }.flatten
+    }
 
     val scaleImageRequests = {
       var t = 0

--- a/kifi-backend/modules/common/app/com/keepit/common/store/ImagePath.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/ImagePath.scala
@@ -1,0 +1,18 @@
+package com.keepit.common.store
+
+import com.keepit.model._
+import play.api.libs.json._
+
+case class ImagePath(path: String) extends AnyVal {
+  override def toString() = path
+  def getUrl(implicit imageConfig: S3ImageConfig): String = imageConfig.cdnBase + "/" + path
+}
+
+object ImagePath {
+  def apply(prefix: String, hash: ImageHash, size: ImageSize, kind: ProcessImageOperation, format: ImageFormat): ImagePath = {
+    val fileName = hash.hash + "_" + size.width + "x" + size.height + kind.fileNameSuffix + "." + format.value
+    ImagePath(prefix + "/" + fileName)
+  }
+
+  implicit val format: Format[ImagePath] = Format(__.read[String].map(ImagePath(_)), Writes(path => JsString(path.path)))
+}

--- a/kifi-backend/modules/common/app/com/keepit/common/store/OrganizationAvatarStore.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/OrganizationAvatarStore.scala
@@ -46,7 +46,8 @@ class S3OrganizationAvatarStoreImpl @Inject() (
   }
 }
 
-class InMemoryOrganizationAvatarStoreImpl() extends OrganizationAvatarStore {
+@Singleton
+class InMemoryOrganizationAvatarStoreImpl @Inject() () extends OrganizationAvatarStore {
 
   require(!(Play.maybeApplication.isDefined && Play.isProd), "Can't have in memory file store in production")
 

--- a/kifi-backend/modules/common/app/com/keepit/common/store/OrganizationAvatarStore.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/OrganizationAvatarStore.scala
@@ -6,28 +6,26 @@ import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.transfer.TransferManager
 import com.google.inject.{ Inject, Singleton }
 import com.keepit.common.core._
-import com.keepit.model.{ ImageFormat, ImageHash, ProcessImageOperation }
 import play.api.Play
-import play.api.libs.Files.TemporaryFile
-import play.api.libs.json._
 import play.api.Play.current
+import play.api.libs.Files.TemporaryFile
 
 import scala.collection.mutable
 import scala.concurrent.{ ExecutionContext, Future }
 
-trait RoverImageStore {
+trait OrganizationAvatarStore {
   def put(key: ImagePath, is: InputStream, contentLength: Int, mimeType: String): Future[Unit]
   def get(key: ImagePath): Future[TemporaryFile]
 }
 
-case class RoverImageStoreInbox(dir: File) extends S3InboxDirectory
+case class OrganizationAvatarStoreInbox(dir: File) extends S3InboxDirectory
 
 @Singleton
-class S3RoverImageStoreImpl @Inject() (
+class S3OrganizationAvatarStoreImpl @Inject() (
     s3ImageConfig: S3ImageConfig,
-    val inbox: RoverImageStoreInbox,
+    val inbox: OrganizationAvatarStoreInbox,
     implicit val transferManager: TransferManager,
-    implicit val executionContext: ExecutionContext) extends RoverImageStore with S3AsyncHelper {
+    implicit val executionContext: ExecutionContext) extends OrganizationAvatarStore with S3AsyncHelper {
 
   def put(key: ImagePath, is: InputStream, contentLength: Int, mimeType: String): Future[Unit] = {
     val om = new ObjectMetadata()
@@ -48,7 +46,7 @@ class S3RoverImageStoreImpl @Inject() (
   }
 }
 
-class InMemoryRoverImageStoreImpl() extends RoverImageStore {
+class InMemoryOrganizationAvatarStoreImpl() extends OrganizationAvatarStore {
 
   require(!(Play.maybeApplication.isDefined && Play.isProd), "Can't have in memory file store in production")
 

--- a/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
@@ -33,8 +33,9 @@ case class Organization(
   def getNonmemberPermissions = basePermissions.forNonmember
   def getRolePermissions(role: OrganizationRole) = basePermissions.forRole(role)
 
-  def newMembership(userId: Id[User], role: OrganizationRole): OrganizationMembership =
+  def newMembership(userId: Id[User], role: OrganizationRole): OrganizationMembership = {
     OrganizationMembership(organizationId = id.get, userId = userId, role = role, permissions = getRolePermissions(role))
+  }
 
   def modifiedMembership(membership: OrganizationMembership, newRole: OrganizationRole): OrganizationMembership =
     membership.copy(role = newRole, permissions = getRolePermissions(newRole))

--- a/kifi-backend/modules/common/test/com/keepit/common/store/FakeStoreModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/store/FakeStoreModule.scala
@@ -28,4 +28,7 @@ trait FakeStoreModule extends StoreModule {
 
   @Provides @Singleton
   def roverImageStore(): RoverImageStore = new InMemoryRoverImageStoreImpl()
+
+  @Provides @Singleton
+  def organizationAvatarStore(): OrganizationAvatarStore = new InMemoryOrganizationAvatarStoreImpl()
 }

--- a/kifi-backend/modules/rover/app/com/keepit/rover/image/RoverImageFetcher.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/image/RoverImageFetcher.scala
@@ -59,7 +59,7 @@ class RoverImageFetcher @Inject() (
                     case croppedImage if croppedImage.kind == ProcessImageOperation.Crop => CropImageRequest(croppedImage.imageSize)
                   }
                   val expectedProcessRequests = calcSizesForImage(sourceImageSize, requiredScaleSizes.toSeq, requiredCropSizes.toSeq)
-                  filterProcessImageRequests(expectedProcessRequests, existingImageProcessRequests)
+                  diffProcessImageRequests(expectedProcessRequests, existingImageProcessRequests)
                 }
 
                 processAndPersistImages(bufferedSourceImage, imagePathPrefix, sourceImage.hash, sourceImage.format, requiredProcessRequests)(photoshop) match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
@@ -110,7 +110,7 @@ class KeepImageCommanderImpl @Inject() (
           val processDoneFOpt = originalImageOpt.map { originalImage =>
 
             val expectedVersions = calcSizesForImage(originalImage.imageSize, KeepImageSizes.scaleSizes, KeepImageSizes.cropSizes)
-            val missingVersions = filterProcessImageRequests(expectedVersions, existingVersions)
+            val missingVersions = diffProcessImageRequests(expectedVersions, existingVersions)
 
             if (missingVersions.nonEmpty) {
               log.info(s"[getBestImagesForKeepsPatiently] keepId=$keepId has missing versions: $missingVersions; existing: $existingVersions; expected $expectedVersions")

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
@@ -1,5 +1,7 @@
 package com.keepit.commanders
 
+import java.awt.image.BufferedImage
+
 import com.google.inject.{ ImplementedBy, Inject, Singleton }
 import com.keepit.commanders.OrganizationAvatarConfiguration._
 import com.keepit.common.core._
@@ -44,137 +46,138 @@ class OrganizationAvatarCommanderImpl @Inject() (
 
   def persistOrganizationAvatarsFromUserUpload(imageFile: TemporaryFile, orgId: Id[Organization]): Future[Either[ImageStoreFailure, ImageHash]] = {
     fetchAndHashLocalImage(imageFile).flatMap {
+      case Left(storeError) => Future.successful(Left(storeError))
       case Right(sourceImage) =>
         validateAndLoadImageFile(sourceImage.file.file) match {
+          case Failure(validationError) => Future.successful(Left(ImageProcessState.InvalidImage(validationError)))
           case Success(bufferedSourceImage) =>
-
-            val sourceImageSize = ImageSize(bufferedSourceImage)
-            val outFormat = inputFormatToOutputFormat(sourceImage.format)
-
-            val existingImageInfos = db.readOnlyMaster { implicit session =>
-              orgAvatarRepo.getByImageHash(sourceImage.hash)
-            }
-            println("[RPB] existingImageInfo = " + existingImageInfos)
-
-            val expectedProcessRequests = {
-              val scaleRequests = scaleSizes.map(scale => ScaleImageRequest(scale.idealSize))
-              val cropRequests = cropSizes.map(crop => CropImageRequest(crop.idealSize))
-              scaleRequests ++ cropRequests
-            }.toSet
-            val existingImageProcessRequests = existingImageInfos.collect {
-              case scaledImage if scaledImage.kind == ProcessImageOperation.Scale => ScaleImageRequest(scaledImage.imageSize)
-              case croppedImage if croppedImage.kind == ProcessImageOperation.Crop => CropImageRequest(croppedImage.imageSize)
-            }.toSet
-            val (necessaryProcessRequests, unnecessaryProcessRequests) = {
-              println("[RPB] Figuring out which processing requests we have to handle")
-              println("[RPB] These ones are already in the store: " + existingImageProcessRequests)
-              println("We want to hit: " + scaleSizes + " and " + cropSizes + " from an image of size " + sourceImageSize)
-              println("[RPB] These are the ones we need to have: " + expectedProcessRequests)
-              val necessaryProcessRequests = filterProcessImageRequests(expectedProcessRequests, existingImageProcessRequests)
-              println("[RPB] These are the ones we need to actually do: " + necessaryProcessRequests)
-              val unnecessaryProcessRequests = intersectProcessImageRequests(existingImageProcessRequests, expectedProcessRequests)
-              println("[RPB] These are the ones we do not need to do: " + unnecessaryProcessRequests)
-              (necessaryProcessRequests, unnecessaryProcessRequests)
-            }
-
-            // Prepare Original Image
-
-            val sourceImageReadyToPersistMaybe = existingImageInfos.find(_.kind == ProcessImageOperation.Original) match {
-              case Some(sourceImageInfo) => Success(None)
-              case None => bufferedImageToInputStream(bufferedSourceImage, sourceImage.format).map {
-                case (is, bytes) =>
-                  println("[RPB] No existing original image found, will have to persist this one")
-                  val key = ImagePath(imagePathPrefix, sourceImage.hash, sourceImageSize, ProcessImageOperation.Original, sourceImage.format)
-                  Some(ImageProcessState.ReadyToPersist(key, outFormat, is, bufferedSourceImage, bytes, ProcessImageOperation.Original))
-              }
-            }
-
-            sourceImageReadyToPersistMaybe match {
-
-              case Success(sourceImageReadyToPersist) =>
-
-                // Prepare Processed Images
-
-                println("[RPB] We have to perform these processing requests: " + necessaryProcessRequests)
-                processAndPersistImages(bufferedSourceImage, imagePathPrefix, sourceImage.hash, sourceImage.format, necessaryProcessRequests)(photoshop) match {
-
-                  case Right(processedImagesReadyToPersist) =>
-
-                    // Upload all images
-                    val newImagesToPersist = processedImagesReadyToPersist ++ sourceImageReadyToPersist
-                    println("[RPB] Done processing, ready to persist all these images: " + newImagesToPersist)
-                    val uploads = newImagesToPersist.map { image =>
-                      imageStore.put(image.key, image.is, image.bytes, imageFormatToMimeType(image.format)).imap { _ =>
-                        ImageProcessState.UploadedImage(image.key, image.format, image.image, image.processOperation)
-                      }
-                    }
-
-                    println("[RPB] Just put all the new images into the image store")
-
-                    // Update RoverImageInfo
-
-                    Future.sequence(uploads).imap(Right(_)).recover {
-                      case error: Exception => Left(ImageProcessState.CDNUploadFailed(error))
-                    }.imap {
-                      case Right(uploadedImages) =>
-                        try {
-                          db.readWrite(attempts = 3) { implicit session =>
-                            uploadedImages.foreach { img =>
-                              val orgAvatar = OrganizationAvatar(organizationId = orgId, width = img.image.getWidth, height = img.image.getHeight, format = sourceImage.format, kind = img.processOperation, imagePath = img.key, source = UserUpload, sourceFileHash = sourceImage.hash, sourceImageURL = None)
-                              orgAvatarRepo.save(orgAvatar)
-                              println("[RPB] Saved to repo: " + orgAvatar)
-                            }
-                            val originalImageOpt = existingImageInfos.find(_.kind == ProcessImageOperation.Original)
-                            if (originalImageOpt.nonEmpty) {
-                              val alreadyExistingImageInfo = originalImageOpt.get
-                              println("[RPB] See? It was here: " + alreadyExistingImageInfo)
-                              val orgAvatar = OrganizationAvatar(organizationId = orgId, width = alreadyExistingImageInfo.width, height = alreadyExistingImageInfo.height, format = sourceImage.format, kind = alreadyExistingImageInfo.kind, imagePath = alreadyExistingImageInfo.imagePath, source = UserUpload, sourceFileHash = sourceImage.hash, sourceImageURL = None)
-                              orgAvatarRepo.save(orgAvatar)
-                            }
-                            unnecessaryProcessRequests.foreach { processOperationRequest =>
-                              println("[RPB] This operation is unnecessary: " + processOperationRequest + " because it's already in the store")
-                              val alreadyExistingImageInfo = existingImageInfos.find(avatar => avatar.kind == processOperationRequest.operation && avatar.imageSize == processOperationRequest.size).get
-                              println("[RPB] See? It was here: " + alreadyExistingImageInfo)
-                              val orgAvatar = OrganizationAvatar(organizationId = orgId, width = alreadyExistingImageInfo.width, height = alreadyExistingImageInfo.height, format = sourceImage.format, kind = alreadyExistingImageInfo.kind, imagePath = alreadyExistingImageInfo.imagePath, source = UserUpload, sourceFileHash = sourceImage.hash, sourceImageURL = None)
-                              orgAvatarRepo.save(orgAvatar)
-                            }
-                          }
-                          println("[RPB] Wrote all the persisted image info to the avatar repo")
-                          Right(sourceImage.hash)
-                        } catch {
-                          case imageInfoError: Exception =>
-                            log.error(s"Failed to update ImageInfoRepo after fetching image from user uploaded file: $imageInfoError")
-                            Left(ImageProcessState.DbPersistFailed(imageInfoError))
-                        }
-                      case Left(uploadError) =>
-                        log.error(s"Failed to upload images generated from user uploaded file: $uploadError")
-                        Left(uploadError)
-                    }
-
-                  case Left(processingError) => {
-                    log.error(s"Failed to resize image fetched from user uploaded file")
-                    Future.successful(Left(processingError))
-                  }
-                }
-              case Failure(sourceImageProcessingError) => {
-                log.error(s"Could not process source image fetched from user uploaded file", sourceImageProcessingError)
-                Future.successful(Left(ImageProcessState.InvalidImage(sourceImageProcessingError)))
-              }
-            }
-          case Failure(validationError) => {
-            log.error(s"Invalid image fetched from user uploaded file", validationError)
-            Future.successful(Left(ImageProcessState.InvalidImage(validationError)))
-          }
+            persistOrganizationAvatarsFromBufferedSourceImage(sourceImage, bufferedSourceImage, orgId)
         }
-      case Left(storeError) => {
-        log.error(s"Could not store image from user uploaded file: $storeError")
-        Future.successful(Left(storeError))
-      }
     }
   }
 
+  def persistOrganizationAvatarsFromBufferedSourceImage(sourceImage: ImageProcessState.ImageLoadedAndHashed, bufferedSourceImage: BufferedImage, orgId: Id[Organization]) = {
+    val sourceImageSize = ImageSize(bufferedSourceImage)
+    val outFormat = inputFormatToOutputFormat(sourceImage.format)
+    val existingAvatars = db.readOnlyMaster { implicit session =>
+      orgAvatarRepo.getByImageHash(sourceImage.hash)
+    }
+    println("[RPB] existingAvatars = " + existingAvatars)
+
+    val (expected, necessary, unnecessary) = determineRequiredProcessImageRequests(sourceImageSize, existingAvatars)
+
+    // Prepare Original Image
+    val sourceImageReadyToPersistMaybe = existingAvatars.find(_.kind == ProcessImageOperation.Original) match {
+      case Some(sourceImageInfo) => Success(None)
+      case None => bufferedImageToInputStream(bufferedSourceImage, sourceImage.format).map {
+        case (is, bytes) =>
+          println("[RPB] No existing original image found, will have to persist this one")
+          val key = ImagePath(imagePathPrefix, sourceImage.hash, sourceImageSize, ProcessImageOperation.Original, sourceImage.format)
+          Some(ImageProcessState.ReadyToPersist(key, outFormat, is, bufferedSourceImage, bytes, ProcessImageOperation.Original))
+      }
+    }
+
+    sourceImageReadyToPersistMaybe match {
+      case Failure(sourceImageProcessingError) => Future.successful(Left(ImageProcessState.InvalidImage(sourceImageProcessingError)))
+      case Success(sourceImageReadyToPersist) =>
+        println("[RPB] We have to perform these processing requests: " + necessary)
+        processAndPersistImages(bufferedSourceImage, imagePathPrefix, sourceImage.hash, sourceImage.format, necessary)(photoshop) match {
+          case Left(processingError) => Future.successful(Left(processingError))
+          case Right(processedImagesReadyToPersist) =>
+            val newImagesToPersist = processedImagesReadyToPersist ++ sourceImageReadyToPersist
+            println("[RPB] Done processing, ready to persist all these images: " + newImagesToPersist)
+            val uploads = newImagesToPersist.map { image =>
+              imageStore.put(image.key, image.is, image.bytes, imageFormatToMimeType(image.format)).imap { _ =>
+                ImageProcessState.UploadedImage(image.key, image.format, image.image, image.processOperation)
+              }
+            }
+
+            println("[RPB] Just put all the new images into the image store")
+
+            // Update RoverImageInfo
+
+            val uploadedImagesFut = Future.sequence(uploads).imap(Right(_)).recover {
+              case error: Exception => Left(ImageProcessState.CDNUploadFailed(error))
+            }
+            uploadedImagesFut.imap {
+              case Left(uploadError) => Left(uploadError)
+              case Right(uploadedImages) => try {
+                saveNewAvatars(orgId, sourceImage, existingAvatars, uploadedImages, unnecessary)
+              } catch {
+                case imageInfoError: Exception =>
+                  log.error(s"Failed to update ImageInfoRepo after fetching image from user uploaded file: $imageInfoError")
+                  Left(ImageProcessState.DbPersistFailed(imageInfoError))
+              }
+            }
+
+        }
+    }
+  }
+
+  def saveNewAvatars(orgId: Id[Organization], sourceImage: ImageProcessState.ImageLoadedAndHashed, existingAvatars: Seq[OrganizationAvatar], uploadedImages: Set[ImageProcessState.UploadedImage], unnecessary: Set[ProcessImageRequest]) = {
+    db.readWrite(attempts = 3) { implicit session =>
+
+      uploadedImages.foreach { img =>
+        val orgAvatar = OrganizationAvatar(organizationId = orgId, width = img.image.getWidth, height = img.image.getHeight, format = sourceImage.format, kind = img.processOperation, imagePath = img.key, source = UserUpload, sourceFileHash = sourceImage.hash, sourceImageURL = None)
+        orgAvatarRepo.save(orgAvatar)
+        println("[RPB] Saved to repo: " + orgAvatar)
+      }
+
+      val originalImageOpt = existingAvatars.find(_.kind == ProcessImageOperation.Original)
+      if (originalImageOpt.nonEmpty) {
+        val alreadyExistingImageInfo = originalImageOpt.get
+        println("[RPB] See? It was here: " + alreadyExistingImageInfo)
+        val orgAvatar = OrganizationAvatar(organizationId = orgId, width = alreadyExistingImageInfo.width, height = alreadyExistingImageInfo.height, format = sourceImage.format, kind = alreadyExistingImageInfo.kind, imagePath = alreadyExistingImageInfo.imagePath, source = UserUpload, sourceFileHash = sourceImage.hash, sourceImageURL = None)
+        orgAvatarRepo.save(orgAvatar)
+      }
+
+      unnecessary.foreach { processOperationRequest =>
+        println("[RPB] This operation is unnecessary: " + processOperationRequest + " because it's already in the store")
+        val alreadyExistingImageInfo = existingAvatars.find(avatar => avatar.kind == processOperationRequest.operation && avatar.imageSize == processOperationRequest.size).get
+        println("[RPB] See? It was here: " + alreadyExistingImageInfo)
+        val orgAvatar = OrganizationAvatar(organizationId = orgId, width = alreadyExistingImageInfo.width, height = alreadyExistingImageInfo.height, format = sourceImage.format, kind = alreadyExistingImageInfo.kind, imagePath = alreadyExistingImageInfo.imagePath, source = UserUpload, sourceFileHash = sourceImage.hash, sourceImageURL = None)
+        orgAvatarRepo.save(orgAvatar)
+      }
+
+      Right(sourceImage.hash)
+    }
+  }
+
+  // What ProcessImageRequests are necessary to perform on an image, given that we have some existing avatars already
+  def determineRequiredProcessImageRequests(imageSize: ImageSize, existingAvatars: Seq[OrganizationAvatar]) = {
+    val expected = {
+      val scaleRequests = scaleSizes.map(scale => ScaleImageRequest(scale.idealSize))
+      val cropRequests = cropSizes.map(crop => CropImageRequest(crop.idealSize))
+      scaleRequests ++ cropRequests
+    }.toSet
+    val existing = existingAvatars.collect {
+      case scaledImage if scaledImage.kind == ProcessImageOperation.Scale => ScaleImageRequest(scaledImage.imageSize)
+      case croppedImage if croppedImage.kind == ProcessImageOperation.Crop => CropImageRequest(croppedImage.imageSize)
+    }.toSet
+
+    println("[RPB] Figuring out which processing requests we have to handle")
+    println("[RPB] These ones are already in the store: " + existing)
+    println("We want to hit: " + scaleSizes + " and " + cropSizes + " from an image of size " + imageSize)
+    val necessary = diffProcessImageRequests(expected, existing)
+    val unnecessary = intersectProcessImageRequests(existing, expected)
+    println("[RPB] These are the ones we need to have: " + expected)
+    println("[RPB] These are the ones we need to actually do: " + necessary)
+    println("[RPB] These are the ones we do not need to do: " + unnecessary)
+
+    (expected, necessary, unnecessary)
+  }
+  // All the ProcessImageRequests in A that are NOT in B
+  def diffProcessImageRequests(A: Set[ProcessImageRequest], B: Set[ProcessImageRequest]): Set[ProcessImageRequest] = {
+    @inline def boundingBox(imageSize: ImageSize): Int = Math.max(imageSize.width, imageSize.height)
+    val Bp = B.collect { case ProcessImageRequest(ProcessImageOperation.Scale, size) => boundingBox(size) }
+    A filterNot {
+      case ProcessImageRequest(ProcessImageOperation.Scale, size) => Bp.contains(boundingBox(size))
+      case otherRequest => B.contains(otherRequest)
+    }
+  }
+
+  // All the ProcessImageRequests in A that ARE in B
   def intersectProcessImageRequests(A: Set[ProcessImageRequest], B: Set[ProcessImageRequest]): Set[ProcessImageRequest] = {
-    // hack to eliminate expecting scale versions that have the same scaled bounding box
     @inline def boundingBox(imageSize: ImageSize): Int = Math.max(imageSize.width, imageSize.height)
     val Bp = B.collect { case ProcessImageRequest(ProcessImageOperation.Scale, size) => boundingBox(size) }
     A filter {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
@@ -1,17 +1,130 @@
 package com.keepit.commanders
 
-import com.google.inject.ImplementedBy
+import com.google.inject.{ImplementedBy, Inject, Singleton}
+import com.keepit.common.core._
 import com.keepit.common.db.Id
-import com.keepit.common.store.ImageSize
-import com.keepit.model.{ Organization, OrganizationAvatar }
+import com.keepit.common.db.slick.Database
+import com.keepit.common.images.Photoshop
+import com.keepit.common.logging.Logging
+import com.keepit.common.net.WebService
+import com.keepit.common.store.{ImagePath, ImageSize, RoverImageStore}
+import com.keepit.model._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 @ImplementedBy(classOf[OrganizationAvatarCommanderImpl])
 trait OrganizationAvatarCommander {
   def getBestImage(orgId: Id[Organization], imageSize: ImageSize): Option[OrganizationAvatar]
 }
 
-class OrganizationAvatarCommanderImpl extends OrganizationAvatarCommander {
+@Singleton
+class OrganizationAvatarCommanderImpl @Inject() (
+  db: Database,
+  imageStore: RoverImageStore,
+  photoshop: Photoshop,
+  val webService: WebService,
+  private implicit val executionContext: ExecutionContext
+  ) extends OrganizationAvatarCommander with ProcessedImageHelper with Logging {
+
   def getBestImage(orgId: Id[Organization], imageSize: ImageSize): Option[OrganizationAvatar] = {
     None // TODO: do this.
+  }
+  def fetchAndStoreRemoteImage(remoteImageUrl: String, imagePathPrefix: String, requiredScaleSizes: Set[ScaledImageSize] = Set.empty, requiredCropSizes: Set[CroppedImageSize] = Set.empty): Future[Either[ImageStoreFailure, ImageHash]] = {
+    fetchAndHashRemoteImage(remoteImageUrl).flatMap {
+      case Right(sourceImage) => {
+        validateAndLoadImageFile(sourceImage.file.file) match {
+          case Success(bufferedSourceImage) =>
+
+            val sourceImageSize = ImageSize(bufferedSourceImage)
+            val outFormat = inputFormatToOutputFormat(sourceImage.format)
+
+            val existingImageInfos = db.readOnlyMaster { implicit session =>
+              imageInfoRepo.getByImageHash(sourceImage.hash)
+            }
+
+            // Prepare Original Image
+
+            val sourceImageReadyToPersistMaybe = existingImageInfos.find(_.kind == ProcessImageOperation.Original) match {
+              case Some(sourceImageInfo) => Success(None)
+              case None => bufferedImageToInputStream(bufferedSourceImage, sourceImage.format).map {
+                case (is, bytes) =>
+                  val key = ImagePath(imagePathPrefix, sourceImage.hash, sourceImageSize, ProcessImageOperation.Original, sourceImage.format)
+                  Some(ImageProcessState.ReadyToPersist(key, outFormat, is, bufferedSourceImage, bytes, ProcessImageOperation.Original))
+              }
+            }
+
+            sourceImageReadyToPersistMaybe match {
+
+              case Success(sourceImageReadyToPersist) => {
+
+                // Prepare Processed Images
+
+                val requiredProcessRequests = {
+                  val existingImageProcessRequests = existingImageInfos.collect {
+                    case scaledImage if scaledImage.kind == ProcessImageOperation.Scale => ScaleImageRequest(scaledImage.imageSize)
+                    case croppedImage if croppedImage.kind == ProcessImageOperation.Crop => CropImageRequest(croppedImage.imageSize)
+                  }
+                  val expectedProcessRequests = calcSizesForImage(sourceImageSize, requiredScaleSizes.toSeq, requiredCropSizes.toSeq)
+                  filterProcessImageRequests(expectedProcessRequests, existingImageProcessRequests)
+                }
+
+                processAndPersistImages(bufferedSourceImage, imagePathPrefix, sourceImage.hash, sourceImage.format, requiredProcessRequests)(photoshop) match {
+
+                  case Right(processedImagesReadyToPersist) => {
+
+                    // Upload all images
+
+                    val uploads = (processedImagesReadyToPersist ++ sourceImageReadyToPersist).map { image =>
+                      imageStore.put(image.key, image.is, image.bytes, imageFormatToMimeType(image.format)).imap { _ =>
+                        ImageProcessState.UploadedImage(image.key, image.format, image.image, image.processOperation)
+                      }
+                    }
+
+                    // Update RoverImageInfo
+
+                    Future.sequence(uploads).imap(Right(_)).recover {
+                      case error: Exception => Left(ImageProcessState.CDNUploadFailed(error))
+                    }.imap {
+                      case Right(uploadedImages) => {
+                        try {
+                          db.readWrite(attempts = 3) { implicit session =>
+                            uploadedImages.foreach(imageInfoRepo.intern(sourceImage.hash, imageSource, sourceImage.sourceImageUrl, _))
+                          }
+                          Right(sourceImage.hash)
+                        } catch {
+                          case imageInfoError: Exception =>
+                            log.error(s"Failed to update ImageInfoRepo after fetching image from $remoteImageUrl: $imageInfoError")
+                            Left(ImageProcessState.DbPersistFailed(imageInfoError))
+                        }
+                      }
+                      case Left(uploadError) => {
+                        log.error(s"Failed to upload images generated from $remoteImageUrl: $uploadError")
+                        Left(uploadError)
+                      }
+                    }
+                  }
+                  case Left(processingError) => {
+                    log.error(s"Failed to resize image fetched from $remoteImageUrl")
+                    Future.successful(Left(processingError))
+                  }
+                }
+              }
+              case Failure(sourceImageProcessingError) => {
+                log.error(s"Could not process source image fetched from $remoteImageUrl", sourceImageProcessingError)
+                Future.successful(Left(ImageProcessState.InvalidImage(sourceImageProcessingError)))
+              }
+            }
+          case Failure(validationError) => {
+            log.error(s"Invalid image fetched from $remoteImageUrl", validationError)
+            Future.successful(Left(ImageProcessState.InvalidImage(validationError)))
+          }
+        }
+      }
+      case Left(fetchError) => {
+        log.error(s"Could not fetch remote image from $remoteImageUrl: $fetchError")
+        Future.successful(Left(fetchError))
+      }
+    }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
@@ -44,7 +44,7 @@ class OrganizationAvatarCommanderImpl @Inject() (
 
   def persistOrganizationAvatarsFromUserUpload(imageFile: TemporaryFile, orgId: Id[Organization]): Future[Either[ImageStoreFailure, ImageHash]] = {
     fetchAndHashLocalImage(imageFile).flatMap {
-      case Right(sourceImage) => {
+      case Right(sourceImage) =>
         validateAndLoadImageFile(sourceImage.file.file) match {
           case Success(bufferedSourceImage) =>
 
@@ -54,6 +54,24 @@ class OrganizationAvatarCommanderImpl @Inject() (
             val existingImageInfos = db.readOnlyMaster { implicit session =>
               orgAvatarRepo.getByImageHash(sourceImage.hash)
             }
+            println("[RPB] existingImageInfo = " + existingImageInfos)
+
+            val expectedProcessRequests = calcSizesForImage(sourceImageSize, scaleSizes, cropSizes)
+            val existingImageProcessRequests = existingImageInfos.collect {
+              case scaledImage if scaledImage.kind == ProcessImageOperation.Scale => ScaleImageRequest(scaledImage.imageSize)
+              case croppedImage if croppedImage.kind == ProcessImageOperation.Crop => CropImageRequest(croppedImage.imageSize)
+            }
+            val (necessaryProcessRequests, unnecessaryProcessRequests) = {
+              println("[RPB] Figuring out which processing requests we have to handle")
+              println("[RPB] These ones are already in the store: " + existingImageProcessRequests)
+              println("We want to hit: " + scaleSizes + " and " + cropSizes + " from an image of size " + sourceImageSize)
+              println("[RPB] These are the ones we need to have: " + expectedProcessRequests)
+              val necessaryProcessRequests = filterProcessImageRequests(expectedProcessRequests, existingImageProcessRequests.toSet)
+              println("[RPB] These are the ones we need to actually do: " + necessaryProcessRequests)
+              val unnecessaryProcessRequests = intersectProcessImageRequests(existingImageProcessRequests.toSet, expectedProcessRequests)
+              println("[RPB] These are the ones we do not need to do: " + unnecessaryProcessRequests)
+              (necessaryProcessRequests, unnecessaryProcessRequests)
+            }
 
             // Prepare Original Image
 
@@ -61,6 +79,7 @@ class OrganizationAvatarCommanderImpl @Inject() (
               case Some(sourceImageInfo) => Success(None)
               case None => bufferedImageToInputStream(bufferedSourceImage, sourceImage.format).map {
                 case (is, bytes) =>
+                  println("[RPB] No existing original image found, will have to persist this one")
                   val key = ImagePath(imagePathPrefix, sourceImage.hash, sourceImageSize, ProcessImageOperation.Original, sourceImage.format)
                   Some(ImageProcessState.ReadyToPersist(key, outFormat, is, bufferedSourceImage, bytes, ProcessImageOperation.Original))
               }
@@ -68,63 +87,71 @@ class OrganizationAvatarCommanderImpl @Inject() (
 
             sourceImageReadyToPersistMaybe match {
 
-              case Success(sourceImageReadyToPersist) => {
+              case Success(sourceImageReadyToPersist) =>
 
                 // Prepare Processed Images
 
-                val requiredProcessRequests = {
-                  val existingImageProcessRequests = existingImageInfos.collect {
-                    case scaledImage if scaledImage.kind == ProcessImageOperation.Scale => ScaleImageRequest(scaledImage.imageSize)
-                    case croppedImage if croppedImage.kind == ProcessImageOperation.Crop => CropImageRequest(croppedImage.imageSize)
-                  }
-                  val expectedProcessRequests = calcSizesForImage(sourceImageSize, scaleSizes, cropSizes)
-                  filterProcessImageRequests(expectedProcessRequests, existingImageProcessRequests.toSet)
-                }
+                println("[RPB] We have to perform these processing requests: " + necessaryProcessRequests)
+                processAndPersistImages(bufferedSourceImage, imagePathPrefix, sourceImage.hash, sourceImage.format, necessaryProcessRequests)(photoshop) match {
 
-                processAndPersistImages(bufferedSourceImage, imagePathPrefix, sourceImage.hash, sourceImage.format, requiredProcessRequests)(photoshop) match {
-
-                  case Right(processedImagesReadyToPersist) => {
+                  case Right(processedImagesReadyToPersist) =>
 
                     // Upload all images
-
-                    val uploads = (processedImagesReadyToPersist ++ sourceImageReadyToPersist).map { image =>
+                    val newImagesToPersist = processedImagesReadyToPersist ++ sourceImageReadyToPersist
+                    println("[RPB] Done processing, ready to persist all these images: " + newImagesToPersist)
+                    val uploads = newImagesToPersist.map { image =>
                       imageStore.put(image.key, image.is, image.bytes, imageFormatToMimeType(image.format)).imap { _ =>
                         ImageProcessState.UploadedImage(image.key, image.format, image.image, image.processOperation)
                       }
                     }
+
+                    println("[RPB] Just put all the new images into the image store")
 
                     // Update RoverImageInfo
 
                     Future.sequence(uploads).imap(Right(_)).recover {
                       case error: Exception => Left(ImageProcessState.CDNUploadFailed(error))
                     }.imap {
-                      case Right(uploadedImages) => {
+                      case Right(uploadedImages) =>
                         try {
                           db.readWrite(attempts = 3) { implicit session =>
                             uploadedImages.foreach { img =>
-                              val orgAvatar = OrganizationAvatar(organizationId = orgId, width = img.image.getWidth, height = img.image.getHeight, format = img.format, kind = ProcessImageOperation.Scale, imagePath = img.key, source = UserUpload, sourceFileHash = sourceImage.hash, sourceImageURL = None)
+                              val orgAvatar = OrganizationAvatar(organizationId = orgId, width = img.image.getWidth, height = img.image.getHeight, format = sourceImage.format, kind = img.processOperation, imagePath = img.key, source = UserUpload, sourceFileHash = sourceImage.hash, sourceImageURL = None)
+                              orgAvatarRepo.save(orgAvatar)
+                              println("[RPB] Saved to repo: " + orgAvatar)
+                            }
+                            val originalImageOpt = existingImageInfos.find(_.kind == ProcessImageOperation.Original)
+                            if (originalImageOpt.nonEmpty) {
+                              val alreadyExistingImageInfo = originalImageOpt.get
+                              println("[RPB] See? It was here: " + alreadyExistingImageInfo)
+                              val orgAvatar = OrganizationAvatar(organizationId = orgId, width = alreadyExistingImageInfo.width, height = alreadyExistingImageInfo.height, format = sourceImage.format, kind = alreadyExistingImageInfo.kind, imagePath = alreadyExistingImageInfo.imagePath, source = UserUpload, sourceFileHash = sourceImage.hash, sourceImageURL = None)
+                              orgAvatarRepo.save(orgAvatar)
+                            }
+                            unnecessaryProcessRequests.foreach { processOperationRequest =>
+                              println("[RPB] This operation is unnecessary: " + processOperationRequest + " because it's already in the store")
+                              val alreadyExistingImageInfo = existingImageInfos.find(avatar => avatar.kind == processOperationRequest.operation && avatar.imageSize == processOperationRequest.size).get
+                              println("[RPB] See? It was here: " + alreadyExistingImageInfo)
+                              val orgAvatar = OrganizationAvatar(organizationId = orgId, width = alreadyExistingImageInfo.width, height = alreadyExistingImageInfo.height, format = sourceImage.format, kind = alreadyExistingImageInfo.kind, imagePath = alreadyExistingImageInfo.imagePath, source = UserUpload, sourceFileHash = sourceImage.hash, sourceImageURL = None)
                               orgAvatarRepo.save(orgAvatar)
                             }
                           }
+                          println("[RPB] Wrote all the persisted image info to the avatar repo")
                           Right(sourceImage.hash)
                         } catch {
                           case imageInfoError: Exception =>
                             log.error(s"Failed to update ImageInfoRepo after fetching image from user uploaded file: $imageInfoError")
                             Left(ImageProcessState.DbPersistFailed(imageInfoError))
                         }
-                      }
-                      case Left(uploadError) => {
+                      case Left(uploadError) =>
                         log.error(s"Failed to upload images generated from user uploaded file: $uploadError")
                         Left(uploadError)
-                      }
                     }
-                  }
+
                   case Left(processingError) => {
                     log.error(s"Failed to resize image fetched from user uploaded file")
                     Future.successful(Left(processingError))
                   }
                 }
-              }
               case Failure(sourceImageProcessingError) => {
                 log.error(s"Could not process source image fetched from user uploaded file", sourceImageProcessingError)
                 Future.successful(Left(ImageProcessState.InvalidImage(sourceImageProcessingError)))
@@ -135,17 +162,86 @@ class OrganizationAvatarCommanderImpl @Inject() (
             Future.successful(Left(ImageProcessState.InvalidImage(validationError)))
           }
         }
-      }
       case Left(storeError) => {
         log.error(s"Could not store image from user uploaded file: $storeError")
         Future.successful(Left(storeError))
       }
     }
   }
+  override def calcSizesForImage(imageSize: ImageSize, scaleCandidates: Seq[ScaledImageSize], cropCandidates: Seq[CroppedImageSize]): Set[ProcessImageRequest] = {
+    val scaleSizes = scaleCandidates.flatMap { size =>
+      calcResizeBoundingBox(imageSize, size.idealSize)
+    }
+    println("[RPB''] In calcSizes we have scaleSizes = " + scaleSizes)
+
+    val scaleImageRequests = {
+      var t = 0
+      scaleSizes.sorted.flatMap { x =>
+        if (x - t > 100) {
+          t = x
+          Some(x)
+        } else None
+      }.filterNot { i => i == Math.max(imageSize.width, imageSize.height) }.
+        map { x => ScaleImageRequest(x) }
+    }
+
+    val imgHeight = imageSize.height
+    val imgWidth = imageSize.width
+
+    log.info(s"[csfi] imageSize=${imageSize.width}x${imageSize.height} cropCandidates=$cropCandidates")
+    val cropImageRequests = cropCandidates.filterNot { cropSize =>
+      val size = cropSize.idealSize
+      def isAlmostSameAspectRatio = Math.abs(imgWidth.toFloat / imgHeight - cropSize.aspectRatio) < 0.01
+
+      // 1) if either the width or height of the actual image is smaller than our crop, abort
+      // 2) or, if the aspect ratio of the image and crop size are the same and there exists
+      //    a scale bounding box close to enough to our crop candidate, we can skip the crop
+      imgWidth < size.width || imgHeight < size.height ||
+        (isAlmostSameAspectRatio && scaleImageRequests.exists { scaleSize =>
+          val candidateCropWidth = cropSize.idealSize.width
+          val candidateCropHeight = cropSize.idealSize.height
+          val scaleWidth = scaleSize.size.width
+          val scaleHeight = scaleSize.size.height
+
+          scaleWidth >= candidateCropWidth && scaleHeight >= candidateCropHeight &&
+            scaleWidth - candidateCropWidth < 100 && scaleHeight - candidateCropHeight < 100
+        })
+    }.map { c => CropImageRequest(c.idealSize) }
+
+    log.info(s"[csfi] imageSize=${imageSize.width}x${imageSize.height} cropRequests=$cropImageRequests")
+    (scaleImageRequests ++ cropImageRequests).toSet
+  }
+  override def calcResizeBoundingBox(imageSize: ImageSize, size: ImageSize): Option[Int] = {
+    println("[RPB'] Using overriden method")
+    val imgHeight = imageSize.height
+    val imgWidth = imageSize.width
+
+    val fudgeFactor = 0.00
+
+    if (size.height * fudgeFactor > imgHeight && size.width * fudgeFactor > imgWidth) {
+      // The size we want is just too far from the original.
+      None
+    } else {
+      val h2 = Math.min(size.height, imgHeight)
+      val w2 = Math.min(size.width, imgWidth)
+      Some(Math.max(h2, w2))
+    }
+  }
+
+  def intersectProcessImageRequests(A: Set[ProcessImageRequest], B: Set[ProcessImageRequest]): Set[ProcessImageRequest] = {
+    // hack to eliminate expecting scale versions that have the same scaled bounding box
+    @inline def boundingBox(imageSize: ImageSize): Int = Math.max(imageSize.width, imageSize.height)
+    val Bp = B.collect { case ProcessImageRequest(ProcessImageOperation.Scale, size) => boundingBox(size) }
+    A filter {
+      case ProcessImageRequest(ProcessImageOperation.Scale, size) => Bp.contains(boundingBox(size))
+      case otherRequest => B.contains(otherRequest)
+    }
+  }
 }
 
 object OrganizationAvatarConfiguration {
   val scaleSizes = Seq(ScaledImageSize.Small, ScaledImageSize.Medium)
-  val cropSizes = Seq.empty[CroppedImageSize]
+  val cropSizes = Seq(CroppedImageSize.Small)
+  val numSizes = scaleSizes.length + cropSizes.length
   val imagePathPrefix = "organization"
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
@@ -1,37 +1,89 @@
 package com.keepit.commanders
 
-import com.google.inject.{ImplementedBy, Inject, Singleton}
+import com.google.inject.{ ImplementedBy, Inject, Singleton }
+import com.keepit.commanders.OrganizationAvatarConfiguration._
 import com.keepit.common.core._
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
 import com.keepit.common.images.Photoshop
 import com.keepit.common.logging.Logging
 import com.keepit.common.net.WebService
-import com.keepit.common.store.{ImagePath, ImageSize, RoverImageStore}
+import com.keepit.common.store.{ ImagePath, ImageSize, OrganizationAvatarStore }
+import com.keepit.model.ImageSource.UserUpload
 import com.keepit.model._
+import play.api.libs.Files.TemporaryFile
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
 
 @ImplementedBy(classOf[OrganizationAvatarCommanderImpl])
 trait OrganizationAvatarCommander {
   def getBestImage(orgId: Id[Organization], imageSize: ImageSize): Option[OrganizationAvatar]
+  def uploadOrganizationAvatarFromFile(image: TemporaryFile, orgId: Id[Organization]): Future[ImageProcessDone]
 }
 
 @Singleton
 class OrganizationAvatarCommanderImpl @Inject() (
-  db: Database,
-  imageStore: RoverImageStore,
-  photoshop: Photoshop,
-  val webService: WebService,
-  private implicit val executionContext: ExecutionContext
-  ) extends OrganizationAvatarCommander with ProcessedImageHelper with Logging {
+    db: Database,
+    orgAvatarRepo: OrganizationAvatarRepo,
+    imageStore: OrganizationAvatarStore,
+    photoshop: Photoshop,
+    val webService: WebService,
+    private implicit val executionContext: ExecutionContext) extends OrganizationAvatarCommander with ProcessedImageHelper with Logging {
 
   def getBestImage(orgId: Id[Organization], imageSize: ImageSize): Option[OrganizationAvatar] = {
-    None // TODO: do this.
+    // Get the image that is the closest to the desired ImageSize, by a sum-of-squares metric
+    def sq(x: Int) = x * x
+    def metric(a: OrganizationAvatar) = sq(a.height - imageSize.height) + sq(a.width - imageSize.width)
+
+    db.readOnlyReplica { implicit session =>
+      val options = orgAvatarRepo.getByOrganization(orgId)
+      options.sortBy(metric).headOption
+    }
   }
-  def fetchAndStoreRemoteImage(remoteImageUrl: String, imagePathPrefix: String, requiredScaleSizes: Set[ScaledImageSize] = Set.empty, requiredCropSizes: Set[CroppedImageSize] = Set.empty): Future[Either[ImageStoreFailure, ImageHash]] = {
-    fetchAndHashRemoteImage(remoteImageUrl).flatMap {
+
+  def uploadOrganizationAvatarFromFile(imageFile: TemporaryFile, orgId: Id[Organization]): Future[ImageProcessDone] = {
+    val fetcher = fetchAndHashLocalImage(imageFile)
+    fetcher.flatMap {
+      case Right(loadedImage) =>
+        buildPersistSet(loadedImage, imagePathPrefix, scaleSizes, cropSizes)(photoshop) match {
+          case Right(toPersist) =>
+            uploadAndPersistImages(loadedImage, toPersist, orgId)
+          case Left(failure) =>
+            Future.successful(failure)
+        }
+      case Left(failure) => Future.successful(failure)
+    }
+  }
+
+  private def uploadAndPersistImages(originalImage: ImageProcessState.ImageLoadedAndHashed, toPersist: Set[ImageProcessState.ReadyToPersist], orgId: Id[Organization]): Future[ImageProcessDone] = {
+    val uploads = toPersist.map { image =>
+      log.info(s"[oac] Persisting ${image.key} (${image.bytes} B)")
+      imageStore.put(image.key, image.is, image.bytes, imageFormatToMimeType(image.format)).map { r =>
+        ImageProcessState.UploadedImage(image.key, image.format, image.image, image.processOperation)
+      }
+    }
+
+    Future.sequence(uploads).map { results =>
+      val orgAvatars = results.map {
+        case uploadedImage =>
+          val orgAvatar = OrganizationAvatar(organizationId = orgId, imagePath = uploadedImage.key, format = uploadedImage.format,
+            width = uploadedImage.image.getWidth, height = uploadedImage.image.getHeight, sourceFileHash = originalImage.hash,
+            state = OrganizationAvatarStates.ACTIVE, sourceImageURL = None, kind = ProcessImageOperation.Original, source = ImageSource.UserUpload)
+          uploadedImage.image.flush() // TODO: what is this for?
+          orgAvatar
+      }
+      db.readWrite(attempts = 3) { implicit session => // because of request consolidator, this can be very race-conditiony
+        val existingImages = orgAvatarRepo.getByOrganization(orgId).toSet
+        existingImages.foreach(orgAvatarRepo.deactivate)
+        orgAvatars.foreach(orgAvatarRepo.save)
+      }
+      ImageProcessState.StoreSuccess(originalImage.format, orgAvatars.filter(_.isOriginal).head.dimensions, originalImage.file.file.length.toInt)
+    }
+  }
+
+  def fetchAndStoreUploadedImage(imageFile: TemporaryFile, orgId: Id[Organization]): Future[Either[ImageStoreFailure, ImageHash]] = {
+    fetchAndHashLocalImage(imageFile).flatMap {
       case Right(sourceImage) => {
         validateAndLoadImageFile(sourceImage.file.file) match {
           case Success(bufferedSourceImage) =>
@@ -40,7 +92,7 @@ class OrganizationAvatarCommanderImpl @Inject() (
             val outFormat = inputFormatToOutputFormat(sourceImage.format)
 
             val existingImageInfos = db.readOnlyMaster { implicit session =>
-              imageInfoRepo.getByImageHash(sourceImage.hash)
+              orgAvatarRepo.getByImageHash(sourceImage.hash)
             }
 
             // Prepare Original Image
@@ -65,8 +117,8 @@ class OrganizationAvatarCommanderImpl @Inject() (
                     case scaledImage if scaledImage.kind == ProcessImageOperation.Scale => ScaleImageRequest(scaledImage.imageSize)
                     case croppedImage if croppedImage.kind == ProcessImageOperation.Crop => CropImageRequest(croppedImage.imageSize)
                   }
-                  val expectedProcessRequests = calcSizesForImage(sourceImageSize, requiredScaleSizes.toSeq, requiredCropSizes.toSeq)
-                  filterProcessImageRequests(expectedProcessRequests, existingImageProcessRequests)
+                  val expectedProcessRequests = calcSizesForImage(sourceImageSize, scaleSizes, cropSizes)
+                  filterProcessImageRequests(expectedProcessRequests, existingImageProcessRequests.toSet)
                 }
 
                 processAndPersistImages(bufferedSourceImage, imagePathPrefix, sourceImage.hash, sourceImage.format, requiredProcessRequests)(photoshop) match {
@@ -89,42 +141,51 @@ class OrganizationAvatarCommanderImpl @Inject() (
                       case Right(uploadedImages) => {
                         try {
                           db.readWrite(attempts = 3) { implicit session =>
-                            uploadedImages.foreach(imageInfoRepo.intern(sourceImage.hash, imageSource, sourceImage.sourceImageUrl, _))
+                            uploadedImages.foreach { img =>
+                              val orgAvatar = OrganizationAvatar(organizationId = orgId, width = img.image.getWidth, height = img.image.getHeight, format = img.format, kind = ProcessImageOperation.Scale, imagePath = img.key, source = UserUpload, sourceFileHash = sourceImage.hash, sourceImageURL = None)
+                              orgAvatarRepo.save(orgAvatar)
+                            }
                           }
                           Right(sourceImage.hash)
                         } catch {
                           case imageInfoError: Exception =>
-                            log.error(s"Failed to update ImageInfoRepo after fetching image from $remoteImageUrl: $imageInfoError")
+                            log.error(s"Failed to update ImageInfoRepo after fetching image from user uploaded file: $imageInfoError")
                             Left(ImageProcessState.DbPersistFailed(imageInfoError))
                         }
                       }
                       case Left(uploadError) => {
-                        log.error(s"Failed to upload images generated from $remoteImageUrl: $uploadError")
+                        log.error(s"Failed to upload images generated from user uploaded file: $uploadError")
                         Left(uploadError)
                       }
                     }
                   }
                   case Left(processingError) => {
-                    log.error(s"Failed to resize image fetched from $remoteImageUrl")
+                    log.error(s"Failed to resize image fetched from user uploaded file")
                     Future.successful(Left(processingError))
                   }
                 }
               }
               case Failure(sourceImageProcessingError) => {
-                log.error(s"Could not process source image fetched from $remoteImageUrl", sourceImageProcessingError)
+                log.error(s"Could not process source image fetched from user uploaded file", sourceImageProcessingError)
                 Future.successful(Left(ImageProcessState.InvalidImage(sourceImageProcessingError)))
               }
             }
           case Failure(validationError) => {
-            log.error(s"Invalid image fetched from $remoteImageUrl", validationError)
+            log.error(s"Invalid image fetched from user uploaded file", validationError)
             Future.successful(Left(ImageProcessState.InvalidImage(validationError)))
           }
         }
       }
       case Left(fetchError) => {
-        log.error(s"Could not fetch remote image from $remoteImageUrl: $fetchError")
+        log.error(s"Could not fetch remote image from user uploaded file: $fetchError")
         Future.successful(Left(fetchError))
       }
     }
   }
+}
+
+object OrganizationAvatarConfiguration {
+  val scaleSizes = Seq(ScaledImageSize.Small, ScaledImageSize.Medium)
+  val cropSizes = Seq.empty[CroppedImageSize]
+  val imagePathPrefix = "organization"
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/store/ShoeboxProdStoreModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/store/ShoeboxProdStoreModule.scala
@@ -58,8 +58,6 @@ case class ShoeboxProdStoreModule() extends ProdStoreModule with ShoeboxStoreMod
 case class ShoeboxDevStoreModule() extends DevStoreModule(ShoeboxProdStoreModule()) with ShoeboxStoreModule {
   def configure() {
     bind[RoverImageStore].to[InMemoryRoverImageStoreImpl]
-    bind[OrganizationAvatarStore].to[InMemoryOrganizationAvatarStoreImpl]
-    bind[ImageDataIntegrityPlugin].to[ImageDataIntegrityPluginImpl].in[AppScoped]
   }
 
   @Singleton

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/store/ShoeboxProdStoreModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/store/ShoeboxProdStoreModule.scala
@@ -16,6 +16,7 @@ trait ShoeboxStoreModule extends StoreModule with Logging
 case class ShoeboxProdStoreModule() extends ProdStoreModule with ShoeboxStoreModule {
   def configure() {
     bind[RoverImageStore].to[S3RoverImageStoreImpl]
+    bind[OrganizationAvatarStore].to[S3OrganizationAvatarStoreImpl]
   }
 
   @Provides @Singleton
@@ -57,6 +58,7 @@ case class ShoeboxProdStoreModule() extends ProdStoreModule with ShoeboxStoreMod
 case class ShoeboxDevStoreModule() extends DevStoreModule(ShoeboxProdStoreModule()) with ShoeboxStoreModule {
   def configure() {
     bind[RoverImageStore].to[InMemoryRoverImageStoreImpl]
+    bind[OrganizationAvatarStore].to[InMemoryOrganizationAvatarStoreImpl]
   }
 
   @Singleton

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/store/ShoeboxProdStoreModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/store/ShoeboxProdStoreModule.scala
@@ -59,6 +59,7 @@ case class ShoeboxDevStoreModule() extends DevStoreModule(ShoeboxProdStoreModule
   def configure() {
     bind[RoverImageStore].to[InMemoryRoverImageStoreImpl]
     bind[OrganizationAvatarStore].to[InMemoryOrganizationAvatarStoreImpl]
+    bind[ImageDataIntegrityPlugin].to[ImageDataIntegrityPluginImpl].in[AppScoped]
   }
 
   @Singleton

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationAvatar.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationAvatar.scala
@@ -11,9 +11,8 @@ case class OrganizationAvatar(
     id: Option[Id[OrganizationAvatar]] = None,
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime,
-    state: State[OrganizationAvatar] = OrganizationImageStates.ACTIVE,
+    state: State[OrganizationAvatar] = OrganizationAvatarStates.ACTIVE,
     organizationId: Id[Organization],
-    position: Option[ImagePosition],
     width: Int,
     height: Int,
     format: ImageFormat,
@@ -22,7 +21,7 @@ case class OrganizationAvatar(
     source: ImageSource,
     sourceFileHash: ImageHash,
     sourceImageURL: Option[String]) extends BaseImage with Model[OrganizationAvatar] {
-  def isOriginal = true
+  def isOriginal = kind == ProcessImageOperation.Original
 
   def dimensions = ImageSize(width, height)
   def withId(id: Id[OrganizationAvatar]) = this.copy(id = Some(id))
@@ -36,7 +35,6 @@ object OrganizationAvatar {
     (__ \ 'updatedAt).format(DateTimeJsonFormat) and
     (__ \ 'state).format(State.format[OrganizationAvatar]) and
     (__ \ 'organizationId).format(Id.format[Organization]) and
-    (__ \ 'position).formatNullable[ImagePosition] and
     (__ \ 'width).format[Int] and
     (__ \ 'height).format[Int] and
     (__ \ 'format).format[ImageFormat] and
@@ -48,13 +46,4 @@ object OrganizationAvatar {
   )(OrganizationAvatar.apply, unlift(OrganizationAvatar.unapply))
 }
 
-case class ImagePosition(x: Int, y: Int)
-
-object ImagePosition {
-  implicit val format: Format[ImagePosition] = (
-    (__ \ 'x).format[Int] and
-    (__ \ 'y).format[Int]
-  )(ImagePosition.apply, unlift(ImagePosition.unapply))
-}
-
-object OrganizationImageStates extends States[OrganizationAvatar]
+object OrganizationAvatarStates extends States[OrganizationAvatar]

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationAvatarRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationAvatarRepo.scala
@@ -80,8 +80,10 @@ class OrganizationAvatarRepoImpl @Inject() (val db: DataBaseComponent, val clock
     getByOrganizationCompiled(organizationId, state).list
   }
 
+  // gets only the DISTINCT images (i.e., only distinct imagePaths)
   def getByImageHash(hash: ImageHash, state: State[OrganizationAvatar] = OrganizationAvatarStates.ACTIVE)(implicit session: RSession): Seq[OrganizationAvatar] = {
-    (for (row <- rows if row.sourceFileHash === hash && row.state === state) yield row).list
+    val matchingAvatars = (for (row <- rows if row.sourceFileHash === hash && row.state === state) yield row).list
+    matchingAvatars.groupBy(_.imagePath).mapValues(_.head).values.toSeq
   }
 
   def deactivate(model: OrganizationAvatar)(implicit session: RWSession): OrganizationAvatar = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationAvatarRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationAvatarRepo.scala
@@ -10,7 +10,7 @@ import org.joda.time.DateTime
 
 @ImplementedBy(classOf[OrganizationAvatarRepoImpl])
 trait OrganizationAvatarRepo extends Repo[OrganizationAvatar] {
-  def getByOrganization(organizationId: Id[Organization])(implicit session: RSession): Seq[OrganizationAvatar]
+  def getByOrganization(organizationId: Id[Organization], state: State[OrganizationAvatar] = OrganizationAvatarStates.ACTIVE)(implicit session: RSession): Seq[OrganizationAvatar]
 }
 
 @Singleton
@@ -23,8 +23,6 @@ class OrganizationAvatarRepoImpl @Inject() (val db: DataBaseComponent, val clock
   type RepoImpl = OrganizationAvatarTable
   class OrganizationAvatarTable(tag: Tag) extends RepoTable[OrganizationAvatar](db, tag, "organization_avatar") {
     def organizationId = column[Id[Organization]]("organization_id", O.NotNull)
-    def xPosition = column[Option[Int]]("x_position", O.Nullable)
-    def yPosition = column[Option[Int]]("y_position", O.Nullable)
     def width = column[Int]("width", O.NotNull)
     def height = column[Int]("height", O.NotNull)
     def format = column[ImageFormat]("format", O.NotNull)
@@ -40,8 +38,6 @@ class OrganizationAvatarRepoImpl @Inject() (val db: DataBaseComponent, val clock
       updatedAt: DateTime,
       state: State[OrganizationAvatar],
       organizationId: Id[Organization],
-      xPosition: Option[Int],
-      yPosition: Option[Int],
       width: Int,
       height: Int,
       format: ImageFormat,
@@ -50,41 +46,36 @@ class OrganizationAvatarRepoImpl @Inject() (val db: DataBaseComponent, val clock
       source: ImageSource,
       sourceFileHash: ImageHash,
       sourceImageURL: Option[String]) = {
-      val imagePosition: Option[ImagePosition] = xPosition.flatMap { x =>
-        yPosition.map(y => ImagePosition(x, y))
-      }
-      OrganizationAvatar(id, createdAt, updatedAt, state, organizationId, imagePosition, width, height, format, kind, imagePath, source, sourceFileHash, sourceImageURL)
+      OrganizationAvatar(id, createdAt, updatedAt, state, organizationId, width, height, format, kind, imagePath, source, sourceFileHash, sourceImageURL)
     }
 
-    def unapplyToDbRow(logo: OrganizationAvatar) = {
-      Some((logo.id,
-        logo.createdAt,
-        logo.updatedAt,
-        logo.state,
-        logo.organizationId,
-        logo.position.map(_.x),
-        logo.position.map(_.y),
-        logo.width,
-        logo.height,
-        logo.format,
-        logo.kind,
-        logo.imagePath,
-        logo.source,
-        logo.sourceFileHash,
-        logo.sourceImageURL))
+    def unapplyToDbRow(avatar: OrganizationAvatar) = {
+      Some((avatar.id,
+        avatar.createdAt,
+        avatar.updatedAt,
+        avatar.state,
+        avatar.organizationId,
+        avatar.width,
+        avatar.height,
+        avatar.format,
+        avatar.kind,
+        avatar.imagePath,
+        avatar.source,
+        avatar.sourceFileHash,
+        avatar.sourceImageURL))
     }
 
-    def * = (id.?, createdAt, updatedAt, state, organizationId, xPosition, yPosition, width, height, format, kind, imagePath, source, sourceFileHash, sourceImageURL) <> ((applyFromDbRow _).tupled, unapplyToDbRow _)
+    def * = (id.?, createdAt, updatedAt, state, organizationId, width, height, format, kind, imagePath, source, sourceFileHash, sourceImageURL) <> ((applyFromDbRow _).tupled, unapplyToDbRow _)
   }
 
   def table(tag: Tag) = new OrganizationAvatarTable(tag)
   initTable()
 
-  def getByOrganizationCompiled = Compiled { (organizationId: Column[Id[Organization]]) =>
-    (for (row <- rows if row.organizationId === organizationId) yield row)
+  def getByOrganizationCompiled = Compiled { (organizationId: Column[Id[Organization]], state: Column[State[OrganizationAvatar]]) =>
+    for (row <- rows if row.organizationId === organizationId && row.state === state) yield row
   }
 
-  def getByOrganization(organizationId: Id[Organization])(implicit session: RSession): Seq[OrganizationAvatar] = {
-    getByOrganizationCompiled(organizationId).list
+  def getByOrganization(organizationId: Id[Organization], state: State[OrganizationAvatar] = OrganizationAvatarStates.ACTIVE)(implicit session: RSession): Seq[OrganizationAvatar] = {
+    getByOrganizationCompiled(organizationId, state).list
   }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationAvatarCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationAvatarCommanderTest.scala
@@ -56,10 +56,10 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
 
         // upload an image
         {
-          val savedF = commander.persistOrganizationAvatarsFromUserUpload(fakeFile2, org1.id.get)
+          val savedF = commander.persistOrganizationAvatarsFromUserUpload(fakeFile1, org1.id.get)
           val saved = Await.result(savedF, Duration("10 seconds"))
           saved must haveClass[Right[ImageStoreFailure, ImageHash]]
-          saved.right.get === ImageHash("1b3d95541538044c2a26598fbe1d06ae")
+          saved.right.get === ImageHash("26dbdc56d54dbc94830f7cfc85031481")
           // if this test fails, make sure imagemagick is installed. Use `brew install imagemagick`
         }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationAvatarCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationAvatarCommanderTest.scala
@@ -1,0 +1,118 @@
+package com.keepit.commanders
+
+import java.io.File
+
+import com.google.inject.Injector
+import com.keepit.common.logging.Logging
+import com.keepit.common.store._
+import com.keepit.model.UserFactoryHelper._
+import com.keepit.model._
+import com.keepit.test.ShoeboxTestInjector
+import org.apache.commons.io.FileUtils
+import org.specs2.mutable.Specification
+import play.api.libs.Files.TemporaryFile
+import com.keepit.commanders.OrganizationAvatarConfiguration.{ scaleSizes, cropSizes }
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInjector with Logging {
+
+  val logger = log
+
+  def modules = Seq()
+
+  def fakeFile1 = {
+    val tf = TemporaryFile(new File("test/data/image1-" + Math.random() + ".png"))
+    tf.file.deleteOnExit()
+    FileUtils.copyFile(new File("test/data/image1.png"), tf.file)
+    tf
+  }
+  def fakeFile2 = {
+    val tf = TemporaryFile(new File("test/data/image2-" + Math.random() + ".png"))
+    tf.file.deleteOnExit()
+    FileUtils.copyFile(new File("test/data/image2.png"), tf.file)
+    tf
+  }
+  def setup()(implicit injector: Injector) = {
+    db.readWrite { implicit session =>
+      val user1 = UserFactory.user().withName("Abe", "Lincoln").withUsername("abe").saved
+      val user2 = UserFactory.user().withName("Bob", "Dole").withUsername("bob").saved
+      val org1 = inject[OrganizationRepo].save(Organization(name = "Abe's Hardware", ownerId = user1.id.get, handle = None))
+      val org2 = inject[OrganizationRepo].save(Organization(name = "Bob's Tools", ownerId = user2.id.get, handle = None))
+      inject[OrganizationMembershipRepo].save(org1.newMembership(userId = user1.id.get, role = OrganizationRole.OWNER))
+      inject[OrganizationMembershipRepo].save(org2.newMembership(userId = user2.id.get, role = OrganizationRole.OWNER))
+      (user1, user2, org1, org2)
+    }
+  }
+
+  "organization avatar commander" should {
+    "upload new avatar, scaled and cropped" in {
+      withDb(modules: _*) { implicit injector =>
+        val commander = inject[OrganizationAvatarCommander]
+        val store = inject[OrganizationAvatarStore].asInstanceOf[InMemoryOrganizationAvatarStoreImpl]
+        val repo = inject[OrganizationAvatarRepo]
+        val (user1, user2, org1, org2) = setup()
+
+        // upload an image
+        {
+          val savedF = commander.persistOrganizationAvatarsFromUserUpload(fakeFile2, org1.id.get)
+          val saved = Await.result(savedF, Duration("10 seconds"))
+          saved must haveClass[Right[ImageStoreFailure, ImageHash]]
+          saved.right.get === ImageHash("1b3d95541538044c2a26598fbe1d06ae")
+          // if this test fails, make sure imagemagick is installed. Use `brew install imagemagick`
+        }
+
+        println("OrgAvatarStore keys: " + store.all.keySet)
+        store.all.keySet.size === scaleSizes.length + cropSizes.length + 1
+
+        db.readOnlyMaster { implicit s =>
+          val org1Avatars = repo.getByOrganization(org1.id.get)
+          org1Avatars.length === scaleSizes.length + cropSizes.length + 1
+        }
+      }
+    }
+    "reuse existing avatars when possible" in {
+      withDb(modules: _*) { implicit injector =>
+        val commander = inject[OrganizationAvatarCommander]
+        val store = inject[OrganizationAvatarStore].asInstanceOf[InMemoryOrganizationAvatarStoreImpl]
+        val repo = inject[OrganizationAvatarRepo]
+        val (user1, user2, org1, org2) = setup()
+
+        // upload an image
+        {
+          val savedF = commander.persistOrganizationAvatarsFromUserUpload(fakeFile2, org1.id.get)
+          val saved = Await.result(savedF, Duration("10 seconds"))
+          saved must haveClass[Right[ImageStoreFailure, ImageHash]]
+          saved.right.get === ImageHash("1b3d95541538044c2a26598fbe1d06ae")
+          // if this test fails, make sure imagemagick is installed. Use `brew install imagemagick`
+        }
+
+        println("OrgAvatarStore keys: " + store.all.keySet)
+        store.all.keySet.size === scaleSizes.length + cropSizes.length + 1
+
+        db.readOnlyMaster { implicit s =>
+          val org1Avatars =
+            repo.getByOrganization(org1.id.get).length === scaleSizes.length + cropSizes.length + 1
+        }
+
+        {
+          val savedF = commander.persistOrganizationAvatarsFromUserUpload(fakeFile2, org2.id.get)
+          val saved = Await.result(savedF, Duration("10 seconds"))
+          saved must haveClass[Right[ImageStoreFailure, ImageHash]]
+          saved.right.get === ImageHash("1b3d95541538044c2a26598fbe1d06ae")
+          // if this test fails, make sure imagemagick is installed. Use `brew install imagemagick`
+        }
+
+        store.all.keySet.size === scaleSizes.length + cropSizes.length + 1
+
+        db.readOnlyMaster { implicit s =>
+          repo.getByOrganization(org1.id.get).length === scaleSizes.length + cropSizes.length + 1
+          repo.getByOrganization(org2.id.get).length === scaleSizes.length + cropSizes.length + 1
+          repo.count === 2 * (scaleSizes.length + cropSizes.length + 1)
+        }
+
+      }
+    }
+  }
+}

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationAvatarRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationAvatarRepoTest.scala
@@ -16,7 +16,7 @@ class OrganizationAvatarRepoTest extends Specification with ShoeboxTestInjector 
         val orgAvatarRepo = inject[OrganizationAvatarRepo]
         val org = db.readWrite { implicit s =>
           val path: ImagePath = ImagePath("prefix", ImageHash("x"), ImageSize(100, 120), ProcessImageOperation.Crop, ImageFormat.JPG)
-          orgAvatarRepo.save(OrganizationAvatar(organizationId = Id[Organization](1), position = Some(ImagePosition(0, 0)),
+          orgAvatarRepo.save(OrganizationAvatar(organizationId = Id[Organization](1),
             width = 100, height = 120, format = ImageFormat.JPG, kind = ProcessImageOperation.Crop,
             imagePath = path, source = ImageSource.UserUpload, sourceFileHash = ImageHash("x"), sourceImageURL = Some("internets")))
         }
@@ -35,7 +35,7 @@ class OrganizationAvatarRepoTest extends Specification with ShoeboxTestInjector 
         db.readWrite { implicit session =>
           for (count <- range) {
             val path: ImagePath = ImagePath("prefix", ImageHash("x"), ImageSize(count, count), ProcessImageOperation.Crop, ImageFormat.JPG)
-            orgAvatarRepo.save(OrganizationAvatar(organizationId = orgId, position = None, width = count, height = count,
+            orgAvatarRepo.save(OrganizationAvatar(organizationId = orgId, width = count, height = count,
               format = ImageFormat.JPG, kind = ProcessImageOperation.Crop, imagePath = path,
               source = ImageSource.UserUpload, sourceFileHash = ImageHash("X"), sourceImageURL = None))
           }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/ShoeboxRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/ShoeboxRepoTest.scala
@@ -57,7 +57,7 @@ class ShoeboxRepoTest extends Specification with ShoeboxApplicationInjector {
         // OrganizationLogoRepo
         val organizationLogoRepo = inject[OrganizationAvatarRepo]
         val logo = db.readWrite { implicit session =>
-          val orgLogo = OrganizationAvatar(organizationId = org.id.get, position = Some(ImagePosition(0, 0)),
+          val orgLogo = OrganizationAvatar(organizationId = org.id.get,
             width = 100, height = 100, format = ImageFormat.JPG, kind = ProcessImageOperation.Scale,
             imagePath = ImagePath(""), source = ImageSource.UserUpload, sourceFileHash = ImageHash("X"),
             sourceImageURL = Some("NONE"))


### PR DESCRIPTION
`OrganizationAvatarCommander` can take a user-uploaded image (as a `TemporaryFile`),
process it to get a range of useful image shapes, persist all of those images to S3 (via
`S3OrganizationAvatarStoreImpl`), and store the relevant S3 image paths in the
`OrganizationAvatarRepo`.

@andrewconner @Colin-Lane @leogrim 
I'll go in and tag places that I'm concerned about.
