### PR TITLE
Permission commander

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -63,7 +63,6 @@ case class Library(
 
   def space: LibrarySpace = LibrarySpace(ownerId, organizationId)
 
-  // TODO(ryan): this is pretty fragile, we should move this type of thing into library creation and store the permissions with the Library
   def permissionsByAccess(access: LibraryAccess): Set[LibraryPermission] = access match {
     case LibraryAccess.READ_ONLY => Set(
       LibraryPermission.VIEW_LIBRARY,

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
@@ -1,0 +1,44 @@
+package com.keepit.commanders
+
+import com.google.inject.{ ImplementedBy, Inject, Singleton }
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.DBSession.RSession
+import com.keepit.common.db.slick.Database
+import com.keepit.common.logging.Logging
+import com.keepit.model._
+
+import scala.concurrent.ExecutionContext
+
+@ImplementedBy(classOf[PermissionCommanderImpl])
+trait PermissionCommander {
+  def getOrganizationPermissions(orgId: Id[Organization], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[OrganizationPermission]
+  def getLibraryPermissions(libId: Id[Library], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[OrganizationPermission]
+}
+
+@Singleton
+class PermissionCommanderImpl @Inject() (
+    db: Database,
+    orgRepo: OrganizationRepo,
+    orgMembershipRepo: OrganizationMembershipRepo,
+    orgInviteRepo: OrganizationInviteRepo,
+    userRepo: UserRepo,
+    libraryRepo: LibraryRepo,
+    libraryMembershipRepo: LibraryMembershipRepo,
+    userExperimentRepo: UserExperimentRepo,
+    orgExperimentRepo: OrganizationExperimentRepo,
+    implicit val executionContext: ExecutionContext) extends PermissionCommander with Logging {
+
+  def getOrganizationPermissions(orgId: Id[Organization], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[OrganizationPermission] = {
+    val org = orgRepo.get(orgId)
+    userIdOpt match {
+      case None => org.getNonmemberPermissions
+      case Some(userId) =>
+        orgMembershipRepo.getByOrgIdAndUserId(orgId, userId).map(_.permissions) getOrElse {
+          val invites = orgInviteRepo.getByOrgIdAndUserId(orgId, userId)
+          if (invites.isEmpty) org.getNonmemberPermissions
+          else org.getNonmemberPermissions + OrganizationPermission.VIEW_ORGANIZATION
+        }
+    }
+  }
+  def getLibraryPermissions(libId: Id[Library], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[OrganizationPermission] = ???
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationController.scala
@@ -5,6 +5,7 @@ import com.keepit.commanders._
 import com.keepit.common.controller._
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.db.ExternalId
+import com.keepit.common.db.slick.Database
 import com.keepit.common.store.S3ImageConfig
 import com.keepit.heimdal.HeimdalContextBuilderFactory
 import com.keepit.model._
@@ -15,12 +16,14 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class MobileOrganizationController @Inject() (
-    val orgCommander: OrganizationCommander,
-    val orgMembershipCommander: OrganizationMembershipCommander,
-    val orgInviteCommander: OrganizationInviteCommander,
+    orgCommander: OrganizationCommander,
+    orgMembershipCommander: OrganizationMembershipCommander,
+    orgInviteCommander: OrganizationInviteCommander,
     userCommander: UserCommander,
     heimdalContextBuilder: HeimdalContextBuilderFactory,
     val userActionsHelper: UserActionsHelper,
+    val db: Database,
+    val permissionCommander: PermissionCommander,
     implicit val imageConfig: S3ImageConfig,
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val executionContext: ExecutionContext) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationInviteController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationInviteController.scala
@@ -4,6 +4,7 @@ import com.google.inject.{ Inject, Singleton }
 import com.keepit.commanders._
 import com.keepit.common.controller._
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
+import com.keepit.common.db.slick.Database
 import com.keepit.common.db.{ Id, ExternalId }
 import com.keepit.common.json.EitherFormat
 import com.keepit.common.mail.EmailAddress
@@ -19,12 +20,14 @@ import scala.util.{ Failure, Success }
 @Singleton
 class MobileOrganizationInviteController @Inject() (
     userCommander: UserCommander,
-    val orgCommander: OrganizationCommander,
-    val orgMembershipCommander: OrganizationMembershipCommander,
-    val orgInviteCommander: OrganizationInviteCommander,
+    orgCommander: OrganizationCommander,
+    orgMembershipCommander: OrganizationMembershipCommander,
+    orgInviteCommander: OrganizationInviteCommander,
     fortyTwoConfig: FortyTwoConfig,
     heimdalContextBuilder: HeimdalContextBuilderFactory,
     val userActionsHelper: UserActionsHelper,
+    val db: Database,
+    val permissionCommander: PermissionCommander,
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val executionContext: ExecutionContext) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationMembershipController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationMembershipController.scala
@@ -1,9 +1,10 @@
 package com.keepit.controllers.mobile
 
 import com.google.inject.{ Inject, Singleton }
-import com.keepit.commanders.{ OrganizationInviteCommander, UserCommander, OrganizationCommander, OrganizationMembershipCommander }
+import com.keepit.commanders._
 import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper }
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
+import com.keepit.common.db.slick.Database
 import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.heimdal.HeimdalContextBuilderFactory
@@ -16,12 +17,14 @@ import scala.util.{ Failure, Success }
 
 @Singleton
 class MobileOrganizationMembershipController @Inject() (
-    val orgCommander: OrganizationCommander,
-    val orgMembershipCommander: OrganizationMembershipCommander,
-    val orgInviteCommander: OrganizationInviteCommander,
+    orgCommander: OrganizationCommander,
+    orgMembershipCommander: OrganizationMembershipCommander,
+    orgInviteCommander: OrganizationInviteCommander,
     userCommander: UserCommander,
     heimdalContextBuilder: HeimdalContextBuilderFactory,
     val userActionsHelper: UserActionsHelper,
+    val db: Database,
+    val permissionCommander: PermissionCommander,
     airbrake: AirbrakeNotifier,
     implicit val publicIdConfig: PublicIdConfiguration) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationAvatarController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationAvatarController.scala
@@ -4,6 +4,7 @@ import com.google.inject.Inject
 import com.keepit.commanders._
 import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper }
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
+import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.store.{ SquareImageCropRegion, ImageCropRegion, ImageOffset, ImageSize }
 import com.keepit.heimdal.HeimdalContextBuilderFactory
@@ -16,12 +17,10 @@ import scala.concurrent.ExecutionContext
 class OrganizationAvatarController @Inject() (
   orgAvatarCommander: OrganizationAvatarCommander,
   heimdalContextBuilder: HeimdalContextBuilderFactory,
-  airbrake: AirbrakeNotifier,
   val userActionsHelper: UserActionsHelper,
-  val publicIdConfig: PublicIdConfiguration,
-  val orgMembershipCommander: OrganizationMembershipCommander,
-  val orgInviteCommander: OrganizationInviteCommander,
-  implicit val config: PublicIdConfiguration,
+  val db: Database,
+  val permissionCommander: PermissionCommander,
+  implicit val publicIdConfig: PublicIdConfiguration,
   private implicit val executionContext: ExecutionContext)
     extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationController.scala
@@ -4,6 +4,7 @@ import com.google.inject.{ Inject, Singleton }
 import com.keepit.commanders._
 import com.keepit.common.controller._
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
+import com.keepit.common.db.slick.Database
 import com.keepit.common.db.{ Id, ExternalId }
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.store.S3ImageConfig
@@ -16,12 +17,14 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class OrganizationController @Inject() (
-    val orgCommander: OrganizationCommander,
-    val orgMembershipCommander: OrganizationMembershipCommander,
-    val orgInviteCommander: OrganizationInviteCommander,
+    orgCommander: OrganizationCommander,
+    orgMembershipCommander: OrganizationMembershipCommander,
+    orgInviteCommander: OrganizationInviteCommander,
     userCommander: UserCommander,
     heimdalContextBuilder: HeimdalContextBuilderFactory,
     val userActionsHelper: UserActionsHelper,
+    val db: Database,
+    val permissionCommander: PermissionCommander,
     airbrake: AirbrakeNotifier,
     implicit val imageConfig: S3ImageConfig,
     implicit val publicIdConfig: PublicIdConfiguration,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationInviteController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationInviteController.scala
@@ -4,6 +4,7 @@ import com.google.inject.{ Inject, Singleton }
 import com.keepit.commanders._
 import com.keepit.common.controller._
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
+import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.db.{ Id, ExternalId }
 import com.keepit.common.json.EitherFormat
@@ -20,15 +21,17 @@ import scala.util.{ Failure, Success }
 @Singleton
 class OrganizationInviteController @Inject() (
     userCommander: UserCommander,
-    val orgCommander: OrganizationCommander,
-    val orgMembershipCommander: OrganizationMembershipCommander,
-    val orgInviteCommander: OrganizationInviteCommander,
+    orgCommander: OrganizationCommander,
+    orgMembershipCommander: OrganizationMembershipCommander,
+    orgInviteCommander: OrganizationInviteCommander,
     organizationInviteCommander: OrganizationInviteCommander,
     typeaheadCommander: TypeaheadCommander,
     fortyTwoConfig: FortyTwoConfig,
     heimdalContextBuilder: HeimdalContextBuilderFactory,
     airbrake: AirbrakeNotifier,
     val userActionsHelper: UserActionsHelper,
+    val db: Database,
+    val permissionCommander: PermissionCommander,
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val executionContext: ExecutionContext) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationMembershipController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationMembershipController.scala
@@ -1,9 +1,10 @@
 package com.keepit.controllers.website
 
 import com.google.inject.{ Inject, Singleton }
-import com.keepit.commanders.{ OrganizationInviteCommander, UserCommander, OrganizationCommander, OrganizationMembershipCommander }
+import com.keepit.commanders._
 import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper }
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
+import com.keepit.common.db.slick.Database
 import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.heimdal.HeimdalContextBuilderFactory
@@ -16,12 +17,14 @@ import scala.util.{ Failure, Success }
 
 @Singleton
 class OrganizationMembershipController @Inject() (
-    val orgCommander: OrganizationCommander,
-    val orgMembershipCommander: OrganizationMembershipCommander,
-    val orgInviteCommander: OrganizationInviteCommander,
+    orgCommander: OrganizationCommander,
+    orgMembershipCommander: OrganizationMembershipCommander,
+    orgInviteCommander: OrganizationInviteCommander,
     userCommander: UserCommander,
     heimdalContextBuilder: HeimdalContextBuilderFactory,
     val userActionsHelper: UserActionsHelper,
+    val db: Database,
+    val permissionCommander: PermissionCommander,
     airbrake: AirbrakeNotifier,
     implicit val publicIdConfig: PublicIdConfiguration) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
@@ -3,9 +3,10 @@ package com.keepit.controllers.website
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.controller.{ UserActions, ShoeboxServiceController, UserActionsHelper }
 import com.keepit.common.db.ExternalId
+import com.keepit.common.db.slick.Database
 import com.keepit.shoebox.controllers.OrganizationAccessActions
 import com.keepit.model.{ OrganizationPermission, Organization }
-import com.keepit.commanders.{ OrganizationCommander, OrganizationMembershipCommander, OrganizationInviteCommander }
+import com.keepit.commanders.{ PermissionCommander, OrganizationCommander, OrganizationMembershipCommander, OrganizationInviteCommander }
 import com.keepit.payments._
 import com.keepit.payments.AccountFeatureSettingsRequest
 
@@ -22,12 +23,14 @@ import org.joda.time.DateTime
 
 @Singleton
 class PaymentsController @Inject() (
-    val orgCommander: OrganizationCommander,
-    val orgMembershipCommander: OrganizationMembershipCommander,
-    val orgInviteCommander: OrganizationInviteCommander,
-    val userActionsHelper: UserActionsHelper,
+    orgCommander: OrganizationCommander,
+    orgMembershipCommander: OrganizationMembershipCommander,
+    orgInviteCommander: OrganizationInviteCommander,
     planCommander: PlanManagementCommander,
     stripeClient: StripeClient,
+    val userActionsHelper: UserActionsHelper,
+    val db: Database,
+    val permissionCommander: PermissionCommander,
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val ec: ExecutionContext) extends UserActions with OrganizationAccessActions with ShoeboxServiceController {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserOrOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserOrOrganizationController.scala
@@ -19,10 +19,11 @@ import scala.util.{ Either, Success, Failure, Try }
 @Singleton
 class UserOrOrganizationController @Inject() (
     val userActionsHelper: UserActionsHelper,
-    db: Database,
+    val db: Database,
+    val permissionCommander: PermissionCommander,
     orgCommander: OrganizationCommander,
-    val orgMembershipCommander: OrganizationMembershipCommander,
-    val orgInviteCommander: OrganizationInviteCommander,
+    orgMembershipCommander: OrganizationMembershipCommander,
+    orgInviteCommander: OrganizationInviteCommander,
     userCommander: UserCommander,
     libraryController: LibraryController,
     heimdalContextBuilder: HeimdalContextBuilderFactory,

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationMembershipControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationMembershipControllerTest.scala
@@ -81,8 +81,10 @@ class MobileOrganizationMembershipControllerTest extends Specification with Shoe
 
           val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
 
-          inject[OrganizationMembershipCommander].getPermissions(orgId = org.id.get, userIdOpt = Some(owner.id.get)).contains(OrganizationPermission.INVITE_MEMBERS) === true
-          inject[OrganizationMembershipCommander].getPermissions(orgId = org.id.get, userIdOpt = Some(members.head.id.get)).contains(OrganizationPermission.INVITE_MEMBERS) === false
+          db.readOnlyMaster { implicit session =>
+            permissionCommander.getOrganizationPermissions(org.id.get, Some(owner.id.get)).contains(OrganizationPermission.INVITE_MEMBERS) === true
+            permissionCommander.getOrganizationPermissions(org.id.get, Some(members.head.id.get)).contains(OrganizationPermission.INVITE_MEMBERS) === false
+          }
 
           inject[FakeUserActionsHelper].setUser(members.head)
           val memberRequest = route.getMembers(publicOrgId)
@@ -119,7 +121,9 @@ class MobileOrganizationMembershipControllerTest extends Specification with Shoe
 
           val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
 
-          inject[OrganizationMembershipCommander].getPermissions(orgId = org.id.get, userIdOpt = Some(owner.id.get)).contains(OrganizationPermission.INVITE_MEMBERS) === true
+          db.readOnlyMaster { implicit session =>
+            permissionCommander.getOrganizationPermissions(org.id.get, Some(owner.id.get)).contains(OrganizationPermission.INVITE_MEMBERS) === true
+          }
 
           inject[FakeUserActionsHelper].setUser(owner)
           val ownerRequest = route.getMembers(publicOrgId)

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationMembershipControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationMembershipControllerTest.scala
@@ -82,8 +82,10 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
 
           val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
 
-          inject[OrganizationMembershipCommander].getPermissions(orgId = org.id.get, userIdOpt = Some(owner.id.get)).contains(OrganizationPermission.INVITE_MEMBERS) === true
-          inject[OrganizationMembershipCommander].getPermissions(orgId = org.id.get, userIdOpt = Some(members.head.id.get)).contains(OrganizationPermission.INVITE_MEMBERS) === false
+          db.readOnlyMaster { implicit session =>
+            permissionCommander.getOrganizationPermissions(org.id.get, Some(owner.id.get)).contains(OrganizationPermission.INVITE_MEMBERS) === true
+            permissionCommander.getOrganizationPermissions(org.id.get, Some(members.head.id.get)).contains(OrganizationPermission.INVITE_MEMBERS) === false
+          }
 
           inject[FakeUserActionsHelper].setUser(members.head)
           val memberRequest = route.getMembers(publicOrgId)
@@ -120,7 +122,9 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
 
           val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
 
-          inject[OrganizationMembershipCommander].getPermissions(orgId = org.id.get, userIdOpt = Some(owner.id.get)).contains(OrganizationPermission.INVITE_MEMBERS) === true
+          db.readOnlyMaster { implicit session =>
+            permissionCommander.getOrganizationPermissions(org.id.get, Some(owner.id.get)).contains(OrganizationPermission.INVITE_MEMBERS) === true
+          }
 
           inject[FakeUserActionsHelper].setUser(owner)
           val ownerRequest = route.getMembers(publicOrgId)

--- a/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxInjectionHelpers.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxInjectionHelpers.scala
@@ -67,4 +67,5 @@ trait ShoeboxInjectionHelpers { self: TestInjectorProvider =>
   def orgInviteCommander(implicit injector: Injector) = inject[OrganizationInviteCommander]
   def libraryChecker(implicit injector: Injector) = inject[LibraryChecker]
   def keepChecker(implicit injector: Injector) = inject[KeepChecker]
+  def permissionCommander(implicit injector: Injector) = inject[PermissionCommander]
 }


### PR DESCRIPTION
@camhashemi @leogrim 

@andrewconner this is another example of a "commander" that is entirely composed of methods that take an implicit session. ((Also, this change got rid of a few session-in-session issues.))
