### PR TITLE
Keep integrity

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -87,6 +87,8 @@ trait KeepCommander {
   def assembleKeepExport(keepExports: Seq[KeepExport]): String
   def numKeeps(userId: Id[User]): Int
   def persistKeep(k: Keep, users: Set[Id[User]], libraries: Set[Id[Library]])(implicit session: RWSession): Keep
+  def refreshLibrariesHash(keep: Keep)(implicit session: RWSession): Keep
+  def refreshParticipantsHash(keep: Keep)(implicit session: RWSession): Keep
   def updateNote(keep: Keep, newNote: Option[String])(implicit session: RWSession): Keep
   def syncWithLibrary(keep: Keep, library: Library)(implicit session: RWSession): Keep
   def changeOwner(keep: Keep, newOwnerId: Id[User])(implicit session: RWSession): Keep
@@ -795,11 +797,11 @@ class KeepCommanderImpl @Inject() (
 
     keep
   }
-  private def refreshLibrariesHash(keep: Keep)(implicit session: RWSession): Keep = {
+  def refreshLibrariesHash(keep: Keep)(implicit session: RWSession): Keep = {
     val libraries = ktlRepo.getAllByKeepId(keep.id.get).map(_.libraryId).toSet
     keepRepo.save(keep.withLibraries(libraries))
   }
-  private def refreshParticipantsHash(keep: Keep)(implicit session: RWSession): Keep = {
+  def refreshParticipantsHash(keep: Keep)(implicit session: RWSession): Keep = {
     val users = ktuRepo.getAllByKeepId(keep.id.get).map(_.userId).toSet
     keepRepo.save(keep.withParticipants(users))
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToUserCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToUserCommander.scala
@@ -22,9 +22,12 @@ trait KeepToUserCommander {
   def removeKeepFromUser(keepId: Id[Keep], userId: Id[User])(implicit session: RWSession): Try[Unit]
   def removeKeepFromAllUsers(keep: Keep)(implicit session: RWSession): Unit
 
+  def deactivate(ktu: KeepToUser)(implicit session: RWSession): Unit
+
   // Fun helper methods
   def isKeepInUser(keepId: Id[Keep], userId: Id[User])(implicit session: RSession): Boolean
   def syncKeep(keep: Keep)(implicit session: RWSession): Unit
+  def syncWithKeep(ktu: KeepToUser, keep: Keep)(implicit session: RWSession): KeepToUser
 }
 
 @Singleton
@@ -49,16 +52,19 @@ class KeepToUserCommanderImpl @Inject() (
     }
   }
 
+  def deactivate(ktu: KeepToUser)(implicit session: RWSession): Unit = {
+    ktuRepo.deactivate(ktu)
+  }
   def removeKeepFromUser(keepId: Id[Keep], userId: Id[User])(implicit session: RWSession): Try[Unit] = {
     ktuRepo.getByKeepIdAndUserId(keepId, userId) match {
       case None => Failure(KeepToUserFail.NOT_CONNECTED_TO_USER)
       case Some(activeKtu) =>
-        ktuRepo.deactivate(activeKtu)
+        deactivate(activeKtu)
         Success(())
     }
   }
   def removeKeepFromAllUsers(keep: Keep)(implicit session: RWSession): Unit = {
-    ktuRepo.getAllByKeepId(keep.id.get).foreach(ktuRepo.deactivate)
+    ktuRepo.getAllByKeepId(keep.id.get).foreach(deactivate)
   }
 
   def isKeepInUser(keepId: Id[Keep], userId: Id[User])(implicit session: RSession): Boolean = {
@@ -69,7 +75,7 @@ class KeepToUserCommanderImpl @Inject() (
     // Sync ALL of the connections (including the dead ones)
     ktuRepo.getAllByKeepId(keep.id.get, excludeStateOpt = None).foreach { ktu => syncWithKeep(ktu, keep) }
   }
-  private def syncWithKeep(ktu: KeepToUser, keep: Keep)(implicit session: RWSession): KeepToUser = {
+  def syncWithKeep(ktu: KeepToUser, keep: Keep)(implicit session: RWSession): KeepToUser = {
     require(ktu.keepId == keep.id.get, "keep.id does not match ktu.keepId")
     ktuRepo.save(ktu.withUriId(keep.uriId))
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/DataIntegrity.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/DataIntegrity.scala
@@ -25,6 +25,7 @@ class DataIntegrityPluginImpl @Inject() (
     scheduleTaskOnOneMachine(actor.system, 7 minutes, EVERY_N_MINUTE minutes, actor.ref, SystemLibraryCheck, getClass.getSimpleName)
     scheduleTaskOnOneMachine(actor.system, 1 minutes, 1 minutes, actor.ref, LibrariesCheck, getClass.getSimpleName)
     scheduleTaskOnOneMachine(actor.system, 10 minutes, 24 hours, actor.ref, PaymentsMembershipCheck, getClass.getSimpleName)
+    scheduleTaskOnOneMachine(actor.system, 1 minutes, 1 minutes, actor.ref, KeepsCheck, getClass.getSimpleName)
   }
 }
 
@@ -32,6 +33,7 @@ private[integrity] case object CleanOrphans
 private[integrity] case object Cron
 private[integrity] case object SequenceNumberCheck
 private[integrity] case object LibrariesCheck
+private[integrity] case object KeepsCheck
 private[integrity] case object SystemLibraryCheck
 private[integrity] case object PaymentsMembershipCheck
 
@@ -40,7 +42,8 @@ private[integrity] class DataIntegrityActor @Inject() (
   orphanCleaner: OrphanCleaner,
   elizaSequenceNumberChecker: ElizaSequenceNumberChecker,
   libraryChecker: LibraryChecker,
-  paymentsChecker: PaymentsIntegrityChecker)
+  paymentsChecker: PaymentsIntegrityChecker,
+  keepChecker: KeepChecker)
     extends FortyTwoActor(airbrake) with Logging {
 
   def receive() = {
@@ -50,6 +53,8 @@ private[integrity] class DataIntegrityActor @Inject() (
       elizaSequenceNumberChecker.check()
     case LibrariesCheck =>
       libraryChecker.check()
+    case KeepsCheck =>
+      keepChecker.check()
     case SystemLibraryCheck =>
       libraryChecker.checkSystemLibraries()
     case PaymentsMembershipCheck =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/KeepChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/KeepChecker.scala
@@ -1,0 +1,165 @@
+package com.keepit.integrity
+
+import com.google.inject.Inject
+import com.keepit.commanders.{ KeepCommander, KeepToLibraryCommander, KeepToUserCommander, LibraryInfoCommander }
+import com.keepit.common.core._
+import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
+import com.keepit.common.db.slick.Database
+import com.keepit.common.db.{ Id, SequenceNumber }
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.logging.{ Logging, NamedStatsdTimer }
+import com.keepit.common.time.{ Clock, _ }
+import com.keepit.model._
+
+class KeepChecker @Inject() (
+    airbrake: AirbrakeNotifier,
+    clock: Clock,
+    db: Database,
+    keepRepo: KeepRepo,
+    keepCommander: KeepCommander,
+    ktlRepo: KeepToLibraryRepo,
+    ktuRepo: KeepToUserRepo,
+    ktlCommander: KeepToLibraryCommander,
+    ktuCommander: KeepToUserCommander,
+    userRepo: UserRepo,
+    libraryRepo: LibraryRepo,
+    organizationRepo: OrganizationRepo,
+    systemValueRepo: SystemValueRepo) extends Logging {
+
+  private[this] val lock = new AnyRef
+  private val timeSlicer = new TimeSlicer(clock)
+
+  private[integrity] val KEEP_URI_CHANGED = Name[SequenceNumber[Keep]]("keep_integrity_plugin_keep_uri_changed")
+  private[integrity] val KEEP_DEACTIVATED = Name[SequenceNumber[Keep]]("keep_integrity_plugin_keep_deactivated")
+  private[integrity] val KEEP_LIBRARY_CHANGED = Name[SequenceNumber[Keep]]("keep_integrity_plugin_keep_library_changed")
+  private[integrity] val KEEP_PARTICIPANT_CHANGED = Name[SequenceNumber[Keep]]("keep_integrity_plugin_keep_participant_changed")
+  private val KEEP_FETCH_SIZE = 100
+
+  private def getLastSeqNum[T](key: Name[SequenceNumber[T]])(implicit session: RSession) = {
+    systemValueRepo.getSequenceNumber(key).getOrElse(SequenceNumber.ZERO[T])
+  }
+
+  def check(): Unit = lock.synchronized {
+    syncOnUriChange() // reads keeps, ensures that uriIds on ktls/ktus are right
+    syncOnDeactivate() // reads dead keeps, ensures that state on ktls/ktus are right
+    syncOnLibraryChange() // reads keeps, ensures that `librariesHash` is right
+    syncOnParticipantChange() // reads keeps, ensures that `participantsHash` is right
+  }
+
+  private[integrity] def syncOnUriChange(): Unit = {
+    val keeps = db.readOnlyReplica { implicit s =>
+      val lastSeq = getLastSeqNum(KEEP_URI_CHANGED)
+      keepRepo.getBySequenceNumber(lastSeq, KEEP_FETCH_SIZE)
+    }
+
+    keeps.foreach { keep =>
+      db.readWrite { implicit session => ensureUriIntegrity(keep.id.get) }
+    }
+
+    keeps.map(_.seq).maxOpt.foreach { maxSeq =>
+      db.readWrite { implicit session => systemValueRepo.setSequenceNumber(KEEP_URI_CHANGED, maxSeq) }
+    }
+  }
+
+  private[integrity] def syncOnDeactivate(): Unit = {
+    val keeps = db.readOnlyReplica { implicit s =>
+      val lastSeq = getLastSeqNum(KEEP_DEACTIVATED)
+      keepRepo.getBySequenceNumber(lastSeq, KEEP_FETCH_SIZE)
+    }
+
+    keeps.filter(_.isInactive).foreach { keep =>
+      db.readWrite { implicit session => ensureStateIntegrity(keep.id.get) }
+    }
+
+    keeps.map(_.seq).maxOpt.foreach { maxSeq =>
+      db.readWrite { implicit session => systemValueRepo.setSequenceNumber(KEEP_DEACTIVATED, maxSeq) }
+    }
+  }
+
+  private[integrity] def syncOnLibraryChange(): Unit = {
+    val keeps = db.readOnlyReplica { implicit s =>
+      val lastSeq = getLastSeqNum(KEEP_LIBRARY_CHANGED)
+      keepRepo.getBySequenceNumber(lastSeq, KEEP_FETCH_SIZE)
+    }
+
+    keeps.foreach { keep =>
+      db.readWrite { implicit session => ensureLibrariesHashIntegrity(keep.id.get) }
+    }
+
+    keeps.map(_.seq).maxOpt.foreach { maxSeq =>
+      db.readWrite { implicit session => systemValueRepo.setSequenceNumber(KEEP_LIBRARY_CHANGED, maxSeq) }
+    }
+  }
+
+  private[integrity] def syncOnParticipantChange(): Unit = {
+    val keeps = db.readOnlyReplica { implicit s =>
+      val lastSeq = getLastSeqNum(KEEP_PARTICIPANT_CHANGED)
+      keepRepo.getBySequenceNumber(lastSeq, KEEP_FETCH_SIZE)
+    }
+
+    keeps.foreach { keep =>
+      db.readWrite { implicit session => ensureParticipantsHashIntegrity(keep.id.get) }
+    }
+
+    keeps.map(_.seq).maxOpt.foreach { maxSeq =>
+      db.readWrite { implicit session => systemValueRepo.setSequenceNumber(KEEP_PARTICIPANT_CHANGED, maxSeq) }
+    }
+  }
+
+  private def ensureUriIntegrity(keepId: Id[Keep]) = db.readWrite { implicit session =>
+    val keep = keepRepo.getNoCache(keepId)
+
+    val allKtus = ktuRepo.getAllByKeepId(keepId, excludeStateOpt = None)
+    for (ktu <- allKtus) {
+      if (ktu.uriId != keep.uriId) {
+        airbrake.notify(s"[KTU-URI-MATCH] KTU ${ktu.id.get}'s URI Id (${ktu.uriId}) does not match keep ${keep.id.get}'s URI id (${keep.uriId})")
+        ktuCommander.syncWithKeep(ktu, keep)
+      }
+    }
+
+    val allKtls = ktlRepo.getAllByKeepId(keepId)
+    for (ktl <- allKtls) {
+      if (ktl.uriId != keep.uriId) {
+        airbrake.notify(s"[KTL-URI-MATCH] KTL ${ktl.id.get}'s URI Id (${ktl.uriId}) does not match keep ${keep.id.get}'s URI id (${keep.uriId})")
+        ktlCommander.syncWithKeep(ktl, keep)
+      }
+    }
+  }
+
+  private def ensureStateIntegrity(keepId: Id[Keep]) = db.readWrite { implicit session =>
+    val keep = keepRepo.getNoCache(keepId)
+    if (keep.isInactive) {
+      val zombieKtus = ktuRepo.getAllByKeepId(keepId, excludeStateOpt = Some(KeepToUserStates.ACTIVE))
+      for (ktu <- zombieKtus) {
+        airbrake.notify(s"[KTU-STATE-MATCH] KTU ${ktu.id.get} is a zombie!")
+        ktuCommander.deactivate(ktu)
+      }
+
+      val zombieKtls = ktlRepo.getAllByKeepId(keepId, excludeStateOpt = Some(KeepToLibraryStates.ACTIVE))
+      for (ktl <- zombieKtls) {
+        airbrake.notify(s"[KTL-STATE-MATCH] KTL ${ktl.id.get} is a zombie!")
+        ktlCommander.deactivate(ktl)
+      }
+    }
+  }
+
+  private def ensureLibrariesHashIntegrity(keepId: Id[Keep]) = db.readWrite { implicit session =>
+    val keep = keepRepo.getNoCache(keepId)
+    val libraries = ktlRepo.getAllByKeepId(keepId).map(_.libraryId).toSet
+    val expectedHash = LibrariesHash(libraries)
+    if (keep.librariesHash != expectedHash) {
+      airbrake.notify(s"[KTL-HASH-MATCH] Keep $keepId's library hash (${keep.librariesHash}) != $libraries ($expectedHash)")
+      keepCommander.refreshLibrariesHash(keep)
+    }
+  }
+
+  private def ensureParticipantsHashIntegrity(keepId: Id[Keep]) = db.readWrite { implicit session =>
+    val keep = keepRepo.getNoCache(keepId)
+    val users = ktuRepo.getAllByKeepId(keepId).map(_.userId).toSet
+    val expectedHash = ParticipantsHash(users)
+    if (keep.participantsHash != expectedHash) {
+      airbrake.notify(s"[KTU-HASH-MATCH] Keep $keepId's participants hash (${keep.participantsHash}) != $users ($expectedHash)")
+      keepCommander.refreshParticipantsHash(keep)
+    }
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
@@ -84,7 +84,7 @@ class KeepRepoImpl @Inject() (
     keepByIdCache: KeepByIdCache,
     keepUriUserCache: KeepUriUserCache,
     libraryMetadataCache: LibraryMetadataCache,
-    countByLibraryCache: CountByLibraryCache) extends DbRepo[Keep] with KeepRepo with ExternalIdColumnDbFunction[Keep] with SeqNumberDbFunction[Keep] with Logging {
+    countByLibraryCache: CountByLibraryCache) extends DbRepo[Keep] with KeepRepo with SeqNumberDbFunction[Keep] with ExternalIdColumnDbFunction[Keep] with Logging {
 
   import db.Driver.simple._
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepToLibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepToLibraryCommanderTest.scala
@@ -17,8 +17,6 @@ import scala.util.Random
 
 class KeepToLibraryCommanderTest extends TestKitSupport with SpecificationLike with ShoeboxTestInjector {
   implicit val context = HeimdalContext.empty
-  implicit def ktlCommander(implicit injector: Injector) = inject[KeepToLibraryCommander]
-  implicit def ktlRepo(implicit injector: Injector) = inject[KeepToLibraryRepo]
 
   def modules = Seq()
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/KeepCheckerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/KeepCheckerTest.scala
@@ -52,7 +52,7 @@ class KeepCheckerTest extends TestKitSupport with SpecificationLike with Shoebox
 
         // Let's see if the checker will fix it
         inject[KeepSequenceNumberAssigner].assignSequenceNumbers()
-        keepChecker.syncOnUriChange()
+        keepChecker.check()
 
         db.readOnlyMaster { implicit session =>
           ktlRepo.getByKeepIdAndLibraryId(keep.id.get, library.id.get).get.uriId === keep.uriId
@@ -82,7 +82,7 @@ class KeepCheckerTest extends TestKitSupport with SpecificationLike with Shoebox
 
         // Let's see if the checker will fix it
         inject[KeepSequenceNumberAssigner].assignSequenceNumbers()
-        keepChecker.syncOnDeactivate()
+        keepChecker.check()
 
         // Make sure it got fixed
         db.readOnlyMaster { implicit session =>
@@ -108,7 +108,7 @@ class KeepCheckerTest extends TestKitSupport with SpecificationLike with Shoebox
 
         // Let's see if the checker will fix it
         inject[KeepSequenceNumberAssigner].assignSequenceNumbers()
-        keepChecker.syncOnLibraryChange()
+        keepChecker.check()
 
         db.readOnlyMaster { implicit session =>
           keepRepo.get(keep.id.get).librariesHash === Some(LibrariesHash(Set(library.id.get)))
@@ -133,7 +133,7 @@ class KeepCheckerTest extends TestKitSupport with SpecificationLike with Shoebox
 
         // Let's see if the checker will fix it
         inject[KeepSequenceNumberAssigner].assignSequenceNumbers()
-        keepChecker.syncOnParticipantChange()
+        keepChecker.check()
 
         db.readOnlyMaster { implicit session =>
           keepRepo.get(keep.id.get).participantsHash === Some(ParticipantsHash(Set(user.id.get)))

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/KeepCheckerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/KeepCheckerTest.scala
@@ -1,0 +1,144 @@
+package com.keepit.integrity
+
+import com.keepit.abook.FakeABookServiceClientModule
+import com.keepit.common.actor.TestKitSupport
+import com.keepit.common.concurrent.FakeExecutionContextModule
+import com.keepit.common.crypto.FakeCryptoModule
+import com.keepit.common.db.Id
+import com.keepit.common.mail.FakeMailModule
+import com.keepit.common.social.FakeSocialGraphModule
+import com.keepit.common.store.FakeShoeboxStoreModule
+import com.keepit.eliza.FakeElizaServiceClientModule
+import com.keepit.heimdal.FakeHeimdalServiceClientModule
+import com.keepit.model.KeepFactoryHelper._
+import com.keepit.model.LibraryFactoryHelper._
+import com.keepit.model.UserFactoryHelper._
+import com.keepit.model._
+import com.keepit.search.FakeSearchServiceClientModule
+import com.keepit.shoebox.KeepSequenceNumberAssigner
+import com.keepit.test.ShoeboxTestInjector
+import org.specs2.mutable.SpecificationLike
+
+class KeepCheckerTest extends TestKitSupport with SpecificationLike with ShoeboxTestInjector {
+  def modules = Seq(
+    FakeExecutionContextModule(),
+    FakeSearchServiceClientModule(),
+    FakeMailModule(),
+    FakeShoeboxStoreModule(),
+    FakeCryptoModule(),
+    FakeSocialGraphModule(),
+    FakeABookServiceClientModule(),
+    FakeElizaServiceClientModule(),
+    FakeHeimdalServiceClientModule()
+  )
+
+  "KeepChecker" should {
+    "fix broken ktl uris" in {
+      withDb(modules: _*) { implicit injector =>
+        val (keep, library) = db.readWrite { implicit session =>
+          val user = UserFactory.user().saved
+          val library = LibraryFactory.library().withOwner(user).saved
+          val keep = KeepFactory.keep().withUser(user).withLibrary(library).saved
+          // Somehow this KTL got messed up
+          ktlRepo.getByKeepIdAndLibraryId(keep.id.get, library.id.get).foreach { ktl =>
+            ktlRepo.save(ktl.withUriId(Id[NormalizedURI](42)))
+          }
+          (keep, library)
+        }
+
+        db.readOnlyMaster { implicit session =>
+          ktlRepo.getByKeepIdAndLibraryId(keep.id.get, library.id.get).get.uriId !== keep.uriId
+        }
+
+        // Let's see if the checker will fix it
+        inject[KeepSequenceNumberAssigner].assignSequenceNumbers()
+        keepChecker.syncOnUriChange()
+
+        db.readOnlyMaster { implicit session =>
+          ktlRepo.getByKeepIdAndLibraryId(keep.id.get, library.id.get).get.uriId === keep.uriId
+        }
+      }
+    }
+    "fix broken ktl states" in {
+      withDb(modules: _*) { implicit injector =>
+        val (keep, library) = db.readWrite { implicit session =>
+          val user = UserFactory.user().saved
+          val library = LibraryFactory.library().withOwner(user).saved
+          val keep = KeepFactory.keep().withUser(user).withLibrary(library).saved
+
+          keepCommander.deactivateKeep(keep)
+          // Somehow this KTL got messed up
+          ktlRepo.getByKeepIdAndLibraryId(keep.id.get, library.id.get, excludeStateOpt = None).foreach { ktl =>
+            ktlRepo.save(ktl.withState(KeepToLibraryStates.ACTIVE))
+          }
+          (keep, library)
+        }
+
+        // Make sure it actually is broken
+        db.readOnlyMaster { implicit session =>
+          ktlRepo.getByKeepIdAndLibraryId(keep.id.get, library.id.get, excludeStateOpt = None).get.state !== KeepToLibraryStates.INACTIVE
+          inject[SystemValueRepo].all.foreach(println)
+        }
+
+        // Let's see if the checker will fix it
+        inject[KeepSequenceNumberAssigner].assignSequenceNumbers()
+        keepChecker.syncOnDeactivate()
+
+        // Make sure it got fixed
+        db.readOnlyMaster { implicit session =>
+          ktlRepo.getByKeepIdAndLibraryId(keep.id.get, library.id.get, excludeStateOpt = None).get.state === KeepToLibraryStates.INACTIVE
+        }
+      }
+    }
+    "fix broken library hashes" in {
+      withDb(modules: _*) { implicit injector =>
+        val (keep, library) = db.readWrite { implicit session =>
+          val user = UserFactory.user().saved
+          val library = LibraryFactory.library().withOwner(user).saved
+          val keep = KeepFactory.keep().withUser(user).withLibrary(library).saved
+
+          // Somehow this library hash got messed up
+          val brokenKeep = keepRepo.save(keep.withLibraries(Set.empty))
+          (brokenKeep, library)
+        }
+
+        db.readOnlyMaster { implicit session =>
+          keepRepo.get(keep.id.get).librariesHash !== Some(LibrariesHash(Set(library.id.get)))
+        }
+
+        // Let's see if the checker will fix it
+        inject[KeepSequenceNumberAssigner].assignSequenceNumbers()
+        keepChecker.syncOnLibraryChange()
+
+        db.readOnlyMaster { implicit session =>
+          keepRepo.get(keep.id.get).librariesHash === Some(LibrariesHash(Set(library.id.get)))
+        }
+      }
+    }
+    "fix broken participant hashes" in {
+      withDb(modules: _*) { implicit injector =>
+        val (keep, user) = db.readWrite { implicit session =>
+          val user = UserFactory.user().saved
+          val library = LibraryFactory.library().withOwner(user).saved
+          val keep = KeepFactory.keep().withUser(user).withLibrary(library).saved
+
+          // Somehow this library hash got messed up
+          val brokenKeep = keepRepo.save(keep.withParticipants(Set.empty))
+          (brokenKeep, user)
+        }
+
+        db.readOnlyMaster { implicit session =>
+          keepRepo.get(keep.id.get).participantsHash !== Some(ParticipantsHash(Set(user.id.get)))
+        }
+
+        // Let's see if the checker will fix it
+        inject[KeepSequenceNumberAssigner].assignSequenceNumbers()
+        keepChecker.syncOnParticipantChange()
+
+        db.readOnlyMaster { implicit session =>
+          keepRepo.get(keep.id.get).participantsHash === Some(ParticipantsHash(Set(user.id.get)))
+        }
+      }
+    }
+  }
+}

--- a/kifi-backend/modules/shoebox/test/com/keepit/integrity/KeepCheckerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/integrity/KeepCheckerTest.scala
@@ -77,7 +77,6 @@ class KeepCheckerTest extends TestKitSupport with SpecificationLike with Shoebox
         // Make sure it actually is broken
         db.readOnlyMaster { implicit session =>
           ktlRepo.getByKeepIdAndLibraryId(keep.id.get, library.id.get, excludeStateOpt = None).get.state !== KeepToLibraryStates.INACTIVE
-          inject[SystemValueRepo].all.foreach(println)
         }
 
         // Let's see if the checker will fix it

--- a/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxInjectionHelpers.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxInjectionHelpers.scala
@@ -2,6 +2,7 @@ package com.keepit.test
 
 import com.keepit.commanders._
 import com.keepit.common.db.slick.SlickSessionProvider
+import com.keepit.integrity.{ KeepChecker, LibraryChecker }
 import com.keepit.model._
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.common.db.FakeSlickSessionProvider
@@ -28,6 +29,11 @@ trait ShoeboxInjectionHelpers { self: TestInjectorProvider =>
   def normalizationService(implicit injector: Injector) = inject[NormalizationService]
   def urlRepo(implicit injector: Injector) = inject[URLRepo]
   def keepRepo(implicit injector: Injector) = inject[KeepRepo]
+  def ktlRepo(implicit injector: Injector) = inject[KeepToLibraryRepo]
+  def ktuRepo(implicit injector: Injector) = inject[KeepToUserRepo]
+  def keepCommander(implicit injector: Injector) = inject[KeepCommander]
+  def ktlCommander(implicit injector: Injector) = inject[KeepToLibraryCommander]
+  def ktuCommander(implicit injector: Injector) = inject[KeepToUserCommander]
   def socialUserInfoRepo(implicit injector: Injector) = inject[SocialUserInfoRepo]
   def installationRepo(implicit injector: Injector) = inject[KifiInstallationRepo]
   def userExperimentRepo(implicit injector: Injector) = inject[UserExperimentRepo]
@@ -58,4 +64,6 @@ trait ShoeboxInjectionHelpers { self: TestInjectorProvider =>
   def orgCommander(implicit injector: Injector) = inject[OrganizationCommander]
   def orgMembershipCommander(implicit injector: Injector) = inject[OrganizationMembershipCommander]
   def orgInviteCommander(implicit injector: Injector) = inject[OrganizationInviteCommander]
+  def libraryChecker(implicit injector: Injector) = inject[LibraryChecker]
+  def keepChecker(implicit injector: Injector) = inject[KeepChecker]
 }


### PR DESCRIPTION
@stkem @leogrim 

Would y'all mind making sure this integrity plugin looks reasonable? This is the first one I've written.

I want to be sure that it won't bomb the system. I have it configured to process 100 keeps/minute, every minute. I think that will be safe.

This should also effectively back-fill all the keeps that don't have a `librariesHash` or `participantsHash`, since they are in an inconsistent state.
