### PR TITLE
Make black the default color for libraries. This way there will never be …

### DIFF
--- a/packrat/styles/keeper/keep_box.less
+++ b/packrat/styles/keeper/keep_box.less
@@ -435,10 +435,8 @@
   height: 28px;
   border-radius: 4px;
   box-shadow: 1px 1px #fff, 2px 2px #d3d3d3;
-  .kifi-system &,
-  .kifi-create & {
-    background-color: #333434;
-  }
+
+  background-color: #333434; // default
 }
 
 .kifi-system.kifi-discoverable .kifi-keep-box-lib-icon {


### PR DESCRIPTION
…a blank library icon. @andrewconner 
