### PR TITLE
More site endpoints

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationFactory.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationFactory.scala
@@ -27,6 +27,6 @@ object OrganizationFactory {
     def withMembers(newMembers: Seq[User]) = this.copy(members = members ++ newMembers)
     def withInvitedUsers(newInvitedUsers: Seq[User]) = this.copy(invitedUsers = invitedUsers ++ newInvitedUsers)
     def withInvitedEmails(newInvitedEmails: Seq[EmailAddress]) = this.copy(invitedEmails = invitedEmails ++ newInvitedEmails)
-    def withHandle(newHandle: PrimaryOrganizationHandle) = this.copy(org = org.copy(handle = Some(newHandle)))
+    def withHandle(newHandle: OrganizationHandle) = this.copy(org = org.copy(handle = Some(PrimaryOrganizationHandle(newHandle, newHandle))))
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -19,6 +19,7 @@ trait OrganizationCommander {
   def getAllOrganizationIds: Seq[Id[Organization]]
   def getOrganizationView(orgId: Id[Organization]): OrganizationView
   def getOrganizationCards(orgIds: Seq[Id[Organization]]): Map[Id[Organization], OrganizationCard]
+  def getLibraries(orgId: Id[Organization]): Seq[LibraryCardInfo]
   def isValidRequest(request: OrganizationRequest)(implicit session: RSession): Boolean
   def createOrganization(request: OrganizationCreateRequest): Either[OrganizationFail, OrganizationCreateResponse]
   def modifyOrganization(request: OrganizationModifyRequest): Either[OrganizationFail, OrganizationModifyResponse]
@@ -104,6 +105,8 @@ class OrganizationCommanderImpl @Inject() (
       numMembers = numMembers,
       numLibraries = numPublicLibs)
   }
+
+  def getLibraries(orgId: Id[Organization]): Seq[LibraryCardInfo] = ???
 
   def isValidRequest(request: OrganizationRequest)(implicit session: RSession): Boolean = {
     getValidationError(request).isEmpty

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
@@ -72,6 +72,10 @@ class OrganizationController @Inject() (
     Json.toJson(orgCommander.getOrganizationView(orgId))(OrganizationView.website)
   }
 
+  def getLibraries(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
+    Ok(Json.obj("libraries" -> Json.toJson(orgCommander.getLibraries(request.orgId))))
+  }
+
   // TODO(ryan): when organizations are no longer hidden behind an experiment, change this to a MaybeUserAction
   def getOrganizationsForUser(extId: ExternalId[User]) = UserAction { request =>
     if (!request.experiments.contains(ExperimentType.ORGANIZATION)) BadRequest(Json.obj("error" -> "insufficient_permissions"))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserOrOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserOrOrganizationController.scala
@@ -5,13 +5,16 @@ import com.keepit.commanders._
 import com.keepit.common.controller._
 import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.heimdal.HeimdalContextBuilderFactory
 import com.keepit.model._
-import play.api.libs.iteratee.Iteratee
-import play.api.libs.json.Json
 import com.keepit.shoebox.controllers.OrganizationAccessActions
+import play.api.libs.iteratee.Iteratee
+import play.api.libs.json.{ JsValue, Json }
+import play.api.mvc.Result
 
-import scala.concurrent.{ Future, ExecutionContext }
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Success, Failure, Try }
 
 @Singleton
 class UserOrOrganizationController @Inject() (
@@ -24,26 +27,36 @@ class UserOrOrganizationController @Inject() (
     userProfileController: UserProfileController,
     orgController: OrganizationController,
     handleCommander: HandleCommander,
+    airbrake: AirbrakeNotifier,
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val executionContext: ExecutionContext) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
-  def getByHandle(handle: Handle) = MaybeUserAction.async { request =>
-    val handleOwnerObjectOpt = db.readOnlyReplica { implicit session => handleCommander.getByHandle(handle) }
-    val actionAndTypeOpt = handleOwnerObjectOpt map {
-      case (Left(org), _) =>
-        (orgController.getOrganization(Organization.publicId(org.id.get)), "org")
-      case (Right(user), _) =>
-        (userProfileController.getProfile(user.username), "user")
+  def extractBody(result: Result): Future[Try[JsValue]] = {
+    result.body.run(Iteratee.getChunks).map { chunks =>
+      Try(Json.parse(chunks.head))
     }
-    actionAndTypeOpt.map {
-      case (action, actionType) =>
-        action(request).flatMap { result =>
-          result.body.run(Iteratee.getChunks).map { chunks =>
-            val payload = chunks.head
-            Ok(Json.obj("type" -> actionType, "result" -> Json.parse(payload)))
-          }
-        }
-    }.getOrElse(Future.successful(NotFound))
   }
 
+  def getByHandle(handle: Handle) = MaybeUserAction.async { request =>
+    val handleOwnerObjectOpt = db.readOnlyReplica { implicit session => handleCommander.getByHandle(handle) }
+    println("[RPB] handleOwner = " + handleOwnerObjectOpt)
+    handleOwnerObjectOpt match {
+      case None => Future.successful(NotFound(Json.obj("error" -> "handle_not_found")))
+      case Some(handleOwnerObject) =>
+        val (action, actionType) = handleOwnerObject match {
+          case (Left(org), _) =>
+            (orgController.getOrganization(Organization.publicId(org.id.get)), "org")
+          case (Right(user), _) =>
+            (userProfileController.getProfile(user.username), "user")
+        }
+        for (result <- action(request); bodyTry <- extractBody(result)) yield {
+          bodyTry match {
+            case Success(body) => Ok(Json.obj("type" -> actionType, "result" -> body))
+            case Failure(ex) =>
+              airbrake.notify("Could not parse the body in getByHandle: " + ex)
+              BadRequest
+          }
+        }
+    }
+  }
 }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -526,7 +526,7 @@ POST          /site/organizations/:id/members/remove            @com.keepit.cont
 
 
 GET           /site/user-or-org/:handle                   @com.keepit.controllers.website.UserOrOrganizationController.getByHandle(handle: Handle)
-#GET           /site/user-or-org/:handle/libraries         @com.keepit.controllers.website.UserOrOrganizationController.getLibrariesByHandle(handle: Handle, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")
+GET           /site/user-or-org/:handle/libraries         @com.keepit.controllers.website.UserOrOrganizationController.getLibrariesByHandle(handle: Handle, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")
 
 ##########################################
 # Email-Link API

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -525,7 +525,8 @@ POST          /site/organizations/:id/members/modify            @com.keepit.cont
 POST          /site/organizations/:id/members/remove            @com.keepit.controllers.website.OrganizationMembershipController.removeMembers(id: PublicId[Organization])
 
 
-GET           /site/user-or-org/:handle                                              @com.keepit.controllers.website.UserOrOrganizationController.getByHandle(handle: Handle)
+GET           /site/user-or-org/:handle                   @com.keepit.controllers.website.UserOrOrganizationController.getByHandle(handle: Handle)
+#GET           /site/user-or-org/:handle/libraries         @com.keepit.controllers.website.UserOrOrganizationController.getLibrariesByHandle(handle: Handle, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")
 
 ##########################################
 # Email-Link API

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
@@ -51,7 +51,7 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
         withDb(controllerTestModules: _*) { implicit injector =>
           val (user, org) = db.readWrite { implicit session =>
             val user = UserFactory.user().saved
-            val handle = OrganizationHandle("Kifi")
+            val handle = OrganizationHandle("kifi")
             val org = OrganizationFactory.organization().withHandle(handle).withOwner(user).withName("Forty Two Kifis").saved
             LibraryFactory.libraries(10).map(_.published().withOrganization(org.id)).saved
             LibraryFactory.libraries(15).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withOrganization(org.id)).saved
@@ -67,7 +67,7 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
 
           val jsonResponse = Json.parse(contentAsString(response))
           (jsonResponse \ "organization" \ "name").as[String] === "Forty Two Kifis"
-          (jsonResponse \ "organization" \ "handle").as[String] === "Kifi"
+          (jsonResponse \ "organization" \ "handle").as[String] === "kifi"
           (jsonResponse \ "organization" \ "numLibraries").as[Int] === 10
         }
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
@@ -51,7 +51,7 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
         withDb(controllerTestModules: _*) { implicit injector =>
           val (user, org) = db.readWrite { implicit session =>
             val user = UserFactory.user().saved
-            val handle = PrimaryOrganizationHandle(original = OrganizationHandle("Kifi"), normalized = OrganizationHandle("kifi"))
+            val handle = OrganizationHandle("Kifi")
             val org = OrganizationFactory.organization().withHandle(handle).withOwner(user).withName("Forty Two Kifis").saved
             LibraryFactory.libraries(10).map(_.published().withOrganization(org.id)).saved
             LibraryFactory.libraries(15).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withOrganization(org.id)).saved
@@ -157,7 +157,7 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
     "when modifyOrganization is called:" in {
       def setupModify(implicit injector: Injector) = db.readWrite { implicit session =>
         val owner = UserFactory.user().withName("Captain", "America").saved
-        val org = OrganizationFactory.organization().withOwner(owner).withName("Worldwide Consortium of Earth").withHandle(PrimaryOrganizationHandle(original = OrganizationHandle("Earth"), normalized = OrganizationHandle("earth"))).saved
+        val org = OrganizationFactory.organization().withOwner(owner).withName("Worldwide Consortium of Earth").withHandle(OrganizationHandle("Earth")).saved
         (org, owner)
       }
 
@@ -218,7 +218,7 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
       def setupDelete(implicit injector: Injector) = db.readWrite { implicit session =>
         val owner = UserFactory.user().withName("Dr", "Papaya").saved
         val member = UserFactory.user().withName("Hansel", "Schmidt").saved
-        val org = OrganizationFactory.organization().withOwner(owner).withName("Papaya Republic of California").withHandle(PrimaryOrganizationHandle(original = OrganizationHandle("papaya_republic"), normalized = OrganizationHandle("earth"))).saved
+        val org = OrganizationFactory.organization().withOwner(owner).withName("Papaya Republic of California").withHandle(OrganizationHandle("papaya_republic")).saved
         inject[OrganizationMembershipRepo].save(org.newMembership(member.id.get, OrganizationRole.MEMBER))
         (org, owner, member)
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
@@ -51,7 +51,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
         withDb(controllerTestModules: _*) { implicit injector =>
           val (user, org) = db.readWrite { implicit session =>
             val user = UserFactory.user().saved
-            val handle = OrganizationHandle("Kifi")
+            val handle = OrganizationHandle("kifi")
             val org = OrganizationFactory.organization().withHandle(handle).withOwner(user).withName("Forty Two Kifis").saved
             LibraryFactory.libraries(10).map(_.published().withOrganization(org.id)).saved
             LibraryFactory.libraries(15).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withOrganization(org.id)).saved
@@ -67,7 +67,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
 
           val jsonResponse = Json.parse(contentAsString(response))
           (jsonResponse \ "organization" \ "name").as[String] === "Forty Two Kifis"
-          (jsonResponse \ "organization" \ "handle").as[String] === "Kifi"
+          (jsonResponse \ "organization" \ "handle").as[String] === "kifi"
           (jsonResponse \ "organization" \ "numLibraries").as[Int] === 10
         }
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
@@ -51,7 +51,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
         withDb(controllerTestModules: _*) { implicit injector =>
           val (user, org) = db.readWrite { implicit session =>
             val user = UserFactory.user().saved
-            val handle = PrimaryOrganizationHandle(original = OrganizationHandle("Kifi"), normalized = OrganizationHandle("kifi"))
+            val handle = OrganizationHandle("Kifi")
             val org = OrganizationFactory.organization().withHandle(handle).withOwner(user).withName("Forty Two Kifis").saved
             LibraryFactory.libraries(10).map(_.published().withOrganization(org.id)).saved
             LibraryFactory.libraries(15).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withOrganization(org.id)).saved
@@ -157,7 +157,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
     "when modifyOrganization is called:" in {
       def setupModify(implicit injector: Injector) = db.readWrite { implicit session =>
         val owner = UserFactory.user().withName("Captain", "America").saved
-        val org = OrganizationFactory.organization().withOwner(owner).withName("Worldwide Consortium of Earth").withHandle(PrimaryOrganizationHandle(original = OrganizationHandle("Earth"), normalized = OrganizationHandle("earth"))).saved
+        val org = OrganizationFactory.organization().withOwner(owner).withName("Worldwide Consortium of Earth").withHandle(OrganizationHandle("Earth")).saved
         (org, owner)
       }
 
@@ -218,7 +218,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
       def setupDelete(implicit injector: Injector) = db.readWrite { implicit session =>
         val owner = UserFactory.user().withName("Dr", "Papaya").saved
         val member = UserFactory.user().withName("Hansel", "Schmidt").saved
-        val org = OrganizationFactory.organization().withOwner(owner).withName("Papaya Republic of California").withHandle(PrimaryOrganizationHandle(original = OrganizationHandle("papaya_republic"), normalized = OrganizationHandle("earth"))).saved
+        val org = OrganizationFactory.organization().withOwner(owner).withName("Papaya Republic of California").withHandle(OrganizationHandle("papaya_republic")).saved
         inject[OrganizationMembershipRepo].save(org.newMembership(member.id.get, OrganizationRole.MEMBER))
         (org, owner, member)
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserOrOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserOrOrganizationControllerTest.scala
@@ -1,0 +1,123 @@
+package com.keepit.controllers.website
+
+import com.google.inject.Injector
+import com.keepit.abook.FakeABookServiceClientModule
+import com.keepit.common.controller.{ FakeUserActionsHelper, ShoeboxServiceController }
+import com.keepit.common.crypto.PublicIdConfiguration
+import com.keepit.common.social.FakeSocialGraphModule
+import com.keepit.heimdal.FakeHeimdalServiceClientModule
+import com.keepit.model.OrganizationFactoryHelper._
+import com.keepit.model.UserFactoryHelper._
+import com.keepit.model._
+import com.keepit.test.ShoeboxTestInjector
+import org.specs2.mutable.Specification
+import play.api.libs.json.{ JsString, Json }
+import play.api.mvc.{ Call, _ }
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class UserOrOrganizationControllerTest extends Specification with ShoeboxTestInjector {
+  implicit def createFakeRequest(route: Call): FakeRequest[AnyContentAsEmpty.type] = FakeRequest(route.method, route.url)
+
+  val modules = Seq(
+    FakeHeimdalServiceClientModule(),
+    FakeABookServiceClientModule(),
+    FakeSocialGraphModule()
+  )
+
+  object TestData extends ShoeboxServiceController {
+    val test1Body = Json.obj("hello" -> "world")
+    val test1 = Ok(test1Body)
+
+    val test2Body = JsString("foo")
+    val test2 = Ok("foo")
+
+    val test3Body = Json.obj("name" -> "Léo")
+    val test3 = Ok(test3Body)
+
+    val test4Body = Json.obj("name" -> "ĄąĲĳ	ɖ	ɞ	ɫ	ɷ	ʱ	ʬ	˕	˨ 	ਠਂ	ਅ	ਉ	ਠੱ")
+    val test4 = Ok(test4Body)
+  }
+
+  "UserOrOrganizationController" should {
+    "be able to extract the body from results" in {
+      "succeed on an easy json object" in {
+        withInjector(modules: _*) { implicit injector =>
+          val result = TestData.test1
+          val extractedBody = Await.result(controller.extractBody(result), Duration(1, SECONDS))
+          extractedBody.isSuccess === true
+          extractedBody.get === TestData.test1Body
+        }
+      }
+      "fail gracefully on non-json string" in {
+        withInjector(modules: _*) { implicit injector =>
+          val result = TestData.test2
+          val extractedBody = Await.result(controller.extractBody(result), Duration(1, SECONDS))
+          extractedBody.isFailure === true
+        }
+      }
+      "succeed on unicode characters" in {
+        withInjector(modules: _*) { implicit injector =>
+          val result = TestData.test3
+          val extractedBody = Await.result(controller.extractBody(result), Duration(1, SECONDS))
+          extractedBody.isSuccess === true
+          extractedBody.get === TestData.test3Body
+        }
+      }
+      "succeed on super weird unicode characters" in {
+        withInjector(modules: _*) { implicit injector =>
+          val result = TestData.test4
+          val extractedBody = Await.result(controller.extractBody(result), Duration(1, SECONDS))
+          extractedBody.isSuccess === true
+          extractedBody.get === TestData.test4Body
+        }
+      }
+    }
+
+    "get user/orgs by handle" in {
+      def testSetup(implicit injector: Injector) = {
+        db.readWrite { implicit session =>
+          val userHandle = Username("myuserhandle")
+          val orgHandle = OrganizationHandle("myorghandle")
+          val user = UserFactory.user().withUsername(userHandle.value).saved
+          val org = OrganizationFactory.organization().withHandle(orgHandle).withOwner(user).saved
+          (user, org)
+        }
+      }
+      "get a user" in {
+        withDb(modules: _*) { implicit injector =>
+          val (user, _) = testSetup
+
+          inject[FakeUserActionsHelper].setUser(user, Set(ExperimentType.ORGANIZATION))
+          val request = route.getByHandle(user.username)
+          val response = controller.getByHandle(user.username)(request)
+
+          val jsonResponse = Json.parse(contentAsString(response))
+          (jsonResponse \ "type").as[String] === "user"
+        }
+      }
+      "get an org" in {
+        withDb(modules: _*) { implicit injector =>
+          val (user, org) = testSetup
+
+          inject[FakeUserActionsHelper].setUser(user, Set(ExperimentType.ORGANIZATION))
+          val request = route.getByHandle(org.getHandle)
+          val response = controller.getByHandle(org.getHandle)(request)
+
+          val jsonResponse = Json.parse(contentAsString(response))
+          (jsonResponse \ "type").as[String] === "org"
+        }
+      }
+    }
+  }
+
+  implicit def publicIdConfig(implicit injector: Injector) = inject[PublicIdConfiguration]
+
+  private def route = com.keepit.controllers.website.routes.UserOrOrganizationController
+
+  private def controller(implicit injector: Injector) = inject[UserOrOrganizationController]
+}
+

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserOrOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserOrOrganizationControllerTest.scala
@@ -82,7 +82,8 @@ class UserOrOrganizationControllerTest extends Specification with ShoeboxTestInj
         db.readWrite { implicit session =>
           val userHandle = Username("myuserhandle")
           val orgHandle = OrganizationHandle("myorghandle")
-          val user = UserFactory.user().withUsername(userHandle.value).saved
+          val userTemplate = UserFactory.user().withUsername(userHandle.value).saved
+          val user = handleCommander.setUsername(userTemplate, userHandle).get
           val org = OrganizationFactory.organization().withHandle(orgHandle).withOwner(user).saved
           (user, org)
         }
@@ -118,7 +119,8 @@ class UserOrOrganizationControllerTest extends Specification with ShoeboxTestInj
         db.readWrite { implicit session =>
           val userHandle = Username("myuserhandle")
           val orgHandle = OrganizationHandle("myorghandle")
-          val user = UserFactory.user().withUsername(userHandle.value).saved
+          val userTemplate = UserFactory.user().withUsername(userHandle.value).saved
+          val user = handleCommander.setUsername(userTemplate, userHandle).get
           val org = OrganizationFactory.organization().withHandle(orgHandle).withOwner(user).saved
           (user, org)
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationFactoryHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationFactoryHelper.scala
@@ -12,7 +12,7 @@ object OrganizationFactoryHelper {
       val org = if (orgTemplate.handle.isEmpty) {
         injector.getInstance(classOf[HandleCommander]).autoSetOrganizationHandle(orgTemplate).get
       } else {
-        orgTemplate
+        injector.getInstance(classOf[HandleCommander]).setOrganizationHandle(orgTemplate, orgTemplate.getHandle).get
       }
       injector.getInstance(classOf[OrganizationMembershipRepo]).save(org.newMembership(org.ownerId, OrganizationRole.OWNER))
       for (member <- partialOrganization.members) {

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationFactoryHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationFactoryHelper.scala
@@ -12,7 +12,7 @@ object OrganizationFactoryHelper {
       val org = if (orgTemplate.handle.isEmpty) {
         injector.getInstance(classOf[HandleCommander]).autoSetOrganizationHandle(orgTemplate).get
       } else {
-        injector.getInstance(classOf[HandleCommander]).setOrganizationHandle(orgTemplate, orgTemplate.getHandle).get
+        injector.getInstance(classOf[HandleCommander]).setOrganizationHandle(orgTemplate, orgTemplate.getHandle, overrideValidityCheck = true).get
       }
       injector.getInstance(classOf[OrganizationMembershipRepo]).save(org.newMembership(org.ownerId, OrganizationRole.OWNER))
       for (member <- partialOrganization.members) {

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UserFactoryHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UserFactoryHelper.scala
@@ -10,8 +10,8 @@ object UserFactoryHelper {
 
   implicit class UserPersister(partialUser: PartialUser) {
     def saved(implicit injector: Injector, session: RWSession): User = {
-      val user = injector.getInstance(classOf[UserRepo]).save(partialUser.get.copy(id = None))
-      injector.getInstance(classOf[HandleCommander]).setUsername(user, user.username)
+      val userTemplate = injector.getInstance(classOf[UserRepo]).save(partialUser.get.copy(id = None))
+      val user = injector.getInstance(classOf[HandleCommander]).setUsername(userTemplate, userTemplate.username, overrideProtection = true, overrideValidityCheck = true).get
       if (partialUser.experiments.nonEmpty) {
         val experimentRepo = injector.getInstance(classOf[UserExperimentRepo])
         partialUser.experiments.foreach { experimentType =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UserFactoryHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UserFactoryHelper.scala
@@ -11,7 +11,8 @@ object UserFactoryHelper {
   implicit class UserPersister(partialUser: PartialUser) {
     def saved(implicit injector: Injector, session: RWSession): User = {
       val userTemplate = injector.getInstance(classOf[UserRepo]).save(partialUser.get.copy(id = None))
-      val user = injector.getInstance(classOf[HandleCommander]).setUsername(userTemplate, userTemplate.username, overrideProtection = true, overrideValidityCheck = true).get
+      //val user = injector.getInstance(classOf[HandleCommander]).setUsername(userTemplate, userTemplate.username, overrideProtection = true, overrideValidityCheck = true).get
+      val user = userTemplate
       if (partialUser.experiments.nonEmpty) {
         val experimentRepo = injector.getInstance(classOf[UserExperimentRepo])
         partialUser.experiments.foreach { experimentType =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UserFactoryHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UserFactoryHelper.scala
@@ -1,5 +1,6 @@
 package com.keepit.model
 
+import com.keepit.commanders.HandleCommander
 import com.keepit.model.UserConnectionFactoryHelper._
 import com.google.inject.Injector
 import com.keepit.common.db.slick.DBSession.RWSession
@@ -10,6 +11,7 @@ object UserFactoryHelper {
   implicit class UserPersister(partialUser: PartialUser) {
     def saved(implicit injector: Injector, session: RWSession): User = {
       val user = injector.getInstance(classOf[UserRepo]).save(partialUser.get.copy(id = None))
+      injector.getInstance(classOf[HandleCommander]).setUsername(user, user.username)
       if (partialUser.experiments.nonEmpty) {
         val experimentRepo = injector.getInstance(classOf[UserExperimentRepo])
         partialUser.experiments.foreach { experimentType =>


### PR DESCRIPTION
`/site/user-or-org/libraries` exists now, @ajkochanowicz, or will as soon as this is deployed.

@andrewconner 
