### PR TITLE
Organization Libraries logic

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
@@ -66,14 +66,11 @@ class OrganizationController @Inject() (
   }
 
   def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
-    Ok(Json.obj("organization" -> getOrganizationHelper(request.orgId)))
-  }
-  def getOrganizationHelper(orgId: Id[Organization]): JsValue = {
-    Json.toJson(orgCommander.getOrganizationView(orgId))(OrganizationView.website)
+    Ok(Json.obj("organization" -> Json.toJson(orgCommander.getOrganizationView(request.orgId))(OrganizationView.website)))
   }
 
-  def getLibraries(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
-    Ok(Json.obj("libraries" -> Json.toJson(orgCommander.getLibraries(request.orgId))))
+  def getOrganizationLibraries(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
+    Ok(Json.obj("libraries" -> Json.toJson(orgCommander.getLibrariesVisibleToUser(request.orgId, request.request.userIdOpt, Offset(offset), Limit(limit)))))
   }
 
   // TODO(ryan): when organizations are no longer hidden behind an experiment, change this to a MaybeUserAction

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserOrOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserOrOrganizationController.scala
@@ -66,7 +66,7 @@ class UserOrOrganizationController @Inject() (
       case Some(handleOwnerObject) =>
         val (action, actionType) = handleOwnerObject match {
           case (Left(org), _) =>
-            (orgController.getLibraries(Organization.publicId(org.id.get)), "org")
+            (orgController.getOrganizationLibraries(Organization.publicId(org.id.get), offset = page * pageSize, limit = pageSize), "org")
           case (Right(user), _) =>
             (userProfileController.getProfileLibraries(user.username, page, pageSize, filter), "user")
         }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -523,6 +523,7 @@ POST          /site/organizations/:id/members/invites/decline   @com.keepit.cont
 POST          /site/organizations/:id/members/invites/link      @com.keepit.controllers.website.OrganizationInviteController.createAnonymousInviteToOrganization(id: PublicId[Organization])
 POST          /site/organizations/:id/members/modify            @com.keepit.controllers.website.OrganizationMembershipController.modifyMembers(id: PublicId[Organization])
 POST          /site/organizations/:id/members/remove            @com.keepit.controllers.website.OrganizationMembershipController.removeMembers(id: PublicId[Organization])
+GET           /site/organizations/:id/libraries                 @com.keepit.controllers.website.OrganizationController.getOrganizationLibraries(id: PublicId[Organization], offset: Int ?= 0, limit: Int ?= 20)
 
 
 GET           /site/user-or-org/:handle                   @com.keepit.controllers.website.UserOrOrganizationController.getByHandle(handle: Handle)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
@@ -1,15 +1,26 @@
 package com.keepit.commanders
 
+import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.common.actor.TestKitSupport
+import com.keepit.common.concurrent.FakeExecutionContextModule
 import com.keepit.common.db.Id
+import com.keepit.common.social.FakeSocialGraphModule
 import com.keepit.model._
 import com.keepit.test.ShoeboxTestInjector
 import org.specs2.mutable.SpecificationLike
+import com.keepit.model.LibraryFactoryHelper._
+import com.keepit.model.OrganizationFactoryHelper._
+import com.keepit.model.UserFactoryHelper._
 
 class OrganizationCommanderTest extends TestKitSupport with SpecificationLike with ShoeboxTestInjector {
+  val modules = Seq(
+    FakeExecutionContextModule(),
+    FakeABookServiceClientModule(),
+    FakeSocialGraphModule()
+  )
   "organization commander" should {
     "create an organization" in {
-      withDb() { implicit injector =>
+      withDb(modules: _*) { implicit injector =>
         val orgRepo = inject[OrganizationRepo]
         val orgCommander = inject[OrganizationCommander]
         val orgMembershipRepo = inject[OrganizationMembershipRepo]
@@ -27,8 +38,33 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
       }
     }
 
+    "grab an organization's visible libraries" in {
+      withDb(modules: _*) { implicit injector =>
+        val (org, owner, nonMember, publicLibs, orgLibs) = db.readWrite { implicit session =>
+          val owner = UserFactory.user().withName("Owner", "McOwnerson").saved
+          val nonMember = UserFactory.user().withName("Rando", "McRanderson").saved
+          val org = OrganizationFactory.organization().withName("Test Org").withOwner(owner).saved
+          val publicLibs = LibraryFactory.libraries(10).map(_.withUser(owner).withVisibility(LibraryVisibility.PUBLISHED).withOrganization(Some(org.id.get))).saved
+          val orgLibs = LibraryFactory.libraries(20).map(_.withUser(owner).withVisibility(LibraryVisibility.ORGANIZATION).withOrganization(Some(org.id.get))).saved
+          (org, owner, nonMember, publicLibs, orgLibs)
+        }
+
+        println(owner)
+        println(nonMember)
+
+        val orgCommander = inject[OrganizationCommander]
+        val ownerVisibleLibraries = orgCommander.getLibrariesVisibleToUser(org.id.get, Some(owner.id.get), offset = Offset(0), limit = Limit(100))
+        val randoVisibleLibraries = orgCommander.getLibrariesVisibleToUser(org.id.get, Some(nonMember.id.get), offset = Offset(0), limit = Limit(100))
+        val nooneVisibleLibraries = orgCommander.getLibrariesVisibleToUser(org.id.get, None, offset = Offset(0), limit = Limit(100))
+
+        ownerVisibleLibraries.length === 30
+        randoVisibleLibraries.length === 10
+        nooneVisibleLibraries.length === 10
+      }
+    }
+
     "modify an organization" in {
-      withDb() { implicit injector =>
+      withDb(modules: _*) { implicit injector =>
         val orgRepo = inject[OrganizationRepo]
         val orgCommander = inject[OrganizationCommander]
         val orgMembershipRepo = inject[OrganizationMembershipRepo]
@@ -67,7 +103,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
     }
 
     "modify an organization's base permissions" in {
-      withDb() { implicit injector =>
+      withDb(modules: _*) { implicit injector =>
         val orgCommander = inject[OrganizationCommander]
         val orgMembershipRepo = inject[OrganizationMembershipRepo]
         val orgMembershipCommander = inject[OrganizationMembershipCommander]
@@ -108,7 +144,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
     }
 
     "delete an organization" in {
-      withDb() { implicit injector =>
+      withDb(modules: _*) { implicit injector =>
         val orgRepo = inject[OrganizationRepo]
         val orgCommander = inject[OrganizationCommander]
         val orgMembershipRepo = inject[OrganizationMembershipRepo]
@@ -152,7 +188,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
       }
     }
     "transfer ownership of an organization" in {
-      withDb() { implicit injector =>
+      withDb(modules: _*) { implicit injector =>
         val orgRepo = inject[OrganizationRepo]
         val orgCommander = inject[OrganizationCommander]
         val orgMembershipRepo = inject[OrganizationMembershipRepo]

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserOrOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserOrOrganizationControllerTest.scala
@@ -138,7 +138,6 @@ class UserOrOrganizationControllerTest extends Specification with ShoeboxTestInj
         }
       }
       "get an org" in {
-        skipped("not implemented yet :(")
         withDb(modules: _*) { implicit injector =>
           val (user, org) = testSetup
 


### PR DESCRIPTION
Added logic for retrieving an organization's libraries.
    Handles both org and library permissions
    Might be kind of slow.

Fixed the way that LibraryCommander was deciding whether a library was visible
Previously it just asked if the user belonged to the organization
This was a problem because private libraries were never private
It now checks to see if the library is ORGANIZATION visible

@andrewconner @leogrim @ajkochanowicz 
