### PR TITLE
Change the header hover-menus to click-menus.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/clickMenu.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/clickMenu.js
@@ -29,7 +29,9 @@ angular.module('kifi')
 
           if (e.which === 1) {
             $target = $(e.target);
-            // Open the menu if we clicked a child of the directive, and that child is not a dropdown item
+            // Open the menu if we clicked a child of the directive,
+            // and that child is not a dropdown item,
+            // and the directive's menu has items to show
             if ($target.closest(element).length &&
                 !$target.hasClass('kf-dropdown-menu-item') &&
                 element.find('menu').children().length) {

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/clickMenu.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/clickMenu.js
@@ -1,3 +1,4 @@
+/* global jQuery: true */
 'use strict';
 
 angular.module('kifi')
@@ -5,6 +6,8 @@ angular.module('kifi')
 .directive('kfClickMenu', [
   '$window',
   function ($window) {
+    var $ = jQuery;
+
     return {
       restrict: 'A',
       link: function (scope, element) {
@@ -21,24 +24,28 @@ angular.module('kifi')
           return element.hasClass('kf-open');
         }
 
-        element.on('click', function (clickedInEvent) {
+        function handleMenuClick(e) {
+          var $target;
 
-          function handleCloseClick(clickedOutEvent) {
-            // When the user clicks anywhere after opening the dropdown,
-            // close it if the click is not on the dropdown.
-            if (clickedOutEvent.target !== clickedInEvent.target) {
-              // Stop listening for close-clicks
-              $window.document.removeEventListener('click', handleCloseClick);
+          if (e.which === 1) {
+            $target = $(e.target);
+            // Open the menu if we clicked a child of the directive, and that child is not a dropdown item
+            if ($target.closest(element).length && !$target.hasClass('kf-dropdown-menu-item')) {
+              // Only open the menu if it's closed
+              if (!isOpen()) {
+                showMenu();
+              }
+            } else {
               hideMenu();
             }
           }
+        }
 
-          if (!isOpen() && clickedInEvent.which === 1) {
-            // Listen for close-clicks
-            $window.document.addEventListener('click', handleCloseClick);
-            showMenu();
-          }
+        element.on('$destroy', function () {
+          $window.document.removeEventListener(handleMenuClick);
         });
+
+        $window.document.addEventListener('click', handleMenuClick);
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/clickMenu.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/clickMenu.js
@@ -30,7 +30,9 @@ angular.module('kifi')
           if (e.which === 1) {
             $target = $(e.target);
             // Open the menu if we clicked a child of the directive, and that child is not a dropdown item
-            if ($target.closest(element).length && !$target.hasClass('kf-dropdown-menu-item')) {
+            if ($target.closest(element).length &&
+                !$target.hasClass('kf-dropdown-menu-item') &&
+                element.find('menu').children().length) {
               // Only open the menu if it's closed
               if (!isOpen()) {
                 showMenu();

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/clickMenu.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/clickMenu.js
@@ -1,0 +1,45 @@
+'use strict';
+
+angular.module('kifi')
+
+.directive('kfClickMenu', [
+  '$window',
+  function ($window) {
+    return {
+      restrict: 'A',
+      link: function (scope, element) {
+
+        function showMenu() {
+          element.addClass('kf-open');
+        }
+
+        function hideMenu() {
+          element.removeClass('kf-open');
+        }
+
+        function isOpen() {
+          return element.hasClass('kf-open');
+        }
+
+        element.on('click', function (clickedInEvent) {
+
+          function handleCloseClick(clickedOutEvent) {
+            // When the user clicks anywhere after opening the dropdown,
+            // close it if the click is not on the dropdown.
+            if (clickedOutEvent.target !== clickedInEvent.target) {
+              // Stop listening for close-clicks
+              $window.document.removeEventListener('click', handleCloseClick);
+              hideMenu();
+            }
+          }
+
+          if (!isOpen() && clickedInEvent.which === 1) {
+            // Listen for close-clicks
+            $window.document.addEventListener('click', handleCloseClick);
+            showMenu();
+          }
+        });
+      }
+    };
+  }
+]);

--- a/kifi-backend/modules/shoebox/angular/src/header/loggedInHeader.styl
+++ b/kifi-backend/modules/shoebox/angular/src/header/loggedInHeader.styl
@@ -326,7 +326,10 @@ input.kf-lih-search-input
   &:not(:hover)>.svg-friends-white
     opacity: .7
 
+.kf-lih-friends
 .kf-lih-profile
+  padding: 0
+  border: 0
   background-size: cover
 
 .kf-lih-settings

--- a/kifi-backend/modules/shoebox/angular/src/header/loggedInHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/header/loggedInHeader.tpl.html
@@ -31,16 +31,16 @@
     <div class="kf-lih-right kifi-guide-target-3 kifi-guide-2">
       <button class="kf-lih-add-link sprite sprite-add-link" ng-click="addKeeps()">Add a link</button>
       <a href="/tags/manage" class="kf-lih-tags"><span class="svg-tag-white"></span>Manage tags</a>
-      <div class="kf-lih-dropdown-parent" kf-hover-menu>
-        <a href="{{me|profileUrl:'connections'}}" class="kf-lih-friends"><span class="svg-friends-white"></span>Connections</a>
+      <div class="kf-lih-dropdown-parent" kf-click-menu>
+        <button class="kf-lih-friends"><span class="svg-friends-white"></span>Connections</button>
         <menu class="kf-dropdown-menu">
           <a class="kf-dropdown-menu-item" href="{{me|profileUrl:'connections'}}">Your Kifi connections</a>
           <a class="kf-dropdown-menu-item" href="/invite">Invite someone to Kifi</a>
         </menu>
       </div>
       <a class="kf-lih-settings" ui-sref="settings"><span class="svg-settings-gear-filled-white"></span>Settings</a>
-      <div class="kf-lih-dropdown-parent" kf-hover-menu>
-        <a href="{{me|profileUrl}}" class="kf-lih-profile" style="background-image:url({{me|pic:100}})"></a>
+      <div class="kf-lih-dropdown-parent" kf-click-menu>
+        <button class="kf-lih-profile" style="background-image:url({{me|pic:100}})">Profile actions</button>
         <menu class="kf-dropdown-menu">
           <a class="kf-dropdown-menu-item" href="{{me|profileUrl}}">Your Profile</a>
           <a class="kf-dropdown-menu-item" ui-sref="settings">Settings</a>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
@@ -120,8 +120,8 @@ angular.module('kifi')
           }
         };
 
-        scope.onAddCoverImageMouseUp = function (event) {
-          if (event.which === 1) {
+        scope.onCameraCoverImageMouseUp = function (event) {
+          if (event.which === 1 && !scope.library.image) {
             angular.element('.kf-lh-cover-file').click();
             libraryService.trackEvent('user_clicked_page', scope.library, { action: 'clickedAddCoverImage' });
           }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
@@ -10,13 +10,13 @@
 
       <button class="kf-lh-manage-btn svg-settings-gear-filled" ng-click="manageLibrary()" ng-if="isOwner() && !library.isSystem"></button>
 
-      <div class="kf-lh-cover-menu-parent" kf-hover-menu ng-if="isOwner() && !library.isSystem">
+      <div class="kf-lh-cover-menu-parent" kf-click-menu ng-if="isOwner() && !library.isSystem">
         <button class="kf-lh-cover-menu-btn svg-camera-filled"></button>
         <menu class="kf-dropdown-menu kf-lh-cover-menu">
-          <button class="kf-dropdown-menu-item kf-lh-cover-add" ng-if="!library.image" kf-hover ng-mouseup="onAddCoverImageMouseUp($event)">Add a cover image</button>
-          <button class="kf-dropdown-menu-item kf-lh-cover-move" ng-if="library.image" kf-hover ng-mouseup="onMoveCoverImageMouseUp($event)">Reposition cover image</button>
-          <button class="kf-dropdown-menu-item kf-lh-cover-change" ng-if="library.image" kf-hover ng-mouseup="onChangeCoverImageMouseUp($event)" onmouseup="event.button?null:angular.element('.kf-lh-cover-file').click()">Change cover image</button>
-          <button class="kf-dropdown-menu-item kf-lh-cover-remove" ng-if="library.image" kf-hover ng-mouseup="onRemoveCoverImageMouseUp($event)">Remove cover image</button>
+          <button class="kf-dropdown-menu-item kf-lh-cover-add" ng-if="!library.image" ng-mouseup="onAddCoverImageMouseUp($event)">Add a cover image</button>
+          <button class="kf-dropdown-menu-item kf-lh-cover-move" ng-if="library.image" ng-mouseup="onMoveCoverImageMouseUp($event)">Reposition cover image</button>
+          <button class="kf-dropdown-menu-item kf-lh-cover-change" ng-if="library.image" ng-mouseup="onChangeCoverImageMouseUp($event)" onmouseup="event.button?null:angular.element('.kf-lh-cover-file').click()">Change cover image</button>
+          <button class="kf-dropdown-menu-item kf-lh-cover-remove" ng-if="library.image" ng-mouseup="onRemoveCoverImageMouseUp($event)">Remove cover image</button>
         </menu>
       </div>
       <input class="kf-lh-cover-file" type="file" accept="image/jpeg,image/png,image/gif" kf-file-change="onCoverImageFileChosen" ng-if="isOwner() && !library.isSystem">

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.tpl.html
@@ -11,9 +11,8 @@
       <button class="kf-lh-manage-btn svg-settings-gear-filled" ng-click="manageLibrary()" ng-if="isOwner() && !library.isSystem"></button>
 
       <div class="kf-lh-cover-menu-parent" kf-click-menu ng-if="isOwner() && !library.isSystem">
-        <button class="kf-lh-cover-menu-btn svg-camera-filled"></button>
+        <button class="kf-lh-cover-menu-btn svg-camera-filled" ng-mouseup="onCameraCoverImageMouseUp($event)"></button>
         <menu class="kf-dropdown-menu kf-lh-cover-menu">
-          <button class="kf-dropdown-menu-item kf-lh-cover-add" ng-if="!library.image" ng-mouseup="onAddCoverImageMouseUp($event)">Add a cover image</button>
           <button class="kf-dropdown-menu-item kf-lh-cover-move" ng-if="library.image" ng-mouseup="onMoveCoverImageMouseUp($event)">Reposition cover image</button>
           <button class="kf-dropdown-menu-item kf-lh-cover-change" ng-if="library.image" ng-mouseup="onChangeCoverImageMouseUp($event)" onmouseup="event.button?null:angular.element('.kf-lh-cover-file').click()">Change cover image</button>
           <button class="kf-dropdown-menu-item kf-lh-cover-remove" ng-if="library.image" ng-mouseup="onRemoveCoverImageMouseUp($event)">Remove cover image</button>


### PR DESCRIPTION
@andrewconner @ajkochanowicz 

Feedback welcome. Here are some decisions I made:
1. Change the links to buttons. I though it was more semantic, since the click should now only open the dropdown, and the link was duplicated in the list of action items anyway.
2. Clicking a second time on the icon doesn't close the dropdown. We could have it so a second click closes the dropdown, but I know some people double-click _everything_ and that might confuse those users.
