### PR TITLE
Fix inserts into notification table having a current timestamp

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/392.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/392.sql
@@ -1,0 +1,12 @@
+# ELIZA
+
+# --- !Ups
+
+ALTER TABLE notification MODIFY COLUMN last_checked DATETIME NULL DEFAULT NULL;
+
+insert into evolutions (name, description) values(
+  '392.sql',
+  'Make notification last_checked extra super null'
+);
+
+# --- !Downs


### PR DESCRIPTION
@andrewconner 
@stkem 
@leogrim 
@ryanpbrewster 

In mysql, specifying 'default null' means that the column becomes a
null column. Inserting null into this column will keep it as null. In
h2, however, only specifying 'default null' means that inserts to the
column will be null, and then become the current timestamp due to h2's sql
behavior. This makes sure that the column is specified as nullable on
both systems.

tl;dr I don't think there is _anything_ I hate more than incompatibilities between h2 and mysql.
