### PR TITLE
Org avatar commander no longer reuses images

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -1,14 +1,12 @@
 package com.keepit.commanders
 
-import java.awt.image.BufferedImage
 import java.io._
 import java.math.BigInteger
 import java.net.URLConnection
 import java.security.MessageDigest
-import javax.imageio.ImageIO
 
 import com.keepit.common.core.File
-import com.keepit.common.images.{ RawImageInfo, Photoshop }
+import com.keepit.common.images.{ Photoshop, RawImageInfo }
 import com.keepit.common.net.{ URI, WebService }
 import com.keepit.common.service.RequestConsolidator
 import com.keepit.common.store.{ ImageOffset, ImagePath, ImageSize }
@@ -22,24 +20,27 @@ import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.util.{ Failure, Success, Try }
 
-sealed abstract case class ProcessImageRequest(operation: ProcessImageOperation, size: ImageSize)
-class ScaleImageRequest(size: ImageSize) extends ProcessImageRequest(operation = ProcessImageOperation.Scale, size)
-class CenteredCropImageRequest(size: ImageSize) extends ProcessImageRequest(operation = ProcessImageOperation.CenteredCrop, size)
-class CropScaleImageRequest(offset: ImageOffset, cropSize: ImageSize, scaledSize: ImageSize) extends ProcessImageRequest(operation = ProcessImageOperation.CropScale, scaledSize)
+sealed abstract class ProcessImageRequest {
+  def operation: ProcessImageOperation
+  def size: ImageSize
+}
+case class ScaleImageRequest(size: ImageSize) extends ProcessImageRequest {
+  val operation = ProcessImageOperation.Scale
+}
+case class CenteredCropImageRequest(size: ImageSize) extends ProcessImageRequest {
+  val operation = ProcessImageOperation.CenteredCrop
+}
+case class CropScaleImageRequest(offset: ImageOffset, cropSize: ImageSize, size: ImageSize) extends ProcessImageRequest {
+  val operation = ProcessImageOperation.CropScale
+}
 
 object ScaleImageRequest {
-  def apply(boundingBox: Int): ScaleImageRequest = new ScaleImageRequest(ImageSize(boundingBox, boundingBox))
-  def apply(imageSize: ImageSize): ScaleImageRequest = new ScaleImageRequest(imageSize)
-  def apply(width: Int, height: Int): ScaleImageRequest = new ScaleImageRequest(ImageSize(width, height))
+  def apply(boundingBox: Int): ScaleImageRequest = ScaleImageRequest(ImageSize(boundingBox, boundingBox))
+  def apply(width: Int, height: Int): ScaleImageRequest = ScaleImageRequest(ImageSize(width, height))
 }
 
 object CenteredCropImageRequest {
-  def apply(imageSize: ImageSize): CenteredCropImageRequest = new CenteredCropImageRequest(imageSize)
   def apply(width: Int, height: Int): CenteredCropImageRequest = new CenteredCropImageRequest(ImageSize(width, height))
-}
-
-object CropScaleImageRequest {
-  def apply(offset: ImageOffset, cropSize: ImageSize, scaledSize: ImageSize): CropScaleImageRequest = new CropScaleImageRequest(offset, cropSize, scaledSize)
 }
 
 trait ProcessedImageHelper {
@@ -118,16 +119,19 @@ trait ProcessedImageHelper {
 
   protected def processAndPersistImages(image: File, baseLabel: String, hash: ImageHash,
     outFormat: ImageFormat, sizes: Set[ProcessImageRequest])(implicit photoshop: Photoshop) = {
-    val resizedImages = sizes.map { processImageSize =>
-      def process(): Try[File] = processImageSize match {
-        case c if c.operation == ProcessImageOperation.CenteredCrop => photoshop.centeredCropImage(image, outFormat, c.size.width, c.size.height)
-        case s => photoshop.resizeImage(image, outFormat, s.size.width, s.size.height)
+    val resizedImages = sizes.map { processImageRequest =>
+      log.info(s"[pih] processing images baseLabel=$baseLabel format=$outFormat to $processImageRequest")
+
+      def process(): Try[File] = processImageRequest match {
+        case CropScaleImageRequest(offset, cropSize, scaleSize) => photoshop.cropScaleImage(image, outFormat, offset.x, offset.y, cropSize.width, cropSize.height, scaleSize.width, scaleSize.height)
+        case CenteredCropImageRequest(size) => photoshop.centeredCropImage(image, outFormat, size.width, size.height)
+        case ScaleImageRequest(size) => photoshop.resizeImage(image, outFormat, size.width, size.height)
       }
 
       process().map { resizedImage =>
         validateAndGetImageInfo(resizedImage).map { imageInfo =>
-          val key = ImagePath(baseLabel, hash, ImageSize(imageInfo.width, imageInfo.height), processImageSize.operation, outFormat)
-          ImageProcessState.ReadyToPersist(key, outFormat, resizedImage, imageInfo, processImageSize.operation)
+          val key = ImagePath(baseLabel, hash, ImageSize(imageInfo.width, imageInfo.height), processImageRequest.operation, outFormat)
+          ImageProcessState.ReadyToPersist(key, outFormat, resizedImage, imageInfo, processImageRequest.operation)
         }
       }.flatten match {
         case Success(img) => Right(img)
@@ -147,9 +151,9 @@ trait ProcessedImageHelper {
   // All the ProcessImageRequests in A that are also in B
   protected def intersectProcessImageRequests(A: Set[ProcessImageRequest], B: Set[ProcessImageRequest]): Set[ProcessImageRequest] = {
     @inline def boundingBox(imageSize: ImageSize): Int = Math.max(imageSize.width, imageSize.height)
-    val Bp = B.collect { case ProcessImageRequest(ProcessImageOperation.Scale, size) => boundingBox(size) }
+    val Bp = B.collect { case ScaleImageRequest(size) => boundingBox(size) }
     A filter {
-      case ProcessImageRequest(ProcessImageOperation.Scale, size) => Bp.contains(boundingBox(size))
+      case ScaleImageRequest(size) => Bp.contains(boundingBox(size))
       case otherRequest => B.contains(otherRequest)
     }
   }
@@ -157,9 +161,9 @@ trait ProcessedImageHelper {
   protected def diffProcessImageRequests(A: Set[ProcessImageRequest], B: Set[ProcessImageRequest]): Set[ProcessImageRequest] = {
     // hack to eliminate expecting scale versions that have the same scaled bounding box
     @inline def boundingBox(imageSize: ImageSize): Int = Math.max(imageSize.width, imageSize.height)
-    val Bp = B.collect { case ProcessImageRequest(ProcessImageOperation.Scale, size) => boundingBox(size) }
+    val Bp = B.collect { case ScaleImageRequest(size) => boundingBox(size) }
     A filterNot {
-      case ProcessImageRequest(ProcessImageOperation.Scale, size) => Bp.contains(boundingBox(size))
+      case ScaleImageRequest(size) => Bp.contains(boundingBox(size))
       case otherRequest => B.contains(otherRequest)
     }
   }
@@ -404,9 +408,12 @@ object ScaledImageSize {
 }
 
 object CroppedImageSize {
-  case object Tiny extends CroppedImageSize("tiny", ImageSize(100, 100))
   case object Small extends CroppedImageSize("small", ImageSize(150, 150))
-  case object Medium extends CroppedImageSize("medium", ImageSize(200, 200))
+}
+
+object CropScaledImageSize {
+  case object Tiny extends CropScaledImageSize("small", ImageSize(100, 100))
+  case object Medium extends CropScaledImageSize("medium", ImageSize(200, 200))
 }
 
 object ProcessedImageSize {

--- a/kifi-backend/modules/common/app/com/keepit/common/images/Image4javaWrapper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/images/Image4javaWrapper.scala
@@ -196,7 +196,7 @@ class Image4javaWrapper @Inject() (
   private def handleExceptions(convert: ConvertCmd, operation: IMOperation): Unit = {
     if (playMode == Mode.Test) {
       // If you need the script printed in tests, uncomment this:
-      //println(getScript(convert, operation))
+      // println(getScript(convert, operation))
     }
     try {
       convert.run(operation)

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/367.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/367.sql
@@ -1,0 +1,9 @@
+# SHOEBOX
+
+# --- !Ups
+
+ALTER TABLE organization_avatar DROP CONSTRAINT organization_logo_u_source_file_hash_size_organization_id;
+
+insert into evolutions (name, description) values('367.sql', 'Drop the unique constraint on source_file_hash for org avatars');
+
+# --- !Downs

--- a/kifi-backend/modules/rover/app/com/keepit/rover/image/RoverImageFetcher.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/image/RoverImageFetcher.scala
@@ -50,7 +50,7 @@ class RoverImageFetcher @Inject() (
             // Prepare Processed Images
 
             val requiredProcessRequests = {
-              val existingImageProcessRequests = existingImageInfos.collect {
+              val existingImageProcessRequests: Set[ProcessImageRequest] = existingImageInfos.collect {
                 case scaledImage if scaledImage.kind == ProcessImageOperation.Scale => ScaleImageRequest(scaledImage.imageSize)
                 case croppedImage if croppedImage.kind == ProcessImageOperation.CenteredCrop => CenteredCropImageRequest(croppedImage.imageSize)
               }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationAvatarController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationAvatarController.scala
@@ -5,6 +5,7 @@ import com.keepit.commanders._
 import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper }
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.store.{ ImageOffset, ImageSize }
 import com.keepit.heimdal.HeimdalContextBuilderFactory
 import com.keepit.model._
 import com.keepit.shoebox.controllers.OrganizationAccessActions
@@ -23,9 +24,9 @@ class OrganizationAvatarController @Inject() (
   private implicit val executionContext: ExecutionContext)
     extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
-  def uploadAvatar(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION).async(parse.temporaryFile) { request =>
+  def uploadAvatar(pubId: PublicId[Organization], x: Int, y: Int, width: Int, height: Int) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION).async(parse.temporaryFile) { request =>
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
-    val uploadImageF = orgAvatarCommander.persistOrganizationAvatarsFromUserUpload(request.body, request.orgId)
+    val uploadImageF = orgAvatarCommander.persistOrganizationAvatarsFromUserUpload(request.orgId, request.body, ImageOffset(x, y), ImageSize(width, height))
     uploadImageF.map {
       case Left(fail) => InternalServerError(Json.obj("error" -> fail.reason))
       case Right(hash) =>

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -527,7 +527,7 @@ POST          /site/organizations/:id/members/invites/link      @com.keepit.cont
 POST          /site/organizations/:id/members/modify            @com.keepit.controllers.website.OrganizationMembershipController.modifyMembers(id: PublicId[Organization])
 POST          /site/organizations/:id/members/remove            @com.keepit.controllers.website.OrganizationMembershipController.removeMembers(id: PublicId[Organization])
 GET           /site/organizations/:id/libraries                 @com.keepit.controllers.website.OrganizationController.getOrganizationLibraries(id: PublicId[Organization], offset: Int ?= 0, limit: Int ?= 20)
-POST          /site/organizations/:id/avatar/upload             @com.keepit.controllers.website.OrganizationAvatarController.uploadAvatar(id: PublicId[Organization])
+POST          /site/organizations/:id/avatar/upload             @com.keepit.controllers.website.OrganizationAvatarController.uploadAvatar(id: PublicId[Organization], x: Int, y: Int, width: Int, height: Int)
 
 
 GET           /site/user-or-org/:handle                   @com.keepit.controllers.website.UserOrOrganizationController.getByHandle(handle: Handle)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationAvatarCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationAvatarCommanderTest.scala
@@ -56,19 +56,18 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
 
         // upload an image
         {
-          val savedF = commander.persistOrganizationAvatarsFromUserUpload(fakeFile1, org1.id.get)
+          val savedF = commander.persistOrganizationAvatarsFromUserUpload(org1.id.get, fakeFile1, offset = ImageOffset(0, 0), cropSize = ImageSize(50, 50))
           val saved = Await.result(savedF, Duration("10 seconds"))
           saved must haveClass[Right[ImageStoreFailure, ImageHash]]
           saved.right.get === ImageHash("26dbdc56d54dbc94830f7cfc85031481")
           // if this test fails, make sure imagemagick is installed. Use `brew install imagemagick`
         }
 
-        println("OrgAvatarStore keys: " + store.all.keySet)
-        store.all.keySet.size === OrganizationAvatarConfiguration.numSizes + 1
+        store.all.keySet.size === OrganizationAvatarConfiguration.numSizes
 
         db.readOnlyMaster { implicit s =>
           val org1Avatars = repo.getByOrganization(org1.id.get)
-          org1Avatars.length === OrganizationAvatarConfiguration.numSizes + 1
+          org1Avatars.length === OrganizationAvatarConfiguration.numSizes
         }
       }
     }
@@ -80,22 +79,20 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
         val (_, _, org1, _) = setup()
 
         {
-          val savedF = commander.persistOrganizationAvatarsFromUserUpload(fakeFile1, org1.id.get)
+          val savedF = commander.persistOrganizationAvatarsFromUserUpload(org1.id.get, fakeFile1, offset = ImageOffset(0, 0), cropSize = ImageSize(50, 50))
           val saved = Await.result(savedF, Duration("10 seconds"))
           saved must haveClass[Right[ImageStoreFailure, ImageHash]]
           saved.right.get === ImageHash("26dbdc56d54dbc94830f7cfc85031481")
         }
 
-        println("OrgAvatarStore keys: " + store.all.keySet)
-        store.all.keySet.size === OrganizationAvatarConfiguration.numSizes + 1
+        store.all.keySet.size === OrganizationAvatarConfiguration.numSizes
 
         db.readOnlyMaster { implicit s =>
-          val org1Avatars =
-            repo.getByOrganization(org1.id.get).length === OrganizationAvatarConfiguration.numSizes + 1
+          repo.getByOrganization(org1.id.get).length === OrganizationAvatarConfiguration.numSizes
         }
 
         {
-          val savedF = commander.persistOrganizationAvatarsFromUserUpload(fakeFile2, org1.id.get)
+          val savedF = commander.persistOrganizationAvatarsFromUserUpload(org1.id.get, fakeFile2, offset = ImageOffset(0, 0), cropSize = ImageSize(50, 50))
           val saved = Await.result(savedF, Duration("10 seconds"))
           saved must haveClass[Right[ImageStoreFailure, ImageHash]]
           saved.right.get === ImageHash("1b3d95541538044c2a26598fbe1d06ae")
@@ -103,55 +100,12 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
         }
 
         // All the images have been uploaded and persisted
-        store.all.keySet.size === 2 * (OrganizationAvatarConfiguration.numSizes + 1)
+        store.all.keySet.size === 2 * OrganizationAvatarConfiguration.numSizes
 
         // Only the second avatars are active
         db.readOnlyMaster { implicit s =>
-          repo.getByOrganization(org1.id.get).length === OrganizationAvatarConfiguration.numSizes + 1
-          repo.count === 2 * (OrganizationAvatarConfiguration.numSizes + 1)
-        }
-
-      }
-    }
-    "reuse existing images when possible" in {
-      withDb(modules: _*) { implicit injector =>
-        val commander = inject[OrganizationAvatarCommander]
-        val store = inject[RoverImageStore].asInstanceOf[InMemoryRoverImageStoreImpl]
-        val repo = inject[OrganizationAvatarRepo]
-        val (_, _, org1, org2) = setup()
-
-        // upload an image
-        {
-          val savedF = commander.persistOrganizationAvatarsFromUserUpload(fakeFile2, org1.id.get)
-          val saved = Await.result(savedF, Duration("10 seconds"))
-          saved must haveClass[Right[ImageStoreFailure, ImageHash]]
-          saved.right.get === ImageHash("1b3d95541538044c2a26598fbe1d06ae")
-          // if this test fails, make sure imagemagick is installed. Use `brew install imagemagick`
-        }
-
-        println("OrgAvatarStore keys: " + store.all.keySet)
-        store.all.keySet.size === OrganizationAvatarConfiguration.numSizes + 1
-
-        db.readOnlyMaster { implicit s =>
-          val org1Avatars =
-            repo.getByOrganization(org1.id.get).length === OrganizationAvatarConfiguration.numSizes + 1
-        }
-
-        {
-          val savedF = commander.persistOrganizationAvatarsFromUserUpload(fakeFile2, org2.id.get)
-          val saved = Await.result(savedF, Duration("10 seconds"))
-          saved must haveClass[Right[ImageStoreFailure, ImageHash]]
-          saved.right.get === ImageHash("1b3d95541538044c2a26598fbe1d06ae")
-        }
-
-        // No new images have been persisted in the image store
-        store.all.keySet.size === OrganizationAvatarConfiguration.numSizes + 1
-
-        // But the appropriate avatars are in the DB now
-        db.readOnlyMaster { implicit s =>
-          repo.getByOrganization(org1.id.get).length === OrganizationAvatarConfiguration.numSizes + 1
-          repo.getByOrganization(org2.id.get).length === OrganizationAvatarConfiguration.numSizes + 1
-          repo.count === 2 * (OrganizationAvatarConfiguration.numSizes + 1)
+          repo.getByOrganization(org1.id.get).length === OrganizationAvatarConfiguration.numSizes
+          repo.count === 2 * OrganizationAvatarConfiguration.numSizes
         }
 
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationAvatarControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationAvatarControllerTest.scala
@@ -52,12 +52,12 @@ class OrganizationAvatarControllerTest extends Specification with ShoeboxTestInj
           val pubId = Organization.publicId(org.id.get)
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val route = com.keepit.controllers.website.routes.OrganizationAvatarController.uploadAvatar(pubId)
+          val route = com.keepit.controllers.website.routes.OrganizationAvatarController.uploadAvatar(pubId, 0, 0, 50, 50)
           val request = FakeRequest(route.method, route.url).withBody(fakeFile)
-          val result = inject[OrganizationAvatarController].uploadAvatar(pubId)(request)
+          val result = inject[OrganizationAvatarController].uploadAvatar(pubId, 0, 0, 50, 50)(request)
 
           status(result) === OK
-          Json.parse(contentAsString(result)) === Json.parse("""{"uploaded": "oa/26dbdc56d54dbc94830f7cfc85031481_200x200_c.png"}""")
+          Json.parse(contentAsString(result)) === Json.parse("""{"uploaded": "oa/26dbdc56d54dbc94830f7cfc85031481_200x200_cs.png"}""")
 
           inject[OrganizationAvatarCommander].getBestImage(org.id.get, OrganizationAvatarConfiguration.defaultSize) must haveClass[Some[OrganizationAvatar]]
         }
@@ -68,9 +68,9 @@ class OrganizationAvatarControllerTest extends Specification with ShoeboxTestInj
           val pubId = Organization.publicId(org.id.get)
 
           inject[FakeUserActionsHelper].setUser(rando)
-          val route = com.keepit.controllers.website.routes.OrganizationAvatarController.uploadAvatar(pubId)
+          val route = com.keepit.controllers.website.routes.OrganizationAvatarController.uploadAvatar(pubId, 0, 0, 50, 50)
           val request = FakeRequest(route.method, route.url).withBody(fakeFile)
-          val result = inject[OrganizationAvatarController].uploadAvatar(pubId)(request)
+          val result = inject[OrganizationAvatarController].uploadAvatar(pubId, 0, 0, 50, 50)(request)
 
           status(result) === FORBIDDEN
           inject[OrganizationAvatarCommander].getBestImage(org.id.get, OrganizationAvatarConfiguration.defaultSize).isEmpty === true


### PR DESCRIPTION
Every time a user uploads an org avatar, it gets processed and uploaded to S3.
It is unlikely that we will be able to reuse anything from the image store
given how many degrees of freedom a cropped scaled image has.

Also changed all the subclasses of ProcessImageRequest into case classes
so we can actually match on them.

Lastly, added URL parameters to the endpoint that specify the `(x,y)` offset and the `(width, height)` of the crop. Sorry if that makes your life horrible, @cvializ 

@andrewconner @leogrim 
