### PR TITLE
Adds ability for library lists to have a specific ordering via LibraryOrdering (mobile only at the moment)

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserProfileCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserProfileCommander.scala
@@ -44,8 +44,12 @@ class UserProfileCommander @Inject() (
     implicit val config: PublicIdConfiguration) {
 
   def getOwnLibrariesForSelf(user: User, page: Paginator, idealSize: ImageSize): ParSeq[LibraryCardInfo] = {
+    getOwnLibrariesForSelf(user, page, idealSize, None)
+  }
+
+  def getOwnLibrariesForSelf(user: User, page: Paginator, idealSize: ImageSize, ordering: Option[LibraryOrdering]): ParSeq[LibraryCardInfo] = {
     val (libraryInfos, memberships) = db.readOnlyMaster { implicit session =>
-      val libs = libraryRepo.getOwnerLibrariesForSelf(user.id.get, page)
+      val libs = libraryRepo.getOwnerLibrariesForSelfWithOrdering(user.id.get, page, ordering)
       val libOwnerIds = libs.map(_.ownerId).toSet
       val owners = basicUserRepo.loadAll(libOwnerIds)
       val libraryIds = libs.map(_.id.get).toSet
@@ -78,13 +82,13 @@ class UserProfileCommander @Inject() (
     }
   }
 
-  def getOwnLibraries(user: User, viewer: Option[User], page: Paginator, idealSize: ImageSize): ParSeq[LibraryCardInfo] = {
+  def getOwnLibraries(user: User, viewer: Option[User], page: Paginator, idealSize: ImageSize, ordering: Option[LibraryOrdering] = None): ParSeq[LibraryCardInfo] = {
     db.readOnlyMaster { implicit session =>
       val libs = viewer match {
         case None =>
-          libraryRepo.getOwnerLibrariesForAnonymous(user.id.get, page)
+          libraryRepo.getOwnerLibrariesForAnonymous(user.id.get, page, ordering)
         case Some(other) =>
-          libraryRepo.getOwnerLibrariesForOtherUser(user.id.get, other.id.get, page)
+          libraryRepo.getOwnerLibrariesForOtherUser(user.id.get, other.id.get, page, ordering)
       }
       val libOwnerIds = libs.map(_.ownerId).toSet
       val owners = basicUserRepo.loadAll(libOwnerIds)
@@ -92,20 +96,20 @@ class UserProfileCommander @Inject() (
     }
   }
 
-  def getFollowingLibraries(user: User, viewer: Option[User], page: Paginator, idealSize: ImageSize): ParSeq[LibraryCardInfo] = {
+  def getFollowingLibraries(user: User, viewer: Option[User], page: Paginator, idealSize: ImageSize, ordering: Option[LibraryOrdering] = None): ParSeq[LibraryCardInfo] = {
     db.readOnlyMaster { implicit session =>
       val libs = viewer match {
         case None =>
           val showFollowLibraries = getUserValueSetting(user.id.get, UserValueName.SHOW_FOLLOWED_LIBRARIES)
           if (showFollowLibraries) {
-            libraryRepo.getFollowingLibrariesForAnonymous(user.id.get, page)
+            libraryRepo.getFollowingLibrariesForAnonymous(user.id.get, page, ordering)
           } else Seq.empty
         case Some(other) if other.id == user.id =>
-          libraryRepo.getFollowingLibrariesForSelf(user.id.get, page)
+          libraryRepo.getFollowingLibrariesForSelf(user.id.get, page, ordering)
         case Some(other) =>
           val showFollowLibraries = getUserValueSetting(user.id.get, UserValueName.SHOW_FOLLOWED_LIBRARIES)
           if (showFollowLibraries) {
-            libraryRepo.getFollowingLibrariesForOtherUser(user.id.get, other.id.get, page)
+            libraryRepo.getFollowingLibrariesForOtherUser(user.id.get, other.id.get, page, ordering)
           } else Seq.empty
       }
       val owners = basicUserRepo.loadAll(libs.map(_.ownerId).toSet)

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -216,6 +216,8 @@ GET     /m/1/user/:username/connections             @com.keepit.controllers.mobi
 GET     /m/1/user/:username/libraries           @com.keepit.controllers.mobile.MobileUserProfileController.getProfileLibraries(username: Username, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")
 GET     /m/1/user/:username/followers           @com.keepit.controllers.mobile.MobileUserProfileController.getProfileFollowers(username: Username, page: Int ?= 0, size: Int ?= 12)
 
+GET     /m/2/user/:id/libraries                 @com.keepit.controllers.mobile.MobileUserProfileController.getProfileLibrariesV2(id: ExternalId[User], page: Int ?= 0, size: Int ?= 12, filter: String ?= "own", ordering: Option[LibraryOrdering])
+
 POST    /m/1/user/:id/unfriend                  @com.keepit.controllers.mobile.MobileUserController.unfriend(id: ExternalId[User])
 POST    /m/1/user/:id/friend                    @com.keepit.controllers.mobile.MobileUserController.friend(id: ExternalId[User])
 POST    /m/1/user/:id/ignoreRequest             @com.keepit.controllers.mobile.MobileUserController.ignoreFriendRequest(id: ExternalId[User])


### PR DESCRIPTION
- Backwards compatible, old endpoints should not be affected, site is untouched
- The new v2 endpoitn for getting profile libraries can now take a LibraryOrdering, which can be:
  - Alphabetical "alphabetical"
  - LastKeptInto "last_kept_into"
  - MemberCount "member_count"
- Tests are accounted for
