### PR TITLE
Only hiding controls for main and secret libraries

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.js
@@ -71,7 +71,7 @@ angular.module('kifi')
           var lib = scope.library;
           lib.descriptionHtml = linkify(lib.description || '').replace(/\n+/g, '<br>');
           lib.absUrl = env.origin + lib.url;
-          lib.isSystem = lib.kind.lastIndexOf('system_', 0) === 0;
+          lib.isSystem = lib.kind === 'system_main' || lib.kind === 'system_secret';
           scope.collabsCanInvite = lib.whoCanInvite === 'collaborator';
 
           $timeout(function () {


### PR DESCRIPTION
Persona based libraries (ones created automatically during registration) are technically "system" libraries because the user didn't create them. However, we can let users edit settings and such. This changes what we define as "system".

@ajkochanowicz @cvializ 
