### PR TITLE
check both a user's and target org's space when creating a library

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -116,7 +116,10 @@ class LibraryCommanderImpl @Inject() (
             case UserSpace(userId) =>
               userId == ownerId // Right now this is guaranteed to be correct, could replace with true
           }
-          val sameSlugOpt = libraryRepo.getBySpaceAndSlug(targetSpace, validSlug)
+          val sameSlugOpt = targetSpace match {
+            case UserSpace(space) => libraryRepo.getBySpaceAndSlug(space, validSlug)
+            case OrganizationSpace(space) => libraryRepo.getBySpaceAndSlug(space, validSlug).orElse(libraryRepo.getBySpaceAndSlug(UserSpace(ownerId), validSlug))
+          }
           (userHasPermissionToCreateInSpace, sameSlugOpt)
         } match {
           case (false, _) =>


### PR DESCRIPTION
@andrewconner need to do this to prevent 500s, will add the alteration
