### PR TITLE
don't send org properties with every event

### DIFF
--- a/kifi-backend/modules/heimdal/app/com/keepit/heimdal/AmplitudeClient.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/heimdal/AmplitudeClient.scala
@@ -149,7 +149,7 @@ trait AmplitudeRequestBuilder {
       primaryOrgProvider.getPrimaryOrg(userId).flatMap {
         case Some(orgId) =>
           primaryOrgProvider.getOrgContextData(orgId).map { orgProps =>
-            (xformToSnakeCase(userProps ++ orgProps), xformToSnakeCase(eventProps ++ orgProps))
+            (xformToSnakeCase(userProps ++ orgProps), xformToSnakeCase(eventProps))
           }
         case None =>
           Future.successful(xformToSnakeCase(userProps), xformToSnakeCase(eventProps))

--- a/kifi-backend/modules/shoebox/angular/src/feed/feed.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/feed/feed.tpl.html
@@ -52,6 +52,7 @@
     </div>
   </section>
   <section class="kf-feed-item" ng-if="!isLoading() && feed.length < 10" >
+  <section class="kf-feed-item" ng-if="!isLoading() && feed.length < 10 && !hasMoreKeeps()" >
     <div class="kf-feed-top"><h3>Add a keep</h3></div>
       <div class="kf-keep kf-feed-empty-add-keep">
         <div kf-create-keep-widget></div>


### PR DESCRIPTION
@eishay @leogrim per https://app.asana.com/0/32728208409723/44164549287773, we should only send org info with `eventProps` where applicable. We send org data with `userProps` every time.
