### PR TITLE
Cleaned up the input/output for org creation

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
@@ -33,6 +33,7 @@ case class Organization(
   override def withUpdateTime(now: DateTime): Organization = this.copy(updatedAt = now)
   def withState(newState: State[Organization]): Organization = this.copy(state = newState)
   def withName(newName: String): Organization = this.copy(name = newName)
+  def withDescription(newDescription: Option[String]): Organization = this.copy(description = newDescription)
   def withBasePermissions(newBasePermissions: BasePermissions): Organization = this.copy(basePermissions = newBasePermissions)
 
   def getNonmemberPermissions = basePermissions.forNonmember

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
@@ -23,7 +23,7 @@ case class OrganizationNotificationInfo(
   image: Option[OrganizationImageInfo])
 
 @json
-case class FullOrganizationInfo(handle: OrganizationHandle, name: String, description: Option[String], avatarPath: Option[ImagePath], members: Seq[ExternalId[User]],
+case class FullOrganizationInfo(pubId: PublicId[Organization], handle: OrganizationHandle, name: String, description: Option[String], avatarPath: Option[ImagePath], members: Seq[ExternalId[User]],
   memberCount: Int, publicLibraries: Int, organizationLibraries: Int, secretLibraries: Int)
 
 object OrganizationNotificationInfo {
@@ -69,16 +69,16 @@ case class OrganizationMembershipRemoveResponse(request: OrganizationMembershipR
 
 @json
 case class OrganizationModifications(
-  newName: Option[String] = None,
-  newBasePermissions: Option[BasePermissions] = None)
+  name: Option[String] = None,
+  description: Option[String] = None,
+  basePermissions: Option[BasePermissions] = None)
 
 sealed abstract class OrganizationRequest
 
 @json
 case class OrganizationCreateRequest(
   requesterId: Id[User],
-  orgName: String,
-  orgDescription: Option[String] = None) extends OrganizationRequest
+  initialValues: OrganizationModifications) extends OrganizationRequest
 
 @json
 case class OrganizationCreateResponse(request: OrganizationCreateRequest, newOrg: Organization)
@@ -109,6 +109,7 @@ object OrganizationFail {
   case object NOT_A_MEMBER extends OrganizationFail(UNAUTHORIZED, "not_a_member")
   case object NO_VALID_INVITATIONS extends OrganizationFail(FORBIDDEN, "no_valid_invitations")
   case object INVALID_PUBLIC_ID extends OrganizationFail(BAD_REQUEST, "invalid_public_id")
+  case object BAD_PARAMETERS extends OrganizationFail(BAD_REQUEST, "bad_parameters")
 
   def apply(str: String): OrganizationFail = {
     str match {
@@ -117,6 +118,7 @@ object OrganizationFail {
       case NOT_A_MEMBER.message => NOT_A_MEMBER
       case NO_VALID_INVITATIONS.message => NO_VALID_INVITATIONS
       case INVALID_PUBLIC_ID.message => INVALID_PUBLIC_ID
+      case BAD_PARAMETERS.message => BAD_PARAMETERS
     }
   }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
@@ -104,7 +104,17 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
           val user = db.readWrite { implicit session => UserFactory.user().withName("foo", "bar").saved }
 
           inject[FakeUserActionsHelper].setUser(user)
-          val request = route.createOrganization().withBody(JsString("{i am really horrible at json}"))
+          val request = route.createOrganization().withBody(Json.parse("""{"asdf": "qwer"}"""))
+          val result = controller.createOrganization(request)
+          status(result) === BAD_REQUEST
+        }
+      }
+      "reject empty names" in {
+        withDb(controllerTestModules: _*) { implicit injector =>
+          val user = db.readWrite { implicit session => UserFactory.user().withName("foo", "bar").saved }
+
+          inject[FakeUserActionsHelper].setUser(user)
+          val request = route.createOrganization().withBody(Json.parse("""{"name": ""}"""))
           val result = controller.createOrganization(request)
           status(result) === BAD_REQUEST
         }


### PR DESCRIPTION
Now it takes in a JSON object with a bunch of optional fields (name required)
and returns the standard FullOrganizationInfo

@leogrim @Colin-Lane @DerekBurch @jaredpetker 
