### PR TITLE
change how user library analytics are sent; adds support for sending these analytics to amplitude

### DIFF
--- a/kifi-backend/modules/common/test/com/keepit/heimdal/FakeHeimdalServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/heimdal/FakeHeimdalServiceClientImpl.scala
@@ -8,6 +8,7 @@ import com.keepit.common.zookeeper.ServiceCluster
 import com.keepit.test.{ FakeRepoWithId, FakeServiceClient }
 import org.joda.time.DateTime
 
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.{ Future, Promise }
 
@@ -79,6 +80,8 @@ class FakeHeimdalServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
   val trackedEvents = ArrayBuffer[HeimdalEvent]()
   def eventsRecorded: Int = synchronized(trackedEvents.size)
 
+  val setUserPropertyCalls = mutable.ListBuffer.empty[(Id[User], Seq[(String, ContextData)])]
+
   def trackEvent(event: HeimdalEvent): Unit = synchronized {
     trackedEvents += event
   }
@@ -93,7 +96,9 @@ class FakeHeimdalServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier) exten
 
   def incrementUserProperties(userId: Id[User], increments: (String, Double)*): Unit = {}
 
-  def setUserProperties(userId: Id[User], properties: (String, ContextData)*): Unit = {}
+  def setUserProperties(userId: Id[User], properties: (String, ContextData)*): Unit = {
+    setUserPropertyCalls.append((userId, properties))
+  }
 
   def setUserAlias(userId: Id[User], externalId: ExternalId[User]) = {}
 

--- a/kifi-backend/modules/heimdal/app/com/keepit/controllers/AnalyticsController.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/controllers/AnalyticsController.scala
@@ -23,10 +23,12 @@ class AnalyticsController @Inject() (mixpanelClient: MixpanelClient, amplitudeCl
   def deleteUser(userId: Id[User]) = Action.async { request =>
     SafeFuture {
       mixpanelClient.delete(userId)
+      // TODO amplitude?
       Ok
     }
   }
 
+  // an amplitude equivalent of this doesn't, exist; use setUserProperties instead
   def incrementUserProperties(userId: Id[User]) = Action.async { request =>
     val increments = request.body.asJson.get.as[JsObject].value.mapValues(_.as[Double]).toMap
     SafeFuture {

--- a/kifi-backend/modules/shoebox/angular/bower.json
+++ b/kifi-backend/modules/shoebox/angular/bower.json
@@ -30,7 +30,7 @@
     "fuse.js": "1.1.0",
     "jquery": "2.1.3",
     "jquery-mousewheel": "3.1.12",
-    "lodash": "2.4.1",
+    "lodash": "3.10.1",
     "normalize-css": "2.1.3",
     "underscore.string": "2.3.3",
     "airbrake-js-client": "~0.4.3",

--- a/kifi-backend/modules/shoebox/angular/gulpfile.js
+++ b/kifi-backend/modules/shoebox/angular/gulpfile.js
@@ -86,7 +86,7 @@ var libCssFiles = [
   'managed-lib/pace/pace.css'
 ];
 var libJsFiles = [
-  ['lib/lodash/dist/lodash.js', 'lib/lodash/dist/lodash.min.js'],
+  ['lib/lodash/lodash.js', 'lib/lodash/lodash.min.js'],
   ['lib/underscore.string/lib/underscore.string.js', 'lib/underscore.string/dist/underscore.string.min.js'],
   ['lib/jquery/dist/jquery.js', 'lib/jquery/dist/jquery.min.js'],
   ['lib/angular/angular.js', 'lib/angular/angular.min.js'],

--- a/kifi-backend/modules/shoebox/angular/src/common/services/mixpanelService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/mixpanelService.js
@@ -59,7 +59,19 @@
       // filter out events we don't care about (this may duplicate some
       // server-side logic for events sent to the proxy)
       if (!_.str.startsWith($window.navigator.userAgent, 'Pingdom')) {
-        $window.amplitude.logEvent(action, props);
+
+        // translates Object keys to snake_case from camelCase
+        var snakeCaseProps = _.mapKeys(props, function(value, key) {
+          var newKey = key.replace(/([A-Z])/g, function($1) { return '_' + $1.toLowerCase(); });
+          if (newKey[0] === '_' && key[0] !== '_') {
+            // ignore leading underscore if the original key didn't have one
+            return newKey.slice(1);
+          } else {
+            return newKey;
+          }
+        });
+
+        $window.amplitude.logEvent(action, snakeCaseProps);
       }
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryAnalytics.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryAnalytics.scala
@@ -304,12 +304,7 @@ class LibraryAnalytics @Inject() (
         contextBuilder.addUrlInfo(bookmark.url)
         heimdal.trackEvent(AnonymousEvent(contextBuilder.build, AnonymousEventTypes.KEPT, keptAt))
     }
-    val kept = keeps.length
-    val keptPrivate = keeps.count(_.isPrivate)
-    val keptPublic = kept - keptPrivate
-    heimdal.incrementUserProperties(userId, "keeps" -> kept, "privateKeeps" -> keptPrivate, "publicKeeps" -> keptPublic)
     userPropertyUpdateActor.ref ! (userId, UserPropertyUpdateInstruction.KeepCounts)
-
     heimdal.setUserProperties(userId, "lastKept" -> ContextDate(keptAt))
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserPropertyUpdateActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserPropertyUpdateActor.scala
@@ -1,0 +1,72 @@
+package com.keepit.commanders
+
+import com.google.inject.Inject
+import com.keepit.common.akka.FortyTwoActor
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.heimdal.{ ContextData, HeimdalContextBuilder, HeimdalServiceClient }
+import com.keepit.model.{ CollectionRepo, KeepRepo, User, UserConnectionRepo }
+
+abstract sealed class UserPropertyUpdateInstruction(val v: Int) {
+  def has(other: UserPropertyUpdateInstruction): Boolean = (this.v & other.v) == other.v
+  override def toString = s"UserPropertyUpdateInstruction($v)"
+}
+
+object UserPropertyUpdateInstruction {
+  object ConnectionCount extends UserPropertyUpdateInstruction(1)
+  object KeepCounts extends UserPropertyUpdateInstruction(2)
+  object TagCount extends UserPropertyUpdateInstruction(4)
+  object All extends UserPropertyUpdateInstruction(ConnectionCount.v | KeepCounts.v | TagCount.v)
+}
+
+class UserPropertyUpdateActor @Inject() (
+    airbrake: AirbrakeNotifier,
+    heimdalServiceClient: HeimdalServiceClient,
+    keepRepo: KeepRepo,
+    userConnectionRepo: UserConnectionRepo,
+    collectionRepo: CollectionRepo,
+    db: Database) extends FortyTwoActor(airbrake) {
+  import UserPropertyUpdateInstruction._
+
+  def receive: Receive = {
+    case id: Id[_] => self ! (id, All)
+    case (id: Id[_], instruction: UserPropertyUpdateInstruction) =>
+      setUserProperties(Id[User](id.id), instruction)
+  }
+
+  def setUserProperties(userId: Id[User], instruction: UserPropertyUpdateInstruction): Map[String, ContextData] = db.readOnlyReplica(attempts = 2) { implicit session =>
+    log.info(s"UserPropertyUpdateActor($userId, $instruction) called")
+
+    val properties: Map[String, ContextData] = {
+      val builder = new HeimdalContextBuilder()
+
+      if (instruction.has(ConnectionCount)) {
+        val connectionCount = userConnectionRepo.getConnectionCount(userId)
+        builder += ("kifiConnections", connectionCount)
+      }
+
+      if (instruction.has(KeepCounts)) {
+        val (privateKeeps, publicKeeps) = keepRepo.getPrivatePublicCountByUser(userId)
+        builder += ("keeps", privateKeeps + publicKeeps)
+        builder += ("publicKeeps", publicKeeps)
+        builder += ("privateKeeps", privateKeeps)
+      }
+
+      if (instruction.has(TagCount)) {
+        val tagsCount = collectionRepo.count(userId)
+        builder += ("tags", tagsCount)
+      }
+
+      builder.build.data
+    }
+
+    if (properties.nonEmpty) {
+      heimdalServiceClient.setUserProperties(userId, properties.toSeq: _*)
+    } else {
+      airbrake.notify(s"UserPropertyUpdateActor (userId=$userId instruction=$instruction) did not set any user properties")
+    }
+
+    properties
+  }
+}

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/UserPropertyUpdateActorTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/UserPropertyUpdateActorTest.scala
@@ -1,0 +1,49 @@
+package com.keepit.commanders
+
+import com.keepit.common.actor.{ ActorInstance, FakeActorSystemModule, TestKitSupport }
+import com.keepit.common.db.Id
+import com.keepit.heimdal.{ ContextData, ContextDoubleData, FakeHeimdalServiceClientImpl, FakeHeimdalServiceClientModule, HeimdalServiceClient }
+import com.keepit.model.User
+import com.keepit.test.ShoeboxTestInjector
+import org.specs2.mutable.SpecificationLike
+
+import scala.collection.mutable.ArrayBuffer
+
+class UserPropertyUpdateActorTest extends TestKitSupport with SpecificationLike with ShoeboxTestInjector {
+
+  def modules = FakeActorSystemModule() :: FakeHeimdalServiceClientModule() :: Nil
+
+  implicit val propertyOrd = new Ordering[(String, ContextData)] {
+    // used to test an array of these without worrying about ordering
+    override def compare(x: (String, ContextData), y: (String, ContextData)): Int = x._1.compareTo(y._1)
+  }
+
+  "UserPropertyUpdateActor" should {
+
+    "send user properties to heimdal" in withDb(modules: _*) { implicit injector =>
+      val heimdalServiceClient = inject[HeimdalServiceClient].asInstanceOf[FakeHeimdalServiceClientImpl]
+      val actorInstance = inject[ActorInstance[UserPropertyUpdateActor]]
+      val (userId1, userId2, userId3) = (Id[User](1), Id[User](2), Id[User](3))
+
+      actorInstance.ref ! userId1
+      actorInstance.ref ! (userId2, UserPropertyUpdateInstruction.ConnectionCount)
+      actorInstance.ref ! (userId3, UserPropertyUpdateInstruction.KeepCounts)
+      actorInstance.ref ! (userId1, UserPropertyUpdateInstruction.TagCount)
+
+      val zero = ContextDoubleData(0f)
+      val keepsProps: ArrayBuffer[(String, ContextData)] = ArrayBuffer(
+        ("keeps", zero),
+        ("privateKeeps", zero),
+        ("publicKeeps", zero))
+      val connectionsProps = ArrayBuffer(("kifiConnections", zero))
+      val tagsProps = ArrayBuffer(("tags", zero))
+
+      val calls = heimdalServiceClient.setUserPropertyCalls
+      calls.head._1 === userId1
+      calls.head._2.sorted === (keepsProps ++ connectionsProps ++ tagsProps).sorted
+      calls(1) === (userId2, connectionsProps)
+      calls(2) === (userId3, keepsProps)
+      calls(3) === (userId1, tagsProps)
+    }
+  }
+}

--- a/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxApplication.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxApplication.scala
@@ -60,7 +60,8 @@ class ShoeboxApplication(overridingModules: Module*)(implicit path: File = new F
     AwsModule(),
     FakeCryptoModule(),
     DevTwilioCredentialsModule(),
-    FakeExecutionContextModule()
+    FakeExecutionContextModule(),
+    FakeActorSystemModule()
   ))
 
 trait ShoeboxApplicationInjector extends TestInjectorProvider with ApplicationInjector with DbInjectionHelper with ShoeboxInjectionHelpers


### PR DESCRIPTION
mixpanel has a way to increment numeric properties by a certain delta, amplitude does not. so to
pass these properties to amplitude we need to fetch the final values of them and call "setUserProperties" instead

this replaces the main (but not the only) consumer of the heimdal incrementUserProperties endpoint to call an actor
instead that will fetch certain properties for the user and call heimdal.setUserProperties

it's certainly noted that this increases load on the database, but I don't think it's enough to be of concern

the motivation behind using an actor here is that these are "fire & forget" functions, but because this results
more queries hitting the database (or cache), the actor gives us additional flexibility to limit concurrency,
debouce/consolidate db or API calls, scale, <insert other akka benefits here>, etc

@andrewconner @stkem 
