### PR TITLE
tweak uri deco reaper speed

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationCleanupCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/RecommendationCleanupCommander.scala
@@ -21,7 +21,7 @@ class RecommendationCleanupCommander @Inject() (
 
   def cleanup(overrideLimit: Option[Int] = None, overrideTimeCutoff: Option[DateTime] = None, useSubset: Boolean = true): Unit = {
     val usersWithReco = db.readOnlyReplica { implicit session => uriRecoRepo.getUsersWithRecommendations() }.toSeq
-    val (idx, ringSize) = timeSlicer.getSliceAndSize(TimeToSliceInDays.ONE_WEEK, OneSliceInMinutes(CuratorTasksPlugin.CLEAN_FREQ))
+    val (idx, ringSize) = timeSlicer.getSliceAndSize(TimeToSliceInDays.TWO_WEEKS, OneSliceInMinutes(CuratorTasksPlugin.CLEAN_FREQ))
     val userToClean = if (useSubset) usersWithReco.filter(_.id % ringSize == idx) else usersWithReco
 
     val timer = new NamedStatsdTimer("RecommendationCleanupCommander.cleanup")


### PR DESCRIPTION
@andrewconner @stkem 

one clean up session costs about 10 minutes. This should at least cut it in half. 

I found that the scheduler stopped scheduling uri reaping at some point. Not sure what could cause it. 
