### PR TITLE
Remove unnecessary then clause for profile promise

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/route.js
+++ b/kifi-backend/modules/shoebox/angular/src/route.js
@@ -170,11 +170,7 @@ angular.module('kifi')
         controller: 'LibraryCtrl',
         resolve: {
           profile: ['$stateParams', 'orgProfileService', function ($stateParams, orgProfileService) {
-            return orgProfileService
-              .userOrOrg($stateParams.handle)
-              .then(function (userOrOrgData) {
-                return userOrOrgData;
-              });
+            return orgProfileService.userOrOrg($stateParams.handle);
           }],
           libraryService: 'libraryService',
           library: ['libraryService', '$stateParams', function (libraryService, $stateParams) {


### PR DESCRIPTION
@adamjgrant I saw this and the useless `.then` callback that just returns its argument was bothering me.
