### PR TITLE
Bunch of random quality-of-life improvements

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
@@ -8,6 +8,7 @@ import com.keepit.common.db._
 import com.keepit.common.strings._
 import com.keepit.common.time._
 import com.kifi.macros.json
+import org.apache.commons.lang3.RandomStringUtils
 import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
@@ -39,6 +40,12 @@ case class Organization(
 
   def modifiedMembership(membership: OrganizationMembership, newRole: OrganizationRole): OrganizationMembership =
     membership.copy(role = newRole, permissions = getRolePermissions(newRole))
+
+  def sanitizeForDelete = this.copy(
+    state = OrganizationStates.INACTIVE,
+    name = RandomStringUtils.randomAlphanumeric(20),
+    description = None
+  )
 }
 
 object Organization extends ModelWithPublicIdCompanion[Organization] {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationAvatar.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationAvatar.scala
@@ -26,6 +26,7 @@ case class OrganizationAvatar(
   def dimensions = ImageSize(width, height)
   def withId(id: Id[OrganizationAvatar]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
+  def withState(newState: State[OrganizationAvatar]) = this.copy(state = newState)
 }
 
 object OrganizationAvatar {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationAvatarRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationAvatarRepo.scala
@@ -87,6 +87,6 @@ class OrganizationAvatarRepoImpl @Inject() (val db: DataBaseComponent, val clock
   }
 
   def deactivate(model: OrganizationAvatar)(implicit session: RWSession): OrganizationAvatar = {
-    save(model.copy(state = OrganizationAvatarStates.INACTIVE))
+    save(model.withState(OrganizationAvatarStates.INACTIVE))
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRepo.scala
@@ -2,7 +2,7 @@ package com.keepit.model
 
 import com.google.inject.{ Provider, ImplementedBy, Inject, Singleton }
 import com.keepit.common.db.{ Id }
-import com.keepit.common.db.slick.DBSession.RSession
+import com.keepit.common.db.slick.DBSession.{ RWSession, RSession }
 import com.keepit.common.db.slick._
 import com.keepit.common.logging.Logging
 import com.keepit.common.time.Clock
@@ -10,8 +10,7 @@ import play.api.libs.json.Json
 
 @ImplementedBy(classOf[OrganizationRepoImpl])
 trait OrganizationRepo extends Repo[Organization] with SeqNumberFunction[Organization] {
-  def updateName(organizationId: Id[Organization], name: String): Organization = ???
-  def updateDescription(organizationId: Id[Organization], description: String): Organization = ???
+  def deactivate(model: Organization)(implicit session: RWSession): Unit
 }
 
 @Singleton
@@ -40,4 +39,8 @@ class OrganizationRepoImpl @Inject() (val db: DataBaseComponent, val clock: Cloc
 
   def table(tag: Tag) = new OrganizationTable(tag)
   initTable()
+
+  def deactivate(model: Organization)(implicit session: RWSession): Unit = {
+    save(model.sanitizeForDelete)
+  }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
@@ -73,7 +73,7 @@ case class OrganizationModifyResponse(request: OrganizationModifyRequest, modifi
 case class OrganizationDeleteRequest(
   orgId: Id[Organization],
   requesterId: Id[User]) extends OrganizationRequest
-case class OrganizationDeleteResponse(request: OrganizationDeleteRequest, deactivatedOrg: Organization)
+case class OrganizationDeleteResponse(request: OrganizationDeleteRequest)
 
 case class OrganizationModifications(
   newName: Option[String] = None,


### PR DESCRIPTION
@leogrim: Removed the deactivated model returned by `orgCommander.deleteOrg`

Also took care of the logic handling explicitly revoked organization permissions.
