### PR TITLE
Upgrade ui-router.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/bower.json
+++ b/kifi-backend/modules/shoebox/angular/bower.json
@@ -24,7 +24,7 @@
     "angular-moment": "0.8.0",
     "angular-resource": "~1.3.15",
     "angular-sanitize": "~1.3.15",
-    "angular-ui-router": "0.2.13",
+    "angular-ui-router": "0.2.15",
     "angulartics": "0.14.17",
     "antiscroll": "fa3f81d3c07b647a63036da1de859fcaf1355993",
     "fuse.js": "1.1.0",


### PR DESCRIPTION
@andrewconner There's an issue on navigating with `{ '#': 'blah' }` that I believe is fixed in the newest UI router.
