### PR TITLE
Macro Annotation that airbrakes when a method is too slow

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/performance/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/performance/package.scala
@@ -192,14 +192,14 @@ package object performance {
             @volatile var lastAlertAt: Option[Long] = None
             @volatile var mean: Long = 0
 
-            def updateAndGetMean(sample: Long): FiniteDuration = synchronized {
+            private def updateAndGetMean(sample: Long): FiniteDuration = synchronized {
               samples = samples + 1
               lastAlertAt = Some(System.nanoTime)
               mean = mean + (sample/samples) - (mean/samples)
               Duration.fromNanos(mean)
             }
 
-            def monitor(t: Long): Unit = {
+            private def monitor(t: Long): Unit = {
               val dur = updateAndGetMean(t)
               if (samples > 10 && dur > limit && !lastAlertAt.exists(_ > System.nanoTime - 600000000000L)) { //alert if the mean is over the limit and the last alert is more than 10 minutes ago
                 airbrake.notify($message)

--- a/kifi-backend/modules/common/app/com/keepit/common/performance/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/performance/package.scala
@@ -190,12 +190,17 @@ package object performance {
             val limit: FiniteDuration = $limit
             @volatile var samples: Long = 0
             @volatile var lastAlertAt: Option[Long] = None
-            @volatile var mean: Long = 0
+            @volatile var total: Long = 0
 
             private def updateAndGetMean(sample: Long): FiniteDuration = synchronized {
+              if (samples > 1000) {
+                samples = 0
+                total = 0
+              }
               samples = samples + 1
               lastAlertAt = Some(System.nanoTime)
-              mean = mean + (sample/samples) - (mean/samples)
+              total = total + sample
+              val mean = total/samples
               Duration.fromNanos(mean)
             }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -18,7 +18,7 @@ import com.keepit.common.social.BasicUserRepo
 import com.keepit.common.store.{ ImageSize, S3ImageStore }
 import com.keepit.common.time._
 import com.keepit.common.util.Paginator
-import com.keepit.common.performance.StatsdTiming
+import com.keepit.common.performance.{ StatsdTiming, AlertingTimer }
 import com.keepit.eliza.{ LibraryPushNotificationCategory, UserPushNotificationCategory, PushNotificationExperiment, ElizaServiceClient }
 import com.keepit.heimdal.{ HeimdalContext, HeimdalContextBuilderFactory, HeimdalServiceClient }
 import com.keepit.model.LibrarySpace.{ UserSpace, OrganizationSpace }
@@ -38,6 +38,7 @@ import com.keepit.common.core._
 
 import scala.collection.parallel.ParSeq
 import scala.concurrent._
+import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
 
 @json case class MarketingSuggestedLibrarySystemValue(
@@ -1585,6 +1586,7 @@ class LibraryCommanderImpl @Inject() (
     }
   }
 
+  @AlertingTimer(2 seconds)
   @StatsdTiming("LibraryCommander.createLibraryCardInfos")
   def createLibraryCardInfos(libs: Seq[Library], owners: Map[Id[User], BasicUser], viewerOpt: Option[User], withFollowing: Boolean, idealSize: ImageSize)(implicit session: RSession): ParSeq[LibraryCardInfo] = {
     val libIds = libs.map(_.id.get).toSet


### PR DESCRIPTION
The goal is to have easy performance monitoring and alerts without needed unreliable external tools like syren.
Usage is pretty simple. If you write

``` scala
@AlertingTimer(5 seconds)
def foo(): T { ... }
```

an Airbrake will be triggered (without affecting function call results) if the mean execution time of `foo` ever goes above 5 seconds. The alert will only fire if the function has been executed at least 10 times total so far (for sufficient sample size) and will only fire at most once every 10 minutes (so as not to flood us if things are consistently slow)
Overhead should be minimal, but I wouldn't use it for really small things, i.e. <50ms.

Similarly, if you have a function that returns a future and you want the alert on the completion time of the future, use 

``` scala
@AlertingTimerAsync(5 seconds)
def foo(): Future[T] { ... }
```

Would love some feedback on this @andrewconner @leogrim @ryanpbrewster @gratimax @eishay or whoever else wants to jump in.
