### PR TITLE
org api change

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
@@ -38,7 +38,7 @@ class OrganizationController @Inject() (
               failure.asErrorResponse
             case Right(response) =>
               val organizationView = orgCommander.getOrganizationView(response.newOrg.id.get, request.userIdOpt)
-              Ok(Json.obj("organization" -> Json.toJson(organizationView)(OrganizationView.websiteWrites)))
+              Ok(OrganizationView.websiteWrites.writes(organizationView))
           }
       }
     }
@@ -54,7 +54,7 @@ class OrganizationController @Inject() (
           case Left(failure) => failure.asErrorResponse
           case Right(response) =>
             val organizationView = orgCommander.getOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt)
-            Ok(Json.obj("organization" -> Json.toJson(organizationView)(OrganizationView.websiteWrites)))
+            Ok(OrganizationView.websiteWrites.writes(organizationView))
         }
     }
   }
@@ -84,7 +84,7 @@ class OrganizationController @Inject() (
 
   def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
     val organizationView = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt)
-    Ok(Json.obj("organization" -> Json.toJson(organizationView)(OrganizationView.websiteWrites)))
+    Ok(OrganizationView.websiteWrites.writes(organizationView))
   }
 
   def getOrganizationLibraries(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInfo.scala
@@ -52,10 +52,10 @@ case class OrganizationView(
   membershipInfo: MembershipInfo)
 
 object OrganizationView {
-  val websiteWrites: Writes[OrganizationView] = (
-    (__ \ 'organizationInfo).write(OrganizationInfo.defaultWrites) and
-    (__ \ 'membershipInfo).write(MembershipInfo.defaultWrites)
-  )(unlift(OrganizationView.unapply))
+  val websiteWrites: Writes[OrganizationView] = new Writes[OrganizationView] {
+    def writes(o: OrganizationView) = Json.obj("organization" -> OrganizationInfo.defaultWrites.writes(o.organizationInfo),
+      "membership" -> MembershipInfo.defaultWrites.writes(o.membershipInfo))
+  }
   val mobileWrites = new Writes[OrganizationView] {
     def writes(o: OrganizationView) = OrganizationInfo.defaultWrites.writes(o.organizationInfo).as[JsObject] ++ MembershipInfo.defaultWrites.writes(o.membershipInfo).as[JsObject]
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
@@ -78,7 +78,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
           val randoResponse = controller.getOrganization(publicId)(randoRequest)
           status(randoResponse) === OK
 
-          val payloads = Seq(ownerResponse, memberResponse, randoResponse).map { response => Json.parse(contentAsString(response)) \ "organization" \ "organizationInfo" }
+          val payloads = Seq(ownerResponse, memberResponse, randoResponse).map { response => Json.parse(contentAsString(response)) \ "organization" }
 
           payloads.foreach(p => (p \ "name").as[String] === "Brewster Corp")
           payloads.foreach(p => (p \ "handle").as[String] === "brewstercorp")
@@ -101,19 +101,19 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
         val ownerRequest = route.getOrganization(publicId)
         val ownerResponse = controller.getOrganization(publicId)(ownerRequest)
         status(ownerResponse) === OK
-        (Json.parse(contentAsString(ownerResponse)) \ "organization" \ "membershipInfo" \ "permissions").as[Set[OrganizationPermission]] === org.basePermissions.forRole(OrganizationRole.ADMIN)
+        (Json.parse(contentAsString(ownerResponse)) \ "membership" \ "permissions").as[Set[OrganizationPermission]] === org.basePermissions.forRole(OrganizationRole.ADMIN)
 
         inject[FakeUserActionsHelper].setUser(member, Set(UserExperimentType.ORGANIZATION))
         val memberRequest = route.getOrganization(publicId)
         val memberResponse = controller.getOrganization(publicId)(memberRequest)
         status(memberResponse) === OK
-        (Json.parse(contentAsString(memberResponse)) \ "organization" \ "membershipInfo" \ "permissions").as[Set[OrganizationPermission]] === org.basePermissions.forRole(OrganizationRole.MEMBER)
+        (Json.parse(contentAsString(memberResponse)) \ "membership" \ "permissions").as[Set[OrganizationPermission]] === org.basePermissions.forRole(OrganizationRole.MEMBER)
 
         inject[FakeUserActionsHelper].setUser(rando, Set(UserExperimentType.ORGANIZATION))
         val randoRequest = route.getOrganization(publicId)
         val randoResponse = controller.getOrganization(publicId)(randoRequest)
         status(randoResponse) === OK
-        (Json.parse(contentAsString(randoResponse)) \ "organization" \ "membershipInfo" \ "permissions").as[Set[OrganizationPermission]] === org.basePermissions.forNonmember
+        (Json.parse(contentAsString(randoResponse)) \ "membership" \ "permissions").as[Set[OrganizationPermission]] === org.basePermissions.forNonmember
       }
       "serve up the right number of libraries depending on viewer permissions" in {
         withDb(controllerTestModules: _*) { implicit injector =>
@@ -134,13 +134,13 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
           val ownerRequest = route.getOrganization(publicId)
           val ownerResponse = controller.getOrganization(publicId)(ownerRequest)
           status(ownerResponse) === OK
-          (Json.parse(contentAsString(ownerResponse)) \ "organization" \ "organizationInfo" \ "numLibraries").as[Int] === 10 + 15
+          (Json.parse(contentAsString(ownerResponse)) \ "organization" \ "numLibraries").as[Int] === 10 + 15
 
           inject[FakeUserActionsHelper].setUser(rando, Set(UserExperimentType.ORGANIZATION))
           val randoRequest = route.getOrganization(publicId)
           val randoResponse = controller.getOrganization(publicId)(randoRequest)
           status(randoResponse) === OK
-          (Json.parse(contentAsString(randoResponse)) \ "organization" \ "organizationInfo" \ "numLibraries").as[Int] === 10
+          (Json.parse(contentAsString(randoResponse)) \ "organization" \ "numLibraries").as[Int] === 10
         }
       }
     }
@@ -307,8 +307,8 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
           status(result) === OK
 
           val createResponseJson = Json.parse(contentAsString(result))
-          (createResponseJson \ "organization" \ "organizationInfo" \ "name").as[String] === orgName
-          (createResponseJson \ "organization" \ "organizationInfo" \ "description").as[Option[String]] === Some(orgDescription)
+          (createResponseJson \ "organization" \ "name").as[String] === orgName
+          (createResponseJson \ "organization" \ "description").as[Option[String]] === Some(orgDescription)
         }
       }
     }


### PR DESCRIPTION
@leo @cvializ @ajkochanowicz @ryanpbrewster this removes the wrapper around `organizationInfo` and `membershipInfo`, now you just get an object with `organization` and `membership` (which were previously suffixed by "info").
