### PR TITLE
versioned graph directory

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -351,7 +351,6 @@ object LibrarySpace {
 
   def apply(ownerId: Id[User], organizationId: Option[Id[Organization]]): LibrarySpace = organizationId.map(OrganizationSpace(_)) getOrElse UserSpace(ownerId)
 
-
   def prettyPrint(space: LibrarySpace): String = space match {
     case OrganizationSpace(orgId) => s"organization $orgId"
     case UserSpace(userId) => s"user $userId"

--- a/kifi-backend/modules/graph/app/com/keepit/graph/manager/GraphVersion.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/manager/GraphVersion.scala
@@ -1,0 +1,17 @@
+package com.keepit.graph.manager
+
+import com.keepit.common.zookeeper.ServiceDiscovery
+
+case class GraphVersion(value: Int) {
+  require(value >= 0)
+
+  def dirSuffix = if (value == 0) "" else s"_v$value"
+}
+
+object GraphVersion {
+  private val activeVersion = GraphVersion(0)
+  private val backupVersion = GraphVersion(0)
+
+  def getVersionByStatus(service: ServiceDiscovery): GraphVersion = if (service.hasBackupCapability) backupVersion else activeVersion
+  def getVersionsForCleanup(): Seq[GraphVersion] = (0 until activeVersion.value).map { v => GraphVersion(v) }
+}


### PR DESCRIPTION
@leogrim 

on deploy, this should do nothing. 

We need to config elb so that a backup machine will not get traffic (as it can build different graphs). This is the same as versioning in search. (cortex has a different version management) 
