### PR TITLE
cache sets of user ids (members) by org id

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/common/cache/ABookCacheModule.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/common/cache/ABookCacheModule.scala
@@ -181,5 +181,5 @@ case class ABookCacheModule(cachePluginModules: CachePluginModule*) extends Cach
 
   @Provides @Singleton
   def organizationMembersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new OrganizationMembersCache(stats, accessLog, (outerRepo, 14 days))
+    new OrganizationMembersCache(stats, accessLog, (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/abook/app/com/keepit/common/cache/ABookCacheModule.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/common/cache/ABookCacheModule.scala
@@ -178,4 +178,8 @@ case class ABookCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Provides @Singleton
   def primaryOrgForUserCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new PrimaryOrgForUserCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 14 days))
+
+  @Provides @Singleton
+  def organizationMembersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new OrganizationMembersCache(stats, accessLog, (outerRepo, 14 days))
 }

--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationMembership.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationMembership.scala
@@ -123,7 +123,7 @@ object IngestableOrganizationMembership {
 
 case class OrganizationMembersKey(id: Id[Organization]) extends Key[Set[Id[User]]] {
   override val version = 1
-  val namespace = "user_ids_by_organization"
+  val namespace = "member_ids_by_organization"
   def toKey(): String = id.id.toString
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationMembership.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationMembership.scala
@@ -1,11 +1,15 @@
 package com.keepit.model
 
+import com.keepit.common.cache.{ JsonCacheImpl, FortyTwoCachePlugin, CacheStatistics, Key }
 import com.keepit.common.db._
+import com.keepit.common.logging.AccessLog
 import com.keepit.common.time._
 import com.kifi.macros.json
 import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+
+import scala.concurrent.duration.Duration
 
 case class OrganizationMembership(
     id: Option[Id[OrganizationMembership]] = None,
@@ -116,4 +120,13 @@ case class IngestableOrganizationMembership(
 object IngestableOrganizationMembership {
   implicit val format = Json.format[IngestableOrganizationMembership]
 }
+
+case class OrganizationMembersKey(id: Id[Organization]) extends Key[Set[Id[User]]] {
+  override val version = 4
+  val namespace = "user_ids_by_organization"
+  def toKey(): String = id.id.toString
+}
+
+class OrganizationMembersCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
+  extends JsonCacheImpl[OrganizationMembersKey, Set[Id[User]]](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
 

--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationMembership.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationMembership.scala
@@ -122,7 +122,7 @@ object IngestableOrganizationMembership {
 }
 
 case class OrganizationMembersKey(id: Id[Organization]) extends Key[Set[Id[User]]] {
-  override val version = 4
+  override val version = 1
   val namespace = "user_ids_by_organization"
   def toKey(): String = id.id.toString
 }

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -159,7 +159,8 @@ case class ShoeboxCacheProvider @Inject() (
   librariesWithWriteAccessCache: LibrariesWithWriteAccessCache,
   userActivePersonaCache: UserActivePersonasCache,
   keepImagesCache: KeepImagesCache,
-  primaryOrgForUserCache: PrimaryOrgForUserCache)
+  primaryOrgForUserCache: PrimaryOrgForUserCache,
+  organizationMembersCache: OrganizationMembersCache)
 
 class ShoeboxServiceClientImpl @Inject() (
   override val serviceCluster: ServiceCluster,
@@ -779,7 +780,9 @@ class ShoeboxServiceClientImpl @Inject() (
   }
 
   def getOrganizationMembers(orgId: Id[Organization]): Future[Set[Id[User]]] = {
-    call(Shoebox.internal.getOrganizationMembers(orgId)).map(_.json.as[Set[Id[User]]])
+    cacheProvider.organizationMembersCache.getOrElseFuture(OrganizationMembersKey(orgId)) {
+      call(Shoebox.internal.getOrganizationMembers(orgId)).map(_.json.as[Set[Id[User]]])
+    }
   }
 
   def hasOrganizationMembership(orgId: Id[Organization], userId: Id[User]): Future[Boolean] = {

--- a/kifi-backend/modules/common/test/com/keepit/common/cache/FakeCacheModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/cache/FakeCacheModule.scala
@@ -176,5 +176,9 @@ case class FakeCacheModule() extends CacheModule(HashMapMemoryCacheModule()) {
   @Provides @Singleton
   def orgTrackingValuesCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new OrgTrackingValuesCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 14 days))
+
+  @Provides @Singleton
+  def organizationMembersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new OrganizationMembersCache(stats, accessLog, (outerRepo, 7 days))
 }
 

--- a/kifi-backend/modules/cortex/app/com/keepit/common/cache/CortexCacheModule.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/cache/CortexCacheModule.scala
@@ -161,4 +161,8 @@ case class CortexCacheModule(cachePluginModules: CachePluginModule*) extends Cac
   @Provides @Singleton
   def primaryOrgForUserCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new PrimaryOrgForUserCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 14 days))
+
+  @Provides @Singleton
+  def organizationMembersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new OrganizationMembersCache(stats, accessLog, (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/curator/app/com/keepit/common/cache/CuratorCacheModule.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/common/cache/CuratorCacheModule.scala
@@ -186,4 +186,8 @@ case class CuratorCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Provides @Singleton
   def primaryOrgForUserCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new PrimaryOrgForUserCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 14 days))
+
+  @Provides @Singleton
+  def organizationMembersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new OrganizationMembersCache(stats, accessLog, (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
@@ -172,4 +172,8 @@ case class ElizaCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Provides @Singleton
   def primaryOrgForUserCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new PrimaryOrgForUserCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 14 days))
+
+  @Provides @Singleton
+  def organizationMembersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new OrganizationMembersCache(stats, accessLog, (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/graph/app/com/keepit/graph/common/cache/GraphCacheModule.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/common/cache/GraphCacheModule.scala
@@ -172,4 +172,8 @@ case class GraphCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Provides @Singleton
   def primaryOrgForUserCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new PrimaryOrgForUserCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 14 days))
+
+  @Provides @Singleton
+  def organizationMembersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new OrganizationMembersCache(stats, accessLog, (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/heimdal/app/com/keepit/common/cache/HeimdalCacheModule.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/common/cache/HeimdalCacheModule.scala
@@ -190,4 +190,8 @@ case class HeimdalCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Provides @Singleton
   def orgTrackingValuesCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new OrgTrackingValuesCache(stats, accessLog, (innerRepo, 1 minutes), (outerRepo, 14 days))
+
+  @Provides @Singleton
+  def organizationMembersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new OrganizationMembersCache(stats, accessLog, (outerRepo, 14 days))
 }

--- a/kifi-backend/modules/rover/app/com/keepit/rover/common/cache/RoverCacheModule.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/common/cache/RoverCacheModule.scala
@@ -211,4 +211,8 @@ case class RoverCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Provides @Singleton
   def orgTrackingValuesCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new OrgTrackingValuesCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 14 days))
+
+  @Provides @Singleton
+  def organizationMembersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new OrganizationMembersCache(stats, accessLog, (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/common/cache/SearchCacheModule.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/common/cache/SearchCacheModule.scala
@@ -174,4 +174,8 @@ case class SearchCacheModule(cachePluginModules: CachePluginModule*) extends Cac
   @Provides @Singleton
   def primaryOrgForUserCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new PrimaryOrgForUserCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 14 days))
+
+  @Provides @Singleton
+  def organizationMembersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new OrganizationMembersCache(stats, accessLog, (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -423,4 +423,8 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Provides @Singleton
   def organizationDomainOwnershipCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new OrganizationDomainOwnershipAllCache(stats, accessLog, (outerRepo, 14 days))
+
+  @Provides @Singleton
+  def organizationMembersCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new OrganizationMembersCache(stats, accessLog, (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationMembershipRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationMembershipRepo.scala
@@ -34,15 +34,18 @@ trait OrganizationMembershipRepo extends Repo[OrganizationMembership] with SeqNu
 @Singleton
 class OrganizationMembershipRepoImpl @Inject() (
     primaryOrgForUserCache: PrimaryOrgForUserCache,
+    orgMembersCache: OrganizationMembersCache,
     val db: DataBaseComponent,
     val clock: Clock) extends OrganizationMembershipRepo with DbRepo[OrganizationMembership] with SeqNumberDbFunction[OrganizationMembership] with Logging {
 
   override def deleteCache(orgMember: OrganizationMembership)(implicit session: RSession): Unit = {
     primaryOrgForUserCache.remove(PrimaryOrgForUserKey(orgMember.userId))
+    orgMembersCache.remove(OrganizationMembersKey(orgMember.organizationId))
   }
 
   override def invalidateCache(orgMember: OrganizationMembership)(implicit session: RSession): Unit = {
     primaryOrgForUserCache.remove(PrimaryOrgForUserKey(orgMember.userId))
+    orgMembersCache.remove(OrganizationMembersKey(orgMember.organizationId))
   }
 
   import db.Driver.simple._


### PR DESCRIPTION
@andrewconner @ryanpbrewster @leogrim 

Let's see how this improves heimdal's day. If we still have trouble, we could think about doing an in-memory cache on the result of `PrimaryOrgProvider.getOrgContextData`, with the TTL of 1 day. This org-stats fetching happens every time an event gets tracked, but we probably don't care that these general org stats are accurate up-to-the-second. Maybe up-to-the-day or 12 hours.
