### PR TITLE
Changing db constraint for library slugs to account for orgs.

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/393.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/393.sql
@@ -1,0 +1,15 @@
+# SHOEBOX
+
+# --- !Ups
+
+-- mysql:
+--    ALTER TABLE library DROP KEY `library_owner_id_slug`;
+--    CREATE UNIQUE INDEX library_owner_id_org_id_slug on library(owner_id, organization_id, slug);
+
+ALTER TABLE library DROP CONSTRAINT IF EXISTS library_owner_id_slug;
+CREATE UNIQUE INDEX library_owner_id_org_id_slug on library(owner_id, organization_id, slug);
+
+insert into evolutions (name, description) values('393.sql', 'Changing constraints for library to account for orgs with lib slugs');
+
+
+# --- !Downs

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibrarySubscriptionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibrarySubscriptionCommander.scala
@@ -37,6 +37,7 @@ class LibrarySubscriptionCommander @Inject() (
     httpClient: HttpClient,
     librarySubscriptionRepo: LibrarySubscriptionRepo,
     userRepo: UserRepo,
+    organizationRepo: OrganizationRepo,
     implicit val executionContext: ExecutionContext,
     protected val airbrake: AirbrakeNotifier) extends Logging {
 
@@ -46,18 +47,19 @@ class LibrarySubscriptionCommander @Inject() (
 
   def sendNewKeepMessage(keep: Keep, library: Library): Seq[Future[ClientResponse]] = {
 
-    val (subscriptions, keeper, owner) = db.readOnlyReplica { implicit session =>
+    val (subscriptions, keeper, handle) = db.readOnlyReplica { implicit session =>
       val subscriptions = librarySubscriptionRepo.getByLibraryIdAndTrigger(library.id.get, SubscriptionTrigger.NEW_KEEP)
       val keeper = userRepo.get(keep.userId)
       val owner = userRepo.get(library.ownerId)
-      (subscriptions, keeper, owner)
+      val handle = keep.organizationId.map(organizationRepo.get).map(_.handle.value).getOrElse(owner.username.value)
+      (subscriptions, keeper, handle)
     }
 
     subscriptions.map { subscription =>
       subscription.info match {
         case info: SlackInfo =>
           val keepTitle = if (keep.title.exists(_.nonEmpty)) { keep.title.get } else { "a keep" }
-          val text = s"<http://www.kifi.com/${keeper.username.value}?kma=1|${keeper.fullName}> just added <${keep.url}|${keepTitle}> to the <http://www.kifi.com/${owner.username.value}/${library.slug.value}?kma=1|${library.name}> library."
+          val text = s"<http://www.kifi.com/${keeper.username.value}?kma=1|${keeper.fullName}> just added <${keep.url}|${keepTitle}> to the <http://www.kifi.com/$handle/${library.slug.value}?kma=1|${library.name}> library."
           val attachments: Seq[SlackAttachment] = keep.note.toSeq.collect { case content if content.nonEmpty => SlackAttachment(fallback = "Check out this keep", text = s"${content} - ${keeper.firstName}") }
           val body = BasicSlackMessage(text = text, channel = Some(subscription.name.toLowerCase), attachments = attachments)
 


### PR DESCRIPTION
This is not strictly correct, since it won't protect against personal libs having the same slug. Since we already check in code for this situation, I'm going with it (right now it's making it so you can't have the same slug in personal and org locations). We _could_ do a `TrueOrNull` thing here, but worth it?

@ryanpbrewster @camhashemi 
