### PR TITLE
increase org invite typeahead limit to buffer filtering of org members

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
@@ -385,9 +385,10 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
   }
 
   def suggestMembers(userId: Id[User], orgId: Id[Organization], query: Option[String], limit: Int): Future[Seq[MaybeOrganizationMember]] = {
+    val limitPlusOrgSize = organizationMembershipRepo.countByOrgId(orgId)
     val friendsAndContactsFut = query.map(_.trim).filter(_.nonEmpty) match {
-      case Some(validQuery) => typeaheadCommander.searchFriendsAndContacts(userId, validQuery, Some(limit))
-      case None => Future.successful(typeaheadCommander.suggestFriendsAndContacts(userId, Some(limit)))
+      case Some(validQuery) => typeaheadCommander.searchFriendsAndContacts(userId, validQuery, Some(limitPlusOrgSize))
+      case None => Future.successful(typeaheadCommander.suggestFriendsAndContacts(userId, Some(limitPlusOrgSize)))
     }
     val activeInvites = db.readOnlyMaster { implicit session =>
       organizationInviteRepo.getAllByOrgIdAndDecisions(orgId, Set(InvitationDecision.PENDING, InvitationDecision.DECLINED))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
@@ -385,10 +385,11 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
   }
 
   def suggestMembers(userId: Id[User], orgId: Id[Organization], query: Option[String], limit: Int): Future[Seq[MaybeOrganizationMember]] = {
-    val limitPlusOrgSize = organizationMembershipRepo.countByOrgId(orgId)
     val friendsAndContactsFut = query.map(_.trim).filter(_.nonEmpty) match {
-      case Some(validQuery) => typeaheadCommander.searchFriendsAndContacts(userId, validQuery, Some(limitPlusOrgSize))
-      case None => Future.successful(typeaheadCommander.suggestFriendsAndContacts(userId, Some(limitPlusOrgSize)))
+      case Some(validQuery) => typeaheadCommander.searchFriendsAndContacts(userId, validQuery, Some(limit))
+      case None =>
+        val memberCount = db.readOnlyMaster { implicit s => organizationMembershipRepo.countByOrgId(orgId) }
+        Future.successful(typeaheadCommander.suggestFriendsAndContacts(userId, Some(limit + memberCount)))
     }
     val activeInvites = db.readOnlyMaster { implicit session =>
       organizationInviteRepo.getAllByOrgIdAndDecisions(orgId, Set(InvitationDecision.PENDING, InvitationDecision.DECLINED))
@@ -435,7 +436,7 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
           }
           MaybeOrganizationMember(Right(contact), role, lastInvitedAt)
         }
-        suggestedUsers ++ suggestedEmailAddresses
+        (suggestedUsers ++ suggestedEmailAddresses).take(limit)
     }
   }
 


### PR DESCRIPTION
@andrewconner this is a cheap solution, augment the limit knowing the result will be filtered. a more robust one I can think of would be to pass a filter function through to `typeaheadCommander` to apply before taking the limit.
