### PR TITLE
KTL ordering using an innerJoin with Keeps

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToLibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToLibraryCommander.scala
@@ -6,6 +6,7 @@ import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
+import com.keepit.common.time._
 import com.keepit.model._
 
 import scala.util.{ Success, Failure, Try }
@@ -29,6 +30,7 @@ trait KeepToLibraryCommander {
 @Singleton
 class KeepToLibraryCommanderImpl @Inject() (
   db: Database,
+  clock: Clock,
   keepRepo: KeepRepo,
   libraryRepo: LibraryRepo,
   libraryMembershipRepo: LibraryMembershipRepo,
@@ -44,7 +46,7 @@ class KeepToLibraryCommanderImpl @Inject() (
           keepId = keep.id.get,
           libraryId = library.id.get,
           addedBy = addedBy,
-          addedAt = keep.keptAt, // TODO(ryan): take this out once we're ready to have keeps in multiple libraries
+          addedAt = clock.now,
           uriId = keep.uriId,
           isPrimary = keep.isPrimary,
           visibility = library.visibility,

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -155,7 +155,7 @@ class LibraryCommanderImpl @Inject() (
   def getKeeps(libraryId: Id[Library], offset: Int, limit: Int): Future[Seq[Keep]] = {
     if (limit > 0) db.readOnlyReplicaAsync { implicit s =>
       val oldWay = keepRepo.getByLibrary(libraryId, offset, limit)
-      val newWay = ktlRepo.getByLibraryId(libraryId, Offset(offset), Limit(limit)) |> ktlCommander.getKeeps
+      val newWay = ktlRepo.getByLibraryIdSorted(libraryId, Offset(offset), Limit(limit))
       if (newWay != oldWay) {
         log.info(s"[KTL-MATCH] getKeeps($libraryId, $offset, $limit): ${newWay.map(_.id.get)} != ${oldWay.map(_.id.get)}")
       }
@@ -287,7 +287,7 @@ class LibraryCommanderImpl @Inject() (
                 } else keepRepo.getByLibrary(library.id.get, 0, maxKeepsShown) //not cached
               case _ =>
                 val oldWay = keepRepo.getByLibrary(library.id.get, 0, maxKeepsShown) //not cached
-                val newWay = ktlRepo.getByLibraryId(library.id.get, Offset(0), Limit(maxKeepsShown)) |> ktlCommander.getKeeps
+                val newWay = ktlRepo.getByLibraryIdSorted(library.id.get, Offset(0), Limit(maxKeepsShown))
                 if (newWay != oldWay) log.info(s"[KTL-MATCH] createFullLibraryInfos(${library.id.get}): ${newWay.map(_.id.get)} != ${oldWay.map(_.id.get)}")
                 oldWay
             }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToLibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToLibraryRepo.scala
@@ -1,6 +1,6 @@
 package com.keepit.model
 
-import com.google.inject.{ ImplementedBy, Inject, Singleton }
+import com.google.inject.{ Provider, ImplementedBy, Inject, Singleton }
 import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
 import com.keepit.common.db.slick._
 import com.keepit.common.db.{ Id, SequenceNumber, State }
@@ -17,9 +17,10 @@ trait KeepToLibraryRepo extends Repo[KeepToLibrary] {
 
   def getCountByLibraryId(libraryId: Id[Library], excludeStates: Set[State[KeepToLibrary]] = Set(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Int
   def getCountsByLibraryIds(libraryIds: Set[Id[Library]], excludeStates: Set[State[KeepToLibrary]] = Set(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Map[Id[Library], Int]
-  def getByLibraryId(libraryId: Id[Library], offset: Offset, limit: Limit, excludeStates: Set[State[KeepToLibrary]] = Set(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Seq[KeepToLibrary]
   def getAllByLibraryId(libraryId: Id[Library], excludeStates: Set[State[KeepToLibrary]] = Set(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Seq[KeepToLibrary]
   def getAllByLibraryIds(libraryIds: Set[Id[Library]], excludeStates: Set[State[KeepToLibrary]] = Set(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Map[Id[Library], Seq[KeepToLibrary]]
+
+  def getByLibraryIdSorted(libraryId: Id[Library], offset: Offset, limit: Limit, excludeStates: Set[State[KeepToLibrary]] = Set(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Seq[Keep]
 
   def getByUserIdAndLibraryId(userId: Id[User], libraryId: Id[Library], excludeStates: Set[State[KeepToLibrary]] = Set(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Seq[KeepToLibrary]
 
@@ -44,8 +45,11 @@ trait KeepToLibraryRepo extends Repo[KeepToLibrary] {
 @Singleton
 class KeepToLibraryRepoImpl @Inject() (
   val db: DataBaseComponent,
-  val clock: Clock)
+  val clock: Clock,
+  keepRepoProvider: Provider[KeepRepoImpl])
     extends KeepToLibraryRepo with DbRepo[KeepToLibrary] with Logging {
+
+  lazy val keepRepo = keepRepoProvider.get
 
   override def deleteCache(orgMember: KeepToLibrary)(implicit session: RSession) {}
   override def invalidateCache(orgMember: KeepToLibrary)(implicit session: RSession) {}
@@ -98,14 +102,17 @@ class KeepToLibraryRepoImpl @Inject() (
     // TODO(ryan): This needs to use a cache, and fall back on a single monster query, not a bunch of tiny queries
     libraryIds.map(libId => libId -> getCountByLibraryId(libId, excludeStates)).toMap
   }
-  def getByLibraryId(libraryId: Id[Library], offset: Offset, limit: Limit, excludeStates: Set[State[KeepToLibrary]] = Set(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Seq[KeepToLibrary] = {
-    getByLibraryIdHelper(libraryId, excludeStates).sortBy(r => (r.addedAt desc, r.keepId desc)).drop(offset.value).take(limit.value).list
-  }
   def getAllByLibraryId(libraryId: Id[Library], excludeStates: Set[State[KeepToLibrary]] = Set(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Seq[KeepToLibrary] = {
     getByLibraryIdHelper(libraryId, excludeStates).list
   }
   def getAllByLibraryIds(libraryIds: Set[Id[Library]], excludeStates: Set[State[KeepToLibrary]] = Set(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Map[Id[Library], Seq[KeepToLibrary]] = {
     getByLibraryIdsHelper(libraryIds, excludeStates).list.groupBy(_.libraryId)
+  }
+
+  def getByLibraryIdSorted(libraryId: Id[Library], offset: Offset, limit: Limit, excludeStates: Set[State[KeepToLibrary]] = Set(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Seq[Keep] = {
+    val q = for ((ktl, keep) <- rows join keepRepo.rows on (_.keepId === _.id) if ktl.libraryId === libraryId && !ktl.state.inSet(excludeStates)) yield (ktl, keep)
+    val sortedKeeps = q.sortBy { case (ktl, keep) => (keep.keptAt desc, keep.id desc) }.map(_._2)
+    sortedKeeps.drop(offset.value).take(limit.value).list
   }
 
   private def getByKeepIdAndLibraryIdHelper(keepId: Id[Keep], libraryId: Id[Library], excludeStates: Set[State[KeepToLibrary]])(implicit session: RSession) = {

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepToLibraryRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepToLibraryRepoTest.scala
@@ -85,7 +85,7 @@ class KeepToLibraryRepoTest extends Specification with ShoeboxTestInjector {
 
             for (lib <- libs) {
               val expected = inject[KeepRepo].getByLibrary(lib.id.get, offset = 10, limit = 20).map(_.id.get)
-              val actual = inject[KeepToLibraryRepo].getByLibraryId(lib.id.get, offset = Offset(10), limit = Limit(20)).map(_.keepId)
+              val actual = inject[KeepToLibraryRepo].getByLibraryIdSorted(lib.id.get, offset = Offset(10), limit = Limit(20)).map(_.id.get)
               actual === expected
             }
           }


### PR DESCRIPTION
This reverts commit e714aff89459cdf8cf4ee89a9eb9284df3fbcb33, reversing
changes made to a5041e1cae65db5f0aaa4378cbc6d70e1bfd4e35.

@leogrim @andrewconner this is the commit that (I think) caused the thread starvation issue last night. Any idea what part of this is problematic?
