### PR TITLE
Somehow I missed this one.

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ZooKeeperClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ZooKeeperClient.scala
@@ -461,7 +461,7 @@ class ZooKeeperSessionImpl(zkClient: ZooKeeperClientImpl, promise: Promise[Unit]
           case e: KeeperException.NoNodeException =>
             watchedChildren -= child
           case e: KeeperException =>
-            log.error(s"Failed to place watch on a child node!: ${child.path}", e)
+            log.error(s"Failed to place watch on a child node!: ${child.path}: ${e.getMessage}")
             watchedChildren -= child
         }
       }

--- a/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ZooKeeperClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/zookeeper/ZooKeeperClient.scala
@@ -444,7 +444,7 @@ class ZooKeeperSessionImpl(zkClient: ZooKeeperClientImpl, promise: Promise[Unit]
           case _ =>
             event.getState match {
               case KeeperState.Disconnected | KeeperState.Expired =>
-                log.info(s"session event, losing a ParentWatcher on ${node.path}") // session event, we intentionally lose this watch
+                log.debug(s"session event, losing a ParentWatcher on ${node.path}") // session event, we intentionally lose this watch
               case _ =>
                 log.info(s"session event, keep watching")
                 doWatchChildren(getChildren(node, new ParentWatcher()))


### PR DESCRIPTION
@stkem @leogrim @eishay 

![](http://acon.s3.amazonaws.com/sP8AF.png)

Massive amount of logging again, we logged over 1gb in about 3 minutes.

![](http://acon.s3.amazonaws.com/UlXNB.png)

ZK again. Any ideas?

I'm seeing two weird things. One, a super tight loop to zk (this has to be a bug on our end, right?):

```
13:07:53.914 [main-EventThread] INFO  c.k.c.zookeeper.ServiceDiscoveryImpl - services in my cluster under SHOEBOX 4
13:07:53.914 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/SHOEBOX/SHOEBOX_0000009959: shoebox-spot-2
13:07:53.914 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/SHOEBOX/SHOEBOX_0000009958: shoebox-demand-2
13:07:53.914 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/SHOEBOX/SHOEBOX_0000009960: shoebox-spot-1
13:07:53.914 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/SHOEBOX/SHOEBOX_0000009957: shoebox-demand-3
13:07:53.914 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - leader is Service Instance of zk node /fortytwo/services/SHOEBOX/SHOEBOX_0000009957 with remote service RemoteService(AmazonInstanceInfo(i-a9e7996b,Some
(shoebox-demand-3),Some(shoebox),ip-10-234-0-121.us-west-1.compute.internal,ec2-54-151-46-115.us-west-1.compute.amazonaws.com,10.234.0.121,54.151.46.115,m3.xlarge,us-west-1a,default,ami-0da85c49,0,Some(shoebox-b-1),Map(Name -> s
hoebox-demand-3, ELB -> shoebox-b-1, Ansible -> v1, Service -> shoebox, Mode -> primary)),UP,SHOEBOX)
13:07:53.914 [main-EventThread] INFO  c.k.c.zookeeper.ZooKeeperSessionImpl - session event, keep watching
13:07:53.915 [main-EventThread] INFO  c.k.c.zookeeper.ServiceDiscoveryImpl - services in my cluster under ROVER 2
13:07:53.915 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/ROVER/ROVER_0000012966: rover-demand-3
13:07:53.916 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/ROVER/ROVER_0000012969: rover-demand-4
13:07:53.916 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - leader is Service Instance of zk node /fortytwo/services/ROVER/ROVER_0000012966 with remote service RemoteService(AmazonInstanceInfo(i-66d6a8a4,Some(rov
er-demand-3),Some(rover),ip-10-235-19-236.us-west-1.compute.internal,ec2-54-177-16-152.us-west-1.compute.amazonaws.com,10.235.19.236,54.177.16.152,m3.xlarge,us-west-1a,default,ami-0da85c49,0,None,Map(Service -> rover, Name -> ro
ver-demand-3, Ansible -> v1, Mode -> primary)),UP,ROVER)
13:07:53.917 [main-EventThread] INFO  c.k.c.zookeeper.ServiceDiscoveryImpl - services in my cluster under SHOEBOX 4
13:07:53.917 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/SHOEBOX/SHOEBOX_0000009959: shoebox-spot-2
13:07:53.917 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/SHOEBOX/SHOEBOX_0000009958: shoebox-demand-2
13:07:53.917 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/SHOEBOX/SHOEBOX_0000009960: shoebox-spot-1
13:07:53.917 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/SHOEBOX/SHOEBOX_0000009957: shoebox-demand-3
13:07:53.917 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - leader is Service Instance of zk node /fortytwo/services/SHOEBOX/SHOEBOX_0000009957 with remote service RemoteService(AmazonInstanceInfo(i-a9e7996b,Some
(shoebox-demand-3),Some(shoebox),ip-10-234-0-121.us-west-1.compute.internal,ec2-54-151-46-115.us-west-1.compute.amazonaws.com,10.234.0.121,54.151.46.115,m3.xlarge,us-west-1a,default,ami-0da85c49,0,Some(shoebox-b-1),Map(Name -> s
hoebox-demand-3, ELB -> shoebox-b-1, Ansible -> v1, Service -> shoebox, Mode -> primary)),UP,SHOEBOX)
13:07:53.917 [main-EventThread] INFO  c.k.c.zookeeper.ZooKeeperSessionImpl - session event, keep watching
13:07:53.918 [main-EventThread] INFO  c.k.c.zookeeper.ServiceDiscoveryImpl - services in my cluster under SHOEBOX 4
13:07:53.918 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/SHOEBOX/SHOEBOX_0000009959: shoebox-spot-2
13:07:53.919 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/SHOEBOX/SHOEBOX_0000009958: shoebox-demand-2
13:07:53.919 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/SHOEBOX/SHOEBOX_0000009960: shoebox-spot-1
13:07:53.919 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - discovered updated node /fortytwo/services/SHOEBOX/SHOEBOX_0000009957: shoebox-demand-3
13:07:53.919 [main-EventThread] INFO  c.k.common.zookeeper.ServiceCluster - leader is Service Instance of zk node /fortytwo/services/SHOEBOX/SHOEBOX_0000009957 with remote service RemoteService(AmazonInstanceInfo(i-a9e7996b,Some
(shoebox-demand-3),Some(shoebox),ip-10-234-0-121.us-west-1.compute.internal,ec2-54-151-46-115.us-west-1.compute.amazonaws.com,10.234.0.121,54.151.46.115,m3.xlarge,us-west-1a,default,ami-0da85c49,0,Some(shoebox-b-1),Map(Name -> s
hoebox-demand-3, ELB -> shoebox-b-1, Ansible -> v1, Service -> shoebox, Mode -> primary)),UP,SHOEBOX)
```

and then a hundred thousand of these:

```
12:46:05.908 [main-EventThread] INFO  c.k.c.zookeeper.ServiceDiscoveryImpl - services in my cluster under SHOEBOX 0
12:46:05.908 [main-EventThread] ERROR c.k.c.zookeeper.ZooKeeperSessionImpl - Failed to place watch on a child node!: /fortytwo/services/SHOEBOX/SHOEBOX_0000009958
org.apache.zookeeper.KeeperException$SessionExpiredException: KeeperErrorCode = Session expired for /fortytwo/services/SHOEBOX/SHOEBOX_0000009958
```

Perhaps I need to become more familiar with how this works, but what would cause these? Shouldn't we be rate limiting ourselves a bit and not running in tight seemingly infinite loops?
