### PR TITLE
Fix lib validation

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
@@ -314,8 +314,8 @@ class AdminLibraryController @Inject() (
       libraryCommander.unsafeTransferLibrary(libId, newOwner)
     }
     val modifyRequest = orgIdOpt match {
-      case Some(orgId) => LibraryModifyRequest(space = Some(LibrarySpace.fromOrganizationId(orgId)), visibility = Some(LibraryVisibility.ORGANIZATION))
-      case None => LibraryModifyRequest(space = Some(LibrarySpace.fromUserId(newOwner)), visibility = Some(LibraryVisibility.PUBLISHED))
+      case Some(orgId) => LibraryModifications(space = Some(LibrarySpace.fromOrganizationId(orgId)), visibility = Some(LibraryVisibility.ORGANIZATION))
+      case None => LibraryModifications(space = Some(LibrarySpace.fromUserId(newOwner)), visibility = Some(LibraryVisibility.PUBLISHED))
     }
     implicit val context = HeimdalContext.empty // TODO(ryan): ask someone that cares to make a HeimdalContext.admin(request) method
     libraryCommander.modifyLibrary(libId, newOwner, modifyRequest)

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -461,7 +461,7 @@ class AdminUserController @Inject() (
 
     (nameOpt, visibilityOpt, slugOpt) match {
       case (Some(name), Some(visibility), Some(slug)) => {
-        val libraryAddRequest = LibraryCreateRequest(name, visibility, slug)
+        val libraryAddRequest = LibraryInitialValues(name, visibility, slug)
 
         implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
         val result: Either[LibraryFail, Library] = libraryCommander.createLibrary(libraryAddRequest, userId)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -257,7 +257,7 @@ class OrganizationCommanderImpl @Inject() (
             val org = handleCommander.autoSetOrganizationHandle(orgRepo.save(orgTemplate)) getOrElse (throw OrganizationFail.HANDLE_UNAVAILABLE)
             orgMembershipRepo.save(org.newMembership(userId = request.requesterId, role = OrganizationRole.ADMIN))
             planManagementCommander.createAndInitializePaidAccountForOrganization(org.id.get, PaidPlan.DEFAULT, request.requesterId, session) //this should get a .get when things are solidified
-            val orgGeneralLibrary = libraryCommander.unsafeCreateLibrary(LibraryCreateRequest.forOrgGeneralLibrary(org), org.ownerId)
+            val orgGeneralLibrary = libraryCommander.unsafeCreateLibrary(LibraryInitialValues.forOrgGeneralLibrary(org), org.ownerId)
             organizationAnalytics.trackOrganizationEvent(org, userRepo.get(request.requesterId), request)
             Right(OrganizationCreateResponse(request, org, orgGeneralLibrary))
           }
@@ -321,7 +321,7 @@ class OrganizationCommanderImpl @Inject() (
         val returningLibsFut = Future {
           libsToReturn.foreach { libId =>
             val lib = db.readOnlyReplica { implicit session => libraryRepo.get(libId) }
-            libraryCommander.unsafeModifyLibrary(lib, LibraryModifyRequest(space = Some(lib.ownerId)))
+            libraryCommander.unsafeModifyLibrary(lib, LibraryModifications(space = Some(lib.ownerId)))
           }
         }
         Right(OrganizationDeleteResponse(request, returningLibsFut, deletingLibsFut))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterWaitlistCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterWaitlistCommander.scala
@@ -110,7 +110,7 @@ class TwitterWaitlistCommanderImpl @Inject() (
 
     (entryOpt, suiOpt, syncOpt) match {
       case (Some(entry), Some(sui), None) if entry.state == TwitterWaitlistEntryStates.ACTIVE && sui.credentials.isDefined && sui.userId.isDefined =>
-        val addRequest = LibraryCreateRequest(
+        val addRequest = LibraryInitialValues(
           name = s"Interesting links from @$handle",
           visibility = LibraryVisibility.PUBLISHED,
           slug = s"interesting-links-from-$handle",

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserPersonaCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserPersonaCommander.scala
@@ -52,7 +52,7 @@ class UserPersonaCommanderImpl @Inject() (
         case (personaName, persona) =>
           val defaultLibraryName = Persona.libraryNames.getOrElse(personaName, personaName.value)
           val defaultLibrarySlug = LibrarySlug.generateFromName(defaultLibraryName)
-          val libraryAddReq = LibraryCreateRequest(name = defaultLibraryName, visibility = LibraryVisibility.PUBLISHED, slug = defaultLibrarySlug, kind = Some(LibraryKind.SYSTEM_PERSONA))
+          val libraryAddReq = LibraryInitialValues(name = defaultLibraryName, visibility = LibraryVisibility.PUBLISHED, slug = defaultLibrarySlug, kind = Some(LibraryKind.SYSTEM_PERSONA))
           if (hasNonDefaultLibrary)
             (persona, Left("already_has_nondefault_libraries"))
           else

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -94,7 +94,7 @@ class ExtLibraryController @Inject() (
   }
 
   def createLibrary() = UserAction(parse.tolerantJson) { request =>
-    val externalCreateRequestValidated = request.body.validate[ExternalLibraryCreateRequest](ExternalLibraryCreateRequest.reads)
+    val externalCreateRequestValidated = request.body.validate[ExternalLibraryInitialValues](ExternalLibraryInitialValues.reads)
 
     externalCreateRequestValidated match {
       case JsError(errs) =>
@@ -107,7 +107,7 @@ class ExtLibraryController @Inject() (
             case ExternalUserSpace(extId) => LibrarySpace.fromUserId(userRepo.getByExternalId(extId).id.get)
             case ExternalOrganizationSpace(pubId) => LibrarySpace.fromOrganizationId(Organization.decodePublicId(pubId).get)
           }
-          LibraryCreateRequest(
+          LibraryInitialValues(
             name = externalCreateRequest.name,
             slug = slug,
             visibility = externalCreateRequest.visibility,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -72,7 +72,7 @@ class MobileLibraryController @Inject() (
   }
 
   def createLibrary() = UserAction(parse.tolerantJson) { request =>
-    val externalCreateRequestValidated = request.body.validate[ExternalLibraryCreateRequest](ExternalLibraryCreateRequest.readsMobileV1)
+    val externalCreateRequestValidated = request.body.validate[ExternalLibraryInitialValues](ExternalLibraryInitialValues.readsMobileV1)
 
     externalCreateRequestValidated match {
       case JsError(errs) =>
@@ -85,7 +85,7 @@ class MobileLibraryController @Inject() (
             case ExternalUserSpace(extId) => LibrarySpace.fromUserId(userRepo.getByExternalId(extId).id.get)
             case ExternalOrganizationSpace(pubId) => LibrarySpace.fromOrganizationId(Organization.decodePublicId(pubId).get)
           }
-          LibraryCreateRequest(
+          LibraryInitialValues(
             name = externalCreateRequest.name,
             slug = slug,
             visibility = externalCreateRequest.visibility,
@@ -121,7 +121,7 @@ class MobileLibraryController @Inject() (
     val newWhoCanInvite = (json \ "newWhoCanInvite").asOpt[LibraryInvitePermissions]
 
     implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.mobile).build
-    val modifyRequest = LibraryModifyRequest(newName, newSlug, newVisibility, newDescription, newColor, newListed, newWhoCanInvite)
+    val modifyRequest = LibraryModifications(newName, newSlug, newVisibility, newDescription, newColor, newListed, newWhoCanInvite)
     val res = libraryCommander.modifyLibrary(libId, request.userId, modifyRequest)
     res match {
       case Left(fail) => sendFailResponse(fail)
@@ -131,7 +131,7 @@ class MobileLibraryController @Inject() (
 
   def modifyLibraryV2(pubId: PublicId[Library]) = (UserAction andThen LibraryOwnerAction(pubId))(parse.tolerantJson) { request =>
     val id = Library.decodePublicId(pubId).get
-    val externalModifyRequestValidated = request.body.validate[ExternalLibraryModifyRequest](ExternalLibraryModifyRequest.readsMobileV1)
+    val externalModifyRequestValidated = request.body.validate[ExternalLibraryModifications](ExternalLibraryModifications.readsMobileV1)
 
     externalModifyRequestValidated match {
       case JsError(errs) =>
@@ -143,7 +143,7 @@ class MobileLibraryController @Inject() (
             case ExternalUserSpace(extId) => LibrarySpace.fromUserId(userRepo.getByExternalId(extId).id.get)
             case ExternalOrganizationSpace(pubOrgId) => LibrarySpace.fromOrganizationId(Organization.decodePublicId(pubOrgId).get)
           }
-          LibraryModifyRequest(
+          LibraryModifications(
             name = externalLibraryModifyRequest.name,
             slug = externalLibraryModifyRequest.slug,
             visibility = externalLibraryModifyRequest.visibility,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -75,7 +75,7 @@ class LibraryController @Inject() (
   }
 
   def addLibrary() = UserAction(parse.tolerantJson) { request =>
-    val externalCreateRequestValidated = request.body.validate[ExternalLibraryCreateRequest](ExternalLibraryCreateRequest.reads)
+    val externalCreateRequestValidated = request.body.validate[ExternalLibraryInitialValues](ExternalLibraryInitialValues.reads)
 
     externalCreateRequestValidated match {
       case JsError(errs) =>
@@ -88,7 +88,7 @@ class LibraryController @Inject() (
             case ExternalUserSpace(extId) => LibrarySpace.fromUserId(userRepo.getByExternalId(extId).id.get)
             case ExternalOrganizationSpace(pubId) => LibrarySpace.fromOrganizationId(Organization.decodePublicId(pubId).get)
           }
-          LibraryCreateRequest(
+          LibraryInitialValues(
             name = externalCreateRequest.name,
             slug = slug,
             visibility = externalCreateRequest.visibility,
@@ -119,14 +119,14 @@ class LibraryController @Inject() (
 
   def modifyLibrary(pubId: PublicId[Library]) = (UserAction andThen LibraryWriteAction(pubId))(parse.tolerantJson) { request =>
     val id = Library.decodePublicId(pubId).get
-    val externalLibraryModifyRequest = request.body.as[ExternalLibraryModifyRequest](ExternalLibraryModifyRequest.reads)
+    val externalLibraryModifyRequest = request.body.as[ExternalLibraryModifications](ExternalLibraryModifications.reads)
 
     val libModifyRequest = db.readOnlyReplica { implicit session =>
       val space = externalLibraryModifyRequest.externalSpace map {
         case ExternalUserSpace(extId) => LibrarySpace.fromUserId(userRepo.getByExternalId(extId).id.get)
         case ExternalOrganizationSpace(pubId) => LibrarySpace.fromOrganizationId(Organization.decodePublicId(pubId).get)
       }
-      LibraryModifyRequest(
+      LibraryModifications(
         name = externalLibraryModifyRequest.name,
         slug = externalLibraryModifyRequest.slug,
         visibility = externalLibraryModifyRequest.visibility,

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
@@ -38,7 +38,7 @@ case class LibraryFail(status: Int, message: String) extends Exception(message)
 @json
 case class LibrarySubscriptionKey(name: String, info: SubscriptionInfo)
 
-case class ExternalLibraryCreateRequest(
+case class ExternalLibraryInitialValues(
   name: String,
   visibility: LibraryVisibility,
   slug: Option[String],
@@ -51,8 +51,34 @@ case class ExternalLibraryCreateRequest(
   space: Option[ExternalLibrarySpace] = None,
   orgMemberAccess: Option[LibraryAccess] = None)
 
-object ExternalLibraryCreateRequest {
-  val readsMobileV1: Reads[ExternalLibraryCreateRequest] = (
+case class LibraryInitialValues(
+    name: String,
+    visibility: LibraryVisibility,
+    slug: String,
+    kind: Option[LibraryKind] = None,
+    description: Option[String] = None,
+    color: Option[LibraryColor] = None,
+    listed: Option[Boolean] = None,
+    whoCanInvite: Option[LibraryInvitePermissions] = None,
+    subscriptions: Option[Seq[LibrarySubscriptionKey]] = None,
+    space: Option[LibrarySpace] = None,
+    orgMemberAccess: Option[LibraryAccess] = None) {
+  def asLibraryModifications: LibraryModifications = LibraryModifications(
+    name = Some(name),
+    visibility = Some(visibility),
+    slug = Some(slug),
+    description = description,
+    color = color,
+    listed = listed,
+    whoCanInvite = whoCanInvite,
+    subscriptions = subscriptions,
+    space = space,
+    orgMemberAccess = orgMemberAccess
+  )
+}
+
+object ExternalLibraryInitialValues {
+  val readsMobileV1: Reads[ExternalLibraryInitialValues] = (
     (__ \ 'name).read[String] and
     (__ \ 'visibility).read[LibraryVisibility] and
     (__ \ 'slug).readNullable[String] and
@@ -64,26 +90,13 @@ object ExternalLibraryCreateRequest {
     (__ \ 'subscriptions).readNullable[Seq[LibrarySubscriptionKey]] and
     (__ \ 'space).readNullable[ExternalLibrarySpace] and
     (__ \ 'orgMemberAccess).readNullable[LibraryAccess]
-  )(ExternalLibraryCreateRequest.apply _)
+  )(ExternalLibraryInitialValues.apply _)
   val reads = readsMobileV1
 }
 
-case class LibraryCreateRequest(
-  name: String,
-  visibility: LibraryVisibility,
-  slug: String,
-  kind: Option[LibraryKind] = None,
-  description: Option[String] = None,
-  color: Option[LibraryColor] = None,
-  listed: Option[Boolean] = None,
-  whoCanInvite: Option[LibraryInvitePermissions] = None,
-  subscriptions: Option[Seq[LibrarySubscriptionKey]] = None,
-  space: Option[LibrarySpace] = None,
-  orgMemberAccess: Option[LibraryAccess] = None)
-
-object LibraryCreateRequest {
-  def forOrgGeneralLibrary(org: Organization): LibraryCreateRequest = {
-    LibraryCreateRequest(
+object LibraryInitialValues {
+  def forOrgGeneralLibrary(org: Organization): LibraryInitialValues = {
+    LibraryInitialValues(
       name = "General",
       visibility = LibraryVisibility.ORGANIZATION,
       slug = "general",
@@ -94,7 +107,7 @@ object LibraryCreateRequest {
   }
 }
 
-case class ExternalLibraryModifyRequest(
+case class ExternalLibraryModifications(
   name: Option[String] = None,
   slug: Option[String] = None,
   visibility: Option[LibraryVisibility] = None,
@@ -106,24 +119,7 @@ case class ExternalLibraryModifyRequest(
   externalSpace: Option[ExternalLibrarySpace] = None,
   orgMemberAccess: Option[LibraryAccess] = None)
 
-object ExternalLibraryModifyRequest {
-  val readsMobileV1: Reads[ExternalLibraryModifyRequest] = (
-    (__ \ 'name).readNullable[String] and
-    (__ \ 'slug).readNullable[String] and
-    (__ \ 'visibility).readNullable[LibraryVisibility] and
-    (__ \ 'description).readNullable[String] and
-    (__ \ 'color).readNullable[LibraryColor] and
-    (__ \ 'listed).readNullable[Boolean] and
-    (__ \ 'whoCanInvite).readNullable[LibraryInvitePermissions] and
-    (__ \ 'subscriptions).readNullable[Seq[LibrarySubscriptionKey]] and
-    (__ \ 'space).readNullable[ExternalLibrarySpace] and
-    (__ \ 'orgMemberAccess).readNullable[LibraryAccess]
-  )(ExternalLibraryModifyRequest.apply _)
-
-  val reads = readsMobileV1 // this can be reassigned, just don't add any breaking changes to an mobile API in prod
-}
-
-case class LibraryModifyRequest(
+case class LibraryModifications(
   name: Option[String] = None,
   slug: Option[String] = None,
   visibility: Option[LibraryVisibility] = None,
@@ -134,6 +130,23 @@ case class LibraryModifyRequest(
   subscriptions: Option[Seq[LibrarySubscriptionKey]] = None,
   space: Option[LibrarySpace] = None,
   orgMemberAccess: Option[LibraryAccess] = None)
+
+object ExternalLibraryModifications {
+  val readsMobileV1: Reads[ExternalLibraryModifications] = (
+    (__ \ 'name).readNullable[String] and
+    (__ \ 'slug).readNullable[String] and
+    (__ \ 'visibility).readNullable[LibraryVisibility] and
+    (__ \ 'description).readNullable[String] and
+    (__ \ 'color).readNullable[LibraryColor] and
+    (__ \ 'listed).readNullable[Boolean] and
+    (__ \ 'whoCanInvite).readNullable[LibraryInvitePermissions] and
+    (__ \ 'subscriptions).readNullable[Seq[LibrarySubscriptionKey]] and
+    (__ \ 'space).readNullable[ExternalLibrarySpace] and
+    (__ \ 'orgMemberAccess).readNullable[LibraryAccess]
+  )(ExternalLibraryModifications.apply _)
+
+  val reads = readsMobileV1 // this can be reassigned, just don't add any breaking changes to an mobile API in prod
+}
 
 case class LibraryModifyResponse(
   modifiedLibrary: Library,

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -335,6 +335,16 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           addResponse must beLeft
         }
       }
+      "fail if a user tries to create nonsensical libraries" in {
+        withDb(modules: _*) { implicit injector =>
+          val user = db.readWrite { implicit session =>
+            UserFactory.user().saved
+          }
+          val addRequest = LibraryInitialValues(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", space = Some(user.id.get))
+          val addResponse = libraryCommander.createLibrary(addRequest, user.id.get)
+          addResponse must beLeft
+        }
+      }
     }
     "when getFullLibraryInfo(s) is called" in {
       "serve up a full library info" in {

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -239,13 +239,13 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             libraryRepo.count === 0
           }
 
-          val lib1Request = LibraryCreateRequest(name = "Avengers Missions", slug = "avengers", visibility = LibraryVisibility.SECRET)
+          val lib1Request = LibraryInitialValues(name = "Avengers Missions", slug = "avengers", visibility = LibraryVisibility.SECRET)
 
-          val lib2Request = LibraryCreateRequest(name = "MURICA", slug = "murica", visibility = LibraryVisibility.PUBLISHED)
+          val lib2Request = LibraryInitialValues(name = "MURICA", slug = "murica", visibility = LibraryVisibility.PUBLISHED)
 
-          val lib3Request = LibraryCreateRequest(name = "Science and Stuff", slug = "science", visibility = LibraryVisibility.PUBLISHED, whoCanInvite = Some(LibraryInvitePermissions.OWNER))
+          val lib3Request = LibraryInitialValues(name = "Science and Stuff", slug = "science", visibility = LibraryVisibility.PUBLISHED, whoCanInvite = Some(LibraryInvitePermissions.OWNER))
 
-          val lib4Request = LibraryCreateRequest(name = "Invalid Param", slug = "", visibility = LibraryVisibility.SECRET)
+          val lib4Request = LibraryInitialValues(name = "Invalid Param", slug = "", visibility = LibraryVisibility.SECRET)
 
           val libraryCommander = inject[LibraryCommander]
           val add1 = libraryCommander.createLibrary(lib1Request, userAgent.id.get)
@@ -296,7 +296,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           }
           val libraryCommander = inject[LibraryCommander]
 
-          val addRequest = LibraryCreateRequest(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", space = Some(org.id.get))
+          val addRequest = LibraryInitialValues(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", space = Some(org.id.get))
           val addResponse = libraryCommander.createLibrary(addRequest, owner.id.get)
           addResponse must beRight
         }
@@ -315,7 +315,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           }
           val libraryCommander = inject[LibraryCommander]
 
-          val addRequest = LibraryCreateRequest(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", space = Some(org.id.get))
+          val addRequest = LibraryInitialValues(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", space = Some(org.id.get))
           val addResponse = libraryCommander.createLibrary(addRequest, member.id.get)
           addResponse must beLeft
         }
@@ -330,7 +330,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           }
           val libraryCommander = inject[LibraryCommander]
 
-          val addRequest = LibraryCreateRequest(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", space = Some(org.id.get))
+          val addRequest = LibraryInitialValues(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", space = Some(org.id.get))
           val addResponse = libraryCommander.createLibrary(addRequest, rando.id.get)
           addResponse must beLeft
         }
@@ -367,27 +367,27 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           val org2 = orgs(1)
           // Move the libraries into the org
           // Only the owner can do this
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = member.id.get, LibraryModifyRequest(space = Some(org1.id.get))) must beLeft
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifyRequest(space = Some(org1.id.get))) must beLeft
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifyRequest(space = Some(org1.id.get))) must beRight
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = member.id.get, LibraryModifications(space = Some(org1.id.get))) must beLeft
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifications(space = Some(org1.id.get))) must beLeft
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifications(space = Some(org1.id.get))) must beRight
 
           // Move the library back into the user's space
           // Again, only the owner can do this
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = member.id.get, LibraryModifyRequest(space = Some(libOwner.id.get))) must beLeft
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifyRequest(space = Some(libOwner.id.get))) must beLeft
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifyRequest(space = Some(libOwner.id.get))) must beRight
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = member.id.get, LibraryModifications(space = Some(libOwner.id.get))) must beLeft
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifications(space = Some(libOwner.id.get))) must beLeft
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifications(space = Some(libOwner.id.get))) must beRight
 
           // Back to org 1
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifyRequest(space = Some(org1.id.get))) must beRight
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifications(space = Some(org1.id.get))) must beRight
           // And then directly into org 2
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = member.id.get, LibraryModifyRequest(space = Some(org2.id.get))) must beLeft
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifyRequest(space = Some(org2.id.get))) must beLeft
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifyRequest(space = Some(org2.id.get))) must beRight
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = member.id.get, LibraryModifications(space = Some(org2.id.get))) must beLeft
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifications(space = Some(org2.id.get))) must beLeft
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifications(space = Some(org2.id.get))) must beRight
 
           // And then back to org 1
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = member.id.get, LibraryModifyRequest(space = Some(org1.id.get))) must beLeft
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifyRequest(space = Some(org1.id.get))) must beLeft
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifyRequest(space = Some(org1.id.get))) must beRight
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = member.id.get, LibraryModifications(space = Some(org1.id.get))) must beLeft
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifications(space = Some(org1.id.get))) must beLeft
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifications(space = Some(org1.id.get))) must beRight
         }
       }
       "let org members with the force-edit permission move libraries" in {
@@ -403,18 +403,18 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // Move the libraries into the org
           // Only the owner can do this
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = member.id.get, LibraryModifyRequest(space = Some(org.id.get))) must beLeft
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifyRequest(space = Some(org.id.get))) must beLeft
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifyRequest(space = Some(org.id.get))) must beRight
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = member.id.get, LibraryModifications(space = Some(org.id.get))) must beLeft
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifications(space = Some(org.id.get))) must beLeft
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifications(space = Some(org.id.get))) must beRight
 
           // Move the library back into the user's space
           // By default, only the owner can do this
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = member.id.get, LibraryModifyRequest(space = Some(libOwner.id.get))) must beLeft
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifyRequest(space = Some(libOwner.id.get))) must beLeft
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifyRequest(space = Some(libOwner.id.get))) must beRight
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = member.id.get, LibraryModifications(space = Some(libOwner.id.get))) must beLeft
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifications(space = Some(libOwner.id.get))) must beLeft
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifications(space = Some(libOwner.id.get))) must beRight
 
           // Back to the org
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifyRequest(space = Some(org.id.get))) must beRight
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifications(space = Some(org.id.get))) must beRight
 
           // However, if we give the admin force-edit permissions
           // TODO(ryan): can we find a way to test this without manually modifying the db?
@@ -423,9 +423,9 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             orgMembershipRepo.save(ownerMembership.withPermissions(ownerMembership.permissions + FORCE_EDIT_LIBRARIES))
           }
           // They still can't steal the library
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifyRequest(space = Some(orgOwner.id.get))) must beLeft
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifications(space = Some(orgOwner.id.get))) must beLeft
           // But they can force it back into the owner's personal space
-          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifyRequest(space = Some(libOwner.id.get))) must beRight
+          libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = orgOwner.id.get, LibraryModifications(space = Some(libOwner.id.get))) must beRight
         }
       }
       "allow changing organizationId of library" in {
@@ -443,7 +443,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           // no privs on org, cannot move from personal space.
           implicit val publicIdConfig = inject[PublicIdConfiguration]
           val cannotMoveOrg = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(space = Some(org.id.get)))
+            LibraryModifications(space = Some(org.id.get)))
           cannotMoveOrg must beLeft
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).organizationId === None
@@ -453,13 +453,13 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // move from personal space to org space
           val canMoveOrg = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(space = Some(org.id.get)))
+            LibraryModifications(space = Some(org.id.get)))
           canMoveOrg must beRight
           canMoveOrg.right.get.modifiedLibrary.organizationId === org.id
 
           // prevent move from org to one without privs
           val attemptToStealLibrary = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(space = Some(starkOrg.id.get)))
+            LibraryModifications(space = Some(starkOrg.id.get)))
           attemptToStealLibrary must beLeft
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).organizationId === org.id
@@ -470,7 +470,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             orgMemberRepo.save(starkOrg.newMembership(userAgent.id.get, OrganizationRole.ADMIN)) // how did he pull that off.
           }
           val moveOrganization = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(space = Some(starkOrg.id.get)))
+            LibraryModifications(space = Some(starkOrg.id.get)))
           moveOrganization must beRight
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).organizationId === starkOrg.id
@@ -478,7 +478,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // try to move library back to owner out of org space.
           val moveHome = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userIron.id.get,
-            LibraryModifyRequest(space = Some(userIron.id.get)))
+            LibraryModifications(space = Some(userIron.id.get)))
           moveHome must beLeft // only the owner can move a library out right now.
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).organizationId === starkOrg.id
@@ -486,7 +486,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // owner moves the library home.
           val moveHomeSucceeds = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(space = Some(userAgent.id.get)))
+            LibraryModifications(space = Some(userAgent.id.get)))
           moveHomeSucceeds must beRight // only the owner can move a library out right now.
           db.readOnlyMaster { implicit session =>
             libraryRepo.get(libShield.id.get).space === LibrarySpace.fromUserId(userAgent.id.get)
@@ -500,36 +500,36 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           val libraryCommander = inject[LibraryCommander]
           val mod1 = libraryCommander.modifyLibrary(libraryId = libShield.id.get, userId = userAgent.id.get,
-            LibraryModifyRequest(description = Some("Samuel L. Jackson was here"), whoCanInvite = Some(LibraryInvitePermissions.OWNER)))
+            LibraryModifications(description = Some("Samuel L. Jackson was here"), whoCanInvite = Some(LibraryInvitePermissions.OWNER)))
           mod1 must beRight
           mod1.right.get.modifiedLibrary.description === Some("Samuel L. Jackson was here")
           mod1.right.get.modifiedLibrary.whoCanInvite === Some(LibraryInvitePermissions.OWNER)
 
           val mod2 = libraryCommander.modifyLibrary(libraryId = libMurica.id.get, userId = userCaptain.id.get,
-            LibraryModifyRequest(name = Some("MURICA #1!!!!!"), slug = Some("murica_#1")))
+            LibraryModifications(name = Some("MURICA #1!!!!!"), slug = Some("murica_#1")))
           mod2 must beRight
           mod2.right.get.modifiedLibrary.name === "MURICA #1!!!!!"
           mod2.right.get.modifiedLibrary.slug === LibrarySlug("murica_#1")
 
           val mod3 = libraryCommander.modifyLibrary(libraryId = libScience.id.get, userId = userIron.id.get,
-            LibraryModifyRequest(visibility = Some(LibraryVisibility.PUBLISHED)))
+            LibraryModifications(visibility = Some(LibraryVisibility.PUBLISHED)))
           mod3 must beRight
           mod3.right.get.modifiedLibrary.visibility === LibraryVisibility.PUBLISHED
 
           val mod3NoChange = libraryCommander.modifyLibrary(libraryId = libScience.id.get, userId = userIron.id.get,
-            LibraryModifyRequest(visibility = Some(LibraryVisibility.PUBLISHED)))
+            LibraryModifications(visibility = Some(LibraryVisibility.PUBLISHED)))
           mod3NoChange must beRight
           mod3NoChange.right.get.modifiedLibrary.visibility === LibraryVisibility.PUBLISHED
 
           val mod4 = libraryCommander.modifyLibrary(libraryId = libScience.id.get, userId = userHulk.id.get,
-            LibraryModifyRequest(name = Some("HULK SMASH")))
+            LibraryModifications(name = Some("HULK SMASH")))
           mod4 must beLeft
           val mod5 = libraryCommander.modifyLibrary(libraryId = libScience.id.get, userId = userIron.id.get,
-            LibraryModifyRequest(name = Some("")))
+            LibraryModifications(name = Some("")))
           mod5 must beLeft
 
           val mod6 = libraryCommander.modifyLibrary(libraryId = libScience.id.get, userId = userIron.id.get,
-            LibraryModifyRequest(color = Some(LibraryColor.SKY_BLUE)))
+            LibraryModifications(color = Some(LibraryColor.SKY_BLUE)))
           mod6 must beRight
           mod6.right.get.modifiedLibrary.color === Some(LibraryColor.SKY_BLUE)
 
@@ -565,7 +565,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // Move it into starkOrg
           val response1 = libraryCommander.modifyLibrary(libraryId = ironLib.id.get, userId = ironMan.id.get,
-            LibraryModifyRequest(space = Some(starkOrg.id.get)))
+            LibraryModifications(space = Some(starkOrg.id.get)))
           response1 must beRight
 
           // Now the library should live in starkOrg, but there is still an alias from ironMan
@@ -580,7 +580,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // Move it back into ironMan's personal space
           val response2 = libraryCommander.modifyLibrary(libraryId = ironLib.id.get, userId = ironMan.id.get,
-            LibraryModifyRequest(space = Some(ironMan.id.get)))
+            LibraryModifications(space = Some(ironMan.id.get)))
           response2 must beRight
 
           // The ironMan one was reclaimed, so it should be inactive now
@@ -598,7 +598,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // Move it into earthOrg
           val response3 = libraryCommander.modifyLibrary(libraryId = ironLib.id.get, userId = ironMan.id.get,
-            LibraryModifyRequest(space = Some(earthOrg.id.get)))
+            LibraryModifications(space = Some(earthOrg.id.get)))
           response3 must beRight
 
           // Two aliases now, both ironMan and starkOrg
@@ -617,7 +617,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
 
           // Try to move it back into starkOrg, should succeed since by default members can remove libraries
           val response4 = libraryCommander.modifyLibrary(libraryId = ironLib.id.get, userId = ironMan.id.get,
-            LibraryModifyRequest(space = Some(starkOrg.id.get)))
+            LibraryModifications(space = Some(starkOrg.id.get)))
           response4 must beRight
         }
       }
@@ -632,7 +632,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             (user, org, lib)
           }
 
-          val res2 = libraryCommander.modifyLibrary(lib1.id.get, user.id.get, LibraryModifyRequest(visibility = Some(LibraryVisibility.SECRET))).right.get
+          val res2 = libraryCommander.modifyLibrary(lib1.id.get, user.id.get, LibraryModifications(visibility = Some(LibraryVisibility.SECRET))).right.get
           Await.result(res2.keepChanges, Duration.Inf)
           val lib2 = res2.modifiedLibrary
           db.readOnlyMaster { implicit session =>
@@ -642,7 +642,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             }
           }
 
-          val res3 = libraryCommander.modifyLibrary(lib2.id.get, user.id.get, LibraryModifyRequest(space = Some(LibrarySpace.fromOrganizationId(org.id.get)), visibility = Some(LibraryVisibility.ORGANIZATION))).right.get
+          val res3 = libraryCommander.modifyLibrary(lib2.id.get, user.id.get, LibraryModifications(space = Some(LibrarySpace.fromOrganizationId(org.id.get)), visibility = Some(LibraryVisibility.ORGANIZATION))).right.get
           Await.result(res3.keepChanges, Duration.Inf)
           val lib3 = res3.modifiedLibrary
           db.readOnlyMaster { implicit session =>
@@ -652,7 +652,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             }
           }
 
-          val res4 = libraryCommander.modifyLibrary(lib3.id.get, user.id.get, LibraryModifyRequest(space = Some(LibrarySpace.fromUserId(user.id.get)), visibility = Some(LibraryVisibility.PUBLISHED))).right.get
+          val res4 = libraryCommander.modifyLibrary(lib3.id.get, user.id.get, LibraryModifications(space = Some(LibrarySpace.fromUserId(user.id.get)), visibility = Some(LibraryVisibility.PUBLISHED))).right.get
           Await.result(res4.keepChanges, Duration.Inf)
           val lib4 = res4.modifiedLibrary
           db.readOnlyMaster { implicit session =>
@@ -662,7 +662,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             }
           }
 
-          val res5 = libraryCommander.modifyLibrary(lib4.id.get, user.id.get, LibraryModifyRequest(space = Some(LibrarySpace.fromOrganizationId(org.id.get)))).right.get
+          val res5 = libraryCommander.modifyLibrary(lib4.id.get, user.id.get, LibraryModifications(space = Some(LibrarySpace.fromOrganizationId(org.id.get)))).right.get
           Await.result(res5.keepChanges, Duration.Inf)
           val lib5 = res5.modifiedLibrary
           db.readOnlyMaster { implicit session =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
@@ -180,7 +180,7 @@ class KifiSiteRouterTest extends Specification with ShoeboxApplicationInjector {
         // Libraries
         val libraryCommander = inject[LibraryCommander]
         val Right(library) = {
-          val libraryRequest = LibraryCreateRequest(name = "Awesome Lib", visibility = LibraryVisibility.PUBLISHED, slug = "awesome-lib")
+          val libraryRequest = LibraryInitialValues(name = "Awesome Lib", visibility = LibraryVisibility.PUBLISHED, slug = "awesome-lib")
           libraryCommander.createLibrary(libraryRequest, user1.id.get)
         }
         actionsHelper.unsetUser
@@ -191,7 +191,7 @@ class KifiSiteRouterTest extends Specification with ShoeboxApplicationInjector {
         route(FakeRequest("GET", "/abeZ1234/awesome-lib?auth=abcdefghiklmnop")) must beRedirect(303, "/abe.z1234/awesome-lib?auth=abcdefghiklmnop")
         route(FakeRequest("GET", "/abeZ1234/awesome-lib/find?q=weee")) must beRedirect(303, "/abe.z1234/awesome-lib/find?q=weee")
 
-        libraryCommander.modifyLibrary(library.id.get, library.ownerId, LibraryModifyRequest(slug = Some("most-awesome-lib")))
+        libraryCommander.modifyLibrary(library.id.get, library.ownerId, LibraryModifications(slug = Some("most-awesome-lib")))
         route(FakeRequest("GET", "/abe.z1234/awesome-lib")) must beRedirect(301, "/abe.z1234/most-awesome-lib")
         route(FakeRequest("GET", "/abe.z1234/most-awesome-lib")) must beWebApp
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationFactoryHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationFactoryHelper.scala
@@ -36,7 +36,7 @@ object OrganizationFactoryHelper {
       }
       val libraryRepo = injector.getInstance(classOf[LibraryRepo])
       val libraryMembershipRepo = injector.getInstance(classOf[LibraryMembershipRepo])
-      val oglCR = LibraryCreateRequest.forOrgGeneralLibrary(org)
+      val oglCR = LibraryInitialValues.forOrgGeneralLibrary(org)
       val lib = libraryRepo.save(Library(ownerId = org.ownerId, name = oglCR.name, slug = LibrarySlug(oglCR.slug), kind = oglCR.kind.get, visibility = oglCR.visibility, organizationId = Some(org.id.get), memberCount = 1 + partialOrganization.admins.length + partialOrganization.members.length))
       libraryMembershipRepo.save(LibraryMembership(libraryId = lib.id.get, userId = org.ownerId, access = LibraryAccess.OWNER))
       (partialOrganization.admins ++ partialOrganization.members).foreach { member =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
@@ -62,34 +62,34 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
 
         // owner can create public libraries
         val libraryCommander = inject[LibraryCommander]
-        val ownerCreateRequest = LibraryCreateRequest(name = "Alphabet Soup", slug = "alphabet", visibility = LibraryVisibility.PUBLISHED, space = Some(LibrarySpace(owner.id.get, org.id)))
+        val ownerCreateRequest = LibraryInitialValues(name = "Alphabet Soup", slug = "alphabet", visibility = LibraryVisibility.PUBLISHED, space = Some(LibrarySpace(owner.id.get, org.id)))
         val ownerLibResponse = libraryCommander.createLibrary(ownerCreateRequest, owner.id.get)
         ownerLibResponse must beRight
 
         // admin can create public libraries
-        val adminCreateRequest = LibraryCreateRequest(name = "Alphabetter Soup", slug = "alphabetter", visibility = LibraryVisibility.PUBLISHED, space = Some(LibrarySpace(admin.id.get, org.id)))
+        val adminCreateRequest = LibraryInitialValues(name = "Alphabetter Soup", slug = "alphabetter", visibility = LibraryVisibility.PUBLISHED, space = Some(LibrarySpace(admin.id.get, org.id)))
         val adminLibResponse = libraryCommander.createLibrary(adminCreateRequest, admin.id.get)
         adminLibResponse must beRight
 
         // member cannot create public libraries
-        val memberCreateRequest1 = LibraryCreateRequest(name = "Alphabest Soup", slug = "alphabest", visibility = LibraryVisibility.PUBLISHED, space = Some(LibrarySpace(member.id.get, org.id)))
+        val memberCreateRequest1 = LibraryInitialValues(name = "Alphabest Soup", slug = "alphabest", visibility = LibraryVisibility.PUBLISHED, space = Some(LibrarySpace(member.id.get, org.id)))
         val memberLibResponse1 = libraryCommander.createLibrary(memberCreateRequest1, member.id.get)
         memberLibResponse1 must beLeft
 
-        val memberCreateRequest2 = LibraryCreateRequest(name = "Alphabest Soup", slug = "alphabest", visibility = LibraryVisibility.SECRET, space = Some(LibrarySpace(member.id.get, org.id)))
+        val memberCreateRequest2 = LibraryInitialValues(name = "Alphabest Soup", slug = "alphabest", visibility = LibraryVisibility.SECRET, space = Some(LibrarySpace(member.id.get, org.id)))
         val memberLibResponse2 = libraryCommander.createLibrary(memberCreateRequest2, member.id.get)
         memberLibResponse2 must beRight
         val library = memberLibResponse2.right.get
 
         // member cannot modify an org library to be public
-        val memberModifyRequest1 = LibraryModifyRequest(visibility = Some(LibraryVisibility.PUBLISHED))
+        val memberModifyRequest1 = LibraryModifications(visibility = Some(LibraryVisibility.PUBLISHED))
         val memberLibResponse3 = libraryCommander.modifyLibrary(library.id.get, member.id.get, memberModifyRequest1)
         memberLibResponse3 must beLeft
 
         // admins can alter feature settings
         planManagementCommander.setAccountFeatureSettings(org.id.get, admin.id.get, FeatureSetting.alterSettings(account.featureSettings, Set(FeatureSetting(feature.name, feature.options.find(_ == "member").get))))
 
-        val memberModifyRequest2 = LibraryModifyRequest(visibility = Some(LibraryVisibility.PUBLISHED))
+        val memberModifyRequest2 = LibraryModifications(visibility = Some(LibraryVisibility.PUBLISHED))
         val memberLibResponse4 = libraryCommander.modifyLibrary(library.id.get, member.id.get, memberModifyRequest2)
         memberLibResponse4 must beRight
       }
@@ -152,9 +152,9 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
 
         val libraryCommander = inject[LibraryCommander]
 
-        val ownerModifyRequest = LibraryModifyRequest(name = Some("Elon's Main Library"))
-        val adminModifyRequest = LibraryModifyRequest(name = Some("Larry's Main Library"))
-        val memberModifyRequest = LibraryModifyRequest(name = Some("Sergey's Main Library"))
+        val ownerModifyRequest = LibraryModifications(name = Some("Elon's Main Library"))
+        val adminModifyRequest = LibraryModifications(name = Some("Larry's Main Library"))
+        val memberModifyRequest = LibraryModifications(name = Some("Sergey's Main Library"))
 
         libraryCommander.modifyLibrary(library.id.get, owner.id.get, ownerModifyRequest) must beRight
         libraryCommander.modifyLibrary(library.id.get, admin.id.get, adminModifyRequest) must beRight
@@ -274,9 +274,9 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
 
         val libraryCommander = inject[LibraryCommander]
 
-        val ownerModifyRequest = LibraryModifyRequest(space = Some(UserSpace(owner.id.get)))
-        val adminModifyRequest = LibraryModifyRequest(space = Some(UserSpace(admin.id.get)))
-        val memberModifyRequest = LibraryModifyRequest(space = Some(UserSpace(member.id.get)))
+        val ownerModifyRequest = LibraryModifications(space = Some(UserSpace(owner.id.get)))
+        val adminModifyRequest = LibraryModifications(space = Some(UserSpace(admin.id.get)))
+        val memberModifyRequest = LibraryModifications(space = Some(UserSpace(member.id.get)))
 
         libraryCommander.modifyLibrary(ownerLibrary.id.get, owner.id.get, ownerModifyRequest) must beLeft
         libraryCommander.modifyLibrary(adminLibrary.id.get, admin.id.get, adminModifyRequest) must beLeft
@@ -317,13 +317,13 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
 
         val libraryCommander = inject[LibraryCommander]
 
-        val ownerModifyRequest = LibraryModifyRequest(subscriptions = Some(Seq(LibrarySubscriptionKey("#general", SlackInfo("https://hooks.slack.com/services/kk/kk")))))
+        val ownerModifyRequest = LibraryModifications(subscriptions = Some(Seq(LibrarySubscriptionKey("#general", SlackInfo("https://hooks.slack.com/services/kk/kk")))))
 
-        val adminModifyRequest = LibraryModifyRequest(subscriptions = Some(Seq(
+        val adminModifyRequest = LibraryModifications(subscriptions = Some(Seq(
           LibrarySubscriptionKey("#general", SlackInfo("https://hooks.slack.com/services/kk/kk")),
           LibrarySubscriptionKey("#eng", SlackInfo("https://hooks.slack.com/services/ok/ok")))))
 
-        val memberModifyRequest = LibraryModifyRequest(subscriptions = Some(Seq(
+        val memberModifyRequest = LibraryModifications(subscriptions = Some(Seq(
           LibrarySubscriptionKey("#general", SlackInfo("https://hooks.slack.com/services/kk/kk")),
           LibrarySubscriptionKey("#eng", SlackInfo("https://hooks.slack.com/services/ok/ok")),
           LibrarySubscriptionKey("#product", SlackInfo("https://hooks.slack.com/services/ko/ko")))))


### PR DESCRIPTION
@leogrim @cvializ 

I feel like there's a lot of overlap between the `validateCreateRequest` and `validateModifyRequest`, but I couldn't think of a clean way to DRY them. Any suggestions?
