### PR TITLE
Do null check to prevent error when image is below 60x40

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
@@ -64,7 +64,7 @@ angular.module('kifi')
               image = {url: url, w: imgW, h: imgH, penalty: penalty, clipBottom: true, maxDescLines: descLines};
             }
           }
-          if (!galleryView) {
+          if (!galleryView && image) {
             image.w = image.h = null;
             image.maxDescLines = 2;
           }


### PR DESCRIPTION
@andrewconner @ajkochanowicz 

Resolves https://fortytwo.airbrake.io/projects/113130/groups/1459812451957517582/notices/1460205644897234397
