### PR TITLE
Refactor BasicUserLikeEntity into a type synonym of Either and associated extractors

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/social/BasicNonUser.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/BasicNonUser.scala
@@ -23,9 +23,7 @@ object NonUserKinds {
   val email = NonUserKind("email")
 }
 
-case class BasicNonUser(kind: NonUserKind, id: String, firstName: Option[String], lastName: Option[String]) extends BasicUserLikeEntity {
-  override def asBasicNonUser: Option[BasicNonUser] = Some(this)
-}
+case class BasicNonUser(kind: NonUserKind, id: String, firstName: Option[String], lastName: Option[String])
 
 object BasicNonUser {
   val DefaultPictureName = S3UserPictureConfig.defaultName + ".jpg"

--- a/kifi-backend/modules/common/app/com/keepit/social/BasicUser.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/BasicUser.scala
@@ -13,30 +13,6 @@ import scala.annotation.switch
 import scala.concurrent.duration.Duration
 import play.api.Play
 
-trait BasicUserLikeEntity {
-  def asBasicUser: Option[BasicUser] = None
-  def asBasicNonUser: Option[BasicNonUser] = None
-}
-
-object BasicUserLikeEntity {
-  private implicit val nonUserTypeFormat = Json.format[NonUserKind]
-  implicit val format = new Format[BasicUserLikeEntity] {
-    def reads(json: JsValue): JsResult[BasicUserLikeEntity] = {
-      // Detect if this is a BasicUser or BasicNonUser
-      (json \ "kind").asOpt[String] match {
-        case Some(kind) => BasicNonUser.format.reads(json)
-        case None => BasicUser.format.reads(json)
-      }
-    }
-    def writes(entity: BasicUserLikeEntity): JsValue = {
-      entity match {
-        case b: BasicUser => BasicUser.format.writes(b)
-        case b: BasicNonUser => BasicNonUser.format.writes(b)
-      }
-    }
-  }
-}
-
 trait BasicUserFields {
   def externalId: ExternalId[User]
   def firstName: String
@@ -60,8 +36,7 @@ case class BasicUser(
     firstName: String,
     lastName: String,
     pictureName: String,
-    username: Username) extends BasicUserLikeEntity with BasicUserFields {
-  override def asBasicUser = Some(this)
+    username: Username) extends BasicUserFields {
   def path: Path = Path(username.value)
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/social/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/package.scala
@@ -1,0 +1,45 @@
+package com.keepit
+
+import play.api.libs.json.{ JsResult, JsValue, Format, Json }
+
+package object social {
+
+  type BasicUserLikeEntity = Either[BasicNonUser, BasicUser]
+
+  object BasicUserLikeEntity {
+    val format = basicUserLikeEntityFormat
+
+    def apply(basicUser: BasicUser): BasicUserLikeEntity = user(basicUser)
+    def apply(basicNonUser: BasicNonUser): BasicUserLikeEntity = nonUser(basicNonUser)
+
+    object user {
+      def apply(basicUser: BasicUser): BasicUserLikeEntity = Right(basicUser)
+      def unapply(that: BasicUserLikeEntity): Option[BasicUser] = that.fold(nonUser => None, user => Some(user))
+    }
+
+    object nonUser {
+      def apply(basicNonUser: BasicNonUser): BasicUserLikeEntity = Left(basicNonUser)
+      def unapply(that: BasicUserLikeEntity): Option[BasicNonUser] = that.fold(nonUser => Some(nonUser), user => None)
+    }
+
+  }
+
+  private implicit val nonUserTypeFormat = Json.format[NonUserKind]
+
+  implicit val basicUserLikeEntityFormat = new Format[BasicUserLikeEntity] {
+    def reads(json: JsValue): JsResult[BasicUserLikeEntity] = {
+      // Detect if this is a BasicUser or BasicNonUser
+      (json \ "kind").asOpt[String] match {
+        case Some(kind) => BasicNonUser.format.reads(json).map { basicNonUser => BasicUserLikeEntity(basicNonUser) }
+        case None => BasicUser.format.reads(json).map { basicUser => BasicUserLikeEntity(basicUser) }
+      }
+    }
+    def writes(entity: BasicUserLikeEntity): JsValue = {
+      entity match {
+        case Right(basicUser) => BasicUser.format.writes(basicUser)
+        case Left(basicNonUser) => BasicNonUser.format.writes(basicNonUser)
+      }
+    }
+  }
+
+}

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
@@ -58,11 +58,12 @@ class MessageFetchingCommander @Inject() (
           url = message.sentOnUrl.getOrElse(""),
           nUrl = thread.nUrl.getOrElse(""), //TODO Stephen: This needs to change when we have detached threads
           user = message.from match {
-            case MessageSender.User(id) => Some(Right(id2BasicUser(id)))
-            case MessageSender.NonUser(nup) => Some(Left(NonUserParticipant.toBasicNonUser(nup)))
+            case MessageSender.User(id) => Some(BasicUserLikeEntity(id2BasicUser(id)))
+            case MessageSender.NonUser(nup) => Some(BasicUserLikeEntity(NonUserParticipant.toBasicNonUser(nup)))
             case _ => None
           },
-          participants = userParticipantSet.toSeq.map(user => Right(id2BasicUser(user))) ++ nonUsers.map(nonUser => Left(nonUser))
+          participants = userParticipantSet.toSeq.map(user => BasicUserLikeEntity(id2BasicUser(user))) ++
+            nonUsers.map(nonUser => BasicUserLikeEntity(nonUser))
         )
       }
     })
@@ -124,7 +125,7 @@ class MessageFetchingCommander @Inject() (
           }
           auxModifiedFuture.map {
             case (text, aux) =>
-              m.copy(auxData = Some(aux), text = text, user = Some(Right(BasicUser(ExternalId[User]("42424242-4242-4242-4242-000000000001"), "Kifi", "", "0.jpg", Username("sssss")))))
+              m.copy(auxData = Some(aux), text = text, user = Some(BasicUserLikeEntity(BasicUser(ExternalId[User]("42424242-4242-4242-4242-000000000001"), "Kifi", "", "0.jpg", Username("sssss")))))
           }
         case None =>
           Promise.successful(m).future

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
@@ -31,7 +31,7 @@ class MessageFetchingCommander @Inject() (
     nUrl: String,
     user: Option[BasicUser],
     participants: Seq[BasicUserLikeEntity]): Future[MessageWithBasicUser] = {
-    modifyMessageWithAuxData(MessageWithBasicUser(id, createdAt, text, source, auxData, url, nUrl, user, participants))
+    modifyMessageWithAuxData(MessageWithBasicUser(id, createdAt, text, source, auxData, url, nUrl, user.map(u => BasicUserLikeEntity(u)), participants))
   }
 
   //this is for internal use (not just this class, also several other commanders and tests). Do not use from a controller!
@@ -58,11 +58,11 @@ class MessageFetchingCommander @Inject() (
           url = message.sentOnUrl.getOrElse(""),
           nUrl = thread.nUrl.getOrElse(""), //TODO Stephen: This needs to change when we have detached threads
           user = message.from match {
-            case MessageSender.User(id) => Some(id2BasicUser(id))
-            case MessageSender.NonUser(nup) => Some(NonUserParticipant.toBasicNonUser(nup))
+            case MessageSender.User(id) => Some(Right(id2BasicUser(id)))
+            case MessageSender.NonUser(nup) => Some(Left(NonUserParticipant.toBasicNonUser(nup)))
             case _ => None
           },
-          participants = userParticipantSet.toSeq.map(id2BasicUser(_)) ++ nonUsers
+          participants = userParticipantSet.toSeq.map(user => Right(id2BasicUser(user))) ++ nonUsers.map(nonUser => Left(nonUser))
         )
       }
     })
@@ -83,11 +83,12 @@ class MessageFetchingCommander @Inject() (
     val adderUserId = Id[User](jsAdderUserId.toLong)
     new SafeFuture(shoebox.getBasicUsers(adderUserId +: addedUsers) map { basicUsers =>
       val adderUser = basicUsers(adderUserId)
-      val addedBasicUsers = addedUsers.map(u => basicUsers(u)) ++ addedNonUsers.map(NonUserParticipant.toBasicNonUser)
+      val addedBasicUsers = addedUsers.map(u => BasicUserLikeEntity(basicUsers(u))) ++
+        addedNonUsers.map(participant => BasicUserLikeEntity(NonUserParticipant.toBasicNonUser(participant)))
       val addedUsersString = addedBasicUsers.map { bule =>
         bule match {
-          case bu: BasicUser => s"${bu.firstName} ${bu.lastName}"
-          case bnu: BasicNonUser => bnu.lastName.map(ln => s"${bnu.firstName.get} $ln").getOrElse(bnu.firstName.get)
+          case BasicUserLikeEntity.user(bu) => s"${bu.firstName} ${bu.lastName}"
+          case BasicUserLikeEntity.nonUser(bnu) => bnu.lastName.map(ln => s"${bnu.firstName.get} $ln").getOrElse(bnu.firstName.get)
           case _ => "Kifi User"
         }
       }.toList match {
@@ -123,7 +124,7 @@ class MessageFetchingCommander @Inject() (
           }
           auxModifiedFuture.map {
             case (text, aux) =>
-              m.copy(auxData = Some(aux), text = text, user = Some(BasicUser(ExternalId[User]("42424242-4242-4242-4242-000000000001"), "Kifi", "", "0.jpg", Username("sssss"))))
+              m.copy(auxData = Some(aux), text = text, user = Some(Right(BasicUser(ExternalId[User]("42424242-4242-4242-4242-000000000001"), "Kifi", "", "0.jpg", Username("sssss")))))
           }
         case None =>
           Promise.successful(m).future

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -18,7 +18,7 @@ import com.keepit.heimdal.HeimdalContext
 import com.keepit.model._
 import com.keepit.realtime.{ UserPushNotification, LibraryUpdatePushNotification, SimplePushNotification }
 import com.keepit.shoebox.ShoeboxServiceClient
-import com.keepit.social.{ NonUserKinds }
+import com.keepit.social.{ BasicUserLikeEntity, NonUserKinds }
 import com.keepit.common.concurrent.PimpMyFuture._
 import scala.util.Try
 
@@ -108,11 +108,15 @@ class MessagingCommander @Inject() (
           (message.externalId, message.createdAt)
         }.toMap
 
-        val nonUsers = thread.participants.map(_.allNonUsers).getOrElse(Set()).map(NonUserParticipant.toBasicNonUser)
+        val nonUsers = thread.participants.map(_.allNonUsers).getOrElse(Set())
+          .map(nu => BasicUserLikeEntity(NonUserParticipant.toBasicNonUser(nu))).toSeq
+
+        val basicUsers = thread.participants.map(_.allUsers).getOrElse(Set())
+          .map(u => BasicUserLikeEntity(userId2BasicUser(u))).toSeq
 
         ElizaThreadInfo(
           externalId = thread.externalId,
-          participants = thread.participants.map(_.allUsers).getOrElse(Set()).map(userId2BasicUser(_)).toSeq ++ nonUsers.toSeq,
+          participants = basicUsers ++ nonUsers,
           digest = lastMessage.messageText,
           lastAuthor = userId2BasicUser(lastMessage.from.asUser.get).externalId,
           messageCount = messagesByThread(thread.id.get).length,
@@ -335,6 +339,7 @@ class MessagingCommander @Inject() (
     val nonUserParticipantsSet = thread.participants.map(_.allNonUsers).getOrElse(Set())
     val id2BasicUser = Await.result(shoebox.getBasicUsers(participantSet.toSeq), 1.seconds) // todo: remove await
     val basicNonUserParticipants = nonUserParticipantsSet.map(NonUserParticipant.toBasicNonUser)
+      .map(nu => BasicUserLikeEntity(nu))
 
     val messageWithBasicUser = MessageWithBasicUser(
       message.externalId,
@@ -345,11 +350,11 @@ class MessagingCommander @Inject() (
       message.sentOnUrl.getOrElse(""),
       thread.nUrl.getOrElse(""), //TODO Stephen: This needs to change when we have detached threads
       message.from match {
-        case MessageSender.User(id) => Some(id2BasicUser(id))
-        case MessageSender.NonUser(nup) => Some(NonUserParticipant.toBasicNonUser(nup))
+        case MessageSender.User(id) => Some(BasicUserLikeEntity(id2BasicUser(id)))
+        case MessageSender.NonUser(nup) => Some(BasicUserLikeEntity(NonUserParticipant.toBasicNonUser(nup)))
         case _ => None
       },
-      participantSet.toSeq.map(id2BasicUser(_)) ++ basicNonUserParticipants
+      participantSet.toSeq.map(u => BasicUserLikeEntity(id2BasicUser(u))) ++ basicNonUserParticipants
     )
 
     // send message through websockets immediately
@@ -375,7 +380,11 @@ class MessagingCommander @Inject() (
     val originalAuthor = threadActivity.filter(_.started).zipWithIndex.head._2
     val numAuthors = threadActivity.count(_.lastActive.isDefined)
 
-    val orderedMessageWithBasicUser = messageWithBasicUser.copy(participants = threadActivity.map { ta => id2BasicUser(ta.userId) } ++ basicNonUserParticipants)
+    val orderedMessageWithBasicUser = messageWithBasicUser.copy(
+      participants = threadActivity.map { ta =>
+        BasicUserLikeEntity(id2BasicUser(ta.userId))
+      } ++ basicNonUserParticipants
+    )
 
     val usersToNotify = from match {
       case MessageSender.User(id) => thread.allParticipantsExcept(id)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationJsonMaker.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationJsonMaker.scala
@@ -89,18 +89,16 @@ class NotificationJsonMaker @Inject() (
 
   private def author(value: JsValue): Future[Option[BasicUserLikeEntity]] = {
     value.asOpt[BasicUserLikeEntity] match {
-      case Some(bu: BasicUser) => updateBasicUser(bu) map Some.apply
+      case Some(BasicUserLikeEntity.user(bu)) => updateBasicUser(bu).map(u => Some(BasicUserLikeEntity(u)))
       case x => Future.successful(x)
     }
   }
 
   private def participants(value: JsValue): Future[Seq[BasicUserLikeEntity]] = {
     value.asOpt[Seq[BasicUserLikeEntity]] map { participants =>
-      Future.sequence(participants.map { participant =>
-        participant match {
-          case p: BasicUser => updateBasicUser(p)
-          case p => Future.successful(p)
-        }
+      Future.sequence(participants.map {
+        case BasicUserLikeEntity.user(p) => updateBasicUser(p).map(u => BasicUserLikeEntity(u))
+        case p => Future.successful(p)
       })
     } getOrElse {
       Future.successful(Seq.empty)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
@@ -166,8 +166,8 @@ class MobileMessagingController @Inject() (
               "text" -> m.text
             )
             val msgJson = baseJson ++ (m.user match {
-              case Some(bu: BasicUser) => Json.obj("userId" -> bu.externalId.toString)
-              case Some(bnu: BasicNonUser) if bnu.kind.name == "email" => Json.obj("userId" -> bnu.id)
+              case Some(BasicUserLikeEntity.user(bu)) => Json.obj("userId" -> bu.externalId.toString)
+              case Some(BasicUserLikeEntity.nonUser(bnu)) if bnu.kind.name == "email" => Json.obj("userId" -> bnu.id)
               case _ => Json.obj()
             })
 
@@ -206,8 +206,8 @@ class MobileMessagingController @Inject() (
               "text" -> m.text
             )
             val msgJson = baseJson ++ (m.user match {
-              case Some(bu: BasicUser) => Json.obj("userId" -> bu.externalId.toString)
-              case Some(bnu: BasicNonUser) if bnu.kind.name == "email" => Json.obj("userId" -> bnu.id)
+              case Some(BasicUserLikeEntity.user(bu)) => Json.obj("userId" -> bu.externalId.toString)
+              case Some(BasicUserLikeEntity.nonUser(bnu)) if bnu.kind.name == "email" => Json.obj("userId" -> bnu.id)
               case _ => Json.obj()
             })
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessagingIndexCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessagingIndexCommander.scala
@@ -7,6 +7,7 @@ import com.keepit.common.db.slick.Database
 import com.keepit.model.User
 import com.keepit.shoebox.ShoeboxServiceClient
 import com.google.inject.Inject
+import com.keepit.social.BasicUserLikeEntity
 
 import scala.concurrent.Future
 
@@ -35,6 +36,7 @@ class MessagingIndexCommander @Inject() (
     val userParticipants: Seq[Id[User]] = thread.participants.map(_.allUsers).getOrElse(Set[Id[User]]()).toSeq
     val participantBasicUsersFuture = shoebox.getBasicUsers(userParticipants)
     val participantBasicNonUsers = thread.participants.map(_.allNonUsers).getOrElse(Set.empty).map(NonUserParticipant.toBasicNonUser)
+      .map(BasicUserLikeEntity.apply)
 
     val messages: Seq[Message] = db.readOnlyReplica { implicit session =>
       messageRepo.get(threadId, 0)
@@ -67,7 +69,7 @@ class MessagingIndexCommander @Inject() (
         mode = FULL,
         id = Id[ThreadContent](threadId.id),
         seq = seq,
-        participants = participantBasicUsers.values.toSeq ++ participantBasicNonUsers,
+        participants = participantBasicUsers.values.toSeq.map(BasicUserLikeEntity.apply) ++ participantBasicNonUsers,
         updatedAt = messages.head.createdAt,
         url = thread.url.getOrElse(""),
         threadExternalId = thread.externalId.id,

--- a/kifi-backend/modules/search/app/com/keepit/search/index/message/MessageIndexer.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/message/MessageIndexer.scala
@@ -13,7 +13,7 @@ import play.api.libs.json.Json
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import java.io.StringReader
-import com.keepit.social.{ BasicUser, BasicNonUser }
+import com.keepit.social.{ BasicUserLikeEntity, BasicUser, BasicNonUser }
 
 object ThreadIndexFields {
   var titleField = "mt_title"
@@ -80,8 +80,8 @@ class MessageContentIndexable(
     val participantNameList = (0 until data.participants.length).map { i =>
       val participant = data.participants(i)
       val participantName = participant match {
-        case user: BasicUser => user.firstName + " " + user.lastName
-        case nonUser: BasicNonUser => {
+        case BasicUserLikeEntity.user(user) => user.firstName + " " + user.lastName
+        case BasicUserLikeEntity.nonUser(nonUser) => {
           val fullNameOpt = for {
             firstName <- nonUser.firstName
             lastName <- nonUser.lastName

--- a/kifi-backend/modules/search/test/com/keepit/search/index/message/MessageSearcherTest.scala
+++ b/kifi-backend/modules/search/test/com/keepit/search/index/message/MessageSearcherTest.scala
@@ -1,7 +1,7 @@
 package com.keepit.search.index.message
 
 import com.keepit.test.CommonTestInjector
-import com.keepit.social.BasicUser
+import com.keepit.social.{ BasicUserLikeEntity, BasicUser }
 import com.keepit.common.db.{ Id, ExternalId, SequenceNumber }
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.time._
@@ -31,7 +31,7 @@ class MessageSearcherTest extends Specification with CommonTestInjector {
       mode = FULL,
       id = Id[ThreadContent](44),
       seq = SequenceNumber(1),
-      participants = Seq(user1, user2),
+      participants = Seq(user1, user2).map(BasicUserLikeEntity.apply),
       updatedAt = currentDateTime,
       url = "http://theenterprise.com",
       threadExternalId = ExternalId().id,
@@ -49,7 +49,7 @@ class MessageSearcherTest extends Specification with CommonTestInjector {
       mode = FULL,
       id = Id[ThreadContent](9),
       seq = SequenceNumber(2),
-      participants = Seq(user1, user2),
+      participants = Seq(user1, user2).map(BasicUserLikeEntity.apply),
       updatedAt = currentDateTime,
       url = "http://thereliant.com",
       threadExternalId = ExternalId().id,
@@ -66,7 +66,7 @@ class MessageSearcherTest extends Specification with CommonTestInjector {
       mode = FULL,
       id = Id[ThreadContent](388),
       seq = SequenceNumber(3),
-      participants = Seq(user1, user3),
+      participants = Seq(user1, user3).map(BasicUserLikeEntity.apply),
       updatedAt = currentDateTime,
       url = "http://amazon.com",
       threadExternalId = ExternalId().id,
@@ -83,7 +83,7 @@ class MessageSearcherTest extends Specification with CommonTestInjector {
       mode = FULL,
       id = Id[ThreadContent](389),
       seq = SequenceNumber(4),
-      participants = Seq(user1),
+      participants = Seq(user1).map(BasicUserLikeEntity.apply),
       updatedAt = currentDateTime.minusDays(30),
       url = "http://amazon.com",
       threadExternalId = ExternalId().id,
@@ -99,7 +99,7 @@ class MessageSearcherTest extends Specification with CommonTestInjector {
       mode = FULL,
       id = Id[ThreadContent](390),
       seq = SequenceNumber(5),
-      participants = Seq(user1),
+      participants = Seq(user1).map(BasicUserLikeEntity.apply),
       updatedAt = currentDateTime.minusDays(7),
       url = "http://amazon.com",
       threadExternalId = ExternalId().id,


### PR DESCRIPTION
@andrewconner 
@stkem 
@ryanpbrewster 

BasicUserLikeEntity had a rather strange hierarchy, being the supertype of both BasicUser and BasicNonUser (which had practically nothing to do with each other). This refactors that type into a synonym for Either as well as some convenience extractor methods to make intentions more clear (`BasicUserLikeEntity.user(u)` instead of `Right(u)`). This makes implementing the new notifications system a bit easier, since it is more clear what is happening during a pattern-match. As an additional bonus, it's possible to use all the Either methods on "BasicUserLikeEntities" now, but I did not convert existing code to do that.
