### PR TITLE
filter out invalid domain names

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/abook/model/RichContact.scala
+++ b/kifi-backend/modules/common/app/com/keepit/abook/model/RichContact.scala
@@ -10,7 +10,7 @@ import play.api.libs.functional.syntax._
 @json case class RichContact(email: EmailAddress, name: Option[String] = None, firstName: Option[String] = None, lastName: Option[String] = None, userId: Option[Id[User]] = None)
 
 case class EmailAccountInfo(emailAccountId: Id[EmailAccountInfo], address: EmailAddress, userId: Option[Id[User]], verified: Boolean, seq: SequenceNumber[EmailAccountInfo]) {
-  def getDomainName = address.address.split("@")(1)
+  def getDomainName: String = address.address.split("@")(1)
 }
 object EmailAccountInfo {
   implicit val format = (

--- a/kifi-backend/modules/common/app/com/keepit/classify/Domain.scala
+++ b/kifi-backend/modules/common/app/com/keepit/classify/Domain.scala
@@ -9,7 +9,7 @@ import org.apache.commons.codec.binary.Base64
 import org.joda.time.DateTime
 import com.keepit.common.db.{ State, States, ModelWithState, Id }
 import com.keepit.common.time._
-import com.keepit.common.logging.AccessLog
+import com.keepit.common.logging.{ Logging, AccessLog }
 import com.keepit.model.{ Normalization }
 import play.api.data.{ Forms, Mapping }
 import play.api.libs.functional.syntax._
@@ -67,7 +67,7 @@ object DomainInfo {
 
 case class NormalizedHostname(value: String) // use NormalizedHostname.fromHostname
 
-object NormalizedHostname {
+object NormalizedHostname extends Logging {
   private val DomainRegex = """^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9]+$""".r
   private val MaxLength = 256
   def isValid(s: String): Boolean = DomainRegex.pattern.matcher(s).matches && s.length < MaxLength && Try(IDN.toASCII(s)).isSuccess
@@ -77,7 +77,7 @@ object NormalizedHostname {
   implicit val format: Format[NormalizedHostname] = new Format[NormalizedHostname] {
     def reads(json: JsValue): JsResult[NormalizedHostname] = {
       val trimmed = json.as[String].trim
-      NormalizedHostname.fromHostname(trimmed).map(JsSuccess(_)).getOrElse { JsError("invalid_hostname") }
+      NormalizedHostname.fromHostname(trimmed).map(JsSuccess(_)).getOrElse { log.error("[NormalizedHostname] invalid hostname: $trimmed"); JsError("invalid_hostname") }
     }
     def writes(o: NormalizedHostname) = JsString(o.value)
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
@@ -274,8 +274,7 @@ class ShoeboxDataPipeController @Inject() (
 
   def internDomainsByDomainNames() = Action.async(parse.json) { request =>
     SafeFuture {
-      val domainNames = (request.body \ "domainNames").as[Set[NormalizedHostname]]
-      implicit val hostnameFormat = NormalizedHostname.format
+      val domainNames = (request.body \ "domainNames").as[Set[String]].flatMap( str => NormalizedHostname.fromHostname(str))
       val domainInfoByName: Map[String, DomainInfo] = db.readWrite { implicit session =>
         domainRepo.internAllByNames(domainNames).map { case (hostname, domain) => hostname.value -> domain.toDomainInfo }
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
@@ -274,7 +274,7 @@ class ShoeboxDataPipeController @Inject() (
 
   def internDomainsByDomainNames() = Action.async(parse.json) { request =>
     SafeFuture {
-      val domainNames = (request.body \ "domainNames").as[Set[String]].flatMap( str => NormalizedHostname.fromHostname(str))
+      val domainNames = (request.body \ "domainNames").as[Set[String]].flatMap(str => NormalizedHostname.fromHostname(str))
       val domainInfoByName: Map[String, DomainInfo] = db.readWrite { implicit session =>
         domainRepo.internAllByNames(domainNames).map { case (hostname, domain) => hostname.value -> domain.toDomainInfo }
       }


### PR DESCRIPTION
@andrewconner @ryanpbrewster @leogrim 

weird bug where `ShoeboxServiceClient` sends a set of valid `NormalizedHostname` to `ShoeboxDataPipeline`, but when deserializing finds that one of the hostnames is invalid. This is a workaround to filter hostnames again in Shoebox. Also added logging.
