### PR TITLE
Center the text on the modal buttons.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/modal/modal.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/modal/modal.styl
@@ -3,7 +3,7 @@
 //
 generic-dialog-button =
   width: 100px
-  padding: 13px 0 10px
+  padding: 10px 0
   border: 1px solid rgba(166, 175, 189, 0.53)
   border-radius: 6px
   font-size: 12px

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMemberManage.styl
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMemberManage.styl
@@ -33,7 +33,7 @@
       box-sizing: border-box
       width: auto
       min-width: 100px
-      padding: 13px 10px 10px
+      padding: 10px
 
 .kf-opmr-wrapper
   display: flex


### PR DESCRIPTION
@andrewconner small fix to make all the buttons look consistent with how we style buttons now (exactly centered vs. more space above the text)
