### PR TITLE
Report HTTP error responses via Airbrake

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -106,11 +106,16 @@ angular.module('kifi', [
 .factory('errorResponseReporter', [
   '$q', '$exceptionHandler',
   function($q, $exceptionHandler) {
+    var ignoredStatuses = [ 403 ];
+
     var errorResponseReporter = {
       responseError: function (response) {
         // This SHOULD only be called for all HTTP 400-599 status codes.
         response = response || {}; // make sure response is defined
-        $exceptionHandler(new Error(response.status), response);
+
+        if (!_.contains(ignoredStatuses, response.status)) {
+          $exceptionHandler(new Error('Client received HTTP status ' + response.status), response);
+        }
 
         // Continue treating the response as an error.
         return $q.reject(response);

--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -110,7 +110,7 @@ angular.module('kifi', [
       responseError: function (response) {
         // This SHOULD only be called for all HTTP 400-599 status codes.
         response = response || {}; // make sure response is defined
-        $exceptionHandler(new Error('Server Error: ' + response.status), response);
+        $exceptionHandler(new Error(response.status), response);
 
         // Continue treating the response as an error.
         return $q.reject(response);

--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -85,13 +85,14 @@ angular.module('kifi', [
 .factory('$exceptionHandler', [
   '$injector', '$window', '$log',
   function ($injector, $window, $log) {
-    function log(exception) {
+    function log(exception, cause) {
       if ($window.Airbrake) {
         $window.Airbrake.push({
           error: {
             message: exception.toString(),
             stack: exception.stack
-          }
+          },
+          params: cause
         });
       } else {
         $log.error(exception);
@@ -99,8 +100,32 @@ angular.module('kifi', [
     }
 
     return _.debounce(log, 5000, true);
-  }]
-)
+  }
+])
+
+.factory('errorResponseReporter', [
+  '$q', '$exceptionHandler',
+  function($q, $exceptionHandler) {
+    var errorResponseReporter = {
+      responseError: function (response) {
+        // This SHOULD only be called for all HTTP 400-599 status codes.
+        response = response || {}; // make sure response is defined
+        $exceptionHandler(new Error('Server Error: ' + response.status), response);
+
+        // Continue treating the response as an error.
+        return $q.reject(response);
+      }
+    };
+    return errorResponseReporter;
+  }
+])
+
+.config([
+  '$httpProvider',
+  function ($httpProvider) {
+    $httpProvider.interceptors.push('errorResponseReporter');
+  }
+])
 
 .controller('AppCtrl', [
   '$scope', '$rootScope', '$rootElement', '$window', '$timeout', '$log', '$analytics', '$location', '$state',


### PR DESCRIPTION
@andrewconner @ajkochanowicz 

Note: It doesn't check status codes, because Angular _should_ only pass error responses to the responseError interceptor.
