### PR TITLE
Org lib create

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationFactory.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationFactory.scala
@@ -23,10 +23,12 @@ object OrganizationFactory {
       invitedEmails: Seq[EmailAddress] = Seq.empty[EmailAddress]) {
 
     def withName(newName: String) = this.copy(org = org.withName(newName))
-    def withOwner(newOwner: User) = this.copy(org = org.copy(ownerId = newOwner.id.get))
+    def withOwner(newOwner: User) = this.copy(org = org.withOwner(newOwner.id.get))
     def withMembers(newMembers: Seq[User]) = this.copy(members = members ++ newMembers)
     def withInvitedUsers(newInvitedUsers: Seq[User]) = this.copy(invitedUsers = invitedUsers ++ newInvitedUsers)
     def withInvitedEmails(newInvitedEmails: Seq[EmailAddress]) = this.copy(invitedEmails = invitedEmails ++ newInvitedEmails)
     def withHandle(newHandle: OrganizationHandle) = this.copy(org = org.copy(handle = Some(PrimaryOrganizationHandle(newHandle, newHandle))))
+    def withBasePermissions(newBasePermissions: BasePermissions) = this.copy(org = org.withBasePermissions(newBasePermissions))
+    def secret() = this.copy(org = org.hiddenFromNonmembers)
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
@@ -36,7 +36,33 @@ case class LibraryFail(status: Int, message: String)
 @json
 case class LibrarySubscriptionKey(name: String, info: SubscriptionInfo)
 
-@json
+case class ExternalLibraryAddRequest(
+  name: String,
+  visibility: LibraryVisibility,
+  slug: String,
+  kind: Option[LibraryKind] = None,
+  description: Option[String] = None,
+  color: Option[LibraryColor] = None,
+  listed: Option[Boolean] = None,
+  whoCanInvite: Option[LibraryInvitePermissions] = None,
+  subscriptions: Option[Seq[LibrarySubscriptionKey]] = None,
+  externalSpace: Option[ExternalLibrarySpace] = None)
+
+object ExternalLibraryAddRequest {
+  implicit val reads: Reads[ExternalLibraryAddRequest] = (
+    (__ \ 'name).read[String] and
+    (__ \ 'visibility).read[LibraryVisibility] and
+    (__ \ 'slug).read[String] and
+    (__ \ 'kind).readNullable[LibraryKind] and
+    (__ \ 'description).readNullable[String] and
+    (__ \ 'color).readNullable[LibraryColor] and
+    (__ \ 'listed).readNullable[Boolean] and
+    (__ \ 'whoCanInvite).readNullable[LibraryInvitePermissions] and
+    (__ \ 'subscriptions).readNullable[Seq[LibrarySubscriptionKey]] and
+    (__ \ 'space).readNullable[ExternalLibrarySpace]
+  )(ExternalLibraryAddRequest.apply _)
+}
+
 case class LibraryAddRequest(
   name: String,
   visibility: LibraryVisibility,
@@ -47,7 +73,7 @@ case class LibraryAddRequest(
   listed: Option[Boolean] = None,
   whoCanInvite: Option[LibraryInvitePermissions] = None,
   subscriptions: Option[Seq[LibrarySubscriptionKey]] = None,
-  orgIdOpt: Option[Id[Organization]] = None)
+  space: Option[LibrarySpace] = None)
 
 case class ExternalLibraryModifyRequest(
   name: Option[String] = None,
@@ -69,7 +95,7 @@ object ExternalLibraryModifyRequest {
     (__ \ 'color).readNullable[LibraryColor] and
     (__ \ 'listed).readNullable[Boolean] and
     (__ \ 'whoCanInvite).readNullable[LibraryInvitePermissions] and
-    (__ \ 'subscription).readNullable[Seq[LibrarySubscriptionKey]] and
+    (__ \ 'subscriptions).readNullable[Seq[LibrarySubscriptionKey]] and
     (__ \ 'space).readNullable[ExternalLibrarySpace]
   )(ExternalLibraryModifyRequest.apply _)
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryView.scala
@@ -46,7 +46,8 @@ case class LibraryAddRequest(
   color: Option[LibraryColor] = None,
   listed: Option[Boolean] = None,
   whoCanInvite: Option[LibraryInvitePermissions] = None,
-  subscriptions: Option[Seq[LibrarySubscriptionKey]] = None)
+  subscriptions: Option[Seq[LibrarySubscriptionKey]] = None,
+  orgIdOpt: Option[Id[Organization]] = None)
 
 case class ExternalLibraryModifyRequest(
   name: Option[String] = None,

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -192,61 +192,110 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
   }
 
   "LibraryCommander" should {
-    "create libraries, memberships & invites" in {
-      withDb(modules: _*) { implicit injector =>
-        val (userIron, userCaptain, userAgent, userHulk) = setupUsers()
+    "create libraries correctly" in {
+      "create libraries, memberships & invites" in {
+        withDb(modules: _*) { implicit injector =>
+          val (userIron, userCaptain, userAgent, userHulk) = setupUsers()
 
-        db.readOnlyMaster { implicit s =>
-          libraryRepo.count === 0
-        }
+          db.readOnlyMaster { implicit s =>
+            libraryRepo.count === 0
+          }
 
-        val lib1Request = LibraryAddRequest(name = "Avengers Missions", slug = "avengers", visibility = LibraryVisibility.SECRET)
+          val lib1Request = LibraryAddRequest(name = "Avengers Missions", slug = "avengers", visibility = LibraryVisibility.SECRET)
 
-        val lib2Request = LibraryAddRequest(name = "MURICA", slug = "murica", visibility = LibraryVisibility.PUBLISHED)
+          val lib2Request = LibraryAddRequest(name = "MURICA", slug = "murica", visibility = LibraryVisibility.PUBLISHED)
 
-        val lib3Request = LibraryAddRequest(name = "Science and Stuff", slug = "science", visibility = LibraryVisibility.PUBLISHED, whoCanInvite = Some(LibraryInvitePermissions.OWNER))
+          val lib3Request = LibraryAddRequest(name = "Science and Stuff", slug = "science", visibility = LibraryVisibility.PUBLISHED, whoCanInvite = Some(LibraryInvitePermissions.OWNER))
 
-        val lib4Request = LibraryAddRequest(name = "Invalid Param", slug = "", visibility = LibraryVisibility.SECRET)
+          val lib4Request = LibraryAddRequest(name = "Invalid Param", slug = "", visibility = LibraryVisibility.SECRET)
 
-        val libraryCommander = inject[LibraryCommander]
-        val add1 = libraryCommander.addLibrary(lib1Request, userAgent.id.get)
-        add1.isRight === true
-        add1.right.get.name === "Avengers Missions"
-        val add2 = libraryCommander.addLibrary(lib2Request, userCaptain.id.get)
-        add2.isRight === true
-        add2.right.get.name === "MURICA"
-        val add3 = libraryCommander.addLibrary(lib3Request, userIron.id.get)
-        add3.isRight === true
-        add3.right.get.name === "Science and Stuff"
-        libraryCommander.addLibrary(lib4Request, userIron.id.get).isRight === false
+          val libraryCommander = inject[LibraryCommander]
+          val add1 = libraryCommander.addLibrary(lib1Request, userAgent.id.get)
+          add1.isRight === true
+          add1.right.get.name === "Avengers Missions"
+          val add2 = libraryCommander.addLibrary(lib2Request, userCaptain.id.get)
+          add2.isRight === true
+          add2.right.get.name === "MURICA"
+          val add3 = libraryCommander.addLibrary(lib3Request, userIron.id.get)
+          add3.isRight === true
+          add3.right.get.name === "Science and Stuff"
+          libraryCommander.addLibrary(lib4Request, userIron.id.get).isRight === false
 
-        db.readOnlyMaster { implicit s =>
-          val allLibs = libraryRepo.all
-          allLibs.length === 3
-          allLibs.map(_.slug.value) === Seq("avengers", "murica", "science")
-          allLibs.map(_.whoCanInvite).flatten === Seq(LibraryInvitePermissions.COLLABORATOR, LibraryInvitePermissions.COLLABORATOR, LibraryInvitePermissions.OWNER)
+          db.readOnlyMaster { implicit s =>
+            val allLibs = libraryRepo.all
+            allLibs.length === 3
+            allLibs.map(_.slug.value) === Seq("avengers", "murica", "science")
+            allLibs.map(_.whoCanInvite).flatten === Seq(LibraryInvitePermissions.COLLABORATOR, LibraryInvitePermissions.COLLABORATOR, LibraryInvitePermissions.OWNER)
 
-          val allMemberships = libraryMembershipRepo.all
-          allMemberships.length === 3
-          allMemberships.map(_.userId) === Seq(userAgent.id.get, userCaptain.id.get, userIron.id.get)
-          allMemberships.map(_.access) === Seq(LibraryAccess.OWNER, LibraryAccess.OWNER, LibraryAccess.OWNER)
-          allMemberships.map(_.lastJoinedAt).flatten.size === 3
-        }
+            val allMemberships = libraryMembershipRepo.all
+            allMemberships.length === 3
+            allMemberships.map(_.userId) === Seq(userAgent.id.get, userCaptain.id.get, userIron.id.get)
+            allMemberships.map(_.access) === Seq(LibraryAccess.OWNER, LibraryAccess.OWNER, LibraryAccess.OWNER)
+            allMemberships.map(_.lastJoinedAt).flatten.size === 3
+          }
 
-        // test re-activating inactive library
-        val libScience = add3.right.get
-        db.readWrite { implicit s =>
-          libraryRepo.save(libScience.copy(state = LibraryStates.INACTIVE))
-        }
-        libraryCommander.addLibrary(lib3Request, userIron.id.get).isRight === true
-        db.readOnlyMaster { implicit s =>
-          val allLibs = libraryRepo.all
-          allLibs.length === 3
-          allLibs.map(_.slug.value) === Seq("avengers", "murica", "science")
-          allLibs.map(_.color.nonEmpty === true)
+          // test re-activating inactive library
+          val libScience = add3.right.get
+          db.readWrite { implicit s =>
+            libraryRepo.save(libScience.copy(state = LibraryStates.INACTIVE))
+          }
+          libraryCommander.addLibrary(lib3Request, userIron.id.get).isRight === true
+          db.readOnlyMaster { implicit s =>
+            val allLibs = libraryRepo.all
+            allLibs.length === 3
+            allLibs.map(_.slug.value) === Seq("avengers", "murica", "science")
+            allLibs.map(_.color.nonEmpty === true)
+          }
         }
       }
+      "let an org member create a library in that org if they have permission" in {
+        withDb(modules: _*) { implicit injector =>
+          val (org, owner) = db.readWrite { implicit session =>
+            val owner = UserFactory.user().saved
+            val org = OrganizationFactory.organization().withName("Kifi").withOwner(owner).saved
+            (org, owner)
+          }
+          val libraryCommander = inject[LibraryCommander]
 
+          val addRequest = LibraryAddRequest(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", orgIdOpt = Some(org.id.get))
+          val addResponse = libraryCommander.addLibrary(addRequest, owner.id.get)
+          addResponse.isRight === true
+        }
+      }
+      "fail if an org member tries to create a library in their org but does not have permission" in {
+        withDb(modules: _*) { implicit injector =>
+          val (org, owner, member) = db.readWrite { implicit session =>
+            val owner = UserFactory.user().saved
+            val member = UserFactory.user().saved
+
+            // This org is super crappy, members can't do anything
+            val crappyBPs = BasePermissions(Map(Some(OrganizationRole.MEMBER) -> Set(OrganizationPermission.VIEW_ORGANIZATION)))
+
+            val org = OrganizationFactory.organization().withName("Kifi").withOwner(owner).withMembers(Seq(member)).withBasePermissions(crappyBPs).saved
+            (org, owner, member)
+          }
+          val libraryCommander = inject[LibraryCommander]
+
+          val addRequest = LibraryAddRequest(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", orgIdOpt = Some(org.id.get))
+          val addResponse = libraryCommander.addLibrary(addRequest, member.id.get)
+          addResponse.isLeft === true
+        }
+      }
+      "fail if a non-member tries to add a library to an organization" in {
+        withDb(modules: _*) { implicit injector =>
+          val (org, owner, rando) = db.readWrite { implicit session =>
+            val owner = UserFactory.user().saved
+            val rando = UserFactory.user().saved
+            val org = OrganizationFactory.organization().withName("Kifi").withOwner(owner).saved
+            (org, owner, rando)
+          }
+          val libraryCommander = inject[LibraryCommander]
+
+          val addRequest = LibraryAddRequest(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", orgIdOpt = Some(org.id.get))
+          val addResponse = libraryCommander.addLibrary(addRequest, rando.id.get)
+          addResponse.isLeft === true
+        }
+      }
     }
     "when modify library is called:" in {
       "allow changing organizationId of library" in {
@@ -387,7 +436,6 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           // Move it into starkOrg
           val response1 = libraryCommander.modifyLibrary(libraryId = ironLib.id.get, userId = ironMan.id.get,
             LibraryModifyRequest(space = Some(starkOrg.id.get)))
-          println(response1)
           response1.isRight === true
 
           // Now the library should live in starkOrg, but there is still an alias from ironMan

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -257,7 +257,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           }
           val libraryCommander = inject[LibraryCommander]
 
-          val addRequest = LibraryAddRequest(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", orgIdOpt = Some(org.id.get))
+          val addRequest = LibraryAddRequest(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", space = Some(org.id.get))
           val addResponse = libraryCommander.addLibrary(addRequest, owner.id.get)
           addResponse.isRight === true
         }
@@ -276,7 +276,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           }
           val libraryCommander = inject[LibraryCommander]
 
-          val addRequest = LibraryAddRequest(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", orgIdOpt = Some(org.id.get))
+          val addRequest = LibraryAddRequest(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", space = Some(org.id.get))
           val addResponse = libraryCommander.addLibrary(addRequest, member.id.get)
           addResponse.isLeft === true
         }
@@ -291,7 +291,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           }
           val libraryCommander = inject[LibraryCommander]
 
-          val addRequest = LibraryAddRequest(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", orgIdOpt = Some(org.id.get))
+          val addRequest = LibraryAddRequest(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", space = Some(org.id.get))
           val addResponse = libraryCommander.addLibrary(addRequest, rando.id.get)
           addResponse.isLeft === true
         }


### PR DESCRIPTION
You can now create libraries directly in organizations (if you have the requisite permissions). To do this, include an (optional) `space: {"org": "<public_org_id>"}` in the add request sent to the controller.
