### PR TITLE
Switching from using BufferedImage to File for image processing

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -142,7 +142,7 @@ trait ProcessedImageHelper {
 
       process().map { resizedImage =>
         validateAndGetImageInfo(resizedImage).map { imageInfo =>
-          println(s"[pih] processAndPersistImages: resized ${imageInfo.width}x${imageInfo.height} vs $processImageSize")
+          log.info(s"[pih] processAndPersistImages: resized ${imageInfo.width}x${imageInfo.height} vs $processImageSize")
           val key = ImagePath(baseLabel, hash, ImageSize(imageInfo.width, imageInfo.height), processImageSize.operation, outFormat)
           ImageProcessState.ReadyToPersist(key, outFormat, resizedImage, imageInfo, resizedImage.length().toInt, processImageSize.operation)
         }

--- a/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -119,7 +119,7 @@ trait ProcessedImageHelper {
           case Right(resizedSet) =>
             val original = {
               val key = ImagePath(baseLabel, sourceImage.hash, imageSize, ProcessImageOperation.Original, sourceImage.format)
-              ImageProcessState.ReadyToPersist(key, outFormat, image, imageInfo, image.length().toInt, ProcessImageOperation.Original)
+              ImageProcessState.ReadyToPersist(key, outFormat, image, imageInfo, ProcessImageOperation.Original)
             }
             Right(resizedSet ++ Set(original))
           case Left(err) => Left(err)
@@ -144,7 +144,7 @@ trait ProcessedImageHelper {
         validateAndGetImageInfo(resizedImage).map { imageInfo =>
           log.info(s"[pih] processAndPersistImages: resized ${imageInfo.width}x${imageInfo.height} vs $processImageSize")
           val key = ImagePath(baseLabel, hash, ImageSize(imageInfo.width, imageInfo.height), processImageSize.operation, outFormat)
-          ImageProcessState.ReadyToPersist(key, outFormat, resizedImage, imageInfo, resizedImage.length().toInt, processImageSize.operation)
+          ImageProcessState.ReadyToPersist(key, outFormat, resizedImage, imageInfo, processImageSize.operation)
         }
       }.flatten match {
         case Success(img) => Right(img)

--- a/kifi-backend/modules/common/app/com/keepit/common/images/Photoshop.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/images/Photoshop.scala
@@ -1,6 +1,6 @@
 package com.keepit.common.images
 
-import java.awt.image.BufferedImage
+import java.io.File
 
 import com.google.inject.ImplementedBy
 import com.keepit.model.ImageFormat
@@ -10,7 +10,10 @@ import scala.util.Try
 @ImplementedBy(classOf[Image4javaWrapper])
 trait Photoshop {
   def checkToolsAvailable(): Unit
-  def resizeImage(image: BufferedImage, format: ImageFormat, boundingBox: Int): Try[BufferedImage]
-  def resizeImage(image: BufferedImage, format: ImageFormat, width: Int, height: Int): Try[BufferedImage]
-  def cropImage(image: BufferedImage, format: ImageFormat, width: Int, height: Int): Try[BufferedImage]
+  def imageInfo(image: File): Try[RawImageInfo]
+  def resizeImage(image: File, format: ImageFormat, boundingBox: Int): Try[File]
+  def resizeImage(image: File, format: ImageFormat, width: Int, height: Int): Try[File]
+  def cropImage(image: File, format: ImageFormat, width: Int, height: Int): Try[File]
 }
+
+case class RawImageInfo(format: String, width: Int, height: Int)

--- a/kifi-backend/modules/common/app/com/keepit/common/store/ImageUtils.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/ImageUtils.scala
@@ -28,8 +28,6 @@ object ImageSize {
     ImageSize(w.toInt, h.toInt)
   }
 
-  def apply(bufferedImage: BufferedImage): ImageSize = ImageSize(bufferedImage.getWidth, bufferedImage.getHeight)
-
   implicit val queryStringBinder = new QueryStringBindable[ImageSize] {
     private val stringBinder = implicitly[QueryStringBindable[String]]
     override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, ImageSize]] = {

--- a/kifi-backend/modules/common/app/com/keepit/common/store/RoverImageStore.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/RoverImageStore.scala
@@ -35,6 +35,7 @@ class S3RoverImageStoreImpl @Inject() (
     if (contentLength > 0) {
       om.setCacheControl("public, max-age=31556926") // standard way to cache "forever" (ie, one year)
       om.setContentLength(contentLength)
+
       asyncUpload(s3ImageConfig.bucketName, key.path, is, om).imap { case _ => () }
     } else {
       Future.failed {

--- a/kifi-backend/modules/common/app/com/keepit/model/BaseImage.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/BaseImage.scala
@@ -1,8 +1,8 @@
 package com.keepit.model
 
-import java.awt.image.BufferedImage
-import java.io.ByteArrayInputStream
+import java.io.{ File, ByteArrayInputStream }
 
+import com.keepit.common.images.RawImageInfo
 import com.keepit.common.store.{ ImagePath, ImageSize }
 import com.keepit.rover.article.{ ArticleKind, Article }
 import org.joda.time.DateTime
@@ -74,9 +74,9 @@ sealed abstract class ImageStoreFailure(val reason: String, val cause: Option[Th
 object ImageProcessState {
   // In-progress
   case class ImageLoadedAndHashed(file: TemporaryFile, format: ImageFormat, hash: ImageHash, sourceImageUrl: Option[String]) extends ImageStoreInProgress
-  case class ImageValid(image: BufferedImage, format: ImageFormat, hash: ImageHash, processOperation: ProcessImageOperation) extends ImageStoreInProgress
-  case class ReadyToPersist(key: ImagePath, format: ImageFormat, is: ByteArrayInputStream, image: BufferedImage, bytes: Int, processOperation: ProcessImageOperation) extends ImageStoreInProgress
-  case class UploadedImage(key: ImagePath, format: ImageFormat, image: BufferedImage, processOperation: ProcessImageOperation) extends ImageStoreInProgress
+  case class ImageValid(image: File, format: ImageFormat, hash: ImageHash, processOperation: ProcessImageOperation) extends ImageStoreInProgress
+  case class ReadyToPersist(key: ImagePath, format: ImageFormat, image: File, imageInfo: RawImageInfo, bytes: Int, processOperation: ProcessImageOperation) extends ImageStoreInProgress
+  case class UploadedImage(key: ImagePath, format: ImageFormat, image: File, imageInfo: RawImageInfo, processOperation: ProcessImageOperation) extends ImageStoreInProgress
 
   // Failures
   case class UpstreamProviderFailed(ex: Throwable) extends ImageStoreFailure("upstream_provider_failed", Some(ex))

--- a/kifi-backend/modules/common/app/com/keepit/model/BaseImage.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/BaseImage.scala
@@ -75,8 +75,8 @@ object ImageProcessState {
   // In-progress
   case class ImageLoadedAndHashed(file: TemporaryFile, format: ImageFormat, hash: ImageHash, sourceImageUrl: Option[String]) extends ImageStoreInProgress
   case class ImageValid(image: File, format: ImageFormat, hash: ImageHash, processOperation: ProcessImageOperation) extends ImageStoreInProgress
-  case class ReadyToPersist(key: ImagePath, format: ImageFormat, image: File, imageInfo: RawImageInfo, bytes: Int, processOperation: ProcessImageOperation) extends ImageStoreInProgress
-  case class UploadedImage(key: ImagePath, format: ImageFormat, image: File, imageInfo: RawImageInfo, processOperation: ProcessImageOperation) extends ImageStoreInProgress
+  case class ReadyToPersist(key: ImagePath, format: ImageFormat, file: File, imageInfo: RawImageInfo, processOperation: ProcessImageOperation) extends ImageStoreInProgress
+  case class UploadedImage(key: ImagePath, format: ImageFormat, file: File, imageInfo: RawImageInfo, processOperation: ProcessImageOperation) extends ImageStoreInProgress
 
   // Failures
   case class UpstreamProviderFailed(ex: Throwable) extends ImageStoreFailure("upstream_provider_failed", Some(ex))

--- a/kifi-backend/modules/common/test/com/keepit/common/images/Image4javaWrapperTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/images/Image4javaWrapperTest.scala
@@ -12,9 +12,9 @@ import play.api.Mode
 
 class Image4javaWrapperTest extends Specification with CommonTestInjector {
 
-  def getPngImage(name: String = "image1"): BufferedImage = ImageIO.read(new File(s"test/data/$name.png"))
-  def getJpgImage(name: String = "image1"): BufferedImage = ImageIO.read(new File(s"test/data/$name.jpg"))
-  def getGifImage(name: String = "image1"): BufferedImage = ImageIO.read(new File(s"test/data/$name.gif"))
+  def getPngImage(name: String = "image1"): File = new File(s"test/data/$name.png")
+  def getJpgImage(name: String = "image1"): File = new File(s"test/data/$name.jpg")
+  def getGifImage(name: String = "image1"): File = new File(s"test/data/$name.gif")
 
   def range(actual: Int, expected: Int, window: Double = 0.25): Result = {
     val delta = Math.abs((actual - expected).toDouble / actual.toDouble)
@@ -26,21 +26,8 @@ class Image4javaWrapperTest extends Specification with CommonTestInjector {
     }
   }
 
-  def imageByteSize(img: BufferedImage, format: String): Int = {
-    val tmp = new ByteArrayOutputStream()
-    ImageIO.write(img, format, tmp)
-    tmp.close()
-    tmp.size()
-  }
-
-  def persistImage(img: BufferedImage, format: String): Int = {
-    val file = new File("image-" + Math.random() + "." + format)
-    val stream = new FileOutputStream(file)
-    ImageIO.write(img, format, stream)
-    stream.close()
-    val size = file.length()
-    println(s"persisting image to file: ${file.getAbsolutePath} of size $size")
-    size.toInt
+  def imageByteSize(img: File): Int = {
+    img.getAbsoluteFile.length().toInt
   }
 
   "ImageMagic4javaWrapper" should {
@@ -51,145 +38,181 @@ class Image4javaWrapperTest extends Specification with CommonTestInjector {
       1 === 1
     }
 
+    "get image info from imagemagick (png)" in {
+      val image = getPngImage()
+      val im = new Image4javaWrapper(Mode.Test)
+      val info = im.imageInfo(image).get
+      info.width === 66
+      info.height === 38
+      1 === 1
+    }
+
     "box resize png" in {
       val image = getPngImage()
-      imageByteSize(image, "png") === 627
-      image.getWidth === 66
-      image.getHeight === 38
+      imageByteSize(image) === 612
       val im = new Image4javaWrapper(Mode.Test)
+
       val resized = im.resizeImage(image, ImageFormat.PNG, 20).get
-      resized.getWidth === 20
-      resized.getHeight === 12 // == 38 * 20 / 66
-      range(imageByteSize(resized, "png"), 329)
-      //      persistImage(resized, "png") === 265
+      val resizedInfo = im.imageInfo(resized).get
+      resizedInfo.width === 20
+      resizedInfo.height === 12 // == 38 * 20 / 66
+      range(imageByteSize(resized), 329)
     }
 
     "box resize jpg" in {
       val image = getJpgImage()
-      image.getWidth === 316
-      image.getHeight === 310
       val im = new Image4javaWrapper(Mode.Test)
+
+      val imageInfo = im.imageInfo(image).get
+      imageInfo.width === 316
+      imageInfo.height === 310
+
       val resized = im.resizeImage(image, ImageFormat.JPG, 100).get
-      resized.getWidth === 100
-      resized.getHeight === 98
-      range(imageByteSize(resized, "jpg"), 2330)
+      val resizedInfo = im.imageInfo(resized).get
+      resizedInfo.width === 100
+      resizedInfo.height === 98
+
+      range(imageByteSize(resized), 2330)
       //      persistImage(resized, "jpg") === 2324
     }
 
     "box resize gif to png" in {
       val image = getGifImage()
-      imageByteSize(image, "gif") === 113130
-      image.getWidth === 852
-      image.getHeight === 480
+      imageByteSize(image) === 3168406
       val im = new Image4javaWrapper(Mode.Test)
+
       val resized = im.resizeImage(image, ImageFormat.GIF, 500).get
-      resized.getWidth === 500
-      resized.getHeight === 282
-      range(imageByteSize(resized, "png"), 299348, 0.1)
+      val resizedInfo = im.imageInfo(resized).get
+      resizedInfo.width === 500
+      resizedInfo.height === 282
+      range(imageByteSize(resized), 260310, 0.1)
       //      persistImage(resized, "png") === 175173
     }
 
     "non box resize png" in {
       val image = getPngImage()
-      imageByteSize(image, "png") === 627
-      image.getWidth === 66
-      image.getHeight === 38
+      imageByteSize(image) === 612
       val im = new Image4javaWrapper(Mode.Test)
+
+      val imageInfo = im.imageInfo(image).get
+      imageInfo.width === 66
+      imageInfo.height === 38
+
       val resized = im.resizeImage(image, ImageFormat.PNG, 60, 30).get
-      resized.getWidth === 52
-      resized.getHeight === 30
-      range(imageByteSize(resized, "png"), 678, 0.25)
+      val resizedInfo = im.imageInfo(resized).get
+      resizedInfo.width === 52
+      resizedInfo.height === 30
+      range(imageByteSize(resized), 678, 0.25)
       //      persistImage(resized, "png") === 606
     }
 
     "non box resize jpg" in {
       val image = getJpgImage()
-      //      imageByteSize(image, "jpg") === 11101
-      image.getWidth === 316
-      image.getHeight === 310
       val im = new Image4javaWrapper(Mode.Test)
+
       val resized = im.resizeImage(image, ImageFormat.JPG, 200, 150).get
-      resized.getWidth === 153
-      resized.getHeight === 150
-      range(imageByteSize(resized, "jpg"), 3670)
+      val resizedInfo = im.imageInfo(resized).get
+      resizedInfo.width === 153
+      resizedInfo.height === 150
+      range(imageByteSize(resized), 3670)
       //      persistImage(resized, "jpg") === 3663
     }
 
     "box crop png" in {
       // the perfect crop of this image is to show only the red Xzibit
       val image = getPngImage("wide_image_3x1")
-      //      imageByteSize(image, "png") === 211103
-      image.getWidth === 1173
-      image.getHeight === 391
       val im = new Image4javaWrapper(Mode.Test)
+
+      val imageInfo = im.imageInfo(image).get
+      imageInfo.width === 1173
+      imageInfo.height === 391
+
       val cropped = im.cropImage(image, ImageFormat.PNG, 200, 200).get
-      cropped.getWidth === 200
-      cropped.getHeight === 200
-      range(imageByteSize(cropped, "png"), 66507)
+      val resizedInfo = im.imageInfo(cropped).get
+      resizedInfo.width === 200
+      resizedInfo.height === 200
+      range(imageByteSize(cropped), 48492)
     }
 
     "box crop jpg" in {
       // the perfect crop of this image is to show only the red Xzibit
       val image = getJpgImage("wide_image_3x1")
-      //            imageByteSize(image, "png") === 211103
-      image.getWidth === 1173
-      image.getHeight === 391
       val im = new Image4javaWrapper(Mode.Test)
+
+      val imageInfo = im.imageInfo(image).get
+      imageInfo.width === 1173
+      imageInfo.height === 391
+
       val cropped = im.cropImage(image, ImageFormat.JPG, 200, 200).get
-      cropped.getWidth === 200
-      cropped.getHeight === 200
-      range(imageByteSize(cropped, "jpg"), 7127)
+      val resizedInfo = im.imageInfo(cropped).get
+      resizedInfo.width === 200
+      resizedInfo.height === 200
+      range(imageByteSize(cropped), 7127)
     }
 
     "box crop gif" in {
       // the perfect crop of this image is to show only the red Xzibit
       val image = getGifImage("wide_image_3x1")
-      //            imageByteSize(image, "png") === 211103
-      image.getWidth === 1173
-      image.getHeight === 391
       val im = new Image4javaWrapper(Mode.Test)
+
+      val imageInfo = im.imageInfo(image).get
+      imageInfo.width === 1173
+      imageInfo.height === 391
+
       val cropped = im.cropImage(image, ImageFormat.GIF, 200, 200).get
-      cropped.getWidth === 200
-      cropped.getHeight === 200
-      range(imageByteSize(cropped, "png"), 57164)
+      val resizedInfo = im.imageInfo(cropped).get
+      resizedInfo.width === 200
+      range(imageByteSize(cropped), 45071)
     }
 
     "non box crop png" in {
       // the perfect crop of this image is to show 2 Xzibits
       val image = getPngImage("wide_image_4x1")
-      //      imageByteSize(image, "png") === 211103
-      image.getWidth === 1564
-      image.getHeight === 391
       val im = new Image4javaWrapper(Mode.Test)
+
+      val imageInfo = im.imageInfo(image).get
+      imageInfo.width === 1564
+      imageInfo.height === 391
+
       val cropped = im.cropImage(image, ImageFormat.PNG, 200, 100).get
-      cropped.getWidth === 200
-      cropped.getHeight === 100
-      range(imageByteSize(cropped, "png"), 23865)
+      val resizedInfo = im.imageInfo(cropped).get
+      resizedInfo.width === 200
+      resizedInfo.height === 100
+      range(imageByteSize(cropped), 23865)
     }
 
     "optimize jpg" in {
       val image = getJpgImage("unoptimized1")
-      imageByteSize(image, "jpg") === 79251
-      image.getWidth === 1200
-      image.getHeight === 720
+      imageByteSize(image) === 79257
       val im = new Image4javaWrapper(Mode.Test)
+
+      val imageInfo = im.imageInfo(image).get
+      imageInfo.width === 1200
+      imageInfo.height === 720
+
       val resized = im.resizeImage(image, ImageFormat.JPG, 1200).get //not really resizing
-      resized.getWidth === 1200
-      resized.getHeight === 720
-      range(imageByteSize(resized, "jpg"), 65445)
-      //      persistImage(resized, "jpg") === 65439
+      val resizedInfo = im.imageInfo(resized).get
+      resizedInfo.width === 1200
+      resizedInfo.height === 720
+
+      range(imageByteSize(resized), 65445)
     }
 
     "optimize png" in {
       val image = getPngImage("unoptimized3")
-      imageByteSize(image, "png") === 465305
-      image.getWidth === 500
-      image.getHeight === 333
+      imageByteSize(image) === 274642
       val im = new Image4javaWrapper(Mode.Test)
+
+      val imageInfo = im.imageInfo(image).get
+      imageInfo.width === 500
+      imageInfo.height === 333
+
       val resized = im.resizeImage(image, ImageFormat.PNG, 500).get //not really resizing
-      resized.getWidth === 500
-      resized.getHeight === 333
-      range(imageByteSize(resized, "png"), 465305, 0.2)
+      val resizedInfo = im.imageInfo(resized).get
+      resizedInfo.width === 500
+      resizedInfo.height === 333
+
+      range(imageByteSize(resized), 272072, 0.2)
       //      persistImage(resized, "png") === 205864
     }
 

--- a/kifi-backend/modules/rover/app/com/keepit/rover/image/RoverImageFetcher.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/image/RoverImageFetcher.scala
@@ -44,7 +44,7 @@ class RoverImageFetcher @Inject() (
               case Some(sourceImageInfo) => None
               case None =>
                 val key = ImagePath(imagePathPrefix, sourceImage.hash, sourceImageSize, ProcessImageOperation.Original, sourceImage.format)
-                Some(ImageProcessState.ReadyToPersist(key, outFormat, sourceImage.file.file, imageInfo, sourceImage.file.file.length().toInt, ProcessImageOperation.Original))
+                Some(ImageProcessState.ReadyToPersist(key, outFormat, sourceImage.file.file, imageInfo, ProcessImageOperation.Original))
             }
 
             // Prepare Processed Images
@@ -65,9 +65,9 @@ class RoverImageFetcher @Inject() (
                 // Upload all images
 
                 val uploads = (processedImagesReadyToPersist ++ sourceImageReadyToPersist).map { image =>
-                  val is: InputStream = new FileInputStream(image.image)
-                  val put = imageStore.put(image.key, is, image.bytes, imageFormatToMimeType(image.format)).imap { _ =>
-                    ImageProcessState.UploadedImage(image.key, image.format, image.image, image.imageInfo, image.processOperation)
+                  val is: InputStream = new FileInputStream(image.file)
+                  val put = imageStore.put(image.key, is, image.file.length.toInt, imageFormatToMimeType(image.format)).imap { _ =>
+                    ImageProcessState.UploadedImage(image.key, image.format, image.file, image.imageInfo, image.processOperation)
                   }
                   put.onComplete { _ => is.close() }
                   put

--- a/kifi-backend/modules/rover/app/com/keepit/rover/model/RoverImageInfoRepo.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/model/RoverImageInfoRepo.scala
@@ -65,7 +65,7 @@ class RoverImageInfoRepoImpl @Inject() (
   }
 
   def intern(sourceImageHash: ImageHash, imageSource: ImageSource, sourceImageUrl: Option[String], uploadedImage: UploadedImage)(implicit session: RWSession): RoverImageInfo = {
-    val imageSize = ImageSize(uploadedImage.image)
+    val imageSize = ImageSize(uploadedImage.imageInfo.width, uploadedImage.imageInfo.height)
     getByImage(sourceImageHash, imageSize, uploadedImage.processOperation, uploadedImage.format) match {
       case Some(existingInfo) => {
         val updatedInfo = existingInfo.copy(state = RoverImageInfoStates.ACTIVE, sourceImageUrl = sourceImageUrl, path = uploadedImage.key)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
@@ -380,10 +380,11 @@ class KeepImageCommanderImpl @Inject() (
     toPersist: Set[ImageProcessState.ReadyToPersist], keepId: Id[Keep], source: ImageSource,
     overwriteExistingImage: Boolean, amendExistingImages: Boolean): Future[ImageProcessDone] = {
     val uploads = toPersist.map { image =>
-      log.info(s"[kic] Persisting ${image.key} (${image.bytes} B)")
-      val is: InputStream = new FileInputStream(image.image)
-      val putF = imageStore.put(image.key, is, image.bytes, imageFormatToMimeType(image.format)).map { r =>
-        ImageProcessState.UploadedImage(image.key, image.format, image.image, image.imageInfo, image.processOperation)
+      val size = image.file.length.toInt
+      log.info(s"[kic] Persisting ${image.key} ($size B)")
+      val is: InputStream = new FileInputStream(image.file)
+      val putF = imageStore.put(image.key, is, size, imageFormatToMimeType(image.format)).map { r =>
+        ImageProcessState.UploadedImage(image.key, image.format, image.file, image.imageInfo, image.processOperation)
       }
       putF.onComplete { _ => is.close() }
       putF

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryImageCommander.scala
@@ -141,11 +141,12 @@ class LibraryImageCommanderImpl @Inject() (
 
   private def uploadAndPersistImages(originalImage: ImageProcessState.ImageLoadedAndHashed, toPersist: Set[ImageProcessState.ReadyToPersist], libraryId: Id[Library], position: LibraryImagePosition, source: ImageSource)(implicit requestId: Option[Id[LibraryImageRequest]]): Future[ImageProcessDone] = {
     val uploads = toPersist.map { image =>
-      log.info(s"[lic] Persisting ${image.key} (${image.bytes} B)")
-      val is: InputStream = new FileInputStream(image.image)
+      val size = image.file.length.toInt
+      log.info(s"[lic] Persisting ${image.key} ($size B)")
+      val is: InputStream = new FileInputStream(image.file)
 
-      val put = imageStore.put(image.key, is, image.bytes, imageFormatToMimeType(image.format)).map { r =>
-        ImageProcessState.UploadedImage(image.key, image.format, image.image, image.imageInfo, image.processOperation)
+      val put = imageStore.put(image.key, is, size, imageFormatToMimeType(image.format)).map { r =>
+        ImageProcessState.UploadedImage(image.key, image.format, image.file, image.imageInfo, image.processOperation)
       }
       put.onComplete { _ => is.close() }
       put

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
@@ -62,10 +62,10 @@ class OrganizationAvatarCommanderImpl @Inject() (
       case Left(processingError) => Future.successful(Left(processingError))
       case Right(processedImagesReadyToPersist) =>
         val uploads = processedImagesReadyToPersist.map { image =>
-          val is: InputStream = new FileInputStream(image.image)
+          val is: InputStream = new FileInputStream(image.file)
 
-          val put = imageStore.put(image.key, is, image.bytes, imageFormatToMimeType(image.format)).imap { _ =>
-            ImageProcessState.UploadedImage(image.key, image.format, image.image, image.imageInfo, image.processOperation)
+          val put = imageStore.put(image.key, is, image.file.length.toInt, imageFormatToMimeType(image.format)).imap { _ =>
+            ImageProcessState.UploadedImage(image.key, image.format, image.file, image.imageInfo, image.processOperation)
           }
           put.onComplete { _ => is.close() }
           put
@@ -95,7 +95,7 @@ class OrganizationAvatarCommanderImpl @Inject() (
       case Some(sourceImageInfo) => None
       case None =>
         val key = ImagePath(imagePathPrefix, sourceImage.hash, sourceImageSize, ProcessImageOperation.Original, sourceImage.format)
-        Some(ImageProcessState.ReadyToPersist(key, outFormat, sourceImage.file.file, imageInfo, sourceImage.file.file.length().toInt, ProcessImageOperation.Original))
+        Some(ImageProcessState.ReadyToPersist(key, outFormat, sourceImage.file.file, imageInfo, ProcessImageOperation.Original))
     }
 
     processAndPersistImages(sourceImage.file.file, imagePathPrefix, sourceImage.hash, sourceImage.format, necessary)(photoshop) match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
@@ -1,13 +1,13 @@
 package com.keepit.commanders
 
-import java.awt.image.BufferedImage
+import java.io.{ FileInputStream, InputStream }
 
 import com.google.inject.{ ImplementedBy, Inject, Singleton }
 import com.keepit.commanders.OrganizationAvatarConfiguration._
 import com.keepit.common.core._
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
-import com.keepit.common.images.Photoshop
+import com.keepit.common.images.{ RawImageInfo, Photoshop }
 import com.keepit.common.logging.Logging
 import com.keepit.common.net.WebService
 import com.keepit.common.store.{ ImagePath, ImageSize, OrganizationAvatarStore }
@@ -29,7 +29,7 @@ class OrganizationAvatarCommanderImpl @Inject() (
     db: Database,
     orgAvatarRepo: OrganizationAvatarRepo,
     imageStore: OrganizationAvatarStore,
-    photoshop: Photoshop,
+    implicit val photoshop: Photoshop,
     val webService: WebService,
     private implicit val executionContext: ExecutionContext) extends OrganizationAvatarCommander with ProcessedImageHelper with Logging {
 
@@ -42,29 +42,33 @@ class OrganizationAvatarCommanderImpl @Inject() (
     fetchAndHashLocalImage(imageFile).flatMap {
       case Left(storeError) => Future.successful(Left(storeError))
       case Right(sourceImage) =>
-        validateAndLoadImageFile(sourceImage.file.file) match {
+        validateAndGetImageInfo(sourceImage.file.file) match {
           case Failure(validationError) => Future.successful(Left(ImageProcessState.InvalidImage(validationError)))
-          case Success(bufferedSourceImage) =>
-            persistOrganizationAvatarsFromBufferedSourceImage(sourceImage, bufferedSourceImage, orgId)
+          case Success(imageInfo) =>
+            persistOrganizationAvatarsFromBufferedSourceImage(sourceImage, imageInfo, orgId)
         }
     }
   }
 
-  def persistOrganizationAvatarsFromBufferedSourceImage(sourceImage: ImageProcessState.ImageLoadedAndHashed, bufferedSourceImage: BufferedImage, orgId: Id[Organization]): Future[Either[ImageStoreFailure, ImageHash]] = {
-    val sourceImageSize = ImageSize(bufferedSourceImage)
+  def persistOrganizationAvatarsFromBufferedSourceImage(sourceImage: ImageProcessState.ImageLoadedAndHashed, imageInfo: RawImageInfo, orgId: Id[Organization]): Future[Either[ImageStoreFailure, ImageHash]] = {
+    val sourceImageSize = ImageSize(imageInfo.width, imageInfo.height)
     val existingAvatars = db.readOnlyMaster { implicit session =>
       orgAvatarRepo.getByImageHash(sourceImage.hash)
     }
 
     val (necessary, unnecessary) = determineRequiredProcessImageRequests(sourceImageSize, existingAvatars)
 
-    prepareNewImagesToBePersisted(sourceImage, bufferedSourceImage, existingAvatars, necessary) match {
+    prepareNewImagesToBePersisted(sourceImage, imageInfo, existingAvatars, necessary) match {
       case Left(processingError) => Future.successful(Left(processingError))
       case Right(processedImagesReadyToPersist) =>
         val uploads = processedImagesReadyToPersist.map { image =>
-          imageStore.put(image.key, image.is, image.bytes, imageFormatToMimeType(image.format)).imap { _ =>
-            ImageProcessState.UploadedImage(image.key, image.format, image.image, image.processOperation)
+          val is: InputStream = new FileInputStream(image.image)
+
+          val put = imageStore.put(image.key, is, image.bytes, imageFormatToMimeType(image.format)).imap { _ =>
+            ImageProcessState.UploadedImage(image.key, image.format, image.image, image.imageInfo, image.processOperation)
           }
+          put.onComplete { _ => is.close() }
+          put
         }
 
         val uploadedImagesFut = Future.sequence(uploads).imap(Right(_)).recover { case error: Exception => Left(ImageProcessState.CDNUploadFailed(error)) }
@@ -83,23 +87,20 @@ class OrganizationAvatarCommanderImpl @Inject() (
     }
   }
 
-  def prepareNewImagesToBePersisted(sourceImage: ImageProcessState.ImageLoadedAndHashed, bufferedSourceImage: BufferedImage, existingAvatars: Seq[OrganizationAvatar], necessary: Set[ProcessImageRequest]): Either[ImageStoreFailure, Set[ImageProcessState.ReadyToPersist]] = {
+  def prepareNewImagesToBePersisted(sourceImage: ImageProcessState.ImageLoadedAndHashed, imageInfo: RawImageInfo, existingAvatars: Seq[OrganizationAvatar], necessary: Set[ProcessImageRequest]): Either[ImageStoreFailure, Set[ImageProcessState.ReadyToPersist]] = {
     val outFormat = inputFormatToOutputFormat(sourceImage.format)
+    val sourceImageSize = ImageSize(imageInfo.width, imageInfo.height)
+
     val sourceImageReadyToPersistMaybe = existingAvatars.find(_.kind == ProcessImageOperation.Original) match {
       case Some(sourceImageInfo) => Success(None)
-      case None => bufferedImageToInputStream(bufferedSourceImage, sourceImage.format).map {
-        case (is, bytes) =>
-          val key = ImagePath(imagePathPrefix, sourceImage.hash, ImageSize(bufferedSourceImage), ProcessImageOperation.Original, sourceImage.format)
-          Some(ImageProcessState.ReadyToPersist(key, outFormat, is, bufferedSourceImage, bytes, ProcessImageOperation.Original))
-      }
+      case None =>
+        val key = ImagePath(imagePathPrefix, sourceImage.hash, sourceImageSize, ProcessImageOperation.Original, sourceImage.format)
+        Success(Some(ImageProcessState.ReadyToPersist(key, outFormat, sourceImage.file.file, imageInfo, sourceImage.file.file.length().toInt, ProcessImageOperation.Original)))
     }
 
     sourceImageReadyToPersistMaybe match {
-      case Failure(sourceImageProcessingError) =>
-        Left(ImageProcessState.InvalidImage(sourceImageProcessingError))
-
       case Success(sourceImageReadyToPersist) =>
-        processAndPersistImages(bufferedSourceImage, imagePathPrefix, sourceImage.hash, sourceImage.format, necessary)(photoshop) match {
+        processAndPersistImages(sourceImage.file.file, imagePathPrefix, sourceImage.hash, sourceImage.format, necessary)(photoshop) match {
           case Left(processingError) =>
             Left(processingError)
           case Right(modifiedImagesReadyToPersist) =>
@@ -115,7 +116,7 @@ class OrganizationAvatarCommanderImpl @Inject() (
       }
 
       for (img <- uploadedImages) {
-        val orgAvatar = OrganizationAvatar(organizationId = orgId, width = img.image.getWidth, height = img.image.getHeight, format = sourceImage.format, kind = img.processOperation, imagePath = img.key, source = UserUpload, sourceFileHash = sourceImage.hash, sourceImageURL = None)
+        val orgAvatar = OrganizationAvatar(organizationId = orgId, width = img.imageInfo.width, height = img.imageInfo.height, format = sourceImage.format, kind = img.processOperation, imagePath = img.key, source = UserUpload, sourceFileHash = sourceImage.hash, sourceImageURL = None)
         orgAvatarRepo.save(orgAvatar)
       }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/ProcessedImageHelperTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/ProcessedImageHelperTest.scala
@@ -85,35 +85,6 @@ class ProcessedImageHelperTest extends Specification with ShoeboxTestInjector wi
       }
     }
 
-    "convert image to input stream" in {
-      withInjector(modules: _*) { implicit injector =>
-        new FakeProcessedImageHelper {
-          {
-            val image = dummyImage(200, 300)
-            val res = bufferedImageToInputStream(image, ImageFormat.PNG)
-            res.isSuccess === true
-            res.get._1 !== null
-            res.get._1.read === 137 // first byte of PNG image
-            res.get._2 must be_>(50) // check if file is greater than 50B
-          }
-          {
-            val image = dummyImage(200, 300)
-            val res = bufferedImageToInputStream(image, ImageFormat.JPG)
-            res.isSuccess === true
-            res.get._1 !== null
-            res.get._1.read === 255 // first byte of JPEG image
-            res.get._1.read === 216 // second byte of JPEG image
-            res.get._2 must be_>(256) // check if file is greater than 256B, which is smaller than any legit jpeg
-          }
-          {
-            val res = bufferedImageToInputStream(null, ImageFormat.JPG)
-            res.isSuccess === false
-          }
-        }
-        1 === 1
-      }
-    }
-
     "hash files with MD5" in {
       withInjector(modules: _*) { implicit injector =>
         new FakeProcessedImageHelper {


### PR DESCRIPTION
Rover has experienced memory pressure problems (including crashing for OOM), partially from the use of `BufferedImage`s during image processing. This is Java's native image in-memory format. It is Bad News™ because it means we load images (including large ones) in memory, persist to disk to perform processing actions, serialize back to memory, etc. Image quality and processing speed also suffers.

This should work, tests pass. But I discovered that not all of our image processing has test coverage, so hopefully the compiler is checking any issues. @leogrim @eishay 

In tests, image processing is about 10x faster, and a couple memory leaks have been fixed. Please review to make sure this makes sense. I'm sure the structure of the code can be cleaned up a bit now.
