### PR TITLE
Fix keep card footer in Firefox.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.styl
@@ -251,7 +251,7 @@ defaultBorderColorOverlayUsingBefore(borderWidth)  // slightly darkens an image'
   display: table-cell
   vertical-align: middle
   text-align: left
-  padding-left: 20px
+  padding: 6px 20px
 
 .kf-keep-keep-btn
 .kf-keep-share-btn


### PR DESCRIPTION
It was not expanding the fit the children's margin. Table-cell bug?

Error:
<img width="618" alt="screen shot 2015-07-09 at 3 34 08 pm" src="https://cloud.githubusercontent.com/assets/2363700/8608589/05d04b08-2651-11e5-9be9-275050171f8f.png">

Fixed:
<img width="528" alt="screen shot 2015-07-09 at 3 41 40 pm" src="https://cloud.githubusercontent.com/assets/2363700/8608590/0b48c97a-2651-11e5-9c9f-cb8df5ec4d7f.png">
