### PR TITLE
Fix evolution 354

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/354.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/354.sql
@@ -2,16 +2,13 @@
 
 # --- !Ups
 
--- alter table url_pattern_rule
--- drop foreign key url_pattern_rule_to_proxy;
+alter table url_pattern_rule drop constraint url_pattern_rule_to_proxy;
 
 drop table http_proxy;
 
-alter table url_pattern_rule
-drop column is_unscrapable;
+alter table url_pattern_rule drop column is_unscrapable;
 
-alter table url_pattern_rule
-drop column use_proxy;
+alter table url_pattern_rule drop column use_proxy;
 
 insert into evolutions(name, description) values('354.sql', 'remove old http_proxy table, take out some columns from old url_pattern_rule');
 


### PR DESCRIPTION
@andrewconner @gratimax 
Just using `drop constraint` instead of `drop foreign key`, as valid syntax for both MySql and H2.
