### PR TITLE
Fixing one-column layout on Safari

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/home/home.styl
+++ b/kifi-backend/modules/shoebox/angular/src/home/home.styl
@@ -10,6 +10,7 @@
     align-items: initial
     flex-direction: row
     flex-flow: row wrap
+    flex-wrap: nowrap
 
 .kf-home-items
   max-width: 600px


### PR DESCRIPTION
Restores issue where homepage would show as only one column in Safari.
