### PR TITLE
placing ip tracking clustering reports behind an actor

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserIpAddressCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserIpAddressCommander.scala
@@ -1,10 +1,12 @@
 package com.keepit.commanders
 
 import com.google.inject.Inject
-import com.keepit.common.akka.SafeFuture
+import com.keepit.common.actor.ActorInstance
+import com.keepit.common.akka.{ UnsupportedActorMessage, FortyTwoActor, SafeFuture }
 import com.keepit.common.controller.UserRequest
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.common.net.{ DirectUrl, HttpClient, UserAgent }
 import com.keepit.common.service.IpAddress
@@ -16,55 +18,56 @@ import play.api.libs.json.{ JsObject, Json }
 import scala.concurrent.{ ExecutionContext, Future }
 
 object UserIpAddressRules {
-  val blacklistCompanies = Set("Digital Ocean", "AT&T Wireless", "Verizon Wireless").map(_.toLowerCase)
+  val blacklistCompanies = Set("Digital Ocean", "AT&T Wireless", "Verizon Wireless", "Best Buy Co.", "Leaseweb USA", "Nobis Technology Group, LLC").map(_.toLowerCase)
 }
 
-class UserIpAddressCommander @Inject() (
+case class UserIpAddressEvent(userId: Id[User], ip: IpAddress, userAgent: UserAgent, reportNewClusters: Boolean = true)
+
+class UserIpAddressActor @Inject() (userIpAddressEventLogger: UserIpAddressEventLogger, airbrake: AirbrakeNotifier) extends FortyTwoActor(airbrake) {
+
+  def receive = {
+    case event: UserIpAddressEvent => userIpAddressEventLogger.logUser(event)
+    case m => throw new UnsupportedActorMessage(m)
+  }
+}
+
+class UserIpAddressEventLogger @Inject() (
     db: Database,
-    implicit val defaultContext: ExecutionContext,
-    clock: Clock,
-    httpClient: HttpClient,
-    userIpAddressRepo: UserIpAddressRepo,
     userRepo: UserRepo,
-    userStatisticsCommander: UserStatisticsCommander) extends Logging {
+    userIpAddressRepo: UserIpAddressRepo,
+    httpClient: HttpClient,
+    userStatisticsCommander: UserStatisticsCommander,
+    clock: Clock) extends Logging {
 
   private val ipClusterSlackChannelUrl = "https://hooks.slack.com/services/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"
   private val clusterMemoryTime = Period.weeks(10) // How long back do we look and still consider a user to be part of a cluster
 
-  def simplifyUserAgent(userAgent: UserAgent): String = {
-    val agentType = userAgent.typeName.toUpperCase()
-    if (agentType.isEmpty) "NONE" else agentType
-  }
-
-  def logUser(userId: Id[User], ip: IpAddress, userAgent: UserAgent, reportNewClusters: Boolean = true): Future[Unit] = SafeFuture {
-    if (ip.ip.toString.startsWith("10.")) {
-      throw new IllegalArgumentException("IP Addresses of the form 10.x.x.x are internal ec2 addresses and should not be logged")
+  def logUser(event: UserIpAddressEvent): Unit = {
+    if (event.ip.ip.toString.startsWith("10.")) {
+      throw new IllegalArgumentException(s"IP Addresses of the form 10.x.x.x are internal ec2 addresses and should not be logged. User ${event.userId}, ip ${event.ip}, agent ${event.userAgent}")
     }
     val now = clock.now()
-    val agentType = simplifyUserAgent(userAgent)
+    val agentType = simplifyUserAgent(event.userAgent)
     if (agentType == "NONE") {
-      log.info("[IPTRACK AGENT] Could not parse an agent type out of: " + userAgent)
+      log.info("[IPTRACK AGENT] Could not parse an agent type out of: " + event.userAgent)
     }
-    val model = UserIpAddress(userId = userId, ipAddress = ip, agentType = agentType)
+    val model = UserIpAddress(userId = event.userId, ipAddress = event.ip, agentType = agentType)
 
     val cluster = db.readWrite { implicit session =>
-      val currentCluster = userIpAddressRepo.getUsersFromIpAddressSince(ip, now.minus(clusterMemoryTime))
+      val currentCluster = userIpAddressRepo.getUsersFromIpAddressSince(event.ip, now.minus(clusterMemoryTime))
       userIpAddressRepo.saveIfNew(model)
       currentCluster.toSet
     }
 
-    if (reportNewClusters && !cluster.contains(userId) && cluster.size >= 1) {
-      log.info("[IPTRACK NOTIFY] Cluster " + cluster + " has new member " + userId)
-      notifySlackChannelAboutCluster(clusterIp = ip, clusterMembers = cluster + userId, newUserId = Some(userId))
+    if (event.reportNewClusters && !cluster.contains(event.userId) && cluster.size >= 1) {
+      log.info("[IPTRACK NOTIFY] Cluster " + cluster + " has new member " + event.userId)
+      notifySlackChannelAboutCluster(clusterIp = event.ip, clusterMembers = cluster + event.userId, newUserId = Some(event.userId))
     }
   }
 
-  def logUserByRequest[T](request: UserRequest[T]): Unit = {
-    val userId = request.userId
-    val userAgent = UserAgent(request.headers.get("user-agent").getOrElse(""))
-    val raw_ip_string = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
-    val ip = IpAddress(raw_ip_string.split(",").head)
-    logUser(userId, ip, userAgent)
+  def simplifyUserAgent(userAgent: UserAgent): String = {
+    val agentType = userAgent.typeName.toUpperCase()
+    if (agentType.isEmpty) "NONE" else agentType
   }
 
   private def formatCluster(ip: IpAddress, users: Seq[UserStatistics], newUserId: Option[Id[User]], location: Option[String] = None, company: Option[String] = None): BasicSlackMessage = {
@@ -86,12 +89,7 @@ class UserIpAddressCommander @Inject() (
     BasicSlackMessage((clusterDeclaration ++ userDeclarations).mkString("\n"))
   }
 
-  def heuristicsSayThisClusterIsRelevant(ipInfo: Option[JsObject]): Boolean = {
-    val companyOpt = ipInfo flatMap { obj => (obj \ "org").asOpt[String] }
-    !companyOpt.exists(company => UserIpAddressRules.blacklistCompanies.contains(company.toLowerCase))
-  }
-
-  def notifySlackChannelAboutCluster(clusterIp: IpAddress, clusterMembers: Set[Id[User]], newUserId: Option[Id[User]] = None): Future[Unit] = SafeFuture {
+  def notifySlackChannelAboutCluster(clusterIp: IpAddress, clusterMembers: Set[Id[User]], newUserId: Option[Id[User]] = None): Unit = {
     log.info("[IPTRACK NOTIFY] Notifying slack channel about " + clusterIp)
     val usersFromCluster = db.readOnlyMaster { implicit session =>
       val userIds = clusterMembers.toSeq
@@ -111,8 +109,32 @@ class UserIpAddressCommander @Inject() (
     }
   }
 
+  private def heuristicsSayThisClusterIsRelevant(ipInfo: Option[JsObject]): Boolean = {
+    val companyOpt = ipInfo flatMap { obj => (obj \ "org").asOpt[String] }
+    !companyOpt.exists(company => UserIpAddressRules.blacklistCompanies.contains(company.toLowerCase))
+  }
+
   def totalNumberOfLogs(): Int = {
     db.readOnlyReplica { implicit session => userIpAddressRepo.count }
+  }
+
+}
+
+class UserIpAddressCommander @Inject() (
+    db: Database,
+    userIpAddressRepo: UserIpAddressRepo,
+    actor: ActorInstance[UserIpAddressActor]) extends Logging {
+
+  def logUser(userId: Id[User], ip: IpAddress, userAgent: UserAgent, reportNewClusters: Boolean = true): Unit = {
+    actor.ref ! UserIpAddressEvent(userId, ip, userAgent, reportNewClusters)
+  }
+
+  def logUserByRequest[T](request: UserRequest[T]): Unit = {
+    val userId = request.userId
+    val userAgent = UserAgent(request.headers.get("user-agent").getOrElse(""))
+    val raw_ip_string = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
+    val ip = IpAddress(raw_ip_string.split(",").head)
+    actor.ref ! UserIpAddressEvent(userId, ip, userAgent)
   }
 
   def countByUser(userId: Id[User]): Int = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileUserController.scala
@@ -31,7 +31,7 @@ class MobileUserController @Inject() (
   val userActionsHelper: UserActionsHelper,
   userCommander: UserCommander,
   userConnectionsCommander: UserConnectionsCommander,
-  val userIpAddressCommander: UserIpAddressCommander,
+  userIpAddressCommander: UserIpAddressCommander,
   typeaheadCommander: TypeaheadCommander,
   keepCountCache: KeepCountCache,
   keepRepo: KeepRepo,

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/cron/UserIpAddressClusterCron.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/cron/UserIpAddressClusterCron.scala
@@ -1,7 +1,7 @@
 package com.keepit.shoebox.cron
 
 import com.google.inject.{ Inject, Singleton }
-import com.keepit.commanders.UserIpAddressCommander
+import com.keepit.commanders.{ UserIpAddressEventLogger, UserIpAddressCommander }
 import com.keepit.common.actor.ActorInstance
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.healthcheck.AirbrakeNotifier
@@ -44,6 +44,7 @@ class UserIpAddressClusterCronPluginImpl @Inject() (
 
 class UserIpAddressClusterActor @Inject() (
     userIpAddressCommander: UserIpAddressCommander,
+    userIpAddressEventLogger: UserIpAddressEventLogger,
     implicit val defaultContext: ExecutionContext,
     airbrake: AirbrakeNotifier) extends FortyTwoActor(airbrake) with Logging {
 
@@ -54,7 +55,7 @@ class UserIpAddressClusterActor @Inject() (
       val clusterIps = userIpAddressCommander.findIpClustersSince(time = timeCutoff, limit = numClusters)
       clusterIps foreach { ip =>
         val usersAtCluster = userIpAddressCommander.getUsersByIpAddressSince(ip, time = timeCutoff)
-        userIpAddressCommander.notifySlackChannelAboutCluster(clusterIp = ip, clusterMembers = usersAtCluster.toSet)
+        userIpAddressEventLogger.notifySlackChannelAboutCluster(clusterIp = ip, clusterMembers = usersAtCluster.toSet)
       }
   }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/UserIpAddressCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/UserIpAddressCommanderTest.scala
@@ -16,7 +16,7 @@ class UserIpAddressCommanderTest extends Specification with ShoeboxTestInjector 
   "UserIpAddressCommander" should {
     "correctly simplify user agent strings" in {
       withInjector() { implicit injector =>
-        val commander = inject[UserIpAddressCommander]
+        val commander = inject[UserIpAddressEventLogger]
         val inputs = Seq(
           "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:20.0) Gecko/20100101 Firefox/20.0",
           "Mozilla/5.0 (X11; CrOS armv7l 2913.260.0) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.99 Safari/537.11",
@@ -37,23 +37,21 @@ class UserIpAddressCommanderTest extends Specification with ShoeboxTestInjector 
 
     "log and recall a user's ip" in {
       withDb() { implicit injector =>
-        val commander = inject[UserIpAddressCommander]
+        val commander = inject[UserIpAddressEventLogger]
 
-        val res = commander.logUser(Id[User](1), IpAddress("127.0.0.1"), UserAgent("iKeefee/1.0.12823 (Device-Type: iPhone, OS: iOS 7.0.6)"))
-        Await.result(res, Duration.Inf)
+        commander.logUser(UserIpAddressEvent(Id[User](1), IpAddress("127.0.0.1"), UserAgent("iKeefee/1.0.12823 (Device-Type: iPhone, OS: iOS 7.0.6)")))
         commander.totalNumberOfLogs() === 1
       }
     }
 
     "ignore rapidly repeating visits" in {
       withDb() { implicit injector =>
-        val commander = inject[UserIpAddressCommander]
+        val commander = inject[UserIpAddressEventLogger]
 
         val n = 10
         val ips = for (ipOff <- 1 to n) yield { IpAddress((100 + ipOff).toString + ".0.0.1") }
         for (uid <- 1 to n; i <- 1 to n) {
-          val res = commander.logUser(Id[User](uid), ips(i - 1), UserAgent(""), reportNewClusters = false)
-          Await.result(res, Duration.Inf)
+          commander.logUser(UserIpAddressEvent(Id[User](uid), ips(i - 1), UserAgent(""), reportNewClusters = false))
         }
 
         commander.totalNumberOfLogs() === n
@@ -62,7 +60,7 @@ class UserIpAddressCommanderTest extends Specification with ShoeboxTestInjector 
 
     "find ip clusters" in {
       withDb() { implicit injector =>
-        val commander = inject[UserIpAddressCommander]
+        val commander = inject[UserIpAddressEventLogger]
 
         val n = 5
         val ips = for (i <- 1 to n) yield {
@@ -71,13 +69,12 @@ class UserIpAddressCommanderTest extends Specification with ShoeboxTestInjector 
         val uids = for (i <- 1 to n) yield (10 * i to 10 * i + i - 1) // ip(i-1) has i user ids going to it
         for (i <- 1 to n) {
           for (uid <- uids(i - 1)) {
-            val res = commander.logUser(Id[User](uid), ips(i - 1), UserAgent(""), reportNewClusters = false)
-            Await.result(res, Duration.Inf)
+            commander.logUser(UserIpAddressEvent(Id[User](uid), ips(i - 1), UserAgent(""), reportNewClusters = false))
           }
         }
 
         commander.totalNumberOfLogs() === n * (n + 1) / 2
-        val clusterIps = commander.findIpClustersSince(DateTime.now.minusHours(1), n)
+        val clusterIps = inject[UserIpAddressCommander].findIpClustersSince(DateTime.now.minusHours(1), n)
         clusterIps === ips.reverse
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserControllerTest.scala
@@ -1,5 +1,6 @@
 package com.keepit.controllers.mobile
 
+import com.keepit.commanders.UserIpAddressEventLogger
 import com.keepit.common.concurrent.FakeExecutionContextModule
 import com.keepit.common.time._
 import com.keepit.model.UserFactoryHelper._
@@ -184,6 +185,7 @@ class FasterMobileUserControllerTest extends Specification with ShoeboxTestInjec
         ctrl.method === "GET"
 
         val controller = inject[MobileUserController]
+        val commander = inject[UserIpAddressEventLogger]
         inject[FakeUserActionsHelper].setUser(user, Set(ExperimentType.ADMIN))
 
         val call = controller.currentUser
@@ -191,7 +193,7 @@ class FasterMobileUserControllerTest extends Specification with ShoeboxTestInjec
         status(result) must equalTo(OK)
         contentType(result) must beSome("application/json")
 
-        controller.userIpAddressCommander.totalNumberOfLogs() === 1
+        commander.totalNumberOfLogs() === 1
       }
     }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
@@ -3,6 +3,7 @@ package com.keepit.controllers.website
 import com.google.inject.Injector
 import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.commanders.{ LibraryCommander, UserCommander }
+import com.keepit.common.actor.FakeActorSystemModule
 import com.keepit.common.concurrent.FakeExecutionContextModule
 import com.keepit.common.controller.{ FakeUserActionsHelper, UserRequest, NonUserRequest }
 import com.keepit.common.crypto.FakeCryptoModule
@@ -36,6 +37,7 @@ class KifiSiteRouterTest extends Specification with ShoeboxApplicationInjector {
 
   val modules = Seq(
     FakeExecutionContextModule(),
+    FakeActorSystemModule(),
     FakeMailModule(),
     FakeABookServiceClientModule(),
     FakeSocialGraphModule(),


### PR DESCRIPTION
1. don't waste lots of futures and possibly create starvation if there's lots of reporting checks to do
2. avoid race condition (dups etc)
