### PR TITLE
use a mobile-custom serialization for organization views

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -24,6 +24,7 @@ import scala.util.{ Failure, Success, Try }
 @ImplementedBy(classOf[OrganizationCommanderImpl])
 trait OrganizationCommander {
   def getOrganizationView(orgId: Id[Organization], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): OrganizationView
+  def getOrganizationViews(orgIds: Set[Id[Organization]], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): Map[Id[Organization], OrganizationView]
   def getOrganizationInfo(orgId: Id[Organization], viewerIdOpt: Option[Id[User]])(implicit session: RSession): OrganizationInfo
   def getOrganizationInfos(orgIds: Set[Id[Organization]], viewerIdOpt: Option[Id[User]]): Map[Id[Organization], OrganizationInfo]
   def getBasicOrganizations(orgIds: Set[Id[Organization]]): Map[Id[Organization], BasicOrganization]
@@ -69,6 +70,12 @@ class OrganizationCommanderImpl @Inject() (
       val organizationInfo = getOrganizationInfo(orgId, viewerIdOpt)
       val membershipInfo = getMembershipInfoHelper(orgId, viewerIdOpt, authTokenOpt)
       OrganizationView(organizationInfo, membershipInfo)
+    }
+  }
+
+  def getOrganizationViews(orgIds: Set[Id[Organization]], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): Map[Id[Organization], OrganizationView] = {
+    db.readOnlyReplica { implicit session =>
+      orgIds.map(id => id -> getOrganizationView(id, viewerIdOpt, authTokenOpt)).toMap
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
@@ -25,6 +25,8 @@ class MobileOrganizationController @Inject() (
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val executionContext: ExecutionContext) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
+  implicit val organizationViewWrites = OrganizationView.mobileWrites
+
   def createOrganization = UserAction(parse.tolerantJson) { request =>
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
     request.body.validate[OrganizationInitialValues](OrganizationInitialValues.mobileV1) match {
@@ -76,10 +78,10 @@ class MobileOrganizationController @Inject() (
   def getOrganizationsForUser(extId: ExternalId[User]) = MaybeUserAction { request =>
     val user = userCommander.getByExternalId(extId)
     val visibleOrgs = orgMembershipCommander.getVisibleOrganizationsForUser(user.id.get, viewerIdOpt = request.userIdOpt)
-    val orgInfosMap = orgCommander.getOrganizationInfos(visibleOrgs.toSet, request.userIdOpt)
+    val orgViewsMap = orgCommander.getOrganizationViews(visibleOrgs.toSet, request.userIdOpt, authTokenOpt = None)
 
-    val orgInfos = visibleOrgs.map(org => orgInfosMap(org))
+    val orgViews = visibleOrgs.map(org => orgViewsMap(org))
 
-    Ok(Json.obj("organizations" -> orgInfos))
+    Ok(Json.obj("organizations" -> orgViews))
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
@@ -27,6 +27,8 @@ class OrganizationController @Inject() (
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val executionContext: ExecutionContext) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
+  implicit val organizationViewWrites = OrganizationView.defaultWrites
+
   def createOrganization = UserAction(parse.tolerantJson) { request =>
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
     request.body.validate[OrganizationInitialValues](OrganizationInitialValues.website) match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInfo.scala
@@ -80,9 +80,14 @@ case class OrganizationView(
   membershipInfo: OrganizationMembershipInfo)
 
 object OrganizationView {
-  implicit val writes: Writes[OrganizationView] = new Writes[OrganizationView] {
+  val defaultWrites: Writes[OrganizationView] = new Writes[OrganizationView] {
     def writes(o: OrganizationView) = Json.obj("organization" -> OrganizationInfo.defaultWrites.writes(o.organizationInfo),
       "membership" -> OrganizationMembershipInfo.defaultWrites.writes(o.membershipInfo))
+  }
+
+  val mobileWrites: Writes[OrganizationView] = new Writes[OrganizationView] {
+    def writes(o: OrganizationView) = OrganizationInfo.defaultWrites.writes(o.organizationInfo).as[JsObject] ++
+      Json.obj("membership" -> OrganizationMembershipInfo.defaultWrites.writes(o.membershipInfo))
   }
 }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
@@ -67,9 +67,9 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
           status(response) === OK
 
           val jsonResponse = Json.parse(contentAsString(response))
-          (jsonResponse \ "organization" \ "name").as[String] === "Forty Two Kifis"
-          (jsonResponse \ "organization" \ "handle").as[String] === "kifi"
-          (jsonResponse \ "organization" \ "numLibraries").as[Int] === 10 + 15
+          (jsonResponse \ "name").as[String] === "Forty Two Kifis"
+          (jsonResponse \ "handle").as[String] === "kifi"
+          (jsonResponse \ "numLibraries").as[Int] === 10 + 15
         }
       }
     }
@@ -153,8 +153,8 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
           status(result) === OK
 
           val createResponseJson = Json.parse(contentAsString(result))
-          (createResponseJson \ "organization" \ "name").as[String] === orgName
-          (createResponseJson \ "organization" \ "description").as[Option[String]] === Some(orgDescription)
+          (createResponseJson \ "name").as[String] === orgName
+          (createResponseJson \ "description").as[Option[String]] === Some(orgDescription)
         }
       }
     }


### PR DESCRIPTION
@andrewconner @ryanpbrewster @jaredpetker @DerekBurch bringing back the mobile-custom org serialization, also sending permissions with a user's org list
