### PR TITLE
Re-using already open db sessions with ThreadLocal (don't merge)

### DIFF
--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DBSession.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DBSession.scala
@@ -16,7 +16,7 @@ import com.keepit.common.db.slick.Database.Master
 
 object DBSession {
   abstract class SessionWrapper(val name: String, val masterSlave: Database.DBMasterReplica, _session: => Session, location: Location) extends SessionDef with Logging with TransactionalCaching {
-    def database = _session.database
+    def database = session.database
     private var open = false
     private var wasOpened = false
     private var doRollback = false

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/Database.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/Database.scala
@@ -21,87 +21,6 @@ import scala.util.Try
 import scala.util.Success
 import scala.util.Failure
 
-class InSessionException(message: String) extends Exception(message)
-
-private object DatabaseSessionLock {
-  val tl = new ThreadLocal[Boolean]
-  sealed trait SourceState
-  case object ReadSession extends SourceState
-  case object WriteSession extends SourceState
-  case object NoSession extends SourceState
-}
-
-// this allows us to replace the database session implementation in tests and check when sessions are being obtained
-@ImplementedBy(classOf[SlickSessionProviderImpl])
-trait SlickSessionProvider {
-  def createReadOnlySession(handle: SlickDatabase): Session
-  def createReadWriteSession(handle: SlickDatabase): Session
-}
-
-@Singleton
-class SlickSessionProviderImpl extends SlickSessionProvider {
-  import com.keepit.common.db.slick.DBSession.ROSession
-
-  private class SessionWrapper(session: Session, onClose: => Unit) extends Session {
-    override def resultSetType = session.resultSetType
-    override def resultSetConcurrency = session.resultSetConcurrency
-    override def resultSetHoldability = session.resultSetHoldability
-    def database = session.database
-    def conn = session.conn
-    def metaData = session.metaData
-    def capabilities = session.capabilities
-    def close() = onClose
-    def rollback() = session.rollback()
-    def withTransaction[T](f: => T) = session.withTransaction(f)
-  }
-
-  // Using two, so we can save a reference to both kinds
-  private val existingROSession = new ThreadLocal[Session]
-  private val existingRWSession = new ThreadLocal[Session]
-
-  def createReadOnlySession(handle: SlickDatabase): Session = {
-    val existingOpt = Option(existingROSession.get).orElse(Option(existingRWSession.get))
-    existingOpt match {
-      case Some(existing) =>
-        new SessionWrapper(existing, {
-          // Do nothing. If working on reducing these, feel free to add logs.
-        })
-      case None => // This is the expected/good case.
-        val rawSession = handle.createSession().forParameters(rsConcurrency = ResultSetConcurrency.ReadOnly)
-        val newSession = new SessionWrapper(rawSession, {
-          existingROSession.set(null)
-          rawSession.close()
-        })
-        existingROSession.set(newSession)
-        newSession
-    }
-  }
-  def createReadWriteSession(handle: SlickDatabase): Session = {
-    val existingOpt = Option(existingRWSession.get)
-    existingOpt match {
-      case Some(existing) =>
-        new SessionWrapper(existing, {
-          existing.conn.commit()
-          // Do nothing else. If working on reducing these, feel free to add logs.
-        })
-      case None => // This is the expected/good case.
-        val rawSession = handle.createSession().forParameters(rsConcurrency = ResultSetConcurrency.Updatable)
-        val newSession = new SessionWrapper(rawSession, {
-          existingRWSession.set(null)
-          rawSession.close()
-        })
-        existingRWSession.set(newSession)
-        newSession
-    }
-  }
-}
-
-case class DbExecutionContext(context: ExecutionContext)
-
-case class SlickDatabaseWrapper(slickDatabase: SlickDatabase, masterReplica: Database.DBMasterReplica)
-
-class ExecutionSkipped extends Exception("skipped. try again! (this is not a real exception)")
-
 object Database {
   private[slick] sealed trait DBMasterReplica
   private[slick] case object Master extends DBMasterReplica
@@ -123,44 +42,6 @@ class Database @Inject() (
   implicit val executionContext = dbExecutionContext.context
 
   val dialect: DatabaseDialect[_] = db.dialect
-
-  def enteringSession[T](f: => T) = {
-    val detectLayeredSessions = false && !Play.maybeApplication.exists(_.mode == Mode.Prod) // Remove `false &&` to enable this
-    if (detectLayeredSessions) {
-      val wasInSession = Option(DatabaseSessionLock.tl.get).getOrElse(false)
-      val verbose = true
-      if (wasInSession) {
-        import DatabaseSessionLock._
-        var sourceState: SourceState = NoSession
-        val databaseSources = Set("Database.scala", "DBSession.scala")
-        val stack = new InSessionException("").getStackTrace.filter(_.getClassName.contains("com.keepit")).flatMap { l =>
-          val testCreatedTheSessionTag = if (l.getFileName.endsWith("Test.scala")) " \u001b[34m(in test)\u001b[0m" else ""
-          if (sourceState == WriteSession && !databaseSources.contains(l.getFileName)) {
-            sourceState = NoSession
-            Some(l.getFileName + ":" + l.getLineNumber + " \u001b[33;1mWRITE\u001b[0m" + testCreatedTheSessionTag)
-          } else if (sourceState == ReadSession && !databaseSources.contains(l.getFileName)) {
-            sourceState = NoSession
-            Some(l.getFileName + ":" + l.getLineNumber + testCreatedTheSessionTag)
-          } else if (l.getFileName == "Database.scala") {
-            if (l.getMethodName.contains("readWrite")) {
-              sourceState = WriteSession
-            } else if (l.getMethodName.contains("readOnly")) {
-              sourceState = ReadSession
-            }
-            None
-          } else {
-            Some("\t" + l.getFileName + ":" + l.getLineNumber)
-          }
-        }
-        println("\uD83D\uDEA6  \u001b[31;4mMultiple sessions created:\u001b[0m\n\t" + stack.mkString("\n\t"))
-      }
-      DatabaseSessionLock.tl.set(true)
-      try f finally DatabaseSessionLock.tl.set(wasInSession)
-    } else {
-      // In production and when not trying to detect layered sessions:
-      f
-    }
-  }
 
   def readOnlyMasterAsync[T](f: ROSession => T)(implicit location: Location): Future[T] = Future { readOnlyOneAttempt(Master)(f)(location) }
   def readOnlyReplicaAsync[T](f: ROSession => T)(implicit location: Location): Future[T] = Future { readOnlyOneAttempt(Replica)(f)(location) }
@@ -303,5 +184,124 @@ class Database @Inject() (
     val partialResults = readWriteBatch(pending)(f)(location)
     results ++ partialResults
   }
+
+  private def enteringSession[T](f: => T) = {
+    val detectLayeredSessions = false && !Play.maybeApplication.exists(_.mode == Mode.Prod) // Remove `false &&` to enable this
+    if (detectLayeredSessions) {
+      val wasInSession = Option(DatabaseSessionLock.tl.get).getOrElse(false)
+      val verbose = true
+      if (wasInSession) {
+        import DatabaseSessionLock._
+        var sourceState: SourceState = NoSession
+        val databaseSources = Set("Database.scala", "DBSession.scala")
+        val stack = new InSessionException("").getStackTrace.filter(_.getClassName.contains("com.keepit")).flatMap { l =>
+          val testCreatedTheSessionTag = if (l.getFileName.endsWith("Test.scala")) " \u001b[34m(in test)\u001b[0m" else ""
+          if (sourceState == WriteSession && !databaseSources.contains(l.getFileName)) {
+            sourceState = NoSession
+            Some(l.getFileName + ":" + l.getLineNumber + " \u001b[33;1mWRITE\u001b[0m" + testCreatedTheSessionTag)
+          } else if (sourceState == ReadSession && !databaseSources.contains(l.getFileName)) {
+            sourceState = NoSession
+            Some(l.getFileName + ":" + l.getLineNumber + testCreatedTheSessionTag)
+          } else if (l.getFileName == "Database.scala") {
+            if (l.getMethodName.contains("readWrite")) {
+              sourceState = WriteSession
+            } else if (l.getMethodName.contains("readOnly")) {
+              sourceState = ReadSession
+            }
+            None
+          } else {
+            Some("\t" + l.getFileName + ":" + l.getLineNumber)
+          }
+        }
+        println("\uD83D\uDEA6  \u001b[31;4mMultiple sessions created:\u001b[0m\n\t" + stack.mkString("\n\t"))
+      }
+      DatabaseSessionLock.tl.set(true)
+      try f finally DatabaseSessionLock.tl.set(wasInSession)
+    } else {
+      // In production and when not trying to detect layered sessions:
+      f
+    }
+  }
 }
+
+class InSessionException(message: String) extends Exception(message)
+
+private object DatabaseSessionLock {
+  val tl = new ThreadLocal[Boolean]
+  sealed trait SourceState
+  case object ReadSession extends SourceState
+  case object WriteSession extends SourceState
+  case object NoSession extends SourceState
+}
+
+// this allows us to replace the database session implementation in tests and check when sessions are being obtained
+@ImplementedBy(classOf[SlickSessionProviderImpl])
+trait SlickSessionProvider {
+  def createReadOnlySession(handle: SlickDatabase): Session
+  def createReadWriteSession(handle: SlickDatabase): Session
+}
+
+@Singleton
+class SlickSessionProviderImpl extends SlickSessionProvider {
+  import com.keepit.common.db.slick.DBSession.ROSession
+
+  private class SessionWrapper(session: Session, onClose: => Unit) extends Session {
+    override def resultSetType = session.resultSetType
+    override def resultSetConcurrency = session.resultSetConcurrency
+    override def resultSetHoldability = session.resultSetHoldability
+    def database = session.database
+    def conn = session.conn
+    def metaData = session.metaData
+    def capabilities = session.capabilities
+    def close() = onClose
+    def rollback() = session.rollback()
+    def withTransaction[T](f: => T) = session.withTransaction(f)
+  }
+
+  // Using two, so we can save a reference to both kinds
+  private val existingROSession = new ThreadLocal[Session]
+  private val existingRWSession = new ThreadLocal[Session]
+
+  def createReadOnlySession(handle: SlickDatabase): Session = {
+    val existingOpt = Option(existingROSession.get).orElse(Option(existingRWSession.get))
+    existingOpt match {
+      case Some(existing) =>
+        new SessionWrapper(existing, {
+          // Do nothing. If working on reducing these, feel free to add logs.
+        })
+      case None => // This is the expected/good case.
+        val rawSession = handle.createSession().forParameters(rsConcurrency = ResultSetConcurrency.ReadOnly)
+        val newSession = new SessionWrapper(rawSession, {
+          existingROSession.set(null)
+          rawSession.close()
+        })
+        existingROSession.set(newSession)
+        newSession
+    }
+  }
+  def createReadWriteSession(handle: SlickDatabase): Session = {
+    val existingOpt = Option(existingRWSession.get)
+    existingOpt match {
+      case Some(existing) =>
+        new SessionWrapper(existing, {
+          existing.conn.commit()
+          // Do nothing else. If working on reducing these, feel free to add logs.
+        })
+      case None => // This is the expected/good case.
+        val rawSession = handle.createSession().forParameters(rsConcurrency = ResultSetConcurrency.Updatable)
+        val newSession = new SessionWrapper(rawSession, {
+          existingRWSession.set(null)
+          rawSession.close()
+        })
+        existingRWSession.set(newSession)
+        newSession
+    }
+  }
+}
+
+case class DbExecutionContext(context: ExecutionContext)
+
+case class SlickDatabaseWrapper(slickDatabase: SlickDatabase, masterReplica: Database.DBMasterReplica)
+
+class ExecutionSkipped extends Exception("skipped. try again! (this is not a real exception)")
 

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/Database.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/Database.scala
@@ -81,7 +81,8 @@ class SlickSessionProviderImpl extends SlickSessionProvider {
     existingOpt match {
       case Some(existing) =>
         new SessionWrapper(existing, {
-          // Do nothing. If working on reducing these, feel free to add logs.
+          existing.conn.commit()
+          // Do nothing else. If working on reducing these, feel free to add logs.
         })
       case None => // This is the expected/good case.
         val rawSession = handle.createSession().forParameters(rsConcurrency = ResultSetConcurrency.Updatable)


### PR DESCRIPTION
@gratimax @eishay @stkem @ryanpbrewster @camhashemi 

This automagically reuses existing ro/rw sessions when possible that were already opened. This is more of a bandaid than an actual fix, but should reduce some acute pain.

The approach is to wrap the underlying Slick session to make `.close()` do nothing if you're in an inner session (or for rw's, commit but do not close). The rest is bookkeeping to track open sessions. I am wrapping the underlying so that from our public API's perspective, nothing changes. Your `ROSession` and `RWSession` work as before and have their own lifecycle in respect to caching and such.

Please review. Since it's the weekend coming up, I'll wait to deploy it so I can monitor closely. This has the potential to leak connections and double close them if done incorrectly.
