### PR TITLE
Clear the library list before when loading a new set of libs

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibraries.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibraries.js
@@ -16,7 +16,9 @@ angular.module('kifi')
     var libraryLazyLoader = new Paginator();
 
     function resetAndFetchLibraries() {
+      $scope.libraries = null;
       newLibraryIds = {};
+
       libraryLazyLoader.reset();
       $scope.fetchLibraries();
     }


### PR DESCRIPTION
@adamjgrant simple fix, I probably introduced this bug when factoring-out the paginator functionality to share it with the orgProfile page
