### PR TITLE
Fixed aliasing bug in library space transfers

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -707,8 +707,8 @@ class LibraryCommanderImpl @Inject() (
 
         val lib = db.readWrite { implicit s =>
           if (newSpace != currentSpace || newSlug != targetLib.slug) {
-            libraryAliasRepo.reclaim(currentSpace, newSlug)
-            libraryAliasRepo.alias(newSpace, targetLib.slug, targetLib.id.get)
+            libraryAliasRepo.reclaim(newSpace, newSlug) // There is now a real library there; dump the alias
+            libraryAliasRepo.alias(currentSpace, targetLib.slug, targetLib.id.get) // Make a new alias for where targetLib used to live
           }
           if (targetMembership.listed != newListed) {
             libraryMembershipRepo.save(targetMembership.copy(listed = newListed))


### PR DESCRIPTION
Now `LibraryCommander.modifyLibrary` correctly aliases/reclaims aliases for
libraries when it is used to move them between spaces (user or organization).

@leogrim 
