### PR TITLE
Add domain-related admin pages

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
@@ -141,12 +141,11 @@ class SliderAdminController @Inject() (
   }
 
   def getDomain(hostname: String) = AdminUserPage { implicit request =>
-    val domain = db.readOnlyReplica { implicit s =>
+    val domainOpt = db.readOnlyReplica { implicit s =>
       domainRepo.get(hostname, None)
     }
-      // TODO this is for testing the form, remove for production
-      .orElse(Some(Domain(id = Some(Id(1)), hostname = hostname)))
-    domain.map { d => Ok(html.admin.domain(d)) }.getOrElse(NotFound)
+
+    domainOpt.map { domain => Ok(html.admin.domain(domain)) }.getOrElse(NotFound)
   }
 
   def getVersionForm = AdminUserPage { implicit request =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
@@ -159,7 +159,7 @@ class SliderAdminController @Inject() (
   def domainToggleEmailProvider(id: Id[Domain]) = AdminUserPage { implicit request =>
     val domain = db.readWrite { implicit s =>
       val domain = domainRepo.get(id)
-      val domainToggled = domain.copy(emailProvider = !domain.emailProvider) //domain
+      val domainToggled = domain.copy(isEmailProvider = !domain.isEmailProvider) //domain
       domainRepo.save(domainToggled)
     }
     Redirect(routes.SliderAdminController.getDomain(id))

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
@@ -136,6 +136,19 @@ class SliderAdminController @Inject() (
     Ok(JsObject(domainSensitiveMap map { case (s, b) => s -> JsBoolean(b) } toSeq))
   }
 
+  def findDomain = AdminUserPage { implicit request =>
+    Ok(html.admin.domainFind())
+  }
+
+  def getDomain(hostname: String) = AdminUserPage { implicit request =>
+    val domain = db.readOnlyReplica { implicit s =>
+      domainRepo.get(hostname, None)
+    }
+      // TODO this is for testing the form, remove for production
+      .orElse(Some(Domain(id = Some(Id(1)), hostname = hostname)))
+    domain.map { d => Ok(html.admin.domain(d)) }.getOrElse(NotFound)
+  }
+
   def getVersionForm = AdminUserPage { implicit request =>
     val details = kifiInstallationStore.getRaw()
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
@@ -136,16 +136,37 @@ class SliderAdminController @Inject() (
     Ok(JsObject(domainSensitiveMap map { case (s, b) => s -> JsBoolean(b) } toSeq))
   }
 
-  def findDomain = AdminUserPage { implicit request =>
+  def searchDomain = AdminUserPage { implicit request =>
     Ok(html.admin.domainFind())
   }
 
-  def getDomain(hostname: String) = AdminUserPage { implicit request =>
-    val domainOpt = db.readOnlyReplica { implicit s =>
+  def findDomainByHostname = AdminUserPage(parse.urlFormEncoded) { implicit request =>
+    val hostname = request.body.get("hostname").get.head
+    val domain = db.readOnlyReplica { implicit s =>
       domainRepo.get(hostname, None)
     }
 
-    domainOpt.map { domain => Ok(html.admin.domain(domain)) }.getOrElse(NotFound)
+    // TODO this is for testing the form with seed data, remove for production
+    val domainSeeded = domain.orElse(Some(Domain(id = Some(Id(1)), hostname = hostname, state = DomainStates.INACTIVE)))
+
+    domainSeeded.map { domain => Redirect(routes.SliderAdminController.getDomain(domain.id.get)) }.getOrElse(NotFound)
+  }
+
+  def getDomain(id: Id[Domain]) = AdminUserPage { implicit request =>
+    val domain = db.readOnlyReplica { implicit s =>
+      domainRepo.get(id)
+    }
+    Ok(html.admin.domain(domain))
+  }
+
+  def domainToggleEmailProvider(id: Id[Domain]) = AdminUserPage { implicit request =>
+    val domain = db.readWrite { implicit s =>
+      val domain = domainRepo.get(id)
+      // TODO waiting on email provider
+      val domainToggled = /*domain.withEmailProvider(!domain.emailProvider)*/ domain
+      domainRepo.save(domainToggled)
+    }
+    Redirect(routes.SliderAdminController.getDomain(id))
   }
 
   def getVersionForm = AdminUserPage { implicit request =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
@@ -145,11 +145,7 @@ class SliderAdminController @Inject() (
     val domain = db.readOnlyReplica { implicit s =>
       domainRepo.get(hostname, None)
     }
-
-    // TODO this is for testing the form with seed data, remove for production
-    val domainSeeded = domain.orElse(Some(Domain(id = Some(Id(1)), hostname = hostname, state = DomainStates.INACTIVE)))
-
-    domainSeeded.map { domain => Redirect(routes.SliderAdminController.getDomain(domain.id.get)) }.getOrElse(NotFound)
+    domain.map { domain => Redirect(routes.SliderAdminController.getDomain(domain.id.get)) }.getOrElse(NotFound)
   }
 
   def getDomain(id: Id[Domain]) = AdminUserPage { implicit request =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/SliderAdminController.scala
@@ -145,6 +145,7 @@ class SliderAdminController @Inject() (
     val domain = db.readOnlyReplica { implicit s =>
       domainRepo.get(hostname, None)
     }
+
     domain.map { domain => Redirect(routes.SliderAdminController.getDomain(domain.id.get)) }.getOrElse(NotFound)
   }
 
@@ -158,8 +159,7 @@ class SliderAdminController @Inject() (
   def domainToggleEmailProvider(id: Id[Domain]) = AdminUserPage { implicit request =>
     val domain = db.readWrite { implicit s =>
       val domain = domainRepo.get(id)
-      // TODO waiting on email provider
-      val domainToggled = /*domain.withEmailProvider(!domain.emailProvider)*/ domain
+      val domainToggled = domain.copy(emailProvider = !domain.emailProvider) //domain
       domainRepo.save(domainToggled)
     }
     Redirect(routes.SliderAdminController.getDomain(id))

--- a/kifi-backend/modules/shoebox/app/views/admin/admin.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/admin.scala.html
@@ -78,7 +78,7 @@
               <li><a href="@com.keepit.controllers.admin.routes.SliderAdminController.getPatterns">Automatic Engagement</a>
               <li><a href="@com.keepit.controllers.admin.routes.SliderAdminController.getDomainTags">Domain Tags</a>
               <li><a href="@com.keepit.controllers.admin.routes.SliderAdminController.getDomainOverrides">Domain Overrides</a>
-              <li><a href="@com.keepit.controllers.admin.routes.SliderAdminController.findDomain">Find Domain</a>
+              <li><a href="@com.keepit.controllers.admin.routes.SliderAdminController.searchDomain">Find Domain</a>
             </ul>
 
                <li class="dropdown">

--- a/kifi-backend/modules/shoebox/app/views/admin/admin.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/admin.scala.html
@@ -78,6 +78,7 @@
               <li><a href="@com.keepit.controllers.admin.routes.SliderAdminController.getPatterns">Automatic Engagement</a>
               <li><a href="@com.keepit.controllers.admin.routes.SliderAdminController.getDomainTags">Domain Tags</a>
               <li><a href="@com.keepit.controllers.admin.routes.SliderAdminController.getDomainOverrides">Domain Overrides</a>
+              <li><a href="@com.keepit.controllers.admin.routes.SliderAdminController.findDomain">Find Domain</a>
             </ul>
 
                <li class="dropdown">

--- a/kifi-backend/modules/shoebox/app/views/admin/domain.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/domain.scala.html
@@ -25,13 +25,11 @@
         <tr>
             <th>Email provider</th>
             <td>
-                <form class="domain-overrides" action="@com.keepit.controllers.admin.routes.SliderAdminController.domainToggleEmailProvider(domain.id.get)" method="POST">
-                    @*TODO uncomment to fill in with actual data*@
-                    @* @domain.emailProvider *@
+                <form class="domain-overrides" action="@com.keepit.controllers.admin.routes.SliderAdminController.domainToggleEmailProvider(domain.id.get)" method="POST"
+                    @domain.emailProvider
                     true
                     <button type="submit" class="btn btn-default btn-small">
-                        @* @if(domain.emailProvider) { *@
-                        @if(true) {
+                        @if(domain.emailProvider) {
                             Make email provider
                         } else {
                             Un-make email provider

--- a/kifi-backend/modules/shoebox/app/views/admin/domain.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/domain.scala.html
@@ -26,13 +26,12 @@
             <th>Email provider</th>
             <td>
                 <form class="domain-overrides" action="@com.keepit.controllers.admin.routes.SliderAdminController.domainToggleEmailProvider(domain.id.get)" method="POST"
-                    @domain.emailProvider
-                    true
+                    @domain.isEmailProvider
                     <button type="submit" class="btn btn-default btn-small">
-                        @if(domain.emailProvider) {
-                            Make email provider
-                        } else {
+                        @if(domain.isEmailProvider) {
                             Un-make email provider
+                        } else {
+                            Make email provider
                         }
                     </button>
                 </form>

--- a/kifi-backend/modules/shoebox/app/views/admin/domain.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/domain.scala.html
@@ -1,55 +1,50 @@
 @(domain: com.keepit.classify.Domain)(implicit request: com.keepit.common.controller.UserRequest[_])
 
 @admin("View Domain", stylesheets = List("admin_slider")) {
-    <form class="domain-overrides" action="@* insert POST route here *@" method="POST">
-        <table class="table table-bordered">
-            <tr>
-                <th>ID</th><td>@domain.id.get.id</td>
-            </tr>
-            <tr>
-                <th>Hostname</th><td>@domain.hostname</td>
-            </tr>
-            <tr>
-                <th>Auto Sensitive</th><td>@domain.autoSensitive.getOrElse(false)</td>
-            </tr>
-            <tr>
-                <th>Manual Sensitive</th><td>@domain.manualSensitive.getOrElse(false)</td>
-            </tr>
-            <tr>
-                <th>State (active?)</th>
-                <td>
-                    <label>
-                        <input type="checkbox" name="state" class="checkbox modifies-form" @if(domain.isActive) {
-                            checked="checked" }>
-                        @domain.state.value
-                    </label>
-                </td>
-            </tr>
-            <tr>
-                <th>Email provider?</th>
-                <td>
-                    <label>
-                        <input type="checkbox" name="emailProvider" class="checkbox modifies-form" checked="checked">
-                        <!-- TODO fill with actual email provider -->
-                        true
-                    </label>
-                </td>
-            </tr>
-            <tr>
-                <th>Created At</th><td>@adminHelper.dateTimeDisplay(domain.createdAt)</td>
-            </tr>
-            <tr>
-                <th>Updated At</th><td>@adminHelper.dateTimeDisplay(domain.updatedAt)</td>
-            </tr>
-        </table>
-        <button type="submit" class="btn btn-primary">Save Changes</button>
-        <span class="unsaved-changes"></span>
-    </form>
+    <table class="table table-bordered">
+        <tr>
+            <th>ID</th><td>@domain.id.get.id</td>
+        </tr>
+        <tr>
+            <th>Hostname</th><td>@domain.hostname</td>
+        </tr>
+        <tr>
+            <th>Auto Sensitive</th><td>@domain.autoSensitive.getOrElse(false)</td>
+        </tr>
+        <tr>
+            <th>Manual Sensitive</th><td>@domain.manualSensitive.getOrElse(false)</td>
+        </tr>
+        <tr>
+            <th>State (active?)</th>
+            <td>
+                <label>
+                    @domain.state.value
+                </label>
+            </td>
+        </tr>
+        <tr>
+            <th>Email provider</th>
+            <td>
+                <form class="domain-overrides" action="@com.keepit.controllers.admin.routes.SliderAdminController.domainToggleEmailProvider(domain.id.get)" method="POST">
+                    @*TODO uncomment to fill in with actual data*@
+                    @* @domain.emailProvider *@
+                    true
+                    <button type="submit" class="btn btn-default btn-small">
+                        @* @if(domain.emailProvider) { *@
+                        @if(true) {
+                            Make email provider
+                        } else {
+                            Un-make email provider
+                        }
+                    </button>
+                </form>
+            </td>
+        </tr>
+        <tr>
+            <th>Created At</th><td>@adminHelper.dateTimeDisplay(domain.createdAt)</td>
+        </tr>
+        <tr>
+            <th>Updated At</th><td>@adminHelper.dateTimeDisplay(domain.updatedAt)</td>
+        </tr>
+    </table>
 }
-<script>
-$(function () {
-    $('.modifies-form').on('change', function () {
-        $('.unsaved-changes').html('(Unsaved Changes)')
-    })
-});
-</script>

--- a/kifi-backend/modules/shoebox/app/views/admin/domain.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/domain.scala.html
@@ -1,0 +1,55 @@
+@(domain: com.keepit.classify.Domain)(implicit request: com.keepit.common.controller.UserRequest[_])
+
+@admin("View Domain", stylesheets = List("admin_slider")) {
+    <form class="domain-overrides" action="@* insert POST route here *@" method="POST">
+        <table class="table table-bordered">
+            <tr>
+                <th>ID</th><td>@domain.id.get.id</td>
+            </tr>
+            <tr>
+                <th>Hostname</th><td>@domain.hostname</td>
+            </tr>
+            <tr>
+                <th>Auto Sensitive</th><td>@domain.autoSensitive.getOrElse(false)</td>
+            </tr>
+            <tr>
+                <th>Manual Sensitive</th><td>@domain.manualSensitive.getOrElse(false)</td>
+            </tr>
+            <tr>
+                <th>State (active?)</th>
+                <td>
+                    <label>
+                        <input type="checkbox" name="state" class="checkbox modifies-form" @if(domain.isActive) {
+                            checked="checked" }>
+                        @domain.state.value
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <th>Email provider?</th>
+                <td>
+                    <label>
+                        <input type="checkbox" name="emailProvider" class="checkbox modifies-form" checked="checked">
+                        <!-- TODO fill with actual email provider -->
+                        true
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <th>Created At</th><td>@adminHelper.dateTimeDisplay(domain.createdAt)</td>
+            </tr>
+            <tr>
+                <th>Updated At</th><td>@adminHelper.dateTimeDisplay(domain.updatedAt)</td>
+            </tr>
+        </table>
+        <button type="submit" class="btn btn-primary">Save Changes</button>
+        <span class="unsaved-changes"></span>
+    </form>
+}
+<script>
+$(function () {
+    $('.modifies-form').on('change', function () {
+        $('.unsaved-changes').html('(Unsaved Changes)')
+    })
+});
+</script>

--- a/kifi-backend/modules/shoebox/app/views/admin/domainFind.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/domainFind.scala.html
@@ -1,0 +1,11 @@
+@()(implicit request: com.keepit.common.controller.UserRequest[_])
+
+@admin("Find Domain", stylesheets = List("admin_slider")) {
+    <form action="/admin/slider/domain" method="GET" class="form-inline">
+        <div class="form-group">
+            <label for="hostname" class="control-label">Domain hostname</label>
+            <input type="text" name="hostname" class="form-control" placeholder="Hostname">
+        </div>
+        <button type="submit" class="btn btn-primary">Find by hostname</button>
+    </form>
+}

--- a/kifi-backend/modules/shoebox/app/views/admin/domainFind.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/domainFind.scala.html
@@ -1,7 +1,7 @@
 @()(implicit request: com.keepit.common.controller.UserRequest[_])
 
 @admin("Find Domain", stylesheets = List("admin_slider")) {
-    <form action="/admin/slider/domain" method="GET" class="form-inline">
+    <form action="@com.keepit.controllers.admin.routes.SliderAdminController.findDomainByHostname" method="POST" class="form-inline">
         <div class="form-group">
             <label for="hostname" class="control-label">Domain hostname</label>
             <input type="text" name="hostname" class="form-control" placeholder="Hostname">

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -724,8 +724,10 @@ GET     /admin/slider/domainTags    @com.keepit.controllers.admin.SliderAdminCon
 POST    /admin/slider/domainTags    @com.keepit.controllers.admin.SliderAdminController.saveDomainTags
 GET     /admin/slider/domains       @com.keepit.controllers.admin.SliderAdminController.getDomainOverrides
 POST    /admin/slider/domains       @com.keepit.controllers.admin.SliderAdminController.saveDomainOverrides
-GET     /admin/slider/findDomain    @com.keepit.controllers.admin.SliderAdminController.findDomain
-GET     /admin/slider/domain        @com.keepit.controllers.admin.SliderAdminController.getDomain(hostname: String)
+GET     /admin/slider/domains/all    @com.keepit.controllers.admin.SliderAdminController.searchDomain
+POST    /admin/slider/domains/find    @com.keepit.controllers.admin.SliderAdminController.findDomainByHostname
+GET     /admin/slider/domains/:id   @com.keepit.controllers.admin.SliderAdminController.getDomain(id: Id[com.keepit.classify.Domain])
+POST    /admin/slider/domains/:id/toggleEmailProvider @com.keepit.controllers.admin.SliderAdminController.domainToggleEmailProvider(id: Id[com.keepit.classify.Domain])
 GET     /admin/slider/version       @com.keepit.controllers.admin.SliderAdminController.getVersionForm
 POST    /admin/slider/version       @com.keepit.controllers.admin.SliderAdminController.broadcastLatestVersion(ver: String)
 POST    /admin/slider/killVersion   @com.keepit.controllers.admin.SliderAdminController.killVersion(ver: String)

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -724,7 +724,7 @@ GET     /admin/slider/domainTags    @com.keepit.controllers.admin.SliderAdminCon
 POST    /admin/slider/domainTags    @com.keepit.controllers.admin.SliderAdminController.saveDomainTags
 GET     /admin/slider/domains       @com.keepit.controllers.admin.SliderAdminController.getDomainOverrides
 POST    /admin/slider/domains       @com.keepit.controllers.admin.SliderAdminController.saveDomainOverrides
-GET     /admin/slider/domains/all    @com.keepit.controllers.admin.SliderAdminController.searchDomain
+GET     /admin/slider/domains/find    @com.keepit.controllers.admin.SliderAdminController.searchDomain
 POST    /admin/slider/domains/find    @com.keepit.controllers.admin.SliderAdminController.findDomainByHostname
 GET     /admin/slider/domains/:id   @com.keepit.controllers.admin.SliderAdminController.getDomain(id: Id[com.keepit.classify.Domain])
 POST    /admin/slider/domains/:id/toggleEmailProvider @com.keepit.controllers.admin.SliderAdminController.domainToggleEmailProvider(id: Id[com.keepit.classify.Domain])

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -724,6 +724,8 @@ GET     /admin/slider/domainTags    @com.keepit.controllers.admin.SliderAdminCon
 POST    /admin/slider/domainTags    @com.keepit.controllers.admin.SliderAdminController.saveDomainTags
 GET     /admin/slider/domains       @com.keepit.controllers.admin.SliderAdminController.getDomainOverrides
 POST    /admin/slider/domains       @com.keepit.controllers.admin.SliderAdminController.saveDomainOverrides
+GET     /admin/slider/findDomain    @com.keepit.controllers.admin.SliderAdminController.findDomain
+GET     /admin/slider/domain        @com.keepit.controllers.admin.SliderAdminController.getDomain(hostname: String)
 GET     /admin/slider/version       @com.keepit.controllers.admin.SliderAdminController.getVersionForm
 POST    /admin/slider/version       @com.keepit.controllers.admin.SliderAdminController.broadcastLatestVersion(ver: String)
 POST    /admin/slider/killVersion   @com.keepit.controllers.admin.SliderAdminController.killVersion(ver: String)


### PR DESCRIPTION
_Do not merge_, depends on #15957 for completion

Adds views for finding domains by hostname (under `admin.SliderAdminController.findDomain`) and viewing/modifying an individual domain (under `admin.SliderAdminController.getDomain`).

Depends on #15957 to access the method to save changes to an individual domain.

@camhashemi 
@leogrim 
