### PR TITLE
add BasicLibraryDetails.permissions (viewer permissions)

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -381,7 +381,8 @@ case class BasicLibraryDetails(
   keepCount: Int,
   membership: Option[LibraryMembershipInfo], // viewer
   ownerId: Id[User],
-  url: Path)
+  url: Path,
+  permissions: Set[LibraryPermission])
 
 sealed abstract class LibraryColor(val hex: String)
 object LibraryColor {

--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/website/WebsiteSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/website/WebsiteSearchController.scala
@@ -371,7 +371,8 @@ class WebsiteSearchController @Inject() (
                   "numKeeps" -> details.keepCount,
                   "membership" -> details.membership,
                   "memberCount" -> (details.numFollowers + details.numCollaborators), // deprecated
-                  "keepCount" -> details.keepCount // deprecated,
+                  "keepCount" -> details.keepCount, // deprecated,
+                  "permissions" -> details.permissions
                 )
             }
           })

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInfoCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInfoCommander.scala
@@ -141,7 +141,8 @@ class LibraryInfoCommanderImpl @Inject() (
         val imageOpt = libraryImageCommander.getBestImageForLibrary(libId, idealImageSize).map(libraryImageCommander.getUrl)
         val membershipOpt = membershipsByLibraryId.get(libId).flatten
         val path = libPathCommander.pathForLibrary(lib)
-        libId -> BasicLibraryDetails(lib.name, lib.slug, lib.color, imageOpt, lib.description, numFollowers, numCollaborators, lib.keepCount, membershipOpt.map(createMembershipInfo), lib.ownerId, path)
+        val permissions = permissionCommander.getLibraryPermissions(libId, viewerId)
+        libId -> BasicLibraryDetails(lib.name, lib.slug, lib.color, imageOpt, lib.description, numFollowers, numCollaborators, lib.keepCount, membershipOpt.map(createMembershipInfo), lib.ownerId, path, permissions)
       }.toMap
     }
   }


### PR DESCRIPTION
@leogrim this was the first (hopefully only) thing to fall through the cracks of the `LibraryCardInfo` and `FullLibraryInfo.permissions` refactor. Front-end expects this object to look like other libraries.
