### PR TITLE
add BasicOrganizationView, giving membership info to org objects

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
@@ -220,7 +220,7 @@ object BasicOrganization {
     (__ \ 'name).format[String] and
     (__ \ 'description).formatNullable[String] and
     (__ \ 'avatarPath).format[ImagePath]
-  )(BasicOrganization.apply, unlift(BasicOrganization.unapply))
+  )(BasicOrganization.apply _, unlift(BasicOrganization.unapply))
 }
 
 @json

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -23,8 +23,8 @@ import scala.util.{ Failure, Success, Try }
 
 @ImplementedBy(classOf[OrganizationCommanderImpl])
 trait OrganizationCommander {
-  def getFullOrganizationView(orgId: Id[Organization], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): FullOrganizationView
-  def getFullOrganizationViews(orgIds: Set[Id[Organization]], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): Map[Id[Organization], FullOrganizationView]
+  def getFullOrganizationView(orgId: Id[Organization], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): OrganizationView
+  def getFullOrganizationViews(orgIds: Set[Id[Organization]], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): Map[Id[Organization], OrganizationView]
   def getBasicOrganizationView(orgId: Id[Organization], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): BasicOrganizationView
   def getBasicOrganizationViews(orgIds: Set[Id[Organization]], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): Map[Id[Organization], BasicOrganizationView]
   def getOrganizationInfo(orgId: Id[Organization], viewerIdOpt: Option[Id[User]])(implicit session: RSession): OrganizationInfo
@@ -67,18 +67,18 @@ class OrganizationCommanderImpl @Inject() (
     basicOrganizationIdCache: BasicOrganizationIdCache,
     implicit val executionContext: ExecutionContext) extends OrganizationCommander with Logging {
 
-  def getFullOrganizationView(orgId: Id[Organization], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): FullOrganizationView = {
+  def getFullOrganizationView(orgId: Id[Organization], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): OrganizationView = {
     db.readOnlyReplica { implicit session => getFullOrganizationViewHelper(orgId, viewerIdOpt, authTokenOpt) }
   }
 
-  def getFullOrganizationViews(orgIds: Set[Id[Organization]], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): Map[Id[Organization], FullOrganizationView] = {
+  def getFullOrganizationViews(orgIds: Set[Id[Organization]], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): Map[Id[Organization], OrganizationView] = {
     db.readOnlyReplica { implicit session => orgIds.map(id => id -> getFullOrganizationViewHelper(id, viewerIdOpt, authTokenOpt)).toMap }
   }
 
-  private def getFullOrganizationViewHelper(orgId: Id[Organization], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String])(implicit session: RSession): FullOrganizationView = {
+  private def getFullOrganizationViewHelper(orgId: Id[Organization], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String])(implicit session: RSession): OrganizationView = {
     val organizationInfo = getOrganizationInfo(orgId, viewerIdOpt)
     val membershipInfo = getMembershipInfoHelper(orgId, viewerIdOpt, authTokenOpt)
-    FullOrganizationView(organizationInfo, membershipInfo)
+    OrganizationView(organizationInfo, membershipInfo)
   }
 
   def getBasicOrganizationView(orgId: Id[Organization], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): BasicOrganizationView = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserProfileCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserProfileCommander.scala
@@ -83,7 +83,6 @@ class UserProfileCommander @Inject() (
           modifiedAt = lib.updatedAt,
           path = info.path,
           org = info.org,
-          orgMembership = info.orgMembership,
           orgMemberAccess = info.orgMemberAccess
         )
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
@@ -25,7 +25,7 @@ class MobileOrganizationController @Inject() (
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val executionContext: ExecutionContext) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
-  implicit val organizationViewWrites = FullOrganizationView.mobileWrites
+  implicit val organizationViewWrites = OrganizationView.mobileWrites
 
   def createOrganization = UserAction(parse.tolerantJson) { request =>
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
@@ -25,7 +25,7 @@ class MobileOrganizationController @Inject() (
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val executionContext: ExecutionContext) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
-  implicit val organizationViewWrites = OrganizationView.mobileWrites
+  implicit val organizationViewWrites = FullOrganizationView.mobileWrites
 
   def createOrganization = UserAction(parse.tolerantJson) { request =>
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
@@ -36,7 +36,7 @@ class MobileOrganizationController @Inject() (
         orgCommander.createOrganization(createRequest) match {
           case Left(failure) => failure.asErrorResponse
           case Right(response) =>
-            val organizationView = orgCommander.getOrganizationView(response.newOrg.id.get, request.userIdOpt, authTokenOpt = None)
+            val organizationView = orgCommander.getFullOrganizationView(response.newOrg.id.get, request.userIdOpt, authTokenOpt = None)
             Ok(Json.toJson(organizationView))
         }
     }
@@ -50,7 +50,7 @@ class MobileOrganizationController @Inject() (
         orgCommander.modifyOrganization(OrganizationModifyRequest(request.request.userId, request.orgId, modifications)) match {
           case Left(failure) => failure.asErrorResponse
           case Right(response) =>
-            val organizationView = orgCommander.getOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt, authTokenOpt = None)
+            val organizationView = orgCommander.getFullOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt, authTokenOpt = None)
             Ok(Json.toJson(organizationView))
         }
     }
@@ -66,7 +66,7 @@ class MobileOrganizationController @Inject() (
   }
 
   def getOrganization(pubId: PublicId[Organization]) = OrganizationAction(pubId, authTokenOpt = None, OrganizationPermission.VIEW_ORGANIZATION) { request =>
-    val organizationView = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt, authTokenOpt = None)
+    val organizationView = orgCommander.getFullOrganizationView(request.orgId, request.request.userIdOpt, authTokenOpt = None)
     Ok(Json.toJson(organizationView))
   }
 
@@ -79,7 +79,7 @@ class MobileOrganizationController @Inject() (
     val user = userCommander.getByExternalId(extId)
     val visibleOrgs = orgMembershipCommander.getVisibleOrganizationsForUser(user.id.get, viewerIdOpt = request.userIdOpt)
 
-    val orgViewsMap = orgCommander.getOrganizationViews(visibleOrgs.toSet, request.userIdOpt, authTokenOpt = None)
+    val orgViewsMap = orgCommander.getFullOrganizationViews(visibleOrgs.toSet, request.userIdOpt, authTokenOpt = None)
 
     val orgViews = visibleOrgs.map(org => orgViewsMap(org))
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationMembershipController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationMembershipController.scala
@@ -26,7 +26,7 @@ class MobileOrganizationMembershipController @Inject() (
     implicit val publicIdConfig: PublicIdConfiguration) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
   // If userIdOpt is provided AND the user can invite members, return invited users as well as members
-  def getMembers(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, authTokenOpt = None, OrganizationPermission.VIEW_ORGANIZATION) { request =>
+  def getMembers(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, authTokenOpt = None, OrganizationPermission.VIEW_ORGANIZATION, OrganizationPermission.VIEW_MEMBERS) { request =>
     if (limit > 30) {
       BadRequest(Json.obj("error" -> "invalid_limit"))
     } else Organization.decodePublicId(pubId) match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -718,7 +718,6 @@ class LibraryController @Inject() (
               kind = info.kind,
               path = info.path,
               org = info.org,
-              orgMembership = info.orgMembership,
               orgMemberAccess = info.orgMemberAccess
             )
           }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
@@ -27,7 +27,7 @@ class OrganizationController @Inject() (
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val executionContext: ExecutionContext) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
-  implicit val organizationViewWrites = FullOrganizationView.defaultWrites
+  implicit val organizationViewWrites = OrganizationView.defaultWrites
 
   def createOrganization = UserAction(parse.tolerantJson) { request =>
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
@@ -27,7 +27,7 @@ class OrganizationController @Inject() (
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val executionContext: ExecutionContext) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
-  implicit val organizationViewWrites = OrganizationView.defaultWrites
+  implicit val organizationViewWrites = FullOrganizationView.defaultWrites
 
   def createOrganization = UserAction(parse.tolerantJson) { request =>
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
@@ -39,7 +39,7 @@ class OrganizationController @Inject() (
           case Left(failure) =>
             failure.asErrorResponse
           case Right(response) =>
-            val organizationView = orgCommander.getOrganizationView(response.newOrg.id.get, request.userIdOpt, authTokenOpt = None)
+            val organizationView = orgCommander.getFullOrganizationView(response.newOrg.id.get, request.userIdOpt, authTokenOpt = None)
             Ok(Json.toJson(organizationView))
         }
     }
@@ -55,7 +55,7 @@ class OrganizationController @Inject() (
         orgCommander.modifyOrganization(OrganizationModifyRequest(request.request.userId, request.orgId, modifications)) match {
           case Left(failure) => failure.asErrorResponse
           case Right(response) =>
-            val organizationView = orgCommander.getOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt, authTokenOpt = None)
+            val organizationView = orgCommander.getFullOrganizationView(response.modifiedOrg.id.get, request.request.userIdOpt, authTokenOpt = None)
             Ok(Json.toJson(organizationView))
         }
     }
@@ -87,7 +87,7 @@ class OrganizationController @Inject() (
   }
 
   def getOrganization(pubId: PublicId[Organization], authTokenOpt: Option[String] = None) = OrganizationAction(pubId, authTokenOpt, OrganizationPermission.VIEW_ORGANIZATION) { request =>
-    val organizationView = orgCommander.getOrganizationView(request.orgId, request.request.userIdOpt, authTokenOpt)
+    val organizationView = orgCommander.getFullOrganizationView(request.orgId, request.request.userIdOpt, authTokenOpt)
     Ok(Json.toJson(organizationView))
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationMembershipController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationMembershipController.scala
@@ -26,7 +26,7 @@ class OrganizationMembershipController @Inject() (
     implicit val publicIdConfig: PublicIdConfiguration) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
   // If userIdOpt is provided AND the user can invite members, return invited users as well as members
-  def getMembers(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, authTokenOpt = None, OrganizationPermission.VIEW_ORGANIZATION) { request =>
+  def getMembers(pubId: PublicId[Organization], offset: Int, limit: Int) = OrganizationAction(pubId, authTokenOpt = None, OrganizationPermission.VIEW_ORGANIZATION, OrganizationPermission.VIEW_MEMBERS) { request =>
     if (limit > 30) {
       BadRequest(Json.obj("error" -> "invalid_limit"))
     } else Organization.decodePublicId(pubId) match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
@@ -13,7 +13,7 @@ import com.kifi.macros.json
 
 import play.api.libs.json.{ Json, JsSuccess, JsError }
 
-import scala.util.{ Try, Success, Failure }
+import scala.util.{ Success, Failure }
 import scala.concurrent.{ ExecutionContext, Future }
 
 import com.google.inject.{ Inject, Singleton }
@@ -31,7 +31,7 @@ class PaymentsController @Inject() (
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val ec: ExecutionContext) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 
-  def getAccountState(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION) { request =>
+  def getAccountState(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.MANAGE_PLAN) { request =>
     Ok(Json.obj(
       "credit" -> planCommander.getCurrentCredit(request.orgId).cents,
       "users" -> orgMembershipCommander.getMemberIds(request.orgId).size,
@@ -39,7 +39,7 @@ class PaymentsController @Inject() (
     ))
   }
 
-  def getCreditCardToken(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION) { request =>
+  def getCreditCardToken(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.MANAGE_PLAN) { request =>
     planCommander.getActivePaymentMethods(request.orgId).find(_.default).map { pm =>
       Ok(Json.obj(
         "token" -> pm.stripeToken.token
@@ -49,7 +49,7 @@ class PaymentsController @Inject() (
     }
   }
 
-  def setCreditCardToken(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION).async(parse.tolerantJson) { request =>
+  def setCreditCardToken(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.MANAGE_PLAN).async(parse.tolerantJson) { request =>
     (request.body \ "token").asOpt[String] match {
       case Some(token) => {
         stripeClient.getPermanentToken(token, s"Card for Org ${request.orgId} added by user ${request.request.userId} with admin ${request.request.adminUserId}").map { realToken =>
@@ -63,11 +63,11 @@ class PaymentsController @Inject() (
     }
   }
 
-  def getAccountContacts(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION) { request =>
+  def getAccountContacts(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.MANAGE_PLAN) { request =>
     Ok(Json.toJson(planCommander.getSimpleContactInfos(request.orgId)))
   }
 
-  def setAccountContacts(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION)(parse.tolerantJson) { request =>
+  def setAccountContacts(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.MANAGE_PLAN)(parse.tolerantJson) { request =>
     request.body.validate[Seq[SimpleAccountContactSettingRequest]] match {
       case JsSuccess(contacts, _) => {
         val attribution = ActionAttribution(user = Some(request.request.userId), admin = request.request.adminUserId)
@@ -80,12 +80,12 @@ class PaymentsController @Inject() (
     }
   }
 
-  def getAccountFeatureSettings(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION) { request =>
+  def getAccountFeatureSettings(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.MANAGE_PLAN) { request =>
     val accountFeatureSettingsResponse = planCommander.getAccountFeatureSettings(request.orgId)
     Ok(Json.toJson(accountFeatureSettingsResponse))
   }
 
-  def setAccountFeatureSettings(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION)(parse.tolerantJson) { request =>
+  def setAccountFeatureSettings(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.MANAGE_PLAN)(parse.tolerantJson) { request =>
     request.body.validate[AccountFeatureSettingsRequest] match {
       case JsError(errs) => BadRequest(Json.obj("error" -> "could_not_parse", "details" -> errs.toString))
       case JsSuccess(settings, _) =>
@@ -94,7 +94,7 @@ class PaymentsController @Inject() (
     }
   }
 
-  def updatePlan(pubId: PublicId[Organization], planPubId: PublicId[PaidPlan]) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION) { request =>
+  def updatePlan(pubId: PublicId[Organization], planPubId: PublicId[PaidPlan]) = OrganizationUserAction(pubId, OrganizationPermission.MANAGE_PLAN) { request =>
     PaidPlan.decodePublicId(planPubId) match {
       case Success(planId) => {
         val attribution = ActionAttribution(user = Some(request.request.userId), admin = request.request.adminUserId)
@@ -108,12 +108,12 @@ class PaymentsController @Inject() (
     }
   }
 
-  def getEvents(pubId: PublicId[Organization], limit: Int) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION) { request =>
+  def getEvents(pubId: PublicId[Organization], limit: Int) = OrganizationUserAction(pubId, OrganizationPermission.MANAGE_PLAN) { request =>
     val infos = planCommander.getAccountEvents(request.orgId, limit, onlyRelatedToBillingFilter = None).map(planCommander.buildSimpleEventInfo)
     Ok(Json.obj("events" -> infos))
   }
 
-  def getEventsBefore(pubId: PublicId[Organization], limit: Int, beforeTime: DateTime, beforePubId: PublicId[AccountEvent]) = OrganizationUserAction(pubId, OrganizationPermission.EDIT_ORGANIZATION) { request =>
+  def getEventsBefore(pubId: PublicId[Organization], limit: Int, beforeTime: DateTime, beforePubId: PublicId[AccountEvent]) = OrganizationUserAction(pubId, OrganizationPermission.MANAGE_PLAN) { request =>
     AccountEvent.decodePublicId(beforePubId) match {
       case Success(beforeId) => {
         val infos = planCommander.getAccountEventsBefore(request.orgId, beforeTime, beforeId, limit, onlyRelatedToBillingFilter = None).map(planCommander.buildSimpleEventInfo)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
@@ -200,8 +200,7 @@ case class LibraryCardInfo(
   kind: LibraryKind,
   invite: Option[LibraryInviteInfo] = None, // currently only for Invited tab on viewer's own user profile
   path: String,
-  org: Option[BasicOrganization],
-  orgMembership: Option[OrganizationMembershipInfo],
+  org: Option[BasicOrganizationView],
   orgMemberAccess: Option[LibraryAccess]) // TODO(cam): (possibly) squash this into LibraryMembershipInfo.access to clean things up, need to confirm with clients that it'd be equivalent in terms of UX
 
 object LibraryCardInfo {
@@ -230,7 +229,6 @@ object LibraryCardInfo {
       "invite" -> o.invite,
       "path" -> o.path,
       "org" -> o.org,
-      "orgMembership" -> o.orgMembership,
       "orgMemberAccess" -> o.orgMemberAccess).nonNullFields
   }
   def chooseCollaborators(collaborators: Seq[BasicUser]): Seq[BasicUser] = {
@@ -274,8 +272,7 @@ case class FullLibraryInfo(
   whoCanInvite: LibraryInvitePermissions,
   modifiedAt: DateTime,
   path: String,
-  org: Option[BasicOrganization],
-  orgMembership: Option[OrganizationMembershipInfo],
+  org: Option[BasicOrganizationView],
   orgMemberAccess: Option[LibraryAccess])
 
 object FullLibraryInfo {
@@ -305,7 +302,6 @@ object FullLibraryInfo {
       "modifiedAt" -> o.modifiedAt,
       "path" -> o.path,
       "org" -> o.org,
-      "orgMembership" -> o.orgMembership,
       "orgMemberAccess" -> o.orgMemberAccess
     ).nonNullFields
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInfo.scala
@@ -111,18 +111,18 @@ object BasicOrganizationView {
   }
 }
 
-case class FullOrganizationView(
+case class OrganizationView(
   organizationInfo: OrganizationInfo,
   membershipInfo: OrganizationMembershipInfo)
 
-object FullOrganizationView {
-  val defaultWrites: Writes[FullOrganizationView] = new Writes[FullOrganizationView] {
-    def writes(o: FullOrganizationView) = Json.obj("organization" -> OrganizationInfo.defaultWrites.writes(o.organizationInfo),
+object OrganizationView {
+  val defaultWrites: Writes[OrganizationView] = new Writes[OrganizationView] {
+    def writes(o: OrganizationView) = Json.obj("organization" -> OrganizationInfo.defaultWrites.writes(o.organizationInfo),
       "membership" -> OrganizationMembershipInfo.defaultWrites.writes(o.membershipInfo))
   }
 
-  val mobileWrites: Writes[FullOrganizationView] = new Writes[FullOrganizationView] {
-    def writes(o: FullOrganizationView) = OrganizationInfo.defaultWrites.writes(o.organizationInfo).as[JsObject] ++
+  val mobileWrites: Writes[OrganizationView] = new Writes[OrganizationView] {
+    def writes(o: OrganizationView) = OrganizationInfo.defaultWrites.writes(o.organizationInfo).as[JsObject] ++
       Json.obj("membership" -> OrganizationMembershipInfo.defaultWrites.writes(o.membershipInfo).as[JsObject])
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationInfo.scala
@@ -95,20 +95,10 @@ object BasicOrganizationView {
     def writes(o: BasicOrganizationView) = Json.toJson(o.basicOrganization).as[JsObject] + ("membership" -> Json.toJson(o.membershipInfo))
   }
 
-  val testReads = new Reads[BasicOrganizationView] {
-    implicit val orgMemInfoReads = OrganizationMembershipInfo.testReads
-    def reads(json: JsValue): JsResult[BasicOrganizationView] = {
-      val id = (json \ "id").as[PublicId[Organization]]
-      val ownerId = (json \ "ownerId").as[ExternalId[User]]
-      val handle = (json \ "handle").as[OrganizationHandle]
-      val name = (json \ "name").as[String]
-      val description = (json \ "description").as[Option[String]]
-      val avatarPath = (json \ "avatarPath").as[ImagePath]
-      val basicOrg = BasicOrganization(id, ownerId, handle, name, description, avatarPath)
-      val membershipInfo = (json \ "membership").as[OrganizationMembershipInfo](OrganizationMembershipInfo.testReads)
-      JsSuccess(BasicOrganizationView(basicOrg, membershipInfo))
-    }
-  }
+  val testReads: Reads[BasicOrganizationView] = (
+    __.read[BasicOrganization] and
+    (__ \ "membership").read[OrganizationMembershipInfo](OrganizationMembershipInfo.testReads)
+  )(BasicOrganizationView.apply _)
 }
 
 case class OrganizationView(

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/PaymentRequest.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/PaymentRequest.scala
@@ -17,7 +17,7 @@ object AccountFeatureSettingsRequest {
     def reads(json: JsValue): JsResult[AccountFeatureSettingsRequest] = {
       json.validate[JsObject].map { obj =>
         val featureSettings = obj.fieldSet.map {
-          case (key, value) if Feature.get(key).isDefined && Feature.get(key).get.verify(value.as[String]) => FeatureSetting(key, value.as[String])
+          case (key: String, value: JsValue) if Feature.get(key).isDefined && Feature.get(key).get.verify(value.as[String]) => FeatureSetting(key, value.as[String])
         }.toSet
         AccountFeatureSettingsRequest(featureSettings)
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -700,11 +700,15 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
 
         firstTime.isBefore(secondTime) === true
 
-        implicit val orgMembershipReads = OrganizationMembershipInfo.testReads
+        implicit val basicOrgViewReads = BasicOrganizationView.testReads
 
         val resultJson = contentAsJson(result1)
-        (resultJson \ "library" \ "org").as[Option[BasicOrganization]] must equalTo(Some(BasicOrganization(Organization.publicId(org1.id.get)(inject[PublicIdConfiguration]), user1.externalId, org1.handle, org1.name, description = None, ImagePath("oa/076fccc32247ae67bb75d48879230953_1024x1024-0x0-200x200_cs.jpg"))))
-        (resultJson \ "library" \ "orgMembership").as[Option[OrganizationMembershipInfo]] must equalTo(Some(OrganizationMembershipInfo(isInvited = false, invite = None, Organization.defaultBasePermissions.forRole(OrganizationRole.ADMIN), Some(OrganizationRole.ADMIN))))
+        (resultJson \ "library" \ "org").as[Option[BasicOrganizationView]] must equalTo(Some(
+          BasicOrganizationView(
+            BasicOrganization(Organization.publicId(org1.id.get)(inject[PublicIdConfiguration]), user1.externalId, org1.handle, org1.name, description = None, ImagePath("oa/076fccc32247ae67bb75d48879230953_1024x1024-0x0-200x200_cs.jpg")),
+            OrganizationMembershipInfo(isInvited = false, invite = None, Organization.defaultBasePermissions.forRole(OrganizationRole.ADMIN), Some(OrganizationRole.ADMIN))
+          )
+        ))
         (resultJson \ "library" \ "orgMemberAccess").as[Option[LibraryAccess]] must equalTo(Some(LibraryAccess.READ_WRITE))
       }
     }


### PR DESCRIPTION
@ryanpbrewster @andrewconner we initially talked about keeping the `membership` independent of the `organization` object, but mobile and @cvializ are asking for this now.
