### PR TITLE
track orgId in messages when all participants share orgs

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -163,7 +163,7 @@ object Shoebox extends Service {
     def getOrganizationInviteViews(orgId: Id[Organization]) = ServiceRoute(GET, "/internal/shoebox/database/getOrganizationInviteViews", Param("orgId", orgId))
     def hasOrganizationMembership(orgId: Id[Organization], userId: Id[User]) = ServiceRoute(GET, "/internal/shoebox/database/hasOrganizationMembership", Param("orgId", orgId), Param("userId", userId))
     def getIngestableOrganizationDomainOwnerships(seqNum: SequenceNumber[OrganizationDomainOwnership], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getIngestableOrganizationDomainOwnerships", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
-    def getOrganizationsForUsers(userIds: String) = ServiceRoute(GET, "/internal/shoebox/database/getOrganizationsForUsers", Param("userIds", userIds))
+    def getOrganizationsForUsers() = ServiceRoute(POST, "/internal/shoebox/database/getOrganizationsForUsers")
   }
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -163,6 +163,7 @@ object Shoebox extends Service {
     def getOrganizationInviteViews(orgId: Id[Organization]) = ServiceRoute(GET, "/internal/shoebox/database/getOrganizationInviteViews", Param("orgId", orgId))
     def hasOrganizationMembership(orgId: Id[Organization], userId: Id[User]) = ServiceRoute(GET, "/internal/shoebox/database/hasOrganizationMembership", Param("orgId", orgId), Param("userId", userId))
     def getIngestableOrganizationDomainOwnerships(seqNum: SequenceNumber[OrganizationDomainOwnership], fetchSize: Int) = ServiceRoute(GET, "/internal/shoebox/database/getIngestableOrganizationDomainOwnerships", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
+    def getOrganizationsForUsers(userIds: String) = ServiceRoute(GET, "/internal/shoebox/database/getOrganizationsForUsers", Param("userIds", userIds))
   }
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/heimdal/EventType.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/EventType.scala
@@ -50,6 +50,9 @@ object UserEventTypes {
   val MODIFIED_LIBRARY = EventType("modified_library")
   val FOLLOWED_LIBRARY = EventType("followed_library")
   val VIEWED_LIBRARY = EventType("viewed_library")
+
+  // Organizations
+  val CREATED_ORGANIZATION = EventType("created_organization")
 }
 
 object SystemEventTypes {

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -130,6 +130,7 @@ trait ShoeboxServiceClient extends ServiceClient {
   def hasOrganizationMembership(orgId: Id[Organization], userId: Id[User]): Future[Boolean]
   def getIngestableOrganizationDomainOwnerships(seqNum: SequenceNumber[OrganizationDomainOwnership], fetchSize: Int): Future[Seq[IngestableOrganizationDomainOwnership]]
   def getPrimaryOrg(userId: Id[User]): Future[Option[Id[Organization]]]
+  def getOrganizationsForUsers(userIds: Set[Id[User]]): Future[Map[Id[User], Set[Id[Organization]]]]
 }
 
 case class ShoeboxCacheProvider @Inject() (
@@ -799,5 +800,11 @@ class ShoeboxServiceClientImpl @Inject() (
         }
       }
     }
+  }
+
+  def getOrganizationsForUsers(userIds: Set[Id[User]]): Future[Map[Id[User], Set[Id[Organization]]]] = {
+    redundantDBConnectionCheck(userIds)
+    val query = userIds.mkString(",")
+    call(Shoebox.internal.getOrganizationsForUsers(query)).map { _.json.as[Map[Id[User], Set[Id[Organization]]]] }
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -803,8 +803,7 @@ class ShoeboxServiceClientImpl @Inject() (
   }
 
   def getOrganizationsForUsers(userIds: Set[Id[User]]): Future[Map[Id[User], Set[Id[Organization]]]] = {
-    redundantDBConnectionCheck(userIds)
-    val query = userIds.mkString(",")
-    call(Shoebox.internal.getOrganizationsForUsers(query)).map { _.json.as[Map[Id[User], Set[Id[Organization]]]] }
+    val payload = Json.toJson(userIds)
+    call(Shoebox.internal.getOrganizationsForUsers(), payload).map { _.json.as[Map[Id[User], Set[Id[Organization]]]] }
   }
 }

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -665,4 +665,5 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, impli
 
   def getPrimaryOrg(userId: Id[User]): Future[Option[Id[Organization]]] = Future.successful(None)
 
+  def getOrganizationsForUsers(userIds: Set[Id[User]]): Future[Map[Id[User], Set[Id[Organization]]]] = Future.successful(Map.empty)
 }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingAnalytics.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingAnalytics.scala
@@ -246,7 +246,7 @@ class MessagingAnalytics @Inject() (
     val orgIdsByUserIdFut = shoebox.getOrganizationsForUsers(participants.allUsers)
     orgIdsByUserIdFut.foreach { orgIdsByUserId =>
       val commonOrgs = orgIdsByUserId.values.reduce[Set[Id[Organization]]] { case (acc, orgSet) => acc.intersect(orgSet) }
-      contextBuilder += ("organizationId", commonOrgs.map(_.toString))
+      contextBuilder += ("organizationId", commonOrgs.map(_.toString).toSeq)
     }
   }
 }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingAnalytics.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingAnalytics.scala
@@ -7,7 +7,7 @@ import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.common.time._
 import com.keepit.common.akka.SafeFuture
-import com.keepit.model.{ NotificationCategory, User }
+import com.keepit.model.{ Organization, NotificationCategory, User }
 import com.keepit.common.db.{ ExternalId, Id }
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import com.keepit.shoebox.ShoeboxServiceClient
@@ -194,6 +194,7 @@ class MessagingAnalytics @Inject() (
           val uriId = thread.uriId.get
           shoebox.getBasicKeeps(userId, Set(uriId)).foreach { basicKeeps =>
             contextBuilder += ("isKeep", basicKeeps.get(uriId).exists(_.nonEmpty))
+            thread.participants.foreach(addOrganizationInfo(contextBuilder, _))
             val context = contextBuilder.build
             heimdal.trackEvent(UserEvent(userId, context, UserEventTypes.MESSAGED, sentAt))
             heimdal.trackEvent(UserEvent(userId, context, UserEventTypes.USED_KIFI, sentAt))
@@ -240,4 +241,12 @@ class MessagingAnalytics @Inject() (
 
   private def anonymise(contextBuilder: HeimdalContextBuilder): Unit =
     contextBuilder.anonymise("userParticipants", "newParticipants", "otherParticipants", "threadId", "messageId", "uriId")
+
+  private def addOrganizationInfo(contextBuilder: HeimdalContextBuilder, participants: MessageThreadParticipants): Unit = {
+    val orgIdsByUserIdFut = shoebox.getOrganizationsForUsers(participants.allUsers)
+    orgIdsByUserIdFut.foreach { orgIdsByUserId =>
+      val commonOrgs = orgIdsByUserId.values.reduce[Set[Id[Organization]]] { case (acc, orgSet) => acc.intersect(orgSet) }
+      contextBuilder += ("organizationId", commonOrgs.map(_.toString))
+    }
+  }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryAnalytics.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryAnalytics.scala
@@ -143,7 +143,7 @@ class LibraryAnalytics @Inject() (
       contextBuilder += ("editColor", edits.get("color").getOrElse(false))
       contextBuilder += ("editMadePrivate", edits.get("madePrivate").getOrElse(false))
       contextBuilder += ("editListed", edits.get("listed").getOrElse(false))
-
+      contextBuilder += ("organizationId", library.organizationId.map(_.toString).getOrElse(""))
       contextBuilder += ("privacySetting", getLibraryVisibility(library.visibility))
       contextBuilder += ("libraryId", library.id.get.toString)
       contextBuilder += ("libraryOwnerId", library.ownerId.toString)
@@ -291,7 +291,7 @@ class LibraryAnalytics @Inject() (
         contextBuilder += ("hasTitle", bookmark.title.isDefined)
         contextBuilder += ("uriId", bookmark.uriId.toString)
         contextBuilder ++= populateLibraryInfoForKeep(library).data
-
+        contextBuilder += ("organizationId", library.organizationId.map(_.toString).getOrElse(""))
         val context = contextBuilder.build
         heimdal.trackEvent(UserEvent(userId, context, UserEventTypes.KEPT, keptAt))
         if (!KeepSource.imports.contains(bookmark.source)) {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAnalytics.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAnalytics.scala
@@ -56,7 +56,6 @@ class OrganizationAnalytics @Inject() (heimdal: HeimdalServiceClient,
   }
 
   def trackInvitationClicked(organization: Organization, invite: OrganizationInvite)(implicit eventContext: HeimdalContext): Unit = {
-
     val numDays = daysSinceOrganizationCreated(organization)
     SafeFuture {
       val builder = new HeimdalContextBuilder
@@ -66,6 +65,7 @@ class OrganizationAnalytics @Inject() (heimdal: HeimdalServiceClient,
       builder += ("inviterId", invite.inviterId.toString)
       builder += ("inviteeId", invite.userId.map(_.toString).getOrElse(""))
       builder += ("inviteeEmail", invite.emailAddress.map(_.address).getOrElse(""))
+      builder += ("daysSinceOrganizationCreated", numDays)
       heimdal.trackEvent(
         invite.userId.map(id => UserEvent(id, builder.build, UserEventTypes.WAS_NOTIFIED))
           .getOrElse(NonUserEvent("", NonUserKinds.email, eventContext, NonUserEventTypes.WAS_NOTIFIED))
@@ -74,6 +74,7 @@ class OrganizationAnalytics @Inject() (heimdal: HeimdalServiceClient,
   }
 
   def trackOrganizationEvent(organization: Organization, requester: User, request: OrganizationRequest)(implicit eventContext: HeimdalContext): Unit = {
+    val numDays = daysSinceOrganizationCreated(organization)
     SafeFuture {
       val builder = new HeimdalContextBuilder
       builder.addExistingContext(eventContext)
@@ -85,9 +86,13 @@ class OrganizationAnalytics @Inject() (heimdal: HeimdalServiceClient,
       }
       builder += ("action", action)
       builder += ("name", organization.name)
-      builder += ("orgId", organization.id.get.toString)
+      builder += ("organizationId", organization.id.get.toString)
       builder += ("requesterName", requester.fullName)
       builder += ("requesterId", requester.id.get.toString)
+      builder += ("daysSinceOrganizationCreated", numDays)
+      heimdal.trackEvent(UserEvent(requester.id.get, builder.build, UserEventTypes.CREATED_ORGANIZATION))
+    }
+  }
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAnalytics.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationAnalytics.scala
@@ -93,6 +93,4 @@ class OrganizationAnalytics @Inject() (heimdal: HeimdalServiceClient,
       heimdal.trackEvent(UserEvent(requester.id.get, builder.build, UserEventTypes.CREATED_ORGANIZATION))
     }
   }
-    }
-  }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
@@ -42,6 +42,7 @@ trait OrganizationMembershipCommander {
   def getOrganizationsForUser(userId: Id[User], limit: Limit, offset: Offset): Seq[Id[Organization]]
   def getPrimaryOrganizationForUser(userId: Id[User]): Option[Id[Organization]]
   def getAllOrganizationsForUser(userId: Id[User]): Seq[Id[Organization]]
+  def getAllForUsers(userIds: Set[Id[User]]): Map[Id[User], Set[OrganizationMembership]]
   def getVisibleOrganizationsForUser(userId: Id[User], viewerIdOpt: Option[Id[User]]): Seq[Id[Organization]]
   def getMemberIds(orgId: Id[Organization]): Set[Id[User]]
 
@@ -147,6 +148,11 @@ class OrganizationMembershipCommanderImpl @Inject() (
   def getAllOrganizationsForUser(userId: Id[User]): Seq[Id[Organization]] = {
     db.readOnlyReplica { implicit session =>
       organizationMembershipRepo.getAllByUserId(userId).map(_.organizationId)
+    }
+  }
+  def getAllForUsers(userIds: Set[Id[User]]): Map[Id[User], Set[OrganizationMembership]] = {
+    db.readOnlyReplica { implicit session =>
+      organizationMembershipRepo.getAllByUserIds(userIds)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -514,4 +514,10 @@ class ShoeboxController @Inject() (
     val inviteViews: Set[OrganizationInviteView] = organizationInviteCommander.getInvitesByOrganizationId(orgId).map(OrganizationInvite.toOrganizationInviteView)
     Ok(Json.toJson(inviteViews))
   }
+
+  def getOrganizationsForUsers(ids: String) = Action { request =>
+    val userIds = ids.split(',').map(id => Id[User](id.toLong)).toSet
+    val orgIdsByUserId = organizationMembershipCommander.getAllForUsers(userIds).mapValues(_.map(_.organizationId))
+    Ok(Json.toJson(orgIdsByUserId))
+  }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -515,8 +515,8 @@ class ShoeboxController @Inject() (
     Ok(Json.toJson(inviteViews))
   }
 
-  def getOrganizationsForUsers(ids: String) = Action { request =>
-    val userIds = ids.split(',').map(id => Id[User](id.toLong)).toSet
+  def getOrganizationsForUsers() = Action(parse.tolerantJson) { request =>
+    val userIds = request.body.as[Set[Id[User]]]
     val orgIdsByUserId = organizationMembershipCommander.getAllForUsers(userIds).mapValues(_.map(_.organizationId))
     Ok(Json.toJson(orgIdsByUserId))
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationMembershipRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationMembershipRepo.scala
@@ -21,6 +21,7 @@ trait OrganizationMembershipRepo extends Repo[OrganizationMembership] with SeqNu
   def getSortedMembershipsByOrgId(orgId: Id[Organization], offset: Offset, limit: Limit, excludeState: Option[State[OrganizationMembership]] = Some(OrganizationMembershipStates.INACTIVE))(implicit session: RSession): Seq[OrganizationMembership]
   def getAllByOrgId(orgId: Id[Organization], excludeState: Option[State[OrganizationMembership]] = Some(OrganizationMembershipStates.INACTIVE))(implicit session: RSession): Set[OrganizationMembership]
   def getAllByIds(membershipIds: Set[Id[OrganizationMembership]], excludeState: Option[State[OrganizationMembership]] = Some(OrganizationMembershipStates.INACTIVE))(implicit session: RSession): Map[Id[OrganizationMembership], OrganizationMembership]
+  def getAllByUserIds(userIds: Set[Id[User]], excludeState: Option[State[OrganizationMembership]] = Some(OrganizationMembershipStates.INACTIVE))(implicit session: RSession): Map[Id[User], Set[OrganizationMembership]]
   def getByOrgIdAndUserId(orgId: Id[Organization], userId: Id[User], excludeState: Option[State[OrganizationMembership]] = Some(OrganizationMembershipStates.INACTIVE))(implicit session: RSession): Option[OrganizationMembership]
   def getByOrgIdAndUserIds(orgId: Id[Organization], userIds: Set[Id[User]], excludeState: Option[State[OrganizationMembership]] = Some(OrganizationMembershipStates.INACTIVE))(implicit session: RSession): Seq[OrganizationMembership]
   def countByOrgId(orgId: Id[Organization], excludeState: Option[State[OrganizationMembership]] = Some(OrganizationMembershipStates.INACTIVE))(implicit session: RSession): Int
@@ -114,6 +115,10 @@ class OrganizationMembershipRepoImpl @Inject() (
 
   def getAllByIds(membershipIds: Set[Id[OrganizationMembership]], excludeState: Option[State[OrganizationMembership]] = Some(OrganizationMembershipStates.INACTIVE))(implicit session: RSession): Map[Id[OrganizationMembership], OrganizationMembership] = {
     (for (row <- rows if row.id.inSet(membershipIds) && row.state =!= excludeState.orNull) yield (row.id, row)).list.toMap
+  }
+
+  def getAllByUserIds(userIds: Set[Id[User]], excludeState: Option[State[OrganizationMembership]] = Some(OrganizationMembershipStates.INACTIVE))(implicit session: RSession): Map[Id[User], Set[OrganizationMembership]] = {
+    (for (row <- rows if row.userId.inSet(userIds) && row.state =!= excludeState.orNull) yield (row.userId, row)).list.groupBy(_._1).mapValues(userIdAndRow => userIdAndRow.map(_._2).toSet)
   }
 
   override def getSortedMembershipsByOrgId(orgId: Id[Organization], offset: Offset, limit: Limit, excludeState: Option[State[OrganizationMembership]] = Some(OrganizationMembershipStates.INACTIVE))(implicit session: RSession): Seq[OrganizationMembership] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationMembershipRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationMembershipRepo.scala
@@ -118,7 +118,7 @@ class OrganizationMembershipRepoImpl @Inject() (
   }
 
   def getAllByUserIds(userIds: Set[Id[User]], excludeState: Option[State[OrganizationMembership]] = Some(OrganizationMembershipStates.INACTIVE))(implicit session: RSession): Map[Id[User], Set[OrganizationMembership]] = {
-    (for (row <- rows if row.userId.inSet(userIds) && row.state =!= excludeState.orNull) yield (row.userId, row)).list.groupBy(_._1).mapValues(userIdAndRow => userIdAndRow.map(_._2).toSet)
+    rows.filter(row => row.userId.inSet(userIds) && row.state =!= excludeState.orNull).list.groupBy(_.userId).mapValues(_.toSet)
   }
 
   override def getSortedMembershipsByOrgId(orgId: Id[Organization], offset: Offset, limit: Limit, excludeState: Option[State[OrganizationMembership]] = Some(OrganizationMembershipStates.INACTIVE))(implicit session: RSession): Seq[OrganizationMembership] = {

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -968,7 +968,7 @@ GET     /internal/shoebox/database/unfriends          @com.keepit.controllers.in
 GET     /internal/shoebox/database/getOrganizationMembers          @com.keepit.controllers.internal.ShoeboxController.getOrganizationMembers(orgId: Id[Organization])
 GET     /internal/shoebox/database/getOrganizationInviteViews      @com.keepit.controllers.internal.ShoeboxController.getOrganizationInviteViews(orgId: Id[Organization])
 GET     /internal/shoebox/database/hasOrganizationMembership       @com.keepit.controllers.internal.ShoeboxController.hasOrganizationMembership(orgId: Id[Organization], userId: Id[User])
-GET     /internal/shoebox/database/getOrganizationsForUsers        @com.keepit.controllers.internal.ShoeboxController.getOrganizationsForUsers(userIds: String)
+POST    /internal/shoebox/database/getOrganizationsForUsers        @com.keepit.controllers.internal.ShoeboxController.getOrganizationsForUsers()
 
 POST    /internal/shoebox/logEvent                    @com.keepit.controllers.ext.ExtEventController.logEvent()
 

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -968,6 +968,7 @@ GET     /internal/shoebox/database/unfriends          @com.keepit.controllers.in
 GET     /internal/shoebox/database/getOrganizationMembers          @com.keepit.controllers.internal.ShoeboxController.getOrganizationMembers(orgId: Id[Organization])
 GET     /internal/shoebox/database/getOrganizationInviteViews      @com.keepit.controllers.internal.ShoeboxController.getOrganizationInviteViews(orgId: Id[Organization])
 GET     /internal/shoebox/database/hasOrganizationMembership       @com.keepit.controllers.internal.ShoeboxController.hasOrganizationMembership(orgId: Id[Organization], userId: Id[User])
+GET     /internal/shoebox/database/getOrganizationsForUsers        @com.keepit.controllers.internal.ShoeboxController.getOrganizationsForUsers(userIds: String)
 
 POST    /internal/shoebox/logEvent                    @com.keepit.controllers.ext.ExtEventController.logEvent()
 


### PR DESCRIPTION
@leogrim @ryanpbrewster 
involves a little more heavy lifting than I'd like, but this is going to be removed once you can message an entire org or at least when keepscussions is a thing
