### PR TITLE
Remove uniqueness on group identifier, make it unique by recipient and kind

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/391.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/391.sql
@@ -2,7 +2,10 @@
 
 # --- !Ups
 
-ALTER TABLE notification DROP INDEX notification_group_identifier;
+ALTER TABLE notification DROP CONSTRAINT notification_group_identifier;
+
+-- mysql
+-- ALTER TABLE notification DROP INDEX notification_group_identifier;
 
 alter table notification add CONSTRAINT notification_group_identifier unique index(recipient, kind, group_identifier);
 

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/391.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/391.sql
@@ -1,0 +1,14 @@
+# ELIZA
+
+# --- !Ups
+
+ALTER TABLE notification DROP INDEX notification_group_identifier;
+
+alter table notification add CONSTRAINT notification_group_identifier unique index(recipient, kind, group_identifier);
+
+insert into evolutions (name, description) values(
+  '391.sql',
+  'Make notification group_identifer non unique and add unique constraint of (recipient, kind, kind group_identifier)'
+);
+
+# --- !Downs

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
@@ -65,7 +65,7 @@ class NotificationCommander @Inject() (
           val time = (json \ "time").as[DateTime]
           val id = (json \ "id").as[String]
 
-          notificationRepo.getByKindAndGroupIdentifier(LegacyNotification, id).fold {
+          notificationRepo.getByGroupIdentifier(recipient, LegacyNotification, id).fold {
             val threadId = (json \ "threadId").as[String]
             val messageThread = messageThreadRepo.get(ExternalId[MessageThread](threadId))
             if (messageThread.replyable) {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NotificationRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NotificationRepo.scala
@@ -14,7 +14,7 @@ trait NotificationRepo extends Repo[Notification] with ExternalIdColumnFunction[
 
   def getLastByRecipientAndKind(recipient: Recipient, kind: NKind)(implicit session: RSession): Option[Notification]
 
-  def getByKindAndGroupIdentifier(kind: NKind, identifier: String)(implicit session: RSession): Option[Notification]
+  def getByGroupIdentifier(recipient: Recipient, kind: NKind, identifier: String)(implicit session: RSession): Option[Notification]
 
   def getUnreadEnabledNotificationsCount(recipient: Recipient)(implicit session: RSession): Int
 
@@ -63,9 +63,9 @@ class NotificationRepoImpl @Inject() (
     query.firstOption
   }
 
-  def getByKindAndGroupIdentifier(kind: NKind, identifier: String)(implicit session: RSession): Option[Notification] = {
+  def getByGroupIdentifier(recipient: Recipient, kind: NKind, identifier: String)(implicit session: RSession): Option[Notification] = {
     val kindStr = kind.name
-    val q = for (row <- rows if row.groupIdentifier === identifier && row.kind === kindStr) yield row
+    val q = for (row <- rows if row.recipient === recipient && row.groupIdentifier === identifier && row.kind === kindStr) yield row
     q.firstOption
   }
 

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationProcessing.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationProcessing.scala
@@ -66,7 +66,7 @@ class NotificationProcessing @Inject() (
     val notif = groupIdentifier match {
       case Some(identifier) =>
         db.readOnlyMaster { implicit session =>
-          notificationRepo.getByKindAndGroupIdentifier(event.kind, identifier)
+          notificationRepo.getByGroupIdentifier(event.recipient, event.kind, identifier)
         } match {
           case Some(notif) => saveToExistingNotification(notif.id.get, event)
           case None => createNewNotification(event)


### PR DESCRIPTION
@stkem 
@andrewconner 
@leogrim 
@ryanpbrewster 

I realized that having group_identifier unique in notification was a bad idea. The primary use case is for message notifications, where the group identifier is the id of the message thread (group identifiers provide a very fast way to group notifications). However, if notifications about a message thread go to multiple users, this doesn't work because then there are multiple notifications with the same group identifier. So instead I added an index based on recipient, kind, and group identifier, which is pretty much what I originally intended.
