### PR TITLE
Turns out airbrake doesn't include a minified source. Quick fix.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/gulpfile.js
+++ b/kifi-backend/modules/shoebox/angular/gulpfile.js
@@ -90,7 +90,7 @@ var libJsFiles = [
   ['lib/jquery/dist/jquery.js', 'lib/jquery/dist/jquery.min.js'],
   ['lib/angular/angular.js', 'lib/angular/angular.min.js'],
   ['lib/angular-cookies/angular-cookies.js', 'lib/angular-cookies/angular-cookies.min.js'],
-  ['lib/airbrake-js-client/dist/client.js', 'lib/airbrake-js-client/dist/client.min.js'],
+  ['lib/airbrake-js-client/dist/client.js', 'lib/airbrake-js-client/dist/client.js'],
   ['lib/angular-resource/angular-resource.js', 'lib/angular-resource/angular-resource.min.js'],
   ['lib/angular-sanitize/angular-sanitize.js', 'lib/angular-sanitize/angular-sanitize.min.js'],
   ['lib/angular-animate/angular-animate.js', 'lib/angular-animate/angular-animate.min.js'],


### PR DESCRIPTION
@cvializ I noticed a JS exception in prod, turns out they don't include a `.min.js`, so it was just failing. This is the quick fix, should gzip okay so isn't awful, but we'd prefer to use a minified source. Gulp may need to do this for us, or we manage this lib ourselves.
