### PR TITLE
add a guard to prevent sending library invite notifications to yourself

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -1642,7 +1642,10 @@ class LibraryCommanderImpl @Inject() (
                   val inviter = userRepo.get(requestUserId)
                   val libOwner = basicUserRepo.load(library.ownerId)
                   val updatedTargetMembership = libraryMembershipRepo.save(targetMem.copy(access = newAccess, subscribedToUpdates = newSubscription, state = LibraryMembershipStates.ACTIVE))
-                  libraryInviteCommander.notifyInviteeAboutInvitationToJoinLibrary(inviter, library, libOwner, Map(targetUserId -> updatedTargetMembership))
+
+                  if (inviter.id.get.id != targetUserId.id) {
+                    libraryInviteCommander.notifyInviteeAboutInvitationToJoinLibrary(inviter, library, libOwner, Map(targetUserId -> updatedTargetMembership))
+                  }
 
                   Right(updatedTargetMembership)
               }


### PR DESCRIPTION
@andrewconner fixes the bug in this card (https://trello.com/c/ZX1oGYEv/60-make-it-easier-to-remove-yourself-as-a-collaborator). We were sending extension notifications from yourself when you demoted yourself to a follower.
