### PR TITLE
Refresh the org data when an org invite is accepted.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .directive('kfOrgProfileHeader', [
-  '$state', '$http', '$analytics', '$location', 'net', 'modalService', 'orgProfileService', '$timeout',
-  function ($state, $http, $analytics, $location, net, modalService, orgProfileService, $timeout) {
+  '$state', '$http', '$analytics', '$location', 'modalService', 'orgProfileService', '$timeout',
+  function ($state, $http, $analytics, $location, modalService, orgProfileService, $timeout) {
 
   return {
     restrict: 'A',
@@ -42,21 +42,22 @@ angular.module('kifi')
           description: scope.profile.description
         };
 
-        return net.updateOrgProfile(scope.profile.id, data).then(function (res) {
-          $analytics.eventTrack('user_clicked_page', {
-            'action': 'updateOrgProfile',
-            'path': $location.path()
+        return orgProfileService
+          .updateOrgProfile(scope.profile.id, data)
+          .then(function (res) {
+            $analytics.eventTrack('user_clicked_page', {
+              'action': 'updateOrgProfile',
+              'path': $location.path()
+            });
+            // TODO (Adam): Should validate.
+            // Success: sets last value to current one, shows success.
+            // Error: Sets current value to last one, shows error.
+            scope.notification = 'save';
+            $timeout(function() {
+              scope.notification = null;
+            }, 1500);
+            return updateMe(res.data);
           });
-          // TODO (Adam): Should validate.
-          // Success: sets last value to current one, shows success.
-          // Error: Sets current value to last one, shows error.
-          scope.notification = 'save';
-          $timeout(function() {
-            scope.notification = null;
-          }, 1500);
-          return updateMe(res.data);
-        });
-
       };
 
       scope.onOrgProfileImageClick = function (event) {
@@ -93,7 +94,7 @@ angular.module('kifi')
           label: 'Decline',
           className: 'kf-decline',
           click: function () {
-            net.declineOrgMemberInvite(scope.profile.id);
+            orgProfileService.declineOrgMemberInvite(scope.profile.id);
             scope.acknowledgedInvite = true;
           }
         },

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .directive('kfOrgProfileHeader', [
-  '$state', '$http', '$analytics', '$location', 'net', 'modalService', '$timeout', 
-  function ($state, $http, $analytics, $location, net, modalService, $timeout) {
+  '$state', '$http', '$analytics', '$location', 'net', 'modalService', 'orgProfileService', '$timeout',
+  function ($state, $http, $analytics, $location, net, modalService, orgProfileService, $timeout) {
 
   return {
     restrict: 'A',
@@ -56,7 +56,7 @@ angular.module('kifi')
           }, 1500);
           return updateMe(res.data);
         });
-      
+
       };
 
       scope.onOrgProfileImageClick = function (event) {
@@ -101,8 +101,12 @@ angular.module('kifi')
           label: 'Accept',
           className: 'kf-accept',
           click: function () {
-            net.acceptOrgMemberInvite(scope.profile.id, $location.search().authToken);
-            scope.acknowledgedInvite = true;
+            orgProfileService
+              .acceptOrgMemberInvite(scope.profile.id, $location.search().authToken)
+              .then(function () {
+                scope.acknowledgedInvite = true;
+                $state.reload();
+              });
           }
         }
       ];

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileInviteSearch.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileInviteSearch.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .directive('kfOrgInviteSearch', [
-  'libraryService', 'profileService', 'socialService', '$timeout', 'util', 'KEY', 'net',
-  function (libraryService, profileService, socialService, $timeout, util, KEY, net) {
+  'libraryService', 'profileService', 'orgProfileService', 'socialService', '$timeout', 'util', 'KEY', 'net',
+  function (libraryService, profileService, orgProfileService, socialService, $timeout, util, KEY, net) {
     return {
       restrict: 'A',
       require: '^kfModal',
@@ -43,7 +43,7 @@ angular.module('kifi')
             opts.message = scope.share.message;
           }
           //return libraryService.shareLibrary(scope.library.id, opts);
-          return net.sendOrgMemberInvite(scope.organization.id, opts);
+          return orgProfileService.sendOrgMemberInvite(scope.organization.id, opts);
         }
 
         // function trackShareEvent(eventName, attr) {
@@ -89,8 +89,8 @@ angular.module('kifi')
 
           scope.showSpinner = true;
 
-          function getFirstLibrary(response) {
-            var libraries = response.data.libraries;
+          function getFirstLibrary(libraryData) {
+            var libraries = libraryData.libraries;
             return libraries && libraries[0];
           }
 
@@ -179,7 +179,8 @@ angular.module('kifi')
           }
 
           // Do the magic to get the contacts given the organization id.
-          net.getOrgLibraries(scope.organization.id)
+          orgProfileService
+            .getOrgLibraries(scope.organization.id)
             .then(getFirstLibrary)
             .then(getSearchContacts)
             .then(updateContacts);

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileLibrariesCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileLibrariesCtrl.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .controller('OrgProfileLibrariesCtrl', [
-  '$scope', 'net', 'profile', 'profileService', 'modalService',
-  function($scope, net, profile, profileService, modalService) {
+  '$scope', 'profile', 'profileService', 'orgProfileService', 'modalService',
+  function ($scope, profile, profileService, orgProfileService, modalService) {
     var organization = profile.organizationInfo;
 
     $scope.libraries = [];
@@ -21,8 +21,10 @@ angular.module('kifi')
       });
     };
 
-    net.getOrgLibraries(organization.id).then(function (response) {
-      $scope.libraries = response.data.libraries;
-    });
+    orgProfileService
+      .getOrgLibraries(organization.id)
+      .then(function (libraryData) {
+        $scope.libraries = libraryData.libraries;
+      });
   }
 ]);

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileService.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileService.js
@@ -1,0 +1,26 @@
+'use strict';
+
+angular.module('kifi')
+
+.factory('orgProfileService', [
+  '$http', '$rootScope', 'profileService', 'routeService', '$q', '$analytics', 'net',
+  function ($http, $rootScope, profileService, routeService, $q, $analytics, net) {
+    function invalidateOrgProfileCache() {
+      [
+        net.getOrgLibraries,
+        net.userOrOrg
+      ].forEach(function (endpoint) {
+        endpoint.clearCache();
+      });
+    }
+
+    var api = {
+      acceptOrgMemberInvite: function (orgId, authToken) {
+        invalidateOrgProfileCache();
+        return net.acceptOrgMemberInvite(orgId, authToken);
+      }
+    };
+
+    return api;
+  }
+]);

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileService.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileService.js
@@ -15,12 +15,34 @@ angular.module('kifi')
     }
 
     var api = {
+      sendOrgMemberInvite: function (orgId, inviteFields) {
+        return net.sendOrgMemberInvite(orgId, inviteFields);
+      },
       acceptOrgMemberInvite: function (orgId, authToken) {
         invalidateOrgProfileCache();
         return net.acceptOrgMemberInvite(orgId, authToken);
       },
+      cancelOrgMemberInvite: function (orgId, cancelFields) {
+        return net.cancelOrgMemberInvite(orgId, cancelFields);
+      },
       declineOrgMemberInvite: function (orgId) {
         return net.declineOrgMemberInvite(orgId);
+      },
+      removeOrgMember: function (orgId, removeFields) {
+        return net.removeOrgMember(orgId, removeFields);
+      },
+      getOrgLibraries: function (orgId) {
+        return net.getOrgLibraries(orgId).then(function (response) {
+          return response.data;
+        });
+      },
+      getOrgMembers: function (orgId) {
+        return net.getOrgMembers(orgId).then(function (response) {
+          return response.data;
+        });
+      },
+      modifyOrgMember: function (orgId, memberFields) {
+        return net.modifyOrgMember(orgId, memberFields);
       },
       updateOrgProfile: function (orgId, modifiedFields) {
         return net.updateOrgProfile(orgId, modifiedFields);
@@ -30,6 +52,7 @@ angular.module('kifi')
           return response.data;
         });
       }
+
     };
 
     return api;

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileService.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileService.js
@@ -18,6 +18,17 @@ angular.module('kifi')
       acceptOrgMemberInvite: function (orgId, authToken) {
         invalidateOrgProfileCache();
         return net.acceptOrgMemberInvite(orgId, authToken);
+      },
+      declineOrgMemberInvite: function (orgId) {
+        return net.declineOrgMemberInvite(orgId);
+      },
+      updateOrgProfile: function (orgId, modifiedFields) {
+        return net.updateOrgProfile(orgId, modifiedFields);
+      },
+      userOrOrg: function (handle) {
+        return net.userOrOrg(handle).then(function (response) {
+          return response.data;
+        });
       }
     };
 

--- a/kifi-backend/modules/shoebox/angular/src/route.js
+++ b/kifi-backend/modules/shoebox/angular/src/route.js
@@ -169,7 +169,7 @@ angular.module('kifi')
         templateUrl: 'libraries/library.tpl.html',
         controller: 'LibraryCtrl',
         resolve: {
-          type: ['orgProfileService', '$stateParams', function ($stateParams, orgProfileService) {
+          type: ['$stateParams', 'orgProfileService', function ($stateParams, orgProfileService) {
             return orgProfileService
               .userOrOrg($stateParams.handle)
               .then(function (userOrOrgData) {
@@ -177,7 +177,7 @@ angular.module('kifi')
               });
           }],
           libraryService: 'libraryService',
-          library: ['libraryService', 'net', '$stateParams', 'type', function (libraryService, net, $stateParams, type) {
+          library: ['libraryService', 'orgProfileService', '$stateParams', 'type', function (libraryService, orgProfileService, $stateParams, type) {
             function getOrgId(userOrOrgData) {
               return userOrOrgData.result.organization.organizationInfo.id;
             }
@@ -202,10 +202,10 @@ angular.module('kifi')
               return libraryService.getLibraryByUserSlug($stateParams.handle, $stateParams.librarySlug, $stateParams.authToken);
             } else {
               // Org Library
-              return userProfileService
+              return orgProfileService
                 .userOrOrg($stateParams.handle)
                 .then(getOrgId)
-                .then(net.getOrgLibraries.bind(net))
+                .then(orgProfileService.getOrgLibraries)
                 .then(getLibraryIdBySlug)
                 .then(libraryService.getLibraryById.bind(libraryService))
                 .then(function (response) {


### PR DESCRIPTION
@andrewconner @ajkochanowicz  I think it's time to have a more centralized location for managing access to org data. Enter: the `orgProfileService`.

I'll be moving all the `net` calls into the service to keep all the knowledge in one place.
