### PR TITLE
Fixed a nasty bug in the permissions checking

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -121,9 +121,7 @@ class LibraryCommanderImpl @Inject() (
     def invalidSpace = {
       val canCreateLibraryInSpace = targetSpace match {
         case OrganizationSpace(orgId) =>
-          val permissions = permissionCommander.getOrganizationPermissions(orgId, Some(ownerId))
-          permissions.contains(OrganizationPermission.ADD_LIBRARIES) &&
-            (libCreateReq.visibility != LibraryVisibility.PUBLISHED || permissions.contains(OrganizationPermission.PUBLISH_LIBRARIES))
+          permissionCommander.getOrganizationPermissions(orgId, Some(ownerId)).contains(OrganizationPermission.ADD_LIBRARIES)
         case UserSpace(userId) =>
           userId == ownerId // Right now this is guaranteed to be correct, could replace with true
       }
@@ -134,7 +132,7 @@ class LibraryCommanderImpl @Inject() (
       (targetSpace, libCreateReq.visibility) match {
         case (UserSpace(_), LibraryVisibility.ORGANIZATION) =>
           Some(LibraryFail(BAD_REQUEST, "invalid_visibility"))
-        case (OrganizationSpace(orgId), LibraryVisibility.PUBLISHED) if permissionCommander.getOrganizationPermissions(orgId, Some(ownerId)).contains(OrganizationPermission.PUBLISH_LIBRARIES) =>
+        case (OrganizationSpace(orgId), LibraryVisibility.PUBLISHED) if !permissionCommander.getOrganizationPermissions(orgId, Some(ownerId)).contains(OrganizationPermission.PUBLISH_LIBRARIES) =>
           Some(LibraryFail(FORBIDDEN, "cannot_publish_libraries_in_space"))
         case _ => None
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
@@ -61,7 +61,6 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         }
 
         // owner can create public libraries
-        val libraryCommander = inject[LibraryCommander]
         val ownerCreateRequest = LibraryInitialValues(name = "Alphabet Soup", slug = "alphabet", visibility = LibraryVisibility.PUBLISHED, space = Some(LibrarySpace(owner.id.get, org.id)))
         val ownerLibResponse = libraryCommander.createLibrary(ownerCreateRequest, owner.id.get)
         ownerLibResponse must beRight


### PR DESCRIPTION
The way that Feature Settings work makes checking permissions more difficult
than it used to be. I want to reiterate that we really need to revisit this
model for org permissions.
