### PR TITLE
I refuse to R5

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToLibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToLibraryCommander.scala
@@ -19,7 +19,6 @@ trait KeepToLibraryCommander {
 
   // Fun helper methods
   def isKeepInLibrary(keepId: Id[Keep], libraryId: Id[Library])(implicit session: RSession): Boolean
-  def getKeeps(ktls: Seq[KeepToLibrary])(implicit session: RSession): Seq[Keep]
   def changeOwner(ktl: KeepToLibrary, newOwnerId: Id[User])(implicit session: RWSession): KeepToLibrary
 
   def syncKeep(keep: Keep)(implicit session: RWSession): Unit
@@ -70,10 +69,6 @@ class KeepToLibraryCommanderImpl @Inject() (
 
   def isKeepInLibrary(keepId: Id[Keep], libraryId: Id[Library])(implicit session: RSession): Boolean = {
     ktlRepo.getByKeepIdAndLibraryId(keepId, libraryId).isDefined
-  }
-  def getKeeps(ktls: Seq[KeepToLibrary])(implicit session: RSession): Seq[Keep] = {
-    val keepsByIds = keepRepo.getByIds(ktls.map(_.keepId).toSet)
-    ktls.map(ktl => keepsByIds(ktl.keepId))
   }
 
   def changeOwner(ktl: KeepToLibrary, newOwnerId: Id[User])(implicit session: RWSession): KeepToLibrary = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepsCommander.scala
@@ -71,6 +71,7 @@ object BulkKeepSelection {
 
 @ImplementedBy(classOf[KeepsCommanderImpl])
 trait KeepsCommander {
+  def idsToKeeps(ids: Seq[Id[Keep]])(implicit session: RSession): Seq[Keep]
   def getKeepsCountFuture(): Future[Int]
   def getKeep(libraryId: Id[Library], keepExtId: ExternalId[Keep], userId: Id[User]): Either[(Int, String), Keep]
   def allKeeps(before: Option[ExternalId[Keep]], after: Option[ExternalId[Keep]], collectionId: Option[ExternalId[Collection]], helprankOpt: Option[String], count: Int, userId: Id[User]): Future[Seq[KeepInfo]]
@@ -136,6 +137,10 @@ class KeepsCommanderImpl @Inject() (
     implicit val defaultContext: ExecutionContext,
     implicit val publicIdConfig: PublicIdConfiguration) extends KeepsCommander with Logging {
 
+  def idsToKeeps(ids: Seq[Id[Keep]])(implicit session: RSession): Seq[Keep] = {
+    val idToKeepMap = keepRepo.getByIds(ids.toSet)
+    ids.map(idToKeepMap)
+  }
   def getKeepsCountFuture(): Future[Int] = {
     globalKeepCountCache.getOrElseFuture(GlobalKeepCountKey()) {
       Future.sequence(searchClient.indexInfoList()).map { results =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -155,7 +155,7 @@ class LibraryCommanderImpl @Inject() (
   def getKeeps(libraryId: Id[Library], offset: Int, limit: Int): Future[Seq[Keep]] = {
     if (limit > 0) db.readOnlyReplicaAsync { implicit s =>
       val oldWay = keepRepo.getByLibrary(libraryId, offset, limit)
-      val newWay = ktlRepo.getByLibraryIdSorted(libraryId, Offset(offset), Limit(limit))
+      val newWay = ktlRepo.getByLibraryIdSorted(libraryId, Offset(offset), Limit(limit)) |> keepCommander.idsToKeeps
       if (newWay != oldWay) {
         log.info(s"[KTL-MATCH] getKeeps($libraryId, $offset, $limit): ${newWay.map(_.id.get)} != ${oldWay.map(_.id.get)}")
       }
@@ -287,7 +287,7 @@ class LibraryCommanderImpl @Inject() (
                 } else keepRepo.getByLibrary(library.id.get, 0, maxKeepsShown) //not cached
               case _ =>
                 val oldWay = keepRepo.getByLibrary(library.id.get, 0, maxKeepsShown) //not cached
-                val newWay = ktlRepo.getByLibraryIdSorted(library.id.get, Offset(0), Limit(maxKeepsShown))
+                val newWay = ktlRepo.getByLibraryIdSorted(library.id.get, Offset(0), Limit(maxKeepsShown)) |> keepCommander.idsToKeeps
                 if (newWay != oldWay) log.info(s"[KTL-MATCH] createFullLibraryInfos(${library.id.get}): ${newWay.map(_.id.get)} != ${oldWay.map(_.id.get)}")
                 oldWay
             }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -335,6 +335,21 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
         }
       }
     }
+    "when getFullLibraryInfo(s) is called" in {
+      "serve up a full library info" in {
+        withDb(modules: _*) { implicit injector =>
+          val (user, lib) = db.readWrite { implicit session =>
+            val user = UserFactory.user().saved
+            val lib = LibraryFactory.library().withOwner(user).saved
+            KeepFactory.keeps(100).map(_.withUser(user).withLibrary(lib)).saved
+            (user, lib)
+          }
+          val fullInfoFut = inject[LibraryCommander].createFullLibraryInfo(Some(user.id.get), true, lib, ProcessedImageSize.XLarge.idealSize, true)
+          val fullInfo = Await.result(fullInfoFut, Duration.Inf)
+          fullInfo.keeps.nonEmpty === true
+        }
+      }
+    }
     "when modify library is called:" in {
       "allow changing organizationId of library" in {
         withDb(modules: _*) { implicit injector =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepToLibraryRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepToLibraryRepoTest.scala
@@ -84,7 +84,7 @@ class KeepToLibraryRepoTest extends Specification with ShoeboxTestInjector {
             val libs = randomLibs(10, owner = user)
 
             for (lib <- libs) {
-              val expected = inject[KeepRepo].getByLibrary(lib.id.get, offset = 10, limit = 20)
+              val expected = inject[KeepRepo].getByLibrary(lib.id.get, offset = 10, limit = 20).map(_.id.get)
               val actual = inject[KeepToLibraryRepo].getByLibraryIdSorted(lib.id.get, offset = Offset(10), limit = Limit(20))
               actual === expected
             }


### PR DESCRIPTION
The issue was with `k.*` in the hand-written SQL query. Those things are super
unreliable and I don't like them. Should've gone with the sketchy Slick thing.

@leogrim 
