### PR TITLE
Unified the way that data models refer to org ids

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationMembershipCandidate.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationMembershipCandidate.scala
@@ -12,7 +12,7 @@ case class OrganizationMembershipCandidate(
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime,
     state: State[OrganizationMembershipCandidate] = OrganizationMembershipCandidateStates.ACTIVE,
-    orgId: Id[Organization],
+    organizationId: Id[Organization],
     userId: Id[User],
     seq: SequenceNumber[OrganizationMembershipCandidate] = SequenceNumber.ZERO) extends ModelWithState[OrganizationMembershipCandidate] with ModelWithSeqNumber[OrganizationMembershipCandidate] {
 
@@ -21,7 +21,7 @@ case class OrganizationMembershipCandidate(
   def withState(newState: State[OrganizationMembershipCandidate]): OrganizationMembershipCandidate = this.copy(state = newState)
 
   def sanitizeForDelete: OrganizationMembershipCandidate = this.copy(state = OrganizationMembershipCandidateStates.INACTIVE)
-  def toIngestableOrganizationMembershipCandidate: IngestableOrganizationMembershipCandidate = IngestableOrganizationMembershipCandidate(this.id.get, this.createdAt, this.state, this.orgId, this.userId, this.seq)
+  def toIngestableOrganizationMembershipCandidate: IngestableOrganizationMembershipCandidate = IngestableOrganizationMembershipCandidate(this.id.get, this.createdAt, this.state, this.organizationId, this.userId, this.seq)
 
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminOrganizationController.scala
@@ -171,7 +171,7 @@ class AdminOrganizationController @Inject() (
                 case Some(cand) =>
                   existedCand.incrementAndGet()
                 case None =>
-                  orgMembershipCandidateRepo.save(OrganizationMembershipCandidate(orgId = org.id.get, userId = userId))
+                  orgMembershipCandidateRepo.save(OrganizationMembershipCandidate(organizationId = org.id.get, userId = userId))
               }
             }
           }

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -276,7 +276,7 @@ class AdminUserController @Inject() (
     val (bookmarkCount, organizations, candidateOrganizations, socialUsers, fortyTwoConnections, kifiInstallations, allowedInvites, emails, invitedByUsers) = db.readOnlyReplica { implicit s =>
       val bookmarkCount = keepRepo.getCountByUser(userId)
       val organizations = orgRepo.getByIds(orgMembershipRepo.getAllByUserId(userId).map(_.organizationId).toSet).values.toList
-      val candidateOrganizations = orgRepo.getByIds(orgMembershipCandidateRepo.getAllByUserId(userId).map(_.orgId).toSet).values.toList
+      val candidateOrganizations = orgRepo.getByIds(orgMembershipCandidateRepo.getAllByUserId(userId).map(_.organizationId).toSet).values.toList
       val socialUsers = socialUserInfoRepo.getSocialUserBasicInfosByUser(userId)
       val fortyTwoConnections = userConnectionRepo.getConnectedUsers(userId).map { userId =>
         userRepo.get(userId)
@@ -1009,7 +1009,7 @@ class AdminUserController @Inject() (
     db.readOnlyReplica { implicit s =>
       val users = userRepo.getAllUsers(userIds).values.toList
       val orgs = users map { user =>
-        val orgsCandidates = orgMembershipCandidateRepo.getByUserId(user.id.get, Limit(10000), Offset(0)).map(_.orgId).toSet
+        val orgsCandidates = orgMembershipCandidateRepo.getByUserId(user.id.get, Limit(10000), Offset(0)).map(_.organizationId).toSet
         val orgMembers = orgMembershipRepo.getByUserId(user.id.get, Limit(10000), Offset(0)).map(_.organizationId).toSet
         user -> orgRepo.getByIds(orgsCandidates ++ orgMembers).values.toSet
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCandidateCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCandidateCommander.scala
@@ -45,7 +45,7 @@ class OrganizationMembershipCandidateCommanderImpl @Inject() (
 
       val userIdsToBeAdded = userIds -- existingCandidates.map(_.userId).toSet
       userIdsToBeAdded.foreach { uid =>
-        orgMembershipCandidateRepo.save(OrganizationMembershipCandidate(orgId = orgId, userId = uid))
+        orgMembershipCandidateRepo.save(OrganizationMembershipCandidate(organizationId = orgId, userId = uid))
       }
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserIpAddressCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserIpAddressCommander.scala
@@ -188,7 +188,7 @@ class UserIpAddressEventLogger @Inject() (
     val usersFromCluster = db.readOnlyMaster { implicit session =>
       val userIds = clusterMembers.toSeq
       userRepo.getUsers(userIds).values.toList map { user =>
-        val candidates = organizationRepo.getByIds(organizationMembershipCandidateRepo.getAllByUserId(user.id.get).map(_.orgId).toSet).values.toList
+        val candidates = organizationRepo.getByIds(organizationMembershipCandidateRepo.getAllByUserId(user.id.get).map(_.organizationId).toSet).values.toList
         val orgs = organizationRepo.getByIds(organizationMembershipRepo.getAllByUserId(user.id.get).map(_.organizationId).toSet).values.toList
         (user, candidates, orgs)
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserStatisticsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserStatisticsCommander.scala
@@ -121,7 +121,7 @@ class UserStatisticsCommander @Inject() (
     val librariesCreated = librariesCountsByAccess(LibraryAccess.OWNER) - 2 //ignoring main and secret
     val librariesFollowed = librariesCountsByAccess(LibraryAccess.READ_ONLY)
     val orgs = orgRepo.getByIds(orgMembershipRepo.getAllByUserId(user.id.get).map(_.organizationId).toSet).values.toList
-    val orgCandidates = orgRepo.getByIds(orgMembershipCandidateRepo.getAllByUserId(user.id.get).map(_.orgId).toSet).values.toList
+    val orgCandidates = orgRepo.getByIds(orgMembershipCandidateRepo.getAllByUserId(user.id.get).map(_.organizationId).toSet).values.toList
 
     UserStatistics(
       user,


### PR DESCRIPTION
Namely, they use `organizationId`.

Changed `orgId` to `organizationId` within `OrganizationMembershipCandidate`

@eishay 
