### PR TITLE
KeepToLibrary sets addedAt to match Keep.keptAt

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToLibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToLibraryCommander.scala
@@ -42,6 +42,7 @@ class KeepToLibraryCommanderImpl @Inject() (
           keepId = keep.id.get,
           libraryId = library.id.get,
           addedBy = addedBy,
+          addedAt = keep.keptAt, // TODO(ryan): take this out once we're ready to have keeps in multiple libraries
           uriId = keep.uriId,
           isPrimary = keep.isPrimary,
           visibility = library.visibility,


### PR DESCRIPTION
This is so that the keep ordering within a library matches existing code. When
we are ready to break from current behavior we should set it back to use
clock.now or something.

@leogrim 
