### PR TITLE
Safer org creation through the controller

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
@@ -76,23 +76,25 @@ sealed abstract class OrganizationRequest
 
 @json
 case class OrganizationCreateRequest(
-  userId: Id[User],
-  orgName: String) extends OrganizationRequest
+  requesterId: Id[User],
+  orgName: String,
+  orgDescription: Option[String] = None) extends OrganizationRequest
+
 @json
 case class OrganizationCreateResponse(request: OrganizationCreateRequest, newOrg: Organization)
 
 @json
 case class OrganizationModifyRequest(
-  orgId: Id[Organization],
   requesterId: Id[User],
+  orgId: Id[Organization],
   modifications: OrganizationModifications) extends OrganizationRequest
 @json
 case class OrganizationModifyResponse(request: OrganizationModifyRequest, modifiedOrg: Organization)
 
 @json
 case class OrganizationDeleteRequest(
-  orgId: Id[Organization],
-  requesterId: Id[User]) extends OrganizationRequest
+  requesterId: Id[User],
+  orgId: Id[Organization]) extends OrganizationRequest
 @json
 case class OrganizationDeleteResponse(request: OrganizationDeleteRequest)
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
@@ -13,7 +13,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
         val orgCommander = inject[OrganizationCommander]
         val orgMembershipRepo = inject[OrganizationMembershipRepo]
 
-        val response = orgCommander.createOrganization(OrganizationCreateRequest(userId = Id[User](1), "Kifi"))
+        val response = orgCommander.createOrganization(OrganizationCreateRequest(requesterId = Id[User](1), "Kifi"))
         response must haveClass[Right[OrganizationFail, OrganizationCreateResponse]]
         val org = response.right.get.newOrg
 
@@ -30,7 +30,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
         val orgCommander = inject[OrganizationCommander]
         val orgMembershipRepo = inject[OrganizationMembershipRepo]
 
-        val createResponse = orgCommander.createOrganization(OrganizationCreateRequest(userId = Id[User](1), "Kifi"))
+        val createResponse = orgCommander.createOrganization(OrganizationCreateRequest(requesterId = Id[User](1), "Kifi"))
         createResponse must haveClass[Right[OrganizationFail, OrganizationCreateResponse]]
         val org = createResponse.right.get.newOrg
 
@@ -68,7 +68,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
         val orgMembershipRepo = inject[OrganizationMembershipRepo]
         val orgMembershipCommander = inject[OrganizationMembershipCommander]
 
-        val createResponse = orgCommander.createOrganization(OrganizationCreateRequest(userId = Id[User](1), "Kifi"))
+        val createResponse = orgCommander.createOrganization(OrganizationCreateRequest(requesterId = Id[User](1), "Kifi"))
         createResponse must haveClass[Right[OrganizationFail, OrganizationCreateResponse]]
         val org = createResponse.right.get.newOrg
 
@@ -108,7 +108,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
         val orgCommander = inject[OrganizationCommander]
         val orgMembershipRepo = inject[OrganizationMembershipRepo]
 
-        val createResponse = orgCommander.createOrganization(OrganizationCreateRequest(userId = Id[User](1), "Kifi"))
+        val createResponse = orgCommander.createOrganization(OrganizationCreateRequest(requesterId = Id[User](1), "Kifi"))
         createResponse must haveClass[Right[OrganizationFail, OrganizationCreateResponse]]
         val org = createResponse.right.get.newOrg
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
@@ -110,8 +110,8 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
         withDb(controllerTestModules: _*) { implicit injector =>
           val user = db.readWrite { implicit session => UserFactory.user().withName("foo", "bar").saved }
 
-          val createRequest = OrganizationCreateRequest(userId = user.id.get, orgName = "Banana Capital, USA")
-          val createRequestJson = Json.toJson(createRequest)
+          val createRequest = OrganizationCreateRequest(requesterId = user.id.get, orgName = "Banana Capital, USA", orgDescription = Some("Fun for the whole family"))
+          val createRequestJson = Json.parse("""{"name": "Banana Capital, USA", "description": "Fun for the whole family"}""")
 
           inject[FakeUserActionsHelper].setUser(user)
           val request = route.createOrganization().withBody(createRequestJson)


### PR DESCRIPTION
The controller now uses the user request to get the user id instead of
trusting the user to provide it

@Colin-Lane @DerekBurch @jaredpetker @leogrim 
