### PR TITLE
Fix feed in safari and delighted display

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/delighted/delighted.styl
+++ b/kifi-backend/modules/shoebox/angular/src/delighted/delighted.styl
@@ -2,6 +2,7 @@
   max-height: 200px
   overflow: hidden
   flex: 1 100%
+  max-width: 1024px
   margin: 0 10%
 
   &.ng-leave

--- a/kifi-backend/modules/shoebox/angular/src/home/home.styl
+++ b/kifi-backend/modules/shoebox/angular/src/home/home.styl
@@ -10,12 +10,14 @@
     align-items: initial
     flex-direction: row
     flex-flow: row wrap
-    flex-wrap: nowrap
 
 .kf-home-items
   max-width: 600px
   width: 100%
   margin-top: 20px
+
+  @media (min-width: appMinWidth)
+    width: 75%
 
   .kf-feed-items
     width: auto


### PR DESCRIPTION
@adamjgrant Derek mentioned delighted was showing up funny, which I knew resulted from our row-wrap fix earlier. I went ahead and knocked it out
