### PR TITLE
Batch methods for org membership commander

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
@@ -33,9 +33,14 @@ trait OrganizationMembershipCommander {
   def isValidRequest(request: OrganizationMembershipRequest)(implicit session: RSession): Boolean
 
   def validateRequests(requests: Seq[OrganizationMembershipRequest]): Map[OrganizationMembershipRequest, Boolean]
+
   def addMembership(request: OrganizationMembershipAddRequest): Either[OrganizationFail, OrganizationMembershipAddResponse]
   def modifyMembership(request: OrganizationMembershipModifyRequest): Either[OrganizationFail, OrganizationMembershipModifyResponse]
   def removeMembership(request: OrganizationMembershipRemoveRequest): Either[OrganizationFail, OrganizationMembershipRemoveResponse]
+
+  def addMemberships(requests: Seq[OrganizationMembershipAddRequest]): Either[OrganizationFail, Map[OrganizationMembershipAddRequest, OrganizationMembershipAddResponse]]
+  def modifyMemberships(requests: Seq[OrganizationMembershipModifyRequest]): Either[OrganizationFail, Map[OrganizationMembershipModifyRequest, OrganizationMembershipModifyResponse]]
+  def removeMemberships(requests: Seq[OrganizationMembershipRemoveRequest]): Either[OrganizationFail, Map[OrganizationMembershipRemoveRequest, OrganizationMembershipRemoveResponse]]
 }
 
 @Singleton
@@ -112,7 +117,8 @@ class OrganizationMembershipCommanderImpl @Inject() (
     requesterOpt exists { requester =>
       request match {
         case OrganizationMembershipAddRequest(_, _, _, newRole) =>
-          targetOpt.isEmpty && (newRole <= requester.role) &&
+          val isInviteOrPromotion = !targetOpt.exists(_.role > newRole)
+          isInviteOrPromotion && (newRole <= requester.role) &&
             requester.permissions.contains(INVITE_MEMBERS)
 
         case OrganizationMembershipModifyRequest(_, _, _, newRole) =>
@@ -134,39 +140,78 @@ class OrganizationMembershipCommanderImpl @Inject() (
     }
   }
 
-  def addMembership(request: OrganizationMembershipAddRequest): Either[OrganizationFail, OrganizationMembershipAddResponse] = {
-    db.readWrite { implicit session =>
-      if (isValidRequest(request)) {
-        val org = organizationRepo.get(request.orgId)
-        val newMembership = organizationMembershipRepo.save(org.newMembership(request.targetId, request.newRole))
-        Right(OrganizationMembershipAddResponse(request, newMembership))
-      } else {
-        Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
+  private def addMembershipHelper(request: OrganizationMembershipAddRequest)(implicit session: RWSession): Either[OrganizationFail, OrganizationMembershipAddResponse] = {
+    if (!isValidRequest(request)) {
+      Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
+    } else {
+      val org = organizationRepo.get(request.orgId)
+      val targetOpt = organizationMembershipRepo.getByOrgIdAndUserId(request.orgId, request.targetId)
+      val newMembership = targetOpt match {
+        case None => organizationMembershipRepo.save(org.newMembership(request.targetId, request.newRole))
+        case Some(membership) => organizationMembershipRepo.save(org.modifiedMembership(membership, request.newRole))
       }
+      Right(OrganizationMembershipAddResponse(request, newMembership))
+    }
+  }
+  private def modifyMembershipHelper(request: OrganizationMembershipModifyRequest)(implicit session: RWSession): Either[OrganizationFail, OrganizationMembershipModifyResponse] = {
+    if (!isValidRequest(request)) {
+      Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
+    } else {
+      val membership = organizationMembershipRepo.getByOrgIdAndUserId(request.orgId, request.targetId).get
+      val org = organizationRepo.get(request.orgId)
+      val newMembership = organizationMembershipRepo.save(org.modifiedMembership(membership, request.newRole))
+      Right(OrganizationMembershipModifyResponse(request, newMembership))
+    }
+  }
+  private def removeMembershipHelper(request: OrganizationMembershipRemoveRequest)(implicit session: RWSession): Either[OrganizationFail, OrganizationMembershipRemoveResponse] = {
+    if (!isValidRequest(request)) {
+      Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
+    } else {
+      val membership = organizationMembershipRepo.getByOrgIdAndUserId(request.orgId, request.targetId).get
+      organizationMembershipRepo.deactivate(membership.id.get)
+      Right(OrganizationMembershipRemoveResponse(request))
     }
   }
 
-  def modifyMembership(request: OrganizationMembershipModifyRequest): Either[OrganizationFail, OrganizationMembershipModifyResponse] = {
-    db.readWrite { implicit session =>
-      if (isValidRequest(request)) {
-        val membership = organizationMembershipRepo.getByOrgIdAndUserId(request.orgId, request.targetId).get
-        val org = organizationRepo.get(request.orgId)
-        val newMembership = organizationMembershipRepo.save(org.modifiedMembership(membership, request.newRole))
-        Right(OrganizationMembershipModifyResponse(request, newMembership))
-      } else {
-        Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
-      }
+  def addMembership(request: OrganizationMembershipAddRequest): Either[OrganizationFail, OrganizationMembershipAddResponse] =
+    db.readWrite { implicit session => addMembershipHelper(request) }
+
+  def modifyMembership(request: OrganizationMembershipModifyRequest): Either[OrganizationFail, OrganizationMembershipModifyResponse] =
+    db.readWrite { implicit session => modifyMembershipHelper(request) }
+
+  def removeMembership(request: OrganizationMembershipRemoveRequest): Either[OrganizationFail, OrganizationMembershipRemoveResponse] =
+    db.readWrite { implicit session => removeMembershipHelper(request) }
+
+  // Accumulates the A -> B results in a Map. If any of the results fail, throw an exception
+  def accumulateWithFail[A, B, F](f: (A => Either[F, B]), xs: Seq[A]): Map[A, B] = {
+    def g(accum: Map[A, B], x: A) = f(x) match {
+      case Left(failure) => throw new Exception
+      case Right(y) => accum + (x -> y)
+    }
+    xs.foldLeft(Map.empty[A, B])(g)
+  }
+
+  def addMemberships(requests: Seq[OrganizationMembershipAddRequest]): Either[OrganizationFail, Map[OrganizationMembershipAddRequest, OrganizationMembershipAddResponse]] = {
+    try {
+      db.readWrite { implicit session => Right(accumulateWithFail(addMembershipHelper, requests)) }
+    } catch {
+      case fail: Exception => Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
     }
   }
-  def removeMembership(request: OrganizationMembershipRemoveRequest): Either[OrganizationFail, OrganizationMembershipRemoveResponse] = {
-    db.readWrite { implicit session =>
-      if (isValidRequest(request)) {
-        val membership = organizationMembershipRepo.getByOrgIdAndUserId(request.orgId, request.targetId).get
-        organizationMembershipRepo.deactivate(membership.id.get)
-        Right(OrganizationMembershipRemoveResponse(request))
-      } else {
-        Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
-      }
+
+  def modifyMemberships(requests: Seq[OrganizationMembershipModifyRequest]): Either[OrganizationFail, Map[OrganizationMembershipModifyRequest, OrganizationMembershipModifyResponse]] = {
+    try {
+      db.readWrite { implicit session => Right(accumulateWithFail(modifyMembershipHelper, requests)) }
+    } catch {
+      case fail: Exception => Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
+    }
+  }
+
+  def removeMemberships(requests: Seq[OrganizationMembershipRemoveRequest]): Either[OrganizationFail, Map[OrganizationMembershipRemoveRequest, OrganizationMembershipRemoveResponse]] = {
+    try {
+      db.readWrite { implicit session => Right(accumulateWithFail(removeMembershipHelper, requests)) }
+    } catch {
+      case fail: Exception => Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
     }
   }
 }


### PR DESCRIPTION
It can perform a sequence of add/modify/remove operations in a single session
and if it encounters an error it will unroll all the changes and return an
OrganizationFail

@leogrim @Colin-Lane @yingjieMiao 
Simpler to have separate PRs for this and the controller work
