### PR TITLE
Operation Gatekeeper

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
@@ -44,6 +44,9 @@ case class Keep(
 
   def withId(id: Id[Keep]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
+  def withNote(newNote: Option[String]) = this.copy(note = newNote)
+  def withVisibility(newVisibility: LibraryVisibility) = this.copy(visibility = newVisibility)
+  def withOwner(newOwner: Id[User]) = this.copy(userId = newOwner)
 
   def withActive(isActive: Boolean) = copy(state = isActive match {
     case true => KeepStates.ACTIVE

--- a/kifi-backend/modules/common/app/com/keepit/model/KeepToCollection.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepToCollection.scala
@@ -16,6 +16,7 @@ case class KeepToCollection(
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime) extends ModelWithState[KeepToCollection] {
   def isActive: Boolean = state == KeepToCollectionStates.ACTIVE
+  def isInactive: Boolean = state == KeepToCollectionStates.INACTIVE
   def withId(id: Id[KeepToCollection]): KeepToCollection = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime): KeepToCollection = this.copy(updatedAt = now)
   def inactivate(): KeepToCollection = this.copy(state = KeepToCollectionStates.INACTIVE)

--- a/kifi-backend/modules/common/test/com/keepit/model/KeepFactory.scala
+++ b/kifi-backend/modules/common/test/com/keepit/model/KeepFactory.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import com.keepit.common.db.{ SequenceNumber, ExternalId, Id, State }
 import com.keepit.common.time._
+import org.apache.commons.lang3.RandomStringUtils
 import org.apache.commons.lang3.RandomStringUtils.random
 import org.joda.time.DateTime
 
@@ -17,6 +18,8 @@ object KeepFactory {
       urlId = Id[URL](-1 * idx.incrementAndGet()),
       url = s"http://${random(5, "abcdefghijklmnopqrstuvwxyz")}.com/${random(5, "abcdefghijklmnopqrstuvwxyz")}",
       visibility = LibraryVisibility.PUBLISHED,
+      title = Some(RandomStringUtils.randomAlphabetic(20)),
+      keptAt = currentDateTime.minusYears(10).plusMinutes(idx.incrementAndGet().toInt),
       userId = userId,
       source = KeepSource.keeper,
       libraryId = None,

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -1407,7 +1407,8 @@ class LibraryCommanderImpl @Inject() (
       case v if v.isEmpty || v.get.access == LibraryAccess.READ_ONLY =>
         (Seq.empty[Keep], keeps.map(_ -> LibraryError.DestPermissionDenied))
       case Some(_) =>
-        val keepResults = applyToKeeps(userId, toLibraryId, keeps, Set(), (k, s) => keepCommander.copyKeep(k, toLibrary, userId, withSource)(s))
+        val sortedKeeps = keeps.sortBy(k => (k.keptAt, k.id.get))
+        val keepResults = applyToKeeps(userId, toLibraryId, sortedKeeps, Set(), (k, s) => keepCommander.copyKeep(k, toLibrary, userId, withSource)(s))
         Future {
           libraryAnalytics.editLibrary(userId, toLibrary, context, Some("copy_keeps"))
         }


### PR DESCRIPTION
In the middle of editing `copyKeeps` and `moveKeeps`

Need to implement:
  KeepsCommander.createKeep
  KeepsCommander.moveKeep

Next:
  Rename to "KeepCommander" (singular)
  For god's sake stop using this request/response thing for something as
  as simple as KTLCommander
