### PR TITLE
pass auth token from UserOrOrgController to OrgController

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
@@ -64,7 +64,7 @@ class MobileOrganizationController @Inject() (
     }
   }
 
-  def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
+  def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, None, OrganizationPermission.VIEW_ORGANIZATION) { request =>
     val organizationView = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt)
     Ok(Json.toJson(organizationView))
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationMembershipController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationMembershipController.scala
@@ -26,7 +26,7 @@ class MobileOrganizationMembershipController @Inject() (
     implicit val publicIdConfig: PublicIdConfiguration) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
   // If userIdOpt is provided AND the user can invite members, return invited users as well as members
-  def getMembers(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
+  def getMembers(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, None, OrganizationPermission.VIEW_ORGANIZATION) { request =>
     if (limit > 30) {
       BadRequest(Json.obj("error" -> "invalid_limit"))
     } else Organization.decodePublicId(pubId) match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
@@ -83,12 +83,12 @@ class OrganizationController @Inject() (
     }
   }
 
-  def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
+  def getOrganization(pubId: PublicId[Organization], authTokenOpt: Option[String] = None) = OrganizationAction(pubId, authTokenOpt, OrganizationPermission.VIEW_ORGANIZATION) { request =>
     val organizationView = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt)
     Ok(Json.toJson(organizationView))
   }
 
-  def getOrganizationLibraries(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
+  def getOrganizationLibraries(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, None, OrganizationPermission.VIEW_ORGANIZATION) { request =>
     Ok(Json.obj("libraries" -> Json.toJson(orgCommander.getOrganizationLibrariesVisibleToUser(request.orgId, request.request.userIdOpt, Offset(offset), Limit(limit)))))
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationMembershipController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationMembershipController.scala
@@ -26,7 +26,7 @@ class OrganizationMembershipController @Inject() (
     implicit val publicIdConfig: PublicIdConfiguration) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
   // If userIdOpt is provided AND the user can invite members, return invited users as well as members
-  def getMembers(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, OrganizationPermission.VIEW_ORGANIZATION) { request =>
+  def getMembers(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, None, OrganizationPermission.VIEW_ORGANIZATION) { request =>
     if (limit > 30) {
       BadRequest(Json.obj("error" -> "invalid_limit"))
     } else Organization.decodePublicId(pubId) match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserOrOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserOrOrganizationController.scala
@@ -48,7 +48,7 @@ class UserOrOrganizationController @Inject() (
       case Some(handleOwnerObject) =>
         val (action, actionType) = handleOwnerObject match {
           case (Left(org), _) =>
-            (orgController.getOrganization(Organization.publicId(org.id.get)), "org")
+            (orgController.getOrganization(Organization.publicId(org.id.get), authTokenOpt = request.getQueryString("authToken")), "org")
           case (Right(user), _) =>
             (userProfileController.getProfile(user.username), "user")
         }

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/controllers/OrganizationAccessActions.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/controllers/OrganizationAccessActions.scala
@@ -43,7 +43,7 @@ trait OrganizationAccessActions {
     requiredPermissions.subsetOf(memberPermissions)
   }
 
-  def OrganizationAction(id: PublicId[Organization], requiredPermissions: OrganizationPermission*) = MaybeUserAction andThen new ActionFunction[MaybeUserRequest, OrganizationRequest] {
+  def OrganizationAction(id: PublicId[Organization], authTokenOpt: Option[String], requiredPermissions: OrganizationPermission*) = MaybeUserAction andThen new ActionFunction[MaybeUserRequest, OrganizationRequest] {
     override def invokeBlock[A](maybeRequest: MaybeUserRequest[A], block: (OrganizationRequest[A]) => Future[Result]): Future[Result] = {
       Organization.decodePublicId(id) match {
         case Success(orgId) =>
@@ -62,7 +62,6 @@ trait OrganizationAccessActions {
                 Future.successful(OrganizationFail.INSUFFICIENT_PERMISSIONS.asErrorResponse)
               }
             case request: NonUserRequest[_] =>
-              val authTokenOpt = request.getQueryString("authToken")
               if (authTokenOpt.exists(authToken => orgInviteCommander.isAuthValid(orgId, authToken))) {
                 val memberPermissions = orgMembershipCommander.getPermissions(orgId, None)
                 block(OrganizationRequest(request, orgId, authTokenOpt, memberPermissions))

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/controllers/OrganizationAccessActions.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/controllers/OrganizationAccessActions.scala
@@ -56,7 +56,6 @@ trait OrganizationAccessActions {
               val requiredPermissionsSet = requiredPermissions.toSet + OrganizationPermission.VIEW_ORGANIZATION
               val memberPermissions = orgMembershipCommander.getPermissions(orgId, userIdOpt)
               if (requiredPermissionsSet.subsetOf(memberPermissions)) {
-                val authTokenOpt = request.getQueryString("authToken")
                 block(OrganizationRequest(request, orgId, authTokenOpt, memberPermissions))
               } else {
                 Future.successful(OrganizationFail.INSUFFICIENT_PERMISSIONS.asErrorResponse)


### PR DESCRIPTION
@ryanpbrewster @andrewconner assumed that the original request from `UserOrOrgController` was passed along implicitly (is this desired behavior?) to `OrganizationController`, but it wasn't.
