### PR TITLE
Intern ArticleImage by url instead of uriId + S3 cleanup

### DIFF
--- a/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverManagerPlugin.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/manager/RoverManagerPlugin.scala
@@ -33,7 +33,7 @@ class RoverManagerPluginImpl @Inject() (
     scheduleTaskOnAllMachines(fetchingActor.system, 250 seconds, 5 minute, fetchingActor.ref, IfYouCouldJustGoAhead)
     scheduleTaskOnLeader(imageSchedulingActor.system, 300 seconds, 8 minute, imageSchedulingActor.ref, IfYouCouldJustGoAhead)
     scheduleTaskOnAllMachines(imageProcessingActor.system, 300 seconds, 5 minute, imageProcessingActor.ref, IfYouCouldJustGoAhead)
-    // scheduleTaskOnOneMachine(articleStoreMigrationActor.system, 400 seconds, 10 minutes, articleStoreMigrationActor.ref, IfYouCouldJustGoAhead, "Article Store Cleanup")
+    scheduleTaskOnOneMachine(articleStoreMigrationActor.system, 400 seconds, 10 minutes, articleStoreMigrationActor.ref, IfYouCouldJustGoAhead, "Article Store Cleanup")
   }
 
   override def onStop(): Unit = {

--- a/kifi-backend/modules/rover/app/com/keepit/rover/model/ArticleImageRepo.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/model/ArticleImageRepo.scala
@@ -79,13 +79,14 @@ class ArticleImageRepoImpl @Inject() (
     getByUrlAndKind(articleInfo.url, articleInfo.articleKind)
   }
 
-  private def getByUriAndKindAndImageHash[A <: Article](uriId: Id[NormalizedURI], kind: ArticleKind[A], imageHash: ImageHash)(implicit session: RSession): Option[ArticleImage] = {
-    val q = (for (r <- rows if r.uriId === uriId && r.kind === kind.typeCode && r.imageHash === imageHash) yield r)
+  private def getByUrlAndKindAndImageHash[A <: Article](url: String, kind: ArticleKind[A], imageHash: ImageHash)(implicit session: RSession): Option[ArticleImage] = {
+    val urlHash = UrlHash.hashUrl(url)
+    val q = (for (r <- rows if r.urlHash === urlHash && r.url === url && r.kind === kind.typeCode && r.imageHash === imageHash) yield r)
     q.firstOption
   }
 
   def intern[A <: Article](url: String, uriId: Id[NormalizedURI], kind: ArticleKind[A], imageHash: ImageHash, imageUrl: String, version: ArticleVersion)(implicit session: RWSession): ArticleImage = {
-    getByUriAndKindAndImageHash(uriId, kind, imageHash) match {
+    getByUrlAndKindAndImageHash(url, kind, imageHash) match {
       case Some(existingImage) => {
         val updatedImage = existingImage.copy(state = ArticleImageStates.ACTIVE, imageUrl = imageUrl, version = version, fetchedAt = currentDateTime)
         save(updatedImage)

--- a/kifi-backend/modules/rover/app/com/keepit/rover/store/RoverUnderlyingArticleStore.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/store/RoverUnderlyingArticleStore.scala
@@ -21,7 +21,7 @@ private[store] class UriIdArticleStoreKey(key: ArticleKey[_]) extends ArticleSto
 }
 
 private[store] object UriIdArticleStoreKey {
-  implicit def apply[A <: Article](key: ArticleKey[A]): UriIdArticleStoreKey = new UriIdArticleStoreKey(key)
+  def apply[A <: Article](key: ArticleKey[A]): UriIdArticleStoreKey = new UriIdArticleStoreKey(key)
 }
 
 private[store] trait RoverUnderlyingArticleStore extends ObjectStore[ArticleStoreKey, Article]


### PR DESCRIPTION
@andrewconner @eishay we're off uriId in Rover, Shoebox shouldn't cause problems / crashes anymore
