### PR TITLE
Fixed a bug in listing an org's members

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
@@ -127,7 +127,8 @@ class OrganizationMembershipCommanderImpl @Inject() (
   }
 
   private def buildMaybeMembers(members: Seq[OrganizationMembership], invitees: Seq[OrganizationInvite]): Seq[MaybeOrganizationMember] = {
-    val (invitedUserIds, invitedEmailAddresses) = invitees.partition(_.userId.nonEmpty)
+    val invitedUserIds = invitees.filter(_.userId.isDefined)
+    val invitedEmailAddresses = invitees.filter(_.emailAddress.isDefined)
     val usersMap = db.readOnlyMaster { implicit session =>
       basicUserRepo.loadAllActive((members.map(_.userId) ++ invitedUserIds.map(_.userId.get)).toSet)
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserProfileControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserProfileControllerTest.scala
@@ -421,7 +421,7 @@ class UserProfileControllerTest extends Specification with ShoeboxTestInjector {
                 "followers":[],
                 "numCollaborators":0,
                 "collaborators":[],
-                "lastKept":${lib3.createdAt.getMillis},
+                "lastKept":${lib3.updatedAt.getMillis},
                 "following": true,
                 "membership": {"access":"read_only","listed":true,"subscribed":false},
                 "modifiedAt":${lib3.updatedAt.getMillis},


### PR DESCRIPTION
Previous code assumed that all invites had either a userId or an emailAddress.
Anonymous invite links have neither, and should not be listed.
