### PR TITLE
Org Invite commander refactor, added invite cancel

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationInvite.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationInvite.scala
@@ -6,6 +6,7 @@ import com.keepit.common.crypto.{ ModelWithPublicId, ModelWithPublicIdCompanion 
 import com.keepit.common.db.{ Id, ModelWithState, State, States }
 import com.keepit.common.mail.EmailAddress
 import com.keepit.common.time._
+import com.keepit.model.InvitationDecision.ACCEPTED
 import com.kifi.macros.json
 import org.apache.commons.lang3.RandomStringUtils
 import org.joda.time.DateTime
@@ -29,6 +30,8 @@ case class OrganizationInvite(
   def withId(id: Id[OrganizationInvite]): OrganizationInvite = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime): OrganizationInvite = this.copy(updatedAt = now)
   def withState(newState: State[OrganizationInvite]): OrganizationInvite = this.copy(state = newState)
+  def accepted: OrganizationInvite = this.copy(decision = InvitationDecision.ACCEPTED)
+  def declined: OrganizationInvite = this.copy(decision = InvitationDecision.DECLINED)
 
   override def toString: String = s"OrganizationInvite[id=$id,organizationId=$organizationId,ownerId=$inviterId,userId=$userId,email=$emailAddress,role=$role,state=$state]"
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -255,7 +255,7 @@ class OrganizationCommanderImpl @Inject() (
           memberships.foreach { membership => orgMembershipRepo.deactivate(membership) }
 
           val invites = orgInviteRepo.getAllByOrganization(org.id.get)
-          invites.foreach { invite => orgInviteRepo.deactivate(invite.id.get) }
+          invites.foreach(orgInviteRepo.deactivate)
 
           orgRepo.save(org.sanitizeForDelete)
           handleCommander.reclaimAll(org.id.get, overrideProtection = true, overrideLock = true)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationInviteController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationInviteController.scala
@@ -5,6 +5,9 @@ import com.keepit.commanders._
 import com.keepit.common.controller._
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.db.ExternalId
+import com.keepit.common.json.EitherFormat
+import com.keepit.common.mail.EmailAddress
 import com.keepit.heimdal.HeimdalContextBuilderFactory
 import com.keepit.inject.FortyTwoConfig
 import com.keepit.model._
@@ -31,16 +34,17 @@ class OrganizationInviteController @Inject() (
   def inviteUsers(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.INVITE_MEMBERS).async(parse.tolerantJson) { request =>
     val messageOpt = (request.body \ "message").asOpt[String].filter(_.nonEmpty)
 
-    (request.body \ "invites").validate[Seq[ExternalOrganizationMemberInvitation]] match {
+    implicit val reads = EitherFormat.keyedReads[ExternalId[User], EmailAddress]("id", "email")
+    val invitesValidated = (request.body \ "invites").validate[Seq[Either[ExternalId[User], EmailAddress]]]
+
+    invitesValidated match {
       case JsError(errs) => Future.successful(BadRequest(Json.obj("error" -> "could_not_parse_invites")))
       case JsSuccess(externalInvites, _) =>
-        val userExternalIds = externalInvites.map(_.invited).collect { case Left(userId) => userId }
+        val userExternalIds = externalInvites.collect { case Left(userId) => userId }
         val externalToInternalIdMap = userCommander.getByExternalIds(userExternalIds).mapValues(_.id.get)
         val invites = externalInvites.map {
-          case ExternalOrganizationMemberInvitation(Left(extId), role) =>
-            OrganizationMemberInvitation(Left(externalToInternalIdMap(extId)), role)
-          case ExternalOrganizationMemberInvitation(Right(email), role) =>
-            OrganizationMemberInvitation(Right(email), role)
+          case Left(extId) => OrganizationMemberInvitation(Left(externalToInternalIdMap(extId)), OrganizationRole.MEMBER)
+          case Right(email) => OrganizationMemberInvitation(Right(email), OrganizationRole.MEMBER)
         }
 
         implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
@@ -53,6 +57,34 @@ class OrganizationInviteController @Inject() (
               case (Right(contact), role) => Json.obj("email" -> contact.email, "role" -> role)
             }
             Ok(Json.obj("result" -> "success", "invitees" -> JsArray(result)))
+        }
+    }
+  }
+  def cancelInvites(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.INVITE_MEMBERS)(parse.tolerantJson) { request =>
+    implicit val reads = EitherFormat.keyedReads[ExternalId[User], EmailAddress]("id", "email")
+    val invitesValidated = (request.body \ "cancel").validate[Seq[Either[ExternalId[User], EmailAddress]]]
+
+    invitesValidated match {
+      case JsError(errs) => BadRequest(Json.obj("error" -> "could_not_parse_cancelations"))
+      case JsSuccess(externalInvites, _) =>
+        val emails = externalInvites.collect { case Right(email) => email }.toSet
+
+        val userExternalIds = externalInvites.collect { case Left(extId) => extId }
+        val externalToInternalIdMap = userCommander.getByExternalIds(userExternalIds).mapValues(_.id.get)
+        val internalToExternalIdMap = externalToInternalIdMap.map(_.swap)
+        val userIds = userExternalIds.map(externalToInternalIdMap.apply).toSet
+
+        val cancelRequest = OrganizationInviteCancelRequest(orgId = request.orgId, requesterId = request.request.userId, targetEmails = emails, targetUserIds = userIds)
+        val cancelResponse = orgInviteCommander.cancelOrganizationInvites(cancelRequest)
+        cancelResponse match {
+          case Left(organizationFail) => organizationFail.asErrorResponse
+          case Right(cancelResult) =>
+            val cancelledEmails = cancelResult.cancelledEmails
+            val cancelledUserIds = cancelResult.cancelledUserIds.map(internalToExternalIdMap.apply)
+
+            val cancelledEmailsJson = JsArray(cancelledEmails.toSeq.map { email => Json.obj("email" -> email) })
+            val cancelledUserIdsJson = JsArray(cancelledUserIds.toSeq.map { userId => Json.obj("id" -> userId) })
+            Ok(Json.obj("cancelled" -> (cancelledUserIdsJson ++ cancelledEmailsJson)))
         }
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInviteRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInviteRepo.scala
@@ -20,7 +20,7 @@ trait OrganizationInviteRepo extends Repo[OrganizationInvite] {
   def getByOrgIdAndUserId(organizationId: Id[Organization], userId: Id[User], state: State[OrganizationInvite] = OrganizationInviteStates.ACTIVE)(implicit s: RSession): Seq[OrganizationInvite]
   def getLastSentByOrgIdAndInviterIdAndUserId(organizationId: Id[Organization], inviterId: Id[User], userId: Id[User], includeStates: Set[State[OrganizationInvite]])(implicit s: RSession): Option[OrganizationInvite]
   def getLastSentByOrgIdAndInviterIdAndEmailAddress(organizationId: Id[Organization], inviterId: Id[User], emailAddress: EmailAddress, includeStates: Set[State[OrganizationInvite]])(implicit s: RSession): Option[OrganizationInvite]
-  def deactivate(invite: Id[OrganizationInvite])(implicit session: RWSession): OrganizationInvite
+  def deactivate(model: OrganizationInvite)(implicit session: RWSession): Unit
 }
 
 @Singleton
@@ -159,7 +159,7 @@ class OrganizationInviteRepoImpl @Inject() (val db: DataBaseComponent, val clock
     getLastSentByOrgIdAndInviterIdAndEmailAddressCompiled(organizationId, inviterId, emailAddress, includeStates).firstOption
   }
 
-  def deactivate(inviteId: Id[OrganizationInvite])(implicit session: RWSession): OrganizationInvite = {
-    save(get(inviteId).copy(state = OrganizationInviteStates.INACTIVE))
+  def deactivate(model: OrganizationInvite)(implicit session: RWSession): Unit = {
+    save(model.withState(OrganizationInviteStates.INACTIVE))
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRequests.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRequests.scala
@@ -24,14 +24,6 @@ case class OrganizationTransferResponse(request: OrganizationTransferRequest, mo
 
 case class OrganizationMemberInvitation(invited: Either[Id[User], EmailAddress], role: OrganizationRole)
 
-case class ExternalOrganizationMemberInvitation(invited: Either[ExternalId[User], EmailAddress], role: OrganizationRole)
-object ExternalOrganizationMemberInvitation {
-  implicit val reads: Reads[ExternalOrganizationMemberInvitation] = (
-    EitherFormat.keyedReads[ExternalId[User], EmailAddress]("id", "email") and // read either "id": ExternalId[User] OR "email": EmailAddress
-    (__ \ 'role).read[OrganizationRole]
-  )(ExternalOrganizationMemberInvitation.apply _)
-}
-
 sealed abstract class OrganizationMembershipRequest {
   def orgId: Id[Organization]
   def requesterId: Id[User]
@@ -58,6 +50,16 @@ case class OrganizationMembershipRemoveRequest(
 case class OrganizationMembershipAddResponse(request: OrganizationMembershipAddRequest, membership: OrganizationMembership)
 case class OrganizationMembershipModifyResponse(request: OrganizationMembershipModifyRequest, membership: OrganizationMembership)
 case class OrganizationMembershipRemoveResponse(request: OrganizationMembershipRemoveRequest)
+
+sealed abstract class OrganizationInviteRequest {
+  def orgId: Id[Organization]
+}
+
+case class OrganizationInviteSendRequest(orgId: Id[Organization], requesterId: Id[User], targetEmails: Set[EmailAddress], targetUserIds: Set[Id[User]]) extends OrganizationInviteRequest
+case class OrganizationInviteCancelRequest(orgId: Id[Organization], requesterId: Id[User], targetEmails: Set[EmailAddress], targetUserIds: Set[Id[User]]) extends OrganizationInviteRequest
+
+case class OrganizationInviteSendResponse(request: OrganizationInviteSendRequest)
+case class OrganizationInviteCancelResponse(request: OrganizationInviteCancelRequest, cancelledEmails: Set[EmailAddress], cancelledUserIds: Set[Id[User]])
 
 sealed abstract class OrganizationFail(val status: Int, val message: String) {
   def asErrorResponse = Status(status)(Json.obj("error" -> message))

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRequests.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRequests.scala
@@ -73,6 +73,7 @@ object OrganizationFail {
   case object NO_VALID_INVITATIONS extends OrganizationFail(BAD_REQUEST, "no_valid_invitations")
   case object INVALID_PUBLIC_ID extends OrganizationFail(BAD_REQUEST, "invalid_public_id")
   case object BAD_PARAMETERS extends OrganizationFail(BAD_REQUEST, "bad_parameters")
+  case object INVITATION_NOT_FOUND extends OrganizationFail(BAD_REQUEST, "invitation_not_found")
 
   def apply(str: String): OrganizationFail = {
     str match {
@@ -82,6 +83,7 @@ object OrganizationFail {
       case NO_VALID_INVITATIONS.message => NO_VALID_INVITATIONS
       case INVALID_PUBLIC_ID.message => INVALID_PUBLIC_ID
       case BAD_PARAMETERS.message => BAD_PARAMETERS
+      case INVITATION_NOT_FOUND.message => INVITATION_NOT_FOUND
     }
   }
 }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -519,6 +519,7 @@ POST          /site/organizations/:id/modify                    @com.keepit.cont
 DELETE        /site/organizations/:id/delete                    @com.keepit.controllers.website.OrganizationController.deleteOrganization(id: PublicId[Organization])
 GET           /site/organizations/:id/members                   @com.keepit.controllers.website.OrganizationMembershipController.getMembers(id: PublicId[Organization], offset: Int ?= 0, limit: Int ?= 20)
 POST          /site/organizations/:id/members/invite            @com.keepit.controllers.website.OrganizationInviteController.inviteUsers(id: PublicId[Organization])
+DELETE        /site/organizations/:id/members/invites/cancel    @com.keepit.controllers.website.OrganizationInviteController.cancelInvites(id: PublicId[Organization])
 POST          /site/organizations/:id/members/invites/accept    @com.keepit.controllers.website.OrganizationInviteController.acceptInvitation(id: PublicId[Organization], authToken: String)
 POST          /site/organizations/:id/members/invites/decline   @com.keepit.controllers.website.OrganizationInviteController.declineInvitation(id: PublicId[Organization])
 POST          /site/organizations/:id/members/invites/link      @com.keepit.controllers.website.OrganizationInviteController.createAnonymousInviteToOrganization(id: PublicId[Organization])

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationInviteControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationInviteControllerTest.scala
@@ -329,6 +329,7 @@ class OrganizationInviteControllerTest extends Specification with ShoeboxTestInj
       }
 
       "fail for member trying to elevate permissions above his own" in {
+        skipped("Invites do not take a role right now")
         withDb(controllerTestModules: _*) { implicit injector =>
           val (org, owner, inviter, cannot_invite, not_a_member) = setupInviters()
           implicit val config = inject[PublicIdConfiguration]


### PR DESCRIPTION
OrgInviteCommander now has the groundwork laid for a request/response internal
API. It is much cleaner, in my opinion.

The new endpoint for cancelling invites is
    /site/organizations/:id/members/invites/cancel
It takes a request of the form
    {"cancel": [{"id": "bleh"}, {"id": "blah"}, {"email": "ryan@kifi.com"}]}
It spits back
    {"cancelled": [{"id": "bleh"}, {"id": "blah"}, {"email": "ryan@kifi.com"}]}

@camhashemi  @ajkochanowicz @cvializ 
