### PR TITLE
Made convenience classes for dealing with billing

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/util/Currency.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/Currency.scala
@@ -5,11 +5,11 @@ case class IllegalBillingCycleDivision(a: BillingCycle, b: BillingCycle) extends
 
 case class Currency(cents: Int) {
   def +(that: Currency): Currency = Currency(this.cents + that.cents)
-  def -(that: Currency): Currency = Currency(this.cents + that.cents)
+  def -(that: Currency): Currency = Currency(this.cents - that.cents)
   def *(lambda: Int): Currency = Currency(this.cents * lambda)
   def /(lambda: Int): Currency = Currency(this.cents / lambda)
   def /(bc: BillingCycle): BillingRate = BillingRate(this, bc)
-  override def toString = s"$$${cents / 100}.${cents % 100}"
+  override def toString = s"$$${cents / Currency.CENTS_PER_DOLLAR}.${cents % Currency.CENTS_PER_DOLLAR}"
 }
 
 object Currency {

--- a/kifi-backend/modules/common/app/com/keepit/common/util/Currency.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/Currency.scala
@@ -1,0 +1,57 @@
+package com.keepit.common.util
+
+case class UnevenBillingRateException(cost: Currency, cycle: BillingCycle) extends Exception(s"$cost cannot be evenly divided into $cycle")
+case class IllegalBillingCycleDivision(a: BillingCycle, b: BillingCycle) extends Exception(s"$a does not divide evenly by $b")
+
+case class Currency(cents: Int) {
+  def +(that: Currency): Currency = Currency(this.cents + that.cents)
+  def -(that: Currency): Currency = Currency(this.cents + that.cents)
+  def *(lambda: Int): Currency = Currency(this.cents * lambda)
+  def /(lambda: Int): Currency = Currency(this.cents / lambda)
+  def /(bc: BillingCycle): BillingRate = BillingRate(this, bc)
+  override def toString = s"$$${cents / 100}.${cents % 100}"
+}
+
+object Currency {
+  private val CENTS_PER_DOLLAR = 100
+  def cents(n: Int) = Currency(n)
+  def dollars(n: Int) = Currency(CENTS_PER_DOLLAR * n)
+}
+
+case class BillingCycle(months: Int) {
+  def +(that: BillingCycle): BillingCycle = BillingCycle(this.months + that.months)
+  def -(that: BillingCycle): BillingCycle = BillingCycle(this.months - that.months)
+  def *(lambda: Int): BillingCycle = BillingCycle(this.months * lambda)
+  def /(lambda: Int): BillingCycle = BillingCycle(this.months / lambda)
+  def /(that: BillingCycle): Int = {
+    if (this.months % that.months != 0) throw new IllegalBillingCycleDivision(this, that)
+    else this.months / that.months
+  }
+
+  override def toString = {
+    if (months > 1) s"$months months"
+    else s"$months month"
+  }
+}
+object BillingCycle {
+  val MIN_LENGTH = BillingCycle.months(1)
+
+  private val MONTHS_PER_YEAR = 12
+  def months(n: Int) = BillingCycle(n)
+  def years(n: Int) = BillingCycle(MONTHS_PER_YEAR * n)
+}
+
+case class BillingRate(cost: Currency) {
+  def +(that: BillingRate): BillingRate = BillingRate(this.cost + that.cost)
+  def -(that: BillingRate): BillingRate = BillingRate(this.cost - that.cost)
+  override def toString = s"$cost / ${BillingRate.canonicalTimePeriod}"
+}
+
+object BillingRate {
+  val canonicalTimePeriod = BillingCycle.months(1)
+  def apply(cost: Currency, time: BillingCycle): BillingRate = {
+    val lambda = time / canonicalTimePeriod
+    if (cost.cents % lambda != 0) throw new UnevenBillingRateException(cost, time)
+    else BillingRate(cost / lambda)
+  }
+}


### PR DESCRIPTION
@stkem I wrote this on the train in this morning.

Currency represents currency. Under the hood it stores things in `cents: Int`.

BillingCycle represents a time period. Under the hood it is using `months: Int`.

BillingRate represents a currency / time. Under the hood it is storing
just the `cost: Currency`, and it has a fixed time period that it uses.
You can construct a BillingRate by dividing a Currency by a BillingCycle,
and it will throw an exception if they are not evenly divisible. I did
that because it is the only way to ensure that
1. We are billing the same amount of money every month
2. We are billing the correct amount of money over the entire billing cycle

If we are willing to relax either of those constraints then we can do other
things (maybe charge a different amount on the last month of a billing cycle).

Now that I'm writing this out it seems more reasonable to only charge once per
billing cycle. I think that might even be what billing cycle actually means...
