### PR TITLE
Use UrlHash instead of Id[NormalizedURI] for S3 article keys

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/store/InMemoryObjectStore.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/InMemoryObjectStore.scala
@@ -28,6 +28,8 @@ trait InMemoryObjectStore[A, B] extends ObjectStore[A, B] with Logging {
 
   def syncGet(id: A): Option[B] = localStore.get(id)
 
+  def copy(sourceId: A, destinationId: A): Boolean = syncGet(sourceId).exists { value => this += (destinationId, value); true }
+
   override def toString = s"[size=${localStore.size} keys=${localStore.keySet}"
 }
 
@@ -57,6 +59,8 @@ trait InMemoryFileStore[A] extends ObjectStore[A, File] {
 
   def syncGet(key: A): Option[File] = pathMap.get(key).map(new File(_))
 
+  def copy(sourceId: A, destinationId: A): Boolean = syncGet(sourceId).exists { file => this += (destinationId, file); true }
+
   override def toString = s"[size=${pathMap.size} keys=${pathMap.keySet}"
 
 }
@@ -82,4 +86,6 @@ trait InMemoryBlobStore[A, B] extends ObjectStore[A, B] {
     localBlobStore.remove(key)
     this
   }
+
+  def copy(sourceId: A, destinationId: A): Boolean = syncGet(sourceId).exists { blob => this += (destinationId, blob); true }
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/store/ObjectStore.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/ObjectStore.scala
@@ -29,6 +29,8 @@ trait ObjectStore[A, B] {
    */
   def syncGet(key: A): Option[B]
 
+  def copy(sourceId: A, destinationId: A): Boolean
+
 }
 
 trait ObjMetadata extends Any { // WIP; if proved useful can be folded into main abstraction

--- a/kifi-backend/modules/common/test/com/keepit/common/store/FakePornWordLikelihoodStore.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/store/FakePornWordLikelihoodStore.scala
@@ -6,4 +6,5 @@ case class FakePornWordLikelihoodStore() extends PornWordLikelihoodStore {
   override def syncGet(key: String) = Some(PornWordLikelihood(Map("a" -> 1f)))
   def -=(key: String) = null
   def +=(kv: (String, PornWordLikelihood)) = null
+  def copy(sourceId: String, destinationId: String): Boolean = syncGet(sourceId).exists { blob => this += (destinationId, blob); true }
 }

--- a/kifi-backend/modules/rover/app/com/keepit/rover/article/ArticleCommander.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/article/ArticleCommander.scala
@@ -217,7 +217,7 @@ class ArticleCommander @Inject() (
       }
       case Some(article) => {
         log.info(s"Persisting latest ${articleInfo.articleKind} for uri ${articleInfo.uriId}: ${articleInfo.url}")
-        articleStore.add(articleInfo.uriId, articleInfo.latestVersion, article)(articleInfo.articleKind).imap { key =>
+        articleStore.add(articleInfo.urlHash, articleInfo.uriId, articleInfo.latestVersion, article)(articleInfo.articleKind).imap { key =>
           log.info(s"Persisted latest ${articleInfo.articleKind} with version ${key.version} for uri ${articleInfo.uriId}: ${articleInfo.url}")
           Some((article, key.version))
         }
@@ -237,7 +237,7 @@ class ArticleCommander @Inject() (
 }
 
 case class ArticleInfoUriKey(uriId: Id[NormalizedURI]) extends Key[Set[ArticleInfo]] {
-  override val version = 1
+  override val version = 2
   val namespace = "article_info_by_uri"
   def toKey(): String = uriId.id.toString
 }

--- a/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverManagerPlugin.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverManagerPlugin.scala
@@ -5,10 +5,10 @@ import javax.inject.{ Inject, Singleton }
 import com.keepit.common.actor.ActorInstance
 import com.keepit.common.plugin.{ SchedulerPlugin, SchedulingProperties }
 import com.keepit.rover.manager.ConcurrentTaskProcessingActor.{ Close, IfYouCouldJustGoAhead }
+import com.keepit.rover.store.RoverArticleStoreMigrationActor
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.util.Random
 
 trait RoverManagerPlugin
 
@@ -19,6 +19,7 @@ class RoverManagerPluginImpl @Inject() (
     fetchingActor: ActorInstance[RoverArticleFetchingActor],
     imageSchedulingActor: ActorInstance[RoverArticleImageSchedulingActor],
     imageProcessingActor: ActorInstance[RoverArticleImageProcessingActor],
+    articleStoreMigrationActor: ActorInstance[RoverArticleStoreMigrationActor],
     implicit val executionContext: ExecutionContext,
     val scheduling: SchedulingProperties) extends RoverManagerPlugin with SchedulerPlugin {
 
@@ -32,6 +33,7 @@ class RoverManagerPluginImpl @Inject() (
     scheduleTaskOnAllMachines(fetchingActor.system, 250 seconds, 5 minute, fetchingActor.ref, IfYouCouldJustGoAhead)
     scheduleTaskOnLeader(imageSchedulingActor.system, 300 seconds, 8 minute, imageSchedulingActor.ref, IfYouCouldJustGoAhead)
     scheduleTaskOnAllMachines(imageProcessingActor.system, 300 seconds, 5 minute, imageProcessingActor.ref, IfYouCouldJustGoAhead)
+    scheduleTaskOnOneMachine(articleStoreMigrationActor.system, 400 seconds, 10 minutes, articleStoreMigrationActor.ref, IfYouCouldJustGoAhead, "Article Key Migration")
   }
 
   override def onStop(): Unit = {

--- a/kifi-backend/modules/rover/app/com/keepit/rover/model/RoverArticleInfo.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/model/RoverArticleInfo.scala
@@ -122,6 +122,8 @@ object RoverArticleInfo {
       info.state == ArticleInfoStates.INACTIVE,
       info.seq,
       info.uriId,
+      info.url,
+      info.urlHash,
       info.kind,
       info.bestVersion,
       info.latestVersion

--- a/kifi-backend/modules/rover/app/com/keepit/rover/store/RoverArticleStore.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/store/RoverArticleStore.scala
@@ -4,7 +4,7 @@ import com.google.inject.{ Inject, Singleton }
 import com.keepit.common.akka.SafeFuture
 import com.keepit.common.db.Id
 import com.keepit.common.service.RequestConsolidator
-import com.keepit.model.NormalizedURI
+import com.keepit.model.{ UrlHash, NormalizedURI }
 import com.keepit.rover.article.{ Article, ArticleKind }
 import com.keepit.rover.model.{ ArticleVersionProvider, ArticleKey, ArticleVersion }
 import scala.concurrent.duration._
@@ -32,9 +32,10 @@ class RoverArticleStore @Inject() (
 
   def get[A <: Article](keyOpt: Option[ArticleKey[A]]): Future[Option[A]] = keyOpt.map(get[A]) getOrElse Future.successful(None)
 
-  def add[A <: Article](uriId: Id[NormalizedURI], previousVersion: Option[ArticleVersion], article: A)(implicit kind: ArticleKind[A]): Future[ArticleKey[A]] = {
+  // todo(Léo): just hash article.url ???
+  def add[A <: Article](urlHash: UrlHash, uriId: Id[NormalizedURI], previousVersion: Option[ArticleVersion], article: A)(implicit kind: ArticleKind[A]): Future[ArticleKey[A]] = {
     SafeFuture {
-      val key = ArticleKey(uriId, kind, ArticleVersionProvider.next[A](previousVersion))
+      val key = ArticleKey(uriId, urlHash, kind, ArticleVersionProvider.next[A](previousVersion))
       val storeKey = ArticleStoreKey(key)
       underlying += (storeKey -> article)
       signatureCommander.computeArticleSignature(article)

--- a/kifi-backend/modules/rover/app/com/keepit/rover/store/RoverArticleStore.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/store/RoverArticleStore.scala
@@ -36,6 +36,8 @@ class RoverArticleStore @Inject() (
   def add[A <: Article](urlHash: UrlHash, uriId: Id[NormalizedURI], previousVersion: Option[ArticleVersion], article: A)(implicit kind: ArticleKind[A]): Future[ArticleKey[A]] = {
     SafeFuture {
       val key = ArticleKey(uriId, urlHash, kind, ArticleVersionProvider.next[A](previousVersion))
+      val urlHashStoreKey = UrlHashArticleStoreKey(key)
+      underlying += (urlHashStoreKey -> article)
       val storeKey = ArticleStoreKey(key)
       underlying += (storeKey -> article)
       signatureCommander.computeArticleSignature(article)

--- a/kifi-backend/modules/rover/app/com/keepit/rover/store/RoverArticleStoreMigrationActor.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/store/RoverArticleStoreMigrationActor.scala
@@ -1,0 +1,61 @@
+package com.keepit.rover.store
+
+import com.google.inject.Inject
+import com.keepit.common.akka.{ SafeFuture, FortyTwoActor }
+import com.keepit.common.db.SequenceNumber
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.model.{ Name, SystemValueRepo }
+import com.keepit.rover.manager.BatchProcessingActor
+import com.keepit.rover.model.{ ArticleKey, ArticleInfoRepo, RoverArticleInfo }
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Success, Failure, Try }
+
+class RoverArticleStoreMigrationActor @Inject() (
+    airbrake: AirbrakeNotifier,
+    db: Database, articleInfoRepo: ArticleInfoRepo,
+    systemValueRepo: SystemValueRepo,
+    articleStore: RoverUnderlyingArticleStore,
+    implicit val ec: ExecutionContext) extends FortyTwoActor(airbrake) with BatchProcessingActor[RoverArticleInfo] {
+
+  val articleStoreMigration = Name[SequenceNumber[RoverArticleInfo]]("migration")
+  val batchSize = 50
+
+  protected val logger = log.logger
+
+  protected def nextBatch = SafeFuture {
+    db.readOnlyMaster { implicit session =>
+      val seq = systemValueRepo.getSequenceNumber(articleStoreMigration) getOrElse SequenceNumber.ZERO
+      articleInfoRepo.getBySequenceNumber(seq, batchSize)
+    }
+  }
+
+  protected def processBatch(batch: Seq[RoverArticleInfo]): Future[Unit] = if (batch.isEmpty) Future.successful(()) else {
+    val allCopied: Seq[Future[Unit]] = batch.map { articleInfo =>
+      SafeFuture {
+        articleInfo.oldestVersion.foreach { oldestVersion =>
+          val latestVersion = articleInfo.latestVersion.get
+          require(oldestVersion.major == latestVersion.major, s"[Unexpected] Major version has been incremented between $oldestVersion and $latestVersion")
+          var version = oldestVersion
+          while (version <= latestVersion) {
+            val key = ArticleKey(articleInfo.uriId, articleInfo.urlHash, articleInfo.articleKind, version)
+            val uriKey = ArticleStoreKey(key)
+            val urlHashKey = UrlHashArticleStoreKey(key)
+            Try(articleStore.copy(uriKey, urlHashKey)) match {
+              case Success(true) => ()
+              case Success(false) => airbrake.notify(s"Did not copy article from $uriKey to $urlHashKey: key not found.")
+              case Failure(error) => airbrake.notify(s"Failed to copy article from $uriKey to $urlHashKey.", error)
+            }
+            version = version.copy(minor = version.minor + 1)
+          }
+        }
+      }
+    }
+    Future.sequence(allCopied).map { _ =>
+      db.readWrite { implicit session =>
+        systemValueRepo.setSequenceNumber(articleStoreMigration, batch.map(_.seq).max)
+      }
+    }
+  }
+}

--- a/kifi-backend/modules/rover/app/com/keepit/rover/store/RoverUnderlyingArticleStore.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/store/RoverUnderlyingArticleStore.scala
@@ -16,6 +16,14 @@ private[store] object ArticleStoreKey {
   implicit def apply[A <: Article](key: ArticleKey[A]): ArticleStoreKey = new ArticleStoreKey(key)
 }
 
+private[store] class UrlHashArticleStoreKey(key: ArticleKey[_]) extends ArticleStoreKey(key) {
+  override def toString = s"${key.urlHash.hash}/${key.kind.typeCode}/${key.version.major.value}.${key.version.minor.value}"
+}
+
+private[store] object UrlHashArticleStoreKey {
+  implicit def apply[A <: Article](key: ArticleKey[A]): UrlHashArticleStoreKey = new UrlHashArticleStoreKey(key)
+}
+
 private[store] trait RoverUnderlyingArticleStore extends ObjectStore[ArticleStoreKey, Article]
 
 private[store] class S3RoverUnderlyingArticleStoreImpl(val bucketName: S3Bucket, val amazonS3Client: AmazonS3, val accessLog: AccessLog)


### PR DESCRIPTION
@andrewconner @eishay 
Double-write for newly fetched articles + copying over existing articles to new keys.
When done, will switch get to using the new keys and delete the old articles.
Easier than I thought, and `BatchProcessingActor` takes out most of the boilerplate for that kind of stuff :)
