### PR TITLE
Argh, comparing different types with `==` should REALLY be a compiler warning

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/AccountEventRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/AccountEventRepo.scala
@@ -102,7 +102,7 @@ class AccountEventRepoImpl @Inject() (
   }
 
   def getMemebershipEventsInOrder(accountId: Id[PaidAccount])(implicit session: RSession): Seq[AccountEvent] = {
-    (for (row <- rows if row.accountId === accountId && (row.eventType == "user_added" || row.eventType == "user_removed")) yield row).sortBy(r => (r.eventTime asc, r.id asc)).list
+    (for (row <- rows if row.accountId === accountId && (row.eventType === "user_added" || row.eventType === "user_removed")) yield row).sortBy(r => (r.eventTime asc, r.id asc)).list
   }
 
 }


### PR DESCRIPTION
I think this might have been what caused the integrity checker to malfunction. We will see shortly.

@ryanpbrewster @camhashemi 
