### PR TITLE
Fixing flashing bad request in prod

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/profile/profileWidget.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profileWidget.tpl.html
@@ -2,7 +2,7 @@
 
   <div class="kf-pw-badge">
     <a href="{{me|profileUrl}}" ng-click="registerEvent('Photo')" class="kf-pw-profileImg">
-      <img src="{{me|pic:100}}" />
+      <img ng-src="{{me|pic:100}}" />
     </a>
     <aside>
       <h1>


### PR DESCRIPTION
@ajkochanowicz Just happened to notice this; minor, but causes the browser to make a bad request.

In production, for a very split moment (could be before a draw?), the browser sees `src="{{me|pic:100}}"` and obediently tries to make a request to `https://www.kifi.com/%7B%7Bme%7Cpic:100%7D%7D`. Letting angular assign the source _after_ it has had the chance to fill in the correct data fixes this.

```
Failed to load resource: the server responded with a status of 404 (Not Found)
```

Why only prod? Not 100% sure, a race perhaps?
