### PR TITLE
Add Airbrake reporting for before and after Angular loads

### DIFF
--- a/kifi-backend/modules/shoebox/angular/bower.json
+++ b/kifi-backend/modules/shoebox/angular/bower.json
@@ -32,7 +32,8 @@
     "jquery-mousewheel": "3.1.12",
     "lodash": "2.4.1",
     "normalize-css": "2.1.3",
-    "underscore.string": "2.3.3"
+    "underscore.string": "2.3.3",
+    "airbrake-js-client": "~0.4.3"
   },
   "devDependencies": {
     "angular-mocks": "~1.3.15"

--- a/kifi-backend/modules/shoebox/angular/dev.html
+++ b/kifi-backend/modules/shoebox/angular/dev.html
@@ -19,6 +19,23 @@
   mixpanel.init("abb7e1226370392c849ec16fadff2584");*/
 </script>
 <script src="/dist/lib.js"></script>
+<!--
+<script>
+  // Uncomment this script to test the Airbrake reporting functionality
+  window.Airbrake = new airbrakeJs.Client({ projectId: '113130', projectKey: '67e9f4bb3c4fbd7d96e1f81a24e6d374' });
+
+  // Configure vanilla JS client-side error reporting.
+  Airbrake.setEnvironmentName('development');
+  window.onerror = _.debounce(function (message, filename, lineno, colno, error) {
+    Airbrake.push({
+      error: {
+        message: error.toString(),
+        stack: error.stack
+      }
+    });
+  }, 5000, true);
+</script>
+ -->
 <script src="/dist/kifi.js"></script>
 <script>angular.bootstrap(document, ['kifi']);</script>
 <script>

--- a/kifi-backend/modules/shoebox/angular/gulpfile.js
+++ b/kifi-backend/modules/shoebox/angular/gulpfile.js
@@ -90,6 +90,7 @@ var libJsFiles = [
   ['lib/jquery/dist/jquery.js', 'lib/jquery/dist/jquery.min.js'],
   ['lib/angular/angular.js', 'lib/angular/angular.min.js'],
   ['lib/angular-cookies/angular-cookies.js', 'lib/angular-cookies/angular-cookies.min.js'],
+  ['lib/airbrake-js-client/dist/client.js', 'lib/airbrake-js-client/dist/client.min.js'],
   ['lib/angular-resource/angular-resource.js', 'lib/angular-resource/angular-resource.min.js'],
   ['lib/angular-sanitize/angular-sanitize.js', 'lib/angular-sanitize/angular-sanitize.min.js'],
   ['lib/angular-animate/angular-animate.js', 'lib/angular-animate/angular-animate.min.js'],

--- a/kifi-backend/modules/shoebox/angular/index.html
+++ b/kifi-backend/modules/shoebox/angular/index.html
@@ -19,6 +19,20 @@
   mixpanel.init("cff752ff16ee39eda30ae01bb6fa3bd6");
 </script>
 <script src="/dist/lib.min.js"></script>
+<script>
+  window.Airbrake = new airbrakeJs.Client({ projectId: '113130', projectKey: '67e9f4bb3c4fbd7d96e1f81a24e6d374' });
+
+  // Configure vanilla JS client-side error reporting.
+  Airbrake.setEnvironmentName('production');
+  window.onerror = _.debounce(function (message, filename, lineno, colno, error) {
+    Airbrake.push({
+      error: {
+        message: error.toString(),
+        stack: error.stack
+      }
+    });
+  }, 5000, true);
+</script>
 <script src="/dist/kifi.min.js"></script>
 <script>angular.bootstrap(document, ['kifi']);</script>
 <script>

--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -82,6 +82,26 @@ angular.module('kifi', [
   }
 ])
 
+.factory('$exceptionHandler', [
+  '$injector', '$window', '$log',
+  function ($injector, $window, $log) {
+    function log(exception) {
+      if ($window.Airbrake) {
+        $window.Airbrake.push({
+          error: {
+            message: exception.toString(),
+            stack: exception.stack
+          }
+        });
+      } else {
+        $log.error(exception);
+      }
+    }
+
+    return _.debounce(log, 5000, true);
+  }]
+)
+
 .controller('AppCtrl', [
   '$scope', '$rootScope', '$rootElement', '$window', '$timeout', '$log', '$analytics', '$location', '$state',
   'profileService', 'platformService', 'libraryService',


### PR DESCRIPTION
@andrewconner @ajkochanowicz 

I decided against using the ngHelperAirbrake because it was just a very thin wrapper that didn't provide enough functionality to justify the extra dependency.

It debounces for 5 seconds, but that's open to change. 
