### PR TITLE
refactor org messaging event properties

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingAnalytics.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingAnalytics.scala
@@ -246,7 +246,7 @@ class MessagingAnalytics @Inject() (
     val orgIdsByUserIdFut = shoebox.getOrganizationsForUsers(participants.allUsers)
     orgIdsByUserIdFut.foreach { orgIdsByUserId =>
       val commonOrgs = orgIdsByUserId.values.reduceLeftOption[Set[Id[Organization]]] { case (acc, orgSet) => acc.intersect(orgSet) }
-      contextBuilder += ("eventOrgId", commonOrgs.map(_.head.toString).toSeq)
+      commonOrgs.flatMap(_.headOption).foreach { orgId: Id[Organization] => contextBuilder += ("allParticipantsInOrgId", orgId.id.toString) }
     }
   }
 }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -651,8 +651,7 @@ class MessagingCommander @Inject() (
       shoebox.hasOrganizationMembership(oid, userId).flatMap {
         case true =>
           //ignoring case of multiple org ids in the same chat, just picking the last one
-          moreContext += ("org_chat", true)
-          moreContext += ("org_id", oid.id)
+          moreContext += ("messagedWholeOrgId", oid.id)
           shoebox.getOrganizationMembers(oid)
         case false =>
           Future.successful(Set.empty[Id[User]])

--- a/kifi-backend/modules/heimdal/app/com/keepit/heimdal/AmplitudeClient.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/heimdal/AmplitudeClient.scala
@@ -16,7 +16,7 @@ object AmplitudeClient {
   val killedProperties = Set("client", "clientBuild", "clientVersion",
     "device", "experiments", "extensionVersion", "kcid_6", "kcid_7", "kcid_8",
     "kcid_9", "kcid_10", "kcid_11", "os", "osVersion", "remoteAddress", "serviceInstance", "serviceZone",
-    "userId", "userSegment", "libraryId", "keepId", "keep")
+    "userId", "userSegment")
 
   private val killedEvents = Set("user_old_slider_sliderShown", "user_expanded_keeper", "user_used_kifi", "user_reco_action",
     "user_logged_in", "visitor_expanded_keeper", "visitor_reco_action", "visitor_viewed_notification",


### PR DESCRIPTION
@andrewconner @joshm1 just being more explicit about what `orgId` refers to, to avoid collisions and confusion
