### PR TITLE
send all orgs to ext contacts (regardless of permissions), flush the ext.

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
@@ -96,6 +96,7 @@ trait ElizaServiceClient extends ServiceClient {
   def sendToUserNoBroadcast(userId: Id[User], data: JsArray): Future[Unit]
   def sendToUser(userId: Id[User], data: JsArray): Future[Unit]
   def sendToAllUsers(data: JsArray): Unit
+  def flush(userId: Id[User]): Future[Unit]
 
   def sendUserPushNotification(userId: Id[User], message: String, recipient: User, pushNotificationExperiment: PushNotificationExperiment, category: UserPushNotificationCategory): Future[Int]
   def sendLibraryPushNotification(userId: Id[User], message: String, libraryId: Id[Library], libraryUrl: String, pushNotificationExperiment: PushNotificationExperiment, category: LibraryPushNotificationCategory, force: Boolean = false): Future[Int]
@@ -183,6 +184,12 @@ class ElizaServiceClientImpl @Inject() (
   def sendToUser(userId: Id[User], data: JsArray): Future[Unit] = {
     implicit val userFormatter = Id.format[User]
     val payload = Json.obj("userId" -> userId, "data" -> data)
+    call(Eliza.internal.sendToUser, payload).map(_ => ())
+  }
+
+  def flush(userId: Id[User]): Future[Unit] = {
+    implicit val userFormatter = Id.format[User]
+    val payload = Json.obj("userId" -> userId, "data" -> Json.arr("flush"))
     call(Eliza.internal.sendToUser, payload).map(_ => ())
   }
 

--- a/kifi-backend/modules/common/test/com/keepit/eliza/FakeElizaServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/eliza/FakeElizaServiceClientImpl.scala
@@ -43,6 +43,8 @@ class FakeElizaServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, schedul
 
   def sendToAllUsers(data: JsArray): Unit = {}
 
+  def flush(userId: Id[User]): Future[Unit] = Future.successful((): Unit)
+
   def connectedClientCount: Future[Seq[Int]] = {
     val p = Promise.successful(Seq[Int](1))
     p.future

--- a/kifi-backend/modules/eliza/app/com/keepit/realtime/AppBoy.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/realtime/AppBoy.scala
@@ -105,10 +105,8 @@ class AppBoy @Inject() (
       case upn: UserPushNotification =>
         val pushType = upn.category match {
           case UserPushNotificationCategory.UserConnectionRequest => "fr"
-          case UserPushNotificationCategory.ContactJoined => "us"
           case UserPushNotificationCategory.NewLibraryFollower => "nf"
-          case UserPushNotificationCategory.NewOrganizationMember => "om"
-          case _ => throw new Exception(s"unsupported user push notification category ${upn.category.name}")
+          case _ => "us" // show the user's profile, the specific category doesn't determine anything
         }
         json.as[JsObject] ++ Json.obj("t" -> pushType, "uid" -> upn.userExtId, "un" -> upn.username.value, "purl" -> upn.pictureUrl)
       case opn: OrganizationPushNotification =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -371,8 +371,8 @@ class LibraryCommanderImpl @Inject() (
   }
 
   def deleteLibrary(libraryId: Id[Library], userId: Id[User])(implicit context: HeimdalContext): Option[LibraryFail] = {
-    val oldLibrary = db.readOnlyMaster { implicit s => libraryRepo.get(libraryId) }
-    if (oldLibrary.ownerId != userId) {
+    val (oldLibrary, libraryPermissions) = db.readOnlyMaster { implicit s => (libraryRepo.get(libraryId), permissionCommander.getLibraryPermissions(libraryId, Some(userId))) }
+    if (!libraryPermissions.contains(LibraryPermission.DELETE_LIBRARY)) {
       Some(LibraryFail(FORBIDDEN, "permission_denied"))
     } else if (oldLibrary.isSystemLibrary) {
       Some(LibraryFail(BAD_REQUEST, "cant_delete_system_generated_library"))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationMembershipCommander.scala
@@ -244,7 +244,7 @@ class OrganizationMembershipCommanderImpl @Inject() (
       libraryMembershipCommander.joinLibrary(request.targetId, lib.id.get)
     }
     planCommander.registerNewUser(request.orgId, request.targetId, ActionAttribution(user = Some(request.requesterId), admin = None))
-    elizaServiceClient.sendToUser(request.targetId, Json.arr("flush"))
+    elizaServiceClient.flush(request.targetId)
 
     OrganizationMembershipAddResponse(request, newMembership)
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtUserController.scala
@@ -30,10 +30,7 @@ class ExtUserController @Inject() (
 
     val orgsToInclude = {
       val orgsUserIsIn = db.readOnlyReplica { implicit s =>
-        orgMemberRepo.getAllByUserId(request.userId).map(_.organizationId)
-          .filter { orgId =>
-            permissionCommander.getOrganizationPermissions(orgId, Some(request.userId)).contains(OrganizationPermission.GROUP_MESSAGING)
-          }
+        orgMemberRepo.getAllByUserId(request.userId).map(_.organizationId) // (10/2/15) don't filter orgs on OrganizationPermission.GROUP_MESSAGING, the ext should disable the action
       }
       val basicOrgs = orgCommander.getBasicOrganizations(orgsUserIsIn.toSet).values
       val orgsToShow = query.getOrElse("") match {

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
@@ -381,21 +381,21 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         } must beTrue
 
         inject[FakeUserActionsHelper].setUser(owner)
-        val ownerExtRequest1 = FakeRequest("GET", mobileRoute)
+        val ownerExtRequest1 = FakeRequest("GET", extRoute)
         val ownerExtResult1 = extUserController.searchForContacts(query = None, limit = None)(ownerExtRequest1)
         contentAsJson(ownerExtResult1).as[Seq[JsObject]].forall { obj =>
           !((obj \ "kind").as[String] == "org" && (obj \ "id").as[PublicId[Organization]] != Organization.publicId(org.id.get))
         } must beTrue
 
         inject[FakeUserActionsHelper].setUser(admin)
-        val adminExtRequest1 = FakeRequest("GET", mobileRoute)
+        val adminExtRequest1 = FakeRequest("GET", extRoute)
         val adminExtResult1 = extUserController.searchForContacts(query = None, limit = None)(adminExtRequest1)
         contentAsJson(adminExtResult1).as[Seq[JsObject]].forall { obj =>
           !((obj \ "kind").as[String] == "org" && (obj \ "id").as[PublicId[Organization]] != Organization.publicId(org.id.get))
         } must beTrue
 
         inject[FakeUserActionsHelper].setUser(member)
-        val memberExtRequest1 = FakeRequest("GET", mobileRoute)
+        val memberExtRequest1 = FakeRequest("GET", extRoute)
         val memberExtResult1 = extUserController.searchForContacts(query = None, limit = None)(memberExtRequest1)
         contentAsJson(memberExtResult1).as[Seq[JsObject]].forall { obj =>
           !((obj \ "kind").as[String] == "org" && (obj \ "id").as[PublicId[Organization]] != Organization.publicId(org.id.get))
@@ -427,24 +427,17 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         } must beTrue
 
         inject[FakeUserActionsHelper].setUser(owner)
-        val ownerExtRequest2 = FakeRequest("GET", mobileRoute)
+        val ownerExtRequest2 = FakeRequest("GET", extRoute)
         val ownerExtResult2 = extUserController.searchForContacts(query = None, limit = None)(ownerExtRequest2)
         contentAsJson(ownerExtResult2).as[Seq[JsObject]].exists { obj =>
           (obj \ "kind").as[String] == "org" && (obj \ "id").as[PublicId[Organization]] == Organization.publicId(org.id.get)
         } must beTrue
 
         inject[FakeUserActionsHelper].setUser(admin)
-        val adminExtRequest2 = FakeRequest("GET", mobileRoute)
+        val adminExtRequest2 = FakeRequest("GET", extRoute)
         val adminExtResult2 = extUserController.searchForContacts(query = None, limit = None)(adminExtRequest2)
         contentAsJson(adminExtResult2).as[Seq[JsObject]].exists { obj =>
           (obj \ "kind").as[String] == "org" && (obj \ "id").as[PublicId[Organization]] == Organization.publicId(org.id.get)
-        } must beTrue
-
-        inject[FakeUserActionsHelper].setUser(member)
-        val memberExtRequest2 = FakeRequest("GET", mobileRoute)
-        val memberExtResult2 = extUserController.searchForContacts(query = None, limit = None)(memberExtRequest2)
-        contentAsJson(memberExtResult2).as[Seq[JsObject]].forall { obj =>
-          !((obj \ "kind").as[String] == "org" && (obj \ "id").as[PublicId[Organization]] == Organization.publicId(org.id.get))
         } must beTrue
 
         // members can send group messages
@@ -473,21 +466,21 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         } must beTrue
 
         inject[FakeUserActionsHelper].setUser(owner)
-        val ownerExtRequest3 = FakeRequest("GET", mobileRoute)
+        val ownerExtRequest3 = FakeRequest("GET", extRoute)
         val ownerExtResult3 = extUserController.searchForContacts(query = None, limit = None)(ownerExtRequest3)
         contentAsJson(ownerExtResult3).as[Seq[JsObject]].exists { obj =>
           (obj \ "kind").as[String] == "org" && (obj \ "id").as[PublicId[Organization]] == Organization.publicId(org.id.get)
         } must beTrue
 
         inject[FakeUserActionsHelper].setUser(admin)
-        val adminExtRequest3 = FakeRequest("GET", mobileRoute)
+        val adminExtRequest3 = FakeRequest("GET", extRoute)
         val adminExtResult3 = extUserController.searchForContacts(query = None, limit = None)(adminExtRequest3)
         contentAsJson(adminExtResult3).as[Seq[JsObject]].exists { obj =>
           (obj \ "kind").as[String] == "org" && (obj \ "id").as[PublicId[Organization]] == Organization.publicId(org.id.get)
         } must beTrue
 
         inject[FakeUserActionsHelper].setUser(member)
-        val memberExtRequest3 = FakeRequest("GET", mobileRoute)
+        val memberExtRequest3 = FakeRequest("GET", extRoute)
         val memberExtResult3 = extUserController.searchForContacts(query = None, limit = None)(memberExtRequest3)
         contentAsJson(memberExtResult3).as[Seq[JsObject]].exists { obj =>
           (obj \ "kind").as[String] == "org" && (obj \ "id").as[PublicId[Organization]] == Organization.publicId(org.id.get)


### PR DESCRIPTION
@ryanpbrewster @andrewconner 

@cvializ until the ext disables the offending action, you'll get 400s from us when sending to an org without permissions. maybe we should coordinate this deploy then.
