### PR TITLE
Return viewer's permissions when they look at an org

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
@@ -66,7 +66,9 @@ class OrganizationController @Inject() (
   }
 
   def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
-    Ok(Json.obj("organization" -> Json.toJson(orgCommander.getOrganizationView(request.orgId))(OrganizationView.website)))
+    val orgView = Json.toJson(orgCommander.getOrganizationView(request.orgId))(OrganizationView.website)
+    val requesterPermissions = Json.toJson(orgMembershipCommander.getPermissions(request.orgId, request.request.userIdOpt))
+    Ok(Json.obj("organization" -> orgView, "viewer_permissions" -> requesterPermissions))
   }
 
   def getOrganizationLibraries(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>


### PR DESCRIPTION
Hitting `/site/organizations/:id` will yield an object with an "organization"
that is an `OrganizationView`, and a "viewer_permissions" that is a JsArray
of org permissions

@andrewconner @ajkochanowicz @cvializ 
