### PR TITLE
Fix incorrect top spacing of persona libraries' titles

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/userProfileLibraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/userProfileLibraryCard.tpl.html
@@ -2,7 +2,7 @@
      ng-class="{'justAddedBelow': lib.justAddedBelow, 'justAddedBelowAcross': lib.justAddedBelowAcross}">
   <a class="kf-upl-card-setting svg-settings-gear" ng-if="::myProfile && isOwner && lib.kind !== 'system_main' && lib.kind !== 'system_secret'" href="javascript:" ng-click="openModifyLibrary(lib, currentPageOrigin)"></a>
   <a class="kf-upl-card-link" href="{{lib.path}}" ng-click="trackUplCardClick(lib, 'clickedLibraryTitle')">
-    <div class="kf-upl-card-icon" ng-class="::{'svg-card-star': lib.kind === 'system_main', 'svg-card-lock': lib.kind === 'system_secret'}" ng-if="::lib.kind.lastIndexOf('system', 0) === 0"></div>
+    <div class="kf-upl-card-icon" ng-class="::{'svg-card-star': lib.kind === 'system_main', 'svg-card-lock': lib.kind === 'system_secret'}" ng-if="::(lib.kind === 'system_main' || lib.kind === 'system_secret')"></div>
     <div class="kf-upl-card-cover">
       <div class="kf-upl-card-cover-image" style="{{::lib.image|bgImageAndPos}}" ng-if="::lib.image"></div>
     </div>


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="465" alt="screen shot 2015-08-13 at 5 49 29 pm" src="https://cloud.githubusercontent.com/assets/2363700/9265164/35472bc8-41e4-11e5-8b0f-907c3bff3433.png"> | <img width="464" alt="screen shot 2015-08-13 at 5 49 42 pm" src="https://cloud.githubusercontent.com/assets/2363700/9265166/392ad154-41e4-11e5-9a53-da46f4c9b8e0.png"> |

@adamjgrant @andrewconner 

The System Library Star/Lock icon was being shown, just without any image inside.
