### PR TITLE
Fix org permissions

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
@@ -186,8 +186,8 @@ case class BasePermissions(permissionsMap: Map[Option[OrganizationRole], Set[Org
   def forNonmember: Set[OrganizationPermission] = permissionsMap(None)
 
   // Return a BasePermissions where "role" has added and removed permissions
-  def modified(role: OrganizationRole, added: Set[OrganizationPermission], removed: Set[OrganizationPermission]): BasePermissions =
-    BasePermissions(permissionsMap.updated(Some(role), forRole(role) ++ added -- removed))
+  def modified(roleOpt: Option[OrganizationRole], added: Set[OrganizationPermission], removed: Set[OrganizationPermission]): BasePermissions =
+    BasePermissions(permissionsMap.updated(roleOpt, permissionsMap(roleOpt) ++ added -- removed))
 }
 
 object BasePermissions {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRequests.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRequests.scala
@@ -74,6 +74,7 @@ object OrganizationFail {
   case object NO_VALID_INVITATIONS extends OrganizationFail(BAD_REQUEST, "no_valid_invitations")
   case object INVALID_PUBLIC_ID extends OrganizationFail(BAD_REQUEST, "invalid_public_id")
   case object BAD_PARAMETERS extends OrganizationFail(BAD_REQUEST, "bad_parameters")
+  case object INVALID_MODIFICATIONS extends OrganizationFail(BAD_REQUEST, "invalid_modifications")
   case object INVITATION_NOT_FOUND extends OrganizationFail(BAD_REQUEST, "invitation_not_found")
   case object ALREADY_A_MEMBER extends OrganizationFail(BAD_REQUEST, "already_a_member")
   case object INVALID_AUTHTOKEN extends OrganizationFail(UNAUTHORIZED, "invalid_authtoken")
@@ -86,6 +87,7 @@ object OrganizationFail {
       case NO_VALID_INVITATIONS.message => NO_VALID_INVITATIONS
       case INVALID_PUBLIC_ID.message => INVALID_PUBLIC_ID
       case BAD_PARAMETERS.message => BAD_PARAMETERS
+      case INVALID_MODIFICATIONS.message => INVALID_MODIFICATIONS
       case INVITATION_NOT_FOUND.message => INVITATION_NOT_FOUND
       case ALREADY_A_MEMBER.message => ALREADY_A_MEMBER
       case INVALID_AUTHTOKEN.message => INVALID_AUTHTOKEN

--- a/kifi-backend/modules/shoebox/app/views/admin/organization.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/organization.scala.html
@@ -53,6 +53,37 @@ orgStats: OrganizationStatistics
     </td>
     </tr>
     <tr>
+        <th>Non-member permissions</th>
+        <td id="permissions-nonmember" class="form-inline">
+            @for(p <- OrganizationPermission.all) {
+            <label class="checkbox">
+                <input type="checkbox" data-permission="@p.value" @if(orgStats.org.getNonmemberPermissions.contains(p)) {checked}>@p.value
+            </label>
+            }
+        </td>
+    </tr>
+    <tr>
+        <th>Member permissions</th>
+        <td id="permissions-member" class="form-inline">
+            @for(p <- OrganizationPermission.all) {
+            <label class="checkbox">
+                <input type="checkbox" data-permission="@p.value" @if(orgStats.org.getRolePermissions(OrganizationRole.MEMBER).contains(p)) {checked}>@p.value
+            </label>
+            }
+        </td>
+    </tr>
+    <tr>
+        <th>Admin permissions</th>
+        <td id="permissions-admin" class="form-inline">
+            @for(p <- OrganizationPermission.all) {
+            <label class="checkbox">
+                <input type="checkbox" data-permission="@p.value" @if(orgStats.org.getRolePermissions(OrganizationRole.ADMIN).contains(p)) {checked}>@p.value
+            </label>
+            }
+        </td>
+    </tr>
+
+    <tr>
         <th>Active</th>
         <td>
             @orgStats.org.state <form action="@com.keepit.controllers.admin.routes.AdminOrganizationController.forceDeactivate(orgStats.orgId)" method="POST" class="form-inline set-inactive">
@@ -258,6 +289,64 @@ orgStats: OrganizationStatistics
             $sp.after($("<i class=icon-exclamation-sign></i> Error. Reload?").delay(3000).fadeOut()).remove();
         }
     });
+
+    // Permissions garbage. I am so sorry for this code. -- Ryan
+    $("#permissions-nonmember").on("click", "input", function() {
+        var $td = $(this).closest("#permissions-nonmember");
+        var $sp = $("<img src=/assets/images/spinner.15.gif>").appendTo($td);
+        if (this.checked) {
+            console.log($(this).data("exp"));
+            $.post('@com.keepit.controllers.admin.routes.AdminOrganizationController.addRolePermission(orgStats.orgId, "none", "yyy")'.replace("yyy", $(this).data("permission")))
+                .done(done).fail(fail);
+        } else {
+            $.ajax('@com.keepit.controllers.admin.routes.AdminOrganizationController.removeRolePermission(orgStats.orgId, "none", "yyy")'.replace("yyy", $(this).data("permission")),
+            {type: "DELETE"}).done(done).fail(fail);
+        }
+        function done() {
+            $sp.after($("<i class=icon-ok-sign>").delay(1000).fadeOut()).remove();
+        }
+        function fail() {
+            $sp.after($("<i class=icon-exclamation-sign></i> Error. Reload?").delay(3000).fadeOut()).remove();
+        }
+    });
+    $("#permissions-member").on("click", "input", function() {
+        var $td = $(this).closest("#permissions-member");
+        var $sp = $("<img src=/assets/images/spinner.15.gif>").appendTo($td);
+        if (this.checked) {
+            console.log($(this).data("exp"));
+            $.post('@com.keepit.controllers.admin.routes.AdminOrganizationController.addRolePermission(orgStats.orgId, "member", "yyy")'.replace("yyy", $(this).data("permission")))
+                .done(done).fail(fail);
+        } else {
+            $.ajax('@com.keepit.controllers.admin.routes.AdminOrganizationController.removeRolePermission(orgStats.orgId, "member", "yyy")'.replace("yyy", $(this).data("permission")),
+            {type: "DELETE"}).done(done).fail(fail);
+        }
+        function done() {
+            $sp.after($("<i class=icon-ok-sign>").delay(1000).fadeOut()).remove();
+        }
+        function fail() {
+            $sp.after($("<i class=icon-exclamation-sign></i> Error. Reload?").delay(3000).fadeOut()).remove();
+        }
+    });
+    $("#permissions-admin").on("click", "input", function() {
+        var $td = $(this).closest("#permissions-admin");
+        var $sp = $("<img src=/assets/images/spinner.15.gif>").appendTo($td);
+        if (this.checked) {
+            console.log($(this).data("exp"));
+            $.post('@com.keepit.controllers.admin.routes.AdminOrganizationController.addRolePermission(orgStats.orgId, "admin", "yyy")'.replace("yyy", $(this).data("permission")))
+                .done(done).fail(fail);
+        } else {
+            $.ajax('@com.keepit.controllers.admin.routes.AdminOrganizationController.removeRolePermission(orgStats.orgId, "admin", "yyy")'.replace("yyy", $(this).data("permission")),
+            {type: "DELETE"}).done(done).fail(fail);
+        }
+        function done() {
+            $sp.after($("<i class=icon-ok-sign>").delay(1000).fadeOut()).remove();
+        }
+        function fail() {
+            $sp.after($("<i class=icon-exclamation-sign></i> Error. Reload?").delay(3000).fadeOut()).remove();
+        }
+    });
+    // Again, I am so sorry.  :'(
+
     function addCandidate(orgId, candidateId) {
       $.post("@com.keepit.controllers.admin.routes.AdminOrganizationController.addCandidate(orgStats.orgId)", { "user-id":  candidateId }).done(done);
     };

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -731,6 +731,8 @@ GET     /admin/organization/:id/disownDomain/:domainHostname @com.keepit.control
 POST    /admin/organization/:id/forceDeactivate              @com.keepit.controllers.admin.AdminOrganizationController.forceDeactivate(id: Id[Organization])
 POST    /admin/organization/:id/experiment/:exp              @com.keepit.controllers.admin.AdminOrganizationController.addExperimentAction(id: Id[Organization], exp: String)
 DELETE  /admin/organization/:id/experiment/:exp              @com.keepit.controllers.admin.AdminOrganizationController.removeExperimentAction(id: Id[Organization], exp: String)
+POST    /admin/organization/:id/permissions/:role/:perm      @com.keepit.controllers.admin.AdminOrganizationController.addRolePermission(id: Id[Organization], role: String, perm: String)
+DELETE  /admin/organization/:id/permissions/:role/:perm      @com.keepit.controllers.admin.AdminOrganizationController.removeRolePermission(id: Id[Organization], role: String, perm: String)
 GET     /admin/organizations                                 @com.keepit.controllers.admin.AdminOrganizationController.organizationsView(page: Int = 0)
 GET     /admin/organizations/:page                           @com.keepit.controllers.admin.AdminOrganizationController.organizationsView(page: Int)
 GET     /admin/fakeOrganizations                             @com.keepit.controllers.admin.AdminOrganizationController.fakeOrganizationsView(page: Int = 0)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
@@ -155,7 +155,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
           try1 === Left(OrganizationFail.INSUFFICIENT_PERMISSIONS)
 
           // An owner can change the base permissions so that members CAN do this
-          val betterBasePermissions = org.basePermissions.modified(OrganizationRole.MEMBER, added = Set(OrganizationPermission.INVITE_MEMBERS), removed = Set())
+          val betterBasePermissions = org.basePermissions.modified(Some(OrganizationRole.MEMBER), added = Set(OrganizationPermission.INVITE_MEMBERS), removed = Set())
           val orgModifyRequest = OrganizationModifyRequest(orgId = org.id.get, requesterId = users(0).id.get,
             modifications = OrganizationModifications(basePermissions = Some(betterBasePermissions)))
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
@@ -335,29 +335,64 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
         }
       }
 
+      "fail on empty name" in {
+        withDb(controllerTestModules: _*) { implicit injector =>
+          val (org, owner) = setupModify
+          inject[FakeUserActionsHelper].setUser(owner)
+          val publicId = Organization.publicId(org.id.get)
+
+          val json = """{ "name": "" }"""
+          val request = route.modifyOrganization(publicId).withBody(Json.parse(json))
+          val response = controller.modifyOrganization(publicId)(request)
+          response === OrganizationFail.INVALID_MODIFICATIONS
+        }
+      }
+
       "succeed for valid modifications" in {
         withDb(controllerTestModules: _*) { implicit injector =>
           val (org, owner) = setupModify
           inject[FakeUserActionsHelper].setUser(owner)
           val publicId = Organization.publicId(org.id.get)
 
-          val json = """ {"none":["view_organization"],"admin":["invite_members","edit_organization","view_organization","remove_libraries","modify_members","remove_members","add_libraries"],"member":["view_organization","add_libraries"]} """
+          db.readOnlyMaster { implicit session =>
+            orgRepo.get(org.id.get).getNonmemberPermissions === Set(OrganizationPermission.VIEW_ORGANIZATION)
+          }
+
+          val json =
+            """{ "basePermissions":
+                {
+                  "none":[],
+                  "member":["view_organization","add_libraries"],
+                  "admin":["invite_members","edit_organization","view_organization","remove_libraries","modify_members","remove_members","add_libraries"]
+                }
+               } """.stripMargin
           val request = route.modifyOrganization(publicId).withBody(Json.parse(json))
           val response = controller.modifyOrganization(publicId)(request)
           status(response) === OK
+
+          db.readOnlyMaster { implicit session =>
+            orgRepo.get(org.id.get).getNonmemberPermissions === Set.empty
+          }
         }
       }
 
-      "fail on invalid modifications" in {
+      "fail if you try and take away admin permissions" in {
         withDb(controllerTestModules: _*) { implicit injector =>
           val (org, owner) = setupModify
           inject[FakeUserActionsHelper].setUser(owner)
           val publicId = Organization.publicId(org.id.get)
 
-          val json = """{ "basePermissions": {"member":[]} }""" // all members must at least be able to view the organization
+          val json =
+            """{ "basePermissions":
+                {
+                  "none":[],
+                  "member":["view_organization","add_libraries"],
+                  "admin":["invite_members","view_organization","remove_libraries","modify_members","remove_members","add_libraries"]
+                }
+               } """.stripMargin
           val request = route.modifyOrganization(publicId).withBody(Json.parse(json))
           val response = controller.modifyOrganization(publicId)(request)
-          response === OrganizationFail.BAD_PARAMETERS
+          response === OrganizationFail.INVALID_MODIFICATIONS
         }
       }
 
@@ -370,7 +405,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
           val json = """{ "basePermissions": {"admin": [], "none": []} }"""
           val request = route.modifyOrganization(publicId).withBody(Json.parse(json))
           val response = controller.modifyOrganization(publicId)(request)
-          response === OrganizationFail.BAD_PARAMETERS
+          response === OrganizationFail.INVALID_MODIFICATIONS
         }
       }
     }
@@ -424,6 +459,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
           val result = controller.deleteOrganization(publicId)(request)
           status(result) === NO_CONTENT
 
+          println("deleted the org")
           val viewRequest = route.getOrganization(publicId)
           val viewResponse = controller.getOrganization(publicId)(viewRequest)
           status(viewResponse) === FORBIDDEN


### PR DESCRIPTION
@eishay @andrewconner @stkem @JRuff42 

Admin pages for an org now allow you to modify the org's base permissions, similar to how we add/remove experiments.

The javascript is horrible, and I'm ashamed of it. I think I know of a way to make it better, but I'm tempted to say we'll cross that bridge when we add another org role.
