### PR TITLE
Update visibility icons on keep cards and library headers

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryHeader.styl
@@ -387,7 +387,6 @@ followerPicDiam = 2.2em
   background-position: .9em .46em
   background-size: .9em auto
   background-repeat: no-repeat
-  background-color: libraryRed
 
   .kf-system-secret &
     display: none
@@ -404,14 +403,12 @@ followerPicDiam = 2.2em
     margin-right: 5px
 
 .kf-lh-org-private
-  background: readableYellowColor
 
   &::after
-    content: 'Organization Private'
+    content: 'Team'
 
 .kf-lh-public
   padding: 0
-  background: transparent
 
   &::after
     content: 'Public'

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibraries.styl
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibraries.styl
@@ -353,10 +353,6 @@ lockRadius = 14px
   &:not(:first-child)
     margin-left: 8px
 
-.kf-upl-card-private
-  background-color: libraryRed
-  padding: 2px
-
 .kf-upl-count
   vertical-align: middle
   font-size: 13px


### PR DESCRIPTION
This removes the background colors on library visibility in the library header, renames 'organization private' to 'team' and removes the red circle behind the private lock on library cards.

https://app.asana.com/0/20751731968782/51714360963530
