### PR TITLE
Lib move logic really fixes denormalized keep info

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -313,7 +313,8 @@ class LibraryCommanderImpl @Inject() (
       val (keeps, lib, curViz) = db.readOnlyMaster { implicit s =>
         val lib = libraryRepo.get(library.id.get)
         val viz = lib.visibility // It may have changed, re-check
-        val keeps = keepRepo.getByLibraryIdAndExcludingVisibility(lib.id.get, Some(viz), 1000)
+        val keepIds = keepRepo.getByLibraryIdAndExcludingVisibility(lib.id.get, Some(viz), 500).map(_.id.get).toSet ++ keepRepo.getByLibraryWithInconsistentOrgId(lib.id.get, lib.organizationId, Limit(500))
+        val keeps = keepRepo.getByIds(keepIds).values.toSeq
         (keeps, lib, viz)
       }
       if (keeps.nonEmpty && curViz == changedVisibility) {

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -661,6 +661,16 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
               keep.organizationId === lib4.organizationId
             }
           }
+
+          val res5 = libraryCommander.modifyLibrary(lib4.id.get, user.id.get, LibraryModifyRequest(space = Some(LibrarySpace.fromOrganizationId(org.id.get)))).right.get
+          Await.result(res5.keepChanges, Duration.Inf)
+          val lib5 = res5.modifiedLibrary
+          db.readOnlyMaster { implicit session =>
+            keepRepo.getByLibrary(lib5.id.get, 0, Int.MaxValue).foreach { keep =>
+              keep.visibility === lib5.visibility
+              keep.organizationId === lib5.organizationId
+            }
+          }
           1 === 1
         }
       }


### PR DESCRIPTION
Previously it was only fixing keeps that had the wrong visibility. Now it
fixes keeps with the wrong visibility and org id.

@andrewconner this fixes the Asana task from a week ago
