### PR TITLE
Semi-fix for managing personas in dev

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/persona/managePersona.js
+++ b/kifi-backend/modules/shoebox/angular/src/persona/managePersona.js
@@ -65,7 +65,7 @@ angular.module('kifi')
         };
 
         scope.close = function() {
-          if (scope.selectedPersonaIds.length > 0) {
+          if (scope.selectedPersonaIds.length > 0 || scope.allPersonas.length === 0) {
             if (_.isFunction(scope.closeAction)) {
               scope.loading = true;
               userPersonaActionService.selectPersonas(scope.selectedPersonaIds).then(function() {

--- a/kifi-backend/modules/shoebox/angular/src/persona/managePersona.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/persona/managePersona.tpl.html
@@ -1,5 +1,5 @@
-<div class="kf-mp dialog-content" ng-if="allPersonas.length > 0">
-  <a class="dialog-x kf-mp-close-x" ng-if="isModal" ng-click="close()" ng-class="{visible: selectedPersonaIds.length > 0}"></a>
+<div class="kf-mp dialog-content">
+  <a class="dialog-x kf-mp-close-x" ng-if="isModal" ng-click="close()" ng-class="{visible: selectedPersonaIds.length > 0 || allPersonas.length == 0}"></a>
   <div class="dialog-body-wrap">
     <div class="dialog-body">
       <h1 class="dialog-header"> Who are you? </h1>


### PR DESCRIPTION
@andrewconner 
When running the app in dev mode, there are no registered personas, so the persona list comes to the web app completely empty. The way this was handled previously was to not show the contents of persona modal (including the close button), making the frontend inoperable. I made a few quick fixes to the logic in order to make it possible to close the modal when there are no personas. It still looks hacky and is somewhat inconvenient to use the site in dev mode (because the guide is started right after), but at least it is operable. There should be no changes in behavior for environments that have more than one persona (also known as production :stuck_out_tongue: ).
