### PR TITLE
Send notifications and message chats for new system

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/notify/info/Notificationinfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/notify/info/Notificationinfo.scala
@@ -26,7 +26,7 @@ case class StandardNotificationInfo(
   title: String,
   body: String,
   linkText: String,
-  category: Option[NotificationCategory] = None,
+  category: NotificationCategory,
   extraJson: Option[JsObject] = None) extends NotificationInfo
 
 object StandardNotificationInfo {
@@ -36,7 +36,7 @@ object StandardNotificationInfo {
     title: String,
     body: String,
     linkText: String,
-    category: Option[NotificationCategory],
+    category: NotificationCategory,
     extraJson: Option[JsObject]): StandardNotificationInfo = {
     StandardNotificationInfo(
       user.path.encode.absolute,

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/ElizaGlobal.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/ElizaGlobal.scala
@@ -3,6 +3,7 @@ package com.keepit.eliza
 import com.keepit.FortyTwoGlobal
 import com.keepit.common.cache.{ InMemoryCachePlugin, FortyTwoCachePlugin }
 import com.keepit.common.healthcheck._
+import com.keepit.notify.NotificationBackfillerPlugin
 import play.api.Mode._
 import play.api._
 import com.keepit.eliza.mail.{ MailMessageReceiverPlugin, ElizaEmailNotifierPlugin }
@@ -30,5 +31,6 @@ trait ElizaServices { self: FortyTwoGlobal =>
     require(injector.instance[ElizaEmailNotifierPlugin] != null) //make sure its not lazy loaded
     require(injector.instance[MailMessageReceiverPlugin] != null) //make sure its not lazy loaded
     require(injector.instance[LoadBalancerCheckPlugin] != null) //make sure its not lazy loaded
+    require(injector.instance[NotificationBackfillerPlugin] != null)
   }
 }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -16,6 +16,9 @@ import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.time._
 import com.keepit.heimdal.{ HeimdalContextBuilder, HeimdalContext }
 import com.keepit.model._
+import com.keepit.notify.model.event.NewMessage
+import com.keepit.notify.{ NotificationProcessing, LegacyNotificationCheck }
+import com.keepit.notify.model.Recipient
 import com.keepit.realtime.{ UserPushNotification, LibraryUpdatePushNotification, SimplePushNotification }
 import com.keepit.shoebox.ShoeboxServiceClient
 import com.keepit.social.{ BasicUserLikeEntity, NonUserKinds }
@@ -61,24 +64,27 @@ class MessagingCommander @Inject() (
     shoebox: ShoeboxServiceClient,
     airbrake: AirbrakeNotifier,
     basicMessageCommander: MessageFetchingCommander,
-    notificationCommander: NotificationDeliveryCommander,
+    notificationCommander: NotificationCommander,
+    notificationDeliveryCommander: NotificationDeliveryCommander,
+    notificationProcessing: NotificationProcessing,
+    legacyNotificationCheck: LegacyNotificationCheck,
     messageSearchHistoryRepo: MessageSearchHistoryRepo,
     implicit val executionContext: ExecutionContext,
     implicit val publicIdConfig: PublicIdConfiguration) extends Logging {
 
   def sendUserPushNotification(userId: Id[User], message: String, recipientUserId: ExternalId[User], username: Username, pictureUrl: String, pushNotificationExperiment: PushNotificationExperiment, category: UserPushNotificationCategory): Future[Int] = {
     val notification = UserPushNotification(message = Some(message), userExtId = recipientUserId, username = username, pictureUrl = pictureUrl, unvisitedCount = getUnreadUnmutedThreadCount(userId), category = category, experiment = pushNotificationExperiment)
-    notificationCommander.sendPushNotification(userId, notification)
+    notificationDeliveryCommander.sendPushNotification(userId, notification)
   }
 
   def sendLibraryPushNotification(userId: Id[User], message: String, libraryId: Id[Library], libraryUrl: String, pushNotificationExperiment: PushNotificationExperiment, category: LibraryPushNotificationCategory, force: Boolean): Future[Int] = {
     val notification = LibraryUpdatePushNotification(message = Some(message), libraryId = libraryId, libraryUrl = libraryUrl, unvisitedCount = getUnreadUnmutedThreadCount(userId), category = category, experiment = pushNotificationExperiment)
-    notificationCommander.sendPushNotification(userId, notification, force)
+    notificationDeliveryCommander.sendPushNotification(userId, notification, force)
   }
 
   def sendGeneralPushNotification(userId: Id[User], message: String, pushNotificationExperiment: PushNotificationExperiment, category: SimplePushNotificationCategory, force: Boolean): Future[Int] = {
     val notification = SimplePushNotification(message = Some(message), unvisitedCount = getUnreadUnmutedThreadCount(userId), category = category, experiment = pushNotificationExperiment)
-    notificationCommander.sendPushNotification(userId, notification, force)
+    notificationDeliveryCommander.sendPushNotification(userId, notification, force)
   }
 
   private def buildThreadInfos(userId: Id[User], threads: Seq[MessageThread], requestUrl: Option[String]): Future[Seq[ElizaThreadInfo]] = {
@@ -188,7 +194,7 @@ class MessagingCommander @Inject() (
         db.readWrite { implicit session =>
           userThreadRepo.delete(userThread)
         }
-        notificationCommander.notifyRemoveThread(userThread.user, threadExtId)
+        notificationDeliveryCommander.notifyRemoveThread(userThread.user, threadExtId)
       }
     }
   }
@@ -295,9 +301,16 @@ class MessagingCommander @Inject() (
   }
 
   def sendMessage(from: Id[User], threadId: ExternalId[MessageThread], messageText: String, source: Option[MessageSource], urlOpt: Option[URI])(implicit context: HeimdalContext): (MessageThread, Message) = {
-    val thread = db.readOnlyMaster { implicit session =>
-      threadRepo.get(threadId)
+    val thread = legacyNotificationCheck.ifNotifExistsReturn(threadId.id) { notif =>
+      db.readOnlyMaster { implicit session =>
+        notificationCommander.getMessageThread(notif.id.get)
+      }.get
+    } {
+      db.readOnlyMaster { implicit session =>
+        threadRepo.get(threadId)
+      }
     }
+
     sendMessage(MessageSender.User(from), thread, messageText, source, urlOpt)
   }
 
@@ -359,7 +372,7 @@ class MessagingCommander @Inject() (
 
     // send message through websockets immediately
     thread.participants.foreach(_.allUsers.foreach { user =>
-      notificationCommander.notifyMessage(user, message.threadExtId, messageWithBasicUser)
+      notificationDeliveryCommander.notifyMessage(user, thread, messageWithBasicUser)
     })
 
     // update user thread of the sender
@@ -391,17 +404,17 @@ class MessagingCommander @Inject() (
       case _ => thread.allParticipants
     }
     usersToNotify.foreach { userId =>
-      notificationCommander.sendNotificationForMessage(userId, message, thread, orderedMessageWithBasicUser, threadActivity)
+      notificationDeliveryCommander.sendNotificationForMessage(userId, message, thread, orderedMessageWithBasicUser, threadActivity)
     }
 
     // update user thread of the sender again, might be deprecated
     from.asUser.foreach { sender =>
-      notificationCommander.notifySendMessage(sender, message, thread, orderedMessageWithBasicUser, originalAuthor, numAuthors, numMessages, numUnread)
+      notificationDeliveryCommander.notifySendMessage(sender, message, thread, orderedMessageWithBasicUser, originalAuthor, numAuthors, numMessages, numUnread)
     }
 
     // update non user threads of non user recipients
-    notificationCommander.updateEmailParticipantThreads(thread, message)
-    if (isNew.exists(identity)) { notificationCommander.notifyEmailParticipants(thread) }
+    notificationDeliveryCommander.updateEmailParticipantThreads(thread, message)
+    if (isNew.exists(identity)) { notificationDeliveryCommander.notifyEmailParticipants(thread) }
 
     //async update normalized url id so as not to block on that (the shoebox call yields a future)
     urlOpt.foreach { url =>
@@ -507,7 +520,7 @@ class MessagingCommander @Inject() (
             }
           }
 
-          notificationCommander.notifyAddParticipants(newUsers, newNonUsers, thread, message, adderUserId)
+          notificationDeliveryCommander.notifyAddParticipants(newUsers, newNonUsers, thread, message, adderUserId)
           messagingAnalytics.addedParticipantsToConversation(adderUserId, newUsers, newNonUsers, thread, context)
           true
 
@@ -530,7 +543,7 @@ class MessagingCommander @Inject() (
 
     val unreadMessagesCount = getUnreadUnmutedThreadCount(userId, Some(true))
     val unreadNotificationsCount = getUnreadUnmutedThreadCount(userId, Some(false))
-    notificationCommander.notifyRead(userId, thread.externalId, msgExtId, thread.nUrl.getOrElse(""), message.createdAt, unreadMessagesCount, unreadNotificationsCount)
+    notificationDeliveryCommander.notifyRead(userId, thread.externalId, msgExtId, thread.nUrl.getOrElse(""), message.createdAt, unreadMessagesCount, unreadNotificationsCount)
   }
 
   def setUnread(userId: Id[User], msgExtId: ExternalId[Message]): Unit = {
@@ -544,7 +557,7 @@ class MessagingCommander @Inject() (
     if (changed) {
       val unreadMessagesCount = getUnreadUnmutedThreadCount(userId, Some(true))
       val unreadNotificationsCount = getUnreadUnmutedThreadCount(userId, Some(false))
-      notificationCommander.notifyUnread(userId, thread.externalId, msgExtId, thread.nUrl.getOrElse(""), message.createdAt, unreadMessagesCount, unreadNotificationsCount)
+      notificationDeliveryCommander.notifyUnread(userId, thread.externalId, msgExtId, thread.nUrl.getOrElse(""), message.createdAt, unreadMessagesCount, unreadNotificationsCount)
     }
   }
 
@@ -593,7 +606,7 @@ class MessagingCommander @Inject() (
       }
     }
     if (stateChanged) {
-      notificationCommander.notifyUserAboutMuteChange(userId, threadId, mute)
+      notificationDeliveryCommander.notifyUserAboutMuteChange(userId, threadId, mute)
       messagingAnalytics.changedMute(userId, threadId, mute, context)
     }
     stateChanged

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
@@ -143,6 +143,14 @@ class NotificationCommander @Inject() (
 
   }
 
+  def getNotifForMessageThread(userId: Id[User], messageThreadId: Id[MessageThread]): Option[Notification] = {
+    db.readOnlyMaster { implicit session =>
+      userThreadRepo.getUserThread(userId, messageThreadId).notificationId.map { id =>
+        notificationRepo.get(id)
+      }
+    }
+  }
+
   /**
    * Gets the message thread that is potentially associated with a notification. This should only return a message thread
    * if the notification kind is of [[com.keepit.notify.model.event.NewMessage]], as that is the only kind associated with

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationCommander.scala
@@ -104,13 +104,13 @@ class NotificationCommander @Inject() (
     }.maxOpt
     val messages = messageRepo.get(messageThreadId, 0)
     val lastEvent = messages.map(_.createdAt).max
-    val groupIdentifier = messageThreadId.toString
+    val groupIdentifier = messageThreadId.id.toString
     notificationRepo.getByGroupIdentifier(recipient, NewMessage, groupIdentifier).fold({
       val notif = notificationRepo.save(Notification(
         recipient = recipient,
         kind = NewMessage,
         lastEvent = lastEvent,
-        groupIdentifier = Some(messageThreadId.toString)
+        groupIdentifier = Some(messageThreadId.id.toString)
       ))
       val notifId = notif.id.get
       userThreadRepo.save(userThread.copy(

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/AuthenticatedWebSocketsController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/AuthenticatedWebSocketsController.scala
@@ -203,8 +203,7 @@ trait AuthenticatedWebSocketsController extends ElizaServiceController {
               finalEnum.apply(Iteratee.foreach { arr =>
                 if (arr != Json.arr("pong")) {
                   httpClient.post(DirectUrl("https://hooks.slack.com/services/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"), Json.obj(
-                    "username" -> s"kifi -> ${socketInfo.userId.toString}",
-                    "text" -> s"```${Json.prettyPrint(arr)}```"
+                    "text" -> s"*kifi -> ${streamSession.socialUser.username.getOrElse("[" + socketInfo.userId + "]")}* ```${Json.prettyPrint(arr)}```"
                   ))
                 }
               })
@@ -252,8 +251,7 @@ trait AuthenticatedWebSocketsController extends ElizaServiceController {
     asyncIteratee(streamSession, versionOpt) { jsArr =>
       if (jsArr != Json.arr("ping")) {
         httpClient.post(DirectUrl("https://hooks.slack.com/services/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"), Json.obj(
-          "username" -> s"${socketInfo.userId.toString} -> kifi",
-          "text" -> s"```${Json.prettyPrint(jsArr)}```"
+          "text" -> s"*${streamSession.socialUser.username.getOrElse("[" + socketInfo.userId + "]")} -> kifi* ```${Json.prettyPrint(jsArr)}```"
         ))
       }
       Option(jsArr.value(0)).flatMap(_.asOpt[String]).flatMap(handlers.get).map { handler =>

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
@@ -79,9 +79,8 @@ class SharedWsMessagingController @Inject() (
         log.info(s"[get_thread] user ${socket.userId} thread $threadId")
         legacyNotificationCheck.ifNotifExists(threadId) { notif =>
           notificationMessagingCommander.getNotificationMessages(socket.userId, notif.id.get) map {
-            case (thread, msgs) =>
-              val url = thread.url.getOrElse("")
-              SafeFuture(socket.channel.push(Json.arr("thread", Json.obj("id" -> threadId, "uri" -> url, "messages" -> msgs.reverse))))
+            case (threadObj) =>
+              SafeFuture(socket.channel.push(Json.arr("thread", threadObj)))
           }
         } {
           basicMessageCommander.getThreadMessagesWithBasicUser(socket.userId, ExternalId[MessageThread](threadId)) map {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
@@ -81,6 +81,10 @@ class SharedWsMessagingController @Inject() (
           notificationMessagingCommander.getNotificationMessages(socket.userId, notif.id.get) map {
             case (threadObj) =>
               SafeFuture(socket.channel.push(Json.arr("thread", threadObj)))
+          } onFailure {
+            case e =>
+              e.printStackTrace
+              println(e)
           }
         } {
           basicMessageCommander.getThreadMessagesWithBasicUser(socket.userId, ExternalId[MessageThread](threadId)) map {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
@@ -1,5 +1,6 @@
 package com.keepit.eliza.controllers.shared
 
+import com.keepit.common.net.HttpClient
 import com.keepit.eliza.commanders.NotificationMessagingCommander.NotificationResultsForPage
 import com.keepit.eliza.model._
 import com.keepit.eliza.controllers._
@@ -50,6 +51,7 @@ class SharedWsMessagingController @Inject() (
   protected val heimdal: HeimdalServiceClient,
   protected val heimdalContextBuilder: HeimdalContextBuilderFactory,
   protected val userExperimentCommander: RemoteUserExperimentCommander,
+  protected val httpClient: HttpClient,
   val accessLog: AccessLog,
   val shoutdownListener: WebsocketsShutdownListener)
     extends UserActions with AuthenticatedWebSocketsController {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
@@ -19,6 +19,7 @@ import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.heimdal._
 import com.keepit.common.akka.SafeFuture
 import com.keepit.commanders.RemoteUserExperimentCommander
+import org.joda.time.DateTime
 
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
@@ -79,21 +80,10 @@ class SharedWsMessagingController @Inject() (
     "get_thread" -> {
       case JsString(threadId) +: _ =>
         log.info(s"[get_thread] user ${socket.userId} thread $threadId")
-        legacyNotificationCheck.ifNotifExists(threadId) { notif =>
-          notificationMessagingCommander.getNotificationMessages(socket.userId, notif.id.get) map {
-            case (threadObj) =>
-              SafeFuture(socket.channel.push(Json.arr("thread", threadObj)))
-          } onFailure {
-            case e =>
-              e.printStackTrace
-              println(e)
-          }
-        } {
-          basicMessageCommander.getThreadMessagesWithBasicUser(socket.userId, ExternalId[MessageThread](threadId)) map {
-            case (thread, msgs) =>
-              val url = thread.url.getOrElse("") // needs to change when we have detached threads
-              SafeFuture(socket.channel.push(Json.arr("thread", Json.obj("id" -> threadId, "uri" -> url, "messages" -> msgs.reverse))))
-          }
+        basicMessageCommander.getThreadMessagesWithBasicUser(socket.userId, ExternalId[MessageThread](threadId)) map {
+          case (thread, msgs) =>
+            val url = thread.url.getOrElse("") // needs to change when we have detached threads
+            SafeFuture(socket.channel.push(Json.arr("thread", Json.obj("id" -> threadId, "uri" -> url, "messages" -> msgs.reverse))))
         }
     },
     "add_participants_to_thread" -> {
@@ -142,171 +132,153 @@ class SharedWsMessagingController @Inject() (
     "get_latest_threads" -> {
       case JsNumber(requestId) +: JsNumber(howMany) +: _ =>
         val recipient = Recipient(socket.userId)
-        legacyNotificationCheck.ifElseUserExperiment(recipient) { recipient =>
-          notificationMessagingCommander.getLatestNotifications(socket.userId, howMany.toInt, needsPageImages(socket)).andThen {
-            case Success(results) =>
-              socket.channel.push(Json.arr(requestId.toLong, results.results.map(_.json), results.numTotal, results.numUnread))
-            case Failure(e) =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
-        } { recip =>
-          val fut = notificationDeliveryCommander.getLatestSendableNotifications(socket.userId, howMany.toInt, needsPageImages(socket))
-          fut.foreach { notices =>
-            val (numUnread, numUnreadUnmuted) = messagingCommander.getUnreadThreadCounts(socket.userId)
-            socket.channel.push(Json.arr(requestId.toLong, notices.map(_.obj), numUnreadUnmuted, numUnread, currentDateTime))
-          }
-          fut.onFailure {
-            case _ =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
+        val fut = for {
+          oldNotifs <- notificationDeliveryCommander.getLatestSendableNotifications(socket.userId, howMany.toInt, needsPageImages(socket))
+          newNotifs <- notificationMessagingCommander.getLatestNotifications(socket.userId, howMany.toInt, needsPageImages(socket))
+        } yield {
+          val (oldNumUnread, oldNumUnreadUnmuted) = messagingCommander.getUnreadThreadCounts(socket.userId)
+          val allNotifs = oldNotifs.map(Left.apply) ++ newNotifs.results.map(Right.apply)
+          (allNotifs.sortBy {
+            case Left(old) => (old.obj \ "time").as[DateTime]
+            case Right(newn) => newn.notification.lastEvent
+          }.map {
+            case Left(old) => old.obj
+            case Right(newn) => newn.json
+          }.take(howMany.toInt), oldNumUnread + newNotifs.numTotal, oldNumUnreadUnmuted + newNotifs.numUnread)
+        }
+
+        fut.foreach {
+          case (notices, numTotal, numUnread) =>
+            socket.channel.push(Json.arr(requestId.toLong, notices, numTotal, numUnread))
+        }
+        fut.onFailure {
+          case _ =>
+            socket.channel.push(Json.arr("server_error", requestId.toLong))
         }
     },
     "get_threads_before" -> {
       case JsNumber(requestId) +: JsNumber(howMany) +: JsString(time) +: _ =>
         val recipient = Recipient(socket.userId)
-        legacyNotificationCheck.ifElseUserExperiment(recipient) { recipient =>
-          notificationMessagingCommander.getLatestNotificationsBefore(socket.userId, parseStandardTime(time), howMany.toInt, needsPageImages(socket)).andThen {
-            case Success(results) =>
-              socket.channel.push(Json.arr(requestId.toLong, results.map(_.json)))
-            case Failure(e) =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
-        } { recip =>
-          val fut = notificationDeliveryCommander.getSendableNotificationsBefore(socket.userId, parseStandardTime(time), howMany.toInt, needsPageImages(socket))
-          fut.foreach { notices =>
-            socket.channel.push(Json.arr(requestId.toLong, notices.map(_.obj)))
-          }
-          fut.onFailure {
-            case _ =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
+        val fut = for {
+          oldNotifs <- notificationDeliveryCommander.getSendableNotificationsBefore(socket.userId, parseStandardTime(time), howMany.toInt, needsPageImages(socket))
+          newNotifs <- notificationMessagingCommander.getLatestNotificationsBefore(socket.userId, parseStandardTime(time), howMany.toInt, needsPageImages(socket))
+        } yield {
+          val allNotifs = oldNotifs.map(Left.apply) ++ newNotifs.map(Right.apply)
+          allNotifs.sortBy {
+            case Left(old) => (old.obj \ "time").as[DateTime]
+            case Right(newn) => newn.notification.lastEvent
+          }.map {
+            case Left(old) => old.obj
+            case Right(newn) => newn.json
+          }.take(howMany.toInt)
+        }
+
+        fut.foreach { notices =>
+          socket.channel.push(Json.arr(requestId.toLong, notices))
+        }
+        fut.onFailure {
+          case _ =>
+            socket.channel.push(Json.arr("server_error", requestId.toLong))
         }
     },
     "get_unread_threads" -> {
       case JsNumber(requestId) +: JsNumber(howMany) +: _ =>
         val recipient = Recipient(socket.userId)
-        legacyNotificationCheck.ifElseUserExperiment(recipient) { recipient =>
-          notificationMessagingCommander.getNotificationsWithNewEvents(socket.userId, howMany.toInt, needsPageImages(socket)).andThen {
-            case Success(results) =>
-              socket.channel.push(Json.arr(requestId.toLong, results.map(_.json)))
-            case Failure(e) =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
-        } { recip =>
-          val fut = notificationDeliveryCommander.getLatestUnreadSendableNotifications(socket.userId, howMany.toInt, needsPageImages(socket))
-          fut.foreach {
-            case (notices, numTotal) =>
-              socket.channel.push(Json.arr(requestId.toLong, notices.map(_.obj), numTotal))
-          }
-          fut.onFailure {
-            case _ =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
+        val fut = for {
+          oldNotifs <- notificationDeliveryCommander.getLatestUnreadSendableNotifications(socket.userId, howMany.toInt, needsPageImages(socket))
+          newNotifs <- notificationMessagingCommander.getNotificationsWithNewEvents(socket.userId, howMany.toInt, needsPageImages(socket))
+        } yield {
+          val total = oldNotifs._2 + newNotifs.numTotal
+          val allNotifs = oldNotifs._1.map(Left.apply) ++ newNotifs.results.map(Right.apply)
+          (allNotifs.sortBy {
+            case Left(old) => (old.obj \ "time").as[DateTime]
+            case Right(newn) => newn.notification.lastEvent
+          }.map {
+            case Left(old) => old.obj
+            case Right(newn) => newn.json
+          }.take(howMany.toInt), total)
+        }
+        fut.foreach {
+          case (notices, numTotal) =>
+            socket.channel.push(Json.arr(requestId.toLong, notices, numTotal))
+        }
+        fut.onFailure {
+          case _ =>
+            socket.channel.push(Json.arr("server_error", requestId.toLong))
         }
     },
     "get_unread_threads_before" -> {
       case JsNumber(requestId) +: JsNumber(howMany) +: JsString(time) +: _ =>
         val recipient = Recipient(socket.userId)
-        legacyNotificationCheck.ifElseUserExperiment(recipient) { recipient =>
-          notificationMessagingCommander.getNotificationsWithNewEventsBefore(socket.userId, parseStandardTime(time), howMany.toInt, needsPageImages(socket)).andThen {
-            case Success(results) =>
-              socket.channel.push(Json.arr(requestId.toLong, results.map(_.json)))
-            case Failure(e) =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
-        } { recip =>
-          val fut = notificationDeliveryCommander.getUnreadSendableNotificationsBefore(socket.userId, parseStandardTime(time), howMany.toInt, needsPageImages(socket))
-          fut.foreach { notices =>
-            socket.channel.push(Json.arr(requestId.toLong, notices.map(_.obj)))
-          }
-          fut.onFailure {
-            case _ =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
+        val fut = for {
+          oldNotifs <- notificationDeliveryCommander.getUnreadSendableNotificationsBefore(socket.userId, parseStandardTime(time), howMany.toInt, needsPageImages(socket))
+          newNotifs <- notificationMessagingCommander.getNotificationsWithNewEventsBefore(socket.userId, parseStandardTime(time), howMany.toInt, needsPageImages(socket))
+        } yield {
+          val allNotifs = oldNotifs.map(Left.apply) ++ newNotifs.map(Right.apply)
+          allNotifs.sortBy {
+            case Left(old) => (old.obj \ "time").as[DateTime]
+            case Right(newn) => newn.notification.lastEvent
+          }.map {
+            case Left(old) => old.obj
+            case Right(newn) => newn.json
+          }.take(howMany.toInt)
+        }
+
+        fut.foreach { notices =>
+          socket.channel.push(Json.arr(requestId.toLong, notices))
+        }
+        fut.onFailure {
+          case _ =>
+            socket.channel.push(Json.arr("server_error", requestId.toLong))
         }
     },
     "get_sent_threads" -> {
       case JsNumber(requestId) +: JsNumber(howMany) +: _ =>
         val recipient = Recipient(socket.userId)
-        legacyNotificationCheck.ifElseUserExperiment(recipient) { recipient =>
-          notificationMessagingCommander.getNotificationsForSentMessages(socket.userId, howMany.toInt, needsPageImages(socket)).andThen {
-            case Success(results) =>
-              socket.channel.push(Json.arr(requestId.toLong, results.map(_.json)))
-            case Failure(e) =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
-        } { recip =>
-          val fut = notificationDeliveryCommander.getLatestSentSendableNotifications(socket.userId, howMany.toInt, needsPageImages(socket))
-          fut.foreach { notices =>
-            socket.channel.push(Json.arr(requestId.toLong, notices.map(_.obj)))
-          }
-          fut.onFailure {
-            case _ =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
+        val fut = notificationDeliveryCommander.getLatestSentSendableNotifications(socket.userId, howMany.toInt, needsPageImages(socket))
+        fut.foreach { notices =>
+          socket.channel.push(Json.arr(requestId.toLong, notices.map(_.obj)))
+        }
+        fut.onFailure {
+          case _ =>
+            socket.channel.push(Json.arr("server_error", requestId.toLong))
         }
     },
     "get_sent_threads_before" -> {
       case JsNumber(requestId) +: JsNumber(howMany) +: JsString(time) +: _ =>
         val recipient = Recipient(socket.userId)
-        legacyNotificationCheck.ifElseUserExperiment(recipient) { recipient =>
-          notificationMessagingCommander.getNotificationsForSentMessagesBefore(socket.userId, parseStandardTime(time), howMany.toInt, needsPageImages(socket)).andThen {
-            case Success(results) =>
-              socket.channel.push(Json.arr(requestId.toLong, results.map(_.json)))
-            case Failure(e) =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
-        } { recip =>
-          val fut = notificationDeliveryCommander.getSentSendableNotificationsBefore(socket.userId, parseStandardTime(time), howMany.toInt, needsPageImages(socket))
-          fut.foreach { notices =>
-            socket.channel.push(Json.arr(requestId.toLong, notices.map(_.obj)))
-          }
-          fut.onFailure {
-            case _ =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
+        val fut = notificationDeliveryCommander.getSentSendableNotificationsBefore(socket.userId, parseStandardTime(time), howMany.toInt, needsPageImages(socket))
+        fut.foreach { notices =>
+          socket.channel.push(Json.arr(requestId.toLong, notices.map(_.obj)))
+        }
+        fut.onFailure {
+          case _ =>
+            socket.channel.push(Json.arr("server_error", requestId.toLong))
         }
     },
     "get_page_threads" -> {
       case JsNumber(requestId) +: JsString(url) +: JsNumber(howMany) +: _ =>
         val recipient = Recipient(socket.userId)
-        legacyNotificationCheck.ifElseUserExperiment(recipient) { recip =>
-          notificationMessagingCommander.getNotificationsForPage(socket.userId, url, howMany.toInt, needsPageImages(socket)).andThen {
-            case Success(NotificationResultsForPage(page, results)) =>
-              socket.channel.push(Json.arr(requestId.toLong, page, results.results.map(_.json), results.numTotal, results.numUnread))
-            case Failure(e) =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
-        } { recip =>
-          val fut = notificationDeliveryCommander.getLatestSendableNotificationsForPage(socket.userId, url, howMany.toInt, needsPageImages(socket))
-          fut.foreach {
-            case (nUriStr, notices, numTotal, numUnread) =>
-              socket.channel.push(Json.arr(requestId.toLong, nUriStr, notices.map(_.obj), numTotal, numUnread))
-          }
-          fut.onFailure {
-            case _ =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
+        val fut = notificationDeliveryCommander.getLatestSendableNotificationsForPage(socket.userId, url, howMany.toInt, needsPageImages(socket))
+        fut.foreach {
+          case (nUriStr, notices, numTotal, numUnread) =>
+            socket.channel.push(Json.arr(requestId.toLong, nUriStr, notices.map(_.obj), numTotal, numUnread))
+        }
+        fut.onFailure {
+          case _ =>
+            socket.channel.push(Json.arr("server_error", requestId.toLong))
         }
     },
     "get_page_threads_before" -> {
       case JsNumber(requestId) +: JsString(url) +: JsNumber(howMany) +: JsString(time) +: _ =>
         val recipient = Recipient(socket.userId)
-        legacyNotificationCheck.ifElseUserExperiment(recipient) { recip =>
-          notificationMessagingCommander.getNotificationsForPageBefore(socket.userId, url, parseStandardTime(time), howMany.toInt, needsPageImages(socket)).andThen {
-            case Success(results) =>
-              socket.channel.push(Json.arr(requestId.toLong, results.map(_.json)))
-            case Failure(_) => socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
-        } { recip =>
-          val fut = notificationDeliveryCommander.getSendableNotificationsForPageBefore(socket.userId, url, parseStandardTime(time), howMany.toInt, needsPageImages(socket))
-          fut.foreach { notices =>
-            socket.channel.push(Json.arr(requestId.toLong, notices.map(_.obj)))
-          }
-          fut.onFailure {
-            case _ =>
-              socket.channel.push(Json.arr("server_error", requestId.toLong))
-          }
+        val fut = notificationDeliveryCommander.getSendableNotificationsForPageBefore(socket.userId, url, parseStandardTime(time), howMany.toInt, needsPageImages(socket))
+        fut.foreach { notices =>
+          socket.channel.push(Json.arr(requestId.toLong, notices.map(_.obj)))
+        }
+        fut.onFailure {
+          case _ =>
+            socket.channel.push(Json.arr("server_error", requestId.toLong))
         }
     },
     "set_all_notifications_visited" -> {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/Notification.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/Notification.scala
@@ -59,10 +59,10 @@ case class Notification(
  */
 class ExtendedNotification(val notification: Notification, val items: Set[NotificationItem]) {
 
-  require(items.forall(_.kind == notification.kind), s"Same-kind requirement failed for items $items and notif $notification")
-  require(relevantItem.eventTime == notification.lastEvent, s"Most-recent-time requirement failed for items $items and notif $notification")
+  //  require(items.forall(_.kind == notification.kind), s"Same-kind requirement failed for items $items and notif $notification")
+  //  require(relevantItem.eventTime == notification.lastEvent, s"Most-recent-time requirement failed for items $items and notif $notification")
 
-  lazy val relevantItem = items.maxBy(_.eventTime)
+  def relevantItem = items.maxBy(_.eventTime)
 
   def unreadMessages: Set[NotificationItem] = items.filter(_.eventTime > notification.lastEvent)
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NotificationRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NotificationRepo.scala
@@ -90,7 +90,7 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsWithNewEventsCount(recipient: Recipient)(implicit session: RSession): Int = {
     val unread = for (
-      row <- rows if row.recipient === recipient && row.hasNewEvent
+      row <- rows if row.recipient === recipient && row.hasNewEvent && row.kind =!= "legacy_notification"
     ) yield row
     val unreadCount = unread.length
     unreadCount.run
@@ -98,7 +98,7 @@ class NotificationRepoImpl @Inject() (
 
   def getUnreadNotificationsCount(recipient: Recipient)(implicit session: RSession): Int = {
     val unread = for (
-      row <- rows if row.recipient === recipient && row.unread
+      row <- rows if row.recipient === recipient && row.unread && row.kind =!= "legacy_notification"
     ) yield row
     val unreadCount = unread.length
     unreadCount.run
@@ -106,7 +106,7 @@ class NotificationRepoImpl @Inject() (
 
   def getUnreadNotificationsCountForKind(recipient: Recipient, kind: String)(implicit session: RSession): Int = {
     val unread = for (
-      row <- rows if row.recipient === recipient && row.kind === kind && row.unread
+      row <- rows if row.recipient === recipient && row.kind === kind && row.unread && row.kind =!= "legacy_notification"
     ) yield row
     val unreadCount = unread.length
     unreadCount.run
@@ -114,7 +114,7 @@ class NotificationRepoImpl @Inject() (
 
   def getUnreadNotificationsCountExceptKind(recipient: Recipient, kind: String)(implicit session: RSession): Int = {
     val unread = for (
-      row <- rows if row.recipient === recipient && row.kind =!= kind && row.unread
+      row <- rows if row.recipient === recipient && row.kind =!= kind && row.unread && row.kind =!= "legacy_notification"
     ) yield row
     val unreadCount = unread.length
     unreadCount.run
@@ -122,14 +122,14 @@ class NotificationRepoImpl @Inject() (
 
   def setAllReadBefore(recipient: Recipient, time: DateTime)(implicit session: RWSession): Unit = {
     val q = for (
-      row <- rows if row.recipient === recipient && row.unread && row.lastEvent < time
+      row <- rows if row.recipient === recipient && row.unread && row.lastEvent < time && row.kind =!= "legacy_notification"
     ) yield row.lastChecked
     q.update(Some(clock.now()))
   }
 
   def getNotificationsForPage(recipient: Recipient, nUri: Id[NormalizedURI], howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient
+      notif <- rows if notif.recipient === recipient && notif.kind =!= "legacy_notification"
       userThread <- userThreadRepoImpl.rows if userThread.notificationId === notif.id && userThread.uriId === nUri
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
@@ -137,7 +137,7 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsForPageBefore(recipient: Recipient, nUri: Id[NormalizedURI], time: DateTime, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.lastEvent < time
+      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= "legacy_notification"
       userThread <- userThreadRepoImpl.rows if userThread.notificationId === notif.id && userThread.uriId === nUri
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
@@ -145,7 +145,7 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsForSentMessages(recipient: Recipient, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient
+      notif <- rows if notif.recipient === recipient && notif.kind =!= "legacy_notification"
       userThread <- userThreadRepoImpl.rows if userThread.notificationId === notif.id && userThread.started
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
@@ -153,7 +153,7 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsForSentMessagesBefore(recipient: Recipient, time: DateTime, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.lastEvent < time
+      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= "legacy_notification"
       userThread <- userThreadRepoImpl.rows if userThread.notificationId === notif.id && userThread.started
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
@@ -161,28 +161,28 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsWithNewEvents(recipient: Recipient, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.hasNewEvent
+      notif <- rows if notif.recipient === recipient && notif.hasNewEvent && notif.kind =!= "legacy_notification"
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
   }
 
   def getNotificationsWithNewEventsBefore(recipient: Recipient, time: DateTime, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.hasNewEvent
+      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.hasNewEvent && notif.kind =!= "legacy_notification"
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
   }
 
   def getLatestNotifications(recipient: Recipient, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient
+      notif <- rows if notif.recipient === recipient && notif.kind =!= "legacy_notification"
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
   }
 
   def getLatestNotificationsBefore(recipient: Recipient, time: DateTime, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.lastEvent < time
+      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= "legacy_notification"
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NotificationRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NotificationRepo.scala
@@ -90,7 +90,7 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsWithNewEventsCount(recipient: Recipient)(implicit session: RSession): Int = {
     val unread = for (
-      row <- rows if row.recipient === recipient && row.hasNewEvent && row.kind =!= "legacy_notification"
+      row <- rows if row.recipient === recipient && row.hasNewEvent && row.kind =!= "legacy"
     ) yield row
     val unreadCount = unread.length
     unreadCount.run
@@ -98,7 +98,7 @@ class NotificationRepoImpl @Inject() (
 
   def getUnreadNotificationsCount(recipient: Recipient)(implicit session: RSession): Int = {
     val unread = for (
-      row <- rows if row.recipient === recipient && row.unread && row.kind =!= "legacy_notification"
+      row <- rows if row.recipient === recipient && row.unread && row.kind =!= "legacy"
     ) yield row
     val unreadCount = unread.length
     unreadCount.run
@@ -106,7 +106,7 @@ class NotificationRepoImpl @Inject() (
 
   def getUnreadNotificationsCountForKind(recipient: Recipient, kind: String)(implicit session: RSession): Int = {
     val unread = for (
-      row <- rows if row.recipient === recipient && row.kind === kind && row.unread && row.kind =!= "legacy_notification"
+      row <- rows if row.recipient === recipient && row.kind === kind && row.unread && row.kind =!= "legacy"
     ) yield row
     val unreadCount = unread.length
     unreadCount.run
@@ -114,7 +114,7 @@ class NotificationRepoImpl @Inject() (
 
   def getUnreadNotificationsCountExceptKind(recipient: Recipient, kind: String)(implicit session: RSession): Int = {
     val unread = for (
-      row <- rows if row.recipient === recipient && row.kind =!= kind && row.unread && row.kind =!= "legacy_notification"
+      row <- rows if row.recipient === recipient && row.kind =!= kind && row.unread && row.kind =!= "legacy"
     ) yield row
     val unreadCount = unread.length
     unreadCount.run
@@ -122,14 +122,14 @@ class NotificationRepoImpl @Inject() (
 
   def setAllReadBefore(recipient: Recipient, time: DateTime)(implicit session: RWSession): Unit = {
     val q = for (
-      row <- rows if row.recipient === recipient && row.unread && row.lastEvent < time && row.kind =!= "legacy_notification"
+      row <- rows if row.recipient === recipient && row.unread && row.lastEvent < time && row.kind =!= "legacy"
     ) yield row.lastChecked
     q.update(Some(clock.now()))
   }
 
   def getNotificationsForPage(recipient: Recipient, nUri: Id[NormalizedURI], howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.kind =!= "legacy_notification"
+      notif <- rows if notif.recipient === recipient && notif.kind =!= "legacy"
       userThread <- userThreadRepoImpl.rows if userThread.notificationId === notif.id && userThread.uriId === nUri
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
@@ -137,7 +137,7 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsForPageBefore(recipient: Recipient, nUri: Id[NormalizedURI], time: DateTime, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= "legacy_notification"
+      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= "legacy"
       userThread <- userThreadRepoImpl.rows if userThread.notificationId === notif.id && userThread.uriId === nUri
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
@@ -145,7 +145,7 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsForSentMessages(recipient: Recipient, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.kind =!= "legacy_notification"
+      notif <- rows if notif.recipient === recipient && notif.kind =!= "legacy"
       userThread <- userThreadRepoImpl.rows if userThread.notificationId === notif.id && userThread.started
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
@@ -153,7 +153,7 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsForSentMessagesBefore(recipient: Recipient, time: DateTime, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= "legacy_notification"
+      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= "legacy"
       userThread <- userThreadRepoImpl.rows if userThread.notificationId === notif.id && userThread.started
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
@@ -161,28 +161,28 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsWithNewEvents(recipient: Recipient, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.hasNewEvent && notif.kind =!= "legacy_notification"
+      notif <- rows if notif.recipient === recipient && notif.hasNewEvent && notif.kind =!= "legacy"
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
   }
 
   def getNotificationsWithNewEventsBefore(recipient: Recipient, time: DateTime, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.hasNewEvent && notif.kind =!= "legacy_notification"
+      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.hasNewEvent && notif.kind =!= "legacy"
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
   }
 
   def getLatestNotifications(recipient: Recipient, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.kind =!= "legacy_notification"
+      notif <- rows if notif.recipient === recipient && notif.kind =!= "legacy"
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
   }
 
   def getLatestNotificationsBefore(recipient: Recipient, time: DateTime, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= "legacy_notification"
+      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= "legacy"
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NotificationRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NotificationRepo.scala
@@ -6,6 +6,7 @@ import com.keepit.common.db.slick.DBSession.{ RWSession, RSession }
 import com.keepit.common.db.slick._
 import com.keepit.common.time._
 import com.keepit.model.{ NormalizedURI, User }
+import com.keepit.notify.model.event.LegacyNotification
 import com.keepit.notify.model.{ Recipient, NKind }
 import org.joda.time.DateTime
 
@@ -90,7 +91,7 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsWithNewEventsCount(recipient: Recipient)(implicit session: RSession): Int = {
     val unread = for (
-      row <- rows if row.recipient === recipient && row.hasNewEvent && row.kind =!= "legacy"
+      row <- rows if row.recipient === recipient && row.hasNewEvent && row.kind =!= LegacyNotification.name
     ) yield row
     val unreadCount = unread.length
     unreadCount.run
@@ -98,7 +99,7 @@ class NotificationRepoImpl @Inject() (
 
   def getUnreadNotificationsCount(recipient: Recipient)(implicit session: RSession): Int = {
     val unread = for (
-      row <- rows if row.recipient === recipient && row.unread && row.kind =!= "legacy"
+      row <- rows if row.recipient === recipient && row.unread && row.kind =!= LegacyNotification.name
     ) yield row
     val unreadCount = unread.length
     unreadCount.run
@@ -106,7 +107,7 @@ class NotificationRepoImpl @Inject() (
 
   def getUnreadNotificationsCountForKind(recipient: Recipient, kind: String)(implicit session: RSession): Int = {
     val unread = for (
-      row <- rows if row.recipient === recipient && row.kind === kind && row.unread && row.kind =!= "legacy"
+      row <- rows if row.recipient === recipient && row.kind === kind && row.unread && row.kind =!= LegacyNotification.name
     ) yield row
     val unreadCount = unread.length
     unreadCount.run
@@ -114,7 +115,7 @@ class NotificationRepoImpl @Inject() (
 
   def getUnreadNotificationsCountExceptKind(recipient: Recipient, kind: String)(implicit session: RSession): Int = {
     val unread = for (
-      row <- rows if row.recipient === recipient && row.kind =!= kind && row.unread && row.kind =!= "legacy"
+      row <- rows if row.recipient === recipient && row.kind =!= kind && row.unread && row.kind =!= LegacyNotification.name
     ) yield row
     val unreadCount = unread.length
     unreadCount.run
@@ -122,14 +123,14 @@ class NotificationRepoImpl @Inject() (
 
   def setAllReadBefore(recipient: Recipient, time: DateTime)(implicit session: RWSession): Unit = {
     val q = for (
-      row <- rows if row.recipient === recipient && row.unread && row.lastEvent < time && row.kind =!= "legacy"
+      row <- rows if row.recipient === recipient && row.unread && row.lastEvent < time && row.kind =!= LegacyNotification.name
     ) yield row.lastChecked
     q.update(Some(clock.now()))
   }
 
   def getNotificationsForPage(recipient: Recipient, nUri: Id[NormalizedURI], howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.kind =!= "legacy"
+      notif <- rows if notif.recipient === recipient && notif.kind =!= LegacyNotification.name
       userThread <- userThreadRepoImpl.rows if userThread.notificationId === notif.id && userThread.uriId === nUri
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
@@ -137,7 +138,7 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsForPageBefore(recipient: Recipient, nUri: Id[NormalizedURI], time: DateTime, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= "legacy"
+      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= LegacyNotification.name
       userThread <- userThreadRepoImpl.rows if userThread.notificationId === notif.id && userThread.uriId === nUri
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
@@ -145,7 +146,7 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsForSentMessages(recipient: Recipient, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.kind =!= "legacy"
+      notif <- rows if notif.recipient === recipient && notif.kind =!= LegacyNotification.name
       userThread <- userThreadRepoImpl.rows if userThread.notificationId === notif.id && userThread.started
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
@@ -153,7 +154,7 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsForSentMessagesBefore(recipient: Recipient, time: DateTime, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= "legacy"
+      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= LegacyNotification.name
       userThread <- userThreadRepoImpl.rows if userThread.notificationId === notif.id && userThread.started
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
@@ -161,28 +162,28 @@ class NotificationRepoImpl @Inject() (
 
   def getNotificationsWithNewEvents(recipient: Recipient, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.hasNewEvent && notif.kind =!= "legacy"
+      notif <- rows if notif.recipient === recipient && notif.hasNewEvent && notif.kind =!= LegacyNotification.name
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
   }
 
   def getNotificationsWithNewEventsBefore(recipient: Recipient, time: DateTime, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.hasNewEvent && notif.kind =!= "legacy"
+      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.hasNewEvent && notif.kind =!= LegacyNotification.name
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
   }
 
   def getLatestNotifications(recipient: Recipient, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.kind =!= "legacy"
+      notif <- rows if notif.recipient === recipient && notif.kind =!= LegacyNotification.name
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
   }
 
   def getLatestNotificationsBefore(recipient: Recipient, time: DateTime, howMany: Int)(implicit session: RSession): Seq[Notification] = {
     val q = for {
-      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= "legacy"
+      notif <- rows if notif.recipient === recipient && notif.lastEvent < time && notif.kind =!= LegacyNotification.name
     } yield notif
     q.sortBy(_.lastEvent.desc).take(howMany).list
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThread.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThread.scala
@@ -2,6 +2,7 @@ package com.keepit.eliza.model
 
 import com.keepit.common.time._
 import com.keepit.common.db.{ Model, Id }
+import com.keepit.eliza.model.UserThreadRepo.RawNotification
 import com.keepit.model.{ User, NormalizedURI }
 
 import play.api.libs.json._
@@ -43,6 +44,8 @@ case class UserThread(
   lazy val summary = s"UserThread[id = $id, created = $createdAt, update = $updateAt, user = $user, thread = $threadId, " +
     s"uriId = $uriId, lastSeen = $lastSeen, unread = $unread, notificationUpdatedAt = $notificationUpdatedAt, " +
     s"notificationLastSeen = $notificationLastSeen, notificationEmailed = $notificationEmailed, replyable = $replyable]"
+
+  def toRawNotification: RawNotification = (lastNotification, unread, uriId)
 }
 
 object UserThread {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
@@ -124,8 +124,7 @@ trait UserThreadRepo extends Repo[UserThread] with RepoWithDelete[UserThread] {
 class UserThreadRepoImpl @Inject() (
     val clock: Clock,
     val db: DataBaseComponent,
-    userThreadStatsForUserIdCache: UserThreadStatsForUserIdCache,
-    notificationRepoImpl: NotificationRepoImpl) extends UserThreadRepo with DbRepo[UserThread] with DbRepoWithDelete[UserThread] with MessagingTypeMappers with Logging {
+    userThreadStatsForUserIdCache: UserThreadStatsForUserIdCache) extends UserThreadRepo with DbRepo[UserThread] with DbRepoWithDelete[UserThread] with MessagingTypeMappers with Logging {
 
   import db.Driver.simple._
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
@@ -528,9 +528,9 @@ class UserThreadRepoImpl @Inject() (
     import com.keepit.common.db.slick.StaticQueryFixed.interpolation
     sql"""
        select id, user_id, last_notification, notification_pending, uri_id from user_thread
-       where user_thread.replyable = FALSE and uri_id is null and last_notification != "null" and not exists (
+       where user_thread.replyable = FALSE and uri_id is null and last_notification != 'null' and not exists (
          select * from notification where recipient = concat('user|', user_thread.user_id)
-         and kind = "legacy_notification" and convert(group_identifier, unsigned integer) = user_thread.id
+         and kind = 'legacy' and convert(group_identifier, signed) = user_thread.id
        ) limit 500;
       """.as[(Id[UserThread], Id[User], JsValue, Boolean, Option[Id[NormalizedURI]])].list
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/LegacyNotificationCheck.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/LegacyNotificationCheck.scala
@@ -10,7 +10,7 @@ import com.keepit.notify.model.{ EmailRecipient, Recipient, UserRecipient }
 import com.keepit.shoebox.ShoeboxServiceClient
 import play.api.{ Mode, Play }
 
-import scala.concurrent.{ExecutionContext, Future, Await}
+import scala.concurrent.{ ExecutionContext, Future, Await }
 import scala.concurrent.duration._
 
 /**

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/LegacyNotificationCheck.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/LegacyNotificationCheck.scala
@@ -66,6 +66,13 @@ class LegacyNotificationCheck @Inject() (
     notifOpt.fold(doElse) { notif => doIfExists(notif) }
   }
 
+  def ifNotifExistsReturn[A](potentialNotifId: String)(doIfExists: Notification => A)(doElse: => A): A = {
+    val notifOpt = db.readOnlyMaster { implicit session =>
+      ExternalId.asOpt[Notification](potentialNotifId).flatMap { id => notificationRepo.getOpt(id) }
+    }
+    notifOpt.fold(doElse) { notif => doIfExists(notif) }
+  }
+
   def ifNotifItemExists(potentialItemId: String)(doIfExists: (Notification, NotificationItem) => Unit)(doElse: => Unit): Unit = {
     val notifItemOpt = db.readOnlyMaster { implicit session =>
       ExternalId.asOpt[NotificationItem](potentialItemId).flatMap { id =>

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationBackfiller.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationBackfiller.scala
@@ -1,0 +1,55 @@
+package com.keepit.notify
+
+import akka.actor.Actor.Receive
+import com.google.inject.{ImplementedBy, Inject}
+import com.keepit.common.actor.ActorInstance
+import com.keepit.common.akka.FortyTwoActor
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.plugin.{SchedulingProperties, SchedulerPlugin}
+import com.keepit.eliza.commanders.NotificationCommander
+import com.keepit.eliza.model.UserThreadRepo
+import com.keepit.notify.NotificationBackfiller.BackfillNotifications
+import play.api.Play
+import scala.concurrent.duration._
+
+@ImplementedBy[NotificationBackfillerPluginImpl]
+trait NotificationBackfillerPlugin extends SchedulerPlugin {
+
+
+}
+
+class NotificationBackfillerPluginImpl @Inject() (
+  actor: ActorInstance[NotificationBackfiller],
+  override val scheduling: SchedulingProperties
+) extends NotificationBackfillerPlugin {
+
+  override def onStart() {
+    for (app <- Play.maybeApplication) {
+      val (initDelay, freq) = if (Play.isDev) (15 seconds, 15 seconds) else (5 minutes, 3 minutes)
+      log.info(s"[onStart] NotificationBackfillerPlugin started with initDelay=$initDelay freq=$freq")
+      scheduleTaskOnOneMachine(actor.system, initDelay, freq, actor.ref, BackfillNotifications, BackfillNotifications.getClass.getName)
+    }
+  }
+
+}
+
+class NotificationBackfiller @Inject() (
+  airbrake: AirbrakeNotifier,
+  db: Database,
+  userThreadRepo: UserThreadRepo,
+  notificationCommander: NotificationCommander
+) extends FortyTwoActor(airbrake) {
+  override def receive: Receive = {
+    case BackfillNotifications =>
+      val needBackfilling = db.readOnlyMaster { implicit session =>
+        
+      }
+  }
+}
+
+object NotificationBackfiller {
+
+  case object BackfillNotifications
+
+}

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationBackfiller.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationBackfiller.scala
@@ -25,6 +25,7 @@ class NotificationBackfillerPluginImpl @Inject() (
     implicit val application: Application,
     override val scheduling: SchedulingProperties) extends NotificationBackfillerPlugin {
 
+  override def enabled: Boolean = true
   override def onStart() {
     for (app <- Play.maybeApplication) {
       val (initDelay, freq) = if (Play.isDev) (15 seconds, 15 seconds) else (5 minutes, 3 minutes)

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationBackfiller.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationBackfiller.scala
@@ -1,28 +1,29 @@
 package com.keepit.notify
 
 import akka.actor.Actor.Receive
-import com.google.inject.{ImplementedBy, Inject}
+import com.google.inject.{ ImplementedBy, Inject }
 import com.keepit.common.actor.ActorInstance
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
-import com.keepit.common.plugin.{SchedulingProperties, SchedulerPlugin}
+import com.keepit.common.net.{ DirectUrl, HttpClient }
+import com.keepit.common.plugin.{ SchedulingProperties, SchedulerPlugin }
 import com.keepit.eliza.commanders.NotificationCommander
 import com.keepit.eliza.model.UserThreadRepo
 import com.keepit.notify.NotificationBackfiller.BackfillNotifications
-import play.api.Play
+import play.api.{ Application, Play }
+import play.api.libs.json.Json
 import scala.concurrent.duration._
 
-@ImplementedBy[NotificationBackfillerPluginImpl]
+@ImplementedBy(classOf[NotificationBackfillerPluginImpl])
 trait NotificationBackfillerPlugin extends SchedulerPlugin {
-
 
 }
 
 class NotificationBackfillerPluginImpl @Inject() (
-  actor: ActorInstance[NotificationBackfiller],
-  override val scheduling: SchedulingProperties
-) extends NotificationBackfillerPlugin {
+    actor: ActorInstance[NotificationBackfiller],
+    implicit val application: Application,
+    override val scheduling: SchedulingProperties) extends NotificationBackfillerPlugin {
 
   override def onStart() {
     for (app <- Play.maybeApplication) {
@@ -35,15 +36,24 @@ class NotificationBackfillerPluginImpl @Inject() (
 }
 
 class NotificationBackfiller @Inject() (
-  airbrake: AirbrakeNotifier,
-  db: Database,
-  userThreadRepo: UserThreadRepo,
-  notificationCommander: NotificationCommander
-) extends FortyTwoActor(airbrake) {
+    airbrake: AirbrakeNotifier,
+    db: Database,
+    httpClient: HttpClient,
+    userThreadRepo: UserThreadRepo,
+    notificationCommander: NotificationCommander) extends FortyTwoActor(airbrake) {
   override def receive: Receive = {
     case BackfillNotifications =>
       val needBackfilling = db.readOnlyMaster { implicit session =>
-        
+        userThreadRepo.getThreadsThatNeedBackfilling()
+      }
+      needBackfilling.foreach {
+        case (userThreadId, userId, lastNotif, pending, uriId) =>
+          val rawNotif = (lastNotif, pending, uriId)
+          notificationCommander.backfillLegacyNotificationsFor(userId, Seq(rawNotif)).foreach { items =>
+            httpClient.post(DirectUrl("https://hooks.slack.com/services/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"), Json.obj(
+              "text" -> s"Backfilled user thread $userThreadId to notif ${items.notification.id.get}"
+            ))
+          }
       }
   }
 }

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationProcessing.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/NotificationProcessing.scala
@@ -63,7 +63,7 @@ class NotificationProcessing @Inject() (
     }
   }
 
-  def processNewEvent(event: NotificationEvent): Notification = {
+  def processNewEvent(event: NotificationEvent, tryDeliver: Boolean = true): Notification = {
     val groupIdentifier = getGroupIdentifier(event)
     val notif = groupIdentifier match {
       case Some(identifier) =>
@@ -92,8 +92,10 @@ class NotificationProcessing @Inject() (
     val items = db.readOnlyMaster { implicit session =>
       notificationItemRepo.getAllForNotification(notif.id.get)
     }.toSet
-    legacyNotificationCheck.ifUserExperiment(notif.recipient) { recipient =>
-      delivery.deliver(recipient, NotificationWithItems(notif, items))
+    if (tryDeliver) {
+      legacyNotificationCheck.ifUserExperiment(notif.recipient) { recipient =>
+        delivery.deliver(recipient, NotificationWithItems(notif, items))
+      }
     }
     notif
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/NotificationJsonFormat.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/NotificationJsonFormat.scala
@@ -127,7 +127,7 @@ class NotificationJsonFormat @Inject() (
             "url" -> messageThread.nUrl,
             "title" -> messageThread.pageTitle,
             "author" -> sender,
-            "locator" -> ("/messages/" + messageThread.externalId.id),
+            "locator" -> ("/messages/" + notif.externalId),
             "unread" -> notif.unread,
             "category" -> NotificationCategory.User.MESSAGE.category,
             "firstAuthor" -> originalAuthor,

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/NotificationJsonFormat.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/NotificationJsonFormat.scala
@@ -237,6 +237,7 @@ class NotificationJsonFormat @Inject() (
           (author, participants) <- participantsF
           basicFormat <- basicFormatF
         } yield {
+          val fullParticipants = participants + author
           val unreadJson =
             if (notif.unread)
               Json.obj(
@@ -252,10 +253,10 @@ class NotificationJsonFormat @Inject() (
               )
 
           val participantsJson =
-            if (participants.isEmpty)
+            if (fullParticipants.isEmpty)
               Json.obj()
             else
-              Json.obj("participants" -> participants)
+              Json.obj("participants" -> fullParticipants)
 
           val uriSummaryJson = uriSummary.fold(Json.obj()) { summary =>
             val image = summary.images.get(idealImageSize)

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/NotificationJsonFormat.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/NotificationJsonFormat.scala
@@ -2,10 +2,10 @@ package com.keepit.notify.delivery
 
 import com.google.inject.Inject
 import com.keepit.common.JsObjectExtensionOps
-import com.keepit.common.db.Id
+import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.store.{ S3ImageConfig, ImageSize }
-import com.keepit.eliza.commanders.{ MessageWithBasicUser, NotificationCommander, NotificationJsonMaker }
+import com.keepit.eliza.commanders.{ MessageFetchingCommander, MessageWithBasicUser, NotificationCommander, NotificationJsonMaker }
 import com.keepit.eliza.model.UserThreadRepo.RawNotification
 import com.keepit.eliza.model._
 import com.keepit.model.{ NotificationCategory, NormalizedURI }
@@ -27,6 +27,7 @@ class NotificationJsonFormat @Inject() (
     db: Database,
     shoeboxServiceClient: ShoeboxServiceClient,
     elizaS3ExternalIdImageStore: ElizaS3ExternalIdImageStore,
+    messageFetchingCommander: MessageFetchingCommander,
     notificationJsonMaker: NotificationJsonMaker,
     messageThreadRepo: MessageThreadRepo,
     messageRepo: MessageRepo,
@@ -53,6 +54,42 @@ class NotificationJsonFormat @Inject() (
       case NotificationWithInfo(notif, items, MessageNotificationInfo(messages)) =>
         val mostRecent = messages.maxBy(_.time)
         messageInfo(notifWithInfo, mostRecent)
+    }
+  }
+
+  def threadMessagesInfo(notifWithInfo: NotificationWithInfo): Future[JsObject] = {
+    notifWithInfo match {
+      case NotificationWithInfo(notif, items, MessageNotificationInfo(newMessages)) =>
+        val messageThreadId = Id[MessageThread](newMessages.head.messageThreadId)
+        val (messageThread, messages) = db.readOnlyMaster { implicit session =>
+          (messageThreadRepo.get(messageThreadId), messageRepo.get(messageThreadId, 0))
+        }
+        val itemIdsByMessageId = items.map(i => i -> i.event).collect {
+          case (i, e: NewMessage) => Id[Message](e.messageId) -> ExternalId[Message](i.externalId.id)
+        }.toMap
+        shoeboxServiceClient.getBasicUsers(messages.map(_.from.asUser).collect { case Some(id) => id }).flatMap { users =>
+          Future.sequence(messages.map { message =>
+            messageFetchingCommander.getMessageWithBasicUser(
+              itemIdsByMessageId(message.id.get),
+              message.createdAt,
+              message.messageText,
+              message.source,
+              message.auxData,
+              messageThread.url.getOrElse(""),
+              messageThread.nUrl.getOrElse(""),
+              message.from.asUser.flatMap(id => users.get(id)),
+              Seq()
+            )
+          })
+        }.map { messagesBasicUsers =>
+          val messagesJson = Json.toJson(messagesBasicUsers)
+          val url: String = messageThread.url.getOrElse("")
+          Json.obj(
+            "id" -> notif.externalId,
+            "url" -> url,
+            "messages" -> messagesJson
+          )
+        }
     }
   }
 

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/NotificationJsonFormat.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/NotificationJsonFormat.scala
@@ -67,7 +67,9 @@ class NotificationJsonFormat @Inject() (
         val itemIdsByMessageId = items.map(i => i -> i.event).collect {
           case (i, e: NewMessage) => Id[Message](e.messageId) -> ExternalId[Message](i.externalId.id)
         }.toMap
-        shoeboxServiceClient.getBasicUsers(messages.map(_.from.asUser).collect { case Some(id) => id }).flatMap { users =>
+        val userIds = messages.map(_.from.asUser).collect { case Some(id) => id }
+        val basicUsers = shoeboxServiceClient.getBasicUsers(userIds)
+        basicUsers.flatMap { users =>
           Future.sequence(messages.map { message =>
             messageFetchingCommander.getMessageWithBasicUser(
               itemIdsByMessageId(message.id.get),

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/NotificationJsonFormat.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/NotificationJsonFormat.scala
@@ -151,8 +151,10 @@ class NotificationJsonFormat @Inject() (
             "time" -> relevantItem.eventTime,
             "thread" -> notif.externalId,
             "unread" -> Json.toJson(notif.unread),
-            "category" -> "triggered",
-            "fullCategory" -> "replace me", // todo replace
+            "category" -> Json.toJson(
+              NotificationCategory.User.kifiMessageFormattingCategory.getOrElse(info.category, "global")
+            ),
+            "fullCategory" -> info.category.category, // todo replace
             "title" -> info.title,
             "bodyHtml" -> info.body,
             "linkText" -> info.linkText,

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/WsNotificationDelivery.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/WsNotificationDelivery.scala
@@ -25,7 +25,7 @@ class WsNotificationDelivery @Inject() (
 
   def deliver(recipient: Recipient, notif: NotificationWithItems): Future[Unit] = {
     notificationInfoGenerator.generateInfo(Seq(notif)).flatMap { infos =>
-      elizaNotificationInfo.basicJson(infos.head).map { notifJson =>
+      elizaNotificationInfo.extendedJson(infos.head).map { notifJson =>
         legacyNotificationCheck.ifUserExperiment(recipient) {
           case UserRecipient(user, _) => notificationRouter.sendToUser(user, Json.arr("notification", notifJson.json))
           case _ =>

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/WsNotificationDelivery.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/WsNotificationDelivery.scala
@@ -17,7 +17,6 @@ import scala.util.Try
 
 class WsNotificationDelivery @Inject() (
     shoeboxServiceClient: ShoeboxServiceClient,
-    deliveryCommander: NotificationDeliveryCommander,
     notificationRouter: WebSocketRouter,
     legacyNotificationCheck: LegacyNotificationCheck,
     notificationInfoGenerator: NotificationInfoGenerator,

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/info/NotificationKindInfoRequests.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/info/NotificationKindInfoRequests.scala
@@ -3,7 +3,7 @@ package com.keepit.notify.info
 import com.google.inject.{Inject, Singleton}
 import com.keepit.common.path.Path
 import com.keepit.eliza.model.{Notification, NotificationItem}
-import com.keepit.model.LibraryAccess
+import com.keepit.model.{NotificationCategory, LibraryAccess}
 import com.keepit.notify.model.NotificationKind
 import com.keepit.notify.model.event._
 import play.api.libs.json.Json
@@ -67,7 +67,7 @@ class NotificationKindInfoRequests @Inject() () {
         extraJson = Some(Json.obj(
           "friend" -> inviter
         )),
-        category = None
+        category = NotificationCategory.User.FRIEND_REQUEST
       )
     }
   }
@@ -86,7 +86,7 @@ class NotificationKindInfoRequests @Inject() () {
         extraJson = Some(Json.obj(
           "friend" -> accepter
         )),
-        category = None
+        category = NotificationCategory.User.FRIEND_ACCEPTED
       )
     }
   }
@@ -112,7 +112,8 @@ class NotificationKindInfoRequests @Inject() () {
             "id" -> newKeep.id,
             "url" -> newKeep.url
           )
-        ))
+        )),
+        category = NotificationCategory.User.NEW_KEEP
       )
     }
   }
@@ -138,7 +139,8 @@ class NotificationKindInfoRequests @Inject() () {
             "id" -> newKeep.id,
             "url" -> newKeep.url
           )
-        ))
+        )),
+        category = NotificationCategory.User.NEW_KEEP
       )
     }
   }
@@ -159,7 +161,7 @@ class NotificationKindInfoRequests @Inject() () {
           "follower" -> accepter,
           "library" -> Json.toJson(invitedLib)
         )),
-        category = None
+        category = NotificationCategory.User.LIBRARY_FOLLOWED
       )
     }
   }
@@ -180,7 +182,7 @@ class NotificationKindInfoRequests @Inject() () {
           "follower" -> accepter,
           "library" -> Json.toJson(acceptedLib)
         )),
-        category = None
+        category = NotificationCategory.User.LIBRARY_FOLLOWED
       )
     }
   }
@@ -202,7 +204,8 @@ class NotificationKindInfoRequests @Inject() () {
           "inviter" -> inviter,
           "library" -> Json.toJson(invitedLib),
           "access" -> LibraryAccess.READ_WRITE
-        ))
+        )),
+        category = NotificationCategory.User.LIBRARY_INVITATION
       )
     }
   }
@@ -224,7 +227,8 @@ class NotificationKindInfoRequests @Inject() () {
           "inviter" -> inviter,
           "library" -> Json.toJson(invitedLib),
           "access" -> LibraryAccess.READ_ONLY
-        ))
+        )),
+        category = NotificationCategory.User.LIBRARY_INVITATION
       )
     }
   }
@@ -238,7 +242,8 @@ class NotificationKindInfoRequests @Inject() () {
         image = PublicImage("http://i.imgur.com/qs8QofA.png"),
         title = s"${plural("A robot")} just grumbled! ${plural("He")} must be depressed...",
         body = s"${NotificationEnglish.englishJoin(events.toSeq.map(_.robotName))} just grumbled about ${NotificationEnglish.englishJoin(events.toSeq.map(_.grumblingAbout))}",
-        linkText = "Organize and share knowledge with Kifi!"
+        linkText = "Organize and share knowledge with Kifi!",
+        category = NotificationCategory.System.ADMIN
       )
     }
   }
@@ -255,7 +260,8 @@ class NotificationKindInfoRequests @Inject() () {
         image = UserImage(inviter),
         title = s"${inviter.firstName} ${inviter.lastName} invited you to join ${invitedOrg.abbreviatedName}!",
         body = s"Help ${invitedOrg.abbreviatedName} by sharing your knowledge with them.",
-        linkText = "Visit organization"
+        linkText = "Visit organization",
+        category = NotificationCategory.User.ORGANIZATION_INVITATION
       )
     }
   }
@@ -276,7 +282,8 @@ class NotificationKindInfoRequests @Inject() () {
         extraJson = Some(Json.obj(
           "member" -> accepter,
           "organization" -> Json.toJson(acceptedOrg)
-        ))
+        )),
+        category = NotificationCategory.User.ORGANIZATION_JOINED
       )
     }
   }
@@ -299,7 +306,7 @@ class NotificationKindInfoRequests @Inject() () {
           "inviter" -> inviter,
           "library" -> Json.toJson(libraryInvited)
         )),
-        category = None
+        category = NotificationCategory.User.LIBRARY_FOLLOWED
       )
     }
   }
@@ -322,7 +329,7 @@ class NotificationKindInfoRequests @Inject() () {
           "inviter" -> inviter,
           "library" -> Json.toJson(libraryInvited)
         )),
-        category = None
+        category = NotificationCategory.User.LIBRARY_FOLLOWED
       )
     }
   }
@@ -343,7 +350,7 @@ class NotificationKindInfoRequests @Inject() () {
           "follower" -> follower,
           "library" -> Json.toJson(libraryFollowed)
         )),
-        category = None
+        category = NotificationCategory.User.LIBRARY_FOLLOWED
       )
     }
   }
@@ -364,7 +371,7 @@ class NotificationKindInfoRequests @Inject() () {
           "follower" -> collaborator, // the mobile clients read it like this
           "library" -> Json.toJson(libraryCollaborating)
         )),
-        category = None
+        category = NotificationCategory.User.LIBRARY_FOLLOWED
       )
     }
   }
@@ -383,7 +390,7 @@ class NotificationKindInfoRequests @Inject() () {
         extraJson = Some(Json.obj(
           "friend" -> friend
         )),
-        category = None
+        category = NotificationCategory.User.SOCIAL_FRIEND_JOINED
       )
     }
   }
@@ -400,7 +407,7 @@ class NotificationKindInfoRequests @Inject() () {
         body = s"To discover ${joiner.firstName}’s public keeps while searching, get connected! Invite ${joiner.firstName} to connect on Kifi »",
         linkText = s"Invite ${joiner.firstName} to connect",
         extraJson = None,
-        category = None
+        category = NotificationCategory.User.CONTACT_JOINED
       )
     }
   }

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/FortyTwoGenericTypeMappers.scala
@@ -267,4 +267,5 @@ trait FortyTwoGenericTypeMappers { self: { val db: DataBaseComponent } =>
   implicit def getOptVersionNumberResult[T] = getResultOptionFromMapper[VersionNumber[T]]
   implicit val getOptDurationResult = getResultOptionFromMapper[Duration]
   implicit val getUrlHashResult = getResultFromMapper[UrlHash]
+  implicit val getJsValueResult = getResultFromMapper[JsValue]
 }


### PR DESCRIPTION
I decided to narrow the scope a bit and take out the stuff dealing with message chats. Now the system only works with notifications, but it is functional and finished. It's ready for us to turn on the experiment and QA it. I also added a backfill plugin that will run over the DB and backfill legacy notifications so we can take out non-replyable message threads and users when it finishes.
