### PR TITLE
Better debugging messages when we resize, so if they file goes missing, we know!

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
@@ -391,16 +391,14 @@ class KeepImageCommanderImpl @Inject() (
     }
 
     Future.sequence(uploads).map { results =>
-      val keepImages = results.map {
-        case uploadedImage =>
+      val keepImages = results.map { uploadedImage =>
+        val isOriginal = uploadedImage.processOperation match {
+          case Original => true
+          case _ => false
+        }
 
-          val isOriginal = uploadedImage.processOperation match {
-            case Original => true
-            case _ => false
-          }
-
-          val ki = KeepImage(keepId = keepId, imagePath = uploadedImage.key, format = uploadedImage.format, width = uploadedImage.imageInfo.width, height = uploadedImage.imageInfo.height, source = source, sourceImageUrl = originalImage.sourceImageUrl, sourceFileHash = originalImage.hash, isOriginal = isOriginal, kind = uploadedImage.processOperation)
-          ki
+        val ki = KeepImage(keepId = keepId, imagePath = uploadedImage.key, format = uploadedImage.format, width = uploadedImage.imageInfo.width, height = uploadedImage.imageInfo.height, source = source, sourceImageUrl = originalImage.sourceImageUrl, sourceFileHash = originalImage.hash, isOriginal = isOriginal, kind = uploadedImage.processOperation)
+        ki
       }
       db.readWrite(attempts = 3) { implicit session => // because of request consolidator, this can be very race-conditiony
         if (amendExistingImages) {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
@@ -161,7 +161,7 @@ class PageCommander @Inject() (
     val otherLibraryIds = libraries.filterNot(_._2 == userId).map(_._1)
     val memberLibraryIds = libraryMembershipRepo.getWithLibraryIdsAndUserId(otherLibraryIds.toSet, userId).filter(lm => lm._2.isDefined).keys
     val libraryIds = otherLibraryIds.diff(memberLibraryIds.toSeq)
-    val libraryMap = libraryRepo.getLibraries(libraryIds.toSet).filter(_._2.state != LibraryStates.ACTIVE)
+    val libraryMap = libraryRepo.getLibraries(libraryIds.toSet).filter(_._2.state == LibraryStates.ACTIVE)
     libraryIds.map(libraryMap)
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
@@ -161,7 +161,7 @@ class PageCommander @Inject() (
     val otherLibraryIds = libraries.filterNot(_._2 == userId).map(_._1)
     val memberLibraryIds = libraryMembershipRepo.getWithLibraryIdsAndUserId(otherLibraryIds.toSet, userId).filter(lm => lm._2.isDefined).keys
     val libraryIds = otherLibraryIds.diff(memberLibraryIds.toSeq)
-    val libraryMap = libraryRepo.getLibraries(libraryIds.toSet)
+    val libraryMap = libraryRepo.getLibraries(libraryIds.toSet).filter(_._2.state != LibraryStates.ACTIVE)
     libraryIds.map(libraryMap)
   }
 


### PR DESCRIPTION
Got an exception in prod about a missing image. Weird, because it doesn't always happen. Adding extra logging, which will helpfully let us know more about the situations it happens in. Files should be deleted by the JVM when it's unloaded, so I'm a bit confused.

`file.length().toInt` most definitely forces the file to exist, so if the line logs, we know it _did_ exist. @leogrim 
