### PR TITLE
use lowercase hostnames in DomainRepo

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/classify/DomainRepo.scala
@@ -63,7 +63,8 @@ class DomainRepoImpl @Inject() (
   }
 
   def internAllByNames(domainNames: Set[String])(implicit session: RWSession): Map[String, Domain] = {
-    val existingDomains = getAllByName(domainNames.toSeq, None).toSet
+    val lowerCasedDomainNames = domainNames.map(_.toLowerCase)
+    val existingDomains = getAllByName(lowerCasedDomainNames.toSeq, None).toSet
 
     val existingDomainByName = existingDomains.map { domain =>
       domain.state match {
@@ -72,7 +73,7 @@ class DomainRepoImpl @Inject() (
       }
     }.toMap
 
-    val newDomainByName = domainNames.diff(existingDomainByName.keys.toSet).map { domainName =>
+    val newDomainByName = lowerCasedDomainNames.diff(existingDomainByName.keys.toSet).map { domainName =>
       domainName -> save(Domain(hostname = domainName))
     }.toMap
 


### PR DESCRIPTION
@leogrim ContactInterner carries much more complexity than this case. hopefully this does the trick, please let me know if you see anything wrong.

one thing that I noticed in the MySQLIntegrityException is that the failed hostname contained this character "ı"? Not sure how this is handled. 
