### PR TITLE
Use cached thread pool in dev mode

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/concurrent/WatchableExecutionContext.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/concurrent/WatchableExecutionContext.scala
@@ -1,6 +1,6 @@
 package com.keepit.common.concurrent
 
-import java.util.concurrent.{ LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit }
+import java.util.concurrent.{Executors, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 
 import com.keepit.common.healthcheck.StackTrace
 import play.api.Mode
@@ -13,7 +13,7 @@ class WatchableExecutionContext(mode: Mode.Mode) extends ScalaExecutionContext {
 
   @volatile private[this] var closed = false
   @volatile private[this] var initiated = false
-  private[this] lazy val originExecutor = new ThreadPoolExecutor(0, 2, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue[Runnable]())
+  private[this] lazy val originExecutor = Executors.newCachedThreadPool()
   private[this] lazy val internalContext: ScalaExecutionContext = {
     initiated = true
     scala.concurrent.ExecutionContext.fromExecutorService(originExecutor)

--- a/kifi-backend/modules/common/app/com/keepit/common/concurrent/WatchableExecutionContext.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/concurrent/WatchableExecutionContext.scala
@@ -1,6 +1,6 @@
 package com.keepit.common.concurrent
 
-import java.util.concurrent.{Executors, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
+import java.util.concurrent._
 
 import com.keepit.common.healthcheck.StackTrace
 import play.api.Mode
@@ -13,7 +13,7 @@ class WatchableExecutionContext(mode: Mode.Mode) extends ScalaExecutionContext {
 
   @volatile private[this] var closed = false
   @volatile private[this] var initiated = false
-  private[this] lazy val originExecutor = Executors.newCachedThreadPool()
+  private[this] lazy val originExecutor = new ThreadPoolExecutor(0, 4, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue[Runnable])
   private[this] lazy val internalContext: ScalaExecutionContext = {
     initiated = true
     scala.concurrent.ExecutionContext.fromExecutorService(originExecutor)

--- a/kifi-backend/modules/common/app/com/keepit/common/concurrent/WatchableExecutionContext.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/concurrent/WatchableExecutionContext.scala
@@ -13,7 +13,7 @@ class WatchableExecutionContext(mode: Mode.Mode) extends ScalaExecutionContext {
 
   @volatile private[this] var closed = false
   @volatile private[this] var initiated = false
-  private[this] lazy val originExecutor = new ThreadPoolExecutor(0, 4, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue[Runnable])
+  private[this] lazy val originExecutor = Executors.newCachedThreadPool()
   private[this] lazy val internalContext: ScalaExecutionContext = {
     initiated = true
     scala.concurrent.ExecutionContext.fromExecutorService(originExecutor)


### PR DESCRIPTION
Some tasks were not completing for me because of the limit on threads in dev mode. There are couple awaits that happen within nested futures, meaning that both threads in the pool were taken up awaiting for a task that could never be scheduled. This raises the number of threads in the thread pool (to essentially infinity) so that more tasks can execute. The better fix would be to not use await inside a whole bunch of nested futures, but this does not change any code that actually executes in production.
