### PR TITLE
add a try-catch to prevent admin from going down with graph

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminOrganizationController.scala
@@ -107,10 +107,9 @@ class AdminOrganizationController @Inject() (
     }
   }
 
-  def organizationViewById(orgId: Id[Organization]) = AdminUserPage.async { implicit request =>
-    val numMemberRecommendations = request.queryString.get("numMemberRecos").map(_.head.toInt).getOrElse(60)
+  def organizationViewById(orgId: Id[Organization], numMemberRecos: Int = 60) = AdminUserPage.async { implicit request =>
     val adminId = request.userId
-    val orgStats = statsCommander.organizationStatistics(orgId, adminId, numMemberRecommendations)
+    val orgStats = statsCommander.organizationStatistics(orgId, adminId, numMemberRecos)
     orgStats.map { os => Ok(html.admin.organization(os)) }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminOrganizationController.scala
@@ -108,7 +108,7 @@ class AdminOrganizationController @Inject() (
   }
 
   def organizationViewById(orgId: Id[Organization]) = AdminUserPage.async { implicit request =>
-    val numMemberRecommendations = request.queryString.get("numMemberRecos").map(_.head.toInt).getOrElse(30)
+    val numMemberRecommendations = request.queryString.get("numMemberRecos").map(_.head.toInt).getOrElse(60)
     val adminId = request.userId
     val orgStats = statsCommander.organizationStatistics(orgId, adminId, numMemberRecommendations)
     orgStats.map { os => Ok(html.admin.organization(os)) }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserStatisticsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserStatisticsCommander.scala
@@ -165,7 +165,7 @@ class UserStatisticsCommander @Inject() (
     Future.sequence(membersStatsFut).imap(_.toMap)
   }
 
-  def organizationStatistics(orgId: Id[Organization], adminId: Id[User], numMemberRecos: Int = 60): Future[OrganizationStatistics] = {
+  def organizationStatistics(orgId: Id[Organization], adminId: Id[User], numMemberRecos: Int): Future[OrganizationStatistics] = {
     val (org, libraries, numKeeps, members, candidates, experiments, membersStatsFut, domains) = db.readOnlyMaster { implicit session =>
       val org = orgRepo.get(orgId)
       val libraries = libraryRepo.getBySpace(LibrarySpace.fromOrganizationId(orgId))

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -697,7 +697,7 @@ POST    /admin/user/:id/ignorePotentialOrgs      @com.keepit.controllers.admin.A
 POST    /admin/user/:userId/hideOrganizationRecommendation @com.keepit.controllers.admin.AdminUserController.hideOrganizationRecoForUser(userId: Id[User], orgId: Id[Organization])
 
 
-GET     /admin/organization/:id                 @com.keepit.controllers.admin.AdminOrganizationController.organizationViewById(id: Id[Organization])
+GET     /admin/organization/:id                 @com.keepit.controllers.admin.AdminOrganizationController.organizationViewById(id: Id[Organization], numMemberRecos: Int ?= 60)
 POST    /admin/organization/:id/setName         @com.keepit.controllers.admin.AdminOrganizationController.setName(id: Id[Organization])
 POST    /admin/organization/:id/setHandle       @com.keepit.controllers.admin.AdminOrganizationController.setHandle(id: Id[Organization])
 POST    /admin/organization/:id/setDescription  @com.keepit.controllers.admin.AdminOrganizationController.setDescription(id: Id[Organization])


### PR DESCRIPTION
@andrewconner @leogrim not sure what you guys think of this, but it's something that @gratimax and Tamila have asked for since graph has been so flaky. this way we report and just return an empty list.
