### PR TITLE
Quick fix to remaining bug with keep card widget

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepToLibraryWidget.tpl.html
@@ -61,6 +61,7 @@
         kf-org-selector
         library-props="libraryProps"
         library="newLibrary"
+        space="{}"
       >
       </div>
     </div>


### PR DESCRIPTION
Suppresses `undefined` warning for keep to library widget
