### PR TITLE
Introduce UserIdentityCache

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/common/cache/ABookCacheModule.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/common/cache/ABookCacheModule.scala
@@ -6,7 +6,7 @@ import com.keepit.shoebox.model.KeepImagesCache
 import scala.concurrent.duration._
 import com.google.inject.{ Provides, Singleton }
 import com.keepit.model._
-import com.keepit.social.BasicUserUserIdCache
+import com.keepit.social.{ UserIdentityCache, BasicUserUserIdCache }
 import com.keepit.search.{ ArticleSearchResultCache, InitialSearchIdCache, ActiveExperimentsCache }
 import com.keepit.common.logging.AccessLog
 import com.keepit.common.usersegment.UserSegmentCache
@@ -50,6 +50,10 @@ case class ABookCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Provides
   def socialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new SocialUserInfoNetworkCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
+
+  @Provides @Singleton
+  def userIdentityCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserIdentityCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/common/app/com/keepit/model/SocialUserInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/SocialUserInfo.scala
@@ -122,15 +122,6 @@ case class SocialUserInfoUserKey(userId: Id[User]) extends Key[Seq[SocialUserInf
 class SocialUserInfoUserCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
   extends JsonCacheImpl[SocialUserInfoUserKey, Seq[SocialUserInfo]](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
 
-case class SocialUserKey(userId: Id[User]) extends Key[Seq[SocialUser]] {
-  val namespace = "social_user_by_userid"
-  override val version = 1
-  def toKey(): String = userId.id.toString
-}
-
-class SocialUserCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
-  extends JsonCacheImpl[SocialUserKey, Seq[SocialUser]](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
-
 case class SocialUserInfoNetworkKey(networkType: SocialNetworkType, id: SocialId) extends Key[SocialUserInfo] {
   override val version = 5
   val namespace = "social_user_info_by_network_and_id"

--- a/kifi-backend/modules/common/app/com/keepit/model/SocialUserInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/SocialUserInfo.scala
@@ -131,15 +131,6 @@ case class SocialUserInfoNetworkKey(networkType: SocialNetworkType, id: SocialId
 class SocialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
   extends JsonCacheImpl[SocialUserInfoNetworkKey, SocialUserInfo](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
 
-case class SocialUserNetworkKey(networkType: SocialNetworkType, id: SocialId) extends Key[SocialUser] {
-  override val version = 1
-  val namespace = "social_user_by_network_and_id"
-  def toKey(): String = networkType.name.toString + "_" + id.id
-}
-
-class SocialUserNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
-  extends JsonCacheImpl[SocialUserNetworkKey, SocialUser](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
-
 case class SocialUserBasicInfoKey(id: Id[SocialUserInfo]) extends Key[SocialUserBasicInfo] {
   val namespace = "social_user_basic_info"
   override val version = 1

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -153,6 +153,7 @@ case class ShoeboxCacheProvider @Inject() (
   userIdCache: UserIdCache,
   socialUserNetworkCache: SocialUserInfoNetworkCache,
   socialUserCache: SocialUserInfoUserCache,
+  userIdentityCache: UserIdentityCache,
   userSessionExternalIdCache: UserSessionViewExternalIdCache,
   userConnectionsCache: UserConnectionIdCache,
   searchFriendsCache: SearchFriendsCache,
@@ -195,8 +196,10 @@ class ShoeboxServiceClientImpl @Inject() (
   }
 
   def getUserIdentity(identityId: IdentityId): Future[Option[UserIdentity]] = {
-    call(Shoebox.internal.getUserIdentity(providerId = identityId.providerId, id = identityId.userId)).map { r =>
-      r.json.asOpt[UserIdentity]
+    cacheProvider.userIdentityCache.getOrElseFutureOpt(UserIdentityIdentityIdKey(identityId)) {
+      call(Shoebox.internal.getUserIdentity(providerId = identityId.providerId, id = identityId.userId)).map { r =>
+        r.json.asOpt[UserIdentity]
+      }
     }
   }
 

--- a/kifi-backend/modules/common/test/com/keepit/common/cache/FakeCacheModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/cache/FakeCacheModule.scala
@@ -61,11 +61,6 @@ case class FakeCacheModule() extends CacheModule(HashMapMemoryCacheModule()) {
 
   @Singleton
   @Provides
-  def socialUserUserCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
-    new SocialUserCache(stats, accessLog, (outerRepo, 30 days))
-
-  @Singleton
-  @Provides
   def socialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new SocialUserInfoNetworkCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 

--- a/kifi-backend/modules/common/test/com/keepit/common/cache/FakeCacheModule.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/cache/FakeCacheModule.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
 import com.google.inject.{ Provides, Singleton }
 import com.keepit.model._
 import com.keepit.search.ActiveExperimentsCache
-import com.keepit.social.BasicUserUserIdCache
+import com.keepit.social.{ UserIdentityCache, BasicUserUserIdCache }
 import com.keepit.common.logging.AccessLog
 import com.keepit.common.usersegment.UserSegmentCache
 import com.keepit.classify.DomainCache
@@ -63,6 +63,10 @@ case class FakeCacheModule() extends CacheModule(HashMapMemoryCacheModule()) {
   @Provides
   def socialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new SocialUserInfoNetworkCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
+
+  @Provides @Singleton
+  def userIdentityCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserIdentityCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/cortex/app/com/keepit/common/cache/CortexCacheModule.scala
+++ b/kifi-backend/modules/cortex/app/com/keepit/common/cache/CortexCacheModule.scala
@@ -8,7 +8,7 @@ import com.keepit.shoebox.model.KeepImagesCache
 import scala.concurrent.duration._
 import com.google.inject.{ Provides, Singleton }
 import com.keepit.model._
-import com.keepit.social.BasicUserUserIdCache
+import com.keepit.social.{ UserIdentityCache, BasicUserUserIdCache }
 import com.keepit.search.{ ArticleSearchResultCache, InitialSearchIdCache, ActiveExperimentsCache }
 import com.keepit.common.logging.AccessLog
 import com.keepit.common.usersegment.UserSegmentCache
@@ -49,6 +49,10 @@ case class CortexCacheModule(cachePluginModules: CachePluginModule*) extends Cac
   @Provides
   def socialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new SocialUserInfoNetworkCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
+
+  @Provides @Singleton
+  def userIdentityCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserIdentityCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/common/cache/ElizaCacheModule.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 import com.keepit.common.logging.AccessLog
 import com.google.inject.{ Provides, Singleton }
 import com.keepit.model._
-import com.keepit.social.BasicUserUserIdCache
+import com.keepit.social.{ UserIdentityCache, BasicUserUserIdCache }
 import com.keepit.eliza.model._
 import com.keepit.search.{ ArticleSearchResultCache, InitialSearchIdCache, ActiveExperimentsCache }
 import com.keepit.common.usersegment.UserSegmentCache
@@ -74,6 +74,10 @@ case class ElizaCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Provides
   def socialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new SocialUserInfoNetworkCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
+
+  @Provides @Singleton
+  def userIdentityCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserIdentityCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/graph/app/com/keepit/graph/common/cache/GraphCacheModule.scala
+++ b/kifi-backend/modules/graph/app/com/keepit/graph/common/cache/GraphCacheModule.scala
@@ -7,7 +7,7 @@ import com.keepit.graph.model._
 import com.keepit.model._
 import com.keepit.model.cache.UserSessionViewExternalIdCache
 import com.keepit.shoebox.model.KeepImagesCache
-import com.keepit.social.BasicUserUserIdCache
+import com.keepit.social.{ UserIdentityCache, BasicUserUserIdCache }
 import com.keepit.search.{ ArticleSearchResultCache, InitialSearchIdCache, ActiveExperimentsCache }
 import com.keepit.common.usersegment.UserSegmentCache
 import scala.concurrent.duration._
@@ -54,6 +54,10 @@ case class GraphCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Provides
   def socialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new SocialUserInfoNetworkCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
+
+  @Provides @Singleton
+  def userIdentityCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserIdentityCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/heimdal/app/com/keepit/common/cache/HeimdalCacheModule.scala
+++ b/kifi-backend/modules/heimdal/app/com/keepit/common/cache/HeimdalCacheModule.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 import com.keepit.common.logging.AccessLog
 import com.google.inject.{ Provides, Singleton }
 import com.keepit.model._
-import com.keepit.social.BasicUserUserIdCache
+import com.keepit.social.{ UserIdentityCache, BasicUserUserIdCache }
 import com.keepit.search.ActiveExperimentsCache
 import com.keepit.common.usersegment.UserSegmentCache
 
@@ -51,6 +51,10 @@ case class HeimdalCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Provides
   def socialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new SocialUserInfoNetworkCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
+
+  @Provides @Singleton
+  def userIdentityCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserIdentityCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/rover/app/com/keepit/rover/common/cache/RoverCacheModule.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/common/cache/RoverCacheModule.scala
@@ -12,7 +12,7 @@ import com.keepit.rover.model.{ RoverUrlRuleAllCache, RoverArticleImagesCache, R
 import com.keepit.rover.sensitivity.UriSensitivityCache
 import com.keepit.rover.store.UrlContentSignatureCache
 import com.keepit.shoebox.model.KeepImagesCache
-import com.keepit.social.BasicUserUserIdCache
+import com.keepit.social.{ UserIdentityCache, BasicUserUserIdCache }
 import com.keepit.search.{ ArticleSearchResultCache, InitialSearchIdCache, ActiveExperimentsCache }
 import com.keepit.common.usersegment.UserSegmentCache
 import scala.concurrent.duration._
@@ -59,6 +59,10 @@ case class RoverCacheModule(cachePluginModules: CachePluginModule*) extends Cach
   @Provides
   def socialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new SocialUserInfoNetworkCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
+
+  @Provides @Singleton
+  def userIdentityCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserIdentityCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/search/app/com/keepit/search/common/cache/SearchCacheModule.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/common/cache/SearchCacheModule.scala
@@ -11,7 +11,7 @@ import com.keepit.rover.model.{ RoverArticleImagesCache, RoverArticleSummaryCach
 import com.keepit.search._
 import com.keepit.search.tracking.{ ClickHistoryBuilder, ClickHistoryUserIdCache, ProbablisticLRUChunkCache }
 import com.keepit.shoebox.model.KeepImagesCache
-import com.keepit.social.BasicUserUserIdCache
+import com.keepit.social.{ UserIdentityCache, BasicUserUserIdCache }
 
 import scala.concurrent.duration._
 
@@ -61,6 +61,10 @@ case class SearchCacheModule(cachePluginModules: CachePluginModule*) extends Cac
   @Provides
   def socialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new SocialUserInfoNetworkCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
+
+  @Provides @Singleton
+  def userIdentityCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserIdentityCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -118,11 +118,6 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
 
   @Singleton
   @Provides
-  def socialUserNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new SocialUserNetworkCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
-
-  @Singleton
-  @Provides
   def urlPatternRuleAllCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new UrlPatternRulesAllCache(stats, accessLog, (innerRepo, 1 hour), (outerRepo, 30 days))
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -113,11 +113,6 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
 
   @Singleton
   @Provides
-  def socialUserCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new SocialUserCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
-
-  @Singleton
-  @Provides
   def socialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new SocialUserInfoNetworkCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 import com.google.inject.{ Provides, Singleton }
 import com.keepit.model._
 import com.keepit.search.{ ArticleSearchResultCache, InitialSearchIdCache, ActiveExperimentsCache }
-import com.keepit.social.{ BasicUserUserIdCache }
+import com.keepit.social.{ UserIdentityCache, BasicUserUserIdCache }
 import com.keepit.classify.{ DomainCache }
 import com.keepit.common.logging.AccessLog
 import com.keepit.common.usersegment.UserSegmentCache
@@ -115,6 +115,10 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Provides
   def socialUserInfoNetworkCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new SocialUserInfoNetworkCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
+
+  @Provides @Singleton
+  def userIdentityCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new UserIdentityCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 30 days))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/SocialUserInfoRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/SocialUserInfoRepo.scala
@@ -35,8 +35,7 @@ class SocialUserInfoRepoImpl @Inject() (
   val clock: Clock,
   val countCache: SocialUserInfoCountCache,
   val networkCache: SocialUserInfoNetworkCache,
-  val basicInfoCache: SocialUserBasicInfoCache,
-  val socialUserNetworkCache: SocialUserNetworkCache)
+  val basicInfoCache: SocialUserBasicInfoCache)
     extends DbRepo[SocialUserInfo] with DbRepoWithDelete[SocialUserInfo] with SeqNumberDbFunction[SocialUserInfo] with SocialUserInfoRepo {
 
   import db.Driver.simple._
@@ -98,7 +97,6 @@ class SocialUserInfoRepoImpl @Inject() (
     socialUser.id map { id =>
       basicInfoCache.remove(SocialUserBasicInfoKey(id))
     }
-    socialUserNetworkCache.remove(SocialUserNetworkKey(socialUser.networkType, socialUser.socialId))
     countCache.remove(SocialUserInfoCountKey())
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserEmailAddressRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserEmailAddressRepo.scala
@@ -3,6 +3,7 @@ package com.keepit.model
 import com.keepit.common.actor.ActorInstance
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.plugin.{ SequencingActor, SequencingPlugin, SchedulingProperties }
+import com.keepit.social.{ UserIdentityIdentityIdKey, UserIdentityCache }
 import org.joda.time.DateTime
 
 import com.google.inject.{ Inject, Singleton, ImplementedBy }
@@ -30,7 +31,8 @@ trait UserEmailAddressRepo extends Repo[UserEmailAddress] with RepoWithDelete[Us
 class UserEmailAddressRepoImpl @Inject() (
     val db: DataBaseComponent,
     val clock: Clock,
-    userRepo: UserRepo) extends DbRepo[UserEmailAddress] with DbRepoWithDelete[UserEmailAddress] with SeqNumberDbFunction[UserEmailAddress] with UserEmailAddressRepo {
+    userRepo: UserRepo,
+    userIdentityCache: UserIdentityCache) extends DbRepo[UserEmailAddress] with DbRepoWithDelete[UserEmailAddress] with SeqNumberDbFunction[UserEmailAddress] with UserEmailAddressRepo {
 
   import db.Driver.simple._
 
@@ -59,7 +61,9 @@ class UserEmailAddressRepoImpl @Inject() (
     super.save(toSave)
   }
 
-  override def deleteCache(emailAddress: UserEmailAddress)(implicit session: RSession): Unit = {}
+  override def deleteCache(emailAddress: UserEmailAddress)(implicit session: RSession): Unit = {
+    userIdentityCache.remove(UserIdentityIdentityIdKey(emailAddress.address))
+  }
   override def invalidateCache(emailAddress: UserEmailAddress)(implicit session: RSession): Unit = {
     deleteCache(emailAddress)
   }


### PR DESCRIPTION
@andrewconner 
The invalidation has to happen in several places. It's not actually a consequence of the new code, just that we used to have stale data in `SocialUserInfo`. We could use the user's external id instead of the email address as the `IdentityId` identifier, would make the invalidation easier in `UserRepo` and `UserCredRepo` (not having to look up all the user's email addresses) but it would still have to happen there as well.
