### PR TITLE
Crazy new keep-library-user set URI merge logic

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
@@ -76,7 +76,7 @@ case class Keep(
   def isActive: Boolean = state == KeepStates.ACTIVE && isPrimary // isPrimary will be removed shortly
   def isInactive: Boolean = state == KeepStates.INACTIVE
 
-  def isOlderThan(other: Keep): Boolean = keptAt > other.keptAt || (keptAt == other.keptAt && id.get.id > other.id.get.id)
+  def isOlderThan(other: Keep): Boolean = keptAt < other.keptAt || (keptAt == other.keptAt && id.get.id < other.id.get.id)
 
   def hasStrictlyLessValuableMetadataThan(other: Keep): Boolean = {
     this.isOlderThan(other) && (true || // TODO(ryan): remove this "(true ||" once we no longer want to mindlessly murder keeps

--- a/kifi-backend/modules/common/app/com/keepit/model/KeepToCollection.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepToCollection.scala
@@ -19,7 +19,9 @@ case class KeepToCollection(
   def isInactive: Boolean = state == KeepToCollectionStates.INACTIVE
   def withId(id: Id[KeepToCollection]): KeepToCollection = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime): KeepToCollection = this.copy(updatedAt = now)
-  def inactivate(): KeepToCollection = this.copy(state = KeepToCollectionStates.INACTIVE)
+  def withState(newState: State[KeepToCollection]): KeepToCollection = this.copy(state = newState)
+  def withKeepId(newKeepId: Id[Keep]): KeepToCollection = this.copy(keepId = newKeepId)
+  def sanitizeForDelete: KeepToCollection = this.withState(KeepToCollectionStates.INACTIVE)
 }
 
 case class CollectionsForKeepKey(keepId: Id[Keep]) extends Key[Seq[Id[Collection]]] {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
@@ -43,6 +43,7 @@ class CollectionCommander @Inject() (
     searchClient: SearchServiceClient,
     libraryAnalytics: LibraryAnalytics,
     basicCollectionCache: BasicCollectionByIdCache,
+    keepToCollectionRepo: KeepToCollectionRepo,
     implicit val executionContext: ExecutionContext,
     clock: Clock) extends Logging {
 
@@ -224,4 +225,17 @@ class CollectionCommander @Inject() (
       }
     }
   }
+  def copyKeepTags(source: Keep, dest: Keep)(implicit session: RWSession): Unit = {
+    keepToCollectionRepo.getByKeep(source.id.get).foreach { ktc =>
+      val newKtcTemplate = ktc.withKeepId(dest.id.get)
+      val existingKtcOpt = keepToCollectionRepo.getOpt(dest.id.get, ktc.collectionId)
+      keepToCollectionRepo.save(newKtcTemplate.copy(id = existingKtcOpt.map(_.id.get)))
+      collectionRepo.collectionChanged(ktc.collectionId, inactivateIfEmpty = true)
+    }
+  }
+
+  def deactivateKeepTags(keep: Keep)(implicit session: RWSession): Unit = {
+    keepToCollectionRepo.getByKeep(keep.id.get).foreach(keepToCollectionRepo.deactivate)
+  }
+
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/integration/AutogenReaper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/integration/AutogenReaper.scala
@@ -126,7 +126,7 @@ private[integration] class AutogenReaper @Inject() (
             // collections & k2c
             for (collection <- collectionRepo.getUnfortunatelyIncompleteTagsByUser(exp.userId)) {
               for (k2c <- k2cRepo.getByCollection(collection.id.get)) {
-                k2cRepo.save(k2c.inactivate)
+                k2cRepo.save(k2c.sanitizeForDelete)
               }
               collectionRepo.save(collection.copy(state = CollectionStates.INACTIVE))
               collectionRepo.collectionChanged(collection.id.get, inactivateIfEmpty = false)

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/UriIntegrityPlugin.scala
@@ -52,7 +52,7 @@ class UriIntegrityActor @Inject() (
   private def handleBookmarks(oldKeeps: Seq[Keep])(implicit session: RWSession): Unit = {
     var urlToUriMap: Map[String, NormalizedURI] = Map()
 
-    val deactivatedKeeps = oldKeeps.map { keep =>
+    oldKeeps.foreach { keep =>
       // must get the new normalized uri from NormalizedURIRepo (cannot trust URLRepo due to its case sensitivity issue)
       val newUri = urlToUriMap.getOrElse(keep.url, {
         val newUri = normalizedURIInterner.internByUri(keep.url, contentWanted = true)
@@ -66,83 +66,9 @@ class UriIntegrityActor @Inject() (
         airbrake.notify(s"double uri redirect found: keepId=${keep.id.get} uriId=${newUri.id.get}")
         (None, None)
       } else {
-        val libId = keep.libraryId.get // fail if there's no library
-        val userId = keep.userId
-        val newUriId = newUri.id.get
-        val currentBookmarkOpt = keepRepo.getPrimaryByUriAndLibrary(newUriId, libId)
-
-        currentBookmarkOpt match {
-          case None =>
-            log.info(s"going to redirect bookmark's uri: (libId, newUriId) = (${libId.id}, ${newUriId.id}), db or cache returns None")
-            keepUriUserCache.remove(KeepUriUserKey(keep.uriId, keep.userId)) // NOTE: we touch two different cache keys here and the following line
-            val newKeep = keepCommander.changeUri(keep, newUri)
-            (Some(newKeep), None)
-          case Some(currentPrimary) =>
-            def save(duplicate: Keep, primary: Keep): (Option[Keep], Option[Keep]) = {
-              // TODO(ryan): This is just killing the old keep. We ought to check if the Keep metadata can be merged
-              // If it can be merged, do the merge. If it can't, let both continue to exist.
-              // Eventually this is going to need to deal with the possibility of more than one Keep/(URI, Library) pair
-              // It will need to check every single Keep to see if the metadata can be merged.
-              val deadKeep = keepRepo.save(duplicate.copy(uriId = newUriId, isPrimary = false, state = KeepStates.INACTIVE))
-              ktlCommander.syncKeep(deadKeep)
-              ktlCommander.removeKeepFromAllLibraries(deadKeep)
-              ktuCommander.syncKeep(deadKeep)
-              ktuCommander.removeKeepFromAllUsers(deadKeep)
-              keepUriUserCache.remove(KeepUriUserKey(deadKeep.uriId, deadKeep.userId))
-              val liveKeep = keepRepo.save(helpers.improveKeepSafely(newUri, primary.copy(uriId = newUriId, isPrimary = true)))
-              ktlCommander.syncKeep(liveKeep)
-              ktuCommander.syncKeep(liveKeep)
-              (Some(deadKeep), Some(liveKeep))
-            }
-
-            def orderByOldness(keep1: Keep, keep2: Keep): (Keep, Keep) = {
-              if (keep1.createdAt.getMillis < keep2.createdAt.getMillis ||
-                (keep1.createdAt.getMillis == keep2.createdAt.getMillis && keep1.id.get.id < keep2.id.get.id)) {
-                (keep1, keep2)
-              } else (keep2, keep1)
-            }
-
-            (keep.isActive, currentPrimary.isActive) match {
-              case (true, true) =>
-                // we are merging two active keeps, take the newer one
-                val (older, newer) = orderByOldness(keep, currentPrimary)
-                save(duplicate = older, primary = newer)
-
-              case (true, false) =>
-                // the current primary is INACTIVE. It will be marked as primary=false. the state remains INACTIVE
-                save(duplicate = currentPrimary, primary = keep)
-
-              case _ =>
-                // keep is already inactive or duplicate, do nothing
-                (None, None)
-            }
-        }
+        keepCommander.changeUri(keep, newUri)
       }
     }
-
-    val collectionsToUpdate = deactivatedKeeps.flatMap {
-      case (Some(oldBm), None) =>
-        keepToCollectionRepo.getCollectionsForKeep(oldBm.id.get).toSet
-      case (Some(oldBm), Some(newBm)) =>
-        var collections = Set.empty[Id[Collection]]
-        keepToCollectionRepo.getByKeep(oldBm.id.get, excludeState = None).foreach { ktc =>
-          collections += ktc.collectionId
-          keepToCollectionRepo.getOpt(newBm.id.get, ktc.collectionId) match {
-            case Some(newKtc) =>
-              if (ktc.state == KeepToCollectionStates.ACTIVE && newKtc.state == KeepToCollectionStates.INACTIVE) {
-                keepToCollectionRepo.save(newKtc.copy(state = KeepToCollectionStates.ACTIVE))
-              }
-              keepToCollectionRepo.save(ktc.copy(state = KeepToCollectionStates.INACTIVE))
-            case None =>
-              keepToCollectionRepo.save(ktc.copy(keepId = newBm.id.get))
-          }
-        }
-        collections
-      case _ =>
-        Set.empty[Id[Collection]]
-    }
-
-    collectionsToUpdate.foreach(collectionRepo.collectionChanged(_, inactivateIfEmpty = true))
   }
 
   /**

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToCollectionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToCollectionRepo.scala
@@ -25,6 +25,7 @@ trait KeepToCollectionRepo extends Repo[KeepToCollection] {
   def remove(keepId: Id[Keep], collectionId: Id[Collection])(implicit session: RWSession): Unit
   def getOpt(keepId: Id[Keep], collectionId: Id[Collection])(implicit session: RSession): Option[KeepToCollection]
   def insertAll(k2c: Seq[KeepToCollection])(implicit session: RWSession): Unit
+  def deactivate(model: KeepToCollection)(implicit session: RWSession): Unit
 }
 
 @Singleton
@@ -120,9 +121,7 @@ class KeepToCollectionRepoImpl @Inject() (
 
   def remove(bookmarkId: Id[Keep], collectionId: Id[Collection])(implicit session: RWSession): Unit = {
     val q = for (r <- rows if r.bookmarkId === bookmarkId && r.collectionId === collectionId) yield r
-    q.list.map { ktc => //there should be only [0, 1], iterating on possibly more for safty
-      save(ktc.inactivate())
-    }
+    q.list.foreach(deactivate)
   }
 
   def insertAll(k2c: Seq[KeepToCollection])(implicit session: RWSession): Unit = {
@@ -137,6 +136,10 @@ class KeepToCollectionRepoImpl @Inject() (
         }
       }
     }
+  }
+
+  def deactivate(model: KeepToCollection)(implicit session: RWSession): Unit = {
+    save(model.sanitizeForDelete)
   }
 
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToLibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToLibraryRepo.scala
@@ -20,9 +20,7 @@ trait KeepToLibraryRepo extends Repo[KeepToLibrary] {
   def getAllByLibraryIds(libraryIds: Set[Id[Library]], excludeStateOpt: Option[State[KeepToLibrary]] = Some(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Map[Id[Library], Seq[KeepToLibrary]]
 
   def getByLibraryIdSorted(libraryId: Id[Library], offset: Offset, limit: Limit)(implicit session: RSession): Seq[Id[Keep]]
-
   def getByUserIdAndLibraryId(userId: Id[User], libraryId: Id[Library], excludeStateOpt: Option[State[KeepToLibrary]] = Some(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Seq[KeepToLibrary]
-
   def getByKeepIdAndLibraryId(keepId: Id[Keep], libraryId: Id[Library], excludeStateOpt: Option[State[KeepToLibrary]] = Some(KeepToLibraryStates.INACTIVE))(implicit session: RSession): Option[KeepToLibrary]
 
   def getVisibileFirstOrderImplicitKeeps(uriIds: Set[Id[NormalizedURI]], libraryIds: Set[Id[Library]])(implicit session: RSession): Set[KeepToLibrary]

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/UriIntegrityPluginTest.scala
@@ -8,6 +8,7 @@ import com.keepit.common.db.slick.Database
 import com.keepit.common.db.SequenceNumber
 import com.keepit.common.zookeeper.CentralConfig
 import com.keepit.model.UserFactoryHelper._
+import com.keepit.model.KeepFactoryHelper._
 import com.keepit.model.UserFactory
 
 class UriIntegrityPluginTest extends TestKitSupport with SpecificationLike with ShoeboxTestInjector {
@@ -156,21 +157,12 @@ class UriIntegrityPluginTest extends TestKitSupport with SpecificationLike with 
 
             val main = libraryRepo.save(Library(name = "Lib", ownerId = user.id.get, visibility = LibraryVisibility.DISCOVERABLE, kind = LibraryKind.SYSTEM_MAIN, slug = LibrarySlug("asdf"), memberCount = 1))
 
-            val hover = KeepSource.keeper
-            val bm0 = bmRepo.save(Keep(title = Some("google"), userId = user.id.get, url = url0.url, urlId = url0.id.get, uriId = uri0.id.get, source = hover,
-              visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(main.id.get)))
-            val bm0better = bmRepo.save(Keep(title = Some("google"), userId = user.id.get, url = url0.url, urlId = url0.id.get, uriId = uri0better.id.get, source = hover,
-              visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(main.id.get)))
-
-            val bm1 = bmRepo.save(Keep(title = Some("google"), userId = user.id.get, url = url1.url, urlId = url1.id.get,
-              uriId = uri1.id.get, source = hover, visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(main.id.get)))
-            val bm1better = bmRepo.save(Keep(title = Some("google"), userId = user.id.get, url = url1.url, urlId = url1.id.get, uriId = uri1better.id.get, source = hover,
-              visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(main.id.get)))
-
-            val bm2 = bmRepo.save(Keep(title = Some("google"), userId = user.id.get, url = url2.url, urlId = url2.id.get,
-              uriId = uri2.id.get, source = hover, visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(main.id.get)))
-            val bm2better = bmRepo.save(Keep(title = Some("google"), userId = user.id.get, url = url2.url, urlId = url2.id.get, uriId = uri2better.id.get, source = hover,
-              visibility = LibraryVisibility.DISCOVERABLE, libraryId = Some(main.id.get)))
+            val bm0 = KeepFactory.keep().withTitle("google").withUser(user).withUri(uri0).withLibrary(main).saved
+            val bm0better = KeepFactory.keep().withTitle("google").withUser(user).withUri(uri0better).withLibrary(main).saved
+            val bm1 = KeepFactory.keep().withTitle("google").withUser(user).withUri(uri1).withLibrary(main).saved
+            val bm1better = KeepFactory.keep().withTitle("google").withUser(user).withUri(uri1better).withLibrary(main).saved
+            val bm2 = KeepFactory.keep().withTitle("google").withUser(user).withUri(uri2).withLibrary(main).saved
+            val bm2better = KeepFactory.keep().withTitle("google").withUser(user).withUri(uri2better).withLibrary(main).saved
 
             val c0 = collectionRepo.save(Collection(userId = user.id.get, name = Hashtag("google")))
             val c1 = collectionRepo.save(Collection(userId = user.id.get, name = Hashtag("googleBetter")))

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
@@ -14,7 +14,7 @@ import org.specs2.mutable._
 class KeepRepoTest extends Specification with ShoeboxTestInjector {
 
   "KeepRepo" should {
-    "save and load a keep correctly from the cache" in {
+    "save and load a keep" in {
       withDb() { implicit injector =>
         db.readWrite { implicit session =>
           val savedKeep = keepRepo.save(Keep(

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
@@ -106,7 +106,7 @@ trait FortyTwoGenericTypeMappers { self: { val db: DataBaseComponent } =>
   implicit val imageSourceMapper = MappedColumnType.base[ImageSource, String](_.name, ImageSource.apply)
   implicit val imageStoreKeyMapper = MappedColumnType.base[ImagePath, String](_.path, ImagePath.apply)
   implicit val processImageOperationMapper = MappedColumnType.base[ProcessImageOperation, String](_.kind, ProcessImageOperation.apply)
-  implicit val keepEntitiesHashMapper = MappedColumnType.base[KeepConnectionsHash, Int](_.value, KeepConnectionsHash.apply)
+  implicit val keepConnectionsHashMapper = MappedColumnType.base[KeepConnectionsHash, Int](_.value, KeepConnectionsHash.apply)
 
   implicit val recipientMapper = MappedColumnType.base[Recipient, String](recip => Recipient.unapply(recip).get, Recipient.apply)
 


### PR DESCRIPTION
Keeps are deactivated based on their connectionsHash and the amount of metadata
they have. For now, in order to comply with URI-to-library constraints,
we ALWAYS deactivate older keeps.

@andrewconner @leogrim
