### PR TITLE
remove test involving org invite w/ role

### DIFF
--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationInviteCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationInviteCommanderTest.scala
@@ -186,25 +186,6 @@ class OrganizationInviteCommanderTest extends TestKitSupport with SpecificationL
           inviteCommander.acceptInvitation(org.id.get, userId, "authToken") === Left(OrganizationFail.NO_VALID_INVITATIONS)
         }
       }
-
-      //      "fail when there are invitations but none are valid" in { // we don't send invites with roles anymore
-      //        withDb(modules: _*) { implicit injector =>
-      //          val inviteCommander = inject[OrganizationInviteCommander]
-      //          val inviteRepo = inject[OrganizationInviteRepo]
-      //          val memberRepo = inject[OrganizationMembershipRepo]
-      //          val inviterId = Id[User](1)
-      //          val userId = Id[User](2)
-      //          val (org, invite) = db.readWrite { implicit session =>
-      //            UserFactory.user().withId(inviterId).saved
-      //            UserFactory.user().withId(userId).saved
-      //            val org = OrganizationFactory.organization().withOwner(inviterId).withHandle(OrganizationHandle("kifi")).saved
-      //            memberRepo.save(org.newMembership(userId = inviterId, role = OrganizationRole.MEMBER))
-      //            val invite = inviteRepo.save(OrganizationInvite(organizationId = org.id.get, inviterId = inviterId, userId = Some(userId), role = OrganizationRole.ADMIN))
-      //            (org, invite)
-      //          }
-      //          inviteCommander.acceptInvitation(org.id.get, userId, invite.authToken) === Left(OrganizationFail.NO_VALID_INVITATIONS)
-      //        }
-      //      }
     }
   }
 }


### PR DESCRIPTION
@ryanpbrewster @leogrim removing this test because 1) we don't send invites w/ a role, 2) we don't allow people to send invites above their role
