### PR TITLE
Rover logging is just stilly right now

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/rover/fetcher/apache/ApacheFetchRequest.scala
+++ b/kifi-backend/modules/common/app/com/keepit/rover/fetcher/apache/ApacheFetchRequest.scala
@@ -46,10 +46,7 @@ class ApacheFetchRequest(httpClient: CloseableHttpClient, airbrake: AirbrakeNoti
     Try {
       executedAt.set(System.currentTimeMillis)
       thread.set(Thread.currentThread())
-      timingWithResult[ApacheFetchResponse](s"fetch(${url}).execute", { r: ApacheFetchResponse => r.getStatusLine.toString }) {
-        System.out.flush()
-        new ApacheFetchResponse(httpClient.execute(httpGet, httpContext))
-      }
+      new ApacheFetchResponse(httpClient.execute(httpGet, httpContext))
     } tap {
       case Success(httpResponse) => respStatusRef.set(httpResponse.getStatusLine)
       case Failure(e @ (_: IOException | _: GeneralSecurityException | _: NullPointerException)) => logAndSetError(e, notify = false) // NullPointerException can happen on BrowserCompatSpec.formatCookies

--- a/kifi-backend/modules/common/app/com/keepit/rover/fetcher/apache/ApacheHttpFetcher.scala
+++ b/kifi-backend/modules/common/app/com/keepit/rover/fetcher/apache/ApacheHttpFetcher.scala
@@ -57,8 +57,11 @@ class ApacheHttpFetcher(val airbrake: AirbrakeNotifier, userAgent: String, conne
           processResponse(request, apacheRequest, apacheResponse, f)
       }
     } recoverWith {
+      case ex: Throwable if Option(ex.getClass.getSimpleName).exists(_ == "FetchThrottlingException") => // Skip logging this one
+        Failure(ex)
       case ex: Throwable =>
-        val msg = s"${ex.getClass.getSimpleName} on fetching url [${request.url}}] if modified since [${request.ifModifiedSince}] using proxy [${request.proxy}]. Cause: ${ex.getMessage}"
+        val proxy = s" using proxy [${request.proxy}]"
+        val msg = s"${ex.getClass.getSimpleName} on fetching url [${request.url}}] if modified since [${request.ifModifiedSince}]$proxy. Cause: ${ex.getMessage}"
         log.error(msg)
         Failure(ex)
     }

--- a/kifi-backend/modules/rover/app/com/keepit/rover/article/ArticleCommander.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/article/ArticleCommander.scala
@@ -220,7 +220,7 @@ class ArticleCommander @Inject() (
       }
       case Some(article) => {
         articleStore.add(articleInfo.urlHash, articleInfo.uriId, articleInfo.latestVersion, article)(articleInfo.articleKind).imap { key =>
-          log.info(s"Persisted latest ${articleInfo.articleKind} with version ${key.version} for uri ${articleInfo.uriId}: ${articleInfo.url}")
+          log.info(s"Persisted latest ${articleInfo.articleKind} with version ${key.version} for uri ${articleInfo.uriId}: ${articleInfo.url.take(80)}")
           Some((article, key.version))
         }
       }

--- a/kifi-backend/modules/rover/app/com/keepit/rover/document/tika/TikaDocument.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/document/tika/TikaDocument.scala
@@ -78,8 +78,8 @@ object TikaDocument extends Logging {
         if (mainHandler.isWriteLimitReached(e)) {
           log.warn("max number of characters reached: " + mainHandler.url)
         } else {
-          e.setStackTrace(new Array[StackTraceElement](0))
-          log.error("extraction failed: ", e)
+          val msg = s"${e.getMessage}: ${Option(e.getCause).map(_.getMessage).getOrElse("")}"
+          log.error(s"extraction failed: $msg")
         }
     } finally {
       try {


### PR DESCRIPTION
@leogrim Hope this is okay? Context in slack, basically youtube is being rate limited, thus exception, and then retrying.

Some of the noisy logs (with numbers stripped out):

```
   1864  ERROR c.k.r.a.f.YoutubeArticleFetcher - Failed to fetch Youtube track: FetchContext(FetchRequestInf
   2447  INFO  c.k.rover.article.ArticleCommander - Persisted latest YoutubeArticle with version . for uri :
   3095  INFO  c.k.r.f.apache.ApacheFetchRequest - lap:.ms; sinceStart:.ms; fetch(https://www.youtube.com/ap
  28752  ERROR c.k.r.f.apache.ApacheHttpFetcher - FetchThrottlingException on fetching url [https://www.yout
  31247  INFO  c.k.r.f.apache.ApacheFetchRequest - lap:.ms; sinceStart:.ms; fetch(https://www.youtube.com/wa
```
