### PR TITLE
KeepRepo.getByIds should not filter inactive keeps

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
@@ -183,7 +183,7 @@ class KeepRepoImpl @Inject() (
   }
 
   def getByIds(ids: Set[Id[Keep]])(implicit session: RSession): Map[Id[Keep], Keep] = {
-    val q = for (b <- rows if b.id.inSet(ids) && b.state === KeepStates.ACTIVE) yield b
+    val q = for (b <- rows if b.id.inSet(ids)) yield b
     q.list.map { keep => (keep.id.get, keep) }.toMap
   }
 


### PR DESCRIPTION
@camhashemi @cvializ @adamjgrant 

This should fix the issue. The underlying problem is one I need to look into further.
