### PR TITLE
Arrange page elements better on mobile screens

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/build-css/constants.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/build-css/constants.styl
@@ -53,6 +53,7 @@ appSidePad2MinWidth = 480px // for @media min-width
 
 appMinWidth = 774px  // for pages not responsive to width
 appMaxWidth = appMinWidth + (2 * appSidePad2)
+appMobileWidth = 480px
 
 appHeaderHeight1 = 48px
 appHeaderHeight2 = 54px

--- a/kifi-backend/modules/shoebox/angular/src/common/modal/modal.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/modal/modal.js
@@ -42,17 +42,13 @@ angular.module('kifi')
         onOpen();
       }],
       link: function (scope, element, attrs) {
-        scope.dialogStyle = {};
+        scope.dialogStyle = {
+          'width': '100%',
+          'max-width': attrs.kfWidth || '550px',
+          'height': attrs.kfHeight
+        };
         scope.backdropStyle = {};
         scope.noUserHide = (attrs.noUserHide !== void 0) || false;
-
-        if (attrs.kfWidth) {
-          scope.dialogStyle.width = attrs.kfWidth;
-        }
-        if (attrs.kfHeight) {
-          scope.dialogStyle.height = attrs.kfHeight;
-        }
-
         scope.backdropStyle.opacity = attrs.kfOpacity || 0.3;
         scope.backdropStyle.backgroundColor = attrs.kfBackdropColor || 'rgba(0, 40, 90, 1)';
 

--- a/kifi-backend/modules/shoebox/angular/src/common/modal/modal.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/modal/modal.styl
@@ -26,7 +26,10 @@ generic-dialog-button =
   top: 50%
   transform: translate(-50%, -50%)
   width: auto
-  margin: 0
+
+  box-sizing: border-box
+  border: 10px transparent solid
+
   z-index: 1050
 
 .modal-content

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.styl
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.styl
@@ -16,6 +16,14 @@ ophImageWidth = 200px
   margin: 0 auto
   display: flex
 
+  @media (max-height: ophSmallMaxDim) and (max-width: ophSmallMaxDim)
+    padding-top: 12px
+    margin-left: 20px
+    margin-right: 20px
+
+  @media (max-width: appMobileWidth)
+    flex-direction: column
+
   textarea.kf-edit-field
     background: transparent
 
@@ -24,16 +32,13 @@ ophImageWidth = 200px
       background: white
       color: textDarkGrey
 
-  @media (max-height: ophSmallMaxDim) and (max-width: ophSmallMaxDim)
-    padding-top: 12px
-    margin-left: 20px
-    margin-right: 20px
 
   .profile-image-widget
     width: ophImageWidth
     height: ophImageWidth
     overflow: hidden
     border-radius: 5%
+    margin: auto
 
 .kf-oph-pic-wrapper
   position: relative
@@ -59,6 +64,10 @@ ophImageWidth = 200px
   flex: 1
   margin-left: 25px
   text-align: left
+
+  @media (max-width: appMobileWidth)
+    margin-right: 25px
+    margin-top: 25px
 
   .kf-oph-input
     width: 100%

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMember.styl
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMember.styl
@@ -31,7 +31,7 @@
 
 .kf-org-member-upper-left
   float: left
-  width: 50%
+  width: 70%
 
 .kf-org-member-upper-right
   float: right

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMemberManage.styl
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMemberManage.styl
@@ -42,6 +42,7 @@
 
 .kf-opmr-member-pic
   flex: 1 0 0
+  margin-right: 10px
 
   img
     border-radius: 50%

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMemberManage.styl
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMemberManage.styl
@@ -1,7 +1,8 @@
 .kf-org-member-manage
+  box-sizing: border-box
   width: 80%;
   max-width: 700px
-  min-width: 400px
+  min-width: 320px
   margin: 40px auto
   overflow: hidden
 


### PR DESCRIPTION
@adamjgrant @andrewconner 

| Before | After |
| --- | --- |
| <img width="432" alt="screen shot 2015-08-17 at 10 37 44 am" src="https://cloud.githubusercontent.com/assets/2363700/9311707/e9012796-44cc-11e5-8c6f-2bb6d8f03e3f.png"> | <img width="432" alt="screen shot 2015-08-17 at 10 38 25 am" src="https://cloud.githubusercontent.com/assets/2363700/9311708/ed82b41a-44cc-11e5-9e53-1e46e9bc7147.png"> |
| <img width="432" alt="screen shot 2015-08-17 at 10 37 50 am" src="https://cloud.githubusercontent.com/assets/2363700/9311713/f2f3a472-44cc-11e5-898c-71a33fe61ca4.png"> | <img width="432" alt="screen shot 2015-08-17 at 10 38 31 am" src="https://cloud.githubusercontent.com/assets/2363700/9311714/f68f447e-44cc-11e5-8087-594ce6dfd4ea.png"> |
