### PR TITLE
Fix editing/deleting keeps from search. Use a distinct keep id.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
@@ -166,7 +166,8 @@ angular.module('kifi')
           var editor = keepEl.find('.kf-knf-editor');
           if (!editor.length) {
             var noteEl = keepEl.find('.kf-keep-note');
-            $injector.get('keepNoteForm').init(noteEl, keep.note, keep.libraryId, keep.id, function update(noteText) {
+            var distinctKeep = keep.keeps.filter(function (k) { return k.libraryId === keep.library.id; })[0];
+            $injector.get('keepNoteForm').init(noteEl, keep.note, keep.library.id, distinctKeep.id, function update(noteText) {
               keep.note = noteText;
             });
           } else {

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.js
@@ -162,7 +162,8 @@ angular.module('kifi')
         scope.deleteKeep = function (event, keep) {
           angular.element(event.target).closest('.kf-keep').find('.kf-knf').remove();
           var libraryId = keep.library.id;
-          keepActionService.unkeepFromLibrary(libraryId, keep.id).then(function () {
+          var distinctKeep = keep.keeps.filter(function (k) { return k.libraryId === keep.library.id; })[0];
+          keepActionService.unkeepFromLibrary(libraryId, distinctKeep.id).then(function () {
             keep.unkept = true;
             keep.keepersTotal--;
 
@@ -189,7 +190,8 @@ angular.module('kifi')
           var editor = keepEl.find('.kf-knf-editor');
           if (!editor.length) {
             var noteEl = keepEl.find('.kf-keep-note');
-            $injector.get('keepNoteForm').init(noteEl, keep.note, keep.libraryId, keep.id, function update(noteText) {
+            var distinctKeep = keep.keeps.filter(function (k) { return k.libraryId === keep.library.id; })[0];
+            $injector.get('keepNoteForm').init(noteEl, keep.note, keep.library.id, distinctKeep.id, function update(noteText) {
               keep.note = noteText;
             });
           } else {


### PR DESCRIPTION
@adamjgrant @andrewconner 

The backend stopped sending `keep.id` and `keep.libraryId` with the keep object, instead putting those values in the `keep.keeps` array and in the `keep.library` object. So we filter a distinct `id` from the `keep.keeps` array using the `keep.library.id` and then pass the correct `id`s to the endpoint
