### PR TITLE
Add 'members' to the list of reserved slugs

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/util.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/util.js
@@ -9,7 +9,7 @@ angular.module('util', [])
     var hyphensToMakeNonBreakingRe = /( \S{1,10})-(?=\S{1,10} )/g;
     var punctuationRe = /[!-\/:-@[-`{-~]/;
 
-    var RESERVED_SLUGS = ['libraries', 'connections', 'followers', 'keeps', 'tags'];
+    var RESERVED_SLUGS = ['libraries', 'connections', 'followers', 'keeps', 'tags', 'members'];
 
     var util = {
       startsWith: function (str, prefix) {


### PR DESCRIPTION
@camhashemi @andrewconner @adamjgrant 

we don't want users to try to create an org library called "members" that they can't access
