### PR TITLE
Safer serialization, and tiny org views

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -14,9 +14,8 @@ import scala.util.{ Success, Failure, Try }
 
 @ImplementedBy(classOf[OrganizationCommanderImpl])
 trait OrganizationCommander {
-  def get(orgId: Id[Organization]): Organization
-  def getFullOrganizationInfo(orgId: Id[Organization]): FullOrganizationInfo
-  def getFullOrganizationInfos(orgIds: Seq[Id[Organization]]): Map[Id[Organization], FullOrganizationInfo]
+  def getOrganizationView(orgId: Id[Organization]): OrganizationView
+  def getOrganizationCards(orgIds: Seq[Id[Organization]]): Map[Id[Organization], OrganizationCard]
   def isValidRequest(request: OrganizationRequest)(implicit session: RSession): Boolean
   def createOrganization(request: OrganizationCreateRequest): Either[OrganizationFail, OrganizationCreateResponse]
   def modifyOrganization(request: OrganizationModifyRequest): Either[OrganizationFail, OrganizationModifyResponse]
@@ -35,34 +34,44 @@ class OrganizationCommanderImpl @Inject() (
     implicit val publicIdConfig: PublicIdConfiguration,
     handleCommander: HandleCommander) extends OrganizationCommander with Logging {
 
-  def get(orgId: Id[Organization]): Organization = db.readOnlyReplica { implicit session => orgRepo.get(orgId) }
+  def getOrganizationView(orgId: Id[Organization]): OrganizationView = {
+    db.readOnlyReplica { implicit session =>
+      val org = orgRepo.get(orgId)
+      val orgHandle = org.getHandle
+      val orgName = org.name
+      val description = org.description
 
-  private def getFullOrganizationInfoHelper(orgId: Id[Organization])(implicit session: RSession): FullOrganizationInfo = {
-    val org = get(orgId)
-    val pubId = Organization.publicId(orgId)
+      val members = orgMembershipRepo.getByOrgId(orgId, Limit(8), Offset(0)).map(_.userId)
+      val memberCount = orgMembershipRepo.countByOrgId(orgId)
+      val libraries = libraryRepo.countLibrariesForOrgByVisibility(orgId)
+
+      val avatarPath = organizationAvatarCommander.getBestImage(orgId, ImageSize(200, 200)).map(_.imagePath)
+
+      // TODO: actually find the number of libraries
+      val numPublicLibs = libraries(LibraryVisibility.PUBLISHED)
+      OrganizationView(orgId = orgId, handle = orgHandle, name = orgName, description = description, avatarPath = avatarPath, members = members,
+        numMembers = memberCount, numLibraries = numPublicLibs)
+    }
+  }
+
+  private def getOrganizationCardHelper(orgId: Id[Organization])(implicit session: RSession): OrganizationCard = {
+    val org = orgRepo.get(orgId)
     val orgHandle = org.getHandle
     val orgName = org.name
     val description = org.description
 
-    val members = orgMembershipRepo.getByOrgId(orgId, Limit(8), Offset(0)).map(_.userId)
-    val memberCount = orgMembershipRepo.countByOrgId(orgId)
+    val numMembers = orgMembershipRepo.countByOrgId(orgId)
     val libraries = libraryRepo.countLibrariesForOrgByVisibility(orgId)
 
     val avatarPath = organizationAvatarCommander.getBestImage(orgId, ImageSize(200, 200)).map(_.imagePath)
-    val publicLibs = libraries(LibraryVisibility.PUBLISHED)
-    val orgLibs = libraries(LibraryVisibility.ORGANIZATION)
-    val privLibs = libraries(LibraryVisibility.SECRET)
-    FullOrganizationInfo(orgId = orgId, handle = orgHandle, name = orgName, description = description, avatarPath = avatarPath, members = members,
-      memberCount = memberCount, publicLibraries = publicLibs, organizationLibraries = orgLibs, secretLibraries = privLibs)
-  }
 
-  def getFullOrganizationInfo(orgId: Id[Organization]): FullOrganizationInfo = {
-    db.readOnlyReplica { implicit session => getFullOrganizationInfoHelper(orgId) }
+    // TODO: actually find the number of libraries
+    val numPublicLibs = libraries(LibraryVisibility.PUBLISHED)
+    OrganizationCard(orgId = orgId, handle = orgHandle, name = orgName, description = description, avatarPath = avatarPath, numMembers = numMembers, numLibraries = numPublicLibs)
   }
-
-  def getFullOrganizationInfos(orgIds: Seq[Id[Organization]]): Map[Id[Organization], FullOrganizationInfo] = {
+  def getOrganizationCards(orgIds: Seq[Id[Organization]]): Map[Id[Organization], OrganizationCard] = {
     db.readOnlyReplica { implicit session =>
-      orgIds.map { orgId => orgId -> getFullOrganizationInfoHelper(orgId) }.toMap
+      orgIds.map { orgId => orgId -> getOrganizationCardHelper(orgId) }.toMap
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
@@ -30,6 +30,8 @@ object MaybeOrganizationMember {
 @ImplementedBy(classOf[OrganizationMembershipCommanderImpl])
 trait OrganizationMembershipCommander {
   def getMembersAndInvitees(orgId: Id[Organization], limit: Limit, offset: Offset, includeInvitees: Boolean): Seq[MaybeOrganizationMember]
+  def getOrganizationsForUser(userId: Id[User], limit: Limit, offset: Offset): Seq[Id[Organization]]
+  def getAllOrganizationsForUser(userId: Id[User]): Seq[Id[Organization]]
 
   def getPermissions(orgId: Id[Organization], userIdOpt: Option[Id[User]]): Set[OrganizationPermission]
   def isValidRequest(request: OrganizationMembershipRequest)(implicit session: RSession): Boolean
@@ -82,6 +84,17 @@ class OrganizationMembershipCommanderImpl @Inject() (
         case false => Seq.empty[OrganizationInvite]
       }
       buildMaybeMembers(members, invitees)
+    }
+  }
+
+  def getOrganizationsForUser(userId: Id[User], limit: Limit, offset: Offset): Seq[Id[Organization]] = {
+    db.readOnlyReplica { implicit session =>
+      organizationMembershipRepo.getByUserId(userId, limit, offset).map(_.organizationId)
+    }
+  }
+  def getAllOrganizationsForUser(userId: Id[User]): Seq[Id[Organization]] = {
+    db.readOnlyReplica { implicit session =>
+      organizationMembershipRepo.getAllByUserId(userId).map(_.organizationId)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
@@ -742,6 +742,9 @@ class UserCommander @Inject() (
   def getByExternalIds(externalIds: Seq[ExternalId[User]]): Map[ExternalId[User], User] = {
     db.readOnlyReplica { implicit session => userRepo.getAllUsersByExternalId(externalIds) }
   }
+  def getByExternalId(externalId: ExternalId[User]): User = {
+    db.readOnlyReplica { implicit session => userRepo.getAllUsersByExternalId(Seq(externalId)).values.head }
+  }
 
   def getAllFakeUsers(): Set[Id[User]] = {
     import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
@@ -5,10 +5,11 @@ import com.keepit.commanders._
 import com.keepit.common.controller._
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.db.ExternalId
+import com.keepit.common.store.{ S3ImageConfig, ImagePath }
 import com.keepit.heimdal.HeimdalContextBuilderFactory
 import com.keepit.model._
 import com.keepit.shoebox.controllers.OrganizationAccessActions
-import play.api.libs.json.{ JsError, JsSuccess, Json }
+import play.api.libs.json._
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Success, Failure }
@@ -17,13 +18,37 @@ import scala.util.{ Success, Failure }
 class MobileOrganizationController @Inject() (
     val orgCommander: OrganizationCommander,
     val orgMembershipCommander: OrganizationMembershipCommander,
+    userCommander: UserCommander,
     heimdalContextBuilder: HeimdalContextBuilderFactory,
     val userActionsHelper: UserActionsHelper,
+    implicit val imageConfig: S3ImageConfig,
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val executionContext: ExecutionContext) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
-  // TODO: add to commander:
-  // getOrganizationCard
+  private def serializeFullOrganizationInfo(fullInfo: FullOrganizationInfo): JsValue = {
+    Json.obj(
+      "id" -> Organization.publicId(fullInfo.orgId),
+      "handle" -> fullInfo.handle,
+      "name" -> fullInfo.name,
+      "description" -> fullInfo.description,
+      "avatarPath" -> fullInfo.avatarPath.map(_.getUrl),
+      "members" -> fullInfo.members,
+      "memberCount" -> fullInfo.memberCount,
+      "publicLibraries" -> fullInfo.publicLibraries,
+      "organizationLibraries" -> fullInfo.organizationLibraries,
+      "secretLibraries" -> fullInfo.secretLibraries
+    )
+  }
+  private def serializeTinyOrganizationInfo(tinyInfo: FullOrganizationInfo): JsValue = {
+    Json.obj(
+      "id" -> Organization.publicId(tinyInfo.orgId),
+      "handle" -> tinyInfo.handle,
+      "name" -> tinyInfo.name,
+      "avatarPath" -> tinyInfo.avatarPath.map(_.getUrl),
+      "memberCount" -> tinyInfo.memberCount,
+      "publicLibraries" -> tinyInfo.publicLibraries
+    )
+  }
 
   def createOrganization = UserAction(parse.tolerantJson) { request =>
     if (!request.experiments.contains(ExperimentType.ORGANIZATION)) BadRequest(Json.obj("error" -> "insufficient_permissions"))
@@ -37,7 +62,8 @@ class MobileOrganizationController @Inject() (
             case Left(failure) =>
               failure.asErrorResponse
             case Right(response) =>
-              Ok(Json.toJson(orgCommander.getFullOrganizationInfo(response.newOrg.id.get)))
+              val fullInfo = orgCommander.getFullOrganizationInfo(response.newOrg.id.get)
+              Ok(serializeFullOrganizationInfo(fullInfo))
           }
       }
     }
@@ -51,7 +77,9 @@ class MobileOrganizationController @Inject() (
           case Some(modifications) =>
             orgCommander.modifyOrganization(OrganizationModifyRequest(requesterId, request.orgId, modifications)) match {
               case Left(failure) => failure.asErrorResponse
-              case Right(response) => Ok(Json.toJson(orgCommander.getFullOrganizationInfo(request.orgId)))
+              case Right(response) =>
+                val fullInfo = orgCommander.getFullOrganizationInfo(response.modifiedOrg.id.get)
+                Ok(serializeFullOrganizationInfo(fullInfo))
             }
           case _ => OrganizationFail.BAD_PARAMETERS.asErrorResponse
         }
@@ -71,11 +99,13 @@ class MobileOrganizationController @Inject() (
   }
 
   def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
-    Ok(Json.toJson(orgCommander.getFullOrganizationInfo(request.orgId)))
+    Ok(serializeFullOrganizationInfo(orgCommander.getFullOrganizationInfo(request.orgId)))
   }
 
   def getOrganizationsForUser(extId: ExternalId[User]) = UserAction { request =>
-    // TODO: provide a Json thing for a bunch of OrganizationCards
-    Ok
+    val user = userCommander.getByExternalIds(Seq(extId)).values.head
+    val publicOrgs = orgMembershipCommander.getAllOrganizationsForUser(user.id.get)
+    val orgInfos = orgCommander.getFullOrganizationInfos(publicOrgs)
+    Ok(JsArray(orgInfos.values.toSeq.map(serializeTinyOrganizationInfo)))
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
@@ -22,8 +22,7 @@ case class OrganizationNotificationInfo(
   handle: Option[PrimaryOrganizationHandle],
   image: Option[OrganizationImageInfo])
 
-@json
-case class FullOrganizationInfo(pubId: PublicId[Organization], handle: OrganizationHandle, name: String, description: Option[String], avatarPath: Option[ImagePath], members: Seq[ExternalId[User]],
+case class FullOrganizationInfo(orgId: Id[Organization], handle: OrganizationHandle, name: String, description: Option[String], avatarPath: Option[ImagePath], members: Seq[Id[User]],
   memberCount: Int, publicLibraries: Int, organizationLibraries: Int, secretLibraries: Int)
 
 object OrganizationNotificationInfo {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
@@ -22,12 +22,15 @@ case class OrganizationNotificationInfo(
   handle: Option[PrimaryOrganizationHandle],
   image: Option[OrganizationImageInfo])
 
-case class FullOrganizationInfo(orgId: Id[Organization], handle: OrganizationHandle, name: String, description: Option[String], avatarPath: Option[ImagePath], members: Seq[Id[User]],
-  memberCount: Int, publicLibraries: Int, organizationLibraries: Int, secretLibraries: Int)
+case class OrganizationView(orgId: Id[Organization], handle: OrganizationHandle, name: String, description: Option[String], avatarPath: Option[ImagePath], members: Seq[Id[User]],
+  numMembers: Int, numLibraries: Int)
+
+case class OrganizationCard(orgId: Id[Organization], handle: OrganizationHandle, name: String, description: Option[String], avatarPath: Option[ImagePath],
+  numMembers: Int, numLibraries: Int)
 
 object OrganizationNotificationInfo {
   def fromOrganization(org: Organization, image: Option[OrganizationAvatar])(implicit config: PublicIdConfiguration): OrganizationNotificationInfo = {
-    OrganizationNotificationInfo(Organization.publicId(org.id.get), org.name, org.handle, image.map(OrganizationImageInfo.createInfo(_)))
+    OrganizationNotificationInfo(Organization.publicId(org.id.get), org.name, org.handle, image.map(OrganizationImageInfo.createInfo))
   }
 }
 

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -285,11 +285,11 @@ POST    /m/1/libraries/recos/feedback      @com.keepit.controllers.website.Libra
 POST    /m/1/content/flagUrl                @com.keepit.controllers.mobile.MobileUriController.flagContent()
 GET     /m/1/inviteInfo                     @com.keepit.controllers.website.InviteController.getGeneralInviteInfo()
 
-POST    /m/1/teams/:id/modify                   @com.keepit.controllers.mobile.MobileOrganizationController.deleteOrganization(id: PublicId[Organization])
 GET     /m/1/teams/:id                          @com.keepit.controllers.mobile.MobileOrganizationController.getOrganization(id: PublicId[Organization])
+GET     /m/1/user/:id/teams                     @com.keepit.controllers.mobile.MobileOrganizationController.getOrganizationsForUser(id: ExternalId[User])
 POST    /m/1/teams/create                       @com.keepit.controllers.mobile.MobileOrganizationController.createOrganization()
 POST    /m/1/teams/:id/modify                   @com.keepit.controllers.mobile.MobileOrganizationController.modifyOrganization(id: PublicId[Organization])
-GET     /m/1/user/:id/teams                     @com.keepit.controllers.mobile.MobileOrganizationController.getOrganizationsForUser(id: ExternalId[User])
+DELETE  /m/1/teams/:id/delete                   @com.keepit.controllers.mobile.MobileOrganizationController.deleteOrganization(id: PublicId[Organization])
 GET     /m/1/teams/:id/members                  @com.keepit.controllers.mobile.MobileOrganizationMembershipController.getMembers(id: PublicId[Organization], offset: Int ?= 0, limit: Int ?= 20)
 POST    /m/1/teams/:id/members/invite           @com.keepit.controllers.mobile.MobileOrganizationInviteController.inviteUsers(id: PublicId[Organization])
 POST    /m/1/teams/:id/members/invites/accept   @com.keepit.controllers.mobile.MobileOrganizationInviteController.acceptInvitation(id: PublicId[Organization], authToken: String)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
@@ -10,6 +10,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
   "organization commander" should {
     "create an organization" in {
       withDb() { implicit injector =>
+        val orgRepo = inject[OrganizationRepo]
         val orgCommander = inject[OrganizationCommander]
         val orgMembershipRepo = inject[OrganizationMembershipRepo]
 
@@ -18,7 +19,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
         createResponse must haveClass[Right[OrganizationFail, OrganizationCreateResponse]]
         val org = createResponse.right.get.newOrg
 
-        orgCommander.get(org.id.get) === org
+        db.readOnlyMaster { implicit session => orgRepo.get(org.id.get) } === org
         val memberships = db.readOnlyMaster { implicit session => orgMembershipRepo.getAllByOrgId(org.id.get) }
         memberships.length === 1
         memberships.head.userId === Id[User](1)
@@ -28,6 +29,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
 
     "modify an organization" in {
       withDb() { implicit injector =>
+        val orgRepo = inject[OrganizationRepo]
         val orgCommander = inject[OrganizationCommander]
         val orgMembershipRepo = inject[OrganizationMembershipRepo]
 
@@ -60,7 +62,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
         ownerModifyResponse.right.get.request === ownerModifyRequest
         ownerModifyResponse.right.get.modifiedOrg.name === "The view is nice from up here"
 
-        orgCommander.get(org.id.get) === ownerModifyResponse.right.get.modifiedOrg
+        db.readOnlyMaster { implicit session => orgRepo.get(org.id.get) } === ownerModifyResponse.right.get.modifiedOrg
       }
     }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
@@ -15,7 +15,7 @@ import com.keepit.model.UserFactoryHelper._
 import com.keepit.model._
 import com.keepit.test.ShoeboxTestInjector
 import org.specs2.mutable.Specification
-import play.api.libs.json.{ JsString, Json }
+import play.api.libs.json.{ JsObject, JsArray, JsString, Json }
 import play.api.mvc.{ Call, Result }
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -33,8 +33,25 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
   )
 
   "MobileOrganizationController" should {
-    "when getOrganization is called:" in {
-      "succeed with user that has view permissions" in {
+    "serve up organization views" in {
+      "fail on bad public id" in {
+        withDb(controllerTestModules: _*) { implicit injector =>
+          val (user, org) = db.readWrite { implicit session =>
+            val user = UserFactory.user().saved
+            val org = OrganizationFactory.organization().withOwner(user).saved
+            (user, org)
+          }
+
+          val publicId = PublicId[Organization]("2267")
+
+          inject[FakeUserActionsHelper].setUser(user, Set(ExperimentType.ORGANIZATION))
+          val request = route.getOrganization(publicId)
+          val response = controller.getOrganization(publicId)(request)
+
+          response === OrganizationFail.INVALID_PUBLIC_ID
+        }
+      }
+      "give an organization view to a user that has view permissions" in {
         withDb(controllerTestModules: _*) { implicit injector =>
           val (user, org) = db.readWrite { implicit session =>
             val user = UserFactory.user().saved
@@ -46,9 +63,7 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
             (user, org)
           }
 
-          implicit val config = inject[PublicIdConfiguration]
           val publicId = Organization.publicId(org.id.get)
-
           inject[FakeUserActionsHelper].setUser(user, Set(ExperimentType.ORGANIZATION))
           val request = route.getOrganization(publicId)
           val response = controller.getOrganization(publicId)(request)
@@ -57,28 +72,32 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
           val jsonResponse = Json.parse(contentAsString(response))
           (jsonResponse \ "name").as[String] === "Forty Two Kifis"
           (jsonResponse \ "handle").as[String] === "Kifi"
-          (jsonResponse \ "publicLibraries").as[Int] === 10
-          (jsonResponse \ "organizationLibraries").as[Int] === 15
-          (jsonResponse \ "secretLibraries").as[Int] === 20
+          (jsonResponse \ "numLibraries").as[Int] === 10
         }
       }
-
-      "fail on bad public id" in {
+    }
+    "serve up organization cards" in {
+      "give a user a list of organizations they belong to" in {
         withDb(controllerTestModules: _*) { implicit injector =>
-          val (user, org) = db.readWrite { implicit session =>
+          val user = db.readWrite { implicit session =>
             val user = UserFactory.user().saved
-            val org = OrganizationFactory.organization().withOwner(user).saved
-            (user, org)
+            for (i <- 1 to 10) {
+              val org = OrganizationFactory.organization().withOwner(user).withName("Justice League").saved
+              LibraryFactory.libraries(i).map(_.published().withOrganization(org.id)).saved
+            }
+            user
           }
 
-          implicit val config = inject[PublicIdConfiguration]
-          val publicId = PublicId[Organization]("2267")
-
           inject[FakeUserActionsHelper].setUser(user, Set(ExperimentType.ORGANIZATION))
-          val request = route.getOrganization(publicId)
-          val response = controller.getOrganization(publicId)(request)
+          val request = route.getOrganizationsForUser(user.externalId)
+          val response = controller.getOrganizationsForUser(user.externalId)(request)
+          status(response) === OK
 
-          response === OrganizationFail.INVALID_PUBLIC_ID
+          val jsonResponse = Json.parse(contentAsString(response))
+          jsonResponse must haveClass[JsArray]
+          val cards = jsonResponse.as[Seq[JsObject]]
+          cards.foreach { card => (card \ "name").as[String] === "Justice League" }
+          cards.map { card => (card \ "numLibraries").as[Int] }.toSet === (1 to 10).toSet
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
@@ -133,10 +133,8 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
           status(result) === OK
 
           val createResponseJson = Json.parse(contentAsString(result))
-          val createResponse = createResponseJson.as[FullOrganizationInfo]
-          Organization.decodePublicId(createResponse.pubId) must haveClass[Success[Id[Organization]]]
-          createResponse.name === orgName
-          createResponse.description === Some(orgDescription)
+          (createResponseJson \ "name").as[String] === orgName
+          (createResponseJson \ "description").as[Option[String]] === Some(orgDescription)
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationMembershipRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationMembershipRepoTest.scala
@@ -64,7 +64,7 @@ class OrganizationMembershipRepoTest extends Specification with ShoeboxTestInjec
           orgs
         }
 
-        val memberships = db.readOnlyMaster { implicit session => orgMemberRepo.getByUserId(Id[User](1)) }
+        val memberships = db.readOnlyMaster { implicit session => orgMemberRepo.getAllByUserId(Id[User](1)) }
         memberships.length === orgs.length
         memberships.map(_.organizationId).diff(orgs.map(_.id.get)) === List.empty[Id[Organization]]
       }


### PR DESCRIPTION
Serialization is now explicitly specified for the MobileOrganizationController
and it also knows how to serve up an entire list of a user's organizations

@jaredpetker @DerekBurch @leogrim @Colin-Lane 
