### PR TITLE
Use the default picture if one does not exist for a push notif

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
@@ -1,6 +1,7 @@
 package com.keepit.eliza
 
 import com.keepit.common.crypto.PublicId
+import com.keepit.common.store.S3UserPictureConfig
 import com.keepit.model._
 import com.keepit.common.db.{ ExternalId, SequenceNumber, Id }
 import com.keepit.common.service.{ ServiceClient, ServiceType }
@@ -112,8 +113,7 @@ class ElizaServiceClientImpl @Inject() (
 
   def sendUserPushNotification(userId: Id[User], message: String, recipient: User, pushNotificationExperiment: PushNotificationExperiment, category: UserPushNotificationCategory): Future[Int] = {
     implicit val userFormatter = Id.format[User]
-    val payload = Json.obj("userId" -> userId, "message" -> message, "recipientId" -> recipient.externalId, "username" -> recipient.username.value, "pictureUrl" -> recipient.pictureName, "pushNotificationExperiment" -> pushNotificationExperiment, "category" -> category.name)
-    log.info(s"[USER PUSH NOTIF DEBUG] Sending payload ${payload}")
+    val payload = Json.obj("userId" -> userId, "message" -> message, "recipientId" -> recipient.externalId, "username" -> recipient.username.value, "pictureUrl" -> recipient.pictureName.getOrElse(S3UserPictureConfig.defaultName), "pushNotificationExperiment" -> pushNotificationExperiment, "category" -> category.name)
     call(Eliza.internal.sendUserPushNotification(), payload, callTimeouts = longTimeout).map { response =>
       response.body.toInt
     }


### PR DESCRIPTION
@andrewconner 
@camhashemi 
Kind of scary that this hasn't been caught and we've basically failed 12000 push notification sends...
