### PR TITLE
Updating "Owner" label on new owner after transfer

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMember.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMember.js
@@ -116,6 +116,7 @@ angular.module('kifi')
         member: $scope.member,
         returnAction: function () {
           $scope.$emit('resetAndFetch');
+          $scope.organization.ownerId = $scope.member.id
         }
       };
       for (var i=0, len=$scope.members.length; i < len; i++) {
@@ -124,6 +125,7 @@ angular.module('kifi')
         }
       }
       modalService.open({
+        // TODO: Template name needs to be longer
         template: 'orgProfile/orgProfileMemberOwnerTransferModal.tpl.html',
         modalData: opts
       });


### PR DESCRIPTION
@andrewconner @cvializ 

This is one of two ways to accomplish this. After transferring ownership, the list of members refreshes, putting the owner at the top, but the "owner" and "admin" labels are still on the same people. This is because ownership is determined by `$scope.organization.ownerId` matching a `$scope.member`'s own id.

After transferring ownership, we do an HTTP request for the members, but not one for the owners. I didn't think it would be reasonable to introduce a second request just to update a label, so this is done manually on the `$scope` iff the request was successful. (line 119)
