### PR TITLE
More resilient Zookeepering

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/controller/LoggingFilter.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/LoggingFilter.scala
@@ -31,8 +31,6 @@ class LoggingFilter() extends EssentialFilter {
         val message = s"Current status of service ${myAmazonInstanceInfo.info.localIp} ${discovery.myStatus.getOrElse("UNKNOWN")}, last changed ${discovery.timeSinceLastStatusChange}ms ago"
         //system is going down, maybe the logger, emails, airbrake are gone already
         println(message)
-        //we can remove this airbrake once we'll see the system works right
-        airbrake.notify(message)
         Done(Result(header = ResponseHeader(Status.SERVICE_UNAVAILABLE), body = Enumerator()))
       } else {
         val timer = accessLog.timer(HTTP_IN)

--- a/kifi-backend/modules/common/app/com/keepit/common/service/ServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/service/ServiceClient.scala
@@ -90,7 +90,7 @@ trait ServiceClient extends CommonServiceUtilities with Logging {
     }
   }
 
-  protected def call(call: ServiceRoute, body: JsValue = JsNull, attempts: Int = 2, callTimeouts: CallTimeouts = CallTimeouts.UseDefaults, routingStrategy: RoutingStrategy = roundRobin): Future[ClientResponse] = {
+  protected def call(call: ServiceRoute, body: JsValue = JsNull, attempts: Int = 3, callTimeouts: CallTimeouts = CallTimeouts.UseDefaults, routingStrategy: RoutingStrategy = roundRobin): Future[ClientResponse] = {
     val tracer = new StackTrace()
     val respFuture = RetryFuture(attempts, { case t: ConnectException => serviceCluster.refresh(); true }) {
       callUrl(call, serviceUri(call.url, routingStrategy), body, ignoreFailure = true, callTimeouts = callTimeouts)

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/FakeZookeeperClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/FakeZookeeperClient.scala
@@ -14,6 +14,7 @@ class FakeZooKeeperClient() extends ZooKeeperClient {
   def onConnected(handler: ZooKeeperSession => Unit): Unit = { handler(zk) }
   def session[T](f: ZooKeeperSession => T): T = f(zk)
   def close() = {}
+  def refreshSession(): Unit = {}
 }
 
 class FakeZooKeeperSession(db: mutable.HashMap[Node, Option[Array[Byte]]]) extends ZooKeeperSession {

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
@@ -107,7 +107,6 @@ class ServiceCluster(val serviceType: ServiceType, airbrake: Provider[AirbrakeNo
         case (node, instance) =>
           val ip = instance.instanceInfo.localIp
           machines.get(ip) foreach { existing =>
-            airbrake.get.notify(s"there are two existing ZK nodes with the same IP address $ip: $existing and $node for service ${instance}, removing the smallest node")
             val newNodeId = instances(node).id.id
             val existingNodeId = instances(existing).id.id
             if (newNodeId == existingNodeId) {

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ZooKeeperClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ZooKeeperClient.scala
@@ -72,6 +72,7 @@ trait ZooKeeperClient {
   def onConnected(handler: ZooKeeperSession => Unit): Unit
   def session[T](f: ZooKeeperSession => T): T
   def close(): Unit
+  def refreshSession(): Unit
 }
 
 trait ZooKeeperSession {
@@ -127,7 +128,7 @@ class ZooKeeperClientImpl(val servers: String, val sessionTimeout: Int,
     zk.execOnConnectHandler(handler) // if already connected, this executes the handler immediately
   }
 
-  def refreshSession(): Unit = Future {
+  def refreshSession(): Unit = {
     val old = zkSession.getAndSet(Await.result(connect(), Duration.Inf))
     if (old != null) try { old.close() } catch { case _: Throwable => } // make sure the old session is closed
   }


### PR DESCRIPTION
We already have a recovery mechanism for connection loss, but it had some weaknesses, perhaps most notably that it was async and not always called when there was a problem. This should help.

Also removed two unnecessary airbrakes which were responsible for some of the recent pagerduties.

No really all that much closer to understanding why this only recently started acting up, but this should (hopefully) reduce the problems.

This should be deployed carefully (i.e. probably in the morning)

@andrewconner @leogrim 
