### PR TITLE
remove "orgId" as a user value (amplitude)

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingAnalytics.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingAnalytics.scala
@@ -246,7 +246,7 @@ class MessagingAnalytics @Inject() (
     val orgIdsByUserIdFut = shoebox.getOrganizationsForUsers(participants.allUsers)
     orgIdsByUserIdFut.foreach { orgIdsByUserId =>
       val commonOrgs = orgIdsByUserId.values.reduceLeftOption[Set[Id[Organization]]] { case (acc, orgSet) => acc.intersect(orgSet) }
-      contextBuilder += ("organizationId", commonOrgs.map(_.head.toString).toSeq)
+      contextBuilder += ("eventOrgId", commonOrgs.map(_.head.toString).toSeq)
     }
   }
 }

--- a/kifi-backend/modules/heimdal/app/com/keepit/heimdal/AmplitudeClient.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/heimdal/AmplitudeClient.scala
@@ -49,7 +49,7 @@ object AmplitudeClient {
     "firstName", "lastName", "$email", "gender",
     "keeps", "kifiConnections", "privateKeeps", "publicKeeps", "socialConnections", "tags", "daysSinceLibraryCreated",
     "daysSinceUserJoined", "orgKeepCount", "orgMessageCount", "orgInviteCount", "orgLibrariesCreated", "orgLibrariesCollaborating",
-    "overallKeepViews", "orgId")
+    "overallKeepViews")
 
   // rename events with these names
   val simpleEventRenames: Map[String, String] = Map(


### PR DESCRIPTION
@andrewconner @eishay @joshm1 

the way `AmplitudeClient` distinguishes between userProps and eventProps is pretty hacky right now, so it's tough to distinguish between an orgId of the user versus an orgId of the event (keep click, library view, etc). @joshm1 hinted at a solution, where `HeimdalContext` has separate maps for userProps and eventProps, that could be helpful to do. Right now I name them `eventOrgId` and `userOrgId`, and most tracking uses `organizationId` without specifying it as a user or event value.
