### PR TITLE
Only execute a prefix search for a trailing query term

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
+++ b/kifi-backend/modules/common/app/com/keepit/search/SearchConfig.scala
@@ -21,7 +21,8 @@ object SearchConfig {
     Map[String, String](
       // Common Query Parser
       "titleBoost" -> "2.0",
-      "prefixBoost" -> "1.0",
+      "prefixBoost" -> "0.0",
+      "trailingPrefixBoost" -> "0.8",
       "phraseBoost" -> "0.33",
       "siteBoost" -> "1.0",
       "concatBoost" -> "0.8",
@@ -65,7 +66,8 @@ object SearchConfig {
     Map[String, String](
       // Common Query Parser
       "titleBoost" -> "boost value for title field vs main content",
-      "prefixBoost" -> "importance of prefix query vs regular text query",
+      "prefixBoost" -> "importance of prefix query vs regular text query for a non-trailing term",
+      "trailingPrefixBoost" -> "importance of prefix query vs regular text query for a trailing term",
       "phraseBoost" -> "boost value for the detected phrase [0f,1f]",
       "siteBoost" -> "boost value for matching website names and domains",
       "concatBoost" -> "boost value for concatenated terms",

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/parser/DefaultSyntax.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/parser/DefaultSyntax.scala
@@ -113,7 +113,7 @@ trait DefaultSyntax extends QueryParser {
 
   override protected def buildQuery(querySpecList: List[QuerySpec]): Option[Query] = {
     val clauses = querySpecList.foldLeft(ArrayBuffer.empty[BooleanClause]) { (clauses, spec) =>
-      val query = getFieldQuery(spec.field, spec.term, spec.quoted)
+      val query = getFieldQuery(spec.field, spec.term, spec.quoted, spec.trailing)
       query.foreach { query => clauses += new BooleanClause(query, spec.occur) }
       clauses
     }

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/parser/DefaultSyntax.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/parser/DefaultSyntax.scala
@@ -14,7 +14,7 @@ object DefaultSyntax {
   val spacesRegex = """\p{Zs}+""".r
   val qualifierRegex = """([+-])[^\p{Zs}]""".r
   val fieldRegex = """(\w+):\p{Zs}*""".r
-  val termRegex = """([^\p{Zs}]+)[\p{Zs}$]*""".r
+  val termRegex = """([^\p{Zs}]+)([\p{Zs}$]*)""".r
   val quotedTermRegex = """\"((([^\"])|(\"[^\p{Zs}]))*)\"([\p{Zs}$]*)""".r
   val endOfQueryRegex = """($)""".r
 }
@@ -61,17 +61,19 @@ trait DefaultSyntax extends QueryParser {
     }
   }
 
-  private def getTerm(m: Match): String = {
+  private def getTerm(m: Match): (String, Boolean) = {
     buf = m.after
-    m.group(1)
+    val term = m.group(1)
+    val trailing = m.group(m.groupCount).isEmpty
+    (term, trailing)
   }
 
-  private def parseQueryTerm(): String = {
+  private def parseQueryTerm(): (String, Boolean) = {
     (termRegex findPrefixMatchOf buf) match {
       case Some(m) => getTerm(m)
       case _ =>
         (endOfQueryRegex findPrefixMatchOf buf) match {
-          case Some(m) => ""
+          case Some(m) => ("", true)
           case _ => throw new QueryParserException(s"failed to parse terms before the end of query input=[${inputText}] buf=[${buf}]")
         }
     }
@@ -84,10 +86,11 @@ trait DefaultSyntax extends QueryParser {
     val field = parseFieldName()
     val occur = parseQualifier(defaultOccur)
 
-    matchQuotedQueryTerm() match {
-      case Some(m) => QuerySpec(occur, field, getTerm(m), true)
-      case _ => QuerySpec(occur, field, parseQueryTerm(), false)
+    val ((term, trailing), quoted) = matchQuotedQueryTerm() match {
+      case Some(m) => (getTerm(m), true)
+      case _ => (parseQueryTerm(), false)
     }
+    QuerySpec(occur, field, term, quoted, trailing)
   }
 
   @tailrec
@@ -98,13 +101,13 @@ trait DefaultSyntax extends QueryParser {
     }
   }
 
-  override def parse(queryText: CharSequence): Option[Query] = {
+  override def parseSpecs(queryText: CharSequence): Option[List[QuerySpec]] = {
     if (queryText == null) {
       None
     } else {
       inputText = queryText
       buf = removeLeadingSpaces(queryText)
-      buildQuery(parse(Nil))
+      Some(parse(Nil))
     }
   }
 

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/parser/KQueryExpansion.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/parser/KQueryExpansion.scala
@@ -28,8 +28,8 @@ trait KQueryExpansion extends QueryParser {
 
   val siteBoost: Float
   val concatBoost: Float
-  val prefixBoost: Float
   val titleBoost: Float
+  def getPrefixBoost(trailing: Boolean): Float
 
   val textQueries: ArrayBuffer[KTextQuery] = ArrayBuffer()
 
@@ -146,7 +146,8 @@ trait KQueryExpansion extends QueryParser {
         }
       }
 
-      if (prefixBoost > 0.0f && trailing) {
+      val prefixBoost = getPrefixBoost(trailing)
+      if (prefixBoost > 0.0f) {
         KPrefixQuery.get("tp", "tv", queryText).foreach { prefixQuery =>
           textQuery.addQuery(prefixQuery, prefixBoost)
         }

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/parser/KQueryExpansion.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/parser/KQueryExpansion.scala
@@ -33,12 +33,12 @@ trait KQueryExpansion extends QueryParser {
 
   val textQueries: ArrayBuffer[KTextQuery] = ArrayBuffer()
 
-  override def getFieldQuery(field: String, queryText: String, quoted: Boolean): Option[Query] = {
+  override def getFieldQuery(field: String, queryText: String, quoted: Boolean, trailing: Boolean): Option[Query] = {
     field.toLowerCase match {
       case "tag" => getTagQuery(queryText)
       case "site" => getSiteQuery(queryText)
       case "media" => getMediaQuery(queryText)
-      case _ => getTextQuery(queryText, quoted)
+      case _ => getTextQuery(queryText, quoted, trailing)
     }
   }
 
@@ -65,7 +65,7 @@ trait KQueryExpansion extends QueryParser {
     }
   }
 
-  protected def getTextQuery(queryText: String, quoted: Boolean): Option[Query] = {
+  protected def getTextQuery(queryText: String, quoted: Boolean, trailing: Boolean): Option[Query] = {
     def copyFieldQuery(query: Query, field: String) = {
       query match {
         case null => null
@@ -101,7 +101,7 @@ trait KQueryExpansion extends QueryParser {
     val textQuery = new KTextQuery(queryText)
     textQueries += textQuery
 
-    super.getFieldQuery("t", queryText, quoted).foreach { q =>
+    super.getFieldQuery("t", queryText, quoted, trailing).foreach { q =>
       textQuery.terms = extractTerms(q)
       val query = if (quoted) q else mayConvertQuery(q, lang)
       textQuery.addQuery(query, titleBoost)
@@ -112,7 +112,7 @@ trait KQueryExpansion extends QueryParser {
     }
 
     altAnalyzer.foreach { alt =>
-      super.getFieldQuery("t", queryText, quoted, alt).foreach { q =>
+      super.getFieldQuery("t", queryText, quoted, trailing, alt).foreach { q =>
         if (!equivalent(textQuery.terms, extractTerms(q))) {
           val query = if (quoted) q else mayConvertQuery(q, alt.lang)
           val boost = if (textQuery.isEmpty) 0.1f else 1.0f
@@ -125,7 +125,7 @@ trait KQueryExpansion extends QueryParser {
     }
 
     if (!quoted) {
-      getStemmedFieldQuery("ts", queryText).foreach { q =>
+      getStemmedFieldQuery("ts", queryText, trailing).foreach { q =>
         textQuery.stems = extractTerms(q)
         val query = mayConvertQuery(q, lang)
         textQuery.addQuery(query, titleBoost)
@@ -134,7 +134,7 @@ trait KQueryExpansion extends QueryParser {
       }
 
       altStemmingAnalyzer.foreach { alt =>
-        getFieldQuery("ts", queryText, false, alt).foreach { q =>
+        getFieldQuery("ts", queryText, false, trailing, alt).foreach { q =>
           if (!equivalent(textQuery.stems, extractTerms(q))) {
             val query = mayConvertQuery(q, alt.lang)
             val boost = if (textQuery.isEmpty) 0.1f else 1.0f
@@ -146,7 +146,7 @@ trait KQueryExpansion extends QueryParser {
         }
       }
 
-      if (prefixBoost > 0.0f) {
+      if (prefixBoost > 0.0f && trailing) {
         KPrefixQuery.get("tp", "tv", queryText).foreach { prefixQuery =>
           textQuery.addQuery(prefixQuery, prefixBoost)
         }
@@ -170,7 +170,7 @@ trait KQueryExpansion extends QueryParser {
 
     // truncate query if there are too many (>100) terms
     querySpecList.take(100).foreach { spec =>
-      val query = getFieldQuery(spec.field, spec.term, spec.quoted)
+      val query = getFieldQuery(spec.field, spec.term, spec.quoted, spec.trailing)
       query match {
         case Some(query) =>
           query match {

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/parser/KQueryParser.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/parser/KQueryParser.scala
@@ -28,7 +28,11 @@ class KQueryParser(
     val titleBoost = config.asFloat("titleBoost")
     val siteBoost = config.asFloat("siteBoost")
     val concatBoost = config.asFloat("concatBoost")
-    val prefixBoost = if (disablePrefixSearch) 0.0f else config.asFloat("prefixBoost")
+    def getPrefixBoost(trailing: Boolean) = {
+      if (disablePrefixSearch) 0.0f
+      else if (trailing) config.asFloat("trailingPrefixBoost")
+      else config.asFloat("prefixBoost")
+    }
     val lang: Lang = qp.analyzer.lang
   }
 

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/parser/QueryParser.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/parser/QueryParser.scala
@@ -25,15 +25,15 @@ abstract class QueryParser(protected val defaultAnalyzer: Analyzer, protected va
     }
   }
 
-  protected def getFieldQuery(field: String, queryText: String, quoted: Boolean): Option[Query] = {
-    getFieldQuery(field, queryText, quoted, defaultAnalyzer)
+  protected def getFieldQuery(field: String, queryText: String, quoted: Boolean, trailing: Boolean): Option[Query] = {
+    getFieldQuery(field, queryText, quoted, trailing, defaultAnalyzer)
   }
 
-  protected def getStemmedFieldQuery(field: String, queryText: String): Option[Query] = {
-    getFieldQuery(field, queryText, false, defaultStemmingAnalyzer)
+  protected def getStemmedFieldQuery(field: String, queryText: String, trailing: Boolean): Option[Query] = {
+    getFieldQuery(field, queryText, false, trailing, defaultStemmingAnalyzer)
   }
 
-  protected def getFieldQuery(field: String, queryText: String, quoted: Boolean, analyzer: Analyzer): Option[Query] = {
+  protected def getFieldQuery(field: String, queryText: String, quoted: Boolean, trailing: Boolean, analyzer: Analyzer): Option[Query] = {
     val it = new TermIterator(field, queryText, analyzer) with Position
     try {
       if (it.hasNext) {

--- a/kifi-backend/modules/search/app/com/keepit/search/engine/parser/QueryParser.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/engine/parser/QueryParser.scala
@@ -13,7 +13,7 @@ abstract class QueryParser(protected val defaultAnalyzer: Analyzer, protected va
 
   val fields: Set[String]
 
-  def parse(queryText: CharSequence): Option[Query]
+  def parse(queryText: CharSequence): Option[Query] = parseSpecs(queryText).flatMap(buildQuery)
 
   protected def getBooleanQuery(clauses: ArrayBuffer[BooleanClause]): Option[Query] = {
     if (clauses.size == 0) {
@@ -62,9 +62,11 @@ abstract class QueryParser(protected val defaultAnalyzer: Analyzer, protected va
   }
 
   protected def buildQuery(querySpecList: List[QuerySpec]): Option[Query]
+
+  protected def parseSpecs(queryText: CharSequence): Option[List[QuerySpec]]
 }
 
-case class QuerySpec(occur: Occur, field: String, term: String, quoted: Boolean)
+case class QuerySpec(occur: Occur, field: String, term: String, quoted: Boolean, trailing: Boolean)
 
 class QueryParserException(msg: String) extends Exception(msg)
 

--- a/kifi-backend/modules/search/app/com/keepit/search/index/message/MessageQueryParser.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/message/MessageQueryParser.scala
@@ -19,17 +19,17 @@ class MessageQueryParser(
     }
   }
 
-  override def getFieldQuery(field: String, queryText: String, quoted: Boolean): Option[Query] = {
+  override def getFieldQuery(field: String, queryText: String, quoted: Boolean, trailing: Boolean): Option[Query] = {
     val disjunct = new DisjunctionMaxQuery(0.5f)
 
-    super.getFieldQuery(ThreadIndexFields.contentField, queryText, quoted).foreach { query =>
+    super.getFieldQuery(ThreadIndexFields.contentField, queryText, quoted, trailing).foreach { query =>
       disjunct.add(query)
       disjunct.add(copyFieldQuery(query, ThreadIndexFields.titleField))
       disjunct.add(copyFieldQuery(query, ThreadIndexFields.participantNameField))
       disjunct.add(copyFieldQuery(query, ThreadIndexFields.urlKeywordField))
     }
 
-    getStemmedFieldQuery(ThreadIndexFields.contentStemmedField, queryText).foreach { query =>
+    getStemmedFieldQuery(ThreadIndexFields.contentStemmedField, queryText, trailing).foreach { query =>
       if (!quoted) {
         disjunct.add(query)
         disjunct.add(copyFieldQuery(query, ThreadIndexFields.titleStemmedField))

--- a/kifi-backend/modules/search/app/com/keepit/search/user/DeprecatedUserQueryParser.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/user/DeprecatedUserQueryParser.scala
@@ -90,4 +90,5 @@ class DeprecatedUserQueryParser(
 
   override protected def buildQuery(querySpecList: List[QuerySpec]): Option[Query] = ???
 
+  override protected def parseSpecs(queryText: CharSequence): Option[List[QuerySpec]] = ???
 }

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/QueryEngineBuilderTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/QueryEngineBuilderTest.scala
@@ -22,7 +22,7 @@ class QueryEngineBuilderTest extends Specification {
       val titleBoost: Float = 2.0f
       val siteBoost: Float = 1.0f
       val concatBoost: Float = 0.5f
-      val prefixBoost: Float = 0.0f
+      def getPrefixBoost(trailing: Boolean): Float = 0.0f
     }
   }
 

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/QueryEngineTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/QueryEngineTest.scala
@@ -54,7 +54,7 @@ class QueryEngineTest extends Specification {
       val titleBoost = 2.0f
       val siteBoost: Float = 1.0f
       val concatBoost: Float = 0.5f
-      val prefixBoost: Float = 0.0f
+      def getPrefixBoost(trailing: Boolean): Float = 0.0f
     }
   }
 

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/parser/KQueryExpansionTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/parser/KQueryExpansionTest.scala
@@ -8,7 +8,7 @@ import org.specs2.mutable._
 
 class KQueryExpansionTest extends Specification {
 
-  private class QueryParserScope(concatBoostValue: Float, prefixBoostValue: Float) extends Scope {
+  private class QueryParserScope(concatBoostValue: Float, trailingPrefixBoost: Float, prefixBoost: Float) extends Scope {
     val english = Lang("en")
     val analyzer = DefaultAnalyzer.getAnalyzer(english)
     val stemmingAnalyzer = DefaultAnalyzer.getAnalyzerWithStemmer(english)
@@ -19,7 +19,7 @@ class KQueryExpansionTest extends Specification {
       val titleBoost: Float = 2.0f
       val siteBoost: Float = 1.0f
       val concatBoost: Float = concatBoostValue
-      val prefixBoost: Float = prefixBoostValue
+      def getPrefixBoost(trailing: Boolean): Float = if (trailing) trailingPrefixBoost else prefixBoost
     }
   }
 
@@ -27,7 +27,7 @@ class KQueryExpansionTest extends Specification {
   private[this] def b(implicit queryExpansion: KQueryExpansion) = if (queryExpansion.titleBoost == 1.0f) "" else s"^${queryExpansion.titleBoost}"
 
   "KQueryExpansion" should {
-    "expand queries (with no concat, with prefix search on trailing term)" in new QueryParserScope(concatBoostValue = 0.0f, prefixBoostValue = 1.0f) {
+    "expand queries (with no concat, with prefix search on trailing term)" in new QueryParserScope(concatBoostValue = 0.0f, trailingPrefixBoost = 1.0f, prefixBoost = 0.0f) {
       var query = parser.parse("super conductivity").get
       query must beAnInstanceOf[KBooleanQuery]
       query.toString ===
@@ -70,12 +70,12 @@ class KQueryExpansionTest extends Specification {
         s"""KTextQuery((t:"spin statistics"$b | c:"spin statistics" | h:"spin statistics")~$tb)"""
     }
 
-    "expand queries (with concat, with prefix search)" in new QueryParserScope(concatBoostValue = 0.5f, prefixBoostValue = 1.0f) {
+    "expand queries (with concat, with prefix search on all terms)" in new QueryParserScope(concatBoostValue = 0.5f, trailingPrefixBoost = 1.0f, prefixBoost = 1.0f) {
       var query = parser.parse("super conductivity").get
       query must beAnInstanceOf[KBooleanQuery]
       query.toString ===
         "KTextQuery(" +
-        s"(t:super$b | c:super | h:super | ts:super$b | cs:super | hs:super |" +
+        s"(t:super$b | c:super | h:super | ts:super$b | cs:super | hs:super | KPrefixQuery(tp-tv: super) |" +
         s" t:superconductivity^0.5 | c:superconductivity^0.5 | h:superconductivity^0.5 | ts:superconductivity^0.5 | cs:superconductivity^0.5 | hs:superconductivity^0.5)~$tb) " +
         "KTextQuery(" +
         s"(t:conductivity$b | c:conductivity | h:conductivity | ts:conductivity$b | cs:conductivity | hs:conductivity | KPrefixQuery(tp-tv: conductivity) |" +
@@ -85,11 +85,11 @@ class KQueryExpansionTest extends Specification {
       query must beAnInstanceOf[KBooleanQuery]
       query.toString ===
         "KTextQuery(" +
-        s"(t:electromagnetically$b | c:electromagnetically | h:electromagnetically | ts:electromagnet$b | cs:electromagnet | hs:electromagnet |" +
+        s"(t:electromagnetically$b | c:electromagnetically | h:electromagnetically | ts:electromagnet$b | cs:electromagnet | hs:electromagnet | KPrefixQuery(tp-tv: electromagnetically) |" +
         s" t:electromagneticallyinduced^0.5 | c:electromagneticallyinduced^0.5 | h:electromagneticallyinduced^0.5 |" +
         s" ts:electromagneticallyinduce^0.5 | cs:electromagneticallyinduce^0.5 | hs:electromagneticallyinduce^0.5)~$tb) " +
         "KTextQuery(" +
-        s"(t:induced$b | c:induced | h:induced | ts:induce$b | cs:induce | hs:induce |" +
+        s"(t:induced$b | c:induced | h:induced | ts:induce$b | cs:induce | hs:induce | KPrefixQuery(tp-tv: induced) |" +
         s" t:electromagneticallyinduced^0.5 | c:electromagneticallyinduced^0.5 | h:electromagneticallyinduced^0.5 | ts:electromagneticallyinduce^0.5 | cs:electromagneticallyinduce^0.5 | hs:electromagneticallyinduce^0.5 |" +
         s" t:inducedtransparency^0.5 | c:inducedtransparency^0.5 | h:inducedtransparency^0.5 | ts:inducedtransparency^0.5 | cs:inducedtransparency^0.5 | hs:inducedtransparency^0.5)~$tb) " +
         "KTextQuery(" +
@@ -100,7 +100,7 @@ class KQueryExpansionTest extends Specification {
       query must beAnInstanceOf[KBooleanQuery]
       query.toString ===
         "KTextQuery(" +
-        s"""(t:"bose einstein"$b | c:"bose einstein" | h:"bose einstein" | ts:"bose einstein"$b | cs:"bose einstein" | hs:"bose einstein" |""" +
+        s"""(t:"bose einstein"$b | c:"bose einstein" | h:"bose einstein" | ts:"bose einstein"$b | cs:"bose einstein" | hs:"bose einstein" | KPrefixQuery(tp-tv: bose-einstein) |""" +
         s""" t:boseeinstein^0.5 | c:boseeinstein^0.5 | h:boseeinstein^0.5 | ts:boseeinstein^0.5 | cs:boseeinstein^0.5 | hs:boseeinstein^0.5 |""" +
         s""" t:boseeinsteincondensate^0.5 | c:boseeinsteincondensate^0.5 | h:boseeinsteincondensate^0.5 | ts:boseeinsteincondensate^0.5 | cs:boseeinsteincondensate^0.5 | hs:boseeinsteincondensate^0.5)~$tb) """ +
         "KTextQuery(" +
@@ -114,7 +114,7 @@ class KQueryExpansionTest extends Specification {
         s"""KTextQuery((t:theorem$b | c:theorem | h:theorem | ts:theorem$b | cs:theorem | hs:theorem | KPrefixQuery(tp-tv: theorem))~$tb)"""
     }
 
-    "expand queries (with no concat, no prefix search)" in new QueryParserScope(concatBoostValue = 0.0f, prefixBoostValue = 0.0f) {
+    "expand queries (with no concat, no prefix search)" in new QueryParserScope(concatBoostValue = 0.0f, trailingPrefixBoost = 0.0f, prefixBoost = 0.0f) {
       var query = parser.parse("super conductivity").get
       query must beAnInstanceOf[KBooleanQuery]
       query.toString ===
@@ -141,7 +141,7 @@ class KQueryExpansionTest extends Specification {
         s"""KTextQuery((t:theorem$b | c:theorem | h:theorem | ts:theorem$b | cs:theorem | hs:theorem)~$tb)"""
     }
 
-    "expand a query with site" in new QueryParserScope(concatBoostValue = 0.0f, prefixBoostValue = 0.0f) {
+    "expand a query with site" in new QueryParserScope(concatBoostValue = 0.0f, trailingPrefixBoost = 0.0f, prefixBoost = 0.0f) {
       parser.parse("www.yahoo.com").get.toString ===
         s"""KTextQuery((t:"www yahoo com"$b | c:"www yahoo com" | h:"www yahoo com" | site:www.yahoo.com | ts:"www yahoo com"$b | cs:"www yahoo com" | hs:"www yahoo com")~$tb)"""
     }

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/parser/KQueryExpansionTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/parser/KQueryExpansionTest.scala
@@ -27,39 +27,55 @@ class KQueryExpansionTest extends Specification {
   private[this] def b(implicit queryExpansion: KQueryExpansion) = if (queryExpansion.titleBoost == 1.0f) "" else s"^${queryExpansion.titleBoost}"
 
   "KQueryExpansion" should {
-    "expand queries (with no concat)" in new QueryParserScope(concatBoostValue = 0.0f, prefixBoostValue = 1.0f) {
+    "expand queries (with no concat, with prefix search on trailing term)" in new QueryParserScope(concatBoostValue = 0.0f, prefixBoostValue = 1.0f) {
       var query = parser.parse("super conductivity").get
       query must beAnInstanceOf[KBooleanQuery]
       query.toString ===
-        s"KTextQuery((t:super$b | c:super | h:super | ts:super$b | cs:super | hs:super | KPrefixQuery(tp-tv: super))~$tb) " +
+        s"KTextQuery((t:super$b | c:super | h:super | ts:super$b | cs:super | hs:super)~$tb) " +
         s"KTextQuery((t:conductivity$b | c:conductivity | h:conductivity | ts:conductivity$b | cs:conductivity | hs:conductivity | KPrefixQuery(tp-tv: conductivity))~$tb)"
 
       query = parser.parse("Electromagnetically induced transparency").get
       query must beAnInstanceOf[KBooleanQuery]
       query.toString ===
-        s"KTextQuery((t:electromagnetically$b | c:electromagnetically | h:electromagnetically | ts:electromagnet$b | cs:electromagnet | hs:electromagnet | KPrefixQuery(tp-tv: electromagnetically))~$tb) " +
-        s"KTextQuery((t:induced$b | c:induced | h:induced | ts:induce$b | cs:induce | hs:induce | KPrefixQuery(tp-tv: induced))~$tb) " +
+        s"KTextQuery((t:electromagnetically$b | c:electromagnetically | h:electromagnetically | ts:electromagnet$b | cs:electromagnet | hs:electromagnet)~$tb) " +
+        s"KTextQuery((t:induced$b | c:induced | h:induced | ts:induce$b | cs:induce | hs:induce)~$tb) " +
         s"KTextQuery((t:transparency$b | c:transparency | h:transparency | ts:transparency$b | cs:transparency | hs:transparency | KPrefixQuery(tp-tv: transparency))~$tb)"
 
       query = parser.parse("bose-einstein condensate").get
       query must beAnInstanceOf[KBooleanQuery]
       query.toString ===
-        s"""KTextQuery((t:"bose einstein"$b | c:"bose einstein" | h:"bose einstein" | ts:"bose einstein"$b | cs:"bose einstein" | hs:"bose einstein" | KPrefixQuery(tp-tv: bose-einstein))~$tb) """ +
+        s"""KTextQuery((t:"bose einstein"$b | c:"bose einstein" | h:"bose einstein" | ts:"bose einstein"$b | cs:"bose einstein" | hs:"bose einstein")~$tb) """ +
         s"""KTextQuery((t:condensate$b | c:condensate | h:condensate | ts:condensate$b | cs:condensate | hs:condensate | KPrefixQuery(tp-tv: condensate))~$tb)"""
+
+      query = parser.parse("bose-einstein condensate ").get
+      query must beAnInstanceOf[KBooleanQuery]
+      query.toString ===
+        s"""KTextQuery((t:"bose einstein"$b | c:"bose einstein" | h:"bose einstein" | ts:"bose einstein"$b | cs:"bose einstein" | hs:"bose einstein")~$tb) """ +
+        s"""KTextQuery((t:condensate$b | c:condensate | h:condensate | ts:condensate$b | cs:condensate | hs:condensate)~$tb)"""
+
+      query = parser.parse("bose-einstein").get
+      query must beAnInstanceOf[KBooleanQuery]
+      query.toString ===
+        s"""KTextQuery((t:"bose einstein"$b | c:"bose einstein" | h:"bose einstein" | ts:"bose einstein"$b | cs:"bose einstein" | hs:"bose einstein" | KPrefixQuery(tp-tv: bose-einstein))~$tb)"""
 
       query = parser.parse("\"Spin-statistics\" theorem").get
       query must beAnInstanceOf[KBooleanQuery]
       query.toString ===
         s"""KTextQuery((t:"spin statistics"$b | c:"spin statistics" | h:"spin statistics")~$tb) """ +
         s"""KTextQuery((t:theorem$b | c:theorem | h:theorem | ts:theorem$b | cs:theorem | hs:theorem | KPrefixQuery(tp-tv: theorem))~$tb)"""
+
+      query = parser.parse("\"Spin-statistics\"").get
+      query must beAnInstanceOf[KBooleanQuery]
+      query.toString ===
+        s"""KTextQuery((t:"spin statistics"$b | c:"spin statistics" | h:"spin statistics")~$tb)"""
     }
 
-    "expand queries (with concat)" in new QueryParserScope(concatBoostValue = 0.5f, prefixBoostValue = 1.0f) {
+    "expand queries (with concat, with prefix search)" in new QueryParserScope(concatBoostValue = 0.5f, prefixBoostValue = 1.0f) {
       var query = parser.parse("super conductivity").get
       query must beAnInstanceOf[KBooleanQuery]
       query.toString ===
         "KTextQuery(" +
-        s"(t:super$b | c:super | h:super | ts:super$b | cs:super | hs:super | KPrefixQuery(tp-tv: super) |" +
+        s"(t:super$b | c:super | h:super | ts:super$b | cs:super | hs:super |" +
         s" t:superconductivity^0.5 | c:superconductivity^0.5 | h:superconductivity^0.5 | ts:superconductivity^0.5 | cs:superconductivity^0.5 | hs:superconductivity^0.5)~$tb) " +
         "KTextQuery(" +
         s"(t:conductivity$b | c:conductivity | h:conductivity | ts:conductivity$b | cs:conductivity | hs:conductivity | KPrefixQuery(tp-tv: conductivity) |" +
@@ -69,11 +85,11 @@ class KQueryExpansionTest extends Specification {
       query must beAnInstanceOf[KBooleanQuery]
       query.toString ===
         "KTextQuery(" +
-        s"(t:electromagnetically$b | c:electromagnetically | h:electromagnetically | ts:electromagnet$b | cs:electromagnet | hs:electromagnet | KPrefixQuery(tp-tv: electromagnetically) |" +
+        s"(t:electromagnetically$b | c:electromagnetically | h:electromagnetically | ts:electromagnet$b | cs:electromagnet | hs:electromagnet |" +
         s" t:electromagneticallyinduced^0.5 | c:electromagneticallyinduced^0.5 | h:electromagneticallyinduced^0.5 |" +
         s" ts:electromagneticallyinduce^0.5 | cs:electromagneticallyinduce^0.5 | hs:electromagneticallyinduce^0.5)~$tb) " +
         "KTextQuery(" +
-        s"(t:induced$b | c:induced | h:induced | ts:induce$b | cs:induce | hs:induce | KPrefixQuery(tp-tv: induced) |" +
+        s"(t:induced$b | c:induced | h:induced | ts:induce$b | cs:induce | hs:induce |" +
         s" t:electromagneticallyinduced^0.5 | c:electromagneticallyinduced^0.5 | h:electromagneticallyinduced^0.5 | ts:electromagneticallyinduce^0.5 | cs:electromagneticallyinduce^0.5 | hs:electromagneticallyinduce^0.5 |" +
         s" t:inducedtransparency^0.5 | c:inducedtransparency^0.5 | h:inducedtransparency^0.5 | ts:inducedtransparency^0.5 | cs:inducedtransparency^0.5 | hs:inducedtransparency^0.5)~$tb) " +
         "KTextQuery(" +
@@ -84,7 +100,7 @@ class KQueryExpansionTest extends Specification {
       query must beAnInstanceOf[KBooleanQuery]
       query.toString ===
         "KTextQuery(" +
-        s"""(t:"bose einstein"$b | c:"bose einstein" | h:"bose einstein" | ts:"bose einstein"$b | cs:"bose einstein" | hs:"bose einstein" | KPrefixQuery(tp-tv: bose-einstein) |""" +
+        s"""(t:"bose einstein"$b | c:"bose einstein" | h:"bose einstein" | ts:"bose einstein"$b | cs:"bose einstein" | hs:"bose einstein" |""" +
         s""" t:boseeinstein^0.5 | c:boseeinstein^0.5 | h:boseeinstein^0.5 | ts:boseeinstein^0.5 | cs:boseeinstein^0.5 | hs:boseeinstein^0.5 |""" +
         s""" t:boseeinsteincondensate^0.5 | c:boseeinsteincondensate^0.5 | h:boseeinsteincondensate^0.5 | ts:boseeinsteincondensate^0.5 | cs:boseeinsteincondensate^0.5 | hs:boseeinsteincondensate^0.5)~$tb) """ +
         "KTextQuery(" +

--- a/kifi-backend/modules/search/test/com/keepit/search/engine/parser/QueryParserTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/engine/parser/QueryParserTest.scala
@@ -124,5 +124,19 @@ class QueryParserTest extends Specification {
       query = parser.parse("aaa site:")
       query.toString === "Some(aaa)"
     }
+
+    "strip leading spaces" in new QueryParserScope {
+      var query = parser.parse("    aaa")
+      query.toString === "Some(aaa)"
+    }
+
+    "detect trailing terms" in new QueryParserScope {
+      parser.parseSpecs("    aaa bbb").get.head === QuerySpec(Occur.SHOULD, "", "aaa", false, false)
+      parser.parseSpecs("    aaa ").get.head === QuerySpec(Occur.SHOULD, "", "aaa", false, false)
+      parser.parseSpecs("    \"aaa\" ").get.head === QuerySpec(Occur.SHOULD, "", "aaa", true, false)
+
+      parser.parseSpecs("    aaa").get.head === QuerySpec(Occur.SHOULD, "", "aaa", false, true)
+      parser.parseSpecs("    \"aaa\"").get.head === QuerySpec(Occur.SHOULD, "", "aaa", true, true)
+    }
   }
 }

--- a/kifi-backend/modules/search/test/com/keepit/search/index/article/ArticleIndexerTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/index/article/ArticleIndexerTest.scala
@@ -54,7 +54,7 @@ class ArticleIndexerTest extends Specification with SearchTestInjector with Sear
     val titleBoost: Float = 2.0f
     val siteBoost: Float = 1.0f
     val concatBoost: Float = 0.0f
-    val prefixBoost: Float = 0.0f
+    def getPrefixBoost(trailing: Boolean): Float = 0.0f
   }
 
   private class IndexerScope(injector: Injector) extends Scope {


### PR DESCRIPTION
@stkem @andrewconner 
Basically, if there's something (including a whitespace) after a term, we should consider that the user is done typing that term and shouldn't use it for a prefix search.

Previously: 
- `Léo Grim` would do a prefix search with both `Léo` and `Grim` and `Léon Grimaldi` would match.

Now:
- `Léo Grim` will do a prefix search on `Grim` but not `Léo`, e.g. `Léon Grimaldi` won't match
- `Léo_` (_ representing a trailing whitespace) will not do a prefix search at all
