### PR TITLE
fetch group shared message count more directly

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaStatsCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaStatsCommander.scala
@@ -37,7 +37,7 @@ class ElizaStatsCommander @Inject() (
   @StatsdTiming("ElizaStatsCommander.getTotalMessageCountForGroup")
   def getTotalMessageCountForGroup(users: Set[Id[User]]): Int = {
     db.readOnlyReplica { implicit session =>
-      val groupThreadStats = userThreadRepo.getAllSharedThreadsForGroup(users.toSeq)
+      val groupThreadStats = userThreadRepo.getSharedThreadsForGroup(users.toSeq)
       val countByThread = messageRepo.getAllMessageCounts(groupThreadStats.map(stats => Id[MessageThread](stats.threadId)).toSet)
       countByThread.values.sum
     }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaStatsCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaStatsCommander.scala
@@ -37,7 +37,7 @@ class ElizaStatsCommander @Inject() (
   @StatsdTiming("ElizaStatsCommander.getTotalMessageCountForGroup")
   def getTotalMessageCountForGroup(users: Set[Id[User]]): Int = {
     db.readOnlyReplica { implicit session =>
-      val groupThreadStats = userThreadRepo.getSharedThreadsForGroupByWeek(users.toSeq)
+      val groupThreadStats = userThreadRepo.getAllSharedThreadsForGroup(users.toSeq)
       val countByThread = messageRepo.getAllMessageCounts(groupThreadStats.map(stats => Id[MessageThread](stats.threadId)).toSet)
       countByThread.values.sum
     }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessageThread.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessageThread.scala
@@ -126,8 +126,8 @@ case class MessageThread(
   def withParticipants(when: DateTime, userIds: Seq[Id[User]], nonUsers: Seq[NonUserParticipant] = Seq.empty) = {
     val newUsers = userIds.map(_ -> when).toMap
     val newNonUsers = nonUsers.map(_ -> when).toMap
-    val newParticpiants = participants.map(ps => MessageThreadParticipants(ps.userParticipants ++ newUsers, ps.nonUserParticipants ++ newNonUsers))
-    this.copy(participants = newParticpiants, participantsHash = newParticpiants.map(_.hash))
+    val newParticipants = participants.map(ps => MessageThreadParticipants(ps.userParticipants ++ newUsers, ps.nonUserParticipants ++ newNonUsers))
+    this.copy(participants = newParticipants, participantsHash = newParticipants.map(_.hash))
   }
 
   def withoutParticipant(userId: Id[User]) = {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
@@ -504,7 +504,7 @@ class UserThreadRepoImpl @Inject() (
     if (users.isEmpty) Seq.empty[GroupThreadStats]
     else {
       val users_list = users.map(_.id).mkString("(", ",", ")")
-      val query = sql"""
+      sql"""
         select thread_id, created_at, count(*) as c from user_thread
           where user_id in #$users_list
           and replyable = 1
@@ -512,9 +512,7 @@ class UserThreadRepoImpl @Inject() (
           group by thread_id
           order by week(created_at)
           desc
-      """
-
-      query.as[(Long, DateTime, Int)].list.map((GroupThreadStats.apply _).tupled)
+      """.as[(Long, DateTime, Int)].list.map((GroupThreadStats.apply _).tupled)
     }
   }
 

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/model/UserThreadRepoTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/model/UserThreadRepoTest.scala
@@ -80,7 +80,6 @@ class UserThreadRepoTest extends Specification with ElizaTestInjector {
             replyable = true
           ))
           userThreadRepo.count === 1
-          // println(userThreadRepo.all) // can be removed?
           val toMail = userThreadRepo.getUserThreadsForEmailing(clock.now().plusMinutes(16))
           toMail.size === 1
           toMail.head.id.get === thread1.id.get


### PR DESCRIPTION
@leogrim @gratimax omitted the "group and sort by week" behavior to speed up the query
