### PR TITLE
Org response

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -57,8 +57,8 @@ class OrganizationCommanderImpl @Inject() (
   def getOrganizationView(orgId: Id[Organization], viewerIdOpt: Option[Id[User]]): OrganizationView = {
     db.readOnlyReplica { implicit session =>
       val organizationInfo = getOrganizationInfoHelper(orgId, viewerIdOpt)
-      val orgViewerRelationship = getMembershipInfoHelper(orgId, viewerIdOpt)
-      OrganizationView(organizationInfo, orgViewerRelationship)
+      val membershipInfo = getMembershipInfoHelper(orgId, viewerIdOpt)
+      OrganizationView(organizationInfo, membershipInfo)
     }
   }
   def getOrganizationCards(orgIds: Seq[Id[Organization]], viewerIdOpt: Option[Id[User]]): Map[Id[Organization], OrganizationCard] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
@@ -79,7 +79,7 @@ class MobileOrganizationController @Inject() (
       val visibleOrgs = orgMembershipCommander.getVisibleOrganizationsForUser(user.id.get, viewerIdOpt = request.userIdOpt)
       val orgCards = orgCommander.getOrganizationCards(visibleOrgs, request.userIdOpt).values.toSeq
 
-      implicit val writes = OrganizationCard.mobileV1
+      implicit val writes = OrganizationCard.mobileWrites
       Ok(Json.obj("organizations" -> Json.toJson(orgCards)))
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
@@ -35,9 +35,9 @@ class MobileOrganizationController @Inject() (
             case Left(failure) =>
               failure.asErrorResponse
             case Right(response) =>
-              val orgResponse = orgCommander.getOrganizationView(response.newOrg.id.get, request.userIdOpt)
+              val organizationView = orgCommander.getOrganizationView(response.newOrg.id.get, request.userIdOpt)
               implicit val writes = OrganizationView.mobileWrites
-              Ok(Json.obj("organization" -> Json.toJson(orgResponse)))
+              Ok(Json.obj("organization" -> Json.toJson(organizationView)))
           }
       }
     }
@@ -50,9 +50,9 @@ class MobileOrganizationController @Inject() (
         orgCommander.modifyOrganization(OrganizationModifyRequest(request.request.userId, request.orgId, modifications)) match {
           case Left(failure) => failure.asErrorResponse
           case Right(response) =>
-            val orgResponse = orgCommander.getOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt)
+            val organizationView = orgCommander.getOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt)
             implicit val writes = OrganizationView.mobileWrites
-            Ok(Json.obj("organization" -> Json.toJson(orgResponse)))
+            Ok(Json.obj("organization" -> Json.toJson(organizationView)))
         }
     }
   }
@@ -66,9 +66,9 @@ class MobileOrganizationController @Inject() (
   }
 
   def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
-    val orgResponse = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt)
+    val organizationView = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt)
     val requesterPermissions = Json.toJson(orgMembershipCommander.getPermissions(request.orgId, request.request.userIdOpt))
-    Ok(Json.obj("organization" -> Json.toJson(orgResponse)(OrganizationView.mobileWrites), "viewer_permissions" -> requesterPermissions))
+    Ok(Json.obj("organization" -> Json.toJson(organizationView)(OrganizationView.mobileWrites), "viewer_permissions" -> requesterPermissions))
   }
 
   // TODO(ryan): when organizations are no longer hidden behind an experiment, change this to a MaybeUserAction

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
@@ -35,9 +35,9 @@ class MobileOrganizationController @Inject() (
             case Left(failure) =>
               failure.asErrorResponse
             case Right(response) =>
-              val orgView = orgCommander.getOrganizationResponse(response.newOrg.id.get, request.userIdOpt)
-              implicit val writes = OrganizationView.mobileV1
-              Ok(Json.obj("organization" -> Json.toJson(orgView)))
+              val orgResponse = orgCommander.getOrganizationView(response.newOrg.id.get, request.userIdOpt)
+              implicit val writes = OrganizationView.mobileWrites
+              Ok(Json.obj("organization" -> Json.toJson(orgResponse)))
           }
       }
     }
@@ -50,9 +50,9 @@ class MobileOrganizationController @Inject() (
         orgCommander.modifyOrganization(OrganizationModifyRequest(request.request.userId, request.orgId, modifications)) match {
           case Left(failure) => failure.asErrorResponse
           case Right(response) =>
-            val orgView = orgCommander.getOrganizationResponse(response.modifiedOrg.id.get, request.request.userIdOpt)
-            implicit val writes = OrganizationView.mobileV1
-            Ok(Json.obj("organization" -> Json.toJson(orgView)))
+            val orgResponse = orgCommander.getOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt)
+            implicit val writes = OrganizationView.mobileWrites
+            Ok(Json.obj("organization" -> Json.toJson(orgResponse)))
         }
     }
   }
@@ -66,9 +66,9 @@ class MobileOrganizationController @Inject() (
   }
 
   def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
-    val orgView = orgCommander.getOrganizationResponse(request.orgId, request.request.userIdOpt)
+    val orgResponse = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt)
     val requesterPermissions = Json.toJson(orgMembershipCommander.getPermissions(request.orgId, request.request.userIdOpt))
-    Ok(Json.obj("organization" -> Json.toJson(orgView)(OrganizationView.mobileV1), "viewer_permissions" -> requesterPermissions))
+    Ok(Json.obj("organization" -> Json.toJson(orgResponse)(OrganizationView.mobileWrites), "viewer_permissions" -> requesterPermissions))
   }
 
   // TODO(ryan): when organizations are no longer hidden behind an experiment, change this to a MaybeUserAction

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
@@ -35,7 +35,7 @@ class MobileOrganizationController @Inject() (
             case Left(failure) =>
               failure.asErrorResponse
             case Right(response) =>
-              val orgView = orgCommander.getOrganizationView(response.newOrg.id.get, request.userIdOpt)
+              val orgView = orgCommander.getOrganizationResponse(response.newOrg.id.get, request.userIdOpt)
               implicit val writes = OrganizationView.mobileV1
               Ok(Json.obj("organization" -> Json.toJson(orgView)))
           }
@@ -50,7 +50,7 @@ class MobileOrganizationController @Inject() (
         orgCommander.modifyOrganization(OrganizationModifyRequest(request.request.userId, request.orgId, modifications)) match {
           case Left(failure) => failure.asErrorResponse
           case Right(response) =>
-            val orgView = orgCommander.getOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt)
+            val orgView = orgCommander.getOrganizationResponse(response.modifiedOrg.id.get, request.request.userIdOpt)
             implicit val writes = OrganizationView.mobileV1
             Ok(Json.obj("organization" -> Json.toJson(orgView)))
         }
@@ -66,7 +66,7 @@ class MobileOrganizationController @Inject() (
   }
 
   def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
-    val orgView = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt)
+    val orgView = orgCommander.getOrganizationResponse(request.orgId, request.request.userIdOpt)
     val requesterPermissions = Json.toJson(orgMembershipCommander.getPermissions(request.orgId, request.request.userIdOpt))
     Ok(Json.obj("organization" -> Json.toJson(orgView)(OrganizationView.mobileV1), "viewer_permissions" -> requesterPermissions))
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
@@ -36,8 +36,8 @@ class OrganizationController @Inject() (
             case Left(failure) =>
               failure.asErrorResponse
             case Right(response) =>
-              val orgView = orgCommander.getOrganizationView(response.newOrg.id.get, request.userIdOpt)
-              Ok(Json.obj("organization" -> Json.toJson(orgView)(OrganizationView.websiteWrites)))
+              val organizationView = orgCommander.getOrganizationView(response.newOrg.id.get, request.userIdOpt)
+              Ok(Json.obj("organization" -> Json.toJson(organizationView)(OrganizationView.websiteWrites)))
           }
       }
     }
@@ -50,8 +50,8 @@ class OrganizationController @Inject() (
         orgCommander.modifyOrganization(OrganizationModifyRequest(request.request.userId, request.orgId, modifications)) match {
           case Left(failure) => failure.asErrorResponse
           case Right(response) =>
-            val orgView = orgCommander.getOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt)
-            Ok(Json.obj("organization" -> Json.toJson(orgView)(OrganizationView.websiteWrites)))
+            val organizationView = orgCommander.getOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt)
+            Ok(Json.obj("organization" -> Json.toJson(organizationView)(OrganizationView.websiteWrites)))
         }
     }
   }
@@ -65,8 +65,8 @@ class OrganizationController @Inject() (
   }
 
   def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
-    val orgResponse = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt)
-    Ok(Json.obj("organization" -> Json.toJson(orgResponse)(OrganizationView.websiteWrites)))
+    val organizationView = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt)
+    Ok(Json.obj("organization" -> Json.toJson(organizationView)(OrganizationView.websiteWrites)))
   }
 
   def getOrganizationLibraries(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
@@ -36,9 +36,8 @@ class OrganizationController @Inject() (
             case Left(failure) =>
               failure.asErrorResponse
             case Right(response) =>
-              val orgView = orgCommander.getOrganizationResponse(response.newOrg.id.get, request.userIdOpt)
-              implicit val writes = OrganizationView.website
-              Ok(Json.obj("organization" -> Json.toJson(orgView)))
+              val orgView = orgCommander.getOrganizationView(response.newOrg.id.get, request.userIdOpt)
+              Ok(Json.obj("organization" -> Json.toJson(orgView)(OrganizationView.websiteWrites)))
           }
       }
     }
@@ -51,9 +50,8 @@ class OrganizationController @Inject() (
         orgCommander.modifyOrganization(OrganizationModifyRequest(request.request.userId, request.orgId, modifications)) match {
           case Left(failure) => failure.asErrorResponse
           case Right(response) =>
-            val orgView = orgCommander.getOrganizationResponse(response.modifiedOrg.id.get, request.request.userIdOpt)
-            implicit val writes = OrganizationView.website
-            Ok(Json.obj("organization" -> Json.toJson(orgView)))
+            val orgView = orgCommander.getOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt)
+            Ok(Json.obj("organization" -> Json.toJson(orgView)(OrganizationView.websiteWrites)))
         }
     }
   }
@@ -67,9 +65,8 @@ class OrganizationController @Inject() (
   }
 
   def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
-    val orgView = orgCommander.getOrganizationResponse(request.orgId, request.request.userIdOpt)
-    val requesterPermissions = Json.toJson(orgMembershipCommander.getPermissions(request.orgId, request.request.userIdOpt))
-    Ok(Json.obj("organization" -> Json.toJson(orgView)(OrganizationView.website), "viewer_permissions" -> requesterPermissions))
+    val orgResponse = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt)
+    Ok(Json.obj("organization" -> Json.toJson(orgResponse)(OrganizationView.websiteWrites)))
   }
 
   def getOrganizationLibraries(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
@@ -81,7 +81,7 @@ class OrganizationController @Inject() (
       val visibleOrgs = orgMembershipCommander.getVisibleOrganizationsForUser(user.id.get, viewerIdOpt = request.userIdOpt)
       val orgCards = orgCommander.getOrganizationCards(visibleOrgs, request.userIdOpt).values.toSeq
 
-      implicit val writes = OrganizationCard.website
+      implicit val writes = OrganizationCard.websiteWrites
       Ok(Json.obj("organizations" -> Json.toJson(orgCards)))
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
@@ -36,7 +36,7 @@ class OrganizationController @Inject() (
             case Left(failure) =>
               failure.asErrorResponse
             case Right(response) =>
-              val orgView = orgCommander.getOrganizationView(response.newOrg.id.get, request.userIdOpt)
+              val orgView = orgCommander.getOrganizationResponse(response.newOrg.id.get, request.userIdOpt)
               implicit val writes = OrganizationView.website
               Ok(Json.obj("organization" -> Json.toJson(orgView)))
           }
@@ -51,7 +51,7 @@ class OrganizationController @Inject() (
         orgCommander.modifyOrganization(OrganizationModifyRequest(request.request.userId, request.orgId, modifications)) match {
           case Left(failure) => failure.asErrorResponse
           case Right(response) =>
-            val orgView = orgCommander.getOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt)
+            val orgView = orgCommander.getOrganizationResponse(response.modifiedOrg.id.get, request.request.userIdOpt)
             implicit val writes = OrganizationView.website
             Ok(Json.obj("organization" -> Json.toJson(orgView)))
         }
@@ -67,7 +67,7 @@ class OrganizationController @Inject() (
   }
 
   def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
-    val orgView = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt)
+    val orgView = orgCommander.getOrganizationResponse(request.orgId, request.request.userIdOpt)
     val requesterPermissions = Json.toJson(orgMembershipCommander.getPermissions(request.orgId, request.request.userIdOpt))
     Ok(Json.obj("organization" -> Json.toJson(orgView)(OrganizationView.website), "viewer_permissions" -> requesterPermissions))
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInfo.scala
@@ -82,8 +82,8 @@ object OrganizationCard {
     (__ \ 'numLibraries).write[Int]
   )(unlift(OrganizationCard.unapply))
 
-  val website = defaultWrites
-  val mobileV1 = defaultWrites
+  val websiteWrites = defaultWrites
+  val mobileWrites = defaultWrites
 }
 
 // OrganizationImageInfo and OrganizationNotificationInfo are strictly for use in the

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
@@ -8,6 +8,16 @@ import com.kifi.macros.json
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
+case class OrganizationGetResponse(
+  organization: OrganizationView,
+  viewerRelationship: Option[OrganizationViewerRelationship])
+object OrganizationGetResponse {
+  val defaultWrites: Writes[OrganizationGetResponse] = (
+    (__ \ 'organization).write(OrganizationView.defaultWrites) and
+    (__ \ 'orgViewerRelationship).writeNullable(OrganizationViewerRelationship.defaultWrites)
+  )(unlift(OrganizationGetResponse.unapply))
+}
+
 // OrganizationView should ONLY contain public information. No internal ids.
 case class OrganizationView(
   orgId: PublicId[Organization],
@@ -20,7 +30,7 @@ case class OrganizationView(
   numMembers: Int,
   numLibraries: Int)
 object OrganizationView {
-  private val defaultWrites: Writes[OrganizationView] = (
+  val defaultWrites: Writes[OrganizationView] = (
     (__ \ 'id).write[PublicId[Organization]] and
     (__ \ 'ownerId).write[ExternalId[User]] and
     (__ \ 'handle).write[OrganizationHandle] and
@@ -31,6 +41,21 @@ object OrganizationView {
     (__ \ 'numMembers).write[Int] and
     (__ \ 'numLibraries).write[Int]
   )(unlift(OrganizationView.unapply))
+
+  val website = defaultWrites
+  val mobileV1 = defaultWrites
+}
+
+case class OrganizationViewerRelationship(
+  isInvited: Boolean = false,
+  role: Option[OrganizationRole],
+  permissions: Set[OrganizationPermission])
+object OrganizationViewerRelationship {
+  val defaultWrites: Writes[OrganizationViewerRelationship] = (
+    (__ \ 'isInvited).write[Boolean] and
+    (__ \ 'role).writeNullable[OrganizationRole] and
+    (__ \ 'permissions).write[Seq[OrganizationPermission]]
+  )(unlift(OrganizationViewerRelationship.unapply))
 
   val website = defaultWrites
   val mobileV1 = defaultWrites

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
@@ -78,7 +78,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
           val randoResponse = controller.getOrganization(publicId)(randoRequest)
           status(randoResponse) === OK
 
-          val payloads = Seq(ownerResponse, memberResponse, randoResponse).map { response => Json.parse(contentAsString(response)) \ "organization" }
+          val payloads = Seq(ownerResponse, memberResponse, randoResponse).map { response => Json.parse(contentAsString(response)) \ "organization" \ "organizationInfo" }
 
           payloads.foreach(p => (p \ "name").as[String] === "Brewster Corp")
           payloads.foreach(p => (p \ "handle").as[String] === "brewstercorp")
@@ -101,19 +101,19 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
         val ownerRequest = route.getOrganization(publicId)
         val ownerResponse = controller.getOrganization(publicId)(ownerRequest)
         status(ownerResponse) === OK
-        (Json.parse(contentAsString(ownerResponse)) \ "viewer_permissions").as[Set[OrganizationPermission]] === org.basePermissions.forRole(OrganizationRole.OWNER)
+        (Json.parse(contentAsString(ownerResponse)) \ "organization" \ "membershipInfo" \ "permissions").as[Set[OrganizationPermission]] === org.basePermissions.forRole(OrganizationRole.OWNER)
 
         inject[FakeUserActionsHelper].setUser(member, Set(UserExperimentType.ORGANIZATION))
         val memberRequest = route.getOrganization(publicId)
         val memberResponse = controller.getOrganization(publicId)(memberRequest)
         status(memberResponse) === OK
-        (Json.parse(contentAsString(memberResponse)) \ "viewer_permissions").as[Set[OrganizationPermission]] === org.basePermissions.forRole(OrganizationRole.MEMBER)
+        (Json.parse(contentAsString(memberResponse)) \ "organization" \ "membershipInfo" \ "permissions").as[Set[OrganizationPermission]] === org.basePermissions.forRole(OrganizationRole.MEMBER)
 
         inject[FakeUserActionsHelper].setUser(rando, Set(UserExperimentType.ORGANIZATION))
         val randoRequest = route.getOrganization(publicId)
         val randoResponse = controller.getOrganization(publicId)(randoRequest)
         status(randoResponse) === OK
-        (Json.parse(contentAsString(randoResponse)) \ "viewer_permissions").as[Set[OrganizationPermission]] === org.basePermissions.forNonmember
+        (Json.parse(contentAsString(randoResponse)) \ "organization" \ "membershipInfo" \ "permissions").as[Set[OrganizationPermission]] === org.basePermissions.forNonmember
       }
       "serve up the right number of libraries depending on viewer permissions" in {
         withDb(controllerTestModules: _*) { implicit injector =>
@@ -134,13 +134,13 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
           val ownerRequest = route.getOrganization(publicId)
           val ownerResponse = controller.getOrganization(publicId)(ownerRequest)
           status(ownerResponse) === OK
-          (Json.parse(contentAsString(ownerResponse)) \ "organization" \ "numLibraries").as[Int] === 10 + 15
+          (Json.parse(contentAsString(ownerResponse)) \ "organization" \ "organizationInfo" \ "numLibraries").as[Int] === 10 + 15
 
           inject[FakeUserActionsHelper].setUser(rando, Set(UserExperimentType.ORGANIZATION))
           val randoRequest = route.getOrganization(publicId)
           val randoResponse = controller.getOrganization(publicId)(randoRequest)
           status(randoResponse) === OK
-          (Json.parse(contentAsString(randoResponse)) \ "organization" \ "numLibraries").as[Int] === 10
+          (Json.parse(contentAsString(randoResponse)) \ "organization" \ "organizationInfo" \ "numLibraries").as[Int] === 10
         }
       }
     }
@@ -307,8 +307,8 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
           status(result) === OK
 
           val createResponseJson = Json.parse(contentAsString(result))
-          (createResponseJson \ "organization" \ "name").as[String] === orgName
-          (createResponseJson \ "organization" \ "description").as[Option[String]] === Some(orgDescription)
+          (createResponseJson \ "organization" \ "organizationInfo" \ "name").as[String] === orgName
+          (createResponseJson \ "organization" \ "organizationInfo" \ "description").as[Option[String]] === Some(orgDescription)
         }
       }
     }


### PR DESCRIPTION
@ryanpbrewster @leogrim @andrewconner OrganizationInfos and MembershipInfos compose OrganizationViews, which are sent to clients. If different clients prefer different serializations of that data, no problem
