### PR TITLE
it really sucks when we swallow exceptions!

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminOrganizationController.scala
@@ -11,6 +11,7 @@ import com.keepit.common.db._
 import com.keepit.common.db.slick.Database
 import com.keepit.heimdal.HeimdalContext
 import com.keepit.model._
+import play.api.{ Mode, Play }
 import play.api.libs.json.Json
 import play.twirl.api.{ HtmlFormat, Html }
 import play.api.mvc.{ Action, AnyContent, Result }
@@ -46,7 +47,7 @@ class AdminOrganizationController @Inject() (
     orgExperimentRepo: OrganizationExperimentRepo,
     implicit val publicIdConfig: PublicIdConfiguration) extends AdminUserActions with PaginationActions {
 
-  import AdminOrganizationController.fakeOwnerId
+  val fakeOwnerId = if (Play.maybeApplication.exists(_.mode == Mode.Prod)) AdminOrganizationController.fakeOwnerId else Id[User](1)
   private val pageSize = 30
 
   // needed to coerce the passed in Int => Call to Int => Html

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -211,7 +211,8 @@ class OrganizationCommanderImpl @Inject() (
     Try {
       db.readWrite { implicit session =>
         getValidationError(request) match {
-          case Some(fail) => Left(fail)
+          case Some(fail) =>
+            Left(fail)
           case None =>
             val orgSkeleton = Organization(ownerId = request.requesterId, name = request.initialValues.name, primaryHandle = None, description = None, site = None)
             val orgTemplate = organizationWithModifications(orgSkeleton, request.initialValues.asOrganizationModifications)
@@ -225,9 +226,13 @@ class OrganizationCommanderImpl @Inject() (
         }
       }
     } match {
-      case Success(Left(fail)) => Left(fail)
-      case Success(Right(response)) => Right(response)
-      case Failure(ex) => log.error(ex.getMessage); Left(OrganizationFail.HANDLE_UNAVAILABLE)
+      case Success(Left(fail)) =>
+        Left(fail)
+      case Success(Right(response)) =>
+        Right(response)
+      case Failure(ex) =>
+        log.error(s"could not create organization via $request", ex)
+        Left(OrganizationFail.HANDLE_UNAVAILABLE)
     }
   }
 


### PR DESCRIPTION
@ryanpbrewster @camhashemi 
Hiding the real cause and just printing the message does not tell me anything about what the root problem of the exception is and its frustrating since its hard to find the error message in the thousands of log lines.
If we print an exception we should get the full stack as well since many has some root cause exception (this one was a db integrity problem), once i printed it the solution was fixed in seconds but finding that exception took way too long (exception cause was `org.h2.jdbc.JdbcSQLException: Referential integrity constraint violation: "ORGANIZATION_F_USER: PUBLIC.ORGANIZATION FOREIGN KEY(OWNER_ID) REFERENCES PUBLIC.USER(ID) (97543)"`).
Whenever we have a system exception we should fail fast and get as much context as possible, when its a user error its fine to just report it in a lower logging intensity.
/cc @andrewconner @leogrim @stkem 
