### PR TITLE
Fix height of Create Library icon-card

### DIFF
--- a/packrat/styles/keeper/keep_box.less
+++ b/packrat/styles/keeper/keep_box.less
@@ -446,14 +446,14 @@
 
 .kifi-create .kifi-keep-box-lib-card {
   width: 20px;
-  height: 20px;
+  height: 28px;
 
   .kifi-keep-box-lib-icon {
     @url: %(@svgLibCardPlusDataUrl, #fff, #fff);
     display: block;
     background: url(@url) center/10px 10px no-repeat;
     width: 20px;
-    height: 20px;
+    height: 28px;
   }
 }
 


### PR DESCRIPTION
I made a change that made the icon-card square (20px by 20px), but it needs to be library-card dimensions (20px by 28px).
