### PR TITLE
Checking membership to apply 'readonly' attribute

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.js
@@ -11,7 +11,8 @@ angular.module('kifi')
         value: '=',
         inputPlaceholder: '=',
         textarea: '=',
-        onSave: '='
+        onSave: '=',
+        readonly: '='
       },
       replace: true,
       link: function ($scope, $element) {

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.styl
@@ -1,7 +1,6 @@
 editButtonWidth = 40px
 
 .kf-click-to-edit:hover:before
-  content: 'edit'
   position: absolute
   right: 0
   width: editButtonWidth
@@ -25,16 +24,20 @@ editButtonWidth = 40px
     background: none
     border-radius: 2px
     color: inherit
-    border: 1px dashed transparent
     line-height: normal
     min-height: 15px
+    border: 1px dashed transparent
 
-    &:hover
-      border-color: rgba(255, 255, 255, 0.25)
+    &:not([readonly="readonly"])
+      &:hover
+        border-color: rgba(255, 255, 255, 0.25)
 
-    &:focus,
-    &:hover:focus
-      border-color: #fff
+        &:before
+          content: 'edit'
+
+      &:focus,
+      &:hover:focus
+        border-color: #fff
 
 .kf-click-to-edit
   .kf-click-to-edit-textarea-tester

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.tpl.html
@@ -1,5 +1,5 @@
 <div class="kf-click-to-edit">
-  <input ng-hide="textarea" ng-model="view.editableValue" ng-keydown="editEvent($event)" ng-blur="onBlur()" placeholder="{{view.inputPlaceholder}}" />
+  <input ng-hide="textarea" ng-readonly="readonly" ng-model="view.editableValue" ng-keydown="editEvent($event)" ng-blur="onBlur()" placeholder="{{view.inputPlaceholder}}" />
   <span class="kf-click-to-edit-textarea kf-click-to-edit-textarea-tester" ng-style="view.textareaWidth">{{view.editableValue}}</span>
-  <textarea class="kf-click-to-edit-textarea" ng-show="textarea" ng-model="view.editableValue" ng-keydown="editEvent($event)" ng-blur="onBlur()" ng-style="view.textareaHeight"></textarea>
+  <textarea ng-readonly="readonly" class="kf-click-to-edit-textarea" ng-show="textarea" ng-model="view.editableValue" ng-keydown="editEvent($event)" ng-blur="onBlur()" ng-style="view.textareaHeight"></textarea>
 </div>

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.js
@@ -18,7 +18,7 @@ angular.module('kifi')
       scope.editing = false;
       scope.notification = null;
       var lastSavedInfo = {};
-
+      scope.readonly = scope.membership.permissions.indexOf('edit_organization') === -1;
       scope.myTextValue = 'Hello';
       scope.acknowledgedInvite = false;
 

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
@@ -25,10 +25,10 @@
     </div>
     <div class="kf-oph-about">
       <div class="kf-oph-about-info">
-        <div class="kf-oph-name" kf-click-to-edit on-save="save" value="profile.name"></div>
-        <div class="kf-oph-description" kf-click-to-edit on-save="save" value="profile.description" textarea="true"></div>
+        <div class="kf-oph-name" kf-click-to-edit on-save="save" value="profile.name" readonly="readonly"></div>
+        <div class="kf-oph-description" kf-click-to-edit on-save="save" value="profile.description" readonly="readonly" textarea="true"></div>
         <p class="kf-oph-url">
-          <span kf-click-to-edit on-save="save" input-placeholder="'e.g. http://example.com'" value="profile.site"></span>
+          <span kf-click-to-edit on-save="save" readonly="readonly" input-placeholder="'e.g. http://example.com'" value="profile.site"></span>
         </p>
       </div>
       <nav class="kf-oph-stats">


### PR DESCRIPTION
Only users who have accepted invites to orgs will be able to edit the text fields (whether or not said changes save on the backend).

https://github.com/kifi/keepit/issues/16389
