### PR TITLE
Some quality-of-life improvements for ip tracking

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserIpAddressCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserIpAddressCommander.scala
@@ -10,7 +10,7 @@ import com.keepit.common.net.{ DirectUrl, HttpClient, UserAgent }
 import com.keepit.common.service.IpAddress
 import com.keepit.model._
 import org.joda.time.{ DateTime, Period }
-import play.api.libs.json.Json
+import play.api.libs.json.{ JsObject, Json }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -38,17 +38,17 @@ class UserIpAddressCommander @Inject() (
     if (agentType == "NONE") {
       log.info("[IPTRACK AGENT] Could not parse an agent type out of: " + userAgent)
     }
-    val model = UserIpAddress(None, now, now, UserIpAddressStates.ACTIVE, userId, ip, agentType)
+    val model = UserIpAddress(userId = userId, ipAddress = ip, agentType = agentType)
 
-    val oldCluster = db.readWrite { implicit session =>
+    val cluster = db.readWrite { implicit session =>
       val currentCluster = userIpAddressRepo.getUsersFromIpAddressSince(ip, now.minus(clusterMemoryTime))
       userIpAddressRepo.saveIfNew(model)
-      currentCluster
+      currentCluster.toSet + userId
     }
 
-    if (reportNewClusters && !oldCluster.isEmpty && !oldCluster.contains(userId)) {
-      log.info("[IPTRACK NOTIFY] Cluster " + oldCluster + " has new member " + userId)
-      notifySlackChannelAboutCluster(ip)
+    if (reportNewClusters && cluster.size > 1) {
+      log.info("[IPTRACK NOTIFY] Cluster " + cluster + " has new member " + userId)
+      notifySlackChannelAboutCluster(clusterIp = ip, clusterMembers = cluster, newUserId = Some(userId))
     }
   }
 
@@ -60,23 +60,37 @@ class UserIpAddressCommander @Inject() (
     logUser(userId, ip, userAgent)
   }
 
-  def formatCluster(ip: IpAddress, users: Seq[User]): BasicSlackMessage = {
-    val clusterDeclaration = s"Found a cluster of ${users.length} at <http://ip-api.com/$ip|$ip>"
-    val userDeclarations = (for { u <- users } yield s"<http://admin.kifi.com/admin/user/${u.id.get}|${u.fullName}>").toList
-    BasicSlackMessage((clusterDeclaration :: userDeclarations).mkString("\n"))
+  def formatCluster(ip: IpAddress, users: Seq[User], newUserId: Option[Id[User]], company: Option[String] = None): BasicSlackMessage = {
+    val clusterDeclaration = Map(
+      true -> s"Found a cluster of ${users.length} at <http://ip-api.com/$ip|$ip>",
+      company.isDefined -> s"I think the company is '$company'"
+    ).filterKeys(b => b).values.toList
+
+    val userDeclarations = users.map { u =>
+      val userDeclaration = s"<http://admin.kifi.com/admin/user/${u.id.get}|${u.fullName}>"
+      if (newUserId.contains(u.id.get)) "*" + userDeclaration + " <-- New Member!!!*"
+      else userDeclaration
+    }.toList
+
+    BasicSlackMessage((clusterDeclaration ++ userDeclarations).mkString("\n"))
   }
 
-  def notifySlackChannelAboutCluster(clusterIp: IpAddress): Unit = {
+  def heuristicsSayThisClusterIsRelevant(ipInfo: Option[JsObject]): Boolean = {
+    val companyOpt = ipInfo flatMap { obj => (obj \ "company").asOpt[String] }
+    val blacklistCompanies = Set.empty[String]
+
+    !companyOpt.exists(company => blacklistCompanies.contains(company))
+  }
+  def notifySlackChannelAboutCluster(clusterIp: IpAddress, clusterMembers: Set[Id[User]], newUserId: Option[Id[User]] = None): Unit = {
     log.info("[IPTRACK NOTIFY] Notifying slack channel about " + clusterIp)
     val usersFromCluster = db.readOnlyMaster { implicit session =>
-      val userIds = userIpAddressRepo.getUsersFromIpAddressSince(clusterIp, DateTime.now.minus(clusterMemoryTime))
-      userRepo.getUsers(userIds).values.toSeq
+      userRepo.getUsers(clusterMembers.toSeq).values.toSeq
     }
-    if (usersFromCluster.length > 1) {
-      val msg = formatCluster(clusterIp, usersFromCluster)
+    val ipInfo = httpClient.get(DirectUrl("http://pro.ip-api.com/json/" + clusterIp + "?key=mnU7wRVZAx6BAyP")).json.asOpt[JsObject]
+
+    if (heuristicsSayThisClusterIsRelevant(ipInfo)) {
+      val msg = formatCluster(clusterIp, usersFromCluster, newUserId)
       httpClient.post(DirectUrl(ipClusterSlackChannelUrl), Json.toJson(msg))
-    } else {
-      log.info("[IPTRACK NONOTIFY] Opted not to notify channel about " + clusterIp + " with " + usersFromCluster.length + " users")
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -393,7 +393,7 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
 
   @Provides @Singleton
   def userIpAddressCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new UserIpAddressCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 1 days))
+    new UserIpAddressCache(stats, accessLog, (innerRepo, 1 second), (outerRepo, 1 hour))
 
   @Provides @Singleton
   def organizationCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserIpAddress.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserIpAddress.scala
@@ -4,7 +4,7 @@ import com.keepit.common.cache.{ Key, CacheStatistics, FortyTwoCachePlugin, Json
 import com.keepit.common.db._
 import com.keepit.common.logging.AccessLog
 import com.keepit.common.service.IpAddress
-import com.keepit.common.time.DateTimeJsonFormat
+import com.keepit.common.time._
 import com.keepit.model.UserIpAddress._
 import com.keepit.shoebox.model.IngestableUserIpAddress
 import org.joda.time.DateTime
@@ -15,10 +15,10 @@ import play.api.libs.json._
 import scala.concurrent.duration.Duration
 
 case class UserIpAddress(
-    id: Option[Id[UserIpAddress]],
-    createdAt: DateTime,
-    updatedAt: DateTime,
-    state: State[UserIpAddress],
+    id: Option[Id[UserIpAddress]] = None,
+    createdAt: DateTime = currentDateTime,
+    updatedAt: DateTime = currentDateTime,
+    state: State[UserIpAddress] = UserIpAddressStates.ACTIVE,
     userId: Id[User],
     ipAddress: IpAddress,
     // TODO: Turn agentType into an Enum?


### PR DESCRIPTION
Shortened the cache lifetimes
Added an external API call to look up ip geolocation info
    ((TODO: maybe cache the geolocation data))
Added a framework for using heuristics to filter down ip cluster reports
Tried to add a few more guards against the (extremely persistent!) accidental
    multiple reports for a single IP

@eishay @andrewconner @camhashemi 
