### PR TITLE
Set height so email user icon isn't an oval

### DIFF
--- a/packrat/styles/keeper/message_participants.less
+++ b/packrat/styles/keeper/message_participants.less
@@ -144,6 +144,7 @@
   .kifi-message-participant-email-image {
     display: table-cell;
     width: @picSize;
+    height: @picSize;
     line-height: 29px;
     text-align: center;
     font-size: 20px;


### PR DESCRIPTION
@andrewconner (@leo) resolves https://app.asana.com/0/42816489233169/46491013594142/f
