### PR TITLE
use library that user kept to

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/feed/feed.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/feed/feed.tpl.html
@@ -1,8 +1,8 @@
 <main class="kf-feed-items kf-main-pane" smart-scroll scroll-distance="scrollDistance" scroll-disabled="!hasMoreKeeps()" scroll-next="fetchKeeps()">
   <section class="kf-feed-item" ng-repeat="feedItem in feed">
     <header class="kf-feed-top">
-      <span ng-bind="feedItem.user | name"></span> kept this into <a ng-href="{{ feedItem.libraries[0][0].path }}" ng-bind="feedItem.libraries[0][0].name"></a>
-      <span ng-if="feedItem.libraries[0].organization" ng-bind="'in ' + feedItem.libraries[0].organization"></span> &mdash; <span am-time-ago="feedItem.createdAt"></span>
+      <span ng-bind="feedItem.user | name"></span> kept this into <a ng-href="{{ feedItem.library.path }}" ng-bind="feedItem.library.name"></a>
+      <span ng-if="feedItem.library.organization" ng-bind="'in ' + feedItem.library.organization"></span> &mdash; <span am-time-ago="feedItem.createdAt"></span>
     </header>
     <div class="kf-keep">
       <div class="kf-feed-item" kf-keep-card="feedItem" boxed="true" gallery-view="true"></div>

--- a/kifi-backend/modules/shoebox/angular/src/feed/feedCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/feed/feedCtrl.js
@@ -13,6 +13,13 @@ angular.module('kifi')
       });
     }
 
+    function libraryKeptTo (keep) {
+      var libraryAndUser = keep.libraries.filter(function(libraryAndUser) {
+        return libraryAndUser[0].id === keep.libraryId;
+      })[0] || keep.libraries[0];
+      return libraryAndUser[0];
+    }
+
     var keepLazyLoader = new Paginator(keepSource, 10);
 
     $scope.feed = [];
@@ -28,7 +35,11 @@ angular.module('kifi')
       keepLazyLoader
       .fetch()
       .then(function (keeps) {
-        $scope.feed = keeps;
+        var updatedKeeps = keeps.map(function(keep) {
+          keep.library = libraryKeptTo(keep);
+          return keep;
+        });
+        $scope.feed = updatedKeeps;
       });
     };
 


### PR DESCRIPTION
@andrewconner @cvializ this is a front-end fix. we were previously grabbing the first library, which gets updated once you rekeep, and is sometimes not the library that the user kept to.

alternatively, could do this on the backend.
