### PR TITLE
3.3.29: Stop treating system libraries as special

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.3.68
+version=3.3.69

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -626,11 +626,7 @@ api.port.on({
         tweet: data.tweet
       }, function done(keep) {
         log('[keep:done]', keep);
-        // main and secret are mutually exclusive
-        var i = mySysLibIds.indexOf(libraryId);
-        if (i >= 0) {
-          d.keeps = d.keeps.filter(libraryIdIsNot(mySysLibIds[1 - i]));
-        }
+
         var j = d.keeps.findIndex(libraryIdIs(libraryId));
         if (j >= 0) {
           d.keeps[j] = keep;


### PR DESCRIPTION
@adamjgrant @cvializ Previously, if you kept in Main, it would remove it from Private (and vice versa) on the server side. No longer the case, so this code stops doing it client side (which was just an optimization so the client looked right before a refresh)
