### PR TITLE
Better way to fix airbrake

### DIFF
--- a/kifi-backend/modules/shoebox/angular/gulpfile.js
+++ b/kifi-backend/modules/shoebox/angular/gulpfile.js
@@ -90,7 +90,7 @@ var libJsFiles = [
   ['lib/jquery/dist/jquery.js', 'lib/jquery/dist/jquery.min.js'],
   ['lib/angular/angular.js', 'lib/angular/angular.min.js'],
   ['lib/angular-cookies/angular-cookies.js', 'lib/angular-cookies/angular-cookies.min.js'],
-  ['lib/airbrake-js-client/dist/client.js', 'lib/airbrake-js-client/dist/client.js'],
+  'lib/airbrake-js-client/dist/client.js',
   ['lib/angular-resource/angular-resource.js', 'lib/angular-resource/angular-resource.min.js'],
   ['lib/angular-sanitize/angular-sanitize.js', 'lib/angular-sanitize/angular-sanitize.min.js'],
   ['lib/angular-animate/angular-animate.js', 'lib/angular-animate/angular-animate.min.js'],

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
@@ -341,7 +341,11 @@ angular.module('kifi')
             }
           });
           xhr.addEventListener('load', function () {
-            deferred.resolve(xhr.response);
+            if (xhr.response && xhr.response.path) {
+              deferred.resolve(xhr.response);
+            } else {
+              deferred.reject();
+            }
           });
           xhr.addEventListener('loadend', function () {
             deferred.reject(); // harmless if resolved


### PR DESCRIPTION
@ajkochanowicz @cvializ Looks like we default to using a published library's `min.js` is available, and if not we minify it. So it's not bad if a lib doesn't provide one.
