### PR TITLE
3.3.70: Workaround for chrome.windows.onFocusChanged bug

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -281,14 +281,19 @@ var api = (function createApi() {
         api.tabs.on.blur.dispatch(page);
       }
     }
-    focusedWinId = winId;
+    // This is incorrect, but is a workaround for https://code.google.com/p/chromium/issues/detail?id=516740
+    // When this bug is fixed, just remove the if block wrapper below (the body stays).
+    // Behavior with this fix is to consider a window in focus if it was the last window to be in focus.
     if (winId !== chrome.windows.WINDOW_ID_NONE) {
-      if (selectedTabIds[winId]) {  // "normal" window
-        topNormalWinId = winId;
-      }
-      var page = pages[selectedTabIds[winId]];
-      if (page && httpRe.test(page.url)) {
-        api.tabs.on.focus.dispatch(page);
+      focusedWinId = winId;
+      if (focusedWinId !== chrome.windows.WINDOW_ID_NONE) {
+        if (selectedTabIds[focusedWinId]) {  // "normal" window
+          topNormalWinId = focusedWinId;
+        }
+        var page = pages[selectedTabIds[focusedWinId]];
+        if (page && httpRe.test(page.url)) {
+          api.tabs.on.focus.dispatch(page);
+        }
       }
     }
   }));

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.3.69
+version=3.3.70


### PR DESCRIPTION
@adamjgrant @cvializ @eishay @leogrim 

This fixes the user reported bug where messages are not marked as read. The issue is a Chrome bug that does not tell us when a window is focused.

I would have preferred to query the Chrome windows and checked focus, but all Chrome APIs are async, and I want to leave `isFocused` as synchronous.
