### PR TITLE
slack: removed uniqueness constraint on name or webhook URL

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/347.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/347.sql
@@ -1,0 +1,9 @@
+# SHOEBOX
+
+# --- !Ups
+
+DROP INDEX library_id ON library_subscription;
+
+insert into evolutions (name, description) values('347.sql', 'removing constraint for unique library subscription name');
+
+# --- !Downs

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibrarySubscriptionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibrarySubscriptionCommander.scala
@@ -94,7 +94,7 @@ class LibrarySubscriptionCommander @Inject() (
     def saveUpdates(currSubs: Seq[LibrarySubscription], subKeys: Seq[LibrarySubscriptionKey])(implicit session: RWSession): Unit = {
       subKeys.foreach { key =>
         currSubs.find {
-          hasSameNameOrEndpoint(key, _)
+          _.equals(key)
         } match {
           case None => saveSubByLibIdAndKey(libId, key) // key represents a new sub, save it
           case Some(equivalentSub) => librarySubscriptionRepo.save(equivalentSub.copy(name = key.name, info = key.info, state = LibrarySubscriptionStates.ACTIVE))
@@ -105,7 +105,7 @@ class LibrarySubscriptionCommander @Inject() (
     def removeDifferences(currSubs: Seq[LibrarySubscription], subKeys: Seq[LibrarySubscriptionKey])(implicit session: RWSession): Unit = {
       currSubs.foreach { currSub =>
         subKeys.find {
-          hasSameNameOrEndpoint(_, currSub)
+          _.equals(currSub)
         } match {
           case None => librarySubscriptionRepo.save(currSub.copy(state = LibrarySubscriptionStates.INACTIVE))
           case Some(key) => // currSub has already been updated above, do nothing


### PR DESCRIPTION
@andrewconner before, we were using name as a unique identifier for a subscription. now, people can subscribe to #general from two different slack teams and it should work. 
