### PR TITLE
New mobile libraries endpoint including org libs, fixing overlapping slugs mis-error

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Persona.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Persona.scala
@@ -57,7 +57,7 @@ object Persona {
   val keeps: Map[PersonaName, PersonaKeep] = Map(
     PersonaName.DEVELOPER -> PersonaKeep(
       title = "Good Tech Lead, Bad Tech Lead",
-      url = "https://medium.com/@jliszka/good-tech-lead-bad-tech-lead-948b2b806d86",
+      url = "https://blog.growth.supply/good-tech-lead-bad-tech-lead-948b2b806d86",
       image = PersonaKeepImageInfo("//d1dwdv9wd966qu.cloudfront.net/img/guide/techlead_960x892.57da042.jpg", 480, 446),
       noun = "blog post",
       query = "tech+lead",

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -238,6 +238,57 @@ class MobileLibraryController @Inject() (
     }
   }
 
+  def getWriteableLibrariesWithUrlV3 = UserAction(parse.tolerantJson) { request =>
+    val urlOpt = (request.body \ "url").asOpt[String]
+    getLibrariesUserCanKeepToWithUrl(request.userId, urlOpt)
+  }
+
+  private def getLibrariesUserCanKeepToWithUrl(userId: Id[User], urlOpt: Option[String]) = {
+    val parseUrl = urlOpt.map { url =>
+      pageCommander.getUrlInfo(url, userId)
+    }
+
+    val libs = libraryInfoCommander.getLibrariesUserCanKeepTo(userId, includeOrgLibraries = true)
+    val libOwnerIds = libs.map(_._1.ownerId).toSet
+    val libraryCards = db.readOnlyReplica { implicit session =>
+      val user = userRepo.get(userId)
+      val libOwners = basicUserRepo.loadAll(libOwnerIds)
+      libraryInfoCommander.createLibraryCardInfos(libs = libs.map(_._1), owners = libOwners, viewerOpt = Some(user), withFollowing = true, idealSize = MobileLibraryController.defaultLibraryImageSize)
+    }
+
+    val writeableLibraryInfos = libraryCards.map { libraryCard =>
+      val access = libraryCard.membership.map(_.access).getOrElse(LibraryAccess.READ_WRITE)
+      val memInfo = Json.obj("access" -> access)
+      val shortDesc = Json.obj("shortDescription" -> libraryCard.description.getOrElse("").take(100))
+
+      Json.toJson(libraryCard).as[JsObject] ++ memInfo ++ shortDesc
+    }.toList
+
+    val libsResponse = Json.obj("libraries" -> writeableLibraryInfos)
+    val keepResponse = parseUrl.collect {
+      case Left(error) =>
+        Json.obj("error" -> error)
+      case Right(keepDataList) if keepDataList.nonEmpty =>
+        val completeKeepData = db.readOnlyMaster { implicit s =>
+          val allKeepExtIds = keepDataList.map(_.id).toSet
+          val keepMap = keepRepo.getByExtIds(allKeepExtIds)
+
+          keepDataList.map { keepData =>
+            keepMap(keepData.id) match {
+              case Some(keep) =>
+                val keepImageUrl = keepImageCommander.getBestImageForKeep(keep.id.get, ScaleImageRequest(MobileLibraryController.defaultKeepImageSize)).flatten.map(keepImageCommander.getUrl)
+                Json.obj("id" -> keep.externalId, "title" -> keep.title, "note" -> Hashtags.formatMobileNote(keep.note, false), "imageUrl" -> keepImageUrl, "libraryId" -> keepData.libraryId)
+              case _ => Json.obj()
+            }
+          }
+        }
+        Json.obj("alreadyKept" -> completeKeepData)
+    }.getOrElse(Json.obj())
+    Ok(libsResponse ++ keepResponse)
+  }
+
+  // Next 3 methods can be removed when everyone's on org mobile clients (Sept 14 2015)
+
   def getWriteableLibrariesWithUrlV1 = UserAction(parse.tolerantJson) { request =>
     val urlOpt = (request.body \ "url").asOpt[String]
     getWriteableLibrariesWithUrl(request.userId, urlOpt, true)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInfo.scala
@@ -122,7 +122,7 @@ object OrganizationModifications {
     (__ \ 'description).readNullable[String] and
     (__ \ 'permissions).readNullable[PermissionsDiff] and
     (__ \ 'site).readNullable[String].map {
-      case Some(site) if "^https?://".r.findFirstMatchIn(site).isEmpty => Some("http://" + site)
+      case Some(site) if httpRegex.findFirstMatchIn(site).isEmpty => Some("http://" + site)
       case Some(site) => Some(site)
       case None => None
     }
@@ -130,4 +130,6 @@ object OrganizationModifications {
 
   val website = defaultReads
   val mobileV1 = defaultReads
+
+  private val httpRegex = "^https?://".r
 }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -264,6 +264,7 @@ POST    /m/1/libraries/:id/delete               @com.keepit.controllers.mobile.M
 GET     /m/1/libraries                          @com.keepit.controllers.mobile.MobileLibraryController.getLibrarySummariesByUser()
 POST    /m/1/libraries                          @com.keepit.controllers.mobile.MobileLibraryController.getWriteableLibrariesWithUrlV1()
 POST    /m/2/libraries                          @com.keepit.controllers.mobile.MobileLibraryController.getWriteableLibrariesWithUrlV2()
+POST    /m/3/libraries                          @com.keepit.controllers.mobile.MobileLibraryController.getWriteableLibrariesWithUrlV3()
 GET     /m/1/libraries/:id                      @com.keepit.controllers.mobile.MobileLibraryController.getLibraryByIdV1(id: PublicId[Library], is: Option[String] ?= None)
 GET     /m/2/libraries/:id                      @com.keepit.controllers.mobile.MobileLibraryController.getLibraryByIdV2(id: PublicId[Library], is: Option[String] ?= None)
 POST    /m/1/libraries/:id/join                 @com.keepit.controllers.mobile.MobileLibraryController.joinLibrary(id: PublicId[Library])
@@ -1073,6 +1074,9 @@ GET     /me/libraries/following    @com.keepit.controllers.website.KifiSiteRoute
 GET     /me/libraries/invited      @com.keepit.controllers.website.KifiSiteRouter.redirectUserToOwnProfile(subpath = "/libraries/invited")
 GET     /profile                   @com.keepit.controllers.website.KifiSiteRouter.redirectUserTo(path = "/settings")
 GET     /settings                  @com.keepit.controllers.website.KifiSiteRouter.serveWebAppToUser
+GET     /teams                     @com.keepit.controllers.website.KifiSiteRouter.serveWebAppToUser
+GET     /teams/new                 @com.keepit.controllers.website.KifiSiteRouter.serveWebAppToUser
+GET     /organizations             @com.keepit.controllers.website.KifiSiteRouter.redirectUserTo(path = "/teams")
 GET     /recommendations           @com.keepit.controllers.website.KifiSiteRouter.redirectUserTo(path = "/")
 GET     /tags/manage               @com.keepit.controllers.website.KifiSiteRouter.serveWebAppToUser
 GET     /:handle                   @com.keepit.controllers.website.KifiSiteRouter.serveWebAppIfHandleFound(handle: Handle)


### PR DESCRIPTION
Fixes Tom's issue from this weekend (not sure why `libraryRepo.getBySpaceAndSlug(UserSpace(ownerId), validSlug)` was being explicitly called... any ideas @camhashemi?)

Mostly copy/paste job for mobile libraries v3, which includes org visible libraries.
