### PR TITLE
Add an entitiesHash to Keep

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
@@ -11,6 +11,8 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import com.keepit.common.crypto.PublicId
 
+import scala.util.hashing.MurmurHash3
+
 case class Keep(
     id: Option[Id[Keep]] = None,
     createdAt: DateTime = currentDateTime,
@@ -31,9 +33,10 @@ case class Keep(
     sourceAttributionId: Option[Id[KeepSourceAttribution]] = None,
     note: Option[String] = None,
     originalKeeperId: Option[Id[User]] = None,
-    organizationId: Option[Id[Organization]] = None) extends ModelWithExternalId[Keep] with ModelWithState[Keep] with ModelWithSeqNumber[Keep] {
+    organizationId: Option[Id[Organization]] = None,
+    entitiesHash: Option[EntitiesHash] = None) extends ModelWithExternalId[Keep] with ModelWithState[Keep] with ModelWithSeqNumber[Keep] {
 
-  def sanitizeForDelete: Keep = copy(title = None, state = KeepStates.INACTIVE)
+  def sanitizeForDelete: Keep = copy(title = None, state = KeepStates.INACTIVE, isPrimary = false, entitiesHash = Some(KeepConnectionEntities.empty.hash)) // good idea?
 
   def clean(): Keep = copy(title = title.map(_.trimAndRemoveLineBreaks()))
 
@@ -68,8 +71,14 @@ case class Keep(
     organizationId = lib.organizationId
   )
 
+  def withEntities(libraries: Set[Id[Library]], users: Set[Id[User]]): Keep = this.copy(entitiesHash = Some(KeepConnectionEntities(libraries, users).hash))
+
   def isActive: Boolean = state == KeepStates.ACTIVE && isPrimary // isPrimary will be removed shortly
   def isInactive: Boolean = state == KeepStates.INACTIVE
+
+  def canBeMergedInto(other: Keep): Boolean = {
+    entitiesHash == other.entitiesHash && keptAt > other.keptAt
+  }
 }
 
 object Keep {
@@ -92,13 +101,13 @@ object Keep {
 
   def applyFromDbRowTuples(firstArguments: KeepFirstArguments, restArguments: KeepRestArguments): Keep = (firstArguments, restArguments) match {
     case ((id, createdAt, updatedAt, externalId, title, uriId, isPrimary, urlId, url),
-      (isPrivate, userId, state, source, seq, libraryId, visibility, keptAt, sourceAttributionId, note, originalKeeperId, organizationId)) =>
+      (isPrivate, userId, state, source, seq, libraryId, visibility, keptAt, sourceAttributionId, note, originalKeeperId, organizationId, entitiesHash)) =>
       _applyFromDbRow(id, createdAt, updatedAt, externalId, title,
         uriId = uriId, isPrivate = isPrivate, isPrimary = isPrimary, urlId = urlId, url = url,
         userId = userId, state = state, source = source,
         seq = seq, libraryId = libraryId, visibility = visibility, keptAt = keptAt,
         sourceAttributionId = sourceAttributionId, note = note, originalKeeperId = originalKeeperId,
-        organizationId = organizationId)
+        organizationId = organizationId, entitiesHash = entitiesHash)
   }
 
   // is_primary: trueOrNull in db
@@ -107,9 +116,9 @@ object Keep {
     urlId: Id[URL], url: String, isPrivate: Boolean, userId: Id[User],
     state: State[Keep], source: KeepSource,
     seq: SequenceNumber[Keep], libraryId: Option[Id[Library]], visibility: LibraryVisibility, keptAt: DateTime,
-    sourceAttributionId: Option[Id[KeepSourceAttribution]], note: Option[String], originalKeeperId: Option[Id[User]], organizationId: Option[Id[Organization]]): Keep = {
+    sourceAttributionId: Option[Id[KeepSourceAttribution]], note: Option[String], originalKeeperId: Option[Id[User]], organizationId: Option[Id[Organization]], entitiesHash: Option[EntitiesHash]): Keep = {
     Keep(id, createdAt, updatedAt, externalId, title, uriId, isPrimary.exists(b => b), urlId, url,
-      visibility, userId, state, source, seq, libraryId, keptAt, sourceAttributionId, note, originalKeeperId.orElse(Some(userId)), organizationId)
+      visibility, userId, state, source, seq, libraryId, keptAt, sourceAttributionId, note, originalKeeperId.orElse(Some(userId)), organizationId, entitiesHash)
   }
 
   def unapplyToDbRow(k: Keep) = {
@@ -118,12 +127,12 @@ object Keep {
         k.uriId, if (k.isPrimary) Some(true) else None, k.urlId, k.url),
       (Keep.visibilityToIsPrivate(k.visibility), k.userId, k.state, k.source,
         k.seq, k.libraryId, k.visibility, k.keptAt, k.sourceAttributionId,
-        k.note, k.originalKeeperId.orElse(Some(k.userId)), k.organizationId)
+        k.note, k.originalKeeperId.orElse(Some(k.userId)), k.organizationId, k.entitiesHash)
     )
   }
 
   private type KeepFirstArguments = (Option[Id[Keep]], DateTime, DateTime, ExternalId[Keep], Option[String], Id[NormalizedURI], Option[Boolean], Id[URL], String)
-  private type KeepRestArguments = (Boolean, Id[User], State[Keep], KeepSource, SequenceNumber[Keep], Option[Id[Library]], LibraryVisibility, DateTime, Option[Id[KeepSourceAttribution]], Option[String], Option[Id[User]], Option[Id[Organization]])
+  private type KeepRestArguments = (Boolean, Id[User], State[Keep], KeepSource, SequenceNumber[Keep], Option[Id[Library]], LibraryVisibility, DateTime, Option[Id[KeepSourceAttribution]], Option[String], Option[Id[User]], Option[Id[Organization]], Option[EntitiesHash])
   def _bookmarkFormat = {
     val fields1To10: Reads[KeepFirstArguments] = (
       (__ \ 'id).readNullable(Id.format[Keep]) and
@@ -147,7 +156,9 @@ object Keep {
       (__ \ 'sourceAttributionId).readNullable(Id.format[KeepSourceAttribution]) and
       (__ \ 'note).readNullable[String] and
       (__ \ 'originalKeeperId).readNullable[Id[User]] and
-      (__ \ 'organizationId).readNullable[Id[Organization]]).tupled
+      (__ \ 'organizationId).readNullable[Id[Organization]] and
+      (__ \ 'entitiesHash).readNullable[EntitiesHash]
+    ).tupled
 
     (fields1To10 and fields10Up).apply(applyFromDbRowTuples _)
   }
@@ -180,10 +191,31 @@ object Keep {
         "sourceAttributionId" -> k.sourceAttributionId,
         "note" -> k.note,
         "originalKeeperId" -> k.originalKeeperId.orElse(Some(k.userId)),
-        "organizationId" -> k.organizationId
+        "organizationId" -> k.organizationId,
+        "entitiesHash" -> k.entitiesHash
       )
     }
   }
+}
+
+// I want this to be a Long, but MurmurHash3 gives Ints. Any good Scala hashing libraries that do 64-bit hashes?
+case class EntitiesHash(value: Int) extends AnyVal
+object EntitiesHash {
+  implicit val format: Format[EntitiesHash] =
+    Format(__.read[Int].map(EntitiesHash(_)), new Writes[EntitiesHash] {
+      def writes(hash: EntitiesHash) = JsNumber(hash.value)
+    })
+}
+case class KeepConnectionEntities(libraries: Set[Id[Library]], users: Set[Id[User]]) {
+  def hash: EntitiesHash = {
+    EntitiesHash(MurmurHash3.orderedHash(Seq(
+      MurmurHash3.setHash(libraries),
+      MurmurHash3.setHash(users)
+    )))
+  }
+}
+object KeepConnectionEntities {
+  val empty = KeepConnectionEntities(Set.empty, Set.empty)
 }
 
 case class KeepCountKey(userId: Id[User]) extends Key[Int] {

--- a/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
@@ -76,8 +76,14 @@ case class Keep(
   def isActive: Boolean = state == KeepStates.ACTIVE && isPrimary // isPrimary will be removed shortly
   def isInactive: Boolean = state == KeepStates.INACTIVE
 
-  def canBeMergedInto(other: Keep): Boolean = {
-    entitiesHash == other.entitiesHash && keptAt > other.keptAt
+  def isOlderThan(other: Keep): Boolean = keptAt > other.keptAt || (keptAt == other.keptAt && id.get.id > other.id.get.id)
+
+  def hasStrictlyLessValuableMetadataThan(other: Keep): Boolean = {
+    this.isOlderThan(other) && (true || // TODO(ryan): remove this "(true ||" once we no longer want to mindlessly murder keeps
+      Seq(
+        title.isEmpty || title == other.title,
+        note.isEmpty || note == other.note
+      ).forall(b => b))
   }
 }
 

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/381.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/381.sql
@@ -1,0 +1,10 @@
+# ABOOK
+
+# --- !Ups
+
+ALTER TABLE bookmark ADD COLUMN `entities_hash` bigint(20) DEFAULT NULL; -- for now!
+ALTER TABLE bookmark ADD INDEX bookmark_i_entities_hash (entities_hash);
+
+insert into evolutions (name, description) values('381.sql', 'add unique column bookmark.entities_hash');
+
+# --- !Downs

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/381.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/381.sql
@@ -2,7 +2,7 @@
 
 # --- !Ups
 
-ALTER TABLE bookmark ADD COLUMN `entities_hash` bigint(20) DEFAULT NULL; -- for now!
+ALTER TABLE bookmark ADD COLUMN `entities_hash` int(10) DEFAULT NULL; -- for now!
 ALTER TABLE bookmark ADD INDEX bookmark_i_entities_hash (entities_hash);
 
 insert into evolutions (name, description) values('381.sql', 'add unique column bookmark.entities_hash');

--- a/kifi-backend/modules/common/test/com/keepit/model/KeepFactory.scala
+++ b/kifi-backend/modules/common/test/com/keepit/model/KeepFactory.scala
@@ -2,7 +2,7 @@ package com.keepit.model
 
 import java.util.concurrent.atomic.AtomicLong
 
-import com.keepit.common.db.{ SequenceNumber, ExternalId, Id, State }
+import com.keepit.common.db.{ ExternalId, Id, State }
 import com.keepit.common.time._
 import org.apache.commons.lang3.RandomStringUtils
 import org.apache.commons.lang3.RandomStringUtils.random
@@ -24,7 +24,8 @@ object KeepFactory {
       source = KeepSource.keeper,
       libraryId = None,
       note = None,
-      originalKeeperId = Some(userId)
+      originalKeeperId = Some(userId),
+      entitiesHash = None
     ))
   }
 

--- a/kifi-backend/modules/common/test/com/keepit/model/KeepFactory.scala
+++ b/kifi-backend/modules/common/test/com/keepit/model/KeepFactory.scala
@@ -25,7 +25,7 @@ object KeepFactory {
       libraryId = None,
       note = None,
       originalKeeperId = Some(userId),
-      entitiesHash = None
+      connectionsHash = None
     ))
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
@@ -33,7 +33,7 @@ class AdminBookmarksController @Inject() (
   keepImageCommander: KeepImageCommander,
   keywordSummaryCommander: KeywordSummaryCommander,
   libraryCommander: LibraryCommander,
-  keepCommander: KeepsCommander,
+  keepCommander: KeepCommander,
   collectionCommander: CollectionCommander,
   collectionRepo: CollectionRepo,
   heimdalContextBuilder: HeimdalContextBuilderFactory,

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -18,6 +18,7 @@ import com.keepit.common.performance._
 import com.keepit.common.time._
 import com.keepit.curator.CuratorServiceClient
 import com.keepit.heimdal._
+import com.keepit.integrity.UriIntegrityHelpers
 import com.keepit.model._
 import com.keepit.normalizer.NormalizedURIInterner
 import com.keepit.search.SearchServiceClient
@@ -55,8 +56,8 @@ object BulkKeepSelection {
   )(BulkKeepSelection.apply _, unlift(BulkKeepSelection.unapply))
 }
 
-@ImplementedBy(classOf[KeepsCommanderImpl])
-trait KeepsCommander {
+@ImplementedBy(classOf[KeepCommanderImpl])
+trait KeepCommander {
   def idsToKeeps(ids: Seq[Id[Keep]])(implicit session: RSession): Seq[Keep]
   def getKeepsCountFuture(): Future[Int]
   def getKeep(libraryId: Id[Library], keepExtId: ExternalId[Keep], userId: Id[User]): Either[(Int, String), Keep]
@@ -83,10 +84,11 @@ trait KeepsCommander {
   def suggestTags(userId: Id[User], keepIdOpt: Option[ExternalId[Keep]], query: Option[String], limit: Int): Future[Seq[(Hashtag, Seq[(Int, Int)])]]
   def assembleKeepExport(keepExports: Seq[KeepExport]): String
   def numKeeps(userId: Id[User]): Int
-  def persistKeep(k: Keep)(implicit session: RWSession): Keep
+  def persistKeep(k: Keep, users: Set[Id[User]], libraries: Set[Id[Library]])(implicit session: RWSession): Keep
   def updateNote(keep: Keep, newNote: Option[String])(implicit session: RWSession): Keep
   def syncWithLibrary(keep: Keep, library: Library)(implicit session: RWSession): Keep
   def changeOwner(keep: Keep, newOwnerId: Id[User])(implicit session: RWSession): Keep
+  def changeUri(keep: Keep, newUri: NormalizedURI)(implicit session: RWSession): Keep
   def deactivateKeep(keep: Keep)(implicit session: RWSession): Unit
   def moveKeep(k: Keep, toLibrary: Library, userId: Id[User])(implicit session: RWSession): Either[LibraryError, Keep]
   def copyKeep(k: Keep, toLibrary: Library, userId: Id[User], withSource: Option[KeepSource] = None)(implicit session: RWSession): Either[LibraryError, Keep]
@@ -94,7 +96,7 @@ trait KeepsCommander {
 }
 
 @Singleton
-class KeepsCommanderImpl @Inject() (
+class KeepCommanderImpl @Inject() (
     db: Database,
     keepInterner: KeepInterner,
     searchClient: SearchServiceClient,
@@ -123,8 +125,9 @@ class KeepsCommanderImpl @Inject() (
     twitterPublishingCommander: TwitterPublishingCommander,
     facebookPublishingCommander: FacebookPublishingCommander,
     librarySubscriptionCommander: LibrarySubscriptionCommander,
+    uriHelpers: UriIntegrityHelpers,
     implicit val defaultContext: ExecutionContext,
-    implicit val publicIdConfig: PublicIdConfiguration) extends KeepsCommander with Logging {
+    implicit val publicIdConfig: PublicIdConfiguration) extends KeepCommander with Logging {
 
   def idsToKeeps(ids: Seq[Id[Keep]])(implicit session: RSession): Seq[Keep] = {
     val idToKeepMap = keepRepo.getByIds(ids.toSet)
@@ -304,7 +307,7 @@ class KeepsCommanderImpl @Inject() (
     val library = db.readOnlyReplica { implicit session =>
       libraryRepo.get(libraryId)
     }
-    val (keep, isNewKeep) = keepInterner.internRawBookmark(rawBookmark, userId, library, source, installationId).get
+    val (keep, isNewKeep) = keepInterner.internRawBookmark(rawBookmark, userId, library, source).get
     if (isNewKeep) { librarySubscriptionCommander.sendNewKeepMessage(keep, library) }
     postSingleKeepReporting(keep, isNewKeep, library, socialShare)
     (keep, isNewKeep)
@@ -525,7 +528,7 @@ class KeepsCommanderImpl @Inject() (
     val library = db.readOnlyReplica { implicit session =>
       libraryRepo.get(libraryId)
     }
-    val (bookmarks, _) = keepInterner.internRawBookmarks(rawBookmark, userId, library, source, installationId = kifiInstallationId)
+    val (bookmarks, _) = keepInterner.internRawBookmarks(rawBookmark, userId, library, source)
     addToCollection(tag.id.get, bookmarks) // why doesn't this update search?
   }
 
@@ -603,7 +606,7 @@ class KeepsCommanderImpl @Inject() (
     val library = db.readOnlyReplica { implicit session =>
       libraryRepo.get(libraryId)
     }
-    keepInterner.internRawBookmark(rawBookmark, userId, library, source, installationId = None) match {
+    keepInterner.internRawBookmark(rawBookmark, userId, library, source) match {
       case Failure(e) => Left(e.getMessage)
       case Success((keep, isNewKeep)) =>
         val tags = db.readWrite { implicit s =>
@@ -757,12 +760,19 @@ class KeepsCommanderImpl @Inject() (
 
   def numKeeps(userId: Id[User]): Int = db.readOnlyReplica { implicit s => keepRepo.getCountByUser(userId) }
 
-  def persistKeep(k: Keep)(implicit session: RWSession): Keep = {
-    val keep = keepRepo.save(k)
+  def persistKeep(k: Keep, users: Set[Id[User]], libraries: Set[Id[Library]])(implicit session: RWSession): Keep = {
+    require(users.contains(k.userId), "keep owner is not one of the connected users")
+    require(libraries.contains(k.libraryId.get), "keep's library is not one of the connected libraries") // TODO(ryan): remove this, keeps don't have to be in a library
+    val keep = keepRepo.save(k.withEntities(libraries, users))
     ktuCommander.internKeepInUser(keep, keep.userId, keep.userId)
     // TODO(ryan): drop this once keeps don't need to exist in libraries
     ktlCommander.internKeepInLibrary(keep, libraryRepo.get(keep.libraryId.get), keep.userId)
     keep
+  }
+  private def refreshEntitiesHash(keep: Keep)(implicit session: RWSession): Keep = {
+    val libraries = ktlRepo.getAllByKeepId(keep.id.get).map(_.libraryId).toSet
+    val users = ktuRepo.getAllByKeepId(keep.id.get).map(_.userId).toSet
+    keepRepo.save(keep.withEntities(libraries, users))
   }
   def updateNote(keep: Keep, newNote: Option[String])(implicit session: RWSession): Keep = {
     keepRepo.save(keep.withNote(newNote))
@@ -773,6 +783,12 @@ class KeepsCommanderImpl @Inject() (
   }
   def changeOwner(keep: Keep, newOwnerId: Id[User])(implicit session: RWSession): Keep = {
     keepRepo.save(keep.withOwner(newOwnerId))
+  }
+  def changeUri(keep: Keep, newUri: NormalizedURI)(implicit session: RWSession): Keep = {
+    val newKeep = keepRepo.save(uriHelpers.improveKeepSafely(newUri, keep.withNormUriId(newUri.id.get)))
+    ktlCommander.syncKeep(newKeep)
+    ktuCommander.syncKeep(newKeep)
+    newKeep
   }
   def deactivateKeep(keep: Keep)(implicit session: RWSession): Unit = {
     ktlCommander.removeKeepFromAllLibraries(keep)
@@ -793,7 +809,7 @@ class KeepsCommanderImpl @Inject() (
         val movedKeep = keepRepo.save(k.withLibrary(toLibrary))
         ktlCommander.removeKeepFromLibrary(k.id.get, k.libraryId.get)
         ktlCommander.internKeepInLibrary(k, toLibrary, userId)
-        Right(movedKeep)
+        Right(refreshEntitiesHash(movedKeep))
       case Some(existingKeep) if existingKeep.isInactive =>
         combineTags(k.id.get, existingKeep.id.get)
 
@@ -803,13 +819,14 @@ class KeepsCommanderImpl @Inject() (
         val movedKeep = keepRepo.save(k.withLibrary(toLibrary).withId(existingKeep.id.get)) // overwrite the old keep
         ktlCommander.internKeepInLibrary(movedKeep, toLibrary, userId)
 
-        Right(movedKeep)
+        Right(refreshEntitiesHash(movedKeep))
       case Some(existingKeep) =>
         if (toLibrary.id.get == k.libraryId.get) {
           Left(LibraryError.AlreadyExistsInDest)
         } else {
-          keepRepo.deactivate(k)
           ktlCommander.removeKeepFromLibrary(k.id.get, k.libraryId.get)
+          refreshEntitiesHash(k)
+          keepRepo.deactivate(k)
           combineTags(k.id.get, existingKeep.id.get)
           Left(LibraryError.AlreadyExistsInDest)
         }
@@ -824,17 +841,18 @@ class KeepsCommanderImpl @Inject() (
       libraryId = Some(toLibrary.id.get),
       visibility = toLibrary.visibility,
       source = withSource.getOrElse(k.source),
-      originalKeeperId = k.originalKeeperId.orElse(Some(userId))
+      originalKeeperId = k.originalKeeperId.orElse(Some(userId)),
+      entitiesHash = None
     )
 
     currentKeepOpt match {
       case None =>
-        val persistedKeep = persistKeep(newKeep)
+        val persistedKeep = persistKeep(newKeep, Set(userId), Set(toLibrary.id.get))
         combineTags(k.id.get, persistedKeep.id.get)
         Right(persistedKeep)
 
       case Some(existingKeep) if existingKeep.isInactive =>
-        val persistedKeep = persistKeep(newKeep.withId(existingKeep.id.get))
+        val persistedKeep = persistKeep(newKeep.withId(existingKeep.id.get), Set(userId), Set(toLibrary.id.get))
         combineTags(k.id.get, persistedKeep.id.get)
         Right(persistedKeep)
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -31,9 +31,9 @@ trait KeepInterner {
   private[commanders] def deDuplicateRawKeep(rawKeeps: Seq[RawKeep]): Seq[RawKeep]
   private[commanders] def deDuplicate(rawBookmarks: Seq[RawBookmarkRepresentation]): Seq[RawBookmarkRepresentation]
   def persistRawKeeps(rawKeeps: Seq[RawKeep], importId: Option[String] = None)(implicit context: HeimdalContext): Unit
-  def internRawBookmarks(rawBookmarks: Seq[RawBookmarkRepresentation], userId: Id[User], library: Library, source: KeepSource, installationId: Option[ExternalId[KifiInstallation]] = None)(implicit context: HeimdalContext): (Seq[Keep], Seq[RawBookmarkRepresentation])
-  def internRawBookmarksWithStatus(rawBookmarks: Seq[RawBookmarkRepresentation], userId: Id[User], library: Library, source: KeepSource, installationId: Option[ExternalId[KifiInstallation]] = None)(implicit context: HeimdalContext): (Seq[Keep], Seq[Keep], Seq[RawBookmarkRepresentation])
-  def internRawBookmark(rawBookmark: RawBookmarkRepresentation, userId: Id[User], library: Library, source: KeepSource, installationId: Option[ExternalId[KifiInstallation]] = None)(implicit context: HeimdalContext): Try[(Keep, Boolean)]
+  def internRawBookmarks(rawBookmarks: Seq[RawBookmarkRepresentation], userId: Id[User], library: Library, source: KeepSource)(implicit context: HeimdalContext): (Seq[Keep], Seq[RawBookmarkRepresentation])
+  def internRawBookmarksWithStatus(rawBookmarks: Seq[RawBookmarkRepresentation], userId: Id[User], library: Library, source: KeepSource)(implicit context: HeimdalContext): (Seq[Keep], Seq[Keep], Seq[RawBookmarkRepresentation])
+  def internRawBookmark(rawBookmark: RawBookmarkRepresentation, userId: Id[User], library: Library, source: KeepSource)(implicit context: HeimdalContext): Try[(Keep, Boolean)]
 }
 
 @Singleton
@@ -42,7 +42,7 @@ class KeepInternerImpl @Inject() (
   normalizedURIInterner: NormalizedURIInterner,
   keepRepo: KeepRepo,
   libraryRepo: LibraryRepo,
-  keepCommander: KeepsCommander,
+  keepCommander: KeepCommander,
   countByLibraryCache: CountByLibraryCache,
   keepToCollectionRepo: KeepToCollectionRepo,
   collectionRepo: CollectionRepo,
@@ -121,13 +121,13 @@ class KeepInternerImpl @Inject() (
     }
   }
 
-  def internRawBookmarks(rawBookmarks: Seq[RawBookmarkRepresentation], userId: Id[User], library: Library, source: KeepSource, installationId: Option[ExternalId[KifiInstallation]] = None)(implicit context: HeimdalContext): (Seq[Keep], Seq[RawBookmarkRepresentation]) = {
-    val (newKeeps, existingKeeps, failures) = internRawBookmarksWithStatus(rawBookmarks, userId, library, source, installationId)
+  def internRawBookmarks(rawBookmarks: Seq[RawBookmarkRepresentation], userId: Id[User], library: Library, source: KeepSource)(implicit context: HeimdalContext): (Seq[Keep], Seq[RawBookmarkRepresentation]) = {
+    val (newKeeps, existingKeeps, failures) = internRawBookmarksWithStatus(rawBookmarks, userId, library, source)
     (newKeeps ++ existingKeeps, failures)
   }
 
-  def internRawBookmarksWithStatus(rawBookmarks: Seq[RawBookmarkRepresentation], userId: Id[User], library: Library, source: KeepSource, installationId: Option[ExternalId[KifiInstallation]] = None)(implicit context: HeimdalContext): (Seq[Keep], Seq[Keep], Seq[RawBookmarkRepresentation]) = {
-    val (persistedBookmarksWithUris, failures) = internUriAndBookmarkBatch(rawBookmarks, userId, library, source, installationId)
+  def internRawBookmarksWithStatus(rawBookmarks: Seq[RawBookmarkRepresentation], userId: Id[User], library: Library, source: KeepSource)(implicit context: HeimdalContext): (Seq[Keep], Seq[Keep], Seq[RawBookmarkRepresentation]) = {
+    val (persistedBookmarksWithUris, failures) = internUriAndBookmarkBatch(rawBookmarks, userId, library, source)
     if (persistedBookmarksWithUris.nonEmpty) {
       db.readWrite { implicit s =>
         libraryRepo.updateLastKept(library.id.get)
@@ -145,9 +145,9 @@ class KeepInternerImpl @Inject() (
     (newKeeps, existingKeeps, failures)
   }
 
-  def internRawBookmark(rawBookmark: RawBookmarkRepresentation, userId: Id[User], library: Library, source: KeepSource, installationId: Option[ExternalId[KifiInstallation]] = None)(implicit context: HeimdalContext): Try[(Keep, Boolean)] = {
+  def internRawBookmark(rawBookmark: RawBookmarkRepresentation, userId: Id[User], library: Library, source: KeepSource)(implicit context: HeimdalContext): Try[(Keep, Boolean)] = {
     db.readWrite(attempts = 2) { implicit s =>
-      internUriAndBookmark(rawBookmark, userId, library, source, installationId)
+      internUriAndBookmark(rawBookmark, userId, library, source)
     } map { persistedBookmarksWithUri =>
       val bookmark = persistedBookmarksWithUri.bookmark
       if (persistedBookmarksWithUri.isNewKeep) {
@@ -163,11 +163,11 @@ class KeepInternerImpl @Inject() (
     }
   }
 
-  private def internUriAndBookmarkBatch(bms: Seq[RawBookmarkRepresentation], userId: Id[User], library: Library, source: KeepSource, installationId: Option[ExternalId[KifiInstallation]]) = {
+  private def internUriAndBookmarkBatch(bms: Seq[RawBookmarkRepresentation], userId: Id[User], library: Library, source: KeepSource) = {
     val (persisted, failed) = bms.map { bm =>
       bm -> Try {
         db.readWrite(attempts = 3) { implicit session =>
-          internUriAndBookmark(bm, userId, library, source, installationId).get
+          internUriAndBookmark(bm, userId, library, source).get
           // This is bad, and I'm not sure why we need to do it now. Previously, we could batch keeps into one db session.
           // It appears that when there's a problem, now, we're fetching from rover with ids that may not exist anymore.
           // So, forcing the Try evaluation to make the db session fail, and then recatching it.
@@ -188,7 +188,7 @@ class KeepInternerImpl @Inject() (
 
   private val httpPrefix = "https?://".r
 
-  private def internUriAndBookmark(rawBookmark: RawBookmarkRepresentation, userId: Id[User], library: Library, source: KeepSource, installationId: Option[ExternalId[KifiInstallation]])(implicit session: RWSession): Try[InternedUriAndKeep] = try {
+  private def internUriAndBookmark(rawBookmark: RawBookmarkRepresentation, userId: Id[User], library: Library, source: KeepSource)(implicit session: RWSession): Try[InternedUriAndKeep] = try {
     if (httpPrefix.findPrefixOf(rawBookmark.url.toLowerCase).isDefined) {
       val uri = try {
         normalizedURIInterner.internByUri(rawBookmark.url, contentWanted = true, candidates = NormalizationCandidate.fromRawBookmark(rawBookmark))
@@ -203,7 +203,7 @@ class KeepInternerImpl @Inject() (
       }
 
       log.info(s"[keepinterner] Persisting keep ${rawBookmark.url}, ${rawBookmark.keptAt}, ${clock.now}")
-      val (isNewKeep, wasInactiveKeep, bookmark) = internKeep(uri, userId, library, installationId, source, rawBookmark.title, rawBookmark.url, rawBookmark.keptAt.getOrElse(clock.now), rawBookmark.sourceAttribution, rawBookmark.note)
+      val (isNewKeep, wasInactiveKeep, bookmark) = internKeep(uri, userId, library, source, rawBookmark.title, rawBookmark.url, rawBookmark.keptAt.getOrElse(clock.now), rawBookmark.sourceAttribution, rawBookmark.note)
       Success(InternedUriAndKeep(bookmark, uri, isNewKeep, wasInactiveKeep))
     } else {
       Failure(new Exception(s"bookmark url is not an http protocol: ${rawBookmark.url}"))
@@ -218,8 +218,7 @@ class KeepInternerImpl @Inject() (
       Failure(e)
   }
 
-  private def internKeep(uri: NormalizedURI, userId: Id[User], library: Library,
-    installationId: Option[ExternalId[KifiInstallation]], source: KeepSource,
+  private def internKeep(uri: NormalizedURI, userId: Id[User], library: Library, source: KeepSource,
     title: Option[String], url: String, keptAt: DateTime,
     sourceAttribution: Option[SourceAttribution], note: Option[String])(implicit session: RWSession) = {
 
@@ -247,7 +246,7 @@ class KeepInternerImpl @Inject() (
               keep.copy(createdAt = clock.now)
             } else keep
           } |> { keep =>
-            keepCommander.persistKeep(keep)
+            keepCommander.persistKeep(keep, Set(userId), Set(library.id.get))
           }
         (false, wasInactiveKeep, savedKeep)
       case None =>
@@ -265,9 +264,10 @@ class KeepInternerImpl @Inject() (
           keptAt = keptAt,
           sourceAttributionId = savedAttr.flatMap { _.id },
           note = note,
-          originalKeeperId = Some(userId)
+          originalKeeperId = Some(userId),
+          entitiesHash = Some(KeepConnectionEntities(Set(library.id.get), Set(userId)).hash)
         )
-        val improvedKeep = keepCommander.persistKeep(integrityHelpers.improveKeepSafely(uri, keep))
+        val improvedKeep = keepCommander.persistKeep(integrityHelpers.improveKeepSafely(uri, keep), Set(userId), Set(library.id.get))
         (true, false, improvedKeep)
     }
     if (wasInactiveKeep) {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -265,7 +265,7 @@ class KeepInternerImpl @Inject() (
           sourceAttributionId = savedAttr.flatMap { _.id },
           note = note,
           originalKeeperId = Some(userId),
-          entitiesHash = Some(KeepConnectionEntities(Set(library.id.get), Set(userId)).hash)
+          connectionsHash = Some(KeepConnections(Set(library.id.get), Set(userId)).hash)
         )
         val improvedKeep = keepCommander.persistKeep(integrityHelpers.improveKeepSafely(uri, keep), Set(userId), Set(library.id.get))
         (true, false, improvedKeep)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToLibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToLibraryCommander.scala
@@ -92,10 +92,6 @@ class KeepToLibraryCommanderImpl @Inject() (
   }
   private def syncWithKeep(ktl: KeepToLibrary, keep: Keep)(implicit session: RWSession): KeepToLibrary = {
     require(ktl.keepId == keep.id.get, "keep.id does not match ktl.keepId")
-    val obstacleKtl = ktlRepo.getPrimaryByUriAndLibrary(keep.uriId, ktl.libraryId)
-    if (obstacleKtl.exists(_.id.get != ktl.id.get) && keep.isPrimary) {
-      log.error(s"[KTL-ERROR] About to sync $ktl with $keep, but ${obstacleKtl.get} is in the way")
-    }
     ktlRepo.save(ktl.withUriId(keep.uriId).withPrimary(keep.isPrimary))
   }
   def syncWithLibrary(ktl: KeepToLibrary, library: Library)(implicit session: RWSession): KeepToLibrary = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -119,7 +119,7 @@ class LibraryCommanderImpl @Inject() (
     userCommander: Provider[UserCommander],
     basicUserRepo: BasicUserRepo,
     keepRepo: KeepRepo,
-    keepCommander: KeepsCommander,
+    keepCommander: KeepCommander,
     keepToCollectionRepo: KeepToCollectionRepo,
     ktlRepo: KeepToLibraryRepo,
     ktlCommander: KeepToLibraryCommander,

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/RawKeepImporterPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/RawKeepImporterPlugin.scala
@@ -47,7 +47,7 @@ private class RawKeepImporterActor @Inject() (
     libraryRepo: LibraryRepo,
     airbrake: AirbrakeNotifier,
     libraryAnalytics: LibraryAnalytics,
-    bookmarksCommanderProvider: Provider[KeepsCommander],
+    bookmarksCommanderProvider: Provider[KeepCommander],
     libraryCommanderProvider: Provider[LibraryCommander],
     rover: RoverServiceClient,
     searchClient: SearchServiceClient,
@@ -246,7 +246,7 @@ case class RawKeepGroupImportContext(userId: Id[User], source: KeepSource, insta
 @Singleton
 class KeepTagImportHelper @Inject() (
     db: Database,
-    keepsCommanderProvider: Provider[KeepsCommander],
+    keepsCommanderProvider: Provider[KeepCommander],
     kifiInstallationRepo: KifiInstallationRepo) extends Logging {
 
   def process(rawKeepGroupImportContext: RawKeepGroupImportContext): Unit = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ActivityFeedEmailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ActivityFeedEmailSender.scala
@@ -2,7 +2,7 @@ package com.keepit.commanders.emails
 
 import com.google.inject.{ ImplementedBy, Inject }
 import com.keepit.commanders.emails.activity._
-import com.keepit.commanders.{ CenteredCropImageRequest, CroppedImageSize, KeepImageCommander, KeepsCommander, LibraryCommander, LocalUserExperimentCommander, RecommendationsCommander }
+import com.keepit.commanders.{ CenteredCropImageRequest, CroppedImageSize, KeepImageCommander, KeepCommander, LibraryCommander, LocalUserExperimentCommander, RecommendationsCommander }
 import com.keepit.common.akka.SafeFuture
 import com.keepit.common.concurrent.{ FutureHelpers, ReactiveLock }
 import com.keepit.common.crypto.PublicIdConfiguration
@@ -115,7 +115,7 @@ class ActivityFeedEmailSenderImpl @Inject() (
     friendRequestRepo: FriendRequestRepo,
     userConnectionRepo: UserConnectionRepo,
     activityEmailRepo: ActivityEmailRepo,
-    keepCommander: KeepsCommander,
+    keepCommander: KeepCommander,
     keepImageCommander: KeepImageCommander,
     postOffice: LocalPostOffice,
     s3Config: S3ImageConfig,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -1,7 +1,7 @@
 package com.keepit.controllers.ext
 
 import com.google.inject.Inject
-import com.keepit.commanders.{ KeepsCommander, LibraryCommander, LibraryData, RawBookmarkRepresentation, _ }
+import com.keepit.commanders.{ KeepCommander, LibraryCommander, LibraryData, RawBookmarkRepresentation, _ }
 import com.keepit.common.akka.SafeFuture
 import com.keepit.common.controller.{ UserActions, UserActionsHelper, ShoeboxServiceController, _ }
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
@@ -29,7 +29,7 @@ class ExtLibraryController @Inject() (
   db: Database,
   val libraryCommander: LibraryCommander,
   libraryImageCommander: LibraryImageCommander,
-  keepsCommander: KeepsCommander,
+  keepsCommander: KeepCommander,
   basicUserRepo: BasicUserRepo,
   libraryMembershipRepo: LibraryMembershipRepo,
   libPathCommander: PathCommander,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
@@ -29,7 +29,7 @@ class MobileKeepsController @Inject() (
   keepRepo: KeepRepo,
   val userActionsHelper: UserActionsHelper,
   keepDecorator: KeepDecorator,
-  keepsCommander: KeepsCommander,
+  keepsCommander: KeepCommander,
   collectionCommander: CollectionCommander,
   collectionRepo: CollectionRepo,
   normalizedURIInterner: NormalizedURIInterner,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -40,7 +40,7 @@ class MobileLibraryController @Inject() (
   userRepo: UserRepo,
   basicUserRepo: BasicUserRepo,
   librarySubscriptionRepo: LibrarySubscriptionRepo,
-  keepsCommander: KeepsCommander,
+  keepsCommander: KeepCommander,
   pageCommander: PageCommander,
   keepDecorator: KeepDecorator,
   userCommander: UserCommander,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileRecommendationsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileRecommendationsController.scala
@@ -1,7 +1,7 @@
 package com.keepit.controllers.mobile
 
 import com.google.inject.Inject
-import com.keepit.commanders.{ KeepsCommander, LocalUserExperimentCommander, RecommendationsCommander }
+import com.keepit.commanders.{ KeepCommander, LocalUserExperimentCommander, RecommendationsCommander }
 import com.keepit.common.controller.{ UserRequest, UserActions, UserActionsHelper, ShoeboxServiceController }
 import com.keepit.common.db.ExternalId
 import com.keepit.common.db.slick.Database
@@ -19,7 +19,7 @@ import scala.concurrent.Future
 class MobileRecommendationsController @Inject() (
     val userActionsHelper: UserActionsHelper,
     commander: RecommendationsCommander,
-    keepsCommander: KeepsCommander,
+    keepsCommander: KeepCommander,
     userExperimentCommander: LocalUserExperimentCommander,
     val db: Database,
     val userRepo: UserRepo,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/BookmarkImporter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/BookmarkImporter.scala
@@ -2,7 +2,7 @@ package com.keepit.controllers.website
 
 import java.util.concurrent.TimeoutException
 
-import com.keepit.commanders.{ TweetImportCommander, KeepsCommander, KeepInterner }
+import com.keepit.commanders.{ TweetImportCommander, KeepCommander, KeepInterner }
 import com.keepit.common.akka.{ TimeoutFuture, SafeFuture }
 import com.keepit.common.controller.{ UserRequest, UserActions, UserActionsHelper, ShoeboxServiceController }
 import com.keepit.common.crypto.{ PublicIdConfiguration, PublicId }
@@ -35,7 +35,7 @@ class BookmarkImporter @Inject() (
     urlClassifier: UrlClassifier,
     keepInterner: KeepInterner,
     heimdalContextBuilderFactoryBean: HeimdalContextBuilderFactory,
-    keepsCommander: KeepsCommander,
+    keepsCommander: KeepCommander,
     tweetCommander: TweetImportCommander,
     clock: Clock,
     implicit val executionContext: ExecutionContext,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
@@ -49,7 +49,7 @@ class HomeController @Inject() (
   userExperimentCommander: LocalUserExperimentCommander,
   curatorServiceClient: CuratorServiceClient,
   applicationConfig: FortyTwoConfig,
-  keepsCommander: KeepsCommander,
+  keepsCommander: KeepCommander,
   smsCommander: SmsCommander,
   clock: Clock)
     extends UserActions with ShoeboxServiceController with Logging {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
@@ -33,7 +33,7 @@ class KeepsController @Inject() (
   collectionRepo: CollectionRepo,
   uriRepo: NormalizedURIRepo,
   collectionCommander: CollectionCommander,
-  keepsCommander: KeepsCommander,
+  keepsCommander: KeepCommander,
   userValueRepo: UserValueRepo,
   clock: Clock,
   normalizedURIInterner: NormalizedURIInterner,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -43,7 +43,7 @@ class LibraryController @Inject() (
   librarySubscriptionRepo: LibrarySubscriptionRepo,
   librarySubscriptionCommander: LibrarySubscriptionCommander,
   libPathCommander: PathCommander,
-  keepsCommander: KeepsCommander,
+  keepsCommander: KeepCommander,
   keepDecorator: KeepDecorator,
   userCommander: UserCommander,
   heimdalContextBuilder: HeimdalContextBuilderFactory,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/MarketingSiteRouter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/MarketingSiteRouter.scala
@@ -75,9 +75,9 @@ object MarketingSiteRouter extends AssetsBuilder with Controller with Logging {
       val pickOpt = Try(request.getQueryString("v").map(_.toInt)).toOption.flatten
 
       pickOpt.flatMap(v => versions.find(_.version == v)).getOrElse {
-//        val ip = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
-//        val hash = Math.abs(ip.hashCode) % 100
-//        (if (hash < 50) Version9 else Version7) tap { w => log.info(s"[landing] remoteAddr=${request.remoteAddress} ip=$ip winner=$w") }
+        //        val ip = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
+        //        val hash = Math.abs(ip.hashCode) % 100
+        //        (if (hash < 50) Version9 else Version7) tap { w => log.info(s"[landing] remoteAddr=${request.remoteAddress} ip=$ip winner=$w") }
         Version9
       }
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
@@ -2,7 +2,7 @@ package com.keepit.integrity
 
 import akka.pattern.{ ask, pipe }
 import com.google.inject.{ ImplementedBy, Inject, Singleton }
-import com.keepit.commanders.{ KeepToUserCommander, KeepToLibraryCommander }
+import com.keepit.commanders.{ KeepCommander, KeepToUserCommander, KeepToLibraryCommander }
 import com.keepit.common.actor.ActorInstance
 import com.keepit.common.akka.{ FortyTwoActor, UnsupportedActorMessage }
 import com.keepit.common.db._
@@ -36,6 +36,7 @@ class UriIntegrityActor @Inject() (
     normalizedURIInterner: NormalizedURIInterner,
     urlRepo: URLRepo,
     val keepRepo: KeepRepo,
+    keepCommander: KeepCommander,
     ktlCommander: KeepToLibraryCommander,
     ktuCommander: KeepToUserCommander,
     changedUriRepo: ChangedURIRepo,
@@ -49,11 +50,9 @@ class UriIntegrityActor @Inject() (
 
   /** tricky point: make sure (library, uri) pair is unique.  */
   private def handleBookmarks(oldKeeps: Seq[Keep])(implicit session: RWSession): Unit = {
-
     var urlToUriMap: Map[String, NormalizedURI] = Map()
 
     val deactivatedKeeps = oldKeeps.map { keep =>
-
       // must get the new normalized uri from NormalizedURIRepo (cannot trust URLRepo due to its case sensitivity issue)
       val newUri = urlToUriMap.getOrElse(keep.url, {
         val newUri = normalizedURIInterner.internByUri(keep.url, contentWanted = true)
@@ -76,10 +75,8 @@ class UriIntegrityActor @Inject() (
           case None =>
             log.info(s"going to redirect bookmark's uri: (libId, newUriId) = (${libId.id}, ${newUriId.id}), db or cache returns None")
             keepUriUserCache.remove(KeepUriUserKey(keep.uriId, keep.userId)) // NOTE: we touch two different cache keys here and the following line
-            val newKeep = keepRepo.save(helpers.improveKeepSafely(newUri, keep.withNormUriId(newUriId)))
-            ktlCommander.syncKeep(newKeep)
-            ktuCommander.syncKeep(newKeep)
-            (Some(keep), None)
+            val newKeep = keepCommander.changeUri(keep, newUri)
+            (Some(newKeep), None)
           case Some(currentPrimary) =>
             def save(duplicate: Keep, primary: Keep): (Option[Keep], Option[Keep]) = {
               // TODO(ryan): This is just killing the old keep. We ought to check if the Keep metadata can be merged

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepsCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepsCommanderTest.scala
@@ -122,7 +122,7 @@ class KeepsCommanderTest extends Specification with ShoeboxTestInjector {
             KeepExport(createdAt = dateTime2, title = Some("title 31"), url = "http://www.hi.com31", tags = None) ::
             Nil
 
-        val result = inject[KeepsCommander].assembleKeepExport(keepExports)
+        val result = inject[KeepCommander].assembleKeepExport(keepExports)
 
         val expected = s"""<!DOCTYPE NETSCAPE-Bookmark-file-1>
              |<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminPersonaControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminPersonaControllerTest.scala
@@ -2,26 +2,26 @@ package com.keepit.controllers.admin
 
 import com.google.inject.Injector
 import com.keepit.common.actor.FakeActorSystemModule
-import com.keepit.common.concurrent.{ FakeExecutionContextModule, ExecutionContextModule }
-import com.keepit.common.controller.{ FakeUserActionsModule, FakeUserActionsHelper }
+import com.keepit.common.concurrent.FakeExecutionContextModule
+import com.keepit.common.controller.{ FakeUserActionsHelper, FakeUserActionsModule }
 import com.keepit.common.healthcheck.FakeAirbrakeModule
 import com.keepit.common.mail.FakeMailModule
 import com.keepit.common.net.FakeHttpClientModule
+import com.keepit.common.social.FakeShoeboxAppSecureSocialModule
 import com.keepit.common.store.FakeShoeboxStoreModule
 import com.keepit.cortex.FakeCortexServiceClientModule
 import com.keepit.curator.FakeCuratorServiceClientModule
 import com.keepit.heimdal.FakeHeimdalServiceClientModule
-import com.keepit.model.UserFactoryHelper._
-import com.keepit.model.UserFactory._
-import com.keepit.model.LibraryFactoryHelper._
-import com.keepit.model.LibraryFactory._
-import com.keepit.model.KeepFactoryHelper._
 import com.keepit.model.KeepFactory._
-import com.keepit.common.social.{ FakeShoeboxAppSecureSocialModule }
+import com.keepit.model.KeepFactoryHelper._
+import com.keepit.model.LibraryFactory._
+import com.keepit.model.LibraryFactoryHelper._
+import com.keepit.model.UserFactory._
+import com.keepit.model.UserFactoryHelper._
 import com.keepit.model._
 import com.keepit.search.FakeSearchServiceClientModule
 import com.keepit.shoebox.FakeShoeboxServiceModule
-import com.keepit.test.{ ShoeboxApplicationInjector, ShoeboxApplication }
+import com.keepit.test.{ ShoeboxApplication, ShoeboxApplicationInjector }
 import org.specs2.mutable.Specification
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
@@ -162,10 +162,10 @@ class AdminPersonaControllerTest extends Specification with ShoeboxApplicationIn
         val (user1, k1, k2, k3, k4) = db.readWrite { implicit s =>
           val user1 = user().withUsername("drogo").saved
           val lib1 = library().withOwner(user1).saved
-          val keep1 = keep().withLibrary(lib1).withNote(Some("")).saved
-          val keep2 = keep().withLibrary(lib1).withNote(None).saved
-          val keep3 = keep().withLibrary(lib1).withNote(Some("[#asdf]")).saved
-          val keep4 = keep().withLibrary(lib1).withNote(Some("[#first] [\\#qwer]")).saved
+          val keep1 = keep().withLibrary(lib1).withUser(user1).withNote(Some("")).saved
+          val keep2 = keep().withLibrary(lib1).withUser(user1).withNote(None).saved
+          val keep3 = keep().withLibrary(lib1).withUser(user1).withNote(Some("[#asdf]")).saved
+          val keep4 = keep().withLibrary(lib1).withUser(user1).withNote(Some("[#first] [\\#qwer]")).saved
 
           val tag1 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("first")))
           val tag2 = collectionRepo.save(Collection(userId = user1.id.get, name = Hashtag("second")))

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepFactoryHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepFactoryHelper.scala
@@ -37,11 +37,9 @@ object KeepFactoryHelper {
         candidate
       }
 
-      val keep = {
-        val candidate = partialKeep.get
-        fixUriReferences(candidate) |> fixLibraryReferences
-      }
-      val finalKeep = injector.getInstance(classOf[KeepRepo]).save(keep.copy(id = None))
+      val keep = partialKeep.get |> fixUriReferences |> fixLibraryReferences
+
+      val finalKeep = injector.getInstance(classOf[KeepRepo]).save(keep.copy(id = None).withEntities(Set(keep.libraryId.get), Set(keep.userId)))
       val library = injector.getInstance(classOf[LibraryRepo]).get(finalKeep.libraryId.get)
 
       val ktl = KeepToLibrary(

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepFactoryHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepFactoryHelper.scala
@@ -39,7 +39,7 @@ object KeepFactoryHelper {
 
       val keep = partialKeep.get |> fixUriReferences |> fixLibraryReferences
 
-      val finalKeep = injector.getInstance(classOf[KeepRepo]).save(keep.copy(id = None).withEntities(Set(keep.libraryId.get), Set(keep.userId)))
+      val finalKeep = injector.getInstance(classOf[KeepRepo]).save(keep.copy(id = None).withConnections(Set(keep.libraryId.get), Set(keep.userId)))
       val library = injector.getInstance(classOf[LibraryRepo]).get(finalKeep.libraryId.get)
 
       val ktl = KeepToLibrary(

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
@@ -26,7 +26,7 @@ class KeepRepoTest extends Specification with ShoeboxTestInjector {
             userId = Id[User](3),
             source = KeepSource.keeper,
             libraryId = Some(Id[Library](4)),
-            entitiesHash = Some(EntitiesHash(5))
+            connectionsHash = Some(KeepConnectionsHash(5))
           ))
           val cacheKeep = keepRepo.get(savedKeep.id.get)
           val dbKeep = keepRepo.getNoCache(savedKeep.id.get)
@@ -35,7 +35,7 @@ class KeepRepoTest extends Specification with ShoeboxTestInjector {
           // The savedKeep is not equal to the dbKeep because of originalKeeperId
           // If you can figure out a way to have keepRepo.save give back the correct model, I will be so happy
           // -- Ryan
-          def f(k: Keep) = (k.id.get, k.uriId, k.isPrimary, k.urlId, k.url, k.visibility, k.userId, k.source, k.libraryId, k.entitiesHash)
+          def f(k: Keep) = (k.id.get, k.uriId, k.isPrimary, k.urlId, k.url, k.visibility, k.userId, k.source, k.libraryId, k.connectionsHash)
           f(dbKeep) === f(savedKeep)
         }
         1 === 1

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
@@ -14,6 +14,27 @@ import org.specs2.mutable._
 class KeepRepoTest extends Specification with ShoeboxTestInjector {
 
   "KeepRepo" should {
+    "save and load a keep" in {
+      skipped("TODO(ryan): Figure out how to make repo.save return the actual model that is saved")
+      withDb() { implicit injector =>
+        db.readWrite { implicit session =>
+          val savedKeep = keepRepo.save(Keep(
+            uriId = Id[NormalizedURI](1),
+            isPrimary = true,
+            urlId = Id[URL](2),
+            url = "http://www.kifi.com",
+            visibility = LibraryVisibility.ORGANIZATION,
+            userId = Id[User](3),
+            source = KeepSource.keeper,
+            libraryId = Some(Id[Library](4)),
+            entitiesHash = Some(EntitiesHash(5))
+          ))
+          keepRepo.get(savedKeep.id.get) === savedKeep
+          keepRepo.getNoCache(savedKeep.id.get) === savedKeep
+        }
+        1 === 1
+      }
+    }
     "getPrivate" in {
       withDb() { implicit injector =>
         val (user1, user2, keep1, keep2, keep3) = db.readWrite { implicit s =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
@@ -14,8 +14,7 @@ import org.specs2.mutable._
 class KeepRepoTest extends Specification with ShoeboxTestInjector {
 
   "KeepRepo" should {
-    "save and load a keep" in {
-      skipped("TODO(ryan): Figure out how to make repo.save return the actual model that is saved")
+    "save and load a keep correctly from the cache" in {
       withDb() { implicit injector =>
         db.readWrite { implicit session =>
           val savedKeep = keepRepo.save(Keep(
@@ -29,8 +28,15 @@ class KeepRepoTest extends Specification with ShoeboxTestInjector {
             libraryId = Some(Id[Library](4)),
             entitiesHash = Some(EntitiesHash(5))
           ))
-          keepRepo.get(savedKeep.id.get) === savedKeep
-          keepRepo.getNoCache(savedKeep.id.get) === savedKeep
+          val cacheKeep = keepRepo.get(savedKeep.id.get)
+          val dbKeep = keepRepo.getNoCache(savedKeep.id.get)
+          cacheKeep === dbKeep
+
+          // The savedKeep is not equal to the dbKeep because of originalKeeperId
+          // If you can figure out a way to have keepRepo.save give back the correct model, I will be so happy
+          // -- Ryan
+          def f(k: Keep) = (k.id.get, k.uriId, k.isPrimary, k.urlId, k.url, k.visibility, k.userId, k.source, k.libraryId, k.entitiesHash)
+          f(dbKeep) === f(savedKeep)
         }
         1 === 1
       }

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
@@ -1,6 +1,13 @@
 package com.keepit.common.db.slick
 
+import java.sql.{Clob, Timestamp}
+import javax.sql.rowset.serial.SerialClob
+
+import com.keepit.classify.{DomainTagName, NormalizedHostname}
 import com.keepit.common.db._
+import com.keepit.common.mail.{EmailAddress, _}
+import com.keepit.common.math.ProbabilityDensity
+import com.keepit.common.net.UserAgent
 import com.keepit.common.store.ImagePath
 import com.keepit.common.time._
 import com.keepit.cortex.models.lda.LDATopic
@@ -18,19 +25,18 @@ import com.keepit.classify.{ NormalizedHostname, DomainTagName }
 import com.keepit.common.mail._
 import com.keepit.social.SocialNetworkType
 import securesocial.core.SocialUser
+import com.keepit.model.{DeepLocator, UrlHash, _}
+import com.keepit.notify.model.Recipient
+import com.keepit.search.{ArticleSearchResult, Lang, SearchConfig}
 import com.keepit.serializer.SocialUserSerializer
-import com.keepit.search.{ SearchConfig, Lang }
-import javax.sql.rowset.serial.SerialClob
-import com.keepit.model.UrlHash
-import play.api.libs.json.JsArray
-import play.api.libs.json.JsString
-import play.api.libs.json.JsObject
-import com.keepit.common.mail.EmailAddress
-import com.keepit.social.SocialId
-import com.keepit.model.DeepLocator
-import com.keepit.search.ArticleSearchResult
-import com.keepit.common.math.ProbabilityDensity
+import com.keepit.social.{SocialId, SocialNetworkType}
+import org.joda.time.{DateTime, LocalTime}
+import play.api.libs.json.{JsArray, JsObject, JsString, _}
+import securesocial.core.SocialUser
+
 import scala.concurrent.duration._
+import scala.slick.ast.TypedType
+import scala.slick.jdbc.{GetResult, SetParameter}
 
 case class InvalidDatabaseEncodingException(msg: String) extends java.lang.Throwable
 
@@ -100,6 +106,7 @@ trait FortyTwoGenericTypeMappers { self: { val db: DataBaseComponent } =>
   implicit val imageSourceMapper = MappedColumnType.base[ImageSource, String](_.name, ImageSource.apply)
   implicit val imageStoreKeyMapper = MappedColumnType.base[ImagePath, String](_.path, ImagePath.apply)
   implicit val processImageOperationMapper = MappedColumnType.base[ProcessImageOperation, String](_.kind, ProcessImageOperation.apply)
+  implicit val keepEntitiesHashMapper = MappedColumnType.base[EntitiesHash, Int](_.value, EntitiesHash.apply)
 
   implicit val recipientMapper = MappedColumnType.base[Recipient, String](recip => Recipient.unapply(recip).get, Recipient.apply)
 

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
@@ -106,7 +106,7 @@ trait FortyTwoGenericTypeMappers { self: { val db: DataBaseComponent } =>
   implicit val imageSourceMapper = MappedColumnType.base[ImageSource, String](_.name, ImageSource.apply)
   implicit val imageStoreKeyMapper = MappedColumnType.base[ImagePath, String](_.path, ImagePath.apply)
   implicit val processImageOperationMapper = MappedColumnType.base[ProcessImageOperation, String](_.kind, ProcessImageOperation.apply)
-  implicit val keepEntitiesHashMapper = MappedColumnType.base[EntitiesHash, Int](_.value, EntitiesHash.apply)
+  implicit val keepEntitiesHashMapper = MappedColumnType.base[KeepConnectionsHash, Int](_.value, KeepConnectionsHash.apply)
 
   implicit val recipientMapper = MappedColumnType.base[Recipient, String](recip => Recipient.unapply(recip).get, Recipient.apply)
 


### PR DESCRIPTION
The entitiesHash encodes the set of (libraries, users) that are connected
to a Keep. This will allow us to quickly find Keeps that have exactly
the same set of connected entities.

I had a really obnoxious bug where I was serializing the Keep into Json
incorrectly, so the Keep cache was getting garbage data (but the DB was fine).
When keepRepo.get was called it was automatically looking in the cache and
pulling out the garbage data. Tough to track down.
