### PR TITLE
Fixing spacing of empty state on org profile header

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.styl
@@ -27,6 +27,12 @@ editButtonWidth = 40px
     word-wrap: break-word
     resize: none
 
+  .kf-click-to-edit-p
+    margin-bottom: 0px
+
+    + .kf-click-to-edit-p
+      margin-top: 5px
+
   &.editable
     &:hover
       textarea

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.tpl.html
@@ -1,4 +1,7 @@
-<div class="kf-click-to-edit" ng-class="{'editable': !readonly}">
+<div 
+  class="kf-click-to-edit" 
+  ng-class="{'editable': !readonly}"
+>
   <div ng-show="!readonly">
     <span class="kf-click-to-edit-textarea kf-click-to-edit-textarea-tester {{ className }}">{{view.editableValue}}</span>
     <textarea placeholder="{{ inputPlaceholder }}" class="kf-click-to-edit-textarea {{ className }}" ng-model="view.editableValue" ng-keydown="editEvent($event)" ng-blur="onBlur()" ng-style="view.textareaHeight"></textarea>

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
@@ -30,7 +30,16 @@
     <div class="kf-oph-about">
       <div class="kf-oph-about-info">
         <div class="kf-oph-name" kf-click-to-edit on-save="save" value="profile.name" class-name="'kf-oph-input'" readonly="readonly"></div>
-        <div class="kf-oph-description" kf-click-to-edit on-save="save" class-name="'kf-oph-input'" input-placeholder="'Description'" value="profile.description" readonly="readonly"></div><div ng-if="showAdminLink"><a class="kf-oph-admin-link" ng-href="https://admin.kifi.com/admin/organization/{{profile.id}}">♡</a></div>
+        <div 
+          class="kf-oph-description"
+          kf-click-to-edit
+          on-save="save"
+          class-name="'kf-oph-input'"
+          input-placeholder="'Description'"
+          value="profile.description"
+          readonly="readonly"
+          ng-if="!(readonly && !profile.description.length)"
+        ></div><div ng-if="showAdminLink"><a class="kf-oph-admin-link" ng-href="https://admin.kifi.com/admin/organization/{{profile.id}}">♡</a></div>
         <p class="kf-oph-url">
           <span kf-click-to-edit on-save="save" readonly="readonly" class-name="'kf-oph-input'" input-placeholder="'Link (e.g. http://example.com)'" linkable="true" value="profile.site"></span>
         </p>


### PR DESCRIPTION
This is just a quick fix to make the org profile header collapse unused space.
![screen shot 2015-09-09 at 2 47 21 pm](https://cloud.githubusercontent.com/assets/320494/9775119/b4c2ee3c-5701-11e5-961f-a183ef243012.png)
![screen shot 2015-09-09 at 2 47 48 pm](https://cloud.githubusercontent.com/assets/320494/9775126/c244b342-5701-11e5-919f-81ff5cff44ab.png)
