### PR TITLE
Make LibraryCommanderTest actually test sort order

### DIFF
--- a/kifi-backend/modules/common/test/com/keepit/model/LibraryFactory.scala
+++ b/kifi-backend/modules/common/test/com/keepit/model/LibraryFactory.scala
@@ -3,6 +3,7 @@ package com.keepit.model
 import java.util.concurrent.atomic.AtomicLong
 
 import com.keepit.common.db.{ ExternalId, Id, State }
+import com.keepit.common.mail.EmailAddress
 import com.keepit.common.time._
 import com.keepit.model.LibraryVisibility.{ ORGANIZATION, PUBLISHED, SECRET, DISCOVERABLE }
 import org.apache.commons.lang3.RandomStringUtils.random
@@ -20,11 +21,13 @@ object LibraryFactory {
   case class PartialLibrary private[LibraryFactory] (
       library: Library,
       followers: Seq[User] = Seq.empty[User],
-      collaborators: Seq[User] = Seq.empty[User]) {
+      collaborators: Seq[User] = Seq.empty[User],
+      invitedUsers: Seq[User] = Seq.empty[User],
+      invitedEmails: Seq[EmailAddress] = Seq.empty[EmailAddress]) {
     def withId(id: Id[Library]) = this.copy(library = library.copy(id = Some(id)))
     def withId(id: Int) = this.copy(library = library.copy(id = Some(Id[Library](id))))
-    def withUser(id: Id[User]) = this.copy(library = library.copy(ownerId = id))
-    def withUser(user: User) = this.copy(library = library.copy(ownerId = user.id.get))
+    def withOwner(id: Id[User]) = this.copy(library = library.copy(ownerId = id))
+    def withOwner(user: User) = this.copy(library = library.copy(ownerId = user.id.get))
     def withMemberCount(memberCount: Int) = this.copy(library = library.copy(memberCount = memberCount, lastKept = Some(currentDateTime)))
     def withKeepCount(keepCount: Int) = this.copy(library = library.copy(keepCount = keepCount))
     def withName(name: String) = this.copy(library = library.copy(name = name))
@@ -43,8 +46,10 @@ object LibraryFactory {
     def withOrganizationIdOpt(id: Option[Id[Organization]]) = this.copy(library = library.copy(organizationId = id))
     def withOrganization(org: Organization) = this.copy(library = library.copy(organizationId = Some(org.id.get)))
 
-    def withFollowers(users: Seq[User]) = this.copy(followers = followers ++ users)
-    def withCollaborators(users: Seq[User]) = this.copy(collaborators = collaborators ++ users)
+    def withFollowers(users: Seq[User]) = this.copy(followers = users)
+    def withCollaborators(users: Seq[User]) = this.copy(collaborators = users)
+    def withInvitedUsers(users: Seq[User]) = this.copy(invitedUsers = users)
+    def withInvitedEmails(emails: Seq[EmailAddress]) = this.copy(invitedEmails = emails)
 
     def get: Library = library
   }

--- a/kifi-backend/modules/common/test/com/keepit/model/LibraryInviteFactory.scala
+++ b/kifi-backend/modules/common/test/com/keepit/model/LibraryInviteFactory.scala
@@ -26,6 +26,7 @@ object LibraryInviteFactory {
     def toUser(id: Int) = new PartialLibraryInvite(invitation.copy(userId = Some(Id[User](id))))
     def toUser(id: Id[User]) = new PartialLibraryInvite(invitation.copy(userId = Some(id)))
     def toUser(user: User) = new PartialLibraryInvite(invitation.copy(userId = Some(user.id.get)))
+    def toEmail(email: EmailAddress) = new PartialLibraryInvite(invitation.copy(userId = None, emailAddress = Some(email)))
     def withState(state: State[LibraryInvite]) = new PartialLibraryInvite(invitation.copy(state = state))
     def get: LibraryInvite = invitation
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/ActivityPushTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/ActivityPushTest.scala
@@ -43,7 +43,7 @@ class ActivityPushTest extends Specification with ShoeboxTestInjector {
           user().saved
           user().saved
           user().saved
-          val lib1 = library().withUser(user1).saved
+          val lib1 = library().withOwner(user1).saved
           keep().withLibrary(lib1).saved
           repo.all().size === 0
           repo.getByUser(user1.id.get) === None

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepToLibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepToLibraryCommanderTest.scala
@@ -25,10 +25,10 @@ class KeepToLibraryCommanderTest extends TestKitSupport with SpecificationLike w
         withDb(modules: _*) { implicit injector =>
           val (user, keep, otherLib) = db.readWrite { implicit session =>
             val user = UserFactory.user().saved
-            val userLib = LibraryFactory.library().withUser(user).saved
+            val userLib = LibraryFactory.library().withOwner(user).saved
             val keep = KeepFactory.keep().withLibrary(userLib).saved
 
-            val otherLib = LibraryFactory.library().withUser(user).saved
+            val otherLib = LibraryFactory.library().withOwner(user).saved
             (user, keep, otherLib)
           }
 
@@ -47,14 +47,14 @@ class KeepToLibraryCommanderTest extends TestKitSupport with SpecificationLike w
         withDb(modules: _*) { implicit injector =>
           val (user, keep, libs) = db.readWrite { implicit session =>
             val user = UserFactory.user().saved
-            val userLib = LibraryFactory.library().withUser(user).saved
+            val userLib = LibraryFactory.library().withOwner(user).saved
             val keep = KeepFactory.keep().withLibrary(userLib).saved
 
             val rando = UserFactory.user().saved
             val randoOrg = OrganizationFactory.organization().withOwner(rando).saved
-            val randoSecretLib = LibraryFactory.library().withUser(rando).secret().saved
-            val randoPublicLib = LibraryFactory.library().withUser(rando).published().saved
-            val randoOrgLib = LibraryFactory.library().withUser(rando).withOrganization(randoOrg).orgVisible().saved
+            val randoSecretLib = LibraryFactory.library().withOwner(rando).secret().saved
+            val randoPublicLib = LibraryFactory.library().withOwner(rando).published().saved
+            val randoOrgLib = LibraryFactory.library().withOwner(rando).withOrganization(randoOrg).orgVisible().saved
             (user, keep, Seq(randoPublicLib, randoSecretLib, randoOrgLib))
           }
 
@@ -71,7 +71,7 @@ class KeepToLibraryCommanderTest extends TestKitSupport with SpecificationLike w
           val (user1, user2, keep, lib) = db.readWrite { implicit session =>
             val user1 = UserFactory.user().saved
             val user2 = UserFactory.user().saved
-            val lib = LibraryFactory.library().withUser(user1).withCollaborators(Seq(user2)).saved
+            val lib = LibraryFactory.library().withOwner(user1).withCollaborators(Seq(user2)).saved
             val keep = KeepFactory.keep().withUser(user1).withLibrary(lib).saved
             (user1, user2, keep, lib)
           }
@@ -94,7 +94,7 @@ class KeepToLibraryCommanderTest extends TestKitSupport with SpecificationLike w
         withDb(modules: _*) { implicit injector =>
           val (user, keep, userLib) = db.readWrite { implicit session =>
             val user = UserFactory.user().saved
-            val userLib = LibraryFactory.library().withUser(user).saved
+            val userLib = LibraryFactory.library().withOwner(user).saved
             val keep = KeepFactory.keep().withUser(user).withLibrary(userLib).saved
             (user, keep, userLib)
           }
@@ -109,14 +109,14 @@ class KeepToLibraryCommanderTest extends TestKitSupport with SpecificationLike w
         withDb(modules: _*) { implicit injector =>
           val (user, keep, libs) = db.readWrite { implicit session =>
             val user = UserFactory.user().saved
-            val userLib = LibraryFactory.library().withUser(user).saved
+            val userLib = LibraryFactory.library().withOwner(user).saved
             val keep = KeepFactory.keep().withUser(user).withLibrary(userLib).saved
 
             val rando = UserFactory.user().saved
             val randoOrg = OrganizationFactory.organization().withOwner(rando).saved
-            val randoSecretLib = LibraryFactory.library().withUser(rando).secret().saved
-            val randoPublicLib = LibraryFactory.library().withUser(rando).published().saved
-            val randoOrgLib = LibraryFactory.library().withUser(rando).withOrganization(randoOrg).orgVisible().saved
+            val randoSecretLib = LibraryFactory.library().withOwner(rando).secret().saved
+            val randoPublicLib = LibraryFactory.library().withOwner(rando).published().saved
+            val randoOrgLib = LibraryFactory.library().withOwner(rando).withOrganization(randoOrg).orgVisible().saved
             (user, keep, Seq(randoPublicLib, randoSecretLib, randoOrgLib))
           }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -30,11 +30,13 @@ import com.keepit.model._
 import com.keepit.search.FakeSearchServiceClientModule
 import com.keepit.social.BasicUser
 import com.keepit.test.{ ShoeboxTestFactory, ShoeboxTestInjector }
+import org.apache.commons.lang3.RandomStringUtils
 import org.joda.time.DateTime
 import org.specs2.mutable.SpecificationLike
 
 import scala.concurrent._
 import scala.concurrent.duration.Duration
+import scala.util.Random
 
 class LibraryCommanderTest extends TestKitSupport with SpecificationLike with ShoeboxTestInjector {
   implicit val context = HeimdalContext.empty
@@ -49,6 +51,29 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
     FakeElizaServiceClientModule(),
     FakeHeimdalServiceClientModule()
   )
+
+  def randomEmails(n: Int): Seq[EmailAddress] = {
+    (for (i <- 1 to 20) yield {
+      RandomStringUtils.randomAlphabetic(15) + "@" + RandomStringUtils.randomAlphabetic(5) + ".com"
+    }).toSeq.map(EmailAddress(_))
+  }
+  // Fill the system with a bunch of garbage
+  def fillWithGarbage()(implicit injector: Injector, session: RWSession): Unit = {
+    val n = 5
+    for (i <- 1 to n) {
+      val orgOwner = UserFactory.user().saved
+      val libOwners = UserFactory.users(n).saved
+      val collaborators = UserFactory.users(20).saved
+      val followers = UserFactory.users(20).saved
+      val invitedUsers = UserFactory.users(20).saved
+      val invitedEmails = randomEmails(20)
+      val org = OrganizationFactory.organization().withOwner(orgOwner).withMembers(libOwners ++ collaborators).withInvitedUsers(followers).saved
+      for (lo <- libOwners) {
+        LibraryFactory.library().withOwner(lo).withCollaborators(collaborators).withFollowers(followers).withInvitedUsers(invitedUsers).withInvitedEmails(invitedEmails).saved
+        LibraryFactory.library().withOwner(lo).withCollaborators(collaborators).withFollowers(followers).withInvitedUsers(invitedUsers).withInvitedEmails(invitedEmails).withOrganization(org).saved
+      }
+    }
+  }
 
   def setupUsers()(implicit injector: Injector) = {
     val t1 = new DateTime(2014, 7, 4, 12, 0, 0, 0, DEFAULT_DATE_TIME_ZONE)
@@ -82,9 +107,9 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
     val t1 = new DateTime(2014, 8, 1, 1, 0, 0, 0, DEFAULT_DATE_TIME_ZONE)
     val t2 = new DateTime(2014, 8, 1, 1, 0, 0, 1, DEFAULT_DATE_TIME_ZONE)
     val (libShield, libMurica, libScience) = db.readWrite { implicit s =>
-      val libShield = library().withUser(userAgent).withName("Avengers Missions").withSlug("avengers").secret().saved
-      val libMurica = library().withUser(userCaptain).withName("MURICA").withSlug("murica").published().saved
-      val libScience = library().withUser(userIron).withName("Science & Stuff").withSlug("science").discoverable().saved
+      val libShield = library().withOwner(userAgent).withName("Avengers Missions").withSlug("avengers").secret().saved
+      val libMurica = library().withOwner(userCaptain).withName("MURICA").withSlug("murica").published().saved
+      val libScience = library().withOwner(userIron).withName("Science & Stuff").withSlug("science").discoverable().saved
       (libShield, libMurica, libScience)
     }
     db.readOnlyMaster { implicit s =>
@@ -437,7 +462,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             val ironMan = UserFactory.user().withName("Tony", "Stark").withUsername("ironman").saved
             val earthOrg = OrganizationFactory.organization().withName("Earth").withOwner(captainPlanet).withMembers(Seq(ironMan)).saved
             val starkOrg = OrganizationFactory.organization().withName("Stark Towers").withOwner(ironMan).saved
-            val ironLib = LibraryFactory.library().withName("Hero Stuff").withSlug("herostuff").withUser(ironMan).saved
+            val ironLib = LibraryFactory.library().withName("Hero Stuff").withSlug("herostuff").withOwner(ironMan).saved
             (ironMan, earthOrg, starkOrg, ironLib)
           }
 
@@ -661,7 +686,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
         val (user, newLibrary, organization, otherOrg) = db.readWrite { implicit s =>
           val orgOwner = UserFactory.user().withName("Bruce", "Lee").saved
           val user: User = UserFactory.user().withName("Jackie", "Chan").saved
-          val newLibrary = library().withUser(user).withVisibility(LibraryVisibility.ORGANIZATION).saved
+          val newLibrary = library().withOwner(user).withVisibility(LibraryVisibility.ORGANIZATION).saved
           val organization = orgRepo.save(Organization(name = "Kung Fu Academy", ownerId = orgOwner.id.get, primaryHandle = None, description = None, site = None))
           val otherOrg = orgRepo.save(Organization(name = "Martial Arts", ownerId = orgOwner.id.get, primaryHandle = None, description = None, site = None))
           orgMemberRepo.save(organization.newMembership(userId = user.id.get, role = OrganizationRole.ADMIN))
@@ -709,7 +734,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           val barry = UserFactory.user().withName("Barry", "Allen").withUsername("The Flash").saved
           val starLabsOrg = orgRepo.save(Organization(name = "Star Labs", ownerId = harrison.id.get, primaryHandle = None, description = None, site = None))
-          val starLabsLib = library().withUser(harrison).withVisibility(LibraryVisibility.ORGANIZATION).withOrganizationIdOpt(starLabsOrg.id).saved
+          val starLabsLib = library().withOwner(harrison).withVisibility(LibraryVisibility.ORGANIZATION).withOrganizationIdOpt(starLabsOrg.id).saved
 
           val membership = orgMemberRepo.save(starLabsOrg.newMembership(userId = barry.id.get, role = OrganizationRole.MEMBER))
 
@@ -984,7 +1009,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             val owner = UserFactory.user().saved
             val member = UserFactory.user().saved
             val org = OrganizationFactory.organization().withOwner(owner).withMembers(Seq(member)).saved
-            val lib = LibraryFactory.library().withUser(owner).withOrganizationIdOpt(Some(org.id.get)).withVisibility(LibraryVisibility.ORGANIZATION).saved
+            val lib = LibraryFactory.library().withOwner(owner).withOrganizationIdOpt(Some(org.id.get)).withVisibility(LibraryVisibility.ORGANIZATION).saved
             (org, owner, member, lib)
           }
 
@@ -1004,7 +1029,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             val owner = UserFactory.user().saved
             val rando = UserFactory.user().saved
             val org = OrganizationFactory.organization().withOwner(owner).saved
-            val lib = LibraryFactory.library().withUser(owner).withOrganizationIdOpt(Some(org.id.get)).withVisibility(LibraryVisibility.ORGANIZATION).saved
+            val lib = LibraryFactory.library().withOwner(owner).withOrganizationIdOpt(Some(org.id.get)).withVisibility(LibraryVisibility.ORGANIZATION).saved
             (org, owner, rando, lib)
           }
 
@@ -1496,23 +1521,57 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
       }
     }
 
-    "get library members" in {
-      withDb(modules: _*) { implicit injector =>
-        val (userIron, userCaptain, userAgent, userHulk, libShield, libMurica, libScience) = setupAcceptedInvites
-        db.readWrite { implicit s =>
-          libraryInviteRepo.save(LibraryInvite(libraryId = libMurica.id.get, inviterId = userCaptain.id.get, emailAddress = Some(EmailAddress("thor@asgard.com")), access = LibraryAccess.READ_ONLY))
-          val memberCounts = libraryMembershipRepo.countWithLibraryIdByAccess(libMurica.id.get)
-          memberCounts.owner === 1
-          memberCounts.readOnly === 2
-          memberCounts.readWrite === 0
+    "build a list of a library's members and invitees" in {
+      "get library members" in {
+        withDb(modules: _*) { implicit injector =>
+          val libraryCommander = inject[LibraryCommander]
+          val (lib, memberships, users) = db.readWrite { implicit s =>
+            fillWithGarbage()
+            val users = Random.shuffle(UserFactory.users(100).saved)
+            val (owner, rest) = (users.head, users.tail)
+            val (collaborators, followers) = rest.splitAt(20)
+            val lib = LibraryFactory.library().published().withOwner(owner).withCollaborators(collaborators).withFollowers(followers).saved
+            val memberships = inject[LibraryMembershipRepo].getWithLibraryId(lib.id.get)
+            (lib, memberships, users)
+          }
+
+          val usersById = users.map(u => u.id.get -> u).toMap
+          def metric(lm: LibraryMembership) = {
+            val user = usersById(lm.userId) // right now we don't use user info at all to sort
+            // LibraryAccess has higher priorities first
+            (-lm.access.priority, lm.id)
+          }
+
+          val canonical = memberships.sortBy(metric).tail // always drop the owner
+          val extToIntMap = users.map(u => u.externalId -> u.id.get).toMap
+          val members = libraryCommander.getLibraryMembersAndInvitees(lib.id.get, 10, 50, false).map(_.member.left.get)
+
+          val expected = canonical.drop(10).take(50)
+          members.map(bu => extToIntMap(bu.externalId)) === expected.map(_.userId)
         }
-        val libraryCommander = inject[LibraryCommander]
-        val maybeMembers = libraryCommander.getLibraryMembersAndInvitees(libMurica.id.get, 0, 10, true).map(_.member)
-        val userIds = maybeMembers.collect { case Left(x) => x }.map(_.externalId)
-        val emails = maybeMembers.collect { case Right(x) => x }.map(_.email)
-        // collaborators
-        userIds === Seq(userIron.externalId, userAgent.externalId, userHulk.externalId)
-        emails === Seq(EmailAddress("thor@asgard.com"))
+      }
+      "get library invitees" in {
+        withDb(modules: _*) { implicit injector =>
+          val libraryCommander = inject[LibraryCommander]
+          val (lib, invites, emails) = db.readWrite { implicit s =>
+            fillWithGarbage()
+            val owner = UserFactory.user().saved
+            val emails = randomEmails(100)
+            val lib = LibraryFactory.library().withOwner(owner).withInvitedEmails(emails).saved
+            val invites = inject[LibraryInviteRepo].getByLibraryIdAndInviterId(lib.id.get, owner.id.get)
+            (lib, invites, emails)
+          }
+
+          def metric(inv: LibraryInvite) = {
+            // LibraryAccess has higher priorities first
+            (-inv.access.priority, inv.id.get.id)
+          }
+
+          val canonical = invites.sortBy(metric)
+          val libraryInvites = libraryCommander.getLibraryMembersAndInvitees(lib.id.get, 10, 50, fillInWithInvites = true).map(_.member.right.get)
+          val expected = canonical.drop(10).take(50)
+          libraryInvites.map(bc => bc.email) === expected.map(_.emailAddress.get)
+        }
       }
     }
 
@@ -1548,9 +1607,9 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
     "query recent top libraries for an owner" in {
       withDb(modules: _*) { implicit injector =>
         db.readWrite { implicit s =>
-          library().withUser(Id[User](1)).withId(1).saved
-          library().withUser(Id[User](1)).withId(2).saved
-          library().withUser(Id[User](2)).withId(3).saved
+          library().withOwner(Id[User](1)).withId(1).saved
+          library().withOwner(Id[User](1)).withId(2).saved
+          library().withOwner(Id[User](2)).withId(3).saved
           membership().withLibraryFollower(Id[Library](1), Id[User](2)).saved
           membership().withLibraryFollower(Id[Library](1), Id[User](3)).saved
           membership().withLibraryFollower(Id[Library](2), Id[User](3)).saved
@@ -1568,7 +1627,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           val user2 = user().withUsername("quicksilver").saved
           val user3 = user().withUsername("scarletwitch").saved
           val user4 = user().withUsername("somerandomshieldagent").saved
-          val lib1 = library().withUser(user1).saved // user1 owns lib1
+          val lib1 = library().withOwner(user1).saved // user1 owns lib1
           membership().withLibraryCollaborator(lib1, user2).saved // user2 is a collaborator lib1 (has read_write access)
           membership().withLibraryFollower(lib1, user3).saved // user3 is a follower to lib1 (has read_only access)
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
@@ -44,9 +44,9 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
           val owner = UserFactory.user().withName("Owner", "McOwnerson").saved
           val nonMember = UserFactory.user().withName("Rando", "McRanderson").saved
           val org = OrganizationFactory.organization().withName("Test Org").withOwner(owner).saved
-          val publicLibs = LibraryFactory.libraries(10).map(_.withUser(owner).withVisibility(LibraryVisibility.PUBLISHED).withOrganizationIdOpt(Some(org.id.get))).saved
-          val orgLibs = LibraryFactory.libraries(20).map(_.withUser(owner).withVisibility(LibraryVisibility.ORGANIZATION).withOrganizationIdOpt(Some(org.id.get))).saved
-          val deletedLibs = LibraryFactory.libraries(15).map(_.withUser(owner).withVisibility(LibraryVisibility.ORGANIZATION).withOrganizationIdOpt(Some(org.id.get))).saved.map(_.deleted)
+          val publicLibs = LibraryFactory.libraries(10).map(_.withOwner(owner).withVisibility(LibraryVisibility.PUBLISHED).withOrganizationIdOpt(Some(org.id.get))).saved
+          val orgLibs = LibraryFactory.libraries(20).map(_.withOwner(owner).withVisibility(LibraryVisibility.ORGANIZATION).withOrganizationIdOpt(Some(org.id.get))).saved
+          val deletedLibs = LibraryFactory.libraries(15).map(_.withOwner(owner).withVisibility(LibraryVisibility.ORGANIZATION).withOrganizationIdOpt(Some(org.id.get))).saved.map(_.deleted)
           (org, owner, nonMember, publicLibs, orgLibs, deletedLibs)
         }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/RecommendationsCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/RecommendationsCommanderTest.scala
@@ -111,9 +111,9 @@ class RecommendationsCommanderTest extends Specification with ShoeboxTestInjecto
       userRepo.count === 2
     }
     val (libMurica, libScience, libIron) = db.readWrite { implicit s =>
-      val libMurica = library().withUser(userCaptain).withName("MURICA").withSlug("murica").published().saved
-      val libScience = library().withUser(userCaptain).withName("Science & Stuff").withSlug("science").published().saved
-      val libIron = library().withUser(userIron).withName("Iron Working").withSlug("iron").published().saved
+      val libMurica = library().withOwner(userCaptain).withName("MURICA").withSlug("murica").published().saved
+      val libScience = library().withOwner(userCaptain).withName("Science & Stuff").withSlug("science").published().saved
+      val libIron = library().withOwner(userIron).withName("Iron Working").withSlug("iron").published().saved
       (libMurica, libScience, libIron)
     }
     db.readOnlyMaster { implicit s =>
@@ -203,9 +203,9 @@ class RecommendationsCommanderTest extends Specification with ShoeboxTestInjecto
             val owner = user().saved
             (
               user().saved,
-              library().withUser(owner).withName("Scala").published().saved,
-              library().withUser(owner).withName("Secret").saved, // secret - shouldn't be a reco
-              library().withUser(owner).withName("Java").published().saved
+              library().withOwner(owner).withName("Scala").published().saved,
+              library().withOwner(owner).withName("Secret").saved, // secret - shouldn't be a reco
+              library().withOwner(owner).withName("Java").published().saved
             )
           }
           db.readWrite { implicit rw =>
@@ -273,7 +273,7 @@ class RecommendationsCommanderTest extends Specification with ShoeboxTestInjecto
           val uriRepo = inject[NormalizedURIRepo]
 
           db.readWrite { implicit s =>
-            library().withUser(Id[User](1)).withName("scala").withSlug("scala").published().withColor(LibraryColor.BLUE).saved
+            library().withOwner(Id[User](1)).withName("scala").withSlug("scala").published().withColor(LibraryColor.BLUE).saved
             uriRepo.save(NormalizedURI(title = Some("scala 101"), url = "http://scala101.org", urlHash = UrlHash("xyz"), state = NormalizedURIStates.SCRAPED, externalId = ExternalId[NormalizedURI]("367f1d08-9dfe-43cb-8d60-d39482b00fb7")))
             user().withName("Martin", "Odersky").withUsername("Martin Odersky").withPictureName("cool").withId(ExternalId[User]("786171c5-f0db-4221-b655-e6aeb9a848f6")).saved
           }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/UserProfileCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/UserProfileCommanderTest.scala
@@ -58,30 +58,30 @@ class UserProfileCommanderTest extends Specification with ShoeboxTestInjector {
         val owner = user().saved
         val other = user().saved
 
-        val libPublishedLots = library().withUser(owner).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withMemberCount(50).withSlug("published-lots").saved
-        val libPublishedFew = library().withUser(owner).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withMemberCount(3).withSlug("published-few").saved
-        val libPublishedFewUpdated = library().withUser(owner).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withMemberCount(3).withLastKept().withSlug("published-few-updated").saved
-        val libPublishedEmpty = library().withUser(owner).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(0).withSlug("published-empty").saved
+        val libPublishedLots = library().withOwner(owner).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withMemberCount(50).withSlug("published-lots").saved
+        val libPublishedFew = library().withOwner(owner).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withMemberCount(3).withSlug("published-few").saved
+        val libPublishedFewUpdated = library().withOwner(owner).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withMemberCount(3).withLastKept().withSlug("published-few-updated").saved
+        val libPublishedEmpty = library().withOwner(owner).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(0).withSlug("published-empty").saved
 
         // a library `owner` has, with another collaborator
-        val libPublishedCollabWithMe = library().withUser(owner).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withMemberCount(2).withSlug("published-collab-with-me").saved
+        val libPublishedCollabWithMe = library().withOwner(owner).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withMemberCount(2).withSlug("published-collab-with-me").saved
         membership().withLibraryCollaborator(libPublishedCollabWithMe, other).saved
         // a library owned by someone else, but `owner` collaborates with
-        val libPublishedCollabWithOther = library().withUser(other).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withMemberCount(2).withSlug("published-collab-with-other").saved
+        val libPublishedCollabWithOther = library().withOwner(other).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withMemberCount(2).withSlug("published-collab-with-other").saved
         membership().withLibraryCollaborator(libPublishedCollabWithOther, owner).saved
 
-        val libPublishedHidden = library().withUser(owner).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withSlug("published-hidden").saved
+        val libPublishedHidden = library().withOwner(owner).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withSlug("published-hidden").saved
         libraryMembershipRepo.getWithLibraryIdAndUserId(libPublishedHidden.id.get, owner.id.get).map { mem =>
           libraryMembershipRepo.save(mem.copy(listed = false))
         }
 
-        val libPrivate = library().withUser(owner).withVisibility(LibraryVisibility.SECRET).withKeepCount(3).withSlug("private").saved
-        val libPrivateFollower = library().withUser(owner).withVisibility(LibraryVisibility.SECRET).withKeepCount(3).withMemberCount(2).withSlug("private-follower").saved
+        val libPrivate = library().withOwner(owner).withVisibility(LibraryVisibility.SECRET).withKeepCount(3).withSlug("private").saved
+        val libPrivateFollower = library().withOwner(owner).withVisibility(LibraryVisibility.SECRET).withKeepCount(3).withMemberCount(2).withSlug("private-follower").saved
         membership().withLibraryFollower(libPrivateFollower, other).saved
-        val libPrivateCollab = library().withUser(owner).withVisibility(LibraryVisibility.SECRET).withKeepCount(3).withMemberCount(2).withSlug("private-collab").saved
+        val libPrivateCollab = library().withOwner(owner).withVisibility(LibraryVisibility.SECRET).withKeepCount(3).withMemberCount(2).withSlug("private-collab").saved
         membership().withLibraryCollaborator(libPrivateCollab, other).saved
 
-        val wrongLib = library().withUser(other).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withSlug("wrong-library").saved
+        val wrongLib = library().withOwner(other).withVisibility(LibraryVisibility.PUBLISHED).withKeepCount(3).withSlug("wrong-library").saved
 
         val ownerLibs = Seq(
           libPublishedLots, // published library (lots of followers) - test ordering
@@ -127,8 +127,8 @@ class UserProfileCommanderTest extends Specification with ShoeboxTestInjector {
     withDb(modules: _*) { implicit injector =>
       db.readWrite { implicit s =>
         val libs = libraries(5)
-        val user1 = libs.take(3).map { _.withUser(Id[User](1)).published() }.saved
-        val user2 = libs.drop(3).map { _.withUser(Id[User](2)).published() }.saved
+        val user1 = libs.take(3).map { _.withOwner(Id[User](1)).published() }.saved
+        val user2 = libs.drop(3).map { _.withOwner(Id[User](2)).published() }.saved
       }
 
       db.readOnlyMaster { implicit s =>
@@ -150,13 +150,13 @@ class UserProfileCommanderTest extends Specification with ShoeboxTestInjector {
         val user1 = user().saved
         val user2 = user().saved
         val user3 = user().saved
-        val lib1 = libraries(2).map(_.published().withUser(user1)).saved.head.savedInvitation(user2)
-        val lib2 = libraries(2).map(_.secret().withUser(user1)).saved.head.savedInvitation(user2).savedInvitation(user3)
-        val lib3 = libraries(2).map(_.published().withUser(user2)).saved.head.savedInvitation(user1)
-        invite().fromLibraryOwner(library.published().withUser(user2).saved).saved.savedStateChange(LibraryInviteStates.ACCEPTED)
-        invite().fromLibraryOwner(library.published().withUser(user2).saved).declined.saved
-        libraries(10).map(_.published().withUser(user1)).saved
-        libraries(10).map(_.published().withUser(user2)).saved
+        val lib1 = libraries(2).map(_.published().withOwner(user1)).saved.head.savedInvitation(user2)
+        val lib2 = libraries(2).map(_.secret().withOwner(user1)).saved.head.savedInvitation(user2).savedInvitation(user3)
+        val lib3 = libraries(2).map(_.published().withOwner(user2)).saved.head.savedInvitation(user1)
+        invite().fromLibraryOwner(library.published().withOwner(user2).saved).saved.savedStateChange(LibraryInviteStates.ACCEPTED)
+        invite().fromLibraryOwner(library.published().withOwner(user2).saved).declined.saved
+        libraries(10).map(_.published().withOwner(user1)).saved
+        libraries(10).map(_.published().withOwner(user2)).saved
         (user1, user2, user3, lib1 :: lib2 :: lib3 :: Nil)
       }
 
@@ -185,11 +185,11 @@ class UserProfileCommanderTest extends Specification with ShoeboxTestInjector {
       val (owner, other, allLibs) = db.readWrite { implicit s =>
         val owner = user().saved
         val other = user().saved
-        val otherFollows1 = libraries(2).map(_.published().withUser(owner)).saved.head.savedFollowerMembership(other)
-        val otherFollows2 = libraries(2).map(_.secret().withUser(owner)).saved.head.savedFollowerMembership(other)
-        libraries(2).map(_.published().withUser(other)).saved.head.savedFollowerMembership(owner)
-        val otherFollows3 = libraries(10).map(_.published().withUser(owner)).saved.map(_.savedFollowerMembership(other))
-        libraries(10).map(_.published().withUser(other)).saved
+        val otherFollows1 = libraries(2).map(_.published().withOwner(owner)).saved.head.savedFollowerMembership(other)
+        val otherFollows2 = libraries(2).map(_.secret().withOwner(owner)).saved.head.savedFollowerMembership(other)
+        libraries(2).map(_.published().withOwner(other)).saved.head.savedFollowerMembership(owner)
+        val otherFollows3 = libraries(10).map(_.published().withOwner(owner)).saved.map(_.savedFollowerMembership(other))
+        libraries(10).map(_.published().withOwner(other)).saved
         (owner, other, List(otherFollows1) ++ otherFollows3)
       }
 
@@ -214,11 +214,11 @@ class UserProfileCommanderTest extends Specification with ShoeboxTestInjector {
       val (owner, other, allLibs) = db.readWrite { implicit s =>
         val owner = user().saved
         val other = user().saved
-        val otherFollows1 = libraries(2).map(_.published().withUser(owner)).saved.head.savedFollowerMembership(other)
-        val otherFollows2 = libraries(2).map(_.secret().withUser(owner)).saved.head.savedFollowerMembership(other)
-        libraries(2).map(_.published().withUser(other)).saved.head.savedFollowerMembership(owner)
-        val otherFollows3 = libraries(10).map(_.published().withUser(owner)).saved.map(_.savedFollowerMembership(other))
-        libraries(10).map(_.published().withUser(other)).saved
+        val otherFollows1 = libraries(2).map(_.published().withOwner(owner)).saved.head.savedFollowerMembership(other)
+        val otherFollows2 = libraries(2).map(_.secret().withOwner(owner)).saved.head.savedFollowerMembership(other)
+        libraries(2).map(_.published().withOwner(other)).saved.head.savedFollowerMembership(owner)
+        val otherFollows3 = libraries(10).map(_.published().withOwner(owner)).saved.map(_.savedFollowerMembership(other))
+        libraries(10).map(_.published().withOwner(other)).saved
         (owner, other, List(otherFollows1, otherFollows2) ++ otherFollows3)
       }
 
@@ -237,12 +237,12 @@ class UserProfileCommanderTest extends Specification with ShoeboxTestInjector {
         val user1 = user().saved
         val user2 = user().saved
         val user3 = user().saved
-        val follows1 = libraries(2).map(_.published().withUser(user1).withName("a")).saved.head.savedFollowerMembership(user2)
-        val follows2 = libraries(2).map(_.secret().withUser(user1).withName("b")).saved.head.savedFollowerMembership(user2).savedFollowerMembership(user3)
-        val follows3 = libraries(10).map(_.secret().withUser(user3).withName("c")).saved.map(_.savedFollowerMembership(user2))
-        libraries(2).map(_.published().withUser(user2).withName("d")).saved.head.savedFollowerMembership(user1)
-        val follows4 = libraries(10).map(_.published().withUser(user1).withName("e")).saved.map(_.savedFollowerMembership(user2))
-        libraries(10).map(_.published().withUser(user2).withName("f")).saved
+        val follows1 = libraries(2).map(_.published().withOwner(user1).withName("a")).saved.head.savedFollowerMembership(user2)
+        val follows2 = libraries(2).map(_.secret().withOwner(user1).withName("b")).saved.head.savedFollowerMembership(user2).savedFollowerMembership(user3)
+        val follows3 = libraries(10).map(_.secret().withOwner(user3).withName("c")).saved.map(_.savedFollowerMembership(user2))
+        libraries(2).map(_.published().withOwner(user2).withName("d")).saved.head.savedFollowerMembership(user1)
+        val follows4 = libraries(10).map(_.published().withOwner(user1).withName("e")).saved.map(_.savedFollowerMembership(user2))
+        libraries(10).map(_.published().withOwner(user2).withName("f")).saved
         (user1, user2, user3, follows1, follows2, follows3, follows4)
       }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/ActivityFeedEmailSenderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/ActivityFeedEmailSenderTest.scala
@@ -56,7 +56,7 @@ class ActivityFeedEmailSenderTest extends Specification with ShoeboxTestInjector
         case (lib, idx) =>
           val libSlug = s"$libName-l$idx"
           val libTitle = libSlug.replace("-", " ").toUpperCase
-          val savedLib = lib.withName(libTitle).withSlug(libSlug).withUser(libOwner).published().saved
+          val savedLib = lib.withName(libTitle).withSlug(libSlug).withOwner(libOwner).published().saved
 
           // add 5 keeps to each library
           val savedKeeps = keeps(numKeeps).zipWithIndex.map {
@@ -180,7 +180,7 @@ class ActivityFeedEmailSenderTest extends Specification with ShoeboxTestInjector
         db.readWrite { implicit rw =>
           Seq(user1, user2).zipWithIndex map {
             case (user, userIdx) =>
-              val lib = library().withUser(user).withSlug(s"u${userIdx + 1}/newFollowersMyLibs").published().saved
+              val lib = library().withOwner(user).withSlug(s"u${userIdx + 1}/newFollowersMyLibs").published().saved
               keep().withLibrary(lib).saved
 
               val followers = util.Random.shuffle(randomFollowers).take(util.Random.nextInt(randomFollowers.size))

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminPersonaControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminPersonaControllerTest.scala
@@ -161,7 +161,7 @@ class AdminPersonaControllerTest extends Specification with ShoeboxApplicationIn
       running(new ShoeboxApplication(modules: _*)) {
         val (user1, k1, k2, k3, k4) = db.readWrite { implicit s =>
           val user1 = user().withUsername("drogo").saved
-          val lib1 = library().withUser(user1).saved
+          val lib1 = library().withOwner(user1).saved
           val keep1 = keep().withLibrary(lib1).withNote(Some("")).saved
           val keep2 = keep().withLibrary(lib1).withNote(None).saved
           val keep3 = keep().withLibrary(lib1).withNote(Some("[#asdf]")).saved

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
@@ -503,7 +503,7 @@ class ExtLibraryControllerTest extends Specification with ShoeboxTestInjector wi
       withDb(controllerTestModules: _*) { implicit injector =>
         val (user1, keep1, lib1) = db.readWrite { implicit s =>
           val user = UserFactory.user().withUsername("spiderman").saved
-          val lib = LibraryFactory.library().withUser(user).saved
+          val lib = LibraryFactory.library().withOwner(user).saved
           val keep = KeepFactory.keep().withUser(user).withLibrary(lib).saved
           (user, keep, lib)
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileKeepsControllerTest.scala
@@ -777,7 +777,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
       withDb(controllerTestModules: _*) { implicit injector =>
         val (user, keep1, keepWithTags, keepInactive) = db.readWrite { implicit session =>
           val user = UserFactory.user().withName("Eishay", "Smith").withUsername("test").saved
-          val lib = library().withUser(user).saved
+          val lib = library().withOwner(user).saved
           val keep1 = KeepFactory.keep().withUser(user).withLibrary(lib).withTitle("default").saved
           val keep2 = KeepFactory.keep().withUser(user).withLibrary(lib).withTitle("default1").saved
           val keepInactive = KeepFactory.keep().withUser(user).withLibrary(lib).withState(KeepStates.INACTIVE).saved
@@ -895,7 +895,7 @@ class MobileKeepsControllerTest extends Specification with ShoeboxTestInjector w
       withDb(controllerTestModules: _*) { implicit injector =>
         val (user, keep1, keepWithTags, keepInactive) = db.readWrite { implicit session =>
           val user = UserFactory.user().withName("Eishay", "Smith").withUsername("test").saved
-          val lib = library().withUser(user).saved
+          val lib = library().withOwner(user).saved
           val keep1 = KeepFactory.keep().withUser(user).withLibrary(lib).withTitle("default").saved
           val keep2 = KeepFactory.keep().withUser(user).withLibrary(lib).withTitle("default1").saved
           val keepInactive = KeepFactory.keep().withUser(user).withLibrary(lib).withState(KeepStates.INACTIVE).saved

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
@@ -270,7 +270,7 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
 
         // test retrieving persona library
         val personaLib = db.readWrite { implicit s =>
-          library().withName("Healthy Habits").withSlug("healthy-habits").withUser(user1).withKind(LibraryKind.SYSTEM_PERSONA).saved
+          library().withName("Healthy Habits").withSlug("healthy-habits").withOwner(user1).withKind(LibraryKind.SYSTEM_PERSONA).saved
         }
         val pubLib2 = Library.publicId(personaLib.id.get)(inject[PublicIdConfiguration])
         val result2 = getLibraryById(user1, pubLib2)
@@ -769,7 +769,7 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
           val user1 = user().withUsername("nickfury").saved
           val user2 = user().withUsername("quicksilver").saved
           val user3 = user().withUsername("scarletwitch").saved
-          val lib1 = library().withUser(user1).saved // user1 owns lib1
+          val lib1 = library().withOwner(user1).saved // user1 owns lib1
           membership().withLibraryCollaborator(lib1, user2).saved // user2 is a collaborator lib1 (has read_write access)
 
           libraryMembershipRepo.getWithLibraryIdAndUserId(lib1.id.get, user1.id.get).get.access === LibraryAccess.OWNER
@@ -798,9 +798,9 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
           val user1 = user().withUsername("nickfury").saved
           val user2 = user().withUsername("quicksilver").saved
           val user3 = user().withUsername("scarletwitch").saved
-          val lib1a = library().withUser(user1).withSlug("secret-shield-stuff").withVisibility(LibraryVisibility.SECRET).saved // user1 owns secret lib1a
+          val lib1a = library().withOwner(user1).withSlug("secret-shield-stuff").withVisibility(LibraryVisibility.SECRET).saved // user1 owns secret lib1a
           membership().withLibraryCollaborator(lib1a, user2).saved // user2 is a collaborator lib1 (has read_write access)
-          val lib1b = library().withUser(user1).withSlug("public-shield-stuff").withVisibility(LibraryVisibility.PUBLISHED).saved // user1 owns publish lib1b
+          val lib1b = library().withOwner(user1).withSlug("public-shield-stuff").withVisibility(LibraryVisibility.PUBLISHED).saved // user1 owns publish lib1b
 
           libraryMembershipRepo.getWithLibraryIdAndUserId(lib1a.id.get, user1.id.get).get.access === LibraryAccess.OWNER
           libraryMembershipRepo.getWithLibraryIdAndUserId(lib1a.id.get, user2.id.get).get.access === LibraryAccess.READ_WRITE

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileMutualUserControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileMutualUserControllerTest.scala
@@ -85,8 +85,8 @@ class MobileMutualUserControllerTest extends Specification with ShoeboxTestInjec
           val user3 = user().withUsername("mrfreeze").saved
           val user4 = user().withUsername("poisonivy").saved
 
-          val lib2 = library().withUser(user2).withSlug("gotham-sucks").saved
-          val lib3 = library().withUser(user3).withSlug("ice-ice-baby").saved
+          val lib2 = library().withOwner(user2).withSlug("gotham-sucks").saved
+          val lib3 = library().withOwner(user3).withSlug("ice-ice-baby").saved
 
           membership().withLibraryFollower(lib2, user1).saved
           membership().withLibraryFollower(lib2, user4).saved

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobilePeopleRecommendationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobilePeopleRecommendationControllerTest.scala
@@ -35,7 +35,7 @@ class MobilePeopleRecommendationControllerTest extends Specification with Shoebo
           val user2 = users(1)
           val user3 = users(2)
           val user4 = users(3)
-          val lib = library().withUser(user4).saved
+          val lib = library().withOwner(user4).saved
           membership().withLibraryFollower(lib.id.get, user1.id.get).saved
           membership().withLibraryFollower(lib.id.get, user2.id.get).saved
           membership().withLibraryFollower(lib.id.get, user3.id.get).saved

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUriControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUriControllerTest.scala
@@ -53,7 +53,7 @@ class MobileUriControllerTest extends Specification with ShoeboxTestInjector {
   private def setupUris()(implicit injector: Injector) = {
     val (user1, keep1) = db.readWrite { implicit s =>
       val user1 = user().withName("Katniss", "Everdeen").saved
-      val lib1 = LibraryFactory.library().withUser(user1).saved
+      val lib1 = LibraryFactory.library().withOwner(user1).saved
       val keep1 = keep().withUser(user1).withLibrary(lib1).saved
       (user1, keep1)
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserProfileControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserProfileControllerTest.scala
@@ -71,14 +71,14 @@ class MobileUserProfileControllerTest extends Specification with ShoeboxTestInje
             user4 -> user1,
             user2 -> user3).saved
 
-          val user1secretLib = libraries(3).map(_.withUser(user1).secret().withKeepCount(3)).saved.head.savedFollowerMembership(user2)
+          val user1secretLib = libraries(3).map(_.withOwner(user1).secret().withKeepCount(3)).saved.head.savedFollowerMembership(user2)
 
-          val user1lib = library().withUser(user1).published().withOrganizationIdOpt(org.id).saved.savedFollowerMembership(user5, user4)
+          val user1lib = library().withOwner(user1).published().withOrganizationIdOpt(org.id).saved.savedFollowerMembership(user5, user4)
           user1lib.visibility === LibraryVisibility.PUBLISHED
 
-          val user3lib = library().withUser(user3).published().withKeepCount(2).saved
-          val user5lib = library().withUser(user5).published().withKeepCount(4).saved.savedFollowerMembership(user1)
-          membership().withLibraryFollower(library().withUser(user5).published().withKeepCount(1).saved, user1).unlisted().saved
+          val user3lib = library().withOwner(user3).published().withKeepCount(2).saved
+          val user5lib = library().withOwner(user5).published().withKeepCount(4).saved.savedFollowerMembership(user1)
+          membership().withLibraryFollower(library().withOwner(user5).published().withKeepCount(1).saved, user1).unlisted().saved
 
           keeps(2).map(_.withLibrary(user1secretLib)).saved
           keeps(3).map(_.withLibrary(user1lib)).saved
@@ -272,9 +272,9 @@ class MobileUserProfileControllerTest extends Specification with ShoeboxTestInje
       withDb(modules: _*) { implicit injector =>
         val (user, highPriorityMemberships, highPriorityLibs) = db.readWrite { implicit session =>
           val user = UserFactory.user().saved
-          val libs1 = LibraryFactory.libraries(3).map(_.withUser(user.id.get)).saved
-          val libs2 = LibraryFactory.libraries(2).map(_.withUser(user.id.get)).saved
-          val libs3 = LibraryFactory.libraries(1).map(_.withUser(user.id.get)).saved
+          val libs1 = LibraryFactory.libraries(3).map(_.withOwner(user.id.get)).saved
+          val libs2 = LibraryFactory.libraries(2).map(_.withOwner(user.id.get)).saved
+          val libs3 = LibraryFactory.libraries(1).map(_.withOwner(user.id.get)).saved
 
           val highPriorityMemberships = for (lib <- libs2) yield {
             val membership = libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId = lib.id.get, userId = user.id.get).get
@@ -522,7 +522,7 @@ class MobileUserProfileControllerTest extends Specification with ShoeboxTestInje
         val profileUsername = Username("cfalc")
         val (user1, user2, user3, user4) = db.readWrite { implicit s =>
           val user1 = user().withName("Captain", "Falcon").withUsername(profileUsername.value).saved
-          val library1 = library().withUser(user1).saved
+          val library1 = library().withOwner(user1).saved
 
           val otherUsers = users(3).saved
           membership().withLibraryFollower(library1, otherUsers(0)).saved

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
@@ -244,7 +244,7 @@ class KifiSiteRouterTest extends Specification with ShoeboxApplicationInjector {
 
         // user-or-orgs
         val orgLibrary = db.readWrite { implicit session =>
-          LibraryFactory.library().withName("Kifi Library").withSlug("kifi-lib").withUser(user1).withOrganizationIdOpt(org.id).saved
+          LibraryFactory.library().withName("Kifi Library").withSlug("kifi-lib").withOwner(user1).withOrganizationIdOpt(org.id).saved
         }
 
         actionsHelper.setUser(user1, experiments = Set(UserExperimentType.ORGANIZATION))

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -302,7 +302,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
         val (user, lib, org) = db.readWrite { implicit s =>
           val user = UserFactory.user().saved
-          val lib = LibraryFactory.library().withSlug("libfoo").withUser(user).saved
+          val lib = LibraryFactory.library().withSlug("libfoo").withOwner(user).saved
           val org = OrganizationFactory.organization().withOwner(user).saved
           (user, lib, org)
         }
@@ -1551,7 +1551,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
       withDb(modules: _*) { implicit injector =>
         val (user1, keep1, lib1) = db.readWrite { implicit s =>
           val user = UserFactory.user().withUsername("spiderman").saved
-          val lib = library().withUser(user).saved
+          val lib = library().withOwner(user).saved
           val keep = KeepFactory.keep().withUser(user).withLibrary(lib).saved
           (user, keep, lib)
         }
@@ -1597,7 +1597,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
           val user1 = user().withUsername("nickfury").saved
           val user2 = user().withUsername("quicksilver").saved
           val user3 = user().withUsername("scarletwitch").saved
-          val lib1 = library().withUser(user1).saved // user1 owns lib1
+          val lib1 = library().withOwner(user1).saved // user1 owns lib1
           membership().withLibraryCollaborator(lib1, user2).saved // user2 is a collaborator in lib1 (has read_write access)
 
           libraryMembershipRepo.getWithLibraryIdAndUserId(lib1.id.get, user1.id.get).get.access === LibraryAccess.OWNER
@@ -1638,11 +1638,11 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
             val user1 = user().withName("John", "Doe").saved
             val user2 = user().withName("Joe", "Blow").saved
             val user3 = user().withName("Jack", "Black").saved
-            val lib1 = library().withName("Scala").withUser(user1).published().withMemberCount(3).saved
-            val lib2 = library().withName("Java").withUser(user1).published().withMemberCount(2).saved
+            val lib1 = library().withName("Scala").withOwner(user1).published().withMemberCount(3).saved
+            val lib2 = library().withName("Java").withOwner(user1).published().withMemberCount(2).saved
 
             // test that private libraries are not returned in the response
-            val lib3 = library().withName("Private").withUser(user1).saved
+            val lib3 = library().withName("Private").withOwner(user1).saved
 
             inject[KeepRepo].all() // force slick to create the table
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryRecommendationsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryRecommendationsControllerTest.scala
@@ -52,7 +52,7 @@ class LibraryRecommendationsControllerTest extends TestKitSupport with Specifica
         val (libs, user1, user2) = db.readWrite { implicit rw =>
           val owner = UserFactory.user().saved
           (
-            LibraryFactory.libraries(5).map(_.withUser(owner).published().saved),
+            LibraryFactory.libraries(5).map(_.withOwner(owner).published().saved),
             UserFactory.user().saved,
             UserFactory.user().saved
           )
@@ -89,7 +89,7 @@ class LibraryRecommendationsControllerTest extends TestKitSupport with Specifica
         val (lib1, user1) = db.readWrite { implicit rw =>
           val owner = UserFactory.user().saved
           val user1 = UserFactory.user().saved
-          val lib = LibraryFactory.library().withUser(owner).published().saved
+          val lib = LibraryFactory.library().withOwner(owner).published().saved
           (lib, user1)
         }
         val libPubId = Library.publicId(lib1.id.get)

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
@@ -152,7 +152,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
             val user = UserFactory.user().saved
             for (i <- 1 to 10) {
               val org = OrganizationFactory.organization().withOwner(user).withName("Justice League").withHandle(OrganizationHandle("justiceleague" + i)).saved
-              LibraryFactory.libraries(i).map(_.published().withUser(user).withOrganizationIdOpt(org.id)).saved
+              LibraryFactory.libraries(i).map(_.published().withOwner(user).withOrganizationIdOpt(org.id)).saved
             }
             user
           }
@@ -176,7 +176,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
             val rando = UserFactory.user().saved
             for (i <- 1 to 10) {
               val org = OrganizationFactory.organization().withOwner(user).withName("Justice League").withHandle(OrganizationHandle("justiceleague" + i)).saved
-              LibraryFactory.libraries(i).map(_.published().withUser(user).withOrganizationIdOpt(org.id)).saved
+              LibraryFactory.libraries(i).map(_.published().withOwner(user).withOrganizationIdOpt(org.id)).saved
               if (i <= 5) {
                 inject[OrganizationRepo].save(org.hiddenFromNonmembers)
               }
@@ -217,9 +217,9 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
           .withMembers(Seq(member))
           .saved
 
-        val publicLibs = LibraryFactory.libraries(numPublicLibs).map(_.published().withUser(owner).withOrganizationIdOpt(org.id)).saved
-        val orgLibs = LibraryFactory.libraries(numOrgLibs).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withUser(owner).withOrganizationIdOpt(org.id)).saved
-        val privateLibs = LibraryFactory.libraries(numPrivateLibs).map(_.secret().withUser(member).withOrganizationIdOpt(org.id)).saved
+        val publicLibs = LibraryFactory.libraries(numPublicLibs).map(_.published().withOwner(owner).withOrganizationIdOpt(org.id)).saved
+        val orgLibs = LibraryFactory.libraries(numOrgLibs).map(_.withVisibility(LibraryVisibility.ORGANIZATION).withOwner(owner).withOrganizationIdOpt(org.id)).saved
+        val privateLibs = LibraryFactory.libraries(numPrivateLibs).map(_.secret().withOwner(member).withOrganizationIdOpt(org.id)).saved
         (org, owner, member, nonmember, publicLibs, orgLibs, privateLibs)
       }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserProfileControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserProfileControllerTest.scala
@@ -69,14 +69,14 @@ class UserProfileControllerTest extends Specification with ShoeboxTestInjector {
             user4 -> user1,
             user2 -> user3).saved
 
-          val user1secretLib = libraries(3).map(_.withUser(user1).secret()).saved.head.savedFollowerMembership(user2)
+          val user1secretLib = libraries(3).map(_.withOwner(user1).secret()).saved.head.savedFollowerMembership(user2)
 
-          val user1lib = library().withUser(user1).published().saved.savedFollowerMembership(user5, user4)
+          val user1lib = library().withOwner(user1).published().saved.savedFollowerMembership(user5, user4)
           user1lib.visibility === LibraryVisibility.PUBLISHED
 
-          val user3lib = library().withUser(user3).published().saved.savedFollowerMembership(user2)
-          val user5lib = library().withUser(user5).published().saved.savedFollowerMembership(user1)
-          membership().withLibraryFollower(library().withUser(user5).published().saved, user1).unlisted().saved
+          val user3lib = library().withOwner(user3).published().saved.savedFollowerMembership(user2)
+          val user5lib = library().withOwner(user5).published().saved.savedFollowerMembership(user1)
+          membership().withLibraryFollower(library().withOwner(user5).published().saved, user1).unlisted().saved
 
           invite().fromLibraryOwner(user3lib).toUser(user1.id.get).withState(LibraryInviteStates.ACTIVE).saved
           invite().fromLibraryOwner(user3lib).toUser(user1.id.get).withState(LibraryInviteStates.ACTIVE).saved // duplicate library invite
@@ -189,15 +189,15 @@ class UserProfileControllerTest extends Specification with ShoeboxTestInjector {
             user4 -> user1,
             user2 -> user3).saved
 
-          val user1secretLib = libraries(3).map(_.withUser(user1).withKind(LibraryKind.USER_CREATED).withKeepCount(3).withMemberCount(4).secret()).saved.head.savedFollowerMembership(user2)
+          val user1secretLib = libraries(3).map(_.withOwner(user1).withKind(LibraryKind.USER_CREATED).withKeepCount(3).withMemberCount(4).secret()).saved.head.savedFollowerMembership(user2)
 
-          val user1lib = library().withUser(user1).withKind(LibraryKind.USER_CREATED).withKeepCount(3).published().withMemberCount(4).withOrganizationIdOpt(org.id).saved.savedFollowerMembership(user5, user4)
+          val user1lib = library().withOwner(user1).withKind(LibraryKind.USER_CREATED).withKeepCount(3).published().withMemberCount(4).withOrganizationIdOpt(org.id).saved.savedFollowerMembership(user5, user4)
           user1lib.visibility === LibraryVisibility.PUBLISHED
 
-          val user3lib = library().withUser(user3).published().withKind(LibraryKind.USER_CREATED).withKeepCount(3).withMemberCount(4).saved
-          val user5lib = library().withUser(user5).published().withKind(LibraryKind.USER_CREATED).withKeepCount(3).withMemberCount(4).saved.savedFollowerMembership(user1)
+          val user3lib = library().withOwner(user3).published().withKind(LibraryKind.USER_CREATED).withKeepCount(3).withMemberCount(4).saved
+          val user5lib = library().withOwner(user5).published().withKind(LibraryKind.USER_CREATED).withKeepCount(3).withMemberCount(4).saved.savedFollowerMembership(user1)
           keep().withLibrary(user5lib).saved
-          membership().withLibraryFollower(library().withUser(user5).published().withKind(LibraryKind.USER_CREATED).withKeepCount(3).saved, user1).unlisted().saved
+          membership().withLibraryFollower(library().withOwner(user5).published().withKind(LibraryKind.USER_CREATED).withKeepCount(3).saved, user1).unlisted().saved
 
           invite().fromLibraryOwner(user3lib).toUser(user1.id.get).withState(LibraryInviteStates.ACTIVE).saved
           invite().fromLibraryOwner(user3lib).toUser(user1.id.get).withState(LibraryInviteStates.ACTIVE).saved // duplicate library invite
@@ -360,9 +360,9 @@ class UserProfileControllerTest extends Specification with ShoeboxTestInjector {
           val user1 = user().withName("first", "user").withUsername("firstuser").saved
           val user2 = user().withName("second", "user").withUsername("seconduser").withPictureName("alf").saved
           val user3 = user().withName("third", "user").withUsername("thirduser").withPictureName("asdf").saved
-          val library1 = library().withName("lib1").withUser(user1).published.withSlug("lib1").withMemberCount(11).withColor("blue").withDesc("My first library!").saved.savedFollowerMembership(user2).savedCollaboratorMembership(user3)
-          val library2 = library().withName("lib2").withUser(user2).secret.withSlug("lib2").withMemberCount(22).saved
-          val library3 = library().withName("lib3").withUser(user2).secret.withSlug("lib3").withMemberCount(33).saved.savedFollowerMembership(user1)
+          val library1 = library().withName("lib1").withOwner(user1).published.withSlug("lib1").withMemberCount(11).withColor("blue").withDesc("My first library!").saved.savedFollowerMembership(user2).savedCollaboratorMembership(user3)
+          val library2 = library().withName("lib2").withOwner(user2).secret.withSlug("lib2").withMemberCount(22).saved
+          val library3 = library().withName("lib3").withOwner(user2).secret.withSlug("lib3").withMemberCount(33).saved.savedFollowerMembership(user1)
           val k1 = keep().withLibrary(library1).saved
           (user1, user2, user3, library1, library2, library3, k1)
         }
@@ -570,8 +570,8 @@ class UserProfileControllerTest extends Specification with ShoeboxTestInjector {
           val user4 = user().withName("John", "Adams").withUsername("jayjayadams").saved
           val user5 = user().withName("Ben", "Franklin").withUsername("Benji").saved
 
-          libraries(3).map(_.withUser(user1).secret()).saved.head.savedFollowerMembership(user2, user3) // create 3 secret libraries, one is follower by user2 and user3
-          library().withUser(user1).published().saved.savedFollowerMembership(user5, user4) // create 1 published library, followed by user4 and user 5
+          libraries(3).map(_.withOwner(user1).secret()).saved.head.savedFollowerMembership(user2, user3) // create 3 secret libraries, one is follower by user2 and user3
+          library().withOwner(user1).published().saved.savedFollowerMembership(user5, user4) // create 1 published library, followed by user4 and user 5
           connect(user1 -> user3).saved
           (user1, user2, user3, user4, user5)
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
@@ -20,13 +20,13 @@ class KeepRepoTest extends Specification with ShoeboxTestInjector {
           val user1 = user().saved
           val user2 = user().saved
 
-          val user1MainLib = LibraryFactory.library().withUser(user1).discoverable().saved
-          val user1PrivateLib = LibraryFactory.library().withUser(user1).secret().saved
-          val user1PublicLib = LibraryFactory.library().withUser(user1).published().saved
+          val user1MainLib = LibraryFactory.library().withOwner(user1).discoverable().saved
+          val user1PrivateLib = LibraryFactory.library().withOwner(user1).secret().saved
+          val user1PublicLib = LibraryFactory.library().withOwner(user1).published().saved
 
-          val user2MainLib = LibraryFactory.library().withUser(user2).discoverable().saved
-          val user2PrivateLib = LibraryFactory.library().withUser(user2).secret().saved
-          val user2PublicLib = LibraryFactory.library().withUser(user2).published().saved
+          val user2MainLib = LibraryFactory.library().withOwner(user2).discoverable().saved
+          val user2PrivateLib = LibraryFactory.library().withOwner(user2).secret().saved
+          val user2PublicLib = LibraryFactory.library().withOwner(user2).published().saved
 
           val user1Keeps = keep().withUser(user1).withLibrary(user1MainLib).saved ::
             keep().withUser(user1).withLibrary(user1PrivateLib).saved ::
@@ -53,8 +53,8 @@ class KeepRepoTest extends Specification with ShoeboxTestInjector {
           val user2 = user().saved
           val user3 = user().saved
 
-          val user1MainLib = LibraryFactory.library().withUser(user1).discoverable().saved
-          val user2MainLib = LibraryFactory.library().withUser(user2).discoverable().saved
+          val user1MainLib = LibraryFactory.library().withOwner(user1).discoverable().saved
+          val user2MainLib = LibraryFactory.library().withOwner(user2).discoverable().saved
           keep().withUser(user1).withKeptAt(new DateTime(2013, 1, 1, 1, 1, 1, DEFAULT_DATE_TIME_ZONE)).withLibrary(user1MainLib).saved
           keep().withUser(user1).withKeptAt(new DateTime(2014, 1, 1, 1, 1, 1, DEFAULT_DATE_TIME_ZONE)).withLibrary(user1MainLib).saved
           keep().withUser(user1).withKeptAt(new DateTime(2015, 1, 1, 1, 1, 1, DEFAULT_DATE_TIME_ZONE)).withLibrary(user1MainLib).saved

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepToLibraryRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepToLibraryRepoTest.scala
@@ -34,12 +34,12 @@ class KeepToLibraryRepoTest extends Specification with ShoeboxTestInjector {
             val user = UserFactory.user().saved
             val otherUser = UserFactory.user().saved
 
-            val userLib = LibraryFactory.library().withUser(user).saved
-            val otherLib = LibraryFactory.library().withUser(otherUser).withFollowers(Seq(user)).saved
-            val deadOtherLib = LibraryFactory.library().withUser(otherUser).withFollowers(Seq(user)).saved
+            val userLib = LibraryFactory.library().withOwner(user).saved
+            val otherLib = LibraryFactory.library().withOwner(otherUser).withFollowers(Seq(user)).saved
+            val deadOtherLib = LibraryFactory.library().withOwner(otherUser).withFollowers(Seq(user)).saved
             val deadOtherLibMembership = inject[LibraryMembershipRepo].getWithLibraryIdAndUserId(deadOtherLib.id.get, user.id.get).get
             inject[LibraryMembershipRepo].save(deadOtherLibMembership.withState(LibraryMembershipStates.INACTIVE))
-            val randoLib = LibraryFactory.library().withUser(otherUser).saved
+            val randoLib = LibraryFactory.library().withOwner(otherUser).saved
 
             val uris = createUris(50).toSeq
             val uri = uris.head

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/LibraryFactoryHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/LibraryFactoryHelper.scala
@@ -20,6 +20,12 @@ object LibraryFactoryHelper {
       for (user <- partialLibrary.collaborators) {
         membership().withLibraryCollaborator(library, user).saved
       }
+      for (user <- partialLibrary.invitedUsers) {
+        invite().fromLibraryOwner(library).toUser(user).saved
+      }
+      for (email <- partialLibrary.invitedEmails) {
+        invite().fromLibraryOwner(library).toEmail(email).saved
+      }
       library
     }
   }


### PR DESCRIPTION
Added a very adversarial tests for sort order.

Also, I'm not sure that sorting by `createdAt` is a good idea. I wish we had
a different metric to sort invites. I personally am a fan of alphabetical.

@camhashemi 
