### PR TITLE
Org avatar upload api change

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -30,8 +30,9 @@ case class ScaleImageRequest(size: ImageSize) extends ProcessImageRequest {
 case class CenteredCropImageRequest(size: ImageSize) extends ProcessImageRequest {
   val operation = ProcessImageOperation.CenteredCrop
 }
-case class CropScaleImageRequest(offset: ImageOffset, cropSize: ImageSize, size: ImageSize) extends ProcessImageRequest {
+case class CropScaleImageRequest(offset: ImageOffset, cropSize: ImageSize, finalSize: ImageSize) extends ProcessImageRequest {
   val operation = ProcessImageOperation.CropScale
+  def size: ImageSize = finalSize
 }
 
 object ScaleImageRequest {

--- a/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -36,7 +36,7 @@ case class CenteredCropImageRequest(size: ImageSize) extends ProcessImageRequest
 case class CropScaleImageRequest(offset: ImageOffset, cropSize: ImageSize, finalSize: ImageSize) extends ProcessImageRequest {
   val operation = ProcessImageOperation.CropScale
   def size: ImageSize = finalSize
-  val pathFragment = s"${cropSize.width}x${cropSize.height}+${offset.x}+${offset.y}->${finalSize.width}x${finalSize.height}" + operation.fileNameSuffix
+  val pathFragment = s"${cropSize.width}x${cropSize.height}+${offset.x}+${offset.y}-${finalSize.width}x${finalSize.height}" + operation.fileNameSuffix
 }
 
 object ScaleImageRequest {

--- a/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -140,7 +140,7 @@ trait ProcessedImageHelper {
       process().map { resizedImage =>
         validateAndGetImageInfo(resizedImage).map { imageInfo =>
           val key = if (isCropScale) {
-            ImagePath(baseLabel, hash, processImageRequest.size, outFormat)
+            ImagePath(baseLabel, hash, processImageRequest, outFormat)
           } else {
             ImagePath(baseLabel, hash, ImageSize(imageInfo.width, imageInfo.height), processImageRequest.operation, outFormat)
           }

--- a/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -23,16 +23,20 @@ import scala.util.{ Failure, Success, Try }
 sealed abstract class ProcessImageRequest {
   def operation: ProcessImageOperation
   def size: ImageSize
+  def pathFragment: String
 }
 case class ScaleImageRequest(size: ImageSize) extends ProcessImageRequest {
   val operation = ProcessImageOperation.Scale
+  val pathFragment = size.width + "x" + size.height + operation.fileNameSuffix
 }
 case class CenteredCropImageRequest(size: ImageSize) extends ProcessImageRequest {
   val operation = ProcessImageOperation.CenteredCrop
+  val pathFragment = size.width + "x" + size.height + operation.fileNameSuffix
 }
 case class CropScaleImageRequest(offset: ImageOffset, cropSize: ImageSize, finalSize: ImageSize) extends ProcessImageRequest {
   val operation = ProcessImageOperation.CropScale
   def size: ImageSize = finalSize
+  val pathFragment = s"${cropSize.width}x${cropSize.height}+${offset.x}+${offset.y}->${finalSize.width}x${finalSize.height}" + operation.fileNameSuffix
 }
 
 object ScaleImageRequest {
@@ -123,6 +127,10 @@ trait ProcessedImageHelper {
     val resizedImages = sizes.map { processImageRequest =>
       log.info(s"[pih] processing images baseLabel=$baseLabel format=$outFormat to $processImageRequest")
 
+      val isCropScale = processImageRequest match {
+        case _: CropScaleImageRequest => true
+        case _ => false
+      }
       def process(): Try[File] = processImageRequest match {
         case CropScaleImageRequest(offset, cropSize, scaleSize) => photoshop.cropScaleImage(image, outFormat, offset.x, offset.y, cropSize.width, cropSize.height, scaleSize.width, scaleSize.height)
         case CenteredCropImageRequest(size) => photoshop.centeredCropImage(image, outFormat, size.width, size.height)
@@ -131,7 +139,11 @@ trait ProcessedImageHelper {
 
       process().map { resizedImage =>
         validateAndGetImageInfo(resizedImage).map { imageInfo =>
-          val key = ImagePath(baseLabel, hash, ImageSize(imageInfo.width, imageInfo.height), processImageRequest.operation, outFormat)
+          val key = if (isCropScale) {
+            ImagePath(baseLabel, hash, processImageRequest.size, outFormat)
+          } else {
+            ImagePath(baseLabel, hash, ImageSize(imageInfo.width, imageInfo.height), processImageRequest.operation, outFormat)
+          }
           ImageProcessState.ReadyToPersist(key, outFormat, resizedImage, imageInfo, processImageRequest.operation)
         }
       }.flatten match {

--- a/kifi-backend/modules/common/app/com/keepit/common/store/ImagePath.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/ImagePath.scala
@@ -1,5 +1,6 @@
 package com.keepit.common.store
 
+import com.keepit.commanders.ProcessImageRequest
 import com.keepit.model._
 import play.api.libs.json._
 
@@ -11,6 +12,11 @@ case class ImagePath(path: String) extends AnyVal {
 object ImagePath {
   def apply(prefix: String, hash: ImageHash, size: ImageSize, kind: ProcessImageOperation, format: ImageFormat): ImagePath = {
     val fileName = hash.hash + "_" + size.width + "x" + size.height + kind.fileNameSuffix + "." + format.value
+    ImagePath(prefix + "/" + fileName)
+  }
+
+  def apply(prefix: String, hash: ImageHash, process: ProcessImageRequest, format: ImageFormat): ImagePath = {
+    val fileName = hash.hash + "_" + process.pathFragment + "." + format.value
     ImagePath(prefix + "/" + fileName)
   }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/store/ImageUtils.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/store/ImageUtils.scala
@@ -14,8 +14,12 @@ import java.awt.Color
 import play.api.libs.functional.syntax._
 
 case class ImageOffset(x: Int, y: Int)
-
 case class ImageSize(width: Int, height: Int)
+case class ImageCropRegion(offset: ImageOffset, size: ImageSize)
+case class SquareImageCropRegion(offset: ImageOffset, s: Int) {
+  def size: ImageSize = ImageSize(s, s)
+}
+
 object ImageSize {
   implicit val format = (
     (__ \ 'width).format[Int] and

--- a/kifi-backend/modules/common/test/com/keepit/common/images/Image4javaWrapperTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/images/Image4javaWrapperTest.scala
@@ -195,6 +195,20 @@ class Image4javaWrapperTest extends Specification with CommonTestInjector {
       resizedInfo.height === 150
       range(imageByteSize(cropscaled), 69859)
     }
+    "cropscale a square png" in {
+      val image = getPngImage("wide_image_4x1")
+      val im = new Image4javaWrapper(Mode.Test)
+
+      val imageInfo = im.imageInfo(image).get
+      imageInfo.width === 1564
+      imageInfo.height === 391
+
+      val cropscaled = im.cropScaleImage(image, ImageFormat.PNG, x = 100, y = 50, width = 50, height = 50, finalWidth = 200, finalHeight = 200).get
+      val resizedInfo = im.imageInfo(cropscaled).get
+      resizedInfo.width === 200
+      resizedInfo.height === 200
+      range(imageByteSize(cropscaled), 29683)
+    }
 
     "optimize jpg" in {
       val image = getJpgImage("unoptimized1")

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -889,8 +889,8 @@ class LibraryCommanderImpl @Inject() (
       val canMoveFromSpace = from match {
         case OrganizationSpace(fromOrg) =>
           library.ownerId == userId
-        // TODO(ryan): when the frontend has UI for this, add it in
-        // organizationMembershipCommander.getPermissions(fromOrg, Some(userId)).contains(OrganizationPermission.REMOVE_LIBRARIES)
+          // TODO(ryan): when the frontend has UI for this, add it in
+          // organizationMembershipCommander.getPermissions(fromOrg, Some(userId)).contains(OrganizationPermission.REMOVE_LIBRARIES)
         case UserSpace(fromUser) => fromUser == userId // Can move libraries from Personal space to Organization Space.
       }
       val canMoveToSpace = to match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -889,8 +889,8 @@ class LibraryCommanderImpl @Inject() (
       val canMoveFromSpace = from match {
         case OrganizationSpace(fromOrg) =>
           library.ownerId == userId
-          // TODO(ryan): when the frontend has UI for this, add it in
-          // organizationMembershipCommander.getPermissions(fromOrg, Some(userId)).contains(OrganizationPermission.REMOVE_LIBRARIES)
+        // TODO(ryan): when the frontend has UI for this, add it in
+        // organizationMembershipCommander.getPermissions(fromOrg, Some(userId)).contains(OrganizationPermission.REMOVE_LIBRARIES)
         case UserSpace(fromUser) => fromUser == userId // Can move libraries from Personal space to Organization Space.
       }
       val canMoveToSpace = to match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationAvatarController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationAvatarController.scala
@@ -5,7 +5,7 @@ import com.keepit.commanders._
 import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper }
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.healthcheck.AirbrakeNotifier
-import com.keepit.common.store.{ ImageOffset, ImageSize }
+import com.keepit.common.store.{ SquareImageCropRegion, ImageCropRegion, ImageOffset, ImageSize }
 import com.keepit.heimdal.HeimdalContextBuilderFactory
 import com.keepit.model._
 import com.keepit.shoebox.controllers.OrganizationAccessActions
@@ -24,9 +24,10 @@ class OrganizationAvatarController @Inject() (
   private implicit val executionContext: ExecutionContext)
     extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
-  def uploadAvatar(pubId: PublicId[Organization], x: Int, y: Int, width: Int, height: Int) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION).async(parse.temporaryFile) { request =>
+  def uploadAvatar(pubId: PublicId[Organization], x: Int, y: Int, s: Int) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION).async(parse.temporaryFile) { request =>
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
-    val uploadImageF = orgAvatarCommander.persistOrganizationAvatarsFromUserUpload(request.orgId, request.body, ImageOffset(x, y), ImageSize(width, height))
+    val cropRegion = SquareImageCropRegion(ImageOffset(x, y), s)
+    val uploadImageF = orgAvatarCommander.persistOrganizationAvatarsFromUserUpload(request.orgId, request.body, cropRegion)
     uploadImageF.map {
       case Left(fail) => InternalServerError(Json.obj("error" -> fail.reason))
       case Right(hash) =>

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -528,7 +528,7 @@ POST          /site/organizations/:id/members/modify            @com.keepit.cont
 POST          /site/organizations/:id/members/remove            @com.keepit.controllers.website.OrganizationMembershipController.removeMembers(id: PublicId[Organization])
 GET           /site/organization/:id/members/suggest            @com.keepit.controllers.website.OrganizationInviteController.suggestMembers(id: PublicId[Organization], query: Option[String], limit: Int)
 GET           /site/organizations/:id/libraries                 @com.keepit.controllers.website.OrganizationController.getOrganizationLibraries(id: PublicId[Organization], offset: Int ?= 0, limit: Int ?= 20)
-POST          /site/organizations/:id/avatar/upload             @com.keepit.controllers.website.OrganizationAvatarController.uploadAvatar(id: PublicId[Organization], x: Int, y: Int, width: Int, height: Int)
+POST          /site/organizations/:id/avatar/upload             @com.keepit.controllers.website.OrganizationAvatarController.uploadAvatar(id: PublicId[Organization], x: Int, y: Int, s: Int)
 
 GET           /site/user-or-org/:handle                   @com.keepit.controllers.website.UserOrOrganizationController.getByHandle(handle: Handle)
 GET           /site/user-or-org/:handle/libraries         @com.keepit.controllers.website.UserOrOrganizationController.getLibrariesByHandle(handle: Handle, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationAvatarCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationAvatarCommanderTest.scala
@@ -117,38 +117,23 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
         val repo = inject[OrganizationAvatarRepo]
         val (_, _, org1, _) = setup()
 
-      {
-        val savedF = commander.persistOrganizationAvatarsFromUserUpload(org1.id.get, fakeFile1, cropRegion = SquareImageCropRegion(ImageOffset(0, 0), 50))
-        val saved = Await.result(savedF, Duration("10 seconds"))
-        saved must haveClass[Right[ImageStoreFailure, ImageHash]]
-        saved.right.get === ImageHash("26dbdc56d54dbc94830f7cfc85031481")
-      }
-
-        store.all.keySet.size === OrganizationAvatarConfiguration.numSizes
-
-        db.readOnlyMaster { implicit s =>
-          repo.getByOrganization(org1.id.get).length === OrganizationAvatarConfiguration.numSizes
+        val n = 20
+        for (x <- 1 to n) {
+          val savedF = commander.persistOrganizationAvatarsFromUserUpload(org1.id.get, fakeFile1, cropRegion = SquareImageCropRegion(ImageOffset(x, x), 50))
+          val saved = Await.result(savedF, Duration("10 seconds"))
+          saved must haveClass[Right[ImageStoreFailure, ImageHash]]
+          saved.right.get === ImageHash("26dbdc56d54dbc94830f7cfc85031481")
         }
 
-      {
-        val savedF = commander.persistOrganizationAvatarsFromUserUpload(org1.id.get, fakeFile2, cropRegion = SquareImageCropRegion(ImageOffset(0, 0), 50))
-        val saved = Await.result(savedF, Duration("10 seconds"))
-        saved must haveClass[Right[ImageStoreFailure, ImageHash]]
-        saved.right.get === ImageHash("1b3d95541538044c2a26598fbe1d06ae")
-        // if this test fails, make sure imagemagick is installed. Use `brew install imagemagick`
-      }
+        store.all.keySet.size === n * OrganizationAvatarConfiguration.numSizes
 
-        // All the images have been uploaded and persisted
-        store.all.keySet.size === 2 * OrganizationAvatarConfiguration.numSizes
-
-        // Only the second avatars are active
         db.readOnlyMaster { implicit s =>
+          repo.count === n * OrganizationAvatarConfiguration.numSizes
+          repo.all.map(_.imagePath).toSet.size === n * OrganizationAvatarConfiguration.numSizes
+          // Now check the actually active avatars
           repo.getByOrganization(org1.id.get).length === OrganizationAvatarConfiguration.numSizes
-          repo.count === 2 * OrganizationAvatarConfiguration.numSizes
         }
-
       }
     }
-  }
   }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationAvatarCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationAvatarCommanderTest.scala
@@ -56,7 +56,7 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
 
         // upload an image
         {
-          val savedF = commander.persistOrganizationAvatarsFromUserUpload(org1.id.get, fakeFile1, offset = ImageOffset(0, 0), cropSize = ImageSize(50, 50))
+          val savedF = commander.persistOrganizationAvatarsFromUserUpload(org1.id.get, fakeFile1, cropRegion = SquareImageCropRegion(ImageOffset(0, 0), 50))
           val saved = Await.result(savedF, Duration("10 seconds"))
           saved must haveClass[Right[ImageStoreFailure, ImageHash]]
           saved.right.get === ImageHash("26dbdc56d54dbc94830f7cfc85031481")
@@ -79,7 +79,7 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
         val (_, _, org1, _) = setup()
 
         {
-          val savedF = commander.persistOrganizationAvatarsFromUserUpload(org1.id.get, fakeFile1, offset = ImageOffset(0, 0), cropSize = ImageSize(50, 50))
+          val savedF = commander.persistOrganizationAvatarsFromUserUpload(org1.id.get, fakeFile1, cropRegion = SquareImageCropRegion(ImageOffset(0, 0), 50))
           val saved = Await.result(savedF, Duration("10 seconds"))
           saved must haveClass[Right[ImageStoreFailure, ImageHash]]
           saved.right.get === ImageHash("26dbdc56d54dbc94830f7cfc85031481")
@@ -92,7 +92,7 @@ class OrganizationAvatarCommanderTest extends Specification with ShoeboxTestInje
         }
 
         {
-          val savedF = commander.persistOrganizationAvatarsFromUserUpload(org1.id.get, fakeFile2, offset = ImageOffset(0, 0), cropSize = ImageSize(50, 50))
+          val savedF = commander.persistOrganizationAvatarsFromUserUpload(org1.id.get, fakeFile2, cropRegion = SquareImageCropRegion(ImageOffset(0, 0), 50))
           val saved = Await.result(savedF, Duration("10 seconds"))
           saved must haveClass[Right[ImageStoreFailure, ImageHash]]
           saved.right.get === ImageHash("1b3d95541538044c2a26598fbe1d06ae")

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationAvatarControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationAvatarControllerTest.scala
@@ -57,7 +57,7 @@ class OrganizationAvatarControllerTest extends Specification with ShoeboxTestInj
           val result = inject[OrganizationAvatarController].uploadAvatar(pubId, 15, 23, 50)(request)
 
           status(result) === OK
-          Json.parse(contentAsString(result)) === Json.parse("""{"uploaded": "oa/26dbdc56d54dbc94830f7cfc85031481_200x200_cs.png"}""")
+          Json.parse(contentAsString(result)) === Json.parse("""{"uploaded": "oa/26dbdc56d54dbc94830f7cfc85031481_50x50+15+23->200x200_cs.png"}""")
 
           inject[OrganizationAvatarCommander].getBestImage(org.id.get, OrganizationAvatarConfiguration.defaultSize) must haveClass[Some[OrganizationAvatar]]
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationAvatarControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationAvatarControllerTest.scala
@@ -52,9 +52,9 @@ class OrganizationAvatarControllerTest extends Specification with ShoeboxTestInj
           val pubId = Organization.publicId(org.id.get)
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val route = com.keepit.controllers.website.routes.OrganizationAvatarController.uploadAvatar(pubId, 0, 0, 50, 50)
+          val route = com.keepit.controllers.website.routes.OrganizationAvatarController.uploadAvatar(pubId, 15, 23, 50)
           val request = FakeRequest(route.method, route.url).withBody(fakeFile)
-          val result = inject[OrganizationAvatarController].uploadAvatar(pubId, 0, 0, 50, 50)(request)
+          val result = inject[OrganizationAvatarController].uploadAvatar(pubId, 15, 23, 50)(request)
 
           status(result) === OK
           Json.parse(contentAsString(result)) === Json.parse("""{"uploaded": "oa/26dbdc56d54dbc94830f7cfc85031481_200x200_cs.png"}""")
@@ -68,9 +68,9 @@ class OrganizationAvatarControllerTest extends Specification with ShoeboxTestInj
           val pubId = Organization.publicId(org.id.get)
 
           inject[FakeUserActionsHelper].setUser(rando)
-          val route = com.keepit.controllers.website.routes.OrganizationAvatarController.uploadAvatar(pubId, 0, 0, 50, 50)
+          val route = com.keepit.controllers.website.routes.OrganizationAvatarController.uploadAvatar(pubId, 15, 23, 50)
           val request = FakeRequest(route.method, route.url).withBody(fakeFile)
-          val result = inject[OrganizationAvatarController].uploadAvatar(pubId, 0, 0, 50, 50)(request)
+          val result = inject[OrganizationAvatarController].uploadAvatar(pubId, 15, 23, 50)(request)
 
           status(result) === FORBIDDEN
           inject[OrganizationAvatarCommander].getBestImage(org.id.get, OrganizationAvatarConfiguration.defaultSize).isEmpty === true

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationAvatarControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationAvatarControllerTest.scala
@@ -57,7 +57,7 @@ class OrganizationAvatarControllerTest extends Specification with ShoeboxTestInj
           val result = inject[OrganizationAvatarController].uploadAvatar(pubId, 15, 23, 50)(request)
 
           status(result) === OK
-          Json.parse(contentAsString(result)) === Json.parse("""{"uploaded": "oa/26dbdc56d54dbc94830f7cfc85031481_50x50+15+23->200x200_cs.png"}""")
+          Json.parse(contentAsString(result)) === Json.parse("""{"uploaded": "oa/26dbdc56d54dbc94830f7cfc85031481_50x50+15+23-200x200_cs.png"}""")
 
           inject[OrganizationAvatarCommander].getBestImage(org.id.get, OrganizationAvatarConfiguration.defaultSize) must haveClass[Some[OrganizationAvatar]]
         }


### PR DESCRIPTION
Org avatar uploads now take 3 `GET` parameters: `(x, y, s)`, defining an `s` by `s` box at position `(x,y)` in the image. That box is first cropped out of the image, then scaled to a couple of useful sizes on the backend (`100x100` and `200x200` currently).
