### PR TITLE
Made KeepChecker log errors instead of airbraking

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/KeepChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/KeepChecker.scala
@@ -60,13 +60,13 @@ class KeepChecker @Inject() (
     val allKtls = ktlRepo.getAllByKeepId(keepId, excludeStateOpt = None)
     for (ktu <- allKtus) {
       if (ktu.uriId != keep.uriId) {
-        airbrake.notify(s"[KTU-URI-MATCH] KTU ${ktu.id.get}'s URI Id (${ktu.uriId}) does not match keep ${keep.id.get}'s URI id (${keep.uriId})")
+        log.error(s"[KTU-URI-MATCH] KTU ${ktu.id.get}'s URI Id (${ktu.uriId}) does not match keep ${keep.id.get}'s URI id (${keep.uriId})")
         ktuCommander.syncWithKeep(ktu, keep)
       }
     }
     for (ktl <- allKtls) {
       if (ktl.uriId != keep.uriId) {
-        airbrake.notify(s"[KTL-URI-MATCH] KTL ${ktl.id.get}'s URI Id (${ktl.uriId}) does not match keep ${keep.id.get}'s URI id (${keep.uriId})")
+        log.error(s"[KTL-URI-MATCH] KTL ${ktl.id.get}'s URI Id (${ktl.uriId}) does not match keep ${keep.id.get}'s URI id (${keep.uriId})")
         ktlCommander.syncWithKeep(ktl, keep)
       }
     }
@@ -77,13 +77,13 @@ class KeepChecker @Inject() (
     if (keep.isInactive) {
       val zombieKtus = ktuRepo.getAllByKeepId(keepId, excludeStateOpt = Some(KeepToUserStates.INACTIVE))
       for (ktu <- zombieKtus) {
-        airbrake.notify(s"[KTU-STATE-MATCH] KTU ${ktu.id.get} (keep ${ktu.keepId} --- user ${ktu.userId}) is a zombie!")
+        log.error(s"[KTU-STATE-MATCH] KTU ${ktu.id.get} (keep ${ktu.keepId} --- user ${ktu.userId}) is a zombie!")
         ktuCommander.deactivate(ktu)
       }
 
       val zombieKtls = ktlRepo.getAllByKeepId(keepId, excludeStateOpt = Some(KeepToLibraryStates.INACTIVE))
       for (ktl <- zombieKtls) {
-        airbrake.notify(s"[KTL-STATE-MATCH] KTL ${ktl.id.get} (keep ${ktl.keepId} --- lib ${ktl.libraryId}) is a zombie!")
+        log.error(s"[KTL-STATE-MATCH] KTL ${ktl.id.get} (keep ${ktl.keepId} --- lib ${ktl.libraryId}) is a zombie!")
         ktlCommander.deactivate(ktl)
       }
     }
@@ -95,7 +95,7 @@ class KeepChecker @Inject() (
     val expectedHash = LibrariesHash(libraries)
     if (keep.librariesHash != Some(expectedHash)) {
       // TODO(ryan): once we have backfilled and made the field not nullable, uncomment this line
-      // airbrake.notify(s"[KTL-HASH-MATCH] Keep $keepId's library hash (${keep.librariesHash}) != $libraries ($expectedHash)")
+      // log.error(s"[KTL-HASH-MATCH] Keep $keepId's library hash (${keep.librariesHash}) != $libraries ($expectedHash)")
       keepCommander.refreshLibrariesHash(keep)
     }
   }
@@ -106,7 +106,7 @@ class KeepChecker @Inject() (
     val expectedHash = ParticipantsHash(users)
     if (keep.participantsHash != Some(expectedHash)) {
       // TODO(ryan): once we have backfilled and made the field not nullable, uncomment this line
-      // airbrake.notify(s"[KTU-HASH-MATCH] Keep $keepId's participants hash (${keep.participantsHash}) != $users ($expectedHash)")
+      // log.error(s"[KTU-HASH-MATCH] Keep $keepId's participants hash (${keep.participantsHash}) != $users ($expectedHash)")
       keepCommander.refreshParticipantsHash(keep)
     }
   }


### PR DESCRIPTION
@andrewconner 

We deleted a user a few days ago, and the user deletion code doesn't deactivate KTL/KTUs, so all 6.8k of that users keeps are in an inconsistent state. I'm switching over to logging for now.

Is there any way to invoke `airbrake.notify` in a "smart" way where it will only airbrake once a minute (or once every `m` minutes) aside from just manually writing some time-keeping code? It'd have to have some way of keeping track of time, so I imagine it'd take a macro or some other sort of Scala magic.
