### PR TITLE
Fixed a few permissions-based visibility bugs

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
@@ -38,6 +38,9 @@ case class Organization(
   def withBasePermissions(newBasePermissions: BasePermissions): Organization = {
     this.copy(basePermissions = new BasePermissions(basePermissions.permissionsMap ++ newBasePermissions.permissionsMap))
   }
+  def hiddenFromNonmembers: Organization = {
+    this.withBasePermissions(BasePermissions(Map(None -> Set())))
+  }
 
   def getNonmemberPermissions = basePermissions.forNonmember
   def getRolePermissions(role: OrganizationRole) = basePermissions.forRole(role)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -54,6 +54,7 @@ trait LibraryCommander {
   def updateLastView(userId: Id[User], libraryId: Id[Library]): Unit
   def getLibraryById(userIdOpt: Option[Id[User]], showPublishedLibraries: Boolean, id: Id[Library], imageSize: ImageSize, viewerId: Option[Id[User]])(implicit context: HeimdalContext): Future[FullLibraryInfo]
   def getLibrarySummaries(libraryIds: Seq[Id[Library]]): Seq[LibraryInfo]
+  def getLibrarySummariesHelper(libraries: Seq[Library])(implicit session: RSession): Seq[LibraryInfo]
   def getLibraryPath(library: Library): String
   def getBasicLibraryDetails(libraryIds: Set[Id[Library]], idealImageSize: ImageSize, viewerId: Option[Id[User]]): Map[Id[Library], BasicLibraryDetails]
   def getLibrarySummaryAndMembership(userIdOpt: Option[Id[User]], libraryId: Id[Library]): (LibraryInfo, Option[LibraryMembershipInfo])
@@ -70,6 +71,7 @@ trait LibraryCommander {
   def getLibrariesWithWriteAccess(userId: Id[User]): Set[Id[Library]]
   def modifyLibrary(libraryId: Id[Library], userId: Id[User], modifyReq: LibraryModifyRequest)(implicit context: HeimdalContext): Either[LibraryFail, Library]
   def removeLibrary(libraryId: Id[Library], userId: Id[User])(implicit context: HeimdalContext): Option[LibraryFail]
+  def canViewLibraryHelper(userId: Option[Id[User]], library: Library, authToken: Option[String] = None)(implicit session: RSession): Boolean
   def canViewLibrary(userId: Option[Id[User]], library: Library, authToken: Option[String] = None): Boolean
   def canViewLibrary(userId: Option[Id[User]], libraryId: Id[Library], accessToken: Option[String]): Boolean
   def canMoveTo(userId: Id[User], libId: Id[Library], to: LibrarySpace): Boolean
@@ -171,14 +173,16 @@ class LibraryCommanderImpl @Inject() (
 
   def getLibrarySummaries(libraryIds: Seq[Id[Library]]): Seq[LibraryInfo] = {
     db.readOnlyMaster { implicit session =>
-      val librariesById = libraryRepo.getLibraries(libraryIds.toSet) // cached
-      val ownersById = basicUserRepo.loadAll(librariesById.values.map(_.ownerId).toSet) // cached
-      libraryIds.map { libId =>
-        val library = librariesById(libId)
-        val owner = ownersById(library.ownerId)
-        val org = library.organizationId.map { orgRepo.get(_) }
-        LibraryInfo.fromLibraryAndOwner(library, None, owner, org) // library images are not used, so no need to include
-      }
+      val libraries = libraryRepo.getLibraries(libraryIds.toSet).values.toSeq // cached
+      getLibrarySummariesHelper(libraries)
+    }
+  }
+  def getLibrarySummariesHelper(libraries: Seq[Library])(implicit session: RSession): Seq[LibraryInfo] = {
+    val ownersById = basicUserRepo.loadAll(libraries.map(_.ownerId).toSet) // cached
+    libraries.map { lib =>
+      val owner = ownersById(lib.ownerId)
+      val org = lib.organizationId.map(orgRepo.get)
+      LibraryInfo.fromLibraryAndOwner(lib, None, owner, org) // library images are not used, so no need to include
     }
   }
 
@@ -807,28 +811,29 @@ class LibraryCommanderImpl @Inject() (
     }
   }
 
-  def canViewLibrary(userId: Option[Id[User]], library: Library, authToken: Option[String] = None): Boolean = {
+  def canViewLibraryHelper(userIdOpt: Option[Id[User]], library: Library, authToken: Option[String] = None)(implicit session: RSession): Boolean = {
     library.visibility == LibraryVisibility.PUBLISHED || // published library
-      db.readOnlyMaster { implicit s =>
-        userId match {
-          case Some(id) =>
-            val userIsInLibrary = libraryMembershipRepo.getWithLibraryIdAndUserId(library.id.get, id).nonEmpty
-            val userIsInvitedToLibrary = libraryInviteRepo.getWithLibraryIdAndUserId(userId = id, libraryId = library.id.get).nonEmpty
-            val userHasValidAuthToken = getValidLibInvitesFromAuthToken(library.id.get, authToken).nonEmpty
-            val userIsInOrg = library.organizationId.flatMap(orgId => organizationMembershipRepo.getByOrgIdAndUserId(orgId, id)).nonEmpty
-            val libIsOrgVisible = library.visibility == LibraryVisibility.ORGANIZATION
-            userIsInLibrary || userIsInvitedToLibrary || userHasValidAuthToken || (libIsOrgVisible && userIsInOrg)
-          case None =>
-            getValidLibInvitesFromAuthToken(library.id.get, authToken).nonEmpty
-        }
-      }
+      (userIdOpt match {
+        case Some(id) =>
+          val userIsInLibrary = libraryMembershipRepo.getWithLibraryIdAndUserId(library.id.get, id).nonEmpty
+          val userIsInvitedToLibrary = libraryInviteRepo.getWithLibraryIdAndUserId(userId = id, libraryId = library.id.get).nonEmpty
+          val userHasValidAuthToken = getValidLibInvitesFromAuthToken(library.id.get, authToken).nonEmpty
+          val userIsInOrg = library.organizationId.flatMap(orgId => organizationMembershipRepo.getByOrgIdAndUserId(orgId, id)).nonEmpty
+          val libIsOrgVisible = library.visibility == LibraryVisibility.ORGANIZATION
+          userIsInLibrary || userIsInvitedToLibrary || userHasValidAuthToken || (libIsOrgVisible && userIsInOrg)
+        case None =>
+          getValidLibInvitesFromAuthToken(library.id.get, authToken).nonEmpty
+      })
+  }
+  def canViewLibrary(userIdOpt: Option[Id[User]], library: Library, authToken: Option[String] = None): Boolean = {
+    db.readOnlyReplica { implicit session => canViewLibraryHelper(userIdOpt, library, authToken) }
   }
 
   def canViewLibrary(userId: Option[Id[User]], libraryId: Id[Library], accessToken: Option[String]): Boolean = {
-    val library = db.readOnlyReplica { implicit session =>
-      libraryRepo.get(libraryId)
+    db.readOnlyReplica { implicit session =>
+      val library = libraryRepo.get(libraryId)
+      library.state == LibraryStates.ACTIVE && canViewLibraryHelper(userId, library, accessToken)
     }
-    library.state == LibraryStates.ACTIVE && canViewLibrary(userId, library, accessToken)
   }
 
   def canMoveTo(userId: Id[User], libId: Id[Library], to: LibrarySpace): Boolean = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -6,6 +6,7 @@ import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
 import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.common.store.ImageSize
@@ -18,8 +19,8 @@ import scala.util.{ Failure, Success, Try }
 @ImplementedBy(classOf[OrganizationCommanderImpl])
 trait OrganizationCommander {
   def getAllOrganizationIds: Seq[Id[Organization]]
-  def getOrganizationView(orgId: Id[Organization]): OrganizationView
-  def getOrganizationCards(orgIds: Seq[Id[Organization]]): Map[Id[Organization], OrganizationCard]
+  def getOrganizationView(orgId: Id[Organization], viewerIdOpt: Option[Id[User]]): OrganizationView
+  def getOrganizationCards(orgIds: Seq[Id[Organization]], viewerIdOpt: Option[Id[User]]): Map[Id[Organization], OrganizationCard]
   def getLibrariesVisibleToUser(orgId: Id[Organization], userIdOpt: Option[Id[User]], offset: Offset, limit: Limit): Seq[LibraryCardInfo]
   def isValidRequest(request: OrganizationRequest)(implicit session: RSession): Boolean
   def createOrganization(request: OrganizationCreateRequest): Either[OrganizationFail, OrganizationCreateResponse]
@@ -43,21 +44,26 @@ class OrganizationCommanderImpl @Inject() (
     libraryRepo: LibraryRepo,
     basicUserRepo: BasicUserRepo,
     libraryCommander: LibraryCommander,
+    airbrake: AirbrakeNotifier,
     implicit val publicIdConfig: PublicIdConfiguration,
     handleCommander: HandleCommander) extends OrganizationCommander with Logging {
 
   // TODO(ryan): do the smart thing and add a limit/offset
   def getAllOrganizationIds: Seq[Id[Organization]] = db.readOnlyReplica { implicit session => orgRepo.all().map(_.id.get) }
 
-  def getOrganizationView(orgId: Id[Organization]): OrganizationView = {
-    db.readOnlyReplica { implicit session => getOrganizationViewHelper(orgId) }
+  def getOrganizationView(orgId: Id[Organization], viewerIdOpt: Option[Id[User]]): OrganizationView = {
+    db.readOnlyReplica { implicit session => getOrganizationViewHelper(orgId, viewerIdOpt) }
   }
-  def getOrganizationCards(orgIds: Seq[Id[Organization]]): Map[Id[Organization], OrganizationCard] = {
+  def getOrganizationCards(orgIds: Seq[Id[Organization]], viewerIdOpt: Option[Id[User]]): Map[Id[Organization], OrganizationCard] = {
     db.readOnlyReplica { implicit session =>
-      orgIds.map { orgId => orgId -> getOrganizationCardHelper(orgId) }.toMap
+      orgIds.map { orgId => orgId -> getOrganizationCardHelper(orgId, viewerIdOpt) }.toMap
     }
   }
-  private def getOrganizationViewHelper(orgId: Id[Organization])(implicit session: RSession): OrganizationView = {
+  private def getOrganizationViewHelper(orgId: Id[Organization], viewerIdOpt: Option[Id[User]])(implicit session: RSession): OrganizationView = {
+    if (!orgMembershipCommander.getPermissionsHelper(orgId, viewerIdOpt).contains(OrganizationPermission.VIEW_ORGANIZATION)) {
+      airbrake.notify(s"Tried to serve up an organization view for org $orgId to viewer $viewerIdOpt, but they do not have permission to view this org")
+    }
+
     val org = orgRepo.get(orgId)
     val orgHandle = org.getHandle
     val orgName = org.name
@@ -70,8 +76,10 @@ class OrganizationCommanderImpl @Inject() (
     val membersAsBasicUsers = members.map(BasicUser.fromUser)
     val memberCount = orgMembershipRepo.countByOrgId(orgId)
     val avatarPath = organizationAvatarCommander.getBestImage(orgId, ImageSize(200, 200)).map(_.imagePath)
-    val librariesByVisibility = libraryRepo.countLibrariesForOrgByVisibility(orgId)
-    val numPublicLibraries = librariesByVisibility(LibraryVisibility.PUBLISHED) // TODO: find libraries that are visible to the requester
+
+    // TODO(ryan): this is so bad, surely there is a better way
+    val numLibraries = getLibrariesVisibleToUserHelper(orgId, viewerIdOpt, offset = Offset(0), limit = Limit(Int.MaxValue)).length
+
     OrganizationView(
       orgId = Organization.publicId(orgId),
       ownerId = ownerId,
@@ -81,10 +89,13 @@ class OrganizationCommanderImpl @Inject() (
       avatarPath = avatarPath,
       members = membersAsBasicUsers,
       numMembers = memberCount,
-      numLibraries = numPublicLibraries)
+      numLibraries = numLibraries)
   }
 
-  private def getOrganizationCardHelper(orgId: Id[Organization])(implicit session: RSession): OrganizationCard = {
+  private def getOrganizationCardHelper(orgId: Id[Organization], viewerIdOpt: Option[Id[User]])(implicit session: RSession): OrganizationCard = {
+    if (!orgMembershipCommander.getPermissionsHelper(orgId, viewerIdOpt).contains(OrganizationPermission.VIEW_ORGANIZATION)) {
+      airbrake.notify(s"Tried to serve up an organization card for org $orgId to viewer $viewerIdOpt, but they do not have permission to view this org")
+    }
     val org = orgRepo.get(orgId)
     val orgHandle = org.getHandle
     val orgName = org.name
@@ -95,8 +106,8 @@ class OrganizationCommanderImpl @Inject() (
     val numMembers = orgMembershipRepo.countByOrgId(orgId)
     val avatarPath = organizationAvatarCommander.getBestImage(orgId, ImageSize(200, 200)).map(_.imagePath)
 
-    val librariesByVisibility = libraryRepo.countLibrariesForOrgByVisibility(orgId)
-    val numPublicLibs = librariesByVisibility(LibraryVisibility.PUBLISHED) // TODO: actually find the number of libraries
+    // TODO(ryan): this is bad, surely there is a better way
+    val numLibraries = getLibrariesVisibleToUserHelper(orgId, viewerIdOpt, offset = Offset(0), limit = Limit(Int.MaxValue)).length
 
     OrganizationCard(
       orgId = Organization.publicId(orgId),
@@ -106,12 +117,11 @@ class OrganizationCommanderImpl @Inject() (
       description = description,
       avatarPath = avatarPath,
       numMembers = numMembers,
-      numLibraries = numPublicLibs)
+      numLibraries = numLibraries)
   }
 
   def getLibrariesVisibleToUser(orgId: Id[Organization], userIdOpt: Option[Id[User]], offset: Offset, limit: Limit): Seq[LibraryCardInfo] = {
-    val allLibraries = db.readOnlyReplica { implicit session => libraryRepo.getBySpace(LibrarySpace.fromOrganizationId(orgId)) }
-    val visibleLibraries = allLibraries.filter(lib => libraryCommander.canViewLibrary(userIdOpt, lib)).slice(offset.value.toInt, offset.value.toInt + limit.value.toInt).toSeq
+    val visibleLibraries = getLibrariesVisibleToUserHelper(orgId, userIdOpt, offset, limit)
 
     val (basicOwnersByOwnerId, viewerOpt) = db.readOnlyReplica { implicit session =>
       val basicOwnersByOwnerId = visibleLibraries.map(lib => lib.ownerId -> basicUserRepo.load(lib.ownerId)).toMap
@@ -123,6 +133,12 @@ class OrganizationCommanderImpl @Inject() (
     db.readOnlyReplica { implicit session =>
       libraryCommander.createLibraryCardInfos(visibleLibraries, basicOwnersByOwnerId, viewerOpt, withFollowing = false, ProcessedImageSize.Medium.idealSize).seq
     }
+  }
+
+  private def getLibrariesVisibleToUserHelper(orgId: Id[Organization], userIdOpt: Option[Id[User]], offset: Offset, limit: Limit)(implicit session: RSession): Seq[Library] = {
+    val allLibraries = libraryRepo.getBySpace(LibrarySpace.fromOrganizationId(orgId)).toSeq
+    val visibleLibraries = allLibraries.filter(lib => libraryCommander.canViewLibraryHelper(userIdOpt, lib))
+    visibleLibraries.drop(offset.value.toInt).take(limit.value.toInt)
   }
 
   def isValidRequest(request: OrganizationRequest)(implicit session: RSession): Boolean = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
@@ -122,7 +122,7 @@ class OrganizationMembershipCommanderImpl @Inject() (
   def getVisibleOrganizationsForUser(userId: Id[User], viewerIdOpt: Option[Id[User]]): Seq[Id[Organization]] = {
     db.readOnlyReplica { implicit session =>
       val allOrgIds = organizationMembershipRepo.getAllByUserId(userId).map(_.organizationId)
-      allOrgIds.filter(getPermissions(_, viewerIdOpt).contains(OrganizationPermission.VIEW_ORGANIZATION))
+      allOrgIds.filter(getPermissionsHelper(_, viewerIdOpt).contains(OrganizationPermission.VIEW_ORGANIZATION))
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
@@ -31,10 +31,12 @@ trait OrganizationMembershipCommander {
   def getMembersAndInvitees(orgId: Id[Organization], limit: Limit, offset: Offset, includeInvitees: Boolean): Seq[MaybeOrganizationMember]
   def getOrganizationsForUser(userId: Id[User], limit: Limit, offset: Offset): Seq[Id[Organization]]
   def getAllOrganizationsForUser(userId: Id[User]): Seq[Id[Organization]]
+  def getVisibleOrganizationsForUser(userId: Id[User], viewerIdOpt: Option[Id[User]]): Seq[Id[Organization]]
   def getMemberIds(orgId: Id[Organization]): Set[Id[User]]
 
   def getMembership(orgId: Id[Organization], userId: Id[User]): Option[OrganizationMembership]
   def getPermissions(orgId: Id[Organization], userIdOpt: Option[Id[User]]): Set[OrganizationPermission]
+  def getPermissionsHelper(orgId: Id[Organization], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[OrganizationPermission]
   def isValidRequest(request: OrganizationMembershipRequest)(implicit session: RSession): Boolean
 
   def validateRequests(requests: Seq[OrganizationMembershipRequest]): Map[OrganizationMembershipRequest, Boolean]
@@ -65,7 +67,10 @@ class OrganizationMembershipCommanderImpl @Inject() (
     }
   }
 
-  def getPermissions(orgId: Id[Organization], userIdOpt: Option[Id[User]]): Set[OrganizationPermission] = db.readOnlyReplica { implicit session =>
+  def getPermissions(orgId: Id[Organization], userIdOpt: Option[Id[User]]): Set[OrganizationPermission] = {
+    db.readOnlyReplica { implicit session => getPermissionsHelper(orgId, userIdOpt) }
+  }
+  def getPermissionsHelper(orgId: Id[Organization], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[OrganizationPermission] = {
     val org = organizationRepo.get(orgId)
     userIdOpt match {
       case None => org.getNonmemberPermissions
@@ -111,6 +116,13 @@ class OrganizationMembershipCommanderImpl @Inject() (
   def getAllOrganizationsForUser(userId: Id[User]): Seq[Id[Organization]] = {
     db.readOnlyReplica { implicit session =>
       organizationMembershipRepo.getAllByUserId(userId).map(_.organizationId)
+    }
+  }
+
+  def getVisibleOrganizationsForUser(userId: Id[User], viewerIdOpt: Option[Id[User]]): Seq[Id[Organization]] = {
+    db.readOnlyReplica { implicit session =>
+      val allOrgIds = organizationMembershipRepo.getAllByUserId(userId).map(_.organizationId)
+      allOrgIds.filter(getPermissions(_, viewerIdOpt).contains(OrganizationPermission.VIEW_ORGANIZATION))
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserIpAddressCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserIpAddressCommander.scala
@@ -113,7 +113,7 @@ class UserIpAddressEventLogger @Inject() (
         val model = UserIpAddress(userId = event.userId, ipAddress = event.ip, agentType = agentType)
         userIpAddressRepo.saveIfNew(model)
       } else {
-         log.info(s"[IPTRACK NOTIFY] Decided to not add user ${event.userId} to the IP address repo, they seem fake")
+        log.info(s"[IPTRACK NOTIFY] Decided to not add user ${event.userId} to the IP address repo, they seem fake")
       }
 
       (currentCluster.toSet, ignoreForPotentialOrgs)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
@@ -35,7 +35,7 @@ class MobileOrganizationController @Inject() (
             case Left(failure) =>
               failure.asErrorResponse
             case Right(response) =>
-              val orgView = orgCommander.getOrganizationView(response.newOrg.id.get)
+              val orgView = orgCommander.getOrganizationView(response.newOrg.id.get, request.userIdOpt)
               implicit val writes = OrganizationView.mobileV1
               Ok(Json.obj("organization" -> Json.toJson(orgView)))
           }
@@ -50,7 +50,7 @@ class MobileOrganizationController @Inject() (
         orgCommander.modifyOrganization(OrganizationModifyRequest(request.request.userId, request.orgId, modifications)) match {
           case Left(failure) => failure.asErrorResponse
           case Right(response) =>
-            val orgView = orgCommander.getOrganizationView(response.modifiedOrg.id.get)
+            val orgView = orgCommander.getOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt)
             implicit val writes = OrganizationView.mobileV1
             Ok(Json.obj("organization" -> Json.toJson(orgView)))
         }
@@ -66,16 +66,18 @@ class MobileOrganizationController @Inject() (
   }
 
   def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
-    Ok(Json.obj("organization" -> Json.toJson(orgCommander.getOrganizationView(request.orgId))(OrganizationView.mobileV1)))
+    val orgView = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt)
+    val requesterPermissions = Json.toJson(orgMembershipCommander.getPermissions(request.orgId, request.request.userIdOpt))
+    Ok(Json.obj("organization" -> Json.toJson(orgView)(OrganizationView.mobileV1), "viewer_permissions" -> requesterPermissions))
   }
 
   // TODO(ryan): when organizations are no longer hidden behind an experiment, change this to a MaybeUserAction
   def getOrganizationsForUser(extId: ExternalId[User]) = UserAction { request =>
     if (!request.experiments.contains(UserExperimentType.ORGANIZATION)) BadRequest(Json.obj("error" -> "insufficient_permissions"))
     else {
-      val user = userCommander.getByExternalIds(Seq(extId)).values.head
-      val publicOrgs = orgMembershipCommander.getAllOrganizationsForUser(user.id.get)
-      val orgCards = orgCommander.getOrganizationCards(publicOrgs).values.toSeq
+      val user = userCommander.getByExternalId(extId)
+      val visibleOrgs = orgMembershipCommander.getVisibleOrganizationsForUser(user.id.get, viewerIdOpt = request.userIdOpt)
+      val orgCards = orgCommander.getOrganizationCards(visibleOrgs, request.userIdOpt).values.toSeq
 
       implicit val writes = OrganizationCard.mobileV1
       Ok(Json.obj("organizations" -> Json.toJson(orgCards)))

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -61,6 +61,10 @@ trait LibraryRepo extends Repo[Library] with SeqNumberFunction[Library] {
   def countMutualLibrariesForUsers(user1: Id[User], users: Set[Id[User]])(implicit session: RSession): Map[Id[User], Int]
   def getMutualLibrariesForUser(user1: Id[User], user2: Id[User], offset: Int, size: Int)(implicit session: RSession): Seq[Library]
 
+  // Org Library methods
+  def countVisibleOrganizationLibraries(orgId: Id[Organization], includeOrgVisibleLibraries: Boolean, viewerLibraryMemberships: Set[Id[Library]])(implicit session: RSession): Int
+  def getVisibleOrganizationLibraries(orgId: Id[Organization], includeOrgVisibleLibraries: Boolean, viewerLibraryMemberships: Set[Id[Library]], offset: Offset, limit: Limit)(implicit session: RSession): Set[Library]
+
   // other
   def getOwnerLibraryCounts(owners: Set[Id[User]])(implicit session: RSession): Map[Id[User], Int]
   def getAllPublishedNonEmptyLibraries(minKeepCount: Int)(implicit session: RSession): Seq[Id[Library]]
@@ -448,6 +452,32 @@ class LibraryRepoImpl @Inject() (
     import com.keepit.common.db.slick.StaticQueryFixed.interpolation
     val query = sql"""select * from library lib where lib.id in (select lm1.library_id from library_membership lm1 inner join library_membership lm2 on lm1.library_id = lm2.library_id where lm1.user_id = $user1 and lm1.access != 'owner' and lm1.state = 'active' and lm2.user_id = $user2 and lm2.access != 'owner' and lm2.state = 'active') order by member_count desc, last_kept desc limit $size offset $offset"""
     query.as[Library].list
+  }
+
+  // Organization Library Repo methods
+  private def visibleOrganizationLibrariesHelper(orgId: Id[Organization], includeOrgVisibleLibraries: Boolean, viewerLibraryMemberships: Set[Id[Library]])(implicit session: RSession) = {
+    if (includeOrgVisibleLibraries) {
+      for {
+        lib <- rows if lib.orgId === orgId && (
+          (lib.visibility === (LibraryVisibility.ORGANIZATION: LibraryVisibility)) ||
+          (lib.visibility === (LibraryVisibility.PUBLISHED: LibraryVisibility)) ||
+          lib.id.inSet(viewerLibraryMemberships) // user's can see any library they are a member of
+        )
+      } yield lib
+    } else {
+      for {
+        lib <- rows if lib.orgId === orgId && (
+          (lib.visibility === (LibraryVisibility.PUBLISHED: LibraryVisibility)) ||
+          lib.id.inSet(viewerLibraryMemberships)
+        )
+      } yield lib
+    }
+  }
+  def countVisibleOrganizationLibraries(orgId: Id[Organization], includeOrgVisibleLibraries: Boolean, viewerLibraryMemberships: Set[Id[Library]])(implicit session: RSession): Int = {
+    visibleOrganizationLibrariesHelper(orgId, includeOrgVisibleLibraries, viewerLibraryMemberships).length.run
+  }
+  def getVisibleOrganizationLibraries(orgId: Id[Organization], includeOrgVisibleLibraries: Boolean, viewerLibraryMemberships: Set[Id[Library]], offset: Offset, limit: Limit)(implicit session: RSession): Set[Library] = {
+    visibleOrganizationLibrariesHelper(orgId, includeOrgVisibleLibraries, viewerLibraryMemberships).drop(offset.value).take(limit.value).list.toSet
   }
 
   def getAllPublishedNonEmptyLibraries(minKeepCount: Int)(implicit session: RSession): Seq[Id[Library]] = {

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
@@ -47,7 +47,7 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
           response === OrganizationFail.INVALID_PUBLIC_ID
         }
       }
-      "give an organization view to a user that has view permissions" in {
+      "give an organization view to a member" in {
         withDb(controllerTestModules: _*) { implicit injector =>
           val (user, org) = db.readWrite { implicit session =>
             val user = UserFactory.user().saved
@@ -68,7 +68,7 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
           val jsonResponse = Json.parse(contentAsString(response))
           (jsonResponse \ "organization" \ "name").as[String] === "Forty Two Kifis"
           (jsonResponse \ "organization" \ "handle").as[String] === "kifi"
-          (jsonResponse \ "organization" \ "numLibraries").as[Int] === 10
+          (jsonResponse \ "organization" \ "numLibraries").as[Int] === 10 + 15
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationMembershipControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationMembershipControllerTest.scala
@@ -67,7 +67,6 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
           val json = Json.parse(contentAsString(result))
           val resultMembersList = (json \ "members").as[Seq[JsValue]]
           resultMembersList.length === n
-          println(json \ "members")
           (json \ "members" \\ "id").length == n
           (json \ "members" \\ "id").map(v => v.as[ExternalId[User]]) == (owner :: members.toList).take(n).map(_.externalId)
           (json \ "members" \\ "lastInvitedAt").length === 0 // members do not have open invitations


### PR DESCRIPTION
Now users can only see libraries that they have permission to see
Same story with organizations

@leogrim @andrewconner @cvializ @ajkochanowicz 

I'd like some feedback on this PR in particular. I did some wonky things with commanders, namely
exposing a lot of internal "helper" methods so that other commanders could use the logic without having to open a ton of DB sessions. I don't feel super confident in it.
