### PR TITLE
Shooting out little tendrils of KeepToLibrary into the code

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
@@ -34,7 +34,7 @@ case class Keep(
     originalKeeperId: Option[Id[User]] = None,
     organizationId: Option[Id[Organization]] = None) extends ModelWithExternalId[Keep] with ModelWithState[Keep] with ModelWithSeqNumber[Keep] {
 
-  def sanitizeForDelete(): Keep = copy(title = None, state = KeepStates.INACTIVE, kifiInstallation = None)
+  def sanitizeForDelete: Keep = copy(title = None, state = KeepStates.INACTIVE, kifiInstallation = None)
 
   def clean(): Keep = copy(title = title.map(_.trimAndRemoveLineBreaks()))
 
@@ -60,7 +60,13 @@ case class Keep(
 
   def withTitle(title: Option[String]) = copy(title = title.map(_.trimAndRemoveLineBreaks()).filter(title => title.nonEmpty && title != url))
 
+  def withLibrary(lib: Library) = this.copy(
+    libraryId = Some(lib.id.get),
+    visibility = lib.visibility
+  )
+
   def isActive: Boolean = state == KeepStates.ACTIVE
+  def isInactive: Boolean = state == KeepStates.INACTIVE
 
   @deprecated("Use `visibility` instead", "2014-08-29")
   def isDiscoverable = !isPrivate

--- a/kifi-backend/modules/common/app/com/keepit/model/KeepToLibrary.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepToLibrary.scala
@@ -3,6 +3,9 @@ package com.keepit.model
 import com.keepit.common.db._
 import com.keepit.common.time._
 import org.joda.time.DateTime
+import play.api.libs.json.Json
+import play.api.mvc.Results.Status
+import play.api.http.Status._
 
 case class KeepToLibrary(
   id: Option[Id[KeepToLibrary]] = None,
@@ -23,3 +26,38 @@ case class KeepToLibrary(
 }
 
 object KeepToLibraryStates extends States[KeepToLibrary]
+
+sealed abstract class KeepToLibraryFail(val status: Int, val message: String) {
+  def asErrorResponse = Status(status)(Json.obj("error" -> message))
+}
+object KeepToLibraryFail {
+  case object INSUFFICIENT_PERMISSIONS extends KeepToLibraryFail(FORBIDDEN, "insufficient_permissions")
+  case object ALREADY_LINKED extends KeepToLibraryFail(BAD_REQUEST, "link_already_exists")
+  case object NOT_LINKED extends KeepToLibraryFail(BAD_REQUEST, "link_does_not_exist")
+
+  def apply(str: String): KeepToLibraryFail = {
+    str match {
+      case INSUFFICIENT_PERMISSIONS.message => INSUFFICIENT_PERMISSIONS
+      case ALREADY_LINKED.message => ALREADY_LINKED
+      case NOT_LINKED.message => NOT_LINKED
+    }
+  }
+}
+
+sealed abstract class KeepToLibraryRequest {
+  def keepId: Id[Keep]
+  def libraryId: Id[Library]
+  def requesterId: Id[User]
+}
+
+case class KeepToLibraryAttachRequest(
+  keepId: Id[Keep],
+  libraryId: Id[Library],
+  requesterId: Id[User]) extends KeepToLibraryRequest
+case class KeepToLibraryAttachResponse(link: KeepToLibrary)
+
+case class KeepToLibraryDetachRequest(
+  keepId: Id[Keep],
+  libraryId: Id[Library],
+  requesterId: Id[User]) extends KeepToLibraryRequest
+case class KeepToLibraryDetachResponse(dummy: Boolean = false)

--- a/kifi-backend/modules/common/test/com/keepit/model/LibraryFactory.scala
+++ b/kifi-backend/modules/common/test/com/keepit/model/LibraryFactory.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import com.keepit.common.db.{ ExternalId, Id, State }
 import com.keepit.common.time._
-import com.keepit.model.LibraryVisibility.{ PUBLISHED, SECRET, DISCOVERABLE }
+import com.keepit.model.LibraryVisibility.{ ORGANIZATION, PUBLISHED, SECRET, DISCOVERABLE }
 import org.apache.commons.lang3.RandomStringUtils.random
 
 object LibraryFactory {
@@ -19,7 +19,8 @@ object LibraryFactory {
 
   case class PartialLibrary private[LibraryFactory] (
       library: Library,
-      followers: Seq[User] = Seq.empty[User]) {
+      followers: Seq[User] = Seq.empty[User],
+      collaborators: Seq[User] = Seq.empty[User]) {
     def withId(id: Id[Library]) = this.copy(library = library.copy(id = Some(id)))
     def withId(id: Int) = this.copy(library = library.copy(id = Some(Id[Library](id))))
     def withUser(id: Int) = this.copy(library = library.copy(ownerId = Id[User](id)))
@@ -38,10 +39,13 @@ object LibraryFactory {
     def secret() = this.copy(library = library.copy(visibility = SECRET))
     def published() = this.copy(library = library.copy(visibility = PUBLISHED))
     def discoverable() = this.copy(library = library.copy(visibility = DISCOVERABLE))
+    def orgVisible() = this.copy(library = library.copy(visibility = ORGANIZATION))
     def withLastKept() = this.copy(library = library.copy(lastKept = Some(currentDateTime)))
-    def withOrganization(id: Option[Id[Organization]]) = this.copy(library = library.copy(organizationId = id))
+    def withOrganizationIdOpt(id: Option[Id[Organization]]) = this.copy(library = library.copy(organizationId = id))
+    def withOrganization(org: Organization) = this.copy(library = library.copy(organizationId = Some(org.id.get)))
 
     def withFollowers(users: Seq[User]) = this.copy(followers = followers ++ users)
+    def withCollaborators(users: Seq[User]) = this.copy(collaborators = collaborators ++ users)
 
     def get: Library = library
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToLibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToLibraryCommander.scala
@@ -2,42 +2,66 @@ package com.keepit.commanders
 
 import com.google.inject.{ ImplementedBy, Inject, Singleton }
 import com.keepit.common.db.Id
-import com.keepit.common.db.slick.DBSession.RWSession
+import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
 import com.keepit.model._
 
 @ImplementedBy(classOf[KeepToLibraryCommanderImpl])
 trait KeepToLibraryCommander {
-  def addKeepToLibrary(keep: Keep, libraryId: Id[Library])(implicit session: RWSession): KeepToLibrary
-  def removeKeepFromLibrary(keepId: Id[Keep], libraryId: Id[Library])(implicit session: RWSession): Unit
+  def attach(ar: KeepToLibraryAttachRequest)(implicit session: RWSession): Either[KeepToLibraryFail, KeepToLibraryAttachResponse]
+  def detach(dr: KeepToLibraryDetachRequest)(implicit session: RWSession): Either[KeepToLibraryFail, KeepToLibraryDetachResponse]
 }
 
 @Singleton
 class KeepToLibraryCommanderImpl @Inject() (
   db: Database,
   keepRepo: KeepRepo,
+  libraryRepo: LibraryRepo,
+  libraryMembershipRepo: LibraryMembershipRepo,
   keepToLibraryRepo: KeepToLibraryRepo)
     extends KeepToLibraryCommander with Logging {
 
-  def addKeepToLibrary(keep: Keep, libraryId: Id[Library])(implicit session: RWSession): KeepToLibrary = {
-    db.readWrite { implicit session =>
-      keepToLibraryRepo.getByKeepIdAndLibraryId(keep.id.get, libraryId, excludeStateOpt = None) match {
-        case Some(keepToLib) if keepToLib.isActive =>
-          keepToLib
-        case Some(keepToLib) if keepToLib.isInactive =>
-          keepToLibraryRepo.activate(keepToLib)
-        case None =>
-          keepToLibraryRepo.save(KeepToLibrary(keepId = keep.id.get, libraryId = libraryId, keeperId = keep.userId))
-      }
+  def getValidationError(r: KeepToLibraryRequest)(implicit session: RSession): Option[KeepToLibraryFail] = {
+    r match {
+      case KeepToLibraryAttachRequest(keepId, libId, requesterId) =>
+        val userCanWrite = libraryMembershipRepo.getWithLibraryIdAndUserId(libId, requesterId).exists(_.canWrite)
+        val keepIsActivelyLinked = keepToLibraryRepo.getByKeepIdAndLibraryId(keepId, libId).exists(_.isActive)
+        if (!userCanWrite) Some(KeepToLibraryFail.INSUFFICIENT_PERMISSIONS)
+        else if (keepIsActivelyLinked) Some(KeepToLibraryFail.ALREADY_LINKED)
+        else None
+
+      case KeepToLibraryDetachRequest(keepId, libId, requesterId) =>
+        val userCanRemove = libraryMembershipRepo.getWithLibraryIdAndUserId(libId, requesterId).exists(_.canWrite)
+        val keepIsActivelyLinked = keepToLibraryRepo.getByKeepIdAndLibraryId(keepId, libId).exists(_.isActive)
+        if (!userCanRemove) Some(KeepToLibraryFail.INSUFFICIENT_PERMISSIONS)
+        else if (!keepIsActivelyLinked) Some(KeepToLibraryFail.NOT_LINKED)
+        else None
     }
   }
 
-  def removeKeepFromLibrary(keepId: Id[Keep], libraryId: Id[Library])(implicit session: RWSession): Unit = {
-    keepToLibraryRepo.getByKeepIdAndLibraryId(keepId, libraryId, excludeStateOpt = None) match {
-      case Some(keepToLib) if keepToLib.isActive =>
-        keepToLibraryRepo.deactivate(keepToLib)
-      case _ => ()
+  def attach(ar: KeepToLibraryAttachRequest)(implicit session: RWSession): Either[KeepToLibraryFail, KeepToLibraryAttachResponse] = {
+    getValidationError(ar) match {
+      case Some(fail) => Left(fail)
+      case None =>
+        keepToLibraryRepo.getByKeepIdAndLibraryId(ar.keepId, ar.libraryId, excludeStateOpt = None) match {
+          case Some(link) => // existing link guaranteed to be inactive
+            val reactivatedLink = keepToLibraryRepo.activate(link.copy(keeperId = ar.requesterId))
+            Right(KeepToLibraryAttachResponse(reactivatedLink))
+          case None =>
+            val newLink = keepToLibraryRepo.save(KeepToLibrary(keepId = ar.keepId, libraryId = ar.libraryId, keeperId = ar.requesterId))
+            Right(KeepToLibraryAttachResponse(newLink))
+        }
+    }
+  }
+
+  def detach(dr: KeepToLibraryDetachRequest)(implicit session: RWSession): Either[KeepToLibraryFail, KeepToLibraryDetachResponse] = {
+    getValidationError(dr) match {
+      case Some(fail) => Left(fail)
+      case None =>
+        val link = keepToLibraryRepo.getByKeepIdAndLibraryId(dr.keepId, dr.libraryId).get // Guaranteed to return an active link
+        keepToLibraryRepo.deactivate(link)
+        Right(KeepToLibraryDetachResponse())
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -125,6 +125,7 @@ class LibraryCommanderImpl @Inject() (
     basicUserRepo: BasicUserRepo,
     keepRepo: KeepRepo,
     keepToCollectionRepo: KeepToCollectionRepo,
+    keepToLibraryCommander: KeepToLibraryCommander,
     keepDecorator: KeepDecorator,
     countByLibraryCache: CountByLibraryCache,
     typeaheadCommander: TypeaheadCommander,
@@ -753,6 +754,7 @@ class LibraryCommanderImpl @Inject() (
         }
 
         // Update visibility of keeps
+        // TODO(ryan): We need to find a new way of describing keep visibility. Denormalizing is no longer possible because it's different for different users
         def updateKeepVisibility(changedVisibility: LibraryVisibility, iter: Int): Future[Unit] = Future {
           val (keeps, curViz) = db.readOnlyMaster { implicit s =>
             val viz = libraryRepo.get(targetLib.id.get).visibility // It may have changed, re-check
@@ -813,27 +815,25 @@ class LibraryCommanderImpl @Inject() (
       Some(LibraryFail(BAD_REQUEST, "cant_delete_system_generated_library"))
     } else {
       val keepsInLibrary = db.readWrite { implicit s =>
-        libraryMembershipRepo.getWithLibraryId(oldLibrary.id.get).map { m =>
+        libraryMembershipRepo.getWithLibraryId(oldLibrary.id.get).foreach { m =>
           libraryMembershipRepo.save(m.withState(LibraryMembershipStates.INACTIVE))
         }
-        libraryInviteRepo.getWithLibraryId(oldLibrary.id.get).map { inv =>
+        libraryInviteRepo.getWithLibraryId(oldLibrary.id.get).foreach { inv =>
           libraryInviteRepo.save(inv.withState(LibraryInviteStates.INACTIVE))
         }
         keepRepo.getByLibrary(oldLibrary.id.get, 0, Int.MaxValue)
       }
-      val savedKeeps = db.readWriteBatch(keepsInLibrary) { (s, keep) =>
-        keepRepo.save(keep.sanitizeForDelete())(s)
+      val savedKeeps = db.readWriteBatch(keepsInLibrary) { (s, keep) => // TODO(ryan): Can this session be made implicit?
+        keepToLibraryCommander.detach(KeepToLibraryDetachRequest(keepId = keep.id.get, libraryId = libraryId, requesterId = userId))(s)
+        keepRepo.deactivate(keep)(s) // TODO(ryan): At some point, remove this code. Keeps should only be detached from libraries
       }
       libraryAnalytics.deleteLibrary(userId, oldLibrary, context)
       libraryAnalytics.unkeptPages(userId, savedKeeps.keySet.toSeq, oldLibrary, context)
       searchClient.updateKeepIndex()
       //Note that this is at the end, if there was an error while cleaning other library assets
       //we would want to be able to get back to the library and clean it again
-      db.readWrite(attempts = 2) { implicit s =>
+      db.readWrite { implicit s =>
         libraryRepo.save(oldLibrary.sanitizeForDelete)
-      }
-      db.readOnlyMaster { implicit s =>
-        require(libraryRepo.get(oldLibrary.id.get).state == LibraryStates.INACTIVE, s"Library ${oldLibrary.id.get} deletion failed")
       }
       searchClient.updateLibraryIndex()
       None
@@ -1214,6 +1214,10 @@ class LibraryCommanderImpl @Inject() (
     }
   }
 
+  // TODO(ryan): is this actually necessary anymore? Check with Léo to see if Search needs it
+  // We may not need to have this concept of "keep ownership" anymore. You can be the author of
+  // a keep, which is its own thing. You can have access to edit a keep, which is also its own
+  // thing.
   private def convertKeepOwnershipToLibraryOwner(userId: Id[User], library: Library) = {
     db.readWrite { implicit s =>
       keepRepo.getByUserIdAndLibraryId(userId, library.id.get).map { keep =>
@@ -1359,15 +1363,18 @@ class LibraryCommanderImpl @Inject() (
 
           val currentKeepOpt = keepRepo.getPrimaryByUriAndLibrary(k.uriId, toLibraryId)
 
+          // TODO(ryan): just use a single function that creates new keeps, and handle the attachment to a library in there
           currentKeepOpt match {
             case None =>
               val newKeep = keepRepo.save(Keep(title = k.title, uriId = k.uriId, url = k.url, urlId = k.urlId, visibility = toLibrary.visibility,
                 userId = userId, note = k.note, source = withSource.getOrElse(k.source), libraryId = Some(toLibraryId), originalKeeperId = k.originalKeeperId.orElse(Some(userId))))
+              keepToLibraryCommander.attach(KeepToLibraryAttachRequest(keepId = newKeep.id.get, libraryId = toLibraryId, requesterId = userId))
               combineTags(k.id.get, newKeep.id.get)
               Right(newKeep)
             case Some(existingKeep) if existingKeep.state == KeepStates.INACTIVE =>
               val newKeep = keepRepo.save(existingKeep.copy(userId = userId, libraryId = Some(toLibraryId), visibility = toLibrary.visibility,
                 source = withSource.getOrElse(k.source), state = KeepStates.ACTIVE))
+              keepToLibraryCommander.attach(KeepToLibraryAttachRequest(keepId = newKeep.id.get, libraryId = toLibraryId, requesterId = userId))
               combineTags(k.id.get, existingKeep.id.get)
               Right(newKeep)
             case Some(existingKeep) =>
@@ -1396,17 +1403,19 @@ class LibraryCommanderImpl @Inject() (
         def saveKeep(k: Keep, s: RWSession): Either[LibraryError, Keep] = {
           implicit val session = s
 
-          val currentKeepOpt = keepRepo.getPrimaryByUriAndLibrary(k.uriId, toLibraryId)
+          val existingKeepOpt = keepRepo.getPrimaryByUriAndLibrary(k.uriId, toLibraryId)
 
-          currentKeepOpt match {
+          existingKeepOpt match {
             case None =>
-              val movedKeep = keepRepo.save(k.copy(libraryId = Some(toLibraryId), visibility = toLibrary.visibility,
-                state = KeepStates.ACTIVE))
+              val movedKeep = keepRepo.save(k.withLibrary(toLibrary))
+              keepToLibraryCommander.detach(KeepToLibraryDetachRequest(keepId = k.id.get, libraryId = k.libraryId.get, requesterId = userId))
+              keepToLibraryCommander.attach(KeepToLibraryAttachRequest(keepId = movedKeep.id.get, libraryId = toLibraryId, requesterId = userId))
               Right(movedKeep)
-            case Some(existingKeep) if existingKeep.state == KeepStates.INACTIVE =>
-              val movedKeep = keepRepo.save(existingKeep.copy(libraryId = Some(toLibraryId), visibility = toLibrary.visibility,
-                state = KeepStates.ACTIVE))
-              keepRepo.save(k.copy(state = KeepStates.INACTIVE))
+            case Some(existingKeep) if existingKeep.isInactive =>
+              val movedKeep = keepRepo.save(k.withId(existingKeep.id.get).withLibrary(toLibrary)) // clone new keep into existing keep's place, wiping out the existing keep
+              keepRepo.deactivate(k) // deactivate the keep in the old library
+              keepToLibraryCommander.detach(KeepToLibraryDetachRequest(keepId = k.id.get, libraryId = k.libraryId.get, requesterId = userId))
+              keepToLibraryCommander.attach(KeepToLibraryAttachRequest(keepId = movedKeep.id.get, libraryId = toLibraryId, requesterId = userId))
               combineTags(k.id.get, existingKeep.id.get)
               Right(movedKeep)
             case Some(existingKeep) =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -832,8 +832,11 @@ class LibraryCommanderImpl @Inject() (
       searchClient.updateKeepIndex()
       //Note that this is at the end, if there was an error while cleaning other library assets
       //we would want to be able to get back to the library and clean it again
-      db.readWrite { implicit s =>
+      db.readWrite(attempts = 2) { implicit s =>
         libraryRepo.save(oldLibrary.sanitizeForDelete)
+      }
+      db.readOnlyMaster { implicit s =>
+        require(libraryRepo.get(oldLibrary.id.get).state == LibraryStates.INACTIVE, s"Library ${oldLibrary.id.get} deletion failed")
       }
       searchClient.updateLibraryIndex()
       None

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -542,6 +542,7 @@ class LibraryController @Inject() (
     }
   }
 
+  // TODO(ryan): This seems to only update the keep title. Is it supposed to do other things?
   def updateKeep(libraryPubId: PublicId[Library], keepExtId: ExternalId[Keep]) = (UserAction andThen LibraryWriteAction(libraryPubId))(parse.tolerantJson) { request =>
     val libraryId = Library.decodePublicId(libraryPubId).get
     val body = request.body

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
@@ -42,6 +42,7 @@ trait KeepRepo extends Repo[Keep] with ExternalIdColumnFunction[Keep] with SeqNu
   def getByUrlId(urlId: Id[URL])(implicit session: RSession): Seq[Keep]
   def delete(id: Id[Keep])(implicit session: RWSession): Unit
   def save(model: Keep)(implicit session: RWSession): Keep
+  def deactivate(model: Keep)(implicit session: RWSession): Unit
   def detectDuplicates()(implicit session: RSession): Seq[(Id[User], Id[NormalizedURI])]
   def getByTitle(title: String)(implicit session: RSession): Seq[Keep]
   def exists(uriId: Id[NormalizedURI])(implicit session: RSession): Boolean
@@ -146,6 +147,10 @@ class KeepRepoImpl @Inject() (
       model.copy(seq = sequence.incrementAndGet())
     }
     super.save(newModel.clean())
+  }
+
+  def deactivate(model: Keep)(implicit session: RWSession): Unit = {
+    save(model.sanitizeForDelete)
   }
 
   def page(page: Int, size: Int, includePrivate: Boolean, excludeStates: Set[State[Keep]])(implicit session: RSession): Seq[Keep] = {

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
@@ -34,7 +34,7 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
 
   "BookmarkInterner" should {
 
-    "persist bookmark" in {
+    "persist keep" in {
       withDb(modules: _*) { implicit injector =>
         val user = db.readWrite { implicit session =>
           UserFactory.user().withName("Shanee", "Smith").withUsername("test").saved

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepToLibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepToLibraryCommanderTest.scala
@@ -1,0 +1,133 @@
+package com.keepit.commanders
+
+import com.google.inject.Injector
+import com.keepit.common.actor.TestKitSupport
+import com.keepit.heimdal.HeimdalContext
+import com.keepit.model._
+import com.keepit.test.ShoeboxTestInjector
+import org.specs2.mutable.SpecificationLike
+
+import com.keepit.model.UserFactoryHelper._
+import com.keepit.model.LibraryFactoryHelper._
+import com.keepit.model.KeepFactoryHelper._
+import com.keepit.model.OrganizationFactoryHelper._
+
+class KeepToLibraryCommanderTest extends TestKitSupport with SpecificationLike with ShoeboxTestInjector {
+  implicit val context = HeimdalContext.empty
+  implicit def ktlCommander(implicit injector: Injector) = inject[KeepToLibraryCommander]
+  implicit def ktlRepo(implicit injector: Injector) = inject[KeepToLibraryRepo]
+
+  def modules = Seq()
+
+  "KeepToLibraryCommander" should {
+    "attach keeps to libraries" in {
+      "properly process an attach request" in {
+        withDb(modules: _*) { implicit injector =>
+          val (user, keep, otherLib) = db.readWrite { implicit session =>
+            val user = UserFactory.user().saved
+            val userLib = LibraryFactory.library().withUser(user).saved
+            val keep = KeepFactory.keep().withLibrary(userLib).saved
+
+            val otherLib = LibraryFactory.library().withUser(user).saved
+            (user, keep, otherLib)
+          }
+
+          val link = db.readWrite { implicit session =>
+            val maybeAttachResponse = ktlCommander.attach(KeepToLibraryAttachRequest(keep.id.get, otherLib.id.get, user.id.get))
+            maybeAttachResponse.isRight === true
+            maybeAttachResponse.right.get.link
+          }
+
+          link.keepId === keep.id.get
+          link.keeperId === user.id.get
+          link.libraryId === otherLib.id.get
+        }
+      }
+      "bail if the user doesn't have write permission" in {
+        withDb(modules: _*) { implicit injector =>
+          val (user, keep, libs) = db.readWrite { implicit session =>
+            val user = UserFactory.user().saved
+            val userLib = LibraryFactory.library().withUser(user).saved
+            val keep = KeepFactory.keep().withLibrary(userLib).saved
+
+            val rando = UserFactory.user().saved
+            val randoOrg = OrganizationFactory.organization().withOwner(rando).saved
+            val randoSecretLib = LibraryFactory.library().withUser(rando).secret().saved
+            val randoPublicLib = LibraryFactory.library().withUser(rando).published().saved
+            val randoOrgLib = LibraryFactory.library().withUser(rando).withOrganization(randoOrg).orgVisible().saved
+            (user, keep, Seq(randoPublicLib, randoSecretLib, randoOrgLib))
+          }
+
+          db.readWrite { implicit session =>
+            for (lib <- libs) {
+              ktlCommander.attach(KeepToLibraryAttachRequest(keep.id.get, lib.id.get, user.id.get)) must beLeft
+            }
+          }
+          1 === 1
+        }
+      }
+      "bail if the keep is already in the target library" in {
+        withDb(modules: _*) { implicit injector =>
+          val (user, keep, lib) = db.readWrite { implicit session =>
+            val user = UserFactory.user().saved
+            val userLib = LibraryFactory.library().withUser(user).saved
+            val keep = KeepFactory.keep().withLibrary(userLib).saved
+
+            val rando = UserFactory.user().saved
+            val randoLib = LibraryFactory.library().withUser(rando).withCollaborators(Seq(user)).saved
+
+            ktlCommander.attach(KeepToLibraryAttachRequest(keep.id.get, randoLib.id.get, user.id.get)) must beRight
+            ktlRepo.countByLibraryId(randoLib.id.get) === 1
+
+            (user, keep, randoLib)
+          }
+
+          db.readWrite { implicit session =>
+            ktlCommander.attach(KeepToLibraryAttachRequest(keep.id.get, lib.id.get, user.id.get)) must beLeft
+          }
+          1 === 1
+        }
+      }
+    }
+    "detach keeps from libraries" in {
+      "properly process a detach request" in {
+        withDb(modules: _*) { implicit injector =>
+          val (user, keep, userLib) = db.readWrite { implicit session =>
+            val user = UserFactory.user().saved
+            val userLib = LibraryFactory.library().withUser(user).saved
+            val keep = KeepFactory.keep().withLibrary(userLib).saved
+            (user, keep, userLib)
+          }
+
+          db.readWrite { implicit session =>
+            ktlCommander.detach(KeepToLibraryDetachRequest(keep.id.get, userLib.id.get, user.id.get)) must beRight
+          }
+          1 === 1
+        }
+      }
+      "bail if the link doesn't exist" in {
+        withDb(modules: _*) { implicit injector =>
+          val (user, keep, libs) = db.readWrite { implicit session =>
+            val user = UserFactory.user().saved
+            val userLib = LibraryFactory.library().withUser(user).saved
+            val keep = KeepFactory.keep().withLibrary(userLib).saved
+
+            val rando = UserFactory.user().saved
+            val randoOrg = OrganizationFactory.organization().withOwner(rando).saved
+            val randoSecretLib = LibraryFactory.library().withUser(rando).secret().saved
+            val randoPublicLib = LibraryFactory.library().withUser(rando).published().saved
+            val randoOrgLib = LibraryFactory.library().withUser(rando).withOrganization(randoOrg).orgVisible().saved
+            (user, keep, Seq(randoPublicLib, randoSecretLib, randoOrgLib))
+          }
+
+          db.readWrite { implicit session =>
+            for (lib <- libs) {
+              ktlCommander.detach(KeepToLibraryDetachRequest(keep.id.get, lib.id.get, user.id.get)) must beLeft
+            }
+          }
+          1 === 1
+        }
+      }
+    }
+  }
+}

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -705,7 +705,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           val barry = UserFactory.user().withName("Barry", "Allen").withUsername("The Flash").saved
           val starLabsOrg = orgRepo.save(Organization(name = "Star Labs", ownerId = harrison.id.get, primaryHandle = None, description = None, site = None))
-          val starLabsLib = library().withUser(harrison).withVisibility(LibraryVisibility.ORGANIZATION).withOrganization(starLabsOrg.id).saved
+          val starLabsLib = library().withUser(harrison).withVisibility(LibraryVisibility.ORGANIZATION).withOrganizationIdOpt(starLabsOrg.id).saved
 
           val membership = orgMemberRepo.save(starLabsOrg.newMembership(userId = barry.id.get, role = OrganizationRole.MEMBER))
 
@@ -980,7 +980,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             val owner = UserFactory.user().saved
             val member = UserFactory.user().saved
             val org = OrganizationFactory.organization().withOwner(owner).withMembers(Seq(member)).saved
-            val lib = LibraryFactory.library().withUser(owner).withOrganization(Some(org.id.get)).withVisibility(LibraryVisibility.ORGANIZATION).saved
+            val lib = LibraryFactory.library().withUser(owner).withOrganizationIdOpt(Some(org.id.get)).withVisibility(LibraryVisibility.ORGANIZATION).saved
             (org, owner, member, lib)
           }
 
@@ -1000,7 +1000,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             val owner = UserFactory.user().saved
             val rando = UserFactory.user().saved
             val org = OrganizationFactory.organization().withOwner(owner).saved
-            val lib = LibraryFactory.library().withUser(owner).withOrganization(Some(org.id.get)).withVisibility(LibraryVisibility.ORGANIZATION).saved
+            val lib = LibraryFactory.library().withUser(owner).withOrganizationIdOpt(Some(org.id.get)).withVisibility(LibraryVisibility.ORGANIZATION).saved
             (org, owner, rando, lib)
           }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
@@ -44,9 +44,9 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
           val owner = UserFactory.user().withName("Owner", "McOwnerson").saved
           val nonMember = UserFactory.user().withName("Rando", "McRanderson").saved
           val org = OrganizationFactory.organization().withName("Test Org").withOwner(owner).saved
-          val publicLibs = LibraryFactory.libraries(10).map(_.withUser(owner).withVisibility(LibraryVisibility.PUBLISHED).withOrganization(Some(org.id.get))).saved
-          val orgLibs = LibraryFactory.libraries(20).map(_.withUser(owner).withVisibility(LibraryVisibility.ORGANIZATION).withOrganization(Some(org.id.get))).saved
-          val deletedLibs = LibraryFactory.libraries(15).map(_.withUser(owner).withVisibility(LibraryVisibility.ORGANIZATION).withOrganization(Some(org.id.get))).saved.map(_.deleted)
+          val publicLibs = LibraryFactory.libraries(10).map(_.withUser(owner).withVisibility(LibraryVisibility.PUBLISHED).withOrganizationIdOpt(Some(org.id.get))).saved
+          val orgLibs = LibraryFactory.libraries(20).map(_.withUser(owner).withVisibility(LibraryVisibility.ORGANIZATION).withOrganizationIdOpt(Some(org.id.get))).saved
+          val deletedLibs = LibraryFactory.libraries(15).map(_.withUser(owner).withVisibility(LibraryVisibility.ORGANIZATION).withOrganizationIdOpt(Some(org.id.get))).saved.map(_.deleted)
           (org, owner, nonMember, publicLibs, orgLibs, deletedLibs)
         }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
@@ -53,9 +53,9 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
             val user = UserFactory.user().saved
             val handle = OrganizationHandle("kifi")
             val org = OrganizationFactory.organization().withHandle(handle).withOwner(user).withName("Forty Two Kifis").saved
-            LibraryFactory.libraries(10).map(_.published().withOrganization(org.id)).saved
-            LibraryFactory.libraries(15).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withOrganization(org.id)).saved
-            LibraryFactory.libraries(20).map(_.secret().withOrganization(org.id)).saved
+            LibraryFactory.libraries(10).map(_.published().withOrganizationIdOpt(org.id)).saved
+            LibraryFactory.libraries(15).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withOrganizationIdOpt(org.id)).saved
+            LibraryFactory.libraries(20).map(_.secret().withOrganizationIdOpt(org.id)).saved
             (user, org)
           }
 
@@ -79,7 +79,7 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
             val user = UserFactory.user().saved
             for (i <- 1 to 10) {
               val org = OrganizationFactory.organization().withOwner(user).withName("Justice League").saved
-              LibraryFactory.libraries(i).map(_.published().withOrganization(org.id)).saved
+              LibraryFactory.libraries(i).map(_.published().withOrganizationIdOpt(org.id)).saved
             }
             user
           }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserProfileControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserProfileControllerTest.scala
@@ -73,7 +73,7 @@ class MobileUserProfileControllerTest extends Specification with ShoeboxTestInje
 
           val user1secretLib = libraries(3).map(_.withUser(user1).secret().withKeepCount(3)).saved.head.savedFollowerMembership(user2)
 
-          val user1lib = library().withUser(user1).published().withOrganization(org.id).saved.savedFollowerMembership(user5, user4)
+          val user1lib = library().withUser(user1).published().withOrganizationIdOpt(org.id).saved.savedFollowerMembership(user5, user4)
           user1lib.visibility === LibraryVisibility.PUBLISHED
 
           val user3lib = library().withUser(user3).published().withKeepCount(2).saved

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
@@ -244,7 +244,7 @@ class KifiSiteRouterTest extends Specification with ShoeboxApplicationInjector {
 
         // user-or-orgs
         val orgLibrary = db.readWrite { implicit session =>
-          LibraryFactory.library().withName("Kifi Library").withSlug("kifi-lib").withUser(user1).withOrganization(org.id).saved
+          LibraryFactory.library().withName("Kifi Library").withSlug("kifi-lib").withUser(user1).withOrganizationIdOpt(org.id).saved
         }
 
         actionsHelper.setUser(user1, experiments = Set(UserExperimentType.ORGANIZATION))

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
@@ -54,9 +54,9 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
             val rando = UserFactory.user().saved
             val org = OrganizationFactory.organization().withHandle(OrganizationHandle("brewstercorp")).withName("Brewster Corp").withOwner(owner).withMembers(Seq(member)).saved
 
-            LibraryFactory.libraries(10).map(_.published().withOrganization(org.id)).saved
-            LibraryFactory.libraries(15).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withOrganization(org.id)).saved
-            LibraryFactory.libraries(20).map(_.secret().withOrganization(org.id)).saved
+            LibraryFactory.libraries(10).map(_.published().withOrganizationIdOpt(org.id)).saved
+            LibraryFactory.libraries(15).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withOrganizationIdOpt(org.id)).saved
+            LibraryFactory.libraries(20).map(_.secret().withOrganizationIdOpt(org.id)).saved
 
             (org, owner, member, rando)
           }
@@ -122,9 +122,9 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
             val rando = UserFactory.user().saved
             val org = OrganizationFactory.organization().withHandle(OrganizationHandle("brewstercorp")).withName("Brewster Corp").withOwner(owner).saved
 
-            LibraryFactory.libraries(10).map(_.published().withOrganization(org.id)).saved
-            LibraryFactory.libraries(15).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withOrganization(org.id)).saved
-            LibraryFactory.libraries(20).map(_.secret().withOrganization(org.id)).saved
+            LibraryFactory.libraries(10).map(_.published().withOrganizationIdOpt(org.id)).saved
+            LibraryFactory.libraries(15).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withOrganizationIdOpt(org.id)).saved
+            LibraryFactory.libraries(20).map(_.secret().withOrganizationIdOpt(org.id)).saved
 
             (org, owner, rando)
           }
@@ -152,7 +152,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
             val user = UserFactory.user().saved
             for (i <- 1 to 10) {
               val org = OrganizationFactory.organization().withOwner(user).withName("Justice League").withHandle(OrganizationHandle("justiceleague" + i)).saved
-              LibraryFactory.libraries(i).map(_.published().withUser(user).withOrganization(org.id)).saved
+              LibraryFactory.libraries(i).map(_.published().withUser(user).withOrganizationIdOpt(org.id)).saved
             }
             user
           }
@@ -176,7 +176,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
             val rando = UserFactory.user().saved
             for (i <- 1 to 10) {
               val org = OrganizationFactory.organization().withOwner(user).withName("Justice League").withHandle(OrganizationHandle("justiceleague" + i)).saved
-              LibraryFactory.libraries(i).map(_.published().withUser(user).withOrganization(org.id)).saved
+              LibraryFactory.libraries(i).map(_.published().withUser(user).withOrganizationIdOpt(org.id)).saved
               if (i <= 5) {
                 inject[OrganizationRepo].save(org.hiddenFromNonmembers)
               }
@@ -217,9 +217,9 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
           .withMembers(Seq(member))
           .saved
 
-        val publicLibs = LibraryFactory.libraries(numPublicLibs).map(_.published().withUser(owner).withOrganization(org.id)).saved
-        val orgLibs = LibraryFactory.libraries(numOrgLibs).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withUser(owner).withOrganization(org.id)).saved
-        val privateLibs = LibraryFactory.libraries(numPrivateLibs).map(_.secret().withUser(member).withOrganization(org.id)).saved
+        val publicLibs = LibraryFactory.libraries(numPublicLibs).map(_.published().withUser(owner).withOrganizationIdOpt(org.id)).saved
+        val orgLibs = LibraryFactory.libraries(numOrgLibs).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withUser(owner).withOrganizationIdOpt(org.id)).saved
+        val privateLibs = LibraryFactory.libraries(numPrivateLibs).map(_.secret().withUser(member).withOrganizationIdOpt(org.id)).saved
         (org, owner, member, nonmember, publicLibs, orgLibs, privateLibs)
       }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserProfileControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserProfileControllerTest.scala
@@ -191,7 +191,7 @@ class UserProfileControllerTest extends Specification with ShoeboxTestInjector {
 
           val user1secretLib = libraries(3).map(_.withUser(user1).withKind(LibraryKind.USER_CREATED).withKeepCount(3).withMemberCount(4).secret()).saved.head.savedFollowerMembership(user2)
 
-          val user1lib = library().withUser(user1).withKind(LibraryKind.USER_CREATED).withKeepCount(3).published().withMemberCount(4).withOrganization(org.id).saved.savedFollowerMembership(user5, user4)
+          val user1lib = library().withUser(user1).withKind(LibraryKind.USER_CREATED).withKeepCount(3).published().withMemberCount(4).withOrganizationIdOpt(org.id).saved.savedFollowerMembership(user5, user4)
           user1lib.visibility === LibraryVisibility.PUBLISHED
 
           val user3lib = library().withUser(user3).published().withKind(LibraryKind.USER_CREATED).withKeepCount(3).withMemberCount(4).saved

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/LibraryFactoryHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/LibraryFactoryHelper.scala
@@ -17,6 +17,9 @@ object LibraryFactoryHelper {
       for (user <- partialLibrary.followers) {
         membership().withLibraryFollower(library, user).saved
       }
+      for (user <- partialLibrary.collaborators) {
+        membership().withLibraryCollaborator(library, user).saved
+      }
       library
     }
   }


### PR DESCRIPTION
The commander can attach/detach keeps to/from libraries. It handles
permissions. It uses a request/response framework. Should be pretty fast.
Probably need to add a cache for KeepToLibrary.

Added tests for KeepToLibraryCommander
