### PR TITLE
remove the list publicly checkbox from library page

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryVisibilitySelector.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryVisibilitySelector.js
@@ -13,14 +13,10 @@ angular.module('kifi')
         library: '=',
         space: '='
       },
-      link: function (scope, element) {
+      link: function (scope) {
         scope.spaceIsOrg = function () {
           return 'numMembers' in scope.space;
         };
-
-        $timeout(function () {
-          element.find('.library-visibility-checkbox-custom-input').addClass('kf-transitions');
-        });
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryVisibilitySelector.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryVisibilitySelector.tpl.html
@@ -1,7 +1,7 @@
 <div class="library-visibility-selector">
   <label ng-if="!spaceIsOrg(space)">
     <input class="library-visibility-checkbox-input" type="checkbox" ng-model="library.visibility" ng-false-value="'published'" ng-true-value="'secret'">
-    <div class="library-visibility-checkbox-custom-input">
+    <div class="library-visibility-checkbox-custom-input kf-transitions">
       <div class="library-visibility-checkbox-custom-input-public-background"></div>
       <div class="library-visibility-checkbox-custom-input-secret-background svg-card-lock"></div>
     </div>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
@@ -189,45 +189,6 @@ select.manage-lib-input
   line-height: 28px
   height: 48px
 
-.manage-lib-listed-visibility
-  color: #9b9b9b
-
-  input[type="checkbox"]
-    display: none;
-
-  input[type="checkbox"] + label span
-    position: relative
-    display: inline-block
-    margin: -5px 5px 0 0
-    border-radius: 3px
-    width: 12px
-    height: 12px
-    background-color: #3b99fa
-    vertical-align: middle
-    cursor: pointer
-
-  input[type="checkbox"]:checked + label span
-    &::before
-    &::after
-      content: ' '
-      position: absolute;
-      border-radius: 2px
-      width: 2px;
-      background: #fff
-      font-size: 0
-
-    &::before
-      left: 60%
-      top: 2px
-      bottom: 2px
-      transform: translate(-1px) rotate(35deg)
-
-    &::after
-      left: 35%
-      top: 5px
-      bottom: 2px
-      transform: translate(-1px) rotate(-45deg)
-
 .manage-lib-color
   display: inline-block
   vertical-align: top

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
@@ -48,13 +48,6 @@
             <div ng-switch="library.visibility" class="manage-lib-visibility-description">
               <div ng-switch-when="published" class="manage-lib-visibility-description-content">
                 Anyone can see and follow this library
-                <div class="manage-lib-listed-visibility">
-                  <input type="checkbox" id="listed-visibility-checkbox" ng-model="library.membership.listed">
-                  <label for="listed-visibility-checkbox">
-                    <span></span>
-                    List this library on my public profile
-                  </label>
-                </div>
               </div>
               <div ng-switch-when="organization" class="manage-lib-visibility-description-content">
                 Only members of {{ space.destination | name }} can see this library


### PR DESCRIPTION
Remove this feature as per Eishay's and Jen's request. Still sets the value to true by default. Keeps existing libraries as they are.
