### PR TITLE
Feature/settings

### DIFF
--- a/kifi-backend/modules/shoebox/angular/npm-debug.log
+++ b/kifi-backend/modules/shoebox/angular/npm-debug.log
@@ -1,0 +1,377 @@
+0 info it worked if it ends with ok
+1 verbose cli [ 'node', '/usr/local/bin/npm', 'install' ]
+2 info using npm@2.11.2
+3 info using node@v0.12.5
+4 verbose readDependencies loading dependencies from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/package.json
+5 warn package.json Dependency 'bower' exists in both dependencies and devDependencies, using 'bower@1.3.12' from dependencies
+6 verbose install where, deps [ '/Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular',
+6 verbose install   [ 'bower',
+6 verbose install     'concurrent-transform',
+6 verbose install     'connect-modrewrite',
+6 verbose install     'event-stream',
+6 verbose install     'gulp',
+6 verbose install     'gulp-awspublish',
+6 verbose install     'gulp-cached',
+6 verbose install     'gulp-cheerio',
+6 verbose install     'gulp-concat',
+6 verbose install     'gulp-connect',
+6 verbose install     'gulp-cssmin',
+6 verbose install     'gulp-if',
+6 verbose install     'gulp-ignore',
+6 verbose install     'gulp-jshint',
+6 verbose install     'gulp-livereload',
+6 verbose install     'gulp-minify-html',
+6 verbose install     'gulp-ng-html2js',
+6 verbose install     'gulp-order',
+6 verbose install     'gulp-plumber',
+6 verbose install     'gulp-protractor',
+6 verbose install     'gulp-remember',
+6 verbose install     'gulp-rename',
+6 verbose install     'gulp-rev-all',
+6 verbose install     'gulp-rimraf',
+6 verbose install     'gulp-sourcemaps',
+6 verbose install     'gulp-stylus',
+6 verbose install     'gulp-svgmin',
+6 verbose install     'gulp-svgstore',
+6 verbose install     'gulp-uglify',
+6 verbose install     'gulp-util',
+6 verbose install     'gulp.spritesmith',
+6 verbose install     'jasmine-core',
+6 verbose install     'jshint-stylish',
+6 verbose install     'jsonminify',
+6 verbose install     'karma',
+6 verbose install     'karma-chrome-launcher',
+6 verbose install     'karma-coverage',
+6 verbose install     'karma-firefox-launcher',
+6 verbose install     'karma-html2js-preprocessor',
+6 verbose install     'karma-jasmine',
+6 verbose install     'karma-phantomjs-launcher',
+6 verbose install     'karma-requirejs',
+6 verbose install     'karma-script-launcher',
+6 verbose install     'lazypipe',
+6 verbose install     'merge',
+6 verbose install     'nib',
+6 verbose install     'protractor',
+6 verbose install     'requirejs',
+6 verbose install     'run-sequence',
+6 verbose install     'shelljs',
+6 verbose install     'through',
+6 verbose install     'vinyl-map' ] ]
+7 verbose install where, peers [ '/Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular',
+7 verbose install   [] ]
+8 verbose installManyTop reading for lifecycle /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/package.json
+9 info preinstall kifi@0.0.0
+10 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/bower/package.json
+11 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/concurrent-transform/package.json
+12 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/connect-modrewrite/package.json
+13 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/event-stream/package.json
+14 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp/package.json
+15 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-awspublish/package.json
+16 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-cached/package.json
+17 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-concat/package.json
+18 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-connect/package.json
+19 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-cssmin/package.json
+20 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-if/package.json
+21 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-ignore/package.json
+22 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-jshint/package.json
+23 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-livereload/package.json
+24 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-minify-html/package.json
+25 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-ng-html2js/package.json
+26 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-order/package.json
+27 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-plumber/package.json
+28 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-protractor/package.json
+29 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-remember/package.json
+30 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-rename/package.json
+31 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-rev-all/package.json
+32 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-rimraf/package.json
+33 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-sourcemaps/package.json
+34 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-stylus/package.json
+35 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-svgmin/package.json
+36 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-uglify/package.json
+37 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-util/package.json
+38 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp.spritesmith/package.json
+39 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/jasmine-core/package.json
+40 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/jshint-stylish/package.json
+41 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/jsonminify/package.json
+42 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma/package.json
+43 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-chrome-launcher/package.json
+44 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-coverage/package.json
+45 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-firefox-launcher/package.json
+46 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-html2js-preprocessor/package.json
+47 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-jasmine/package.json
+48 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-phantomjs-launcher/package.json
+49 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-requirejs/package.json
+50 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-script-launcher/package.json
+51 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/lazypipe/package.json
+52 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/merge/package.json
+53 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/nib/package.json
+54 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/protractor/package.json
+55 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/requirejs/package.json
+56 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/run-sequence/package.json
+57 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/shelljs/package.json
+58 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/through/package.json
+59 verbose installManyTop reading scoped package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/vinyl-map/package.json
+60 info package.json karma-chrome-launcher@0.1.7 No README data
+61 info package.json karma-coverage@0.2.7 No README data
+62 info package.json karma-firefox-launcher@0.1.4 No README data
+63 info package.json karma-phantomjs-launcher@0.1.4 No README data
+64 info package.json bower@1.3.12 No license field.
+65 info package.json concurrent-transform@1.0.0 No license field.
+66 info package.json connect-modrewrite@0.7.6 No license field.
+67 info package.json event-stream@3.1.7 No license field.
+68 info package.json gulp@3.8.10 No license field.
+69 info package.json gulp-awspublish@0.0.20 No license field.
+70 info package.json gulp-cached@1.0.1 No license field.
+71 info package.json gulp-concat@2.3.4 No license field.
+72 info package.json gulp-if@1.2.4 No license field.
+73 info package.json gulp-ignore@1.2.0 No license field.
+74 info package.json gulp-minify-html@0.1.8 No license field.
+75 info package.json gulp-jshint@1.9.2 No license field.
+76 info package.json gulp-ng-html2js@0.1.7 No license field.
+77 info package.json gulp-order@1.1.1 license should be a valid SPDX license expression
+78 info package.json gulp-protractor@0.0.11 No license field.
+79 info package.json gulp-remember@0.2.0 No license field.
+80 info package.json gulp-rename@1.2.0 No license field.
+81 info package.json gulp-rimraf@0.1.0 No license field.
+82 info package.json gulp-util@3.0.0 No license field.
+83 info package.json gulp.spritesmith@3.7.0 No license field.
+84 info package.json jsonminify@0.2.3 No license field.
+85 info package.json lazypipe@0.2.2 No license field.
+86 info package.json requirejs@2.1.14 No license field.
+87 info package.json run-sequence@0.3.6 No license field.
+88 info package.json shelljs@0.5.1 license should be a valid SPDX license expression
+89 verbose readDependencies loading dependencies from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/package.json
+90 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/bower/package.json
+91 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/concurrent-transform/package.json
+92 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/connect-modrewrite/package.json
+93 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/event-stream/package.json
+94 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp/package.json
+95 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-awspublish/package.json
+96 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-cached/package.json
+97 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-concat/package.json
+98 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-connect/package.json
+99 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-cssmin/package.json
+100 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-if/package.json
+101 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-ignore/package.json
+102 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-jshint/package.json
+103 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-livereload/package.json
+104 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-minify-html/package.json
+105 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-ng-html2js/package.json
+106 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-order/package.json
+107 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-plumber/package.json
+108 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-protractor/package.json
+109 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-remember/package.json
+110 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-rename/package.json
+111 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-rev-all/package.json
+112 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-rimraf/package.json
+113 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-sourcemaps/package.json
+114 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-stylus/package.json
+115 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-svgmin/package.json
+116 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-uglify/package.json
+117 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp-util/package.json
+118 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/gulp.spritesmith/package.json
+119 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/jasmine-core/package.json
+120 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/jshint-stylish/package.json
+121 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/jsonminify/package.json
+122 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma/package.json
+123 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-chrome-launcher/package.json
+124 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-coverage/package.json
+125 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-firefox-launcher/package.json
+126 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-html2js-preprocessor/package.json
+127 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-jasmine/package.json
+128 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-phantomjs-launcher/package.json
+129 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-requirejs/package.json
+130 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/karma-script-launcher/package.json
+131 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/lazypipe/package.json
+132 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/merge/package.json
+133 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/nib/package.json
+134 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/protractor/package.json
+135 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/requirejs/package.json
+136 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/run-sequence/package.json
+137 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/shelljs/package.json
+138 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/through/package.json
+139 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/vinyl-map/package.json
+140 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/.bin/bower/package.json
+141 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/.bin/gulp/package.json
+142 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/.bin/protractor/package.json
+143 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/.bin/r.js/package.json
+144 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/.bin/shjs/package.json
+145 verbose targetResolver reading package data from /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular/node_modules/.bin/webdriver-manager/package.json
+146 verbose already installed skipping gulp-if@1.2.4 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+147 verbose already installed skipping gulp-ignore@1.2.0 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+148 verbose already installed skipping gulp-jshint@1.9.2 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+149 verbose already installed skipping gulp-livereload@2.1.0 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+150 verbose already installed skipping gulp-minify-html@0.1.8 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+151 verbose already installed skipping gulp-ng-html2js@0.1.7 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+152 verbose already installed skipping gulp-order@1.1.1 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+153 verbose already installed skipping gulp-plumber@1.0.1 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+154 verbose already installed skipping gulp-protractor@0.0.11 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+155 verbose already installed skipping gulp-remember@0.2.0 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+156 verbose already installed skipping gulp-rename@1.2.0 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+157 verbose already installed skipping gulp-rev-all@0.8.21 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+158 verbose already installed skipping gulp-rimraf@0.1.0 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+159 verbose already installed skipping gulp-sourcemaps@^1.5.2 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+160 verbose already installed skipping gulp-stylus@2.0.7 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+161 silly cache add args [ 'gulp-svgmin@1.2.0', null ]
+162 verbose cache add spec gulp-svgmin@1.2.0
+163 silly cache add parsed spec { raw: 'gulp-svgmin@1.2.0',
+163 silly cache add   scope: null,
+163 silly cache add   name: 'gulp-svgmin',
+163 silly cache add   rawSpec: '1.2.0',
+163 silly cache add   spec: '1.2.0',
+163 silly cache add   type: 'version' }
+164 silly addNamed gulp-svgmin@1.2.0
+165 verbose addNamed "1.2.0" is a plain semver version for gulp-svgmin
+166 silly mapToRegistry name gulp-svgmin
+167 silly mapToRegistry using default registry
+168 silly mapToRegistry registry https://registry.npmjs.org/
+169 silly mapToRegistry uri https://registry.npmjs.org/gulp-svgmin
+170 verbose addNameVersion registry:https://registry.npmjs.org/gulp-svgmin not in flight; fetching
+171 silly cache add args [ 'gulp-svgstore@0.6.2', null ]
+172 verbose cache add spec gulp-svgstore@0.6.2
+173 silly cache add parsed spec { raw: 'gulp-svgstore@0.6.2',
+173 silly cache add   scope: null,
+173 silly cache add   name: 'gulp-svgstore',
+173 silly cache add   rawSpec: '0.6.2',
+173 silly cache add   spec: '0.6.2',
+173 silly cache add   type: 'version' }
+174 silly addNamed gulp-svgstore@0.6.2
+175 verbose addNamed "0.6.2" is a plain semver version for gulp-svgstore
+176 silly mapToRegistry name gulp-svgstore
+177 silly mapToRegistry using default registry
+178 silly mapToRegistry registry https://registry.npmjs.org/
+179 silly mapToRegistry uri https://registry.npmjs.org/gulp-svgstore
+180 verbose addNameVersion registry:https://registry.npmjs.org/gulp-svgstore not in flight; fetching
+181 verbose already installed skipping gulp-uglify@0.3.1 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+182 verbose already installed skipping gulp-util@3.0.0 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+183 verbose request uri https://registry.npmjs.org/gulp-svgmin
+184 verbose request no auth needed
+185 info attempt registry request try #1 at 10:29:07 AM
+186 verbose request id 20dc5edfd1c186bc
+187 verbose etag "A2HR6SUCWSSY0U5K42B01QJEP"
+188 http request GET https://registry.npmjs.org/gulp-svgmin
+189 verbose already installed skipping gulp.spritesmith@3.7.0 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+190 verbose already installed skipping jasmine-core@2.1.3 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+191 verbose already installed skipping jshint-stylish@2.0.0 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+192 verbose already installed skipping jsonminify@0.2.3 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+193 verbose already installed skipping karma@0.12.31 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+194 verbose already installed skipping karma-chrome-launcher@0.1.7 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+195 verbose already installed skipping karma-coverage@0.2.7 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+196 verbose already installed skipping karma-firefox-launcher@0.1.4 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+197 verbose already installed skipping karma-html2js-preprocessor@0.1.0 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+198 verbose already installed skipping karma-jasmine@0.3.5 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+199 verbose already installed skipping karma-phantomjs-launcher@0.1.4 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+200 verbose already installed skipping karma-requirejs@0.2.2 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+201 verbose request uri https://registry.npmjs.org/gulp-svgstore
+202 verbose request no auth needed
+203 info attempt registry request try #1 at 10:29:07 AM
+204 verbose etag "8IQCLX5MMGVPWXMFNO3KAILNR"
+205 http request GET https://registry.npmjs.org/gulp-svgstore
+206 verbose already installed skipping karma-script-launcher@0.1.0 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+207 verbose already installed skipping lazypipe@0.2.2 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+208 verbose already installed skipping merge@1.1.3 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+209 verbose already installed skipping nib@1.1.0 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+210 verbose already installed skipping protractor@1.0.0 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+211 verbose already installed skipping requirejs@2.1.14 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+212 verbose already installed skipping run-sequence@0.3.6 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+213 verbose already installed skipping shelljs@^0.5.1 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+214 verbose already installed skipping through@2.3.4 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+215 verbose already installed skipping vinyl-map@1.0.1 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+216 verbose already installed skipping bower@1.3.12 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+217 verbose already installed skipping concurrent-transform@1.0.0 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+218 verbose already installed skipping connect-modrewrite@0.7.6 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+219 verbose already installed skipping event-stream@3.1.7 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+220 verbose already installed skipping gulp@3.8.10 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+221 verbose already installed skipping gulp-awspublish@0.0.20 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+222 verbose already installed skipping gulp-cached@1.0.1 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+223 silly cache add args [ 'gulp-cheerio@0.6.2', null ]
+224 verbose cache add spec gulp-cheerio@0.6.2
+225 silly cache add parsed spec { raw: 'gulp-cheerio@0.6.2',
+225 silly cache add   scope: null,
+225 silly cache add   name: 'gulp-cheerio',
+225 silly cache add   rawSpec: '0.6.2',
+225 silly cache add   spec: '0.6.2',
+225 silly cache add   type: 'version' }
+226 silly addNamed gulp-cheerio@0.6.2
+227 verbose addNamed "0.6.2" is a plain semver version for gulp-cheerio
+228 silly mapToRegistry name gulp-cheerio
+229 silly mapToRegistry using default registry
+230 silly mapToRegistry registry https://registry.npmjs.org/
+231 silly mapToRegistry uri https://registry.npmjs.org/gulp-cheerio
+232 verbose addNameVersion registry:https://registry.npmjs.org/gulp-cheerio not in flight; fetching
+233 verbose already installed skipping gulp-concat@2.3.4 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+234 verbose already installed skipping gulp-connect@2.0.6 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+235 verbose request uri https://registry.npmjs.org/gulp-cheerio
+236 verbose request no auth needed
+237 info attempt registry request try #1 at 10:29:07 AM
+238 verbose etag "5F3DK8T3CRBS0JUREJ7PB7TAG"
+239 http request GET https://registry.npmjs.org/gulp-cheerio
+240 verbose already installed skipping gulp-cssmin@0.1.6 /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+241 http 304 https://registry.npmjs.org/gulp-svgmin
+242 silly get cb [ 304,
+242 silly get   { date: 'Fri, 02 Oct 2015 17:29:07 GMT',
+242 silly get     via: '1.1 varnish',
+242 silly get     'cache-control': 'max-age=60',
+242 silly get     etag: '"A2HR6SUCWSSY0U5K42B01QJEP"',
+242 silly get     age: '0',
+242 silly get     connection: 'keep-alive',
+242 silly get     'x-served-by': 'cache-sjc3135-SJC',
+242 silly get     'x-cache': 'HIT',
+242 silly get     'x-cache-hits': '1',
+242 silly get     'x-timer': 'S1443806947.820415,VS0,VE86',
+242 silly get     vary: 'Accept' } ]
+243 verbose etag https://registry.npmjs.org/gulp-svgmin from cache
+244 verbose get saving gulp-svgmin to /Users/carlos/.npm/registry.npmjs.org/gulp-svgmin/.cache.json
+245 http 304 https://registry.npmjs.org/gulp-svgstore
+246 silly get cb [ 304,
+246 silly get   { date: 'Fri, 02 Oct 2015 17:29:07 GMT',
+246 silly get     via: '1.1 varnish',
+246 silly get     'cache-control': 'max-age=60',
+246 silly get     etag: '"8IQCLX5MMGVPWXMFNO3KAILNR"',
+246 silly get     age: '0',
+246 silly get     connection: 'keep-alive',
+246 silly get     'x-served-by': 'cache-sjc3128-SJC',
+246 silly get     'x-cache': 'HIT',
+246 silly get     'x-cache-hits': '1',
+246 silly get     'x-timer': 'S1443806947.827475,VS0,VE84',
+246 silly get     vary: 'Accept' } ]
+247 verbose etag https://registry.npmjs.org/gulp-svgstore from cache
+248 verbose get saving gulp-svgstore to /Users/carlos/.npm/registry.npmjs.org/gulp-svgstore/.cache.json
+249 http 304 https://registry.npmjs.org/gulp-cheerio
+250 silly get cb [ 304,
+250 silly get   { date: 'Fri, 02 Oct 2015 17:29:07 GMT',
+250 silly get     via: '1.1 varnish',
+250 silly get     'cache-control': 'max-age=60',
+250 silly get     etag: '"5F3DK8T3CRBS0JUREJ7PB7TAG"',
+250 silly get     age: '0',
+250 silly get     connection: 'keep-alive',
+250 silly get     'x-served-by': 'cache-sjc3134-SJC',
+250 silly get     'x-cache': 'MISS',
+250 silly get     'x-cache-hits': '0',
+250 silly get     'x-timer': 'S1443806947.832604,VS0,VE84',
+250 silly get     vary: 'Accept' } ]
+251 verbose etag https://registry.npmjs.org/gulp-cheerio from cache
+252 verbose get saving gulp-cheerio to /Users/carlos/.npm/registry.npmjs.org/gulp-cheerio/.cache.json
+253 silly cache afterAdd gulp-svgmin@1.2.0
+254 verbose afterAdd /Users/carlos/.npm/gulp-svgmin/1.2.0/package/package.json not in flight; writing
+255 silly cache afterAdd gulp-cheerio@0.6.2
+256 verbose afterAdd /Users/carlos/.npm/gulp-cheerio/0.6.2/package/package.json not in flight; writing
+257 verbose afterAdd /Users/carlos/.npm/gulp-svgmin/1.2.0/package/package.json written
+258 verbose afterAdd /Users/carlos/.npm/gulp-cheerio/0.6.2/package/package.json written
+259 verbose stack Error: version not found: gulp-svgstore@0.6.2
+259 verbose stack     at setData (/usr/local/lib/node_modules/npm/lib/cache/add-named.js:137:12)
+259 verbose stack     at RES (/usr/local/lib/node_modules/npm/node_modules/inflight/inflight.js:23:14)
+259 verbose stack     at f (/usr/local/lib/node_modules/npm/node_modules/once/once.js:17:25)
+259 verbose stack     at fixName (/usr/local/lib/node_modules/npm/lib/cache/add-named.js:29:5)
+259 verbose stack     at saved (/usr/local/lib/node_modules/npm/lib/cache/caching-client.js:173:7)
+259 verbose stack     at FSReqWrap.oncomplete (fs.js:95:15)
+260 verbose statusCode 404
+261 verbose cwd /Users/carlos/workspace/keepit/kifi-backend/modules/shoebox/angular
+262 error Darwin 14.5.0
+263 error argv "node" "/usr/local/bin/npm" "install"
+264 error node v0.12.5
+265 error npm  v2.11.2
+266 error version not found: gulp-svgstore@0.6.2
+267 error If you need help, you may report this error at:
+267 error     <https://github.com/npm/npm/issues>
+268 verbose exit [ 1, true ]

--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -184,6 +184,11 @@ angular.module('kifi', [
           $scope.errorParams = toParams;
         }
       });
+
+      $rootScope.$on('errorImmediately', function (error, params) {
+        $scope.errorStatus = error.status || 404;
+        $scope.errorParams = params;
+      });
     }
 
     function paramsDiffer(stateName, p1, p2) {

--- a/kifi-backend/modules/shoebox/angular/src/common/components/link.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/components/link.styl
@@ -2,7 +2,6 @@
   display: inline-block
   padding: 0
   border: 0
-  color: accentGreen
   background: 0
   cursor: pointer
 
@@ -11,6 +10,24 @@
 .kf-link-underline
   text-decoration: underline
 
+.kf-link-parent:hover:not(:active)
+.kf-link-underline:hover:not(:active)
+  text-decoration: none
+
 .kf-link-parent:hover:not(:active) .kf-link
 .kf-link:hover:not(:active)
-  color: lighten(accentGreen, 20%)
+  color: darken(accentGreen, 20%)
+
+kf-link-color(linkColor)
+  &.kf-link
+    color: linkColor
+
+  &.kf-link-parent:hover:not(:active) .kf-link
+  &.kf-link:hover:not(:active)
+    color: lighten(linkColor, 20%)
+
+// regular
+kf-link-color(accentGreen)
+
+.kf-link-white
+  kf-link-color(#fff)

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
@@ -105,7 +105,7 @@
             ui-sref="orgProfile.settings.team"
             ng-click="onClickTrack($event, 'clickedProfileSettings')"
             ng-class="{ 'active': state.current.activetab ==='settings'}"
-            ng-if="!readonly && viewer.membership.role === 'admin' && isKifiAdmin"
+            ng-if="!readonly && viewer.membership.role === 'admin'"
           >
             <div class="kf-oph-stats-name">Settings</div>
           </a>

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettings.styl
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettings.styl
@@ -12,7 +12,7 @@
       height: 60px
       visibility: hidden
 
-  .kf-row
+  .kf-ops-row
     flex-direction: column
 
     @media (min-width: 480px)

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettings.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettings.tpl.html
@@ -40,7 +40,7 @@
             ui-sref="orgProfile.settings.contacts"
           >Billing Contacts</a>
         </li>
-        <li ng-if="isAdminExperiment"  class="kf-ops-nav-item" ng-class="{ 'kf-ops-nav-active': state.current.activenav === 'export-keeps' }">
+        <li ng-if="isAdminExperiment && canExportKeeps"  class="kf-ops-nav-item" ng-class="{ 'kf-ops-nav-active': state.current.activenav === 'export-keeps' }">
           <a
             class="kf-link"
             ui-sref="orgProfile.settings.export"

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettings.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettings.tpl.html
@@ -1,5 +1,5 @@
 <main class="kf-ops kf-wrapper">
-  <div class="kf-row">
+  <div class="kf-row kf-ops-row">
     <div class="kf-container kf-ops-nav">
       <div class="kf-container-header">
         <h1>Navigation</h1>

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettingsCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettingsCtrl.js
@@ -3,8 +3,10 @@
 angular.module('kifi')
 
 .controller('OrgProfileSettingsCtrl', [
-  '$window', '$scope', '$timeout', '$state', 'settings', 'profileService', 'ORG_PERMISSION',
-  function ($window, $scope, $timeout, $state, settings, profileService, ORG_PERMISSION) {
+  '$window', '$rootScope', '$scope','$timeout', '$state', 'settings',
+  'profileService', 'ORG_PERMISSION',
+  function ($window, $rootScope, $scope, $timeout, $state, settings,
+            profileService, ORG_PERMISSION) {
     $scope.state = $state;
     $scope.settings = settings.settings;
     $scope.canExportKeeps = ($scope.viewer.permissions.indexOf(ORG_PERMISSION.EXPORT_KEEPS) !== -1);
@@ -23,5 +25,9 @@ angular.module('kifi')
     $scope.$on('$destroy', function () {
       $window.removeEventListener('hashchange', onHashChange);
     });
+
+    if (!($scope.viewer && $scope.viewer.membership && $scope.viewer.membership.role === 'admin')) {
+      $rootScope.$emit('errorImmediately');
+    }
   }
 ]);

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettingsCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettingsCtrl.js
@@ -26,7 +26,7 @@ angular.module('kifi')
       $window.removeEventListener('hashchange', onHashChange);
     });
 
-    if (!($scope.viewer && $scope.viewer.membership && $scope.viewer.membership.role === 'admin')) {
+    if (!$scope.viewer.membership || $scope.viewer.membership.role !== 'admin') {
       $rootScope.$emit('errorImmediately');
     }
   }

--- a/kifi-backend/modules/shoebox/angular/src/route.js
+++ b/kifi-backend/modules/shoebox/angular/src/route.js
@@ -108,15 +108,7 @@ angular.module('kifi')
             'orgProfileService', 'profile', 'messageTicker', 'ORG_PERMISSION',
             function (orgProfileService, profile, messageTicker, ORG_PERMISSION) {
               if (profile.viewer.permissions.indexOf(ORG_PERMISSION.MANAGE_PLAN) !== -1) {
-                return orgProfileService
-                .getOrgSettings(profile.organization.id)
-                ['catch'](function(response) {
-                  messageTicker({
-                    text: response.statusText + ': Could not retrieve your settings. Please refresh and try again',
-                    type: 'red',
-                    delay: 0
-                  });
-                });
+                return orgProfileService.getOrgSettings(profile.organization.id);
               } else {
                 return {};
               }

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/billingContacts.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/billingContacts.tpl.html
@@ -1,4 +1,4 @@
-<div class="kf-billing-contacts">
+<div class="kf-billing-contacts kf-container">
   <h1>Billing Contacts</h1>
   <p>Select which team admins should receive billing notifications via email</p>
   <div class="kf-container">

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/paymentPlan.styl
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/paymentPlan.styl
@@ -1,0 +1,92 @@
+freePlanColor = #8A74B9
+basicPlanColor = #1067BD
+enterprisePlanColor = #118730
+
+.kf-team-plan-cards
+  justify-content: space-around
+
+.kf-team-plan-card
+  box-sizing: border-box
+  position: relative
+  display: inline-block
+  width: 160px
+  height: 160px  * (7/5)
+  margin: 5px
+  padding: 5px 10px
+  border-radius: 12px
+  box-shadow: 2px 2px 15px 2px rgba(0, 0, 0, .5)
+  font-size: 12px
+  text-align: center
+  color: #fff
+
+.kf-team-plan-card-description
+  margin: 0
+  font-smoothing: antialiased
+
+  + .kf-team-plan-card-description
+    margin-top: 5px
+
+.kf-team-plan-card-title
+  heading_lg()
+  font-weight: bold
+
+.kf-team-plan-card-cost
+  position: relative
+  display: inline-block
+  font-size: 36px
+  font-weight: bold
+
+  &::first-letter
+    font-size: 48px
+
+  &:before
+    content: '$'
+    position: absolute
+    top: 0
+    right: 100%
+    font-size: 24px
+
+.kf-team-plan-card-bottom
+  position: absolute
+  right: 0
+  bottom: 0
+  left: 0
+  margin-bottom: 10px
+
+.kf-team-plan-card-cta
+  margin-top: 8px
+  padding: 5px 10px
+  background: none
+  border: 1px solid #fff
+  border-radius: 5px
+  color: #fff
+  font-size: 14px
+  box-shadow: 0 0 0 0 rgba(0, 0, 0, .15)
+  transition: box-shadow .33s
+  font-smoothing: antialiased
+
+  &:hover
+    box-shadow: 0 0 8px 4px rgba(0, 0, 0, .15)
+    text-decoration: underline
+
+  &:active
+    transition: none
+    box-shadow: 0 0 4px 2px rgba(0, 0, 0, .15)
+
+.kf-team-plan-card-soon
+  width: 160px
+  padding: 18px 0
+  margin: 0 -10px
+  background-color: rgba(255, 255, 255, .25)
+  font-size: 18px
+  font-smoothing: antialiased
+
+
+.kf-team-plan-card-free
+  background-color: freePlanColor
+
+.kf-team-plan-card-basic
+  background-color: basicPlanColor
+
+.kf-team-plan-card-enterprise
+  background-color: enterprisePlanColor

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/paymentPlan.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/paymentPlan.tpl.html
@@ -1,6 +1,36 @@
-<div class="kf-team-plan">
-  <h1>Team Plan</h1>
-  <div>
+<div class="kf-team-plan kf-container">
+  <div class="kf-container-header">
+    <h1>Team Plan</h1>
+  </div>
+  <div class="kf-container-main">
+    <div class="kf-row kf-team-plan-cards">
+      <div class="kf-team-plan-card kf-team-plan-card-free">
+        <div class="kf-team-plan-card-title">Free</div>
+        <div class="kf-team-plan-card-cost">0</div>
+        <div class="kf-team-plan-card-bottom">
+          <p class="kf-team-plan-card-description"><a class="kf-link kf-link-white kf-link-underline" href="#">Details</a></p>
+          <button class="kf-team-plan-card-cta">Upgrade now</button>
+        </div>
+      </div>
+      <div class="kf-team-plan-card kf-team-plan-card-basic">
+        <div class="kf-team-plan-card-title">Basic</div>
+        <div class="kf-team-plan-card-cost">6.67</div>
+        <p class="kf-team-plan-card-description">per user per month when billed anually</p>
+        <p class="kf-team-plan-card-description">$8 billed monthly</p>
+        <div class="kf-team-plan-card-bottom">
+          <p class="kf-team-plan-card-description"><a class="kf-link kf-link-white kf-link-underline" href="#">Details</a></p>
+          <button class="kf-team-plan-card-cta">Upgrade now</button>
+        </div>
+      </div>
+      <div class="kf-team-plan-card kf-team-plan-card-enterprise">
+        <div class="kf-team-plan-card-title">Enterprise</div>
+        <p class="kf-team-plan-card-soon">Coming Soon</p>
+        <div class="kf-team-plan-card-bottom">
+          <p class="kf-team-plan-card-description"><a class="kf-link kf-link-white kf-link-underline" href="#">Details</a></p>
+          <button class="kf-team-plan-card-cta">Contact us</button>
+        </div>
+      </div>
+    </div>
     <h2>Select your plan</h2>
     <p>Select your team's plan. Get details on the plans we offer on the <a class="kf-link" href="#">pricing page</a></p>
     <select>

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.js
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.js
@@ -3,10 +3,10 @@
 angular.module('kifi')
 
 .controller('TeamSettingsCtrl', [
-  '$window', '$scope', 'orgProfileService', 'profileService', 'billingService',
-  'messageTicker', 'ORG_SETTING_VALUE',
-  function ($window, $scope, orgProfileService, profileService, billingService,
-            messageTicker, ORG_SETTING_VALUE) {
+  '$window', '$rootScope', '$scope', 'orgProfileService', 'profileService',
+  'billingService', 'messageTicker', 'ORG_SETTING_VALUE',
+  function ($window, $rootScope, $scope, orgProfileService, profileService,
+            billingService, messageTicker, ORG_SETTING_VALUE) {
     $scope.settingsSectionTemplateData = [
       {
         heading: '',
@@ -174,7 +174,7 @@ angular.module('kifi')
       return message;
     }
 
-    if ($scope.viewer.membership.role === 'admin') {
+    if ($scope.viewer && $scope.viewer.membership && $scope.viewer.membership.role === 'admin') {
       billingService
       .getBillingState($scope.profile.id)
       .then(function (stateData) {

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.js
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.js
@@ -174,7 +174,7 @@ angular.module('kifi')
       return message;
     }
 
-    if ($scope.viewer && $scope.viewer.membership && $scope.viewer.membership.role === 'admin') {
+    if ($scope.viewer.membership && $scope.viewer.membership.role === 'admin') {
       billingService
       .getBillingState($scope.profile.id)
       .then(function (stateData) {

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.js
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.js
@@ -96,6 +96,14 @@ angular.module('kifi')
             ),
             fieldKey: 'create_slack_integration',
             selectOptions: getOptions(ORG_SETTING_VALUE.DISABLED, ORG_SETTING_VALUE.ADMIN, ORG_SETTING_VALUE.MEMBER)
+          },
+          {
+            title: 'Who can export team keeps?',
+            description: (
+              'Download all of your team\'s keeps for safe keeping'
+            ),
+            fieldKey: 'export_keeps',
+            selectOptions: getOptions(ORG_SETTING_VALUE.DISABLED, ORG_SETTING_VALUE.ADMIN, ORG_SETTING_VALUE.MEMBER)
           }
         ]
       }

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.styl
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.styl
@@ -1,6 +1,9 @@
 .kf-team-settings-field
   margin-top: 20px
 
+.kf-team-settings-top-header
+  margin: 10px 0
+
 h2.kf-team-settings-heading
   heading_lg()
   margin-top: 15px

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.tpl.html
@@ -1,9 +1,7 @@
 <div ng-if="viewer.membership.role === 'admin' && billingState.credit > 0" kf-credit-banner credit="{{ billingState.credit }}"></div>
 <div class="kf-container kf-team-settings-fields">
-  <div class="kf-container-header">
-    <h1 id="team-settings">Team Settings</h1>
-  </div>
   <div class="kf-container-main">
+    <h1 class="kf-team-settings-top-header">Team Settings</h1>
     <section ng-repeat="section in settingsSectionTemplateData">
       <h2 class="kf-team-settings-heading" id="{{ getHeadingAnchor(section.heading) }}" ng-show="section.heading">{{ section.heading }}</h2>
       <div ng-repeat="field in section.fields" class="kf-row kf-team-settings-field">


### PR DESCRIPTION
@andrewconner ( @camhashemi ) remove the Kifi-admin experiment guard on team-settings. The incomplete settings tabs (like Plan Settings, billing, etc) are still Kifi-admin only. Add the Angular 404 for non-admins trying to access the team settings page.
