### PR TITLE
Minor fixes, mostly dealing with org collaboration

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
@@ -216,17 +216,11 @@ angular.module('kifi')
               scope.$emit('keepAdded', [fullKeep], clickedLibrary);
             };
 
-            (scope.keep.id ? // Recommended keeps have no keep.id.
-              keepActionService.copyToLibrary([scope.keep.id], clickedLibrary.id, scope.galleryView).then(function (result) {
-                if (result.successes.length > 0) {
-                  return keepActionService.fetchFullKeepInfo(scope.keep).then(fetchKeepInfoCallback);
-                }
-              }) :
-              keepActionService.keepToLibrary([{title: scope.keep.title, url: scope.keep.url}], clickedLibrary.id).then(function (result) {
-                if ((!result.failures || !result.failures.length) && result.alreadyKept.length === 0) {
-                  return keepActionService.fetchFullKeepInfo(result.keeps[0]).then(fetchKeepInfoCallback);
-                }
-              }))['catch'](modalService.openGenericErrorModal);
+            keepActionService.keepToLibrary([{title: scope.keep.title, url: scope.keep.url}], clickedLibrary.id).then(function (result) {
+              if ((!result.failures || !result.failures.length) && result.alreadyKept.length === 0) {
+                return keepActionService.fetchFullKeepInfo(result.keeps[0]).then(fetchKeepInfoCallback);
+              }
+            })['catch'](modalService.openGenericErrorModal);
           }
         };
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -281,7 +281,7 @@ class LibraryCommanderImpl @Inject() (
     val newColor = modifyReq.color.orElse(library.color)
     val newInviteToCollab = modifyReq.whoCanInvite.orElse(library.whoCanInvite)
     val newOrgMemberAccessOpt = newOrgIdOpt match {
-      case Some(orgId) => Some(modifyReq.organizationMemberAccess orElse library.organizationMemberAccess getOrElse (LibraryAccess.READ_WRITE))
+      case Some(orgId) => Some(modifyReq.organizationMemberAccess orElse library.organizationMemberAccess getOrElse LibraryAccess.READ_WRITE)
       case None => library.organizationMemberAccess
     }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInfoCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInfoCommander.scala
@@ -381,7 +381,7 @@ class LibraryInfoCommanderImpl @Inject() (
   }
 
   def getLibrariesUserCanKeepTo(userId: Id[User], includeOrgLibraries: Boolean): Seq[(Library, Option[LibraryMembership], Set[Id[User]])] = {
-    db.readOnlyMaster { implicit s =>
+    db.readOnlyReplica { implicit s =>
       val libsWithMembership: Seq[(Library, LibraryMembership)] = libraryRepo.getLibrariesWithWriteAccess(userId)
       val libsWithMembershipIds = libsWithMembership.map(_._1.id.get).toSet
 
@@ -392,10 +392,26 @@ class LibraryInfoCommanderImpl @Inject() (
         } yield library
       } else Seq.empty
 
-      val libIds = libsWithMembershipIds ++ libsFromOrganizations.map(_.id.get)
+      val memberOrOpenOrgLibIds = libsWithMembershipIds ++ libsFromOrganizations.map(_.id.get).toSet
+
+      // Include org libs that user is invited to
+      val libsInvitedToInOrgs = if (includeOrgLibraries) {
+        libraryInviteRepo.getByUser(userId, Set(LibraryInviteStates.DECLINED, LibraryInviteStates.ACCEPTED, LibraryInviteStates.INACTIVE)).collect {
+          case ((invite, lib)) if !memberOrOpenOrgLibIds.contains(lib.id.get) && lib.organizationId.isDefined =>
+            lib
+        }
+      } else Seq.empty
+
+      val libIds = memberOrOpenOrgLibIds ++ libsInvitedToInOrgs.map(_.id.get).toSet
+
+      val nonMemberLibraries = libsInvitedToInOrgs ++ libsFromOrganizations
+
       val collaborators: Map[Id[Library], Set[Id[User]]] = libraryMembershipRepo.getCollaboratorsByLibrary(libIds)
-      libsWithMembership.map { case (lib, membership) => (lib, Some(membership), collaborators(lib.id.get)) } ++
-        libsFromOrganizations.map { lib => (lib, None, collaborators(lib.id.get)) }
+
+      libsWithMembership.map {
+        case (lib, membership) =>
+          (lib, Some(membership), collaborators(lib.id.get))
+      } ++ nonMemberLibraries.map { lib => (lib, None, collaborators(lib.id.get)) }
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInfoCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInfoCommander.scala
@@ -329,7 +329,7 @@ class LibraryInfoCommanderImpl @Inject() (
           modifiedAt = lib.updatedAt,
           path = LibraryPathHelper.formatLibraryPath(owner = owner, orgHandleOpt = basicOrgOpt.map(_.handle), slug = lib.slug),
           org = basicOrgOpt,
-          orgMemberAccess = lib.organizationMemberAccess
+          orgMemberAccess = if (lib.organizationId.isDefined) Some(lib.organizationMemberAccess.getOrElse(LibraryAccess.READ_WRITE)) else None
         )
       }
     }
@@ -745,7 +745,7 @@ class LibraryInfoCommanderImpl @Inject() (
       kind = lib.kind,
       path = path,
       org = basicOrg,
-      orgMemberAccess = lib.organizationMemberAccess
+      orgMemberAccess = if (lib.organizationId.isDefined) Some(lib.organizationMemberAccess.getOrElse(LibraryAccess.READ_WRITE)) else None
     )
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryMembershipCommander.scala
@@ -136,10 +136,10 @@ class LibraryMembershipCommanderImpl @Inject() (
     } else if (!userCanJoinLibraryWithoutInvite && inviteList.isEmpty && existingActiveMembership.isEmpty) {
       // private library & no library invites with matching authtoken
       Left(LibraryFail(FORBIDDEN, "cant_join_library_without_an_invite"))
-    } else {
+    } else { // User can at least view the library, so can join as read_only. Determine if they could do better.
       val maxAccess: LibraryAccess = {
         val orgMemberAccess: Option[LibraryAccess] = if (lib.isSecret) None else lib.organizationId.flatMap { orgId =>
-          lib.organizationMemberAccess.filter { _ => organizationMembershipCommander.getMembership(orgId, userId).isDefined }
+          lib.organizationMemberAccess.orElse(Some(LibraryAccess.READ_WRITE)).filter { _ => organizationMembershipCommander.getMembership(orgId, userId).isDefined }
         }
         (inviteList.map(_.access).toSet ++ orgMemberAccess).maxOpt.getOrElse(LibraryAccess.READ_ONLY)
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
@@ -69,6 +69,10 @@ class ExtAuthController @Inject() (
         })
 
     val (libraries, organizations, installation, urlPatterns, isInstall, isUpdate) = db.readWrite { implicit s =>
+      val user = request.user
+      if (user.state != UserStates.ACTIVE) {
+        throw new RuntimeException(s"User $userId (${user.firstName} ${user.lastName}) is not active, denying access.")
+      }
       val libraries = libraryInfoCommander.getMainAndSecretLibrariesForUser(userId)
       val orgIds = orgMembershipCommander.getAllOrganizationsForUser(userId)
       val basicOrgs = orgCommander.getBasicOrganizations(orgIds.toSet).values.toSeq

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
@@ -50,6 +50,11 @@ class ExtAuthController @Inject() (
 
   def start = UserAction(parse.tolerantJson) { implicit request =>
     val userId = request.userId
+    val user = request.user
+    if (user.state != UserStates.ACTIVE) {
+      throw new RuntimeException(s"User $userId (${user.firstName} ${user.lastName}) is not active, denying access.")
+    }
+
     val json = request.body
     val (userAgent, version, installationIdOpt) =
       (UserAgent(request.headers.get("user-agent").getOrElse("")),
@@ -69,10 +74,6 @@ class ExtAuthController @Inject() (
         })
 
     val (libraries, organizations, installation, urlPatterns, isInstall, isUpdate) = db.readWrite { implicit s =>
-      val user = request.user
-      if (user.state != UserStates.ACTIVE) {
-        throw new RuntimeException(s"User $userId (${user.firstName} ${user.lastName}) is not active, denying access.")
-      }
       val libraries = libraryInfoCommander.getMainAndSecretLibrariesForUser(userId)
       val orgIds = orgMembershipCommander.getAllOrganizationsForUser(userId)
       val basicOrgs = orgCommander.getBasicOrganizations(orgIds.toSet).values.toSeq

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -235,7 +235,8 @@ class LibraryRepoImpl @Inject() (
 
   def getLibrariesWithOpenWriteAccess(organizationId: Id[Organization], excludeState: Option[State[Library]] = Some(LibraryStates.INACTIVE))(implicit session: RSession): Seq[Library] = {
     val collaborativePermissions = LibraryAccess.collaborativePermissions
-    val q = for { r <- rows if r.orgId === organizationId && r.state =!= excludeState.orNull && r.orgMemberAccess.inSet(collaborativePermissions) } yield r
+    val whyCantScalaTypeInfer: LibraryVisibility = LibraryVisibility.SECRET
+    val q = for { r <- rows if r.orgId === organizationId && r.state =!= excludeState.orNull && r.visibility =!= whyCantScalaTypeInfer && r.orgMemberAccess.inSet(collaborativePermissions) } yield r
     q.list
   }
 


### PR DESCRIPTION
@adamjgrant This fixes your issue where org member access didn't come down. We now assume read write everywhere (serialization and deserialization) when appropriate if not set.

@cvializ This excludes secret libraries from the org keep list, and includes invited libraries. We'll have to check performance, but should be okay—I may add a cache to this. I _believe_ this fixes the issue you saw earlier. If not, bug me and we'll keep digging.

@JRuff42 This makes re-keeping from a keep always mean they you're keeping the URL, _not_ copying the keep.

@camhashemi This blocks non-active users from using the extension.
