### PR TITLE
Drained the execution context to let tests finish

### DIFF
--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationMembershipControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationMembershipControllerTest.scala
@@ -3,6 +3,7 @@ package com.keepit.controllers.mobile
 import com.google.inject.Injector
 import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.commanders.OrganizationMembershipCommander
+import com.keepit.common.concurrent.WatchableExecutionContext
 import com.keepit.common.controller.FakeUserActionsHelper
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.db.{ ExternalId, Id }
@@ -273,6 +274,11 @@ class MobileOrganizationMembershipControllerTest extends Specification with Shoe
           val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
           val result = controller.removeMembers(publicOrgId)(request)
           status(result) === OK
+
+          // there are futures running in the background that will blow up if the test ends and the db is dumped
+          inject[WatchableExecutionContext].drain()
+
+          1 === 1
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationMembershipControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationMembershipControllerTest.scala
@@ -3,6 +3,7 @@ package com.keepit.controllers.website
 import com.google.inject.Injector
 import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.commanders.OrganizationMembershipCommander
+import com.keepit.common.concurrent.WatchableExecutionContext
 import com.keepit.common.controller.FakeUserActionsHelper
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.db.{ ExternalId, Id }
@@ -274,6 +275,11 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
           val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
           val result = controller.removeMembers(publicOrgId)(request)
           status(result) === OK
+
+          // there are futures running in the background that will blow up if the test ends and the db is dumped
+          inject[WatchableExecutionContext].drain()
+
+          1 === 1
         }
       }
       "let a user leave the org" in {
@@ -289,6 +295,11 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
           val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
           val result = controller.removeMembers(publicOrgId)(request)
           status(result) === OK
+
+          // there are futures running in the background that will blow up if the test ends and the db is dumped
+          inject[WatchableExecutionContext].drain()
+
+          1 === 1
         }
       }
     }


### PR DESCRIPTION
There are some tests that launch Futures that need the db table. If the test
finishes before the Future needs the db table, the table will be dropped (and
the Future will blow up when it finally gets around to reaching for the table).

This just blocks the test from finishing until the Future executes, so no more
scary JdbcSQLExceptions

Thanks, @andrewconner 
