### PR TITLE
Update the title when the user visits the stream.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/home/homeCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/home/homeCtrl.js
@@ -3,8 +3,10 @@
 angular.module('kifi')
 
 .controller('HomeCtrl', [
-  '$rootScope', '$scope', 'profileService',
-  function($rootScope, $scope, profileService) {
+  '$window', '$rootScope', '$scope', 'profileService',
+  function($window, $rootScope, $scope, profileService) {
+
+    $window.document.title = 'Kifi • Your stream';
 
     $scope.showDelightedSurvey = profileService.prefs.show_delighted_question;
 


### PR DESCRIPTION
@adamjgrant @andrewconner 

It wasn't updating when moving from an org profile or user profile, so it showed the feed as having a user profile title.
