### PR TITLE
Fix nondeterministic websocket test

### DIFF
--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/ws/ElizaWebSocketTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/ws/ElizaWebSocketTest.scala
@@ -180,9 +180,10 @@ class ElizaWebSocketTest extends Specification with ElizaApplicationInjector wit
         val messageContent = message(2)
         (messageContent \ "text").as[String] === "So long and thanks for all the fish"
         (messageContent \ "participants").asInstanceOf[JsArray].value.length === 2
+        socket.out(0).as[String] === "notification"
+        socket.out === Json.arr("unread_notifications_count", 1, 1, 0)
         socket.close
         socket.out === Json.arr("bye", "session")
-
       }
     }
 


### PR DESCRIPTION
Fixes the nondeterministic websocket test by receiving all the messages for the notification before closing the socket.

@ryanpbrewster 
