### PR TITLE
Allow org admins with FORCE_EDIT_LIBRARIES to move libraries as if they own them

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
@@ -3,20 +3,20 @@ package com.keepit.model
 import java.net.URLEncoder
 import javax.crypto.spec.IvParameterSpec
 
-import com.keepit.common.cache.{ JsonCacheImpl, FortyTwoCachePlugin, CacheStatistics, Key }
-import com.keepit.common.crypto.{ PublicId, ModelWithPublicId, ModelWithPublicIdCompanion }
+import com.keepit.common.cache.{ CacheStatistics, FortyTwoCachePlugin, JsonCacheImpl, Key }
+import com.keepit.common.crypto.{ ModelWithPublicId, ModelWithPublicIdCompanion, PublicId }
 import com.keepit.common.db._
 import com.keepit.common.logging.AccessLog
 import com.keepit.common.store.ImagePath
 import com.keepit.common.strings._
 import com.keepit.common.time._
-import com.keepit.model.OrganizationPermission.VIEW_ORGANIZATION
+import com.keepit.model.OrganizationPermission._
 import com.kifi.macros.json
 import org.apache.commons.lang3.RandomStringUtils
 import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import play.api.mvc.{ QueryStringBindable, PathBindable }
+import play.api.mvc.PathBindable
 
 import scala.concurrent.duration.Duration
 import scala.util.Try
@@ -88,11 +88,20 @@ object Organization extends ModelWithPublicIdCompanion[Organization] {
 
   val defaultBasePermissions: BasePermissions =
     BasePermissions(
-      None -> Set(OrganizationPermission.VIEW_ORGANIZATION),
-      Some(OrganizationRole.ADMIN) -> OrganizationPermission.all,
+      None -> Set(VIEW_ORGANIZATION),
+      Some(OrganizationRole.ADMIN) -> Set(
+        VIEW_ORGANIZATION,
+        EDIT_ORGANIZATION,
+        INVITE_MEMBERS,
+        MODIFY_MEMBERS,
+        REMOVE_MEMBERS,
+        ADD_LIBRARIES,
+        REMOVE_LIBRARIES
+      ),
       Some(OrganizationRole.MEMBER) -> Set(
-        OrganizationPermission.VIEW_ORGANIZATION,
-        OrganizationPermission.ADD_LIBRARIES
+        VIEW_ORGANIZATION,
+        ADD_LIBRARIES,
+        REMOVE_LIBRARIES
       )
     )
   val totallyInvisiblePermissions: BasePermissions =

--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationPermission.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationPermission.scala
@@ -13,7 +13,7 @@ object OrganizationPermission {
   case object REMOVE_MEMBERS extends OrganizationPermission("remove_members")
   case object ADD_LIBRARIES extends OrganizationPermission("add_libraries")
   case object REMOVE_LIBRARIES extends OrganizationPermission("remove_libraries")
-  case object EDIT_LIBRARIES extends OrganizationPermission("edit_libraries")
+  case object FORCE_EDIT_LIBRARIES extends OrganizationPermission("force_edit_libraries")
 
   def all: Set[OrganizationPermission] = Set(
     VIEW_ORGANIZATION,
@@ -23,7 +23,7 @@ object OrganizationPermission {
     REMOVE_MEMBERS,
     ADD_LIBRARIES,
     REMOVE_LIBRARIES,
-    EDIT_LIBRARIES
+    FORCE_EDIT_LIBRARIES
   )
 
   implicit val format: Format[OrganizationPermission] =
@@ -40,7 +40,8 @@ object OrganizationPermission {
       case REMOVE_MEMBERS.value => REMOVE_MEMBERS
       case ADD_LIBRARIES.value => ADD_LIBRARIES
       case REMOVE_LIBRARIES.value => REMOVE_LIBRARIES
-      case EDIT_LIBRARIES.value => EDIT_LIBRARIES
+      case "edit_libraries" => FORCE_EDIT_LIBRARIES // for temp backwards compatibility
+      case FORCE_EDIT_LIBRARIES.value => FORCE_EDIT_LIBRARIES
     }
   }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
@@ -163,7 +163,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
           orgModifyResponse must beRight
           orgModifyResponse.right.get.request === orgModifyRequest
           orgModifyResponse.right.get.modifiedOrg.basePermissions === org.basePermissions.applyPermissionsDiff(permissionsDiff)
-          orgModifyResponse.right.get.modifiedOrg.basePermissions.forRole(OrganizationRole.MEMBER) === Set(OrganizationPermission.ADD_LIBRARIES, OrganizationPermission.INVITE_MEMBERS, OrganizationPermission.VIEW_ORGANIZATION)
+          orgModifyResponse.right.get.modifiedOrg.basePermissions.forRole(OrganizationRole.MEMBER) === Set(OrganizationPermission.ADD_LIBRARIES, OrganizationPermission.REMOVE_LIBRARIES, OrganizationPermission.INVITE_MEMBERS, OrganizationPermission.VIEW_ORGANIZATION)
 
           // Now the member should be able to invite others
           val try2 = orgMembershipCommander.addMembership(memberInviteMember)

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminOrganizationControllerTest.scala
@@ -6,7 +6,7 @@ import com.keepit.common.concurrent.WatchableExecutionContext
 import com.keepit.common.controller.FakeUserActionsHelper
 import com.keepit.common.social.FakeSocialGraphModule
 import com.keepit.model.OrganizationFactoryHelper._
-import com.keepit.model.OrganizationPermission.{ ADD_LIBRARIES, REMOVE_LIBRARIES, VIEW_ORGANIZATION }
+import com.keepit.model.OrganizationPermission.{ INVITE_MEMBERS, ADD_LIBRARIES, REMOVE_LIBRARIES, VIEW_ORGANIZATION }
 import com.keepit.model.UserFactoryHelper._
 import com.keepit.model._
 import com.keepit.test.ShoeboxTestInjector
@@ -36,11 +36,11 @@ class AdminOrganizationControllerTest extends Specification with ShoeboxTestInje
 
         db.readOnlyMaster { implicit session =>
           orgRepo.all.forall { org => org.basePermissions.forRole(OrganizationRole.ADMIN) === Organization.defaultBasePermissions.forRole(OrganizationRole.ADMIN) }
-          orgRepo.all.forall { org => org.basePermissions.forRole(OrganizationRole.MEMBER) === Set(VIEW_ORGANIZATION, ADD_LIBRARIES) }
+          orgRepo.all.forall { org => org.basePermissions.forRole(OrganizationRole.MEMBER) === Set(VIEW_ORGANIZATION, ADD_LIBRARIES, REMOVE_LIBRARIES) }
         }
 
         inject[FakeUserActionsHelper].setUser(admin, Set(UserExperimentType.ADMIN))
-        val payload: JsValue = Json.obj("permission" -> "remove_libraries", "confirmation" -> "i swear i know what i am doing")
+        val payload: JsValue = Json.obj("permission" -> "invite_members", "confirmation" -> "i swear i know what i am doing")
         val request = route.addPermissionToAllOrganizations().withBody(payload)
         val result = controller.addPermissionToAllOrganizations()(request)
         status(result) === OK
@@ -49,7 +49,7 @@ class AdminOrganizationControllerTest extends Specification with ShoeboxTestInje
 
         db.readOnlyMaster { implicit session =>
           orgRepo.all.forall { org => org.basePermissions.forRole(OrganizationRole.ADMIN) === Organization.defaultBasePermissions.forRole(OrganizationRole.ADMIN) }
-          orgRepo.all.forall { org => org.basePermissions.forRole(OrganizationRole.MEMBER) === Set(VIEW_ORGANIZATION, ADD_LIBRARIES, REMOVE_LIBRARIES) }
+          orgRepo.all.forall { org => org.basePermissions.forRole(OrganizationRole.MEMBER) === Set(VIEW_ORGANIZATION, ADD_LIBRARIES, REMOVE_LIBRARIES, INVITE_MEMBERS) }
         }
         1 === 1
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
@@ -214,7 +214,7 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
 
           db.readOnlyMaster { implicit session =>
             orgRepo.get(org.id.get).getNonmemberPermissions === Set.empty
-            orgRepo.get(org.id.get).getRolePermissions(OrganizationRole.MEMBER) === Set(OrganizationPermission.ADD_LIBRARIES, OrganizationPermission.INVITE_MEMBERS, OrganizationPermission.VIEW_ORGANIZATION)
+            orgRepo.get(org.id.get).getRolePermissions(OrganizationRole.MEMBER) === Set(OrganizationPermission.ADD_LIBRARIES, OrganizationPermission.REMOVE_LIBRARIES, OrganizationPermission.INVITE_MEMBERS, OrganizationPermission.VIEW_ORGANIZATION)
           }
         }
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
@@ -371,7 +371,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
 
           db.readOnlyMaster { implicit session =>
             orgRepo.get(org.id.get).getNonmemberPermissions === Set.empty
-            orgRepo.get(org.id.get).getRolePermissions(OrganizationRole.MEMBER) === Set(OrganizationPermission.ADD_LIBRARIES, OrganizationPermission.INVITE_MEMBERS, OrganizationPermission.VIEW_ORGANIZATION)
+            orgRepo.get(org.id.get).getRolePermissions(OrganizationRole.MEMBER) === Set(OrganizationPermission.ADD_LIBRARIES, OrganizationPermission.REMOVE_LIBRARIES, OrganizationPermission.INVITE_MEMBERS, OrganizationPermission.VIEW_ORGANIZATION)
           }
         }
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxInjectionHelpers.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxInjectionHelpers.scala
@@ -46,6 +46,7 @@ trait ShoeboxInjectionHelpers { self: TestInjectorProvider =>
   def changedURIRepo(implicit injector: Injector) = inject[ChangedURIRepo]
   def sessionProvider(implicit injector: Injector) = inject[SlickSessionProvider].asInstanceOf[FakeSlickSessionProvider]
   def libraryRepo(implicit injector: Injector) = inject[LibraryRepo]
+  def libraryCommander(implicit injector: Injector) = inject[LibraryCommander]
   def libraryMembershipRepo(implicit injector: Injector) = inject[LibraryMembershipRepo]
   def librarySubscriptionRepo(implicit injector: Injector) = inject[LibrarySubscriptionRepo]
   def libraryInviteRepo(implicit injector: Injector) = inject[LibraryInviteRepo]


### PR DESCRIPTION
Don't merge until you backfill REMOVE_LIBRARY permissions
