### PR TITLE
Some session-in-session fixes

### DIFF
--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/LibraryRecommendationGenerationCommander.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/LibraryRecommendationGenerationCommander.scala
@@ -124,7 +124,7 @@ class LibraryRecommendationGenerationCommander @Inject() (
     lazy val usersFollowedLibraries: Set[Id[Library]] = db.readOnlyReplica { implicit s => libMembershipRepo.getLibrariesByUserId(userId).toSet }
 
     def precomputeRecommendations() = {
-      val state: LibraryRecommendationGenerationState = db.readOnlyReplica { implicit session =>
+      val state: LibraryRecommendationGenerationState = {
         val state = getStateOfUser()
         if (state.id.exists(_ => selectionParams.reset)) state.copy(seq = SequenceNumber.ZERO) else state
       }

--- a/kifi-backend/modules/curator/app/com/keepit/curator/commanders/persona/PersonaRecommendationIngestor.scala
+++ b/kifi-backend/modules/curator/app/com/keepit/curator/commanders/persona/PersonaRecommendationIngestor.scala
@@ -58,7 +58,7 @@ class PersonaRecommendationIngestor @Inject() (
   private def ingestLibraryRecos(userId: Id[User], libRecos: Seq[LibraryRecommendation], reverseIngestion: Boolean): Unit = {
     val (existing, uniqueLibRecosToIngest) = db.readOnlyMaster { implicit s =>
       val userLibs = libMembershipRepo.getLibrariesByUserId(userId).toSet
-      val existing = db.readOnlyMaster { implicit s => libRecRepo.getLibraryIdsForUser(userId) }
+      val existing = libRecRepo.getLibraryIdsForUser(userId)
       val uniqueLibRecosToIngest = libRecos.groupBy(_.libraryId).map { case (id, recos) => recos.head }.toSeq.filter(x => !userLibs.contains(x.libraryId))
       (existing, uniqueLibRecosToIngest)
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/SendgridCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/SendgridCommanderTest.scala
@@ -149,7 +149,9 @@ class SendgridCommanderTest extends Specification with ShoeboxTestInjector {
 
           db.readOnlyMaster { implicit session =>
             optOutRepo.hasOptedOut(emailAddr.address) should beFalse
-            commander.processNewEvents(Seq(sgEvent))
+          }
+          commander.processNewEvents(Seq(sgEvent))
+          db.readOnlyMaster { implicit session =>
             optOutRepo.hasOptedOut(emailAddr.address) should beTrue
           }
         }
@@ -165,7 +167,9 @@ class SendgridCommanderTest extends Specification with ShoeboxTestInjector {
 
           db.readOnlyMaster { implicit session =>
             optOutRepo.hasOptedOut(emailAddr.address) should beFalse
-            commander.processNewEvents(Seq(sgEvent))
+          }
+          commander.processNewEvents(Seq(sgEvent))
+          db.readOnlyMaster { implicit session =>
             optOutRepo.hasOptedOut(emailAddr.address) should beTrue
           }
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/normalizer/FakeNormalizationServiceModule.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/normalizer/FakeNormalizationServiceModule.scala
@@ -8,11 +8,11 @@ import scala.concurrent.Future
 
 case class FakeNormalizationServiceModule() extends ScalaModule {
   def configure() {
-    bind[NormalizationService].toInstance(PrenormalizationService)
+    bind[NormalizationService].toInstance(FakePrenormalizationService)
   }
 }
 
-object PrenormalizationService extends NormalizationService {
+object FakePrenormalizationService extends NormalizationService {
   def update(current: NormalizationReference, candidates: Set[NormalizationCandidate]) = Future.successful(None)
   def prenormalize(uriString: String) = Prenormalizer(uriString)
 }

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/Database.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/Database.scala
@@ -76,7 +76,7 @@ class Database @Inject() (
   val dialect: DatabaseDialect[_] = db.dialect
 
   def enteringSession[T](f: => T) = {
-    val detectLayeredSessions = !Play.maybeApplication.exists(_.mode == Mode.Prod) // Remove `false &&` to enable this
+    val detectLayeredSessions = false && !Play.maybeApplication.exists(_.mode == Mode.Prod) // Remove `false &&` to enable this
     if (detectLayeredSessions) {
       val wasInSession = Option(DatabaseSessionLock.tl.get).getOrElse(false)
       val verbose = true


### PR DESCRIPTION
All minor, trying to isolate the problems to shoebox. Taking a break again from it.

Biggest offenders by just running tests (just in terms of incidence, which _does_ mean better tested code gets hit more—but there's ideally at least a loose correlation with test coverage and importance):

```
 181   PlanManagementCommander.scala:315
  75   OrganizationAvatarCommander.scala:40
  60   OrganizationCommander.scala:74
  50   LibraryImageCommander.scala:53
  41   OrganizationCommander.scala:103
  35   UserProfileCommander.scala:196
  35   OrganizationCommander.scala:66
  33   KeepCommander.scala:574
  30   OrganizationCommander.scala:274
  30   LibraryCommander.scala:373
```
