### PR TITLE
return emails in typeahead even if they are attached to a user

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
@@ -270,8 +270,7 @@ class TypeaheadCommander @Inject() (
         }
         val kifi: Future[Seq[NetworkTypeAndHit]] = kifiF.map { hits => hits.map(hit => (SocialNetworks.FORTYTWO, hit)) }
         val abook: Future[Seq[NetworkTypeAndHit]] = abookF.map { hits =>
-          val nonUsers = hits.filter(_.info.userId.isEmpty)
-          val distinctEmails = dedupBy(nonUsers)(_.info.email.address.toLowerCase)
+          val distinctEmails = dedupBy(hits)(_.info.email.address.toLowerCase)
           distinctEmails.map { SocialNetworks.EMAIL -> _ }
         }
         val nf: Future[Seq[NetworkTypeAndHit]] = nfUsersF.map { hits => hits.map(hit => (SocialNetworks.FORTYTWO_NF, hit)) }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/TypeaheadControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/TypeaheadControllerTest.scala
@@ -181,7 +181,7 @@ class TypeaheadControllerTest extends Specification with ShoeboxTestInjector {
         res1.head.value === "email/chan@jing.com"
 
         val res2 = search("doug")
-        res2.length === 1 // email de-duped
+        res2.length === 2 // email de-duped
         res2.head.label === "Douglas Adams"
 
         val res3 = search("郭靖")


### PR DESCRIPTION
@leogrim @andrewconner 

If you type "camhashemi@gmail.com" (associated with my user), you should get that email in the typeahead, not nothing. Even if we want to filter out emails associated with users, we should instead provide that user in the typeahead (more complicated, possibly better). Or better yet, if you send a message to an email associated with a user, send the user the notif, not just the email (could do that too).
