### PR TITLE
Added a General library to orgs

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -58,7 +58,7 @@ case class Library(
   def withOwner(newOwner: Id[User]) = this.copy(ownerId = newOwner)
   val isPublished: Boolean = visibility == LibraryVisibility.PUBLISHED
   val isSecret: Boolean = visibility == LibraryVisibility.SECRET
-  def isUserCreated: Boolean = kind == LibraryKind.USER_CREATED
+  def isUserCreated: Boolean = kind == LibraryKind.USER_CREATED || kind == LibraryKind.SYSTEM_PERSONA
   def isSystemCreated: Boolean = !isUserCreated
 
   def space: LibrarySpace = LibrarySpace(ownerId, organizationId)
@@ -310,10 +310,11 @@ sealed abstract class LibraryKind(val value: String, val priority: Int) {
 object LibraryKind {
   case object SYSTEM_MAIN extends LibraryKind("system_main", 0)
   case object SYSTEM_SECRET extends LibraryKind("system_secret", 1)
-  case object SYSTEM_PERSONA extends LibraryKind("system_persona", 2)
-  case object USER_CREATED extends LibraryKind("user_created", 2)
-  case object SYSTEM_READ_IT_LATER extends LibraryKind("system_read_it_later", 2)
-  case object SYSTEM_GUIDE extends LibraryKind("system_guide", 3)
+  case object SYSTEM_ORG_GENERAL extends LibraryKind("system_org_general", 2)
+  case object SYSTEM_PERSONA extends LibraryKind("system_persona", 3)
+  case object USER_CREATED extends LibraryKind("user_created", 3)
+  case object SYSTEM_READ_IT_LATER extends LibraryKind("system_read_it_later", 3)
+  case object SYSTEM_GUIDE extends LibraryKind("system_guide", 4)
 
   implicit def format[T]: Format[LibraryKind] =
     Format(__.read[String].map(LibraryKind(_)), new Writes[LibraryKind] { def writes(o: LibraryKind) = JsString(o.value) })
@@ -322,6 +323,7 @@ object LibraryKind {
     str match {
       case SYSTEM_MAIN.value => SYSTEM_MAIN
       case SYSTEM_SECRET.value => SYSTEM_SECRET
+      case SYSTEM_ORG_GENERAL.value => SYSTEM_ORG_GENERAL
       case SYSTEM_PERSONA.value => SYSTEM_PERSONA
       case SYSTEM_READ_IT_LATER.value => SYSTEM_READ_IT_LATER
       case SYSTEM_GUIDE.value => SYSTEM_GUIDE

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
@@ -310,7 +310,9 @@ class AdminLibraryController @Inject() (
     val body = request.body.asFormUrlEncoded.get.mapValues(_.head)
     val newOwner = Id[User](body.get("user-id").get.toLong)
     val orgIdOpt = body.get("org-id").flatMap(id => Try(id.toLong).toOption).map(id => Id[Organization](id))
-    libraryCommander.unsafeTransferLibrary(libId, newOwner)
+    db.readWrite { implicit session =>
+      libraryCommander.unsafeTransferLibrary(libId, newOwner)
+    }
     val modifyRequest = orgIdOpt match {
       case Some(orgId) => LibraryModifyRequest(space = Some(LibrarySpace.fromOrganizationId(orgId)), visibility = Some(LibraryVisibility.ORGANIZATION))
       case None => LibraryModifyRequest(space = Some(LibrarySpace.fromUserId(newOwner)), visibility = Some(LibraryVisibility.PUBLISHED))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationMembershipController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationMembershipController.scala
@@ -43,48 +43,47 @@ class MobileOrganizationMembershipController @Inject() (
     }
   }
 
-  def modifyMembers(pubId: PublicId[Organization]) = OrganizationUserAction(pubId)(parse.tolerantJson) { request =>
+  def modifyMember(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.MODIFY_MEMBERS)(parse.tolerantJson) { request =>
     implicit val format = KeyFormat.key2Format[ExternalId[User], OrganizationRole]("userId", "newRole")
-    val modifyParamsValidated = (request.body \ "members").validate[Seq[(ExternalId[User], OrganizationRole)]]
+    val modifyParamsValidated = request.body.validate[(ExternalId[User], OrganizationRole)]
 
     modifyParamsValidated match {
       case JsError(errs) =>
-        airbrake.notify(s"Could not json-validate modifyRequests from ${request.request.userId}", new JsResultException(errs))
+        airbrake.notify(s"Could not json-validate modifyRequests from ${request.request.userId}: ${request.body}", new JsResultException(errs))
         BadRequest(Json.obj("error" -> "badly_formatted_request"))
       case JsSuccess(modifyParams, _) =>
-        val (externalIds, roles) = modifyParams.unzip
+        val (externalId, newRole) = modifyParams
 
-        val roleMap = (externalIds, roles).zipped.toMap
-        val userIdMap = userCommander.getByExternalIds(externalIds).mapValues(_.id.get)
-        val externalIdMap = userIdMap.map(_.swap)
-        val modifyRequests = externalIds.map { extId =>
-          OrganizationMembershipModifyRequest(request.orgId, request.request.userId, targetId = userIdMap(extId), newRole = roleMap(extId))
+        val targetId = userCommander.getByExternalId(externalId).id.get
+        val modifyRequest = OrganizationMembershipModifyRequest(request.orgId, request.request.userId, targetId = targetId, newRole = newRole)
+        orgMembershipCommander.modifyMembership(modifyRequest) match {
+          case Left(fail) => fail.asErrorResponse
+          case Right(response) =>
+            val modification = externalId -> response.membership.role
+            Ok(Json.obj("modification" -> modification))
         }
-        val modifyResponses = orgMembershipCommander.modifyMemberships(modifyRequests) collect { case (_, Right(success)) => success }
-        val modifications = modifyResponses.map(r => (externalIdMap(r.request.targetId), r.request.newRole)).toMap
-        Ok(Json.obj("modifications" -> modifications))
     }
   }
 
-  def removeMembers(pubId: PublicId[Organization]) = OrganizationUserAction(pubId)(parse.tolerantJson) { request =>
+  def removeMember(pubId: PublicId[Organization]) = OrganizationUserAction(pubId)(parse.tolerantJson) { request =>
     implicit val format = KeyFormat.key1Format[ExternalId[User]]("userId")
-    val removeParamsValidated = (request.body \ "members").validate[Seq[ExternalId[User]]]
+    val removeParamsValidated = request.body.validate[ExternalId[User]]
 
     removeParamsValidated match {
       case JsError(errs) =>
-        airbrake.notify(s"Could not json-validate removeRequests from ${request.request.userId}", new JsResultException(errs))
+        airbrake.notify(s"Could not json-validate removeRequests from ${request.request.userId}: ${request.body}", new JsResultException(errs))
         BadRequest(Json.obj("error" -> "badly_formatted_request"))
       case JsSuccess(removeParams, _) =>
-        val externalIds = removeParams
+        val externalId = removeParams
 
-        val userIdMap = userCommander.getByExternalIds(externalIds).mapValues(_.id.get)
-        val externalIdMap = userIdMap.map(_.swap)
-        val removeRequests = externalIds.map { extId =>
-          OrganizationMembershipRemoveRequest(request.orgId, request.request.userId, targetId = userIdMap(extId))
+        val targetId = userCommander.getByExternalId(externalId).id.get
+        val removeRequest = OrganizationMembershipRemoveRequest(request.orgId, request.request.userId, targetId = targetId)
+        orgMembershipCommander.removeMembership(removeRequest) match {
+          case Left(fail) => fail.asErrorResponse
+          case Right(response) =>
+            val removal = externalId
+            Ok(Json.obj("removal" -> removal))
         }
-        val removeResponses = orgMembershipCommander.removeMemberships(removeRequests) collect { case (_, Right(success)) => success }
-        val removals = removeResponses.map(r => externalIdMap(r.request.targetId))
-        Ok(Json.obj("removals" -> removals))
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationMembershipController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileOrganizationMembershipController.scala
@@ -60,12 +60,9 @@ class MobileOrganizationMembershipController @Inject() (
         val modifyRequests = externalIds.map { extId =>
           OrganizationMembershipModifyRequest(request.orgId, request.request.userId, targetId = userIdMap(extId), newRole = roleMap(extId))
         }
-        orgMembershipCommander.modifyMemberships(modifyRequests) match {
-          case Left(failure) => failure.asErrorResponse
-          case Right(responses) =>
-            val modifications = responses.keys.map(r => (externalIdMap(r.targetId), r.newRole))
-            Ok(Json.obj("modifications" -> modifications))
-        }
+        val modifyResponses = orgMembershipCommander.modifyMemberships(modifyRequests) collect { case (_, Right(success)) => success }
+        val modifications = modifyResponses.map(r => (externalIdMap(r.request.targetId), r.request.newRole)).toMap
+        Ok(Json.obj("modifications" -> modifications))
     }
   }
 
@@ -85,12 +82,9 @@ class MobileOrganizationMembershipController @Inject() (
         val removeRequests = externalIds.map { extId =>
           OrganizationMembershipRemoveRequest(request.orgId, request.request.userId, targetId = userIdMap(extId))
         }
-        orgMembershipCommander.removeMemberships(removeRequests) match {
-          case Left(failure) => failure.asErrorResponse
-          case Right(responses) =>
-            val removals = responses.keys.map(r => externalIdMap(r.targetId))
-            Ok(Json.obj("removals" -> removals))
-        }
+        val removeResponses = orgMembershipCommander.removeMemberships(removeRequests) collect { case (_, Right(success)) => success }
+        val removals = removeResponses.map(r => externalIdMap(r.request.targetId))
+        Ok(Json.obj("removals" -> removals))
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationMembershipController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/OrganizationMembershipController.scala
@@ -60,12 +60,9 @@ class OrganizationMembershipController @Inject() (
         val modifyRequests = externalIds.map { extId =>
           OrganizationMembershipModifyRequest(request.orgId, request.request.userId, targetId = userIdMap(extId), newRole = roleMap(extId))
         }
-        orgMembershipCommander.modifyMemberships(modifyRequests) match {
-          case Left(failure) => failure.asErrorResponse
-          case Right(responses) =>
-            val modifications = responses.keys.map(r => (externalIdMap(r.targetId), r.newRole))
-            Ok(Json.obj("modifications" -> modifications))
-        }
+        val modifyResponses = orgMembershipCommander.modifyMemberships(modifyRequests) collect { case (_, Right(success)) => success }
+        val modifications = modifyResponses.map(r => externalIdMap(r.membership.userId) -> r.membership.role)
+        Ok(Json.obj("modifications" -> modifications))
     }
   }
 
@@ -85,12 +82,10 @@ class OrganizationMembershipController @Inject() (
         val removeRequests = externalIds.map { extId =>
           OrganizationMembershipRemoveRequest(request.orgId, request.request.userId, targetId = userIdMap(extId))
         }
-        orgMembershipCommander.removeMemberships(removeRequests) match {
-          case Left(failure) => failure.asErrorResponse
-          case Right(responses) =>
-            val removals = responses.keys.map(r => externalIdMap(r.targetId))
-            Ok(Json.obj("removals" -> removals))
-        }
+        val removeResponses = orgMembershipCommander.removeMemberships(removeRequests) collect { case (_, Right(success)) => success }
+        val removals = removeResponses.map { r => externalIdMap(r.request.targetId) }
+
+        Ok(Json.obj("removals" -> removals))
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
@@ -81,6 +81,19 @@ case class LibraryCreateRequest(
   space: Option[LibrarySpace] = None,
   orgMemberAccess: Option[LibraryAccess] = None)
 
+object LibraryCreateRequest {
+  def forOrgGeneralLibrary(org: Organization): LibraryCreateRequest = {
+    LibraryCreateRequest(
+      name = "General",
+      visibility = LibraryVisibility.ORGANIZATION,
+      slug = "general",
+      kind = Some(LibraryKind.SYSTEM_ORG_GENERAL),
+      space = Some(LibrarySpace.fromOrganizationId(org.id.get)),
+      orgMemberAccess = Some(LibraryAccess.READ_WRITE)
+    )
+  }
+}
+
 case class ExternalLibraryModifyRequest(
   name: Option[String] = None,
   slug: Option[String] = None,

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRequests.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRequests.scala
@@ -20,7 +20,7 @@ case class OrganizationModifyRequest(requesterId: Id[User], orgId: Id[Organizati
 case class OrganizationModifyResponse(request: OrganizationModifyRequest, modifiedOrg: Organization)
 
 case class OrganizationDeleteRequest(requesterId: Id[User], orgId: Id[Organization]) extends OrganizationRequest
-case class OrganizationDeleteResponse(request: OrganizationDeleteRequest, returningLibsFut: Future[Unit])
+case class OrganizationDeleteResponse(request: OrganizationDeleteRequest, returningLibsFut: Future[Unit], deletingLibsFut: Future[Unit])
 
 case class OrganizationTransferRequest(requesterId: Id[User], orgId: Id[Organization], newOwner: Id[User]) extends OrganizationRequest
 case class OrganizationTransferResponse(request: OrganizationTransferRequest, modifiedOrg: Organization)

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -306,8 +306,8 @@ POST    /m/1/organizations/:id/members/invite            @com.keepit.controllers
 POST    /m/1/organizations/:id/members/invites/accept    @com.keepit.controllers.mobile.MobileOrganizationInviteController.acceptInvitation(id: PublicId[Organization], authToken: Option[String] ?= None)
 POST    /m/1/organizations/:id/members/invites/decline   @com.keepit.controllers.mobile.MobileOrganizationInviteController.declineInvitation(id: PublicId[Organization])
 POST    /m/1/organizations/:id/members/invites/link      @com.keepit.controllers.mobile.MobileOrganizationInviteController.createAnonymousInviteToOrganization(id: PublicId[Organization])
-POST    /m/1/organizations/:id/members/modify            @com.keepit.controllers.mobile.MobileOrganizationMembershipController.modifyMembers(id: PublicId[Organization])
-POST    /m/1/organizations/:id/members/remove            @com.keepit.controllers.mobile.MobileOrganizationMembershipController.removeMembers(id: PublicId[Organization])
+POST    /m/1/organizations/:id/members/modify            @com.keepit.controllers.mobile.MobileOrganizationMembershipController.modifyMember(id: PublicId[Organization])
+POST    /m/1/organizations/:id/members/remove            @com.keepit.controllers.mobile.MobileOrganizationMembershipController.removeMember(id: PublicId[Organization])
 GET     /m/1/organizations/:id/libraries                 @com.keepit.controllers.mobile.MobileOrganizationController.getOrganizationLibraries(id: PublicId[Organization], offset: Int, limit: Int)
 
 ##########################################
@@ -541,8 +541,8 @@ POST          /site/organizations/:id/members/invites/cancel    @com.keepit.cont
 POST          /site/organizations/:id/members/invites/accept    @com.keepit.controllers.website.OrganizationInviteController.acceptInvitation(id: PublicId[Organization], authToken: Option[String] ?= None)
 POST          /site/organizations/:id/members/invites/decline   @com.keepit.controllers.website.OrganizationInviteController.declineInvitation(id: PublicId[Organization])
 POST          /site/organizations/:id/members/invites/link      @com.keepit.controllers.website.OrganizationInviteController.createAnonymousInviteToOrganization(id: PublicId[Organization])
-POST          /site/organizations/:id/members/modify            @com.keepit.controllers.website.OrganizationMembershipController.modifyMembers(id: PublicId[Organization])
-POST          /site/organizations/:id/members/remove            @com.keepit.controllers.website.OrganizationMembershipController.removeMembers(id: PublicId[Organization])
+POST          /site/organizations/:id/members/modify            @com.keepit.controllers.website.OrganizationMembershipController.modifyMember(id: PublicId[Organization])
+POST          /site/organizations/:id/members/remove            @com.keepit.controllers.website.OrganizationMembershipController.removeMember(id: PublicId[Organization])
 GET           /site/organizations/:id/members/suggest            @com.keepit.controllers.website.OrganizationInviteController.suggestMembers(id: PublicId[Organization], query: Option[String], limit: Int)
 GET           /site/organizations/:id/libraries                 @com.keepit.controllers.website.OrganizationController.getOrganizationLibraries(id: PublicId[Organization], offset: Int ?= 0, limit: Int ?= 20)
 POST          /site/organizations/:id/avatar/upload             @com.keepit.controllers.website.OrganizationAvatarController.uploadAvatar(id: PublicId[Organization], x: Int, y: Int, s: Int)

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
@@ -44,9 +44,46 @@ class ExtLibraryControllerTest extends Specification with ShoeboxTestInjector wi
   )
 
   "ExtLibraryController" should {
+    "format a library properly" in {
+      withDb(controllerTestModules: _*) { implicit injector =>
+        val (user, lib) = db.readWrite { implicit s =>
+          val user = UserFactory.user().withName("Morgan", "Freeman").withUsername("morgan").saved
+          val lib = LibraryFactory.library().withName("Million Dollar Baby").withOwner(user).withVisibility(LibraryVisibility.PUBLISHED).withSlug("baby").withColor(LibraryColor.RED).saved
+          (user, lib)
+        }
+        implicit val config = inject[PublicIdConfiguration]
+        val pubId = Library.publicId(lib.id.get).id
+        val basicUserRepo = inject[BasicUserRepo]
+        val result = getLibraries(user)
+        status(result) must equalTo(OK)
+        contentType(result) must beSome("application/json")
+
+        db.readOnlyMaster { implicit session =>
+          val payload = Json.parse(contentAsString(result))
+          val libraryJson = (payload \ "libraries").as[Seq[JsObject]].head
+          libraryJson === Json.obj(
+            "id" -> pubId,
+            "name" -> "Million Dollar Baby",
+            "color" -> LibraryColor.RED,
+            "visibility" -> "published",
+            "path" -> "/morgan/baby",
+            "hasCollaborators" -> false,
+            "subscribedToUpdates" -> false,
+            "collaborators" -> Json.arr(),
+            "membership" -> Json.obj(
+              "access" -> LibraryAccess.OWNER,
+              "listed" -> true,
+              "subscribed" -> false,
+              "permissions" -> Json.toJson(permissionCommander.libraryPermissionsByAccess(lib, LibraryAccess.OWNER))
+            )
+          )
+        }
+      }
+    }
+
     "get libraries" in {
       withDb(controllerTestModules: _*) { implicit injector =>
-        val (user1, user2, lib1, lib2, lib3, lib4) = db.readWrite { implicit s =>
+        val (user1, user2, lib1, lib2, lib3, lib4, orgGeneralLib) = db.readWrite { implicit s =>
           val user1 = UserFactory.user().withName("Morgan", "Freeman").withUsername("morgan").saved
           val lib1 = LibraryFactory.library().withName("Million Dollar Baby").withOwner(user1).withVisibility(LibraryVisibility.PUBLISHED).withSlug("baby").withColor(LibraryColor.RED).saved
 
@@ -63,7 +100,9 @@ class ExtLibraryControllerTest extends Specification with ShoeboxTestInjector wi
           val org = OrganizationFactory.organization().withName("Braff").withHandle(OrganizationHandle("braff")).withOwner(user2).withMembers(Seq(user1)).saved
           val lib4 = LibraryFactory.library().withName("Going In Style").withOwner(user2).withOrganization(org).withVisibility(LibraryVisibility.ORGANIZATION).withOrgMemberCollaborativePermission(Some(LibraryAccess.READ_WRITE)).withSlug("robbers").withColor(LibraryColor.SKY_BLUE).saved
 
-          (user1, user2, lib1, lib2, lib3, lib4)
+          val orgGeneralLib = libraryRepo.getBySpaceAndKind(org.id.get, LibraryKind.SYSTEM_ORG_GENERAL).head
+
+          (user1, user2, lib1, lib2, lib3, lib4, orgGeneralLib)
         }
         implicit val config = inject[PublicIdConfiguration]
         val pubId1 = Library.publicId(lib1.id.get).id
@@ -76,53 +115,10 @@ class ExtLibraryControllerTest extends Specification with ShoeboxTestInjector wi
         contentType(result) must beSome("application/json")
 
         db.readOnlyMaster { implicit session =>
-          Json.parse(contentAsString(result)) === Json.obj(
-            "libraries" -> Seq(
-              Json.obj(
-                "id" -> pubId2,
-                "name" -> "Dark Knight",
-                "color" -> LibraryColor.BLUE,
-                "visibility" -> "published",
-                "path" -> "/michael/darkknight",
-                "hasCollaborators" -> true,
-                "subscribedToUpdates" -> false,
-                "collaborators" -> Seq(basicUserRepo.load(user2.id.get)),
-                "membership" -> Json.obj(
-                  "access" -> LibraryAccess.READ_WRITE,
-                  "listed" -> true,
-                  "subscribed" -> false,
-                  "permissions" -> Json.toJson(permissionCommander.libraryPermissionsByAccess(lib2, LibraryAccess.READ_WRITE))
-                )
-              ),
-              Json.obj(
-                "id" -> pubId1,
-                "name" -> "Million Dollar Baby",
-                "color" -> LibraryColor.RED,
-                "visibility" -> "published",
-                "path" -> "/morgan/baby",
-                "hasCollaborators" -> false,
-                "subscribedToUpdates" -> false,
-                "collaborators" -> Seq.empty[BasicUser],
-                "membership" -> Json.obj(
-                  "access" -> LibraryAccess.OWNER,
-                  "listed" -> true,
-                  "subscribed" -> false,
-                  "permissions" -> Json.toJson(permissionCommander.libraryPermissionsByAccess(lib1, LibraryAccess.OWNER))
-                )
-              ),
-              Json.obj(
-                "id" -> pubId4,
-                "name" -> "Going In Style",
-                "color" -> LibraryColor.SKY_BLUE,
-                "visibility" -> "organization",
-                "path" -> "/braff/robbers",
-                "hasCollaborators" -> true,
-                "subscribedToUpdates" -> false,
-                "collaborators" -> Seq(basicUserRepo.load(user2.id.get)),
-                "orgAvatar" -> "oa/076fccc32247ae67bb75d48879230953_1024x1024-0x0-200x200_cs.jpg"
-              )
-            )
-          )
+          val payload = Json.parse(contentAsString(result))
+          val librariesJson = (payload \ "libraries").as[Seq[JsObject]]
+          librariesJson.length === 4
+          librariesJson.map(j => (j \ "name").as[String]).toSet === Set(lib1, lib2, lib4, orgGeneralLib).map(_.name)
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationControllerTest.scala
@@ -70,7 +70,7 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
           val jsonResponse = Json.parse(contentAsString(response))
           (jsonResponse \ "name").as[String] === "Forty Two Kifis"
           (jsonResponse \ "handle").as[String] === "kifi"
-          (jsonResponse \ "numLibraries").as[Int] === 10 + 15
+          (jsonResponse \ "numLibraries").as[Int] === 10 + 15 + 1 // for org general lib
         }
       }
     }
@@ -216,7 +216,6 @@ class MobileOrganizationControllerTest extends Specification with ShoeboxTestInj
                } """.stripMargin
           val request = route.modifyOrganization(publicId).withBody(Json.parse(json))
           val response = controller.modifyOrganization(publicId)(request)
-          println(contentAsString(response))
           status(response) === OK
 
           db.readOnlyMaster { implicit session =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationMembershipControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationMembershipControllerTest.scala
@@ -194,7 +194,8 @@ class MobileOrganizationMembershipControllerTest extends Specification with Shoe
           val request = route.modifyMembers(publicOrgId).withBody(jsonPayload)
           val result = controller.modifyMembers(publicOrgId)(request)
 
-          status(result) === FORBIDDEN
+          status(result) === OK
+          (contentAsJson(result) \ "modifications").as[Seq[JsValue]] === Seq.empty
         }
       }
       "modify members if the requester has permission" in {
@@ -265,7 +266,8 @@ class MobileOrganizationMembershipControllerTest extends Specification with Shoe
           val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
           val result = controller.removeMembers(publicOrgId)(request)
 
-          status(result) === FORBIDDEN
+          status(result) === OK
+          (contentAsJson(result) \ "removals").as[Seq[ExternalId[User]]] === Seq.empty
         }
       }
       "remove members if the requester has permission" in {

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationMembershipControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileOrganizationMembershipControllerTest.scala
@@ -160,11 +160,11 @@ class MobileOrganizationMembershipControllerTest extends Specification with Shoe
           val (org, owner, _) = setup()
           val publicOrgId = PublicId[Organization]("NoWayThisOneIsValid")
 
-          val jsonPayload = Json.parse("""{"members": []}""")
+          val jsonPayload = JsString("")
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val request = route.modifyMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.modifyMembers(publicOrgId)(request)
+          val request = route.modifyMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.modifyMember(publicOrgId)(request)
           status(result) === BAD_REQUEST
         }
       }
@@ -172,11 +172,11 @@ class MobileOrganizationMembershipControllerTest extends Specification with Shoe
         withDb(controllerTestModules: _*) { implicit injector =>
           val (org, owner, members) = setup()
           val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
-          val jsonPayload = Json.parse(s"""{"members": [{"userId": "${members.head.externalId}", "newRole": 42}]}""")
+          val jsonPayload = Json.parse(s"""{"userId": "${members.head.externalId}", "newRole": 42}""")
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val request = route.modifyMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.modifyMembers(publicOrgId)(request)
+          val request = route.modifyMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.modifyMember(publicOrgId)(request)
           status(result) === BAD_REQUEST
         }
       }
@@ -188,14 +188,13 @@ class MobileOrganizationMembershipControllerTest extends Specification with Shoe
           val m1 = members(0)
           val m2 = members(1)
 
-          val jsonPayload = Json.parse(s"""{"members": [{"userId": "${m2.externalId}", "newRole": "admin"}]}""")
+          val jsonPayload = Json.parse(s"""{"userId": "${m2.externalId}", "newRole": "admin"}""")
 
           inject[FakeUserActionsHelper].setUser(m1)
-          val request = route.modifyMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.modifyMembers(publicOrgId)(request)
+          val request = route.modifyMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.modifyMember(publicOrgId)(request)
 
-          status(result) === OK
-          (contentAsJson(result) \ "modifications").as[Seq[JsValue]] === Seq.empty
+          status(result) === FORBIDDEN
         }
       }
       "modify members if the requester has permission" in {
@@ -203,11 +202,11 @@ class MobileOrganizationMembershipControllerTest extends Specification with Shoe
           val (org, owner, members) = setup()
           val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
 
-          val jsonPayload = Json.parse(s"""{"members": [{"userId": "${members.head.externalId}", "newRole": "member"}]}""")
+          val jsonPayload = Json.parse(s"""{"userId": "${members.head.externalId}", "newRole": "member"}""")
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val request = route.modifyMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.modifyMembers(publicOrgId)(request)
+          val request = route.modifyMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.modifyMember(publicOrgId)(request)
           status(result) === OK
         }
       }
@@ -232,11 +231,11 @@ class MobileOrganizationMembershipControllerTest extends Specification with Shoe
           val (org, owner, _) = setup()
           val publicOrgId = PublicId[Organization]("NoWayThisOneIsValid")
 
-          val jsonPayload = Json.parse("""{"members": []}""")
+          val jsonPayload = JsString("")
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.removeMembers(publicOrgId)(request)
+          val request = route.removeMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.removeMember(publicOrgId)(request)
           status(result) === BAD_REQUEST
         }
       }
@@ -244,11 +243,11 @@ class MobileOrganizationMembershipControllerTest extends Specification with Shoe
         withDb(controllerTestModules: _*) { implicit injector =>
           val (org, owner, members) = setup()
           val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
-          val jsonPayload = Json.parse(s"""{"members": [{"userId": 42}]}""")
+          val jsonPayload = Json.parse(s"""{"userId": 42}""")
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.removeMembers(publicOrgId)(request)
+          val request = route.removeMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.removeMember(publicOrgId)(request)
           status(result) === BAD_REQUEST
         }
       }
@@ -260,14 +259,13 @@ class MobileOrganizationMembershipControllerTest extends Specification with Shoe
           val m1 = members(0)
           val m2 = members(1)
 
-          val jsonPayload = Json.parse(s"""{"members": [{"userId": "${m2.externalId}"}]}""")
+          val jsonPayload = Json.parse(s"""{"userId": "${m2.externalId}"}""")
 
           inject[FakeUserActionsHelper].setUser(m1)
-          val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.removeMembers(publicOrgId)(request)
+          val request = route.removeMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.removeMember(publicOrgId)(request)
 
-          status(result) === OK
-          (contentAsJson(result) \ "removals").as[Seq[ExternalId[User]]] === Seq.empty
+          status(result) === FORBIDDEN
         }
       }
       "remove members if the requester has permission" in {
@@ -275,11 +273,11 @@ class MobileOrganizationMembershipControllerTest extends Specification with Shoe
           val (org, owner, members) = setup()
           val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
 
-          val jsonPayload = Json.parse(s"""{"members": [{"userId": "${members.head.externalId}"}]}""")
+          val jsonPayload = Json.parse(s"""{"userId": "${members.head.externalId}"}""")
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.removeMembers(publicOrgId)(request)
+          val request = route.removeMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.removeMember(publicOrgId)(request)
           status(result) === OK
 
           // there are futures running in the background that will blow up if the test ends and the db is dumped

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserProfileControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileUserProfileControllerTest.scala
@@ -124,7 +124,7 @@ class MobileUserProfileControllerTest extends Specification with ShoeboxTestInje
         status(selfViewer) must equalTo(OK)
         contentType(selfViewer) must beSome("application/json")
         val res3 = contentAsJson(selfViewer)
-        (res3 \ "numLibraries").as[Int] === 4
+        (res3 \ "numLibraries").as[Int] === 4 + 1 // for org general lib
       }
     }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationControllerTest.scala
@@ -136,7 +136,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
           val ownerRequest = route.getOrganization(publicId)
           val ownerResponse = controller.getOrganization(publicId)(ownerRequest)
           status(ownerResponse) === OK
-          (Json.parse(contentAsString(ownerResponse)) \ "organization" \ "numLibraries").as[Int] === 10 + 15
+          (Json.parse(contentAsString(ownerResponse)) \ "organization" \ "numLibraries").as[Int] === 10 + 15 + 1 // for org general library
 
           inject[FakeUserActionsHelper].setUser(rando)
           inject[FakeUserActionsHelper].setUser(rando)
@@ -239,7 +239,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
 
           val jsonResponse = Json.parse(contentAsString(response))
           (jsonResponse \ "libraries") must haveClass[JsArray]
-          (jsonResponse \ "libraries").as[Seq[JsValue]].length === numPublicLibs + numOrgLibs
+          (jsonResponse \ "libraries").as[Seq[JsValue]].length === numPublicLibs + numOrgLibs + 1 // for org general library
         }
       }
       "give public libraries to a nonmember" in {
@@ -271,7 +271,7 @@ class OrganizationControllerTest extends Specification with ShoeboxTestInjector 
 
           val jsonResponse = Json.parse(contentAsString(response))
           (jsonResponse \ "libraries") must haveClass[JsArray]
-          (jsonResponse \ "libraries").as[Seq[JsValue]].length === numPublicLibs + numOrgLibs + numPrivateLibs
+          (jsonResponse \ "libraries").as[Seq[JsValue]].length === numPublicLibs + numOrgLibs + numPrivateLibs + 1
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationMembershipControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationMembershipControllerTest.scala
@@ -161,11 +161,11 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
           val (org, owner, _) = setup()
           val publicOrgId = PublicId[Organization]("NoWayThisOneIsValid")
 
-          val jsonPayload = Json.parse("""{"members": []}""")
+          val jsonPayload = JsString("")
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val request = route.modifyMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.modifyMembers(publicOrgId)(request)
+          val request = route.modifyMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.modifyMember(publicOrgId)(request)
           status(result) === BAD_REQUEST
         }
       }
@@ -173,11 +173,11 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
         withDb(controllerTestModules: _*) { implicit injector =>
           val (org, owner, members) = setup()
           val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
-          val jsonPayload = Json.parse(s"""{"members": [{"userId": "${members.head.externalId}", "newRole": 42}]}""")
+          val jsonPayload = Json.parse(s"""{"userId": "${members.head.externalId}", "newRole": 42}""")
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val request = route.modifyMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.modifyMembers(publicOrgId)(request)
+          val request = route.modifyMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.modifyMember(publicOrgId)(request)
           status(result) === BAD_REQUEST
         }
       }
@@ -189,11 +189,11 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
           val m1 = members(0)
           val m2 = members(1)
 
-          val jsonPayload = Json.parse(s"""{"members": [{"userId": "${m2.externalId}", "newRole": "owner"}]}""")
+          val jsonPayload = Json.parse(s"""{"userId": "${m2.externalId}", "newRole": "owner"}""")
 
           inject[FakeUserActionsHelper].setUser(m1)
-          val request = route.modifyMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.modifyMembers(publicOrgId)(request)
+          val request = route.modifyMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.modifyMember(publicOrgId)(request)
 
           status(result) === FORBIDDEN
         }
@@ -203,11 +203,11 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
           val (org, owner, members) = setup()
           val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
 
-          val jsonPayload = Json.parse(s"""{"members": [{"userId": "${members.head.externalId}", "newRole": "member"}]}""")
+          val jsonPayload = Json.parse(s"""{"userId": "${members.head.externalId}", "newRole": "member"}""")
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val request = route.modifyMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.modifyMembers(publicOrgId)(request)
+          val request = route.modifyMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.modifyMember(publicOrgId)(request)
           status(result) === OK
         }
       }
@@ -232,11 +232,11 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
           val (org, owner, _) = setup()
           val publicOrgId = PublicId[Organization]("NoWayThisOneIsValid")
 
-          val jsonPayload = Json.parse("""{"members": []}""")
+          val jsonPayload = JsString("")
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.removeMembers(publicOrgId)(request)
+          val request = route.removeMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.removeMember(publicOrgId)(request)
           status(result) === BAD_REQUEST
         }
       }
@@ -244,11 +244,11 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
         withDb(controllerTestModules: _*) { implicit injector =>
           val (org, owner, members) = setup()
           val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
-          val jsonPayload = Json.parse(s"""{"members": [{"userId": 42}]}""")
+          val jsonPayload = Json.parse(s"""{"userId": 42}""")
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.removeMembers(publicOrgId)(request)
+          val request = route.removeMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.removeMember(publicOrgId)(request)
           status(result) === BAD_REQUEST
         }
       }
@@ -260,14 +260,13 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
           val m1 = members(0)
           val m2 = members(1)
 
-          val jsonPayload = Json.parse(s"""{"members": [{"userId": "${m2.externalId}"}]}""")
+          val jsonPayload = Json.parse(s"""{"userId": "${m2.externalId}"}""")
 
           inject[FakeUserActionsHelper].setUser(m1)
-          val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.removeMembers(publicOrgId)(request)
+          val request = route.removeMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.removeMember(publicOrgId)(request)
 
-          status(result) === OK
-          (contentAsJson(result) \ "removals").as[Seq[ExternalId[User]]] === Seq.empty
+          status(result) === FORBIDDEN
         }
       }
       "remove members if the requester has permission" in {
@@ -275,11 +274,11 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
           val (org, owner, members) = setup()
           val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
 
-          val jsonPayload = Json.parse(s"""{"members": [{"userId": "${members.head.externalId}"}]}""")
+          val jsonPayload = Json.parse(s"""{"userId": "${members.head.externalId}"}""")
 
           inject[FakeUserActionsHelper].setUser(owner)
-          val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.removeMembers(publicOrgId)(request)
+          val request = route.removeMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.removeMember(publicOrgId)(request)
           status(result) === OK
 
           // there are futures running in the background that will blow up if the test ends and the db is dumped
@@ -295,11 +294,11 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
           val member = members.head
           val publicOrgId = Organization.publicId(org.id.get)(inject[PublicIdConfiguration])
 
-          val jsonPayload = Json.parse(s"""{"members": [{"userId": "${member.externalId}"}]}""")
+          val jsonPayload = Json.parse(s"""{"userId": "${member.externalId}"}""")
 
           inject[FakeUserActionsHelper].setUser(member)
-          val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
-          val result = controller.removeMembers(publicOrgId)(request)
+          val request = route.removeMember(publicOrgId).withBody(jsonPayload)
+          val result = controller.removeMember(publicOrgId)(request)
           status(result) === OK
 
           // there are futures running in the background that will blow up if the test ends and the db is dumped

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationMembershipControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/OrganizationMembershipControllerTest.scala
@@ -266,7 +266,8 @@ class OrganizationMembershipControllerTest extends Specification with ShoeboxTes
           val request = route.removeMembers(publicOrgId).withBody(jsonPayload)
           val result = controller.removeMembers(publicOrgId)(request)
 
-          status(result) === FORBIDDEN
+          status(result) === OK
+          (contentAsJson(result) \ "removals").as[Seq[ExternalId[User]]] === Seq.empty
         }
       }
       "remove members if the requester has permission" in {

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationFactoryHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationFactoryHelper.scala
@@ -34,6 +34,15 @@ object OrganizationFactoryHelper {
       for (member <- partialOrganization.members) {
         orgMemRepo.save(org.newMembership(member.id.get, OrganizationRole.MEMBER))
       }
+      val libraryRepo = injector.getInstance(classOf[LibraryRepo])
+      val libraryMembershipRepo = injector.getInstance(classOf[LibraryMembershipRepo])
+      val oglCR = LibraryCreateRequest.forOrgGeneralLibrary(org)
+      val lib = libraryRepo.save(Library(ownerId = org.ownerId, name = oglCR.name, slug = LibrarySlug(oglCR.slug), kind = oglCR.kind.get, visibility = oglCR.visibility, organizationId = Some(org.id.get), memberCount = 1 + partialOrganization.admins.length + partialOrganization.members.length))
+      libraryMembershipRepo.save(LibraryMembership(libraryId = lib.id.get, userId = org.ownerId, access = LibraryAccess.OWNER))
+      (partialOrganization.admins ++ partialOrganization.members).foreach { member =>
+        libraryMembershipRepo.save(LibraryMembership(libraryId = lib.id.get, userId = member.id.get, access = LibraryAccess.READ_WRITE))
+      }
+
       val orgInvRepo = injector.getInstance(classOf[OrganizationInviteRepo])
       for (invitedUser <- partialOrganization.invitedUsers) {
         orgInvRepo.save(OrganizationInvite(organizationId = org.id.get, inviterId = org.ownerId, userId = Some(invitedUser.id.get), role = OrganizationRole.MEMBER))


### PR DESCRIPTION
It is a system library. It is created automatically when an org is created. Org
members are automatically added to the library when they join the org, and they
are removed when they leave or are kicked out.

The library cannot be modified or deleted. It automatically transfers ownership
when the org owner changes. It is deleted when the org is deleted.

@andrewconner @leogrim 
