### PR TITLE
Removed scaled images from Org Avatar Commander

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -418,7 +418,9 @@ object ScaledImageSize {
 }
 
 object CroppedImageSize {
-  case object Small extends CroppedImageSize("small", ImageSize(150, 150))
+  case object Tiny extends CroppedImageSize("small", ImageSize(100, 100))
+  case object Small extends CroppedImageSize("medium", ImageSize(150, 150))
+  case object Medium extends CroppedImageSize("medium", ImageSize(200, 200))
 
   val allSizes: Seq[CroppedImageSize] = Seq(Small)
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAvatarCommander.scala
@@ -130,13 +130,8 @@ class OrganizationAvatarCommanderImpl @Inject() (
 
   // What ProcessImageRequests are necessary to perform on an image, given that we have some existing avatars already
   def determineRequiredProcessImageRequests(imageSize: ImageSize, existingAvatars: Seq[OrganizationAvatar]) = {
-    val required = {
-      val scaleRequests = scaleSizes.map(scale => ScaleImageRequest(scale.idealSize))
-      val cropRequests = cropSizes.map(crop => CropImageRequest(crop.idealSize))
-      scaleRequests ++ cropRequests
-    }.toSet
-    val existing = existingAvatars.collect {
-      case scaledImage if scaledImage.kind == ProcessImageOperation.Scale => ScaleImageRequest(scaledImage.imageSize)
+    val required: Set[ProcessImageRequest] = cropSizes.map(crop => CropImageRequest(crop.idealSize)).toSet
+    val existing: Set[ProcessImageRequest] = existingAvatars.collect { // currently we only crop org avatars, but it's possible we may later do other things
       case croppedImage if croppedImage.kind == ProcessImageOperation.Crop => CropImageRequest(croppedImage.imageSize)
     }.toSet
 
@@ -148,10 +143,8 @@ class OrganizationAvatarCommanderImpl @Inject() (
 }
 
 object OrganizationAvatarConfiguration {
-  val defaultSize = ScaledImageSize.Medium.idealSize
-
-  val scaleSizes = Seq(ScaledImageSize.Small, ScaledImageSize.Medium)
-  val cropSizes = Seq(CroppedImageSize.Small)
-  val numSizes = scaleSizes.length + cropSizes.length
+  val cropSizes = Seq(CroppedImageSize.Tiny, CroppedImageSize.Medium)
+  val defaultSize = cropSizes.last.idealSize
+  val numSizes = cropSizes.length
   val imagePathPrefix = "oa"
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationAvatarCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationAvatarCommanderTest.scala
@@ -11,7 +11,7 @@ import com.keepit.test.ShoeboxTestInjector
 import org.apache.commons.io.FileUtils
 import org.specs2.mutable.Specification
 import play.api.libs.Files.TemporaryFile
-import com.keepit.commanders.OrganizationAvatarConfiguration.{ scaleSizes, cropSizes }
+import com.keepit.commanders.OrganizationAvatarConfiguration._
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -47,7 +47,7 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
   }
 
   "organization avatar commander" should {
-    "upload new avatar, scaled and cropped" in {
+    "upload new avatar, and all processed derivatives" in {
       withDb(modules: _*) { implicit injector =>
         val commander = inject[OrganizationAvatarCommander]
         val store = inject[RoverImageStore].asInstanceOf[InMemoryRoverImageStoreImpl]
@@ -64,11 +64,11 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
         }
 
         println("OrgAvatarStore keys: " + store.all.keySet)
-        store.all.keySet.size === scaleSizes.length + cropSizes.length + 1
+        store.all.keySet.size === OrganizationAvatarConfiguration.numSizes + 1
 
         db.readOnlyMaster { implicit s =>
           val org1Avatars = repo.getByOrganization(org1.id.get)
-          org1Avatars.length === scaleSizes.length + cropSizes.length + 1
+          org1Avatars.length === OrganizationAvatarConfiguration.numSizes + 1
         }
       }
     }
@@ -87,11 +87,11 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
         }
 
         println("OrgAvatarStore keys: " + store.all.keySet)
-        store.all.keySet.size === scaleSizes.length + cropSizes.length + 1
+        store.all.keySet.size === OrganizationAvatarConfiguration.numSizes + 1
 
         db.readOnlyMaster { implicit s =>
           val org1Avatars =
-            repo.getByOrganization(org1.id.get).length === scaleSizes.length + cropSizes.length + 1
+            repo.getByOrganization(org1.id.get).length === OrganizationAvatarConfiguration.numSizes + 1
         }
 
         {
@@ -103,12 +103,12 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
         }
 
         // All the images have been uploaded and persisted
-        store.all.keySet.size === 2 * (scaleSizes.length + cropSizes.length + 1)
+        store.all.keySet.size === 2 * (OrganizationAvatarConfiguration.numSizes + 1)
 
         // Only the second avatars are active
         db.readOnlyMaster { implicit s =>
-          repo.getByOrganization(org1.id.get).length === scaleSizes.length + cropSizes.length + 1
-          repo.count === 2 * (scaleSizes.length + cropSizes.length + 1)
+          repo.getByOrganization(org1.id.get).length === OrganizationAvatarConfiguration.numSizes + 1
+          repo.count === 2 * (OrganizationAvatarConfiguration.numSizes + 1)
         }
 
       }
@@ -130,11 +130,11 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
         }
 
         println("OrgAvatarStore keys: " + store.all.keySet)
-        store.all.keySet.size === scaleSizes.length + cropSizes.length + 1
+        store.all.keySet.size === OrganizationAvatarConfiguration.numSizes + 1
 
         db.readOnlyMaster { implicit s =>
           val org1Avatars =
-            repo.getByOrganization(org1.id.get).length === scaleSizes.length + cropSizes.length + 1
+            repo.getByOrganization(org1.id.get).length === OrganizationAvatarConfiguration.numSizes + 1
         }
 
         {
@@ -145,13 +145,13 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
         }
 
         // No new images have been persisted in the image store
-        store.all.keySet.size === scaleSizes.length + cropSizes.length + 1
+        store.all.keySet.size === OrganizationAvatarConfiguration.numSizes + 1
 
         // But the appropriate avatars are in the DB now
         db.readOnlyMaster { implicit s =>
-          repo.getByOrganization(org1.id.get).length === scaleSizes.length + cropSizes.length + 1
-          repo.getByOrganization(org2.id.get).length === scaleSizes.length + cropSizes.length + 1
-          repo.count === 2 * (scaleSizes.length + cropSizes.length + 1)
+          repo.getByOrganization(org1.id.get).length === OrganizationAvatarConfiguration.numSizes + 1
+          repo.getByOrganization(org2.id.get).length === OrganizationAvatarConfiguration.numSizes + 1
+          repo.count === 2 * (OrganizationAvatarConfiguration.numSizes + 1)
         }
 
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationAvatarControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationAvatarControllerTest.scala
@@ -57,7 +57,7 @@ class OrganizationAvatarControllerTest extends Specification with ShoeboxTestInj
           val result = inject[OrganizationAvatarController].uploadAvatar(pubId)(request)
 
           status(result) === OK
-          Json.parse(contentAsString(result)) === Json.parse("""{"uploaded": "oa/26dbdc56d54dbc94830f7cfc85031481_400x230_s.png"}""")
+          Json.parse(contentAsString(result)) === Json.parse("""{"uploaded": "oa/26dbdc56d54dbc94830f7cfc85031481_200x200_c.png"}""")
 
           inject[OrganizationAvatarCommander].getBestImage(org.id.get, OrganizationAvatarConfiguration.defaultSize) must haveClass[Some[OrganizationAvatar]]
         }


### PR DESCRIPTION
This is desired because org avatars should not preserve aspect ratio (they
ought to be square). It also happens to fix a bug where square images were
being scaled and "cropped" to the same size, breaking a DB constraint.

@andrewconner @cvializ 
