### PR TITLE
Added explicit library permissions to library json

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -60,6 +60,37 @@ case class Library(
   val isSecret: Boolean = visibility == LibraryVisibility.SECRET
 
   def space: LibrarySpace = LibrarySpace(ownerId, organizationId)
+
+  def permissionsByAccess(access: LibraryAccess): Set[LibraryPermission] = access match {
+    case LibraryAccess.READ_ONLY => Set(
+      LibraryPermission.VIEW_LIBRARY,
+      LibraryPermission.INVITE_FOLLOWERS
+    )
+
+    case LibraryAccess.READ_WRITE => Set(
+      LibraryPermission.VIEW_LIBRARY,
+      LibraryPermission.INVITE_FOLLOWERS,
+      LibraryPermission.ADD_KEEPS,
+      LibraryPermission.EDIT_OWN_KEEPS,
+      LibraryPermission.REMOVE_OWN_KEEPS
+    ) ++ whoCanInvite.collect { case LibraryInvitePermissions.COLLABORATOR => LibraryPermission.INVITE_COLLABORATORS }
+
+    case LibraryAccess.OWNER => Set(
+      LibraryPermission.VIEW_LIBRARY,
+      LibraryPermission.EDIT_LIBRARY,
+      LibraryPermission.INVITE_FOLLOWERS,
+      LibraryPermission.INVITE_COLLABORATORS,
+      LibraryPermission.REMOVE_MEMBERS,
+      LibraryPermission.ADD_KEEPS,
+      LibraryPermission.EDIT_OWN_KEEPS,
+      LibraryPermission.EDIT_ANY_KEEPS,
+      LibraryPermission.REMOVE_OWN_KEEPS,
+      LibraryPermission.REMOVE_ANY_KEEPS
+    )
+  }
+  def getMembershipInfo(mem: LibraryMembership): LibraryMembershipInfo = {
+    LibraryMembershipInfo(mem.access, mem.listed, mem.subscribedToUpdates, permissionsByAccess(mem.access))
+  }
 }
 
 object Library extends ModelWithPublicIdCompanion[Library] {
@@ -374,7 +405,8 @@ case class BasicLibraryDetails(
   numFollowers: Int,
   numCollaborators: Int,
   keepCount: Int,
-  membership: Option[LibraryMembership], // viewer
+  membership: Option[LibraryMembershipInfo], // viewer
+  ownerId: Id[User],
   url: Path)
 
 sealed abstract class LibraryColor(val hex: String)

--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -83,7 +83,6 @@ case class Library(
       LibraryPermission.REMOVE_MEMBERS,
       LibraryPermission.ADD_KEEPS,
       LibraryPermission.EDIT_OWN_KEEPS,
-      LibraryPermission.EDIT_ANY_KEEPS,
       LibraryPermission.REMOVE_OWN_KEEPS,
       LibraryPermission.REMOVE_ANY_KEEPS
     )

--- a/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
@@ -102,7 +102,7 @@ sealed abstract class LibraryPermission(val value: String)
 object LibraryPermission {
   case object VIEW_LIBRARY extends LibraryPermission("view_library")
   case object EDIT_LIBRARY extends LibraryPermission("edit_library")
-  case object INVITE_FOLLOWERS extends LibraryPermission("invite_members")
+  case object INVITE_FOLLOWERS extends LibraryPermission("invite_followers")
   case object INVITE_COLLABORATORS extends LibraryPermission("invite_collaborators")
   case object REMOVE_MEMBERS extends LibraryPermission("remove_members")
   case object ADD_KEEPS extends LibraryPermission("add_keeps")

--- a/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
@@ -66,13 +66,8 @@ object LibraryMembership {
   )(LibraryMembership.apply, unlift(LibraryMembership.unapply))
 }
 
-@json case class LibraryMembershipInfo(access: LibraryAccess, listed: Boolean, subscribed: Boolean)
-
-object LibraryMembershipInfo {
-  def fromMembership(mem: LibraryMembership): LibraryMembershipInfo = {
-    LibraryMembershipInfo(mem.access, mem.listed, mem.subscribedToUpdates)
-  }
-}
+@json
+case class LibraryMembershipInfo(access: LibraryAccess, listed: Boolean, subscribed: Boolean, permissions: Set[LibraryPermission])
 
 object LibraryMembershipStates extends States[LibraryMembership]
 
@@ -100,6 +95,55 @@ object LibraryAccess {
 
   val all: Seq[LibraryAccess] = Seq(OWNER, READ_WRITE, READ_ONLY)
   val collaborativePermissions: Set[LibraryAccess] = Set(OWNER, READ_WRITE)
+}
+
+sealed abstract class LibraryPermission(val value: String)
+
+object LibraryPermission {
+  case object VIEW_LIBRARY extends LibraryPermission("view_library")
+  case object EDIT_LIBRARY extends LibraryPermission("edit_library")
+  case object INVITE_FOLLOWERS extends LibraryPermission("invite_members")
+  case object INVITE_COLLABORATORS extends LibraryPermission("invite_collaborators")
+  case object REMOVE_MEMBERS extends LibraryPermission("remove_members")
+  case object ADD_KEEPS extends LibraryPermission("add_keeps")
+  case object EDIT_OWN_KEEPS extends LibraryPermission("edit_own_keeps")
+  case object EDIT_ANY_KEEPS extends LibraryPermission("edit_any_keeps")
+  case object REMOVE_OWN_KEEPS extends LibraryPermission("remove_own_keeps")
+  case object REMOVE_ANY_KEEPS extends LibraryPermission("remove_any_keeps")
+
+  def all: Set[LibraryPermission] = Set(
+    VIEW_LIBRARY,
+    EDIT_LIBRARY,
+    INVITE_FOLLOWERS,
+    INVITE_COLLABORATORS,
+    REMOVE_MEMBERS,
+    ADD_KEEPS,
+    EDIT_ANY_KEEPS,
+    EDIT_ANY_KEEPS,
+    REMOVE_OWN_KEEPS,
+    REMOVE_ANY_KEEPS
+  )
+
+  implicit val format: Format[LibraryPermission] =
+    Format(__.read[String].map(LibraryPermission(_)), new Writes[LibraryPermission] {
+      def writes(o: LibraryPermission) = JsString(o.value)
+    })
+
+  def apply(str: String): LibraryPermission = {
+    str match {
+      case VIEW_LIBRARY.value => VIEW_LIBRARY
+      case EDIT_LIBRARY.value => EDIT_LIBRARY
+      case INVITE_FOLLOWERS.value => INVITE_FOLLOWERS
+      case INVITE_COLLABORATORS.value => INVITE_COLLABORATORS
+      case REMOVE_MEMBERS.value => REMOVE_MEMBERS
+      case ADD_KEEPS.value => ADD_KEEPS
+      case EDIT_OWN_KEEPS.value => EDIT_OWN_KEEPS
+      case EDIT_ANY_KEEPS.value => EDIT_ANY_KEEPS
+      case REMOVE_OWN_KEEPS.value => REMOVE_OWN_KEEPS
+      case REMOVE_ANY_KEEPS.value => REMOVE_ANY_KEEPS
+      // TODO(ryan): should we have a `case _ => ???` here, and what should ??? be
+    }
+  }
 }
 
 case class CountWithLibraryIdByAccess(readOnly: Int, readWrite: Int, owner: Int)

--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/website/WebsiteSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/website/WebsiteSearchController.scala
@@ -351,7 +351,6 @@ class WebsiteSearchController @Inject() (
                 val collaborators = orderWithPictureFirst(collaboratorIds.map(usersById(_)))
                 val followers = orderWithPictureFirst(followerIds.map(usersById(_)))
                 val description = library.description.getOrElse("")
-                val membershipInfo = details.membership.map(LibraryMembershipInfo.fromMembership)
 
                 // todo(Léo): in a perfect world, this converges towards LibraryCardInfo
                 Json.obj(
@@ -370,7 +369,7 @@ class WebsiteSearchController @Inject() (
                   "numFollowers" -> details.numFollowers,
                   "numCollaborators" -> details.numCollaborators,
                   "numKeeps" -> details.keepCount,
-                  "membership" -> membershipInfo,
+                  "membership" -> details.membership,
                   "memberCount" -> (details.numFollowers + details.numCollaborators), // deprecated
                   "keepCount" -> details.keepCount // deprecated,
                 )

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryMembershipCommander.scala
@@ -395,5 +395,4 @@ class LibraryMembershipCommanderImpl @Inject() (
         suggestedUsers ++ suggestedEmailAddresses
     }
   }
-
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserProfileCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserProfileCommander.scala
@@ -78,7 +78,7 @@ class UserProfileCommander @Inject() (
           collaborators = info.collaborators,
           lastKept = lib.lastKept.getOrElse(lib.createdAt),
           following = Some(true),
-          membership = (memberships(lib.id.get)) map (LibraryMembershipInfo.fromMembership(_)),
+          membership = memberships(lib.id.get).map(lib.getMembershipInfo),
           modifiedAt = lib.updatedAt,
           path = info.path,
           org = info.org

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -79,7 +79,7 @@ class ExtLibraryController @Inject() (
           subscribedToUpdates = membership.exists(_.subscribedToUpdates),
           collaborators = collabs,
           orgAvatar = lib.organizationId.flatMap(orgId => orgAvatarsById(orgId).map(_.imagePath)),
-          membership = membership.map(LibraryMembershipInfo.fromMembership)
+          membership = membership.map(lib.getMembershipInfo)
         )
     }
     Ok(Json.obj("libraries" -> datas))
@@ -129,7 +129,7 @@ class ExtLibraryController @Inject() (
                 subscribedToUpdates = membership.exists(_.subscribedToUpdates),
                 collaborators = Seq.empty,
                 orgAvatar = orgAvatar,
-                membership = membership.map(LibraryMembershipInfo.fromMembership)
+                membership = membership.map(lib.getMembershipInfo)
               )
             }
             Ok(Json.toJson(data))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -319,16 +319,13 @@ class LibraryController @Inject() (
         BadRequest(Json.obj("error" -> "invalid_id"))
       case Success(libId) =>
         implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
-        db.readOnlyMaster { implicit s =>
-          libraryMembershipRepo.getWithLibraryIdAndUserId(libId, request.userId)
-        }
 
         println("Joining with subscribed = " + subscribedOpt)
         libraryMembershipCommander.joinLibrary(request.userId, libId, authToken, subscribedOpt) match {
           case Left(fail) =>
             Status(fail.status)(Json.obj("error" -> fail.message))
-          case Right((_, mem)) =>
-            Ok(Json.obj("membership" -> LibraryMembershipInfo.fromMembership(mem)))
+          case Right((lib, mem)) =>
+            Ok(Json.obj("membership" -> lib.getMembershipInfo(mem)))
         }
     }
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
@@ -90,7 +90,8 @@ class ExtLibraryControllerTest extends Specification with ShoeboxTestInjector wi
                 "membership" -> Json.obj(
                   "access" -> LibraryAccess.OWNER,
                   "listed" -> true,
-                  "subscribed" -> false
+                  "subscribed" -> false,
+                  "permissions" -> Json.arr("invite_collaborators", "invite_followers", "view_library", "remove_own_keeps", "remove_any_keeps", "edit_library", "edit_own_keeps", "remove_members", "add_keeps")
                 )
               ),
               Json.obj(
@@ -105,7 +106,8 @@ class ExtLibraryControllerTest extends Specification with ShoeboxTestInjector wi
                 "membership" -> Json.obj(
                   "access" -> LibraryAccess.READ_WRITE,
                   "listed" -> true,
-                  "subscribed" -> false
+                  "subscribed" -> false,
+                  "permissions" -> Json.arr("invite_followers", "view_library", "remove_own_keeps", "edit_own_keeps", "add_keeps")
                 )
               ),
               Json.obj(

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
@@ -202,7 +202,8 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
                 "membership":{
                   "access" : "owner",
                   "listed" : true,
-                  "subscribed" : false
+                  "subscribed" : false,
+                  "permissions":["invite_collaborators","invite_followers","view_library","remove_own_keeps","remove_any_keeps","edit_library","edit_own_keeps","remove_members","add_keeps"]
                 },
                 "invite": null
               },
@@ -260,7 +261,8 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
                  "membership":{
                    "access" : "owner",
                    "listed" : true,
-                   "subscribed" : false
+                   "subscribed" : false,
+                  "permissions":["invite_collaborators","invite_followers","view_library","remove_own_keeps","remove_any_keeps","edit_library","edit_own_keeps","remove_members","add_keeps"]
                  },
                  "invite" : null,
                  "path": "/spongebob/krabby-patty"

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserProfileControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserProfileControllerTest.scala
@@ -432,7 +432,7 @@ class MobileUserProfileControllerTest extends Specification with ShoeboxTestInje
                   "collaborators":[],
                   "lastKept": ${lib2.createdAt.getMillis},
                   "following":true,
-                  "membership":{"access":"owner","listed":true,"subscribed":false},
+                  "membership":{"access":"owner","listed":true,"subscribed":false, "permissions":["invite_collaborators","invite_members","view_library","remove_own_keeps","remove_any_keeps","edit_library","edit_own_keeps","remove_members","add_keeps"]},
                   "modifiedAt":${lib2.updatedAt.getMillis},
                   "path": "/spongebob/catching-jellyfish"
                 },
@@ -459,7 +459,7 @@ class MobileUserProfileControllerTest extends Specification with ShoeboxTestInje
                   "collaborators": [],
                   "lastKept": ${lib1.createdAt.getMillis},
                   "following":true,
-                  "membership":{"access":"owner","listed":true,"subscribed":false},
+                  "membership":{"access":"owner","listed":true,"subscribed":false, "permissions":["invite_collaborators","invite_members","view_library","remove_own_keeps","remove_any_keeps","edit_library","edit_own_keeps","remove_members","add_keeps"]},
                   "modifiedAt":${lib1.updatedAt.getMillis},
                   "path": "/spongebob/krabby-patty"
                 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserProfileControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserProfileControllerTest.scala
@@ -432,7 +432,7 @@ class MobileUserProfileControllerTest extends Specification with ShoeboxTestInje
                   "collaborators":[],
                   "lastKept": ${lib2.createdAt.getMillis},
                   "following":true,
-                  "membership":{"access":"owner","listed":true,"subscribed":false, "permissions":["invite_collaborators","invite_members","view_library","remove_own_keeps","remove_any_keeps","edit_library","edit_own_keeps","remove_members","add_keeps"]},
+                  "membership":{"access":"owner","listed":true,"subscribed":false, "permissions":["invite_collaborators","invite_followers","view_library","remove_own_keeps","remove_any_keeps","edit_library","edit_own_keeps","remove_members","add_keeps"]},
                   "modifiedAt":${lib2.updatedAt.getMillis},
                   "path": "/spongebob/catching-jellyfish"
                 },
@@ -459,7 +459,7 @@ class MobileUserProfileControllerTest extends Specification with ShoeboxTestInje
                   "collaborators": [],
                   "lastKept": ${lib1.createdAt.getMillis},
                   "following":true,
-                  "membership":{"access":"owner","listed":true,"subscribed":false, "permissions":["invite_collaborators","invite_members","view_library","remove_own_keeps","remove_any_keeps","edit_library","edit_own_keeps","remove_members","add_keeps"]},
+                  "membership":{"access":"owner","listed":true,"subscribed":false, "permissions":["invite_collaborators","invite_followers","view_library","remove_own_keeps","remove_any_keeps","edit_library","edit_own_keeps","remove_members","add_keeps"]},
                   "modifiedAt":${lib1.updatedAt.getMillis},
                   "path": "/spongebob/krabby-patty"
                 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -467,7 +467,8 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
              "membership": {
               "access" : "owner",
               "listed":true,
-              "subscribed":false
+              "subscribed":false,
+              "permissions":["invite_collaborators","invite_followers","view_library","remove_own_keeps","remove_any_keeps","edit_library","edit_own_keeps","remove_members","add_keeps"]
              },
              "invite": null,
              "path": "${LibraryPathHelper.formatLibraryPath(basicUser1, None, lib1.slug)}"
@@ -630,7 +631,8 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                "membership":{
                 "access":"owner",
                 "listed":false,
-                "subscribed":false
+                "subscribed":false,
+                "permissions":["invite_collaborators","invite_followers","view_library","remove_own_keeps","remove_any_keeps","edit_library","edit_own_keeps","remove_members","add_keeps"]
                },
                "invite": null,
                "path": "${LibraryPathHelper.formatLibraryPath(basicUser1, None, lib1.slug)}"
@@ -731,7 +733,8 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                "membership":{
                 "access":"owner",
                 "listed":false,
-                "subscribed":false
+                "subscribed":false,
+                "permissions":["invite_collaborators","invite_followers","view_library","remove_own_keeps","remove_any_keeps","edit_library","edit_own_keeps","remove_members","add_keeps"]
                },
                "invite": null
               },
@@ -1034,14 +1037,14 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
         val basicUser2 = db.readOnlyMaster { implicit s => basicUserRepo.load(user2.id.get) }
 
-        val expected1 = Json.parse("""{"membership": {"access": "read_write", "listed": true, "subscribed": true}}""")
+        val expected1 = Json.parse("""{"membership": {"access": "read_write", "listed": true, "subscribed": true, "permissions":["invite_followers","view_library","remove_own_keeps","edit_own_keeps","add_keeps"]}}""")
         Json.parse(contentAsString(result1)) must equalTo(expected1)
 
         val result11 = libraryController.joinLibrary(pubLibId1, None, Some(true))(request1)
         status(result11) must equalTo(OK)
         contentType(result11) must beSome("application/json")
 
-        val expected11 = Json.parse("""{"membership": {"access": "read_write", "listed": true, "subscribed": true}}""")
+        val expected11 = Json.parse("""{"membership": {"access": "read_write", "listed": true, "subscribed": true, "permissions":["invite_followers","view_library","remove_own_keeps","edit_own_keeps","add_keeps"]}}""")
         Json.parse(contentAsString(result11)) must equalTo(expected11)
 
         val request2 = FakeRequest("POST", testPathDecline)

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserProfileControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/UserProfileControllerTest.scala
@@ -448,7 +448,7 @@ class UserProfileControllerTest extends Specification with ShoeboxTestInjector {
                   }],
                 "lastKept":${keep1.createdAt.getMillis},
                 "following":true,
-                "membership":{"access":"owner","listed":true,"subscribed":false},
+                "membership":{"access":"owner","listed":true,"subscribed":false,"permissions":["invite_collaborators","invite_followers","view_library","remove_own_keeps","remove_any_keeps","edit_library","edit_own_keeps","remove_members","add_keeps"]},
                 "modifiedAt":${lib1Updated.updatedAt.getMillis},
                 "path": "/firstuser/lib1",
                 "subscriptions": []
@@ -485,7 +485,7 @@ class UserProfileControllerTest extends Specification with ShoeboxTestInjector {
                 "collaborators":[],
                 "lastKept":${lib3.lastKept.get.getMillis},
                 "following": true,
-                "membership": {"access":"read_only","listed":true,"subscribed":false},
+                "membership": {"access":"read_only","listed":true,"subscribed":false, "permissions":["view_library", "invite_followers"]},
                 "modifiedAt":${lib3.updatedAt.getMillis},
                 "path": "/seconduser/lib3",
                 "kind":"user_created"


### PR DESCRIPTION
They are not used for anything besides sending information to clients, but I
think we should try and move over to using them internally as well. Explicit is
better than implicit.

@andrewconner @jaredpetker @DerekBurch 

This does not pass tests. The hyper-fragile LibraryController tests are failing, and I look at them and fall into a deep, dark despair. I need to take a walk or something before I tackle them.
