### PR TITLE
Org move cleanup

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Handle.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Handle.scala
@@ -2,9 +2,12 @@ package com.keepit.model
 
 import java.net.URLEncoder
 
-import com.keepit.common.db.Id
+import com.keepit.common.crypto.PublicId
+import com.keepit.common.db.{ ExternalId, Id }
+import com.keepit.common.json.EitherFormat
 import com.keepit.common.strings._
 import com.kifi.macros.json
+import play.api.libs.json.Reads
 import play.api.mvc.{ QueryStringBindable, PathBindable }
 
 @json
@@ -41,13 +44,29 @@ object LibrarySpace {
   case class UserSpace(id: Id[User]) extends LibrarySpace
   case class OrganizationSpace(id: Id[Organization]) extends LibrarySpace
 
-  implicit def fromUserId(userId: Id[User]) = UserSpace(userId)
-  implicit def fromOrganizationId(organizationId: Id[Organization]) = OrganizationSpace(organizationId)
+  implicit def fromUserId(userId: Id[User]): UserSpace = UserSpace(userId)
+  implicit def fromOrganizationId(organizationId: Id[Organization]): OrganizationSpace = OrganizationSpace(organizationId)
 
-  def apply(ownerId: Id[User], organizationId: Option[Id[Organization]]): LibrarySpace = organizationId.map(OrganizationSpace(_)) getOrElse UserSpace(ownerId)
+  def apply(ownerId: Id[User], organizationId: Option[Id[Organization]]): LibrarySpace = organizationId.map(OrganizationSpace) getOrElse UserSpace(ownerId)
 
   def prettyPrint(space: LibrarySpace): String = space match {
     case OrganizationSpace(orgId) => s"organization $orgId"
     case UserSpace(userId) => s"user $userId"
+  }
+}
+
+sealed trait ExternalLibrarySpace
+object ExternalLibrarySpace {
+  case class ExternalUserSpace(userId: ExternalId[User]) extends ExternalLibrarySpace
+  case class ExternalOrganizationSpace(orgId: PublicId[Organization]) extends ExternalLibrarySpace
+
+  implicit def fromUserId(userId: ExternalId[User]): ExternalUserSpace = ExternalUserSpace(userId)
+  implicit def fromOrganizationId(organizationId: PublicId[Organization]): ExternalOrganizationSpace = ExternalOrganizationSpace(organizationId)
+
+  implicit val reads: Reads[ExternalLibrarySpace] = Reads[ExternalLibrarySpace] { payload =>
+    payload.validate[Either[ExternalId[User], PublicId[Organization]]](EitherFormat.keyedReads("user", "org")).map {
+      case Left(userId) => ExternalUserSpace(userId)
+      case Right(orgId) => ExternalOrganizationSpace(orgId)
+    }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -20,7 +20,6 @@ import com.keepit.common.time._
 import com.keepit.common.util.Paginator
 import com.keepit.eliza.{ LibraryPushNotificationCategory, UserPushNotificationCategory, PushNotificationExperiment, ElizaServiceClient }
 import com.keepit.heimdal.{ HeimdalContext, HeimdalContextBuilderFactory, HeimdalServiceClient }
-import com.keepit.model.ExternalLibrarySpace.{ ExternalOrganizationSpace, ExternalUserSpace }
 import com.keepit.model.LibrarySpace.{ UserSpace, OrganizationSpace }
 import com.keepit.model._
 import com.keepit.search.SearchServiceClient
@@ -676,12 +675,7 @@ class LibraryCommanderImpl @Inject() (
 
       val targetMembership = targetMembershipOpt.get
       val currentSpace = targetLib.space
-      val newSpaceOpt = db.readOnlyMaster { implicit session =>
-        modifyReq.space.map {
-          case ExternalUserSpace(extId) => LibrarySpace.fromUserId(userRepo.getByExternalId(extId).id.get)
-          case ExternalOrganizationSpace(pubId) => LibrarySpace.fromOrganizationId(Organization.decodePublicId(pubId).get)
-        }
-      }
+      val newSpaceOpt = modifyReq.space
       val newSubKeysOpt = modifyReq.subscriptions
 
       val result = for {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -192,7 +192,7 @@ class LibraryRepoImpl @Inject() (
   }
 
   private def getByUserIdAndSlug(userId: Id[User], slug: LibrarySlug, excludeStates: Set[State[Library]])(implicit session: RSession): Option[Library] = {
-    (for (b <- rows if b.slug === slug && b.ownerId === userId && !b.state.inSet(excludeStates)) yield b).firstOption
+    (for (b <- rows if b.slug === slug && b.ownerId === userId && b.orgId.isEmpty && !b.state.inSet(excludeStates)) yield b).firstOption
   }
   private def getByOrgIdAndSlug(orgId: Id[Organization], slug: LibrarySlug, excludeStates: Set[State[Library]])(implicit session: RSession): Option[Library] = {
     (for (b <- rows if b.slug === slug && b.orgId === orgId && !b.state.inSet(excludeStates)) yield b).firstOption

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
@@ -48,10 +48,6 @@ case class LibraryAddRequest(
   whoCanInvite: Option[LibraryInvitePermissions] = None,
   subscriptions: Option[Seq[LibrarySubscriptionKey]] = None)
 
-@json
-case class OrganizationMoveRequest(orgId: Option[PublicId[Organization]])
-
-@json
 case class LibraryModifyRequest(
   name: Option[String] = None,
   slug: Option[String] = None,
@@ -61,11 +57,10 @@ case class LibraryModifyRequest(
   listed: Option[Boolean] = None,
   whoCanInvite: Option[LibraryInvitePermissions] = None,
   subscriptions: Option[Seq[LibrarySubscriptionKey]] = None,
-  // We can move the library from org to user space.
-  orgMove: Option[OrganizationMoveRequest] = None)
+  space: Option[ExternalLibrarySpace] = None)
 
-object ModifyRequest {
-  private val defaultReads: Reads[LibraryModifyRequest] = (
+object LibraryModifyRequest {
+  implicit val reads: Reads[LibraryModifyRequest] = (
     (__ \ 'name).readNullable[String] and
     (__ \ 'slug).readNullable[String] and
     (__ \ 'visibility).readNullable[LibraryVisibility] and
@@ -74,11 +69,8 @@ object ModifyRequest {
     (__ \ 'listed).readNullable[Boolean] and
     (__ \ 'whoCanInvite).readNullable[LibraryInvitePermissions] and
     (__ \ 'subscription).readNullable[Seq[LibrarySubscriptionKey]] and
-    (__ \ 'space).readNullable[OrganizationMoveRequest]
+    (__ \ 'space).readNullable[ExternalLibrarySpace]
   )(LibraryModifyRequest.apply _)
-
-  val website = defaultReads
-  val mobileV1 = defaultReads
 }
 
 case class LibraryInfo(

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
@@ -48,7 +48,7 @@ case class LibraryAddRequest(
   whoCanInvite: Option[LibraryInvitePermissions] = None,
   subscriptions: Option[Seq[LibrarySubscriptionKey]] = None)
 
-case class LibraryModifyRequest(
+case class ExternalLibraryModifyRequest(
   name: Option[String] = None,
   slug: Option[String] = None,
   visibility: Option[LibraryVisibility] = None,
@@ -57,10 +57,10 @@ case class LibraryModifyRequest(
   listed: Option[Boolean] = None,
   whoCanInvite: Option[LibraryInvitePermissions] = None,
   subscriptions: Option[Seq[LibrarySubscriptionKey]] = None,
-  space: Option[ExternalLibrarySpace] = None)
+  externalSpace: Option[ExternalLibrarySpace] = None)
 
-object LibraryModifyRequest {
-  implicit val reads: Reads[LibraryModifyRequest] = (
+object ExternalLibraryModifyRequest {
+  implicit val reads: Reads[ExternalLibraryModifyRequest] = (
     (__ \ 'name).readNullable[String] and
     (__ \ 'slug).readNullable[String] and
     (__ \ 'visibility).readNullable[LibraryVisibility] and
@@ -70,8 +70,19 @@ object LibraryModifyRequest {
     (__ \ 'whoCanInvite).readNullable[LibraryInvitePermissions] and
     (__ \ 'subscription).readNullable[Seq[LibrarySubscriptionKey]] and
     (__ \ 'space).readNullable[ExternalLibrarySpace]
-  )(LibraryModifyRequest.apply _)
+  )(ExternalLibraryModifyRequest.apply _)
 }
+
+case class LibraryModifyRequest(
+  name: Option[String] = None,
+  slug: Option[String] = None,
+  visibility: Option[LibraryVisibility] = None,
+  description: Option[String] = None,
+  color: Option[LibraryColor] = None,
+  listed: Option[Boolean] = None,
+  whoCanInvite: Option[LibraryInvitePermissions] = None,
+  subscriptions: Option[Seq[LibrarySubscriptionKey]] = None,
+  space: Option[LibrarySpace] = None)
 
 case class LibraryInfo(
   id: PublicId[Library],

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserRepo.scala
@@ -38,6 +38,7 @@ trait UserRepo extends Repo[User] with RepoWithDelete[User] with ExternalIdColum
   def getUsersSince(seq: SequenceNumber[User], fetchSize: Int)(implicit session: RSession): Seq[User]
   def getUsers(ids: Seq[Id[User]])(implicit session: RSession): Map[Id[User], User]
   def getAllUsers(ids: Seq[Id[User]])(implicit session: RSession): Map[Id[User], User]
+  def getByExternalId(id: ExternalId[User])(implicit session: RSession): User
   def getAllUsersByExternalId(ids: Seq[ExternalId[User]])(implicit session: RSession): Map[ExternalId[User], User]
   def getByUsername(username: Username)(implicit session: RSession): Option[User]
   def getRecentActiveUsers(since: DateTime = currentDateTime.minusDays(1))(implicit session: RSession): Seq[Id[User]]
@@ -242,6 +243,10 @@ class UserRepoImpl @Inject() (
       }
       valueMap.map { case (k, v) => (k.id -> v) }
     }
+  }
+
+  def getByExternalId(id: ExternalId[User])(implicit session: RSession): User = {
+    getAllUsersByExternalId(Seq(id)).values.head
   }
 
   def getAllUsersByExternalId(ids: Seq[ExternalId[User]])(implicit session: RSession): Map[ExternalId[User], User] = {

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -264,7 +264,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           // no privs on org, cannot move from personal space.
           implicit val publicIdConfig = inject[PublicIdConfiguration]
           val cannotMoveOrg = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(space = Some(Organization.publicId(org.id.get))))
+            LibraryModifyRequest(space = Some(org.id.get)))
           cannotMoveOrg.isLeft === true
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).organizationId === None
@@ -274,13 +274,13 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // move from personal space to org space
           val canMoveOrg = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(space = Some(Organization.publicId(org.id.get))))
+            LibraryModifyRequest(space = Some(org.id.get)))
           canMoveOrg.isRight === true
           canMoveOrg.right.get.organizationId === org.id
 
           // prevent move from org to one without privs
           val attemptToStealLibrary = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(space = Some(Organization.publicId(starkOrg.id.get))))
+            LibraryModifyRequest(space = Some(starkOrg.id.get)))
           attemptToStealLibrary.isLeft === true
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).organizationId === org.id
@@ -291,7 +291,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             orgMemberRepo.save(starkOrg.newMembership(userAgent.id.get, OrganizationRole.OWNER)) // how did he pull that off.
           }
           val moveOrganization = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(space = Some(Organization.publicId(starkOrg.id.get))))
+            LibraryModifyRequest(space = Some(starkOrg.id.get)))
           moveOrganization.isRight === true
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).organizationId === starkOrg.id
@@ -299,7 +299,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // try to move library back to owner out of org space.
           val moveHome = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userIron.id.get,
-            LibraryModifyRequest(space = Some(userIron.externalId)))
+            LibraryModifyRequest(space = Some(userIron.id.get)))
           moveHome.isLeft === true // only the owner can move a library out right now.
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).organizationId === starkOrg.id
@@ -307,7 +307,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // owner moves the library home.
           val moveHomeSucceeds = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(space = Some(userAgent.externalId)))
+            LibraryModifyRequest(space = Some(userAgent.id.get)))
           moveHomeSucceeds.isRight === true // only the owner can move a library out right now.
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).space === LibrarySpace.fromUserId(userAgent.id.get)
@@ -386,7 +386,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // Move it into starkOrg
           val response1 = libraryCommander.modifyLibrary(libraryId = ironLib.id.get, userId = ironMan.id.get,
-            LibraryModifyRequest(space = Some(Organization.publicId(starkOrg.id.get))))
+            LibraryModifyRequest(space = Some(starkOrg.id.get)))
           println(response1)
           response1.isRight === true
 
@@ -402,7 +402,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // Move it back into ironMan's personal space
           val response2 = libraryCommander.modifyLibrary(libraryId = ironLib.id.get, userId = ironMan.id.get,
-            LibraryModifyRequest(space = Some(ironMan.externalId)))
+            LibraryModifyRequest(space = Some(ironMan.id.get)))
           response2.isRight === true
 
           // The ironMan one was reclaimed, so it should be inactive now
@@ -420,7 +420,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // Move it into earthOrg
           val response3 = libraryCommander.modifyLibrary(libraryId = ironLib.id.get, userId = ironMan.id.get,
-            LibraryModifyRequest(space = Some(Organization.publicId(earthOrg.id.get))))
+            LibraryModifyRequest(space = Some(earthOrg.id.get)))
           response3.isRight === true
 
           // Two aliases now, both ironMan and starkOrg
@@ -439,7 +439,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // Try to move it back into starkOrg, should fail since by default members cannot remove libraries
           val response4 = libraryCommander.modifyLibrary(libraryId = ironLib.id.get, userId = ironMan.id.get,
-            LibraryModifyRequest(space = Some(Organization.publicId(starkOrg.id.get))))
+            LibraryModifyRequest(space = Some(starkOrg.id.get)))
           response4.isLeft === true
         }
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -264,7 +264,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           // no privs on org, cannot move from personal space.
           implicit val publicIdConfig = inject[PublicIdConfiguration]
           val cannotMoveOrg = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(orgMove = Some(OrganizationMoveRequest(Some(Organization.publicId(org.id.get))))))
+            LibraryModifyRequest(space = Some(Organization.publicId(org.id.get))))
           cannotMoveOrg.isLeft === true
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).organizationId === None
@@ -274,13 +274,13 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // move from personal space to org space
           val canMoveOrg = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(orgMove = Some(OrganizationMoveRequest(Some(Organization.publicId(org.id.get))))))
+            LibraryModifyRequest(space = Some(Organization.publicId(org.id.get))))
           canMoveOrg.isRight === true
           canMoveOrg.right.get.organizationId === org.id
 
           // prevent move from org to one without privs
           val attemptToStealLibrary = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(orgMove = Some(OrganizationMoveRequest(Some(Organization.publicId(starkOrg.id.get))))))
+            LibraryModifyRequest(space = Some(Organization.publicId(starkOrg.id.get))))
           attemptToStealLibrary.isLeft === true
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).organizationId === org.id
@@ -291,7 +291,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             orgMemberRepo.save(starkOrg.newMembership(userAgent.id.get, OrganizationRole.OWNER)) // how did he pull that off.
           }
           val moveOrganization = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(orgMove = Some(OrganizationMoveRequest(Some(Organization.publicId(starkOrg.id.get))))))
+            LibraryModifyRequest(space = Some(Organization.publicId(starkOrg.id.get))))
           moveOrganization.isRight === true
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).organizationId === starkOrg.id
@@ -299,7 +299,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // try to move library back to owner out of org space.
           val moveHome = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userIron.id.get,
-            LibraryModifyRequest(orgMove = Some(OrganizationMoveRequest(None))))
+            LibraryModifyRequest(space = Some(userIron.externalId)))
           moveHome.isLeft === true // only the owner can move a library out right now.
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).organizationId === starkOrg.id
@@ -307,7 +307,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // owner moves the library home.
           val moveHomeSucceeds = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(orgMove = Some(OrganizationMoveRequest(None))))
+            LibraryModifyRequest(space = Some(userAgent.externalId)))
           moveHomeSucceeds.isRight === true // only the owner can move a library out right now.
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).space === LibrarySpace.fromUserId(userAgent.id.get)
@@ -386,7 +386,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // Move it into starkOrg
           val response1 = libraryCommander.modifyLibrary(libraryId = ironLib.id.get, userId = ironMan.id.get,
-            LibraryModifyRequest(orgMove = Some(OrganizationMoveRequest(Some(Organization.publicId(starkOrg.id.get))))))
+            LibraryModifyRequest(space = Some(Organization.publicId(starkOrg.id.get))))
           println(response1)
           response1.isRight === true
 
@@ -402,7 +402,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // Move it back into ironMan's personal space
           val response2 = libraryCommander.modifyLibrary(libraryId = ironLib.id.get, userId = ironMan.id.get,
-            LibraryModifyRequest(orgMove = Some(OrganizationMoveRequest(None))))
+            LibraryModifyRequest(space = Some(ironMan.externalId)))
           response2.isRight === true
 
           // The ironMan one was reclaimed, so it should be inactive now
@@ -420,7 +420,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // Move it into earthOrg
           val response3 = libraryCommander.modifyLibrary(libraryId = ironLib.id.get, userId = ironMan.id.get,
-            LibraryModifyRequest(orgMove = Some(OrganizationMoveRequest(Some(Organization.publicId(earthOrg.id.get))))))
+            LibraryModifyRequest(space = Some(Organization.publicId(earthOrg.id.get))))
           response3.isRight === true
 
           // Two aliases now, both ironMan and starkOrg
@@ -439,7 +439,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // Try to move it back into starkOrg, should fail since by default members cannot remove libraries
           val response4 = libraryCommander.modifyLibrary(libraryId = ironLib.id.get, userId = ironMan.id.get,
-            LibraryModifyRequest(orgMove = Some(OrganizationMoveRequest(Some(Organization.publicId(starkOrg.id.get))))))
+            LibraryModifyRequest(space = Some(Organization.publicId(starkOrg.id.get))))
           response4.isLeft === true
         }
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -21,6 +21,7 @@ import com.keepit.model.LibraryFactory._
 import com.keepit.model.LibraryFactoryHelper._
 import com.keepit.model.LibraryMembershipFactory._
 import com.keepit.model.LibraryMembershipFactoryHelper._
+import com.keepit.model.OrganizationFactoryHelper._
 import com.keepit.model.UserFactory._
 import com.keepit.model.UserFactoryHelper._
 import com.keepit.model._
@@ -52,6 +53,10 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
     FakeSocialGraphModule(),
     FakeShoeboxServiceModule()
   )
+
+  implicit def publicIdConfig(implicit injector: Injector) = inject[PublicIdConfiguration]
+  private def controller(implicit injector: Injector) = inject[LibraryController]
+  private def route = com.keepit.controllers.website.routes.LibraryController
 
   private def fakeImage1 = {
     val tf = TemporaryFile(new File("test/data/image1-" + Math.random() + ".png"))
@@ -146,7 +151,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
     "modify library" in {
       withDb(modules: _*) { implicit injector =>
-        implicit val config = inject[PublicIdConfiguration]
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
 
@@ -222,9 +226,55 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
       }
     }
 
+    "move a library from space to space" in {
+      withDb(modules: _*) { implicit injector =>
+        val libraryController = inject[LibraryController]
+
+        val (user, lib, org) = db.readWrite { implicit s =>
+          val user = UserFactory.user().saved
+          val lib = LibraryFactory.library().withSlug("libfoo").withUser(user).saved
+          val org = OrganizationFactory.organization().withOwner(user).saved
+          (user, lib, org)
+        }
+
+        val libPubId = Library.publicId(lib.id.get)
+        val orgPubId = Organization.publicId(org.id.get)
+
+        inject[FakeUserActionsHelper].setUser(user, Set(ExperimentType.ORGANIZATION))
+
+        // At first, lib is in the user space
+        db.readOnlyMaster { implicit session =>
+          libraryRepo.getBySpaceAndSlug(space = user.id.get, slug = LibrarySlug("libfoo")).isDefined === true
+          libraryRepo.getBySpaceAndSlug(space = org.id.get, slug = LibrarySlug("libfoo")).isDefined === false
+        }
+
+        val testPath = route.modifyLibrary(libPubId).url
+        val inputJson1 = Json.obj("space" -> Json.obj("org" -> orgPubId))
+        val request1 = FakeRequest("POST", testPath).withBody(inputJson1)
+        val result1 = controller.modifyLibrary(libPubId)(request1)
+        status(result1) === OK
+
+        // Now it's in the org space
+        db.readOnlyMaster { implicit session =>
+          libraryRepo.getBySpaceAndSlug(space = user.id.get, slug = LibrarySlug("libfoo")).isDefined === false
+          libraryRepo.getBySpaceAndSlug(space = org.id.get, slug = LibrarySlug("libfoo")).isDefined === true
+        }
+
+        val inputJson2 = Json.obj("space" -> Json.obj("user" -> user.externalId))
+        val request2 = FakeRequest("POST", testPath).withBody(inputJson2)
+        val result2 = controller.modifyLibrary(libPubId)(request2)
+        status(result2) === OK
+
+        // Back in user space
+        db.readOnlyMaster { implicit session =>
+          libraryRepo.getBySpaceAndSlug(space = user.id.get, slug = LibrarySlug("libfoo")).isDefined === true
+          libraryRepo.getBySpaceAndSlug(space = org.id.get, slug = LibrarySlug("libfoo")).isDefined === false
+        }
+      }
+    }
+
     "remove library" in {
       withDb(modules: _*) { implicit injector =>
-        implicit val config = inject[PublicIdConfiguration]
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
 
@@ -257,7 +307,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
     "get library by public id" in {
       withDb(modules: _*) { implicit injector =>
-        implicit val config = inject[PublicIdConfiguration]
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
 
@@ -391,7 +440,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
     "get library by path" in {
       withDb(modules: _*) { implicit injector =>
-        implicit val config = inject[PublicIdConfiguration]
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
 
@@ -489,7 +537,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
     "get libraries of user" in {
       withDb(modules: _*) { implicit injector =>
-        implicit val config = inject[PublicIdConfiguration]
         val t1 = new DateTime(2015, 1, 1, 0, 0, 0, 1, DEFAULT_DATE_TIME_ZONE)
         val t2 = new DateTime(2015, 1, 1, 0, 0, 0, 2, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
@@ -551,7 +598,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
     "invite users to library" in {
       withDb(modules: _*) { implicit injector =>
-        implicit val config = inject[PublicIdConfiguration]
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
 
@@ -639,7 +685,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
       "succeed when inviter tries to uninvite" in {
         withDb(modules: _*) { implicit injector =>
-          implicit val config = inject[PublicIdConfiguration]
           val libraryController = inject[LibraryController]
           val (invitee: User, inviter: User, library: Library, invite: LibraryInvite) = setupUninvite()
           val libraryId = Library.publicId(library.id.get)
@@ -662,7 +707,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
       }
       "fail when someone else tries to uninvite" in {
         withDb(modules: _*) { implicit injector =>
-          implicit val config = inject[PublicIdConfiguration]
           val libraryController = inject[LibraryController]
           val (invitee: User, inviter: User, library: Library, invite: LibraryInvite) = setupUninvite()
           val libraryId = Library.publicId(library.id.get)
@@ -684,7 +728,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
       "fail for invalid library id" in {
         withDb(modules: _*) { implicit injector =>
-          implicit val config = inject[PublicIdConfiguration]
           val libraryController = inject[LibraryController]
           val (invitee: User, inviter: User, library: Library, invite: LibraryInvite) = setupUninvite()
           val libraryId = PublicId[Library]("x")
@@ -706,7 +749,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
       "fail for invalid user type" in {
         withDb(modules: _*) { implicit injector =>
-          implicit val config = inject[PublicIdConfiguration]
           val libraryController = inject[LibraryController]
           val (invitee: User, inviter: User, library: Library, invite: LibraryInvite) = setupUninvite()
           val libraryId = Library.publicId(library.id.get)
@@ -728,7 +770,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
       "fail for invalid user externalId" in {
         withDb(modules: _*) { implicit injector =>
-          implicit val config = inject[PublicIdConfiguration]
           val libraryController = inject[LibraryController]
           val (invitee: User, inviter: User, library: Library, invite: LibraryInvite) = setupUninvite()
           val libraryId = Library.publicId(library.id.get)
@@ -751,7 +792,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
     "join or decline library invites" in {
       withDb(modules: _*) { implicit injector =>
-        implicit val config = inject[PublicIdConfiguration]
         val libraryController = inject[LibraryController]
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
 
@@ -804,7 +844,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
     "leave library" in {
       withDb(modules: _*) { implicit injector =>
-        implicit val config = inject[PublicIdConfiguration]
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
 
@@ -834,7 +873,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
     "get keeps" in {
       withDb(modules: _*) { implicit injector =>
-        implicit val config = inject[PublicIdConfiguration]
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
 
@@ -929,7 +967,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
     "copy & move keeps between libraries" in {
       withDb(modules: _*) { implicit injector =>
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
-        implicit val config = inject[PublicIdConfiguration]
         val libraryController = inject[LibraryController]
 
         val (userA, userB, lib1, lib2, keep1, keep2) = db.readWrite { implicit s =>
@@ -1039,7 +1076,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
     "get members" in {
       withDb(modules: _*) { implicit injector =>
-        implicit val config = inject[PublicIdConfiguration]
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
 
@@ -1130,7 +1166,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
     "add keeps to library" in {
       withDb(modules: _*) { implicit injector =>
-        implicit val config = inject[PublicIdConfiguration]
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
 
@@ -1232,7 +1267,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
     "remove keeps from library" in {
       withDb(modules: _*) { implicit injector =>
-        implicit val config = inject[PublicIdConfiguration]
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
 
@@ -1304,7 +1338,6 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
     "update keep in library" in {
       withDb(modules: _*) { implicit injector =>
-        implicit val config = inject[PublicIdConfiguration]
         val t1 = new DateTime(2014, 7, 21, 6, 59, 0, 0, DEFAULT_DATE_TIME_ZONE)
         val libraryController = inject[LibraryController]
 
@@ -1349,7 +1382,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
           (user, keep, lib)
         }
         val libraryController = inject[LibraryController]
-        val pubId1 = Library.publicId(lib1.id.get)(inject[PublicIdConfiguration])
+        val pubId1 = Library.publicId(lib1.id.get)
         val testPath = com.keepit.controllers.website.routes.LibraryController.editKeepNote(pubId1, keep1.externalId).url
         inject[FakeUserActionsHelper].setUser(user1)
 
@@ -1400,8 +1433,8 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
         def updateLibraryMembership(user: User, targetUser: User, lib: Library, access: String) = {
           val libraryController = inject[LibraryController]
-          val pubLibId = Library.publicId(lib.id.get)(inject[PublicIdConfiguration])
           inject[FakeUserActionsHelper].setUser(user)
+          val pubLibId = Library.publicId(lib.id.get)
           val testPath = com.keepit.controllers.website.routes.LibraryController.updateLibraryMembership(pubLibId, targetUser.externalId).url
           val jsonBody = Json.obj("access" -> access)
           libraryController.updateLibraryMembership(pubLibId, targetUser.externalId)(FakeRequest("POST", testPath).withBody(jsonBody))


### PR DESCRIPTION
@leogrim @ajkochanowicz @cvializ 

Cleaned up library transfers to/from orgs/users. The new format is
`{"space": {"user": ext-id}}` for moving to a user space (right now it only allows moving to the library owner's space, by the library owner)
`{"space": {"org": pub-id}}` for moving to an org.

I'm open to changing `"space"` to `"move"` or `"destination"` for the purpose of deserialization.
