### PR TITLE
truncate org names that are longer than 30 chars

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
@@ -46,6 +46,8 @@ case class Organization(
     this.withBasePermissions(BasePermissions(Map(None -> Set())))
   }
 
+  def truncatedName = if (this.name.length > 30) this.name.take(30) + "..." else this.name
+
   def getNonmemberPermissions = basePermissions.forNonmember
   def getRolePermissions(role: OrganizationRole) = basePermissions.forRole(role)
 

--- a/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
@@ -46,7 +46,7 @@ case class Organization(
     this.withBasePermissions(BasePermissions(Map(None -> Set())))
   }
 
-  def truncatedName = if (this.name.length > 30) this.name.take(30) + "..." else this.name
+  def abbreviatedName = this.name.abbreviate(33)
 
   def getNonmemberPermissions = basePermissions.forNonmember
   def getRolePermissions(role: OrganizationRole) = basePermissions.forRole(role)

--- a/kifi-backend/modules/common/app/com/keepit/notify/model/event/OrgEvent.scala
+++ b/kifi-backend/modules/common/app/com/keepit/notify/model/event/OrgEvent.scala
@@ -32,8 +32,8 @@ trait OrgNewInviteImpl extends NonGroupingNotificationKind[OrgNewInvite] {
       NotificationInfo(
         url = Path(invitedOrg.handle.value).encode.absolute,
         imageUrl = inviterImage,
-        title = s"${inviter.firstName} ${inviter.lastName} invited you to join ${invitedOrg.truncatedName}!",
-        body = s"Help ${invitedOrg.truncatedName} by sharing your knowledge with them.",
+        title = s"${inviter.firstName} ${inviter.lastName} invited you to join ${invitedOrg.abbreviatedName}!",
+        body = s"Help ${invitedOrg.abbreviatedName} by sharing your knowledge with them.",
         linkText = "Visit organization"
       )
     }
@@ -64,8 +64,8 @@ trait OrgInviteAcceptedImpl extends NonGroupingNotificationKind[OrgInviteAccepte
       NotificationInfo(
         url = Path(acceptedOrg.handle.value).encode.absolute,
         imageUrl = accepterId,
-        title = s"${accepter.firstName} accepted your invitation to join ${acceptedOrg.truncatedName}!",
-        body = s"You invited ${accepter.firstName} to join ${acceptedOrg.truncatedName}",
+        title = s"${accepter.firstName} accepted your invitation to join ${acceptedOrg.abbreviatedName}!",
+        body = s"You invited ${accepter.firstName} to join ${acceptedOrg.abbreviatedName}",
         linkText = "Visit organization",
         extraJson = Some(Json.obj(
           "member" -> BasicUser.fromUser(accepter),

--- a/kifi-backend/modules/common/app/com/keepit/notify/model/event/OrgEvent.scala
+++ b/kifi-backend/modules/common/app/com/keepit/notify/model/event/OrgEvent.scala
@@ -32,8 +32,8 @@ trait OrgNewInviteImpl extends NonGroupingNotificationKind[OrgNewInvite] {
       NotificationInfo(
         url = Path(invitedOrg.handle.value).encode.absolute,
         imageUrl = inviterImage,
-        title = s"${inviter.firstName} ${inviter.lastName} invited you to join ${invitedOrg.name}!",
-        body = s"Help ${invitedOrg.name} by sharing your knowledge with them.",
+        title = s"${inviter.firstName} ${inviter.lastName} invited you to join ${invitedOrg.truncatedName}!",
+        body = s"Help ${invitedOrg.truncatedName} by sharing your knowledge with them.",
         linkText = "Visit organization"
       )
     }
@@ -64,8 +64,8 @@ trait OrgInviteAcceptedImpl extends NonGroupingNotificationKind[OrgInviteAccepte
       NotificationInfo(
         url = Path(acceptedOrg.handle.value).encode.absolute,
         imageUrl = accepterId,
-        title = s"${accepter.firstName} accepted your invitation to join ${acceptedOrg.name}!",
-        body = s"You invited ${accepter.firstName} to join ${acceptedOrg.name}",
+        title = s"${accepter.firstName} accepted your invitation to join ${acceptedOrg.truncatedName}!",
+        body = s"You invited ${accepter.firstName} to join ${acceptedOrg.truncatedName}",
         linkText = "Visit organization",
         extraJson = Some(Json.obj(
           "member" -> BasicUser.fromUser(accepter),

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
@@ -231,8 +231,8 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
 
     elizaClient.sendGlobalNotification( //push sent
       userIds = invitees,
-      title = s"${inviter.firstName} ${inviter.lastName} invited you to join ${org.truncatedName}!",
-      body = s"Help ${org.truncatedName} by sharing your knowledge with them.",
+      title = s"${inviter.firstName} ${inviter.lastName} invited you to join ${org.abbreviatedName}!",
+      body = s"Help ${org.abbreviatedName} by sharing your knowledge with them.",
       linkText = "Let's do it!",
       linkUrl = orgLink,
       imageUrl = userImage,
@@ -323,13 +323,13 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
     val inviteeImage = s3ImageStore.avatarUrlByUser(invitee)
     val orgImageOpt = organizationAvatarCommander.getBestImageByOrgId(org.id.get, ProcessedImageSize.Medium.idealSize)
     invitesToAlert foreach { invite =>
-      val title = s"${invitee.firstName} accepted your invitation to join ${org.truncatedName}!"
+      val title = s"${invitee.firstName} accepted your invitation to join ${org.abbreviatedName}!"
       val inviterId = invite.inviterId
       elizaClient.sendGlobalNotification( //push sent
         userIds = Set(inviterId),
         title = title,
-        body = s"Click here to view ${org.truncatedName}’s libraries.",
-        linkText = s"See ${org.truncatedName}’s libraries",
+        body = s"Click here to view ${org.abbreviatedName}’s libraries.",
+        linkText = s"See ${org.abbreviatedName}’s libraries",
         linkUrl = s"https://www.kifi.com/${org.handle.value}",
         imageUrl = inviteeImage,
         sticky = false,

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
@@ -231,8 +231,8 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
 
     elizaClient.sendGlobalNotification( //push sent
       userIds = invitees,
-      title = s"${inviter.firstName} ${inviter.lastName} invited you to join ${org.name}!",
-      body = s"Help ${org.name} by sharing your knowledge with them.",
+      title = s"${inviter.firstName} ${inviter.lastName} invited you to join ${org.truncatedName}!",
+      body = s"Help ${org.truncatedName} by sharing your knowledge with them.",
       linkText = "Let's do it!",
       linkUrl = orgLink,
       imageUrl = userImage,
@@ -323,13 +323,13 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
     val inviteeImage = s3ImageStore.avatarUrlByUser(invitee)
     val orgImageOpt = organizationAvatarCommander.getBestImageByOrgId(org.id.get, ProcessedImageSize.Medium.idealSize)
     invitesToAlert foreach { invite =>
-      val title = s"${invitee.firstName} accepted your invitation to join ${org.name}!"
+      val title = s"${invitee.firstName} accepted your invitation to join ${org.truncatedName}!"
       val inviterId = invite.inviterId
       elizaClient.sendGlobalNotification( //push sent
         userIds = Set(inviterId),
         title = title,
-        body = s"Click here to view ${org.name}’s libraries.",
-        linkText = s"See ${org.name}’s libraries",
+        body = s"Click here to view ${org.truncatedName}’s libraries.",
+        linkText = s"See ${org.truncatedName}’s libraries",
         linkUrl = s"https://www.kifi.com/${org.handle.value}",
         imageUrl = inviteeImage,
         sticky = false,


### PR DESCRIPTION
@leogrim @gratimax  https://app.asana.com/0/32728208409723/43146000537263. 30 chars is a bit less than 2 std above the mean, also keeps notifs looking clean.
