### PR TITLE
Kill logs

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -137,7 +137,7 @@ trait ProcessedImageHelper {
 
     resizedImages.find(_.isLeft) match {
       case Some(error) => // failure of at least one of the images
-        log.error(s"[pih] resizedImages failure $error")
+        log.error(s"[pih] resizedImages failure ${error.toString.take(220)}")
         Left(error.left.get)
       case None =>
         Right(resizedImages.map(_.right.get))

--- a/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/UserActions.scala
@@ -232,7 +232,7 @@ trait UserActions extends Logging { self: Controller =>
       val result = userActionsHelper.getUserIdOptWithFallback flatMap { userIdOpt =>
         userIdOpt match {
           case Some(userId) => buildUserAction(userId, block)
-          case None => Future.successful(Forbidden) tap { _ => log.warn(s"[UserAction] Failed to retrieve userId for request=$request; headers=${request.headers.toMap}") }
+          case None => Future.successful(Forbidden) tap { _ => log.warn(s"[UserAction] Failed to retrieve userId for request=$request") }
         }
       }
       result.map(maybeAugmentCORS(_))

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
@@ -65,7 +65,6 @@ class ServiceCluster(val serviceType: ServiceType, airbrake: Provider[AirbrakeNo
   def instanceForNode(node: Node): Option[ServiceInstance] = instances.get(node)
 
   private def addNewNode(newInstances: TrieMap[Node, ServiceInstance], childNode: Node, nodeData: String) = try {
-    log.info(s"data for node $childNode is $nodeData")
     val remoteService = RemoteService.fromJson(nodeData)
     newInstances(childNode) = newInstances.get(childNode) match {
       case Some(instance) =>

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceCluster.scala
@@ -68,7 +68,7 @@ class ServiceCluster(val serviceType: ServiceType, airbrake: Provider[AirbrakeNo
     val remoteService = RemoteService.fromJson(nodeData)
     newInstances(childNode) = newInstances.get(childNode) match {
       case Some(instance) =>
-        log.info(s"discovered updated node $childNode: $remoteService, adding to ${newInstances.keys}")
+        log.info(s"discovered updated node $childNode: ${remoteService.amazonInstanceInfo.getName}, adding to ${newInstances.keys}")
         new ServiceInstance(childNode, instance.thisInstance, remoteService)
       case None =>
         log.info(s"discovered new node $childNode: $remoteService, adding to ${newInstances.keys}")

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
@@ -146,7 +146,7 @@ class ServiceDiscoveryImpl(
   private def watchService(zk: ZooKeeperSession, cluster: ServiceCluster): Unit = {
     zk.create(cluster.servicePath)
     zk.watchChildrenWithData[String](cluster.servicePath, { children: Seq[(Node, String)] =>
-      log.info(s"""services in my cluster under ${cluster.servicePath.name}: ${children.mkString(", ")}""")
+      log.info(s"""services in my cluster under ${cluster.servicePath.name} ${children.length}""")
       cluster.update(zk, children)
     })
   }

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ServiceDiscovery.scala
@@ -114,17 +114,17 @@ class ServiceDiscoveryImpl(
       case Some(instance) if instance == myInstance.get =>
         require(myCluster.size > 0)
         if (logMe) {
-          logLeader(s"I'm the leader! ${myInstance.get}")
+          logLeader(s"I'm the leader! ${myInstance.get.instanceInfo.getName}")
           statsd.gauge(s"service.leader.${myCluster.serviceType.shortName}", 1)
         }
         return true
       case Some(instance) =>
-        val msg = s"I'm not the leader since my instance is ${myInstance.get} and the leader is $instance"
+        val msg = s"I'm not the leader since my instance is ${myInstance.get.instanceInfo.getName} and the leader is ${instance.instanceInfo.getName}"
         if (logMe) logLeader(msg)
         require(myCluster.size > 1, s"$msg; cluster size is ${myCluster.size}")
         return false
       case None =>
-        val msg = s"I'm not the leader since my instance is ${myInstance.get} and I have no idea who the leader is"
+        val msg = s"I'm not the leader since my instance is ${myInstance.get.instanceInfo.getName} and I have no idea who the leader is"
         if (logMe) logLeader(msg)
         require(myCluster.size == 0, s"$msg; cluster size is ${myCluster.size}")
         return false
@@ -204,7 +204,7 @@ class ServiceDiscoveryImpl(
       val myNode = zk.createChild(myCluster.servicePath, myCluster.serviceType.name + "_", RemoteService.toJson(thisRemoteService), EPHEMERAL_SEQUENTIAL)
       myInstance = Some(new ServiceInstance(myNode, true, thisRemoteService))
       myCluster.register(myInstance.get)
-      log.info(s"registered as ${myInstance.get}")
+      log.info(s"registered as ${myInstance.get.instanceInfo.getName}")
       watchServices(zk)
     }
   }

--- a/kifi-backend/modules/rover/app/com/keepit/rover/article/ArticleCommander.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/article/ArticleCommander.scala
@@ -219,7 +219,6 @@ class ArticleCommander @Inject() (
         Future.successful(None)
       }
       case Some(article) => {
-        log.info(s"Persisting latest ${articleInfo.articleKind} for uri ${articleInfo.uriId}: ${articleInfo.url}")
         articleStore.add(articleInfo.urlHash, articleInfo.uriId, articleInfo.latestVersion, article)(articleInfo.articleKind).imap { key =>
           log.info(s"Persisted latest ${articleInfo.articleKind} with version ${key.version} for uri ${articleInfo.uriId}: ${articleInfo.url}")
           Some((article, key.version))

--- a/kifi-backend/modules/search/app/com/keepit/search/augmentation/AugmentationCommander.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/augmentation/AugmentationCommander.scala
@@ -61,7 +61,6 @@ class AugmentationCommanderImpl @Inject() (
   }
 
   def augmentation(itemAugmentationRequest: ItemAugmentationRequest): Future[ItemAugmentationResponse] = {
-    log.info(s"Processing $itemAugmentationRequest")
     val uris = (itemAugmentationRequest.context.corpus.keySet ++ itemAugmentationRequest.items).map(_.uri)
     val restrictedPlan = getRestrictedDistributionPlan(itemAugmentationRequest.context.userId, uris)
     plannedAugmentation(restrictedPlan, itemAugmentationRequest)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepImageCommander.scala
@@ -355,7 +355,6 @@ class KeepImageCommanderImpl @Inject() (
           val image = KeepImage(state = KeepImageStates.ACTIVE, keepId = keepId, imagePath = prev.imagePath, format = prev.format,
             width = prev.width, height = prev.height, source = source, sourceFileHash = prev.sourceFileHash,
             sourceImageUrl = prev.sourceImageUrl, isOriginal = prev.isOriginal, kind = prev.kind)
-          log.info(s"saving new image [$image] derived from [$prev]")
           Some(image)
         }
       }


### PR DESCRIPTION
@stkem @leogrim 

This is my current mega one-liner to find bad logs:

```
grep "" app.log | sed -r 's/[0-9]+//g; s/(play\-akka\.actor\.default\-dispatcher\-|pool--thread-|prod-actor-system-akka.actor.default-dispatcher-)|(main-EventThread)|(prod-actor-system-db-thread-pool-dispatcher-)//g; s/::\. \[\]//g' | grep '.\{100\}' | cut -c1-200 | sort | uniq -c | sort -n | tail -n30
```

You can pre-filter with the `grep`, and also filter line length (ie, I only want lines longer than x)
