### PR TITLE
Added a JsObject key-based json formatter

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
@@ -5,6 +5,49 @@ import play.api.data.validation.ValidationError
 
 package object json {
 
+  object KeyFormat {
+    def key1Reads[A](strA: String)(implicit aReads: Reads[A]): Reads[A] = Reads[A] {
+      case obj: JsObject => for {
+        a <- aReads.reads(obj \ strA)
+      } yield a
+      case _ => JsError(Seq(JsPath() -> Seq(ValidationError(s"Expected a JsObject"))))
+    }
+    def key1Writes[A](strA: String)(implicit aWrites: Writes[A]): Writes[(A)] = Writes[(A)] {
+      tup: (A) => JsObject(Seq(strA -> aWrites.writes(tup)))
+    }
+    def key1Format[A](strA: String)(implicit aFormat: Format[A]): Format[(A)] = {
+      Format(key1Reads[A](strA), key1Writes[A](strA))
+    }
+
+    def key2Reads[A, B](strA: String, strB: String)(implicit aReads: Reads[A], bReads: Reads[B]): Reads[(A, B)] = Reads[(A, B)] {
+      case obj: JsObject => for {
+        a <- aReads.reads(obj \ strA)
+        b <- bReads.reads(obj \ strB)
+      } yield (a, b)
+      case _ => JsError(Seq(JsPath() -> Seq(ValidationError(s"Expected a JsObject"))))
+    }
+    def key2Writes[A, B](strA: String, strB: String)(implicit aWrites: Writes[A], bWrites: Writes[B]): Writes[(A, B)] = Writes[(A, B)] {
+      tup: (A, B) => JsObject(Seq(strA -> aWrites.writes(tup._1), strB -> bWrites.writes(tup._2)))
+    }
+    def key2Format[A, B](strA: String, strB: String)(implicit aFormat: Format[A], bFormat: Format[B]): Format[(A, B)] = {
+      Format(key2Reads[A, B](strA, strB), key2Writes[A, B](strA, strB))
+    }
+
+    def key3Reads[A, B, C](strA: String, strB: String, strC: String)(implicit aReads: Reads[A], bReads: Reads[B], cReads: Reads[C]): Reads[(A, B, C)] = Reads[(A, B, C)] {
+      case obj: JsObject => for {
+        a <- aReads.reads(obj \ strA)
+        b <- bReads.reads(obj \ strB)
+        c <- cReads.reads(obj \ strC)
+      } yield (a, b, c)
+      case _ => JsError(Seq(JsPath() -> Seq(ValidationError(s"Expected a JsObject"))))
+    }
+    def key3Writes[A, B, C](strA: String, strB: String, strC: String)(implicit aWrites: Writes[A], bWrites: Writes[B], cWrites: Writes[C]): Writes[(A, B, C)] = Writes[(A, B, C)] {
+      tup: (A, B, C) => JsObject(Seq(strA -> aWrites.writes(tup._1), strB -> bWrites.writes(tup._2), strC -> cWrites.writes(tup._3)))
+    }
+    def key3Format[A, B, C](strA: String, strB: String, strC: String)(implicit aFormat: Format[A], bFormat: Format[B], cFormat: Format[C]): Format[(A, B, C)] = {
+      Format(key3Reads[A, B, C](strA, strB, strC), key3Writes[A, B, C](strA, strB, strC))
+    }
+  }
   object TupleFormat {
     /* Inspired from https://coderwall.com/p/orci8g */
     implicit def tuple2Reads[A, B](implicit aReads: Reads[A], bReads: Reads[B]): Reads[(A, B)] = Reads[(A, B)] {
@@ -15,11 +58,11 @@ package object json {
       case _ => JsError(Seq(JsPath() -> Seq(ValidationError("Expected array of two elements"))))
     }
 
-    implicit def tuple2Writes[A, B](implicit aWrites: Writes[A], bWrites: Writes[B]): Writes[(A, B)] = new Writes[(A, B)] {
-      def writes(tuple: (A, B)) = JsArray(Seq(aWrites.writes(tuple._1), bWrites.writes(tuple._2)))
+    implicit def tuple2Writes[A, B](implicit aWrites: Writes[A], bWrites: Writes[B]): Writes[(A, B)] = Writes[(A, B)] {
+      tup: (A, B) => JsArray(Seq(aWrites.writes(tup._1), bWrites.writes(tup._2)))
     }
 
-    implicit def tuple2Format[A, B](implicit aReads: Format[A], bReads: Format[B]): Format[(A, B)] = {
+    implicit def tuple2Format[A, B](implicit aFormat: Format[A], bFormat: Format[B]): Format[(A, B)] = {
       Format(tuple2Reads[A, B], tuple2Writes[A, B])
     }
 
@@ -36,7 +79,7 @@ package object json {
       def writes(tuple: (A, B, C)) = JsArray(Seq(aWrites.writes(tuple._1), bWrites.writes(tuple._2), cWrites.writes(tuple._3)))
     }
 
-    implicit def tuple3Format[A, B, C](implicit aReads: Format[A], bReads: Format[B], cReads: Format[C]): Format[(A, B, C)] = {
+    implicit def tuple3Format[A, B, C](implicit aFormat: Format[A], bFormat: Format[B], cFormat: Format[C]): Format[(A, B, C)] = {
       Format(tuple3Reads[A, B, C], tuple3Writes[A, B, C])
     }
   }


### PR DESCRIPTION
Example use: deserializing
    `val input = """[ {"name": "Alice", "age": 24},
                        {"name": "Bob", "age": 42} ]"""`

The format you want is `tuple2KeyFormat`, so something like
`val format = tuple2KeyFormat[String, Int]("name", "age")`
`val info: Seq[(String,Int)] = Json.parse(input).as[Seq[(String, Int)]](format)`
