### PR TITLE
Fix kf-symbol-sprite in Safari

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/symbol-sprite.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/symbol-sprite.js
@@ -13,7 +13,7 @@ angular.module('kifi')
         var svgElement = element[0];
 
         var paths = angular.element('symbol#' + attrs.icon);
-        svgElement.innerHTML = paths.html();
+        svgElement.appendChild(paths.find('g').clone()[0]);
 
         var className = svgElement.getAttribute('class') || '';
         svgElement.setAttribute('class', className + (className ? ' ' : '') + 'symbol-sprite');


### PR DESCRIPTION
@andrewconner Safari doesn't like working with `innerHTML` on SVGs, go figure
