### PR TITLE
Fixed bug that kept members from leaving an org

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationMembershipController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationMembershipController.scala
@@ -63,7 +63,7 @@ class OrganizationMembershipController @Inject() (
     }
   }
 
-  def removeMembers(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.REMOVE_MEMBERS)(parse.tolerantJson) { request =>
+  def removeMembers(pubId: PublicId[Organization]) = OrganizationUserAction(pubId)(parse.tolerantJson) { request =>
     implicit val format = KeyFormat.key1Format[ExternalId[User]]("userId")
     val removeParamsValidated = (request.body \ "members").validate[Seq[ExternalId[User]]]
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationMembershipControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationMembershipControllerTest.scala
@@ -275,6 +275,21 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
           status(result) === OK
         }
       }
+      "let a user leave the org" in {
+        withDb(controllerTestModules: _*) { implicit injector =>
+          val (org, owner, members) = setup()
+
+          val member = members.head
+          val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
+
+          val jsonPayload = Json.parse(s"""{"members": [{"userId": "${member.externalId}"}]}""")
+
+          inject[FakeUserActionsHelper].setUser(member, Set(UserExperimentType.ORGANIZATION))
+          val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
+          val result = controller.removeMembers(publicOrgId)(request)
+          status(result) === OK
+        }
+      }
     }
   }
 


### PR DESCRIPTION
We were checking `REMOVE_MEMBERS` permissions right at the start. Members
without that permission can still remove themself.

@camhashemi @cvializ 
