### PR TITLE
Fix notif time

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/Notification.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/Notification.scala
@@ -33,8 +33,8 @@ case class Notification(
     recipient: Recipient,
     lastChecked: Option[DateTime] = None,
     kind: NKind,
-    groupIdentifier: Option[String] = None,
-    lastEvent: DateTime = currentDateTime,
+    groupIdentifier: Option[String],
+    lastEvent: DateTime,
     disabled: Boolean = false,
     externalId: ExternalId[Notification] = ExternalId()) extends ModelWithExternalId[Notification] {
 

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationProcessing.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationProcessing.scala
@@ -39,9 +39,9 @@ class NotificationProcessing @Inject() (
         event = event,
         eventTime = event.time
       ))
-      log.info(s"[ELIZA DEBUG] Event time is ${event.time}")
       val notif = notificationRepo.get(notifId)
       notificationRepo.save(notif.copy(lastEvent = event.time))
+      notificationRepo.get(notifId)
     }
   }
 
@@ -59,7 +59,7 @@ class NotificationProcessing @Inject() (
         event = event,
         eventTime = event.time
       ))
-      notif
+      notificationRepo.get(notif.id.get)
     }
   }
 
@@ -70,10 +70,10 @@ class NotificationProcessing @Inject() (
         db.readOnlyMaster { implicit session =>
           notificationRepo.getByGroupIdentifier(event.recipient, event.kind, identifier)
         } match {
-          case Some(notif) => saveToExistingNotification(notif.id.get, event)
+          case Some(notifGrouped) => saveToExistingNotification(notifGrouped.id.get, event)
           case None => createNewNotification(event)
         }
-      case None => {
+      case None =>
         db.readOnlyMaster { implicit session =>
           notificationRepo.getLastByRecipientAndKind(event.recipient, event.kind)
         } match {
@@ -88,7 +88,6 @@ class NotificationProcessing @Inject() (
             }
           case _ => createNewNotification(event)
         }
-      }
     }
     val items = db.readOnlyMaster { implicit session =>
       notificationItemRepo.getAllForNotification(notif.id.get)

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationProcessing.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationProcessing.scala
@@ -39,6 +39,7 @@ class NotificationProcessing @Inject() (
         event = event,
         eventTime = event.time
       ))
+      log.info(s"[ELIZA DEBUG] Event time is ${event.time}")
       val notif = notificationRepo.get(notifId)
       notificationRepo.save(notif.copy(lastEvent = event.time))
     }
@@ -49,6 +50,7 @@ class NotificationProcessing @Inject() (
       val notif = notificationRepo.save(Notification(
         recipient = event.recipient,
         kind = event.kind,
+        groupIdentifier = None,
         lastEvent = event.time
       ))
       notificationItemRepo.save(NotificationItem(


### PR DESCRIPTION
@stkem 
@andrewconner 
@leogrim 
@ryanpbrewster 

As it turns out, MySQL doesn't store milliseconds on dates, while h2 does. Locally this code worked fine since the returned dates all matched, but in MySQL the millisecond part of the date gets chopped off so that some returned dates are rounded, while others are not. This PR makes sure that read notifications and items all come from the datastore so that we are sure they have consistent time.

tl;dr I'm going to kill something when I happen upon another incompatibility between h2 and mysql...
