### PR TITLE
Serve legacy notifications

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -568,7 +568,11 @@ class MessagingCommander @Inject() (
 
   def getUnreadUnmutedThreadCount(userId: Id[User], filterByReplyable: Option[Boolean] = None): Int = {
     db.readOnlyReplica { implicit session =>
-      userThreadRepo.getUnreadUnmutedThreadCount(userId, filterByReplyable) + (filterByReplyable match {
+      val userThreadCount = filterByReplyable match {
+        case Some(false) => 0
+        case _ => userThreadRepo.getUnreadUnmutedThreadCount(userId, filterByReplyable)
+      }
+      userThreadCount + (filterByReplyable match {
         case Some(true) => notificationRepo.getUnreadNotificationsCountForKind(Recipient(userId), NewMessage.name)
         case Some(false) => notificationRepo.getUnreadNotificationsCountExceptKind(Recipient(userId), NewMessage.name)
         case None => notificationRepo.getUnreadNotificationsCount(Recipient(userId))

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -570,7 +570,7 @@ class MessagingCommander @Inject() (
     db.readOnlyReplica { implicit session =>
       val userThreadCount = filterByReplyable match {
         case Some(false) => 0
-        case _ => userThreadRepo.getUnreadUnmutedThreadCount(userId, filterByReplyable)
+        case _ => userThreadRepo.getUnreadUnmutedThreadCount(userId, Some(true))
       }
       userThreadCount + (filterByReplyable match {
         case Some(true) => notificationRepo.getUnreadNotificationsCountForKind(Recipient(userId), NewMessage.name)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationDeliveryCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationDeliveryCommander.scala
@@ -477,13 +477,13 @@ class NotificationDeliveryCommander @Inject() (
 
   def getLatestSendableNotifications(userId: Id[User], howMany: Int, includeUriSummary: Boolean, filterByReplyable: Option[Boolean] = None): Future[Seq[NotificationJson]] = {
     notificationJsonMaker.make(db.readOnlyReplica { implicit session =>
-      userThreadRepo.getLatestRawNotifications(userId, howMany, filterByReplyable)
+      userThreadRepo.getLatestRawNotifications(userId, howMany, Some(true))
     }, includeUriSummary)
   }
 
   def getSendableNotificationsBefore(userId: Id[User], time: DateTime, howMany: Int, includeUriSummary: Boolean, filterByReplyable: Option[Boolean] = None): Future[Seq[NotificationJson]] = {
     notificationJsonMaker.make(db.readOnlyReplica { implicit session =>
-      userThreadRepo.getRawNotificationsBefore(userId, time, howMany, filterByReplyable)
+      userThreadRepo.getRawNotificationsBefore(userId, time, howMany, Some(true))
     }, includeUriSummary)
   }
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
@@ -52,12 +52,6 @@ class MobileMessagingController @Inject() (
   }
 
   def getSystemNotifications(howMany: Int, before: Option[String]) = UserAction.async { request =>
-    val threadNoticesFuture = before match {
-      case Some(before) =>
-        notificationCommander.getSendableNotificationsBefore(request.userId, parseStandardTime(before), howMany.toInt, includeUriSummary = true, filterByReplyable = Some(false))
-      case None =>
-        notificationCommander.getLatestSendableNotifications(request.userId, howMany.toInt, includeUriSummary = true, filterByReplyable = Some(false))
-    }
     val noticesFuture = before match {
       case Some(before) =>
         notificationMessagingCommander.getLatestNotificationsBefore(request.userId, parseStandardTime(before), howMany.toInt, true)
@@ -65,11 +59,10 @@ class MobileMessagingController @Inject() (
         notificationMessagingCommander.getLatestNotifications(request.userId, howMany.toInt, true).map(_.results)
     }
     for {
-      threadNotices <- threadNoticesFuture
       notices <- noticesFuture
     } yield {
       val numUnreadUnmuted = messagingCommander.getUnreadUnmutedThreadCount(request.userId, filterByReplyable = Some(false))
-      Ok(Json.arr("notifications", notificationMessagingCommander.combineNotificationsWithThreads(threadNotices, notices, Some(howMany)), numUnreadUnmuted))
+      Ok(Json.arr("notifications", notificationMessagingCommander.combineNotificationsWithThreads(Seq(), notices, Some(howMany)), numUnreadUnmuted))
     }
   }
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
@@ -281,7 +281,7 @@ class UserThreadRepoImpl @Inject() (
       row <- rows if row.user === userId &&
         row.unread &&
         row.lastNotification =!= JsNull.asInstanceOf[JsValue] &&
-        !row.replyable
+        row.replyable
     ) yield row)
       .sortBy(row => (row.notificationUpdatedAt) desc)
       .take(howMany).map(row => (row.lastNotification, row.unread, row.uriId))
@@ -294,7 +294,7 @@ class UserThreadRepoImpl @Inject() (
         row.unread &&
         row.notificationUpdatedAt < time &&
         row.lastNotification =!= JsNull.asInstanceOf[JsValue] &&
-        !row.replyable
+        row.replyable
     ) yield row)
       .sortBy(row => (row.notificationUpdatedAt) desc)
       .take(howMany).map(row => (row.lastNotification, row.unread, row.uriId))
@@ -363,11 +363,11 @@ class UserThreadRepoImpl @Inject() (
   }
 
   def getUnreadThreadCounts(userId: Id[User])(implicit session: RSession): (Int, Int) = {
-    StaticQuery.queryNA[(Int, Int)](s"select count(*), sum(not muted) from user_thread where user_id = $userId and notification_pending and not replyable").first
+    StaticQuery.queryNA[(Int, Int)](s"select count(*), sum(not muted) from user_thread where user_id = $userId and notification_pending and replyable").first
   }
 
   def getUnreadThreadCount(userId: Id[User])(implicit session: RSession): Int = {
-    StaticQuery.queryNA[Int](s"select count(*) from user_thread where user_id = $userId and notification_pending and not replyable").first
+    StaticQuery.queryNA[Int](s"select count(*) from user_thread where user_id = $userId and notification_pending and replyable").first
   }
 
   def getUserThread(userId: Id[User], threadId: Id[MessageThread])(implicit session: RSession): UserThread = {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
@@ -280,7 +280,8 @@ class UserThreadRepoImpl @Inject() (
     (for (
       row <- rows if row.user === userId &&
         row.unread &&
-        row.lastNotification =!= JsNull.asInstanceOf[JsValue]
+        row.lastNotification =!= JsNull.asInstanceOf[JsValue] &&
+        !row.replyable
     ) yield row)
       .sortBy(row => (row.notificationUpdatedAt) desc)
       .take(howMany).map(row => (row.lastNotification, row.unread, row.uriId))
@@ -292,7 +293,8 @@ class UserThreadRepoImpl @Inject() (
       row <- rows if row.user === userId &&
         row.unread &&
         row.notificationUpdatedAt < time &&
-        row.lastNotification =!= JsNull.asInstanceOf[JsValue]
+        row.lastNotification =!= JsNull.asInstanceOf[JsValue] &&
+        !row.replyable
     ) yield row)
       .sortBy(row => (row.notificationUpdatedAt) desc)
       .take(howMany).map(row => (row.lastNotification, row.unread, row.uriId))
@@ -361,11 +363,11 @@ class UserThreadRepoImpl @Inject() (
   }
 
   def getUnreadThreadCounts(userId: Id[User])(implicit session: RSession): (Int, Int) = {
-    StaticQuery.queryNA[(Int, Int)](s"select count(*), sum(not muted) from user_thread where user_id = $userId and notification_pending").first
+    StaticQuery.queryNA[(Int, Int)](s"select count(*), sum(not muted) from user_thread where user_id = $userId and notification_pending and not replyable").first
   }
 
   def getUnreadThreadCount(userId: Id[User])(implicit session: RSession): Int = {
-    StaticQuery.queryNA[Int](s"select count(*) from user_thread where user_id = $userId and notification_pending").first
+    StaticQuery.queryNA[Int](s"select count(*) from user_thread where user_id = $userId and notification_pending and not replyable").first
   }
 
   def getUserThread(userId: Id[User], threadId: Id[MessageThread])(implicit session: RSession): UserThread = {


### PR DESCRIPTION
First nail in the coffin for non-replyable user threads/message threads. Stops serving non-replyable user threads (next PR will be last nail in the coffin, getting rid of them)
