### PR TITLE
fix org access actions erring

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/controllers/OrganizationAccessActions.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/controllers/OrganizationAccessActions.scala
@@ -60,7 +60,7 @@ trait OrganizationAccessActions {
               } else {
                 Future.successful(OrganizationFail.INSUFFICIENT_PERMISSIONS.asErrorResponse)
               }
-            case request: NonUserRequest[_] =>
+            case request: NonUserRequest[_] if authTokenOpt.isDefined =>
               if (authTokenOpt.exists(authToken => orgInviteCommander.isAuthValid(orgId, authToken))) {
                 val memberPermissions = orgMembershipCommander.getPermissions(orgId, None)
                 block(OrganizationRequest(request, orgId, authTokenOpt, memberPermissions))


### PR DESCRIPTION
@ryanpbrewster @eishay 

fixes this: https://fortytwo.airbrake.io/projects/113130/groups/1485755346564589597/notices/1485755346564589596

return 404 when no auth token is present instead of "invalid_authtoken"
