### PR TITLE
Sub source to kept events

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalContext.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalContext.scala
@@ -269,7 +269,7 @@ class HeimdalContextBuilderFactory @Inject() (
   def withRequestInfo(request: RequestHeader): HeimdalContextBuilder = {
     val contextBuilder = apply()
     contextBuilder.addRequestInfo(request)
-    request.getQueryString("subsource").foreach { subsource =>
+    request.getQueryString("subsource").collect { case subsource if subsource.nonEmpty =>
       contextBuilder.+=("subsource" -> subsource)
     }
     contextBuilder

--- a/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalContext.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalContext.scala
@@ -269,6 +269,9 @@ class HeimdalContextBuilderFactory @Inject() (
   def withRequestInfo(request: RequestHeader): HeimdalContextBuilder = {
     val contextBuilder = apply()
     contextBuilder.addRequestInfo(request)
+    request.getQueryString("subsource").foreach { subsource =>
+      contextBuilder.+=("subsource" -> subsource)
+    }
     contextBuilder
   }
 


### PR DESCRIPTION
@DerekBurch Alright, this tiny bit should do it.

Basically, on any sane keeping endpoint, if you throw in a `subsource` url query string, it'll make its way to the event. If you don't, it won't. Same on any platform. Works?
