### PR TITLE
counting four possible visibility levels levels of keeps instead of only two and removing the ALL_KEEPS_VIEW experiment

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/UserExperiment.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserExperiment.scala
@@ -66,7 +66,6 @@ object UserExperimentType {
   val PLAIN_EMAIL = UserExperimentType("plain_email")
 
   val ACTIVITY_EMAIL = UserExperimentType("activity_email")
-  val ALL_KEEPS_VIEW = UserExperimentType("all_keeps_view")
   val EXPLICIT_SOCIAL_POSTING = UserExperimentType("explicit_social_posting")
   val RELATED_PAGE_INFO = UserExperimentType("related_page_info")
   val NEXT_GEN_RECOS = UserExperimentType("next_gen_recos")
@@ -82,7 +81,7 @@ object UserExperimentType {
     DEMO :: EXTENSION_LOGGING :: SHOW_HIT_SCORES :: SHOW_DISCUSSIONS ::
     MOBILE_REDIRECT :: DELIGHTED_SURVEY_PERMANENT :: SPECIAL_CURATOR ::
     GRAPH_BASED_PEOPLE_TO_INVITE :: CORTEX_NEW_MODEL :: CURATOR_DIVERSE_TOPIC_RECOS ::
-    ACTIVITY_EMAIL :: ALL_KEEPS_VIEW :: EXPLICIT_SOCIAL_POSTING :: RELATED_PAGE_INFO :: NEXT_GEN_RECOS ::
+    ACTIVITY_EMAIL :: EXPLICIT_SOCIAL_POSTING :: RELATED_PAGE_INFO :: NEXT_GEN_RECOS ::
     RECO_FASTLANE :: RECO_SUBSAMPLE :: APPLY_RECO_FEEDBACK :: PLAIN_EMAIL :: SEARCH_LAB ::
     NEW_NOTIFS_SYSTEM :: KEEP_MULTILIB :: Nil
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
@@ -146,7 +146,9 @@ class AdminBookmarksController @Inject() (
       }
     }
 
-    val bookmarkTotalCountFuture = keepCommander.getKeepsCountFuture()
+    val bookmarkTotalCountFuture = keepCommander.getKeepsCountFuture().recover {
+      case ex: Throwable => -1
+    }
 
     val bookmarkTodayAllCountsFuture = Future {
       timing("load bookmarks counts from today") {
@@ -214,7 +216,9 @@ class AdminBookmarksController @Inject() (
     val PAGE_SIZE = 25
 
     val bmsFut = Future { db.readOnlyReplica { implicit s => keepRepo.page(page, PAGE_SIZE, false, Set(KeepStates.INACTIVE)) } }
-    val bookmarkTotalCountFuture = keepCommander.getKeepsCountFuture()
+    val bookmarkTotalCountFuture = keepCommander.getKeepsCountFuture().recover {
+      case ex: Throwable => -1
+    }
 
     bmsFut.flatMap { bms =>
       val uris = bms.map { _.uriId }

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -774,11 +774,11 @@ class AdminUserController @Inject() (
         properties += ("userId", user.id.get.id)
         properties += ("admin", "https://admin.kifi.com" + com.keepit.controllers.admin.routes.AdminUserController.userView(user.id.get).url)
 
-        val (privateKeeps, publicKeeps) = keepRepo.getPrivatePublicCountByUser(userId)
-        val keeps = privateKeeps + publicKeeps
+        val keepVisibilityCount = keepRepo.getPrivatePublicCountByUser(userId)
+        val keeps = keepVisibilityCount.all
         properties += ("keeps", keeps)
-        properties += ("publicKeeps", publicKeeps)
-        properties += ("privateKeeps", privateKeeps)
+        properties += ("publicKeeps", keepVisibilityCount.published + keepVisibilityCount.discoverable + keepVisibilityCount.organization)
+        properties += ("privateKeeps", keepVisibilityCount.secret)
         properties += ("tags", collectionRepo.count(userId))
         properties += ("kifiConnections", userConnectionRepo.getConnectionCount(userId))
         properties += ("socialConnections", socialConnectionRepo.getUserConnectionCount(userId))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserPropertyUpdateActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserPropertyUpdateActor.scala
@@ -47,10 +47,10 @@ class UserPropertyUpdateActor @Inject() (
       }
 
       if (instruction.has(KeepCounts)) {
-        val (privateKeeps, publicKeeps) = keepRepo.getPrivatePublicCountByUser(userId)
-        builder += ("keeps", privateKeeps + publicKeeps)
-        builder += ("publicKeeps", publicKeeps)
-        builder += ("privateKeeps", privateKeeps)
+        val keepVisibilityCount = keepRepo.getPrivatePublicCountByUser(userId)
+        builder += ("keeps", keepVisibilityCount.all)
+        builder += ("publicKeeps", keepVisibilityCount.discoverable + keepVisibilityCount.organization + keepVisibilityCount.published)
+        builder += ("privateKeeps", keepVisibilityCount.secret)
       }
 
       if (instruction.has(TagCount)) {

--- a/kifi-backend/modules/shoebox/app/views/admin/organization.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/organization.scala.html
@@ -138,7 +138,7 @@ orgStats: OrganizationStatistics
             <th>Role</th>
             <th class="sorter-mmddyy">Last Keep</th>
             <th>Libs</th>
-            <th>Keeps PRV/PUB</th>
+            <th>Keeps PRV/PUB/ORG/DISC</th>
             <th>Chats</th>
             <th>Remove</th>
             <th>Make an owner</th>
@@ -151,7 +151,7 @@ orgStats: OrganizationStatistics
                 <td>@membership.role</td>
                 <td>@orgStats.membersStatistics(membership.userId).dateLastManualKeep.map(d => adminHelper.dateTimeDisplay(d)).getOrElse("")</td>
                 <td>@orgStats.membersStatistics(membership.userId).numLibrariesCreated</td>
-                <td>@orgStats.membersStatistics(membership.userId).numPrivateKeeps / @orgStats.membersStatistics(membership.userId).numPublicKeeps</td>
+                <td>@orgStats.membersStatistics(membership.userId).keepVisibilityCount.secret / @orgStats.membersStatistics(membership.userId).keepVisibilityCount.published / @orgStats.membersStatistics(membership.userId).keepVisibilityCount.organization / @orgStats.membersStatistics(membership.userId).keepVisibilityCount.discoverable</td>
                 <td>@orgStats.membersStatistics(membership.userId).numChats</td>
                 <td><form action="@com.keepit.controllers.admin.routes.AdminOrganizationController.removeMember(orgStats.orgId)" method="POST" class="form-inline add-candidate">
                     <input type="hidden" name="user-id" value="@membership.userId"><button type="submit" class="btn btn-default btn-xs">Remove</button></form></td>
@@ -169,7 +169,7 @@ orgStats: OrganizationStatistics
             <th>Candidate Name</th>
             <th class="sorter-mmddyy">Last Keep</th>
             <th>Boards</th>
-            <th>Keeps PRV/PUB</th>
+            <th>Keeps PRV/PUB/ORG/DISC</th>
             <th>Chats</th>
             <th>Remove</th>
             <th>Make member</th>
@@ -183,7 +183,7 @@ orgStats: OrganizationStatistics
                 <td>@adminHelper.userDisplay(orgStats.membersStatistics(candidate.userId).user)</td>
                 <td>@orgStats.membersStatistics(candidate.userId).dateLastManualKeep.map(d => adminHelper.dateTimeDisplay(d)).getOrElse("")</td>
                 <td>@orgStats.membersStatistics(candidate.userId).numLibrariesCreated</td>
-                <td>@orgStats.membersStatistics(candidate.userId).numPrivateKeeps / @orgStats.membersStatistics(candidate.userId).numPublicKeeps</td>
+                <td>@orgStats.membersStatistics(candidate.userId).keepVisibilityCount.secret / @orgStats.membersStatistics(candidate.userId).keepVisibilityCount.published / @orgStats.membersStatistics(candidate.userId).keepVisibilityCount.organization / @orgStats.membersStatistics(candidate.userId).keepVisibilityCount.discoverable</td>
                 <td>@orgStats.membersStatistics(candidate.userId).numChats</td>
                 <td><form action="@com.keepit.controllers.admin.routes.AdminOrganizationController.removeCandidate(orgStats.orgId)" method="POST" class="form-inline add-candidate">
                     <input type="hidden" name="user-id" value="@candidate.userId"><button type="submit" class="btn btn-default btn-xs">Remove</button></form></td>

--- a/kifi-backend/modules/shoebox/app/views/admin/users.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/users.scala.html
@@ -110,7 +110,7 @@
               <th>Messages all/active/started</th>
               <th>Lib create/follow</th>
               <th>Network</th>
-              <th>Keeps PRV/PUB</th>
+              <th>Keeps PRV/PUB/ORG/DISC</th>
               <th>Email Address</th>
               <th>Version</th>
               <th class="sorter-mmddyy">Date Joined</th>
@@ -130,7 +130,7 @@
               <td>@{userData.getUserThreadStats(userStatistics.user).all}/@{userData.getUserThreadStats(userStatistics.user).active}/@{userData.getUserThreadStats(userStatistics.user).started}</td>
               <td>@{userStatistics.librariesCreated}/@{userStatistics.librariesFollowed}</td>
               <td>@for(u <- userStatistics.socialUsers){ @networkLogoLink(u) }</td>
-              <td>@userStatistics.privateKeeps / @userStatistics.publicKeeps</td>
+              <td>@userStatistics.keepVisibilityCount.secret / @userStatistics.keepVisibilityCount.published / @userStatistics.keepVisibilityCount.organization / @userStatistics.keepVisibilityCount.discoverable</td>
               <td>@userStatistics.emailAddress.map(_.address).getOrElse("n/a")</td>
               <td>@formatKifiInstallations(userStatistics.kifiInstallations)</td>
               <td>@adminHelper.dateTimeDisplay(userStatistics.user.createdAt)</td>


### PR DESCRIPTION
There's a question of wether its right to count "org visible" as "public" keeps, but we can have it in a secondary PR since this PR is not changing the current status.
