### PR TITLE
Make sure org member candidates are deactivated

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -38,6 +38,7 @@ class OrganizationCommanderImpl @Inject() (
     orgRepo: OrganizationRepo,
     orgMembershipRepo: OrganizationMembershipRepo,
     orgMembershipCommander: OrganizationMembershipCommander,
+    organizationMembershipCandidateRepo: OrganizationMembershipCandidateRepo,
     orgInviteRepo: OrganizationInviteRepo,
     organizationAvatarCommander: OrganizationAvatarCommander,
     userRepo: UserRepo,
@@ -263,6 +264,9 @@ class OrganizationCommanderImpl @Inject() (
 
           val memberships = orgMembershipRepo.getAllByOrgId(org.id.get)
           memberships.foreach { membership => orgMembershipRepo.deactivate(membership) }
+
+          val membershipCandidates = organizationMembershipCandidateRepo.getAllByOrgId(org.id.get)
+          membershipCandidates.foreach { mc => organizationMembershipCandidateRepo.deactivate(mc) }
 
           val invites = orgInviteRepo.getAllByOrganization(org.id.get)
           invites.foreach(orgInviteRepo.deactivate)


### PR DESCRIPTION
When an org is deleted, all of its org member candidates also need to be
deactivated. Otherwise when an admin visits their page it will look up their
candidacies and try to load the associated org (despite the org being
inactive).
