### PR TITLE
Added a cache from (orgId, userId) => permissions

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
@@ -7,6 +7,7 @@ import com.keepit.common.db.slick.DBSession.RSession
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.{ AccessLog, Logging }
+import com.keepit.common.performance.StatsdTiming
 import com.keepit.model._
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
@@ -39,6 +40,7 @@ class PermissionCommanderImpl @Inject() (
     airbrake: AirbrakeNotifier,
     implicit val executionContext: ExecutionContext) extends PermissionCommander with Logging {
 
+  @StatsdTiming("PermissionCommander.getOrganizationPermissions")
   def getOrganizationPermissions(orgId: Id[Organization], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[OrganizationPermission] = {
     /*
     PSA regarding these caches:
@@ -70,6 +72,7 @@ class PermissionCommanderImpl @Inject() (
     }
   }
 
+  @StatsdTiming("PermissionCommander.getLibraryPermissions")
   def getLibraryPermissions(libId: Id[Library], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[LibraryPermission] = {
     val lib = libraryRepo.get(libId)
     val libMembershipOpt = userIdOpt.flatMap { userId => libraryMembershipRepo.getWithLibraryIdAndUserId(libId, userId) }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
@@ -49,7 +49,7 @@ class PermissionCommanderImpl @Inject() (
         2. (Id[Organization, Int, Option[Id[User]]) => Set[OrganizationPermission]
     With two caches, we can invalidate an entire organization by changing its value in cache 1
     */
-    val orgPermissionsNamespace = orgPermissionsNamespaceCache.getOrElse(OrganizationPermissionsNamespaceKey(orgId))(OrganizationPermissionsNamespace(Random.nextInt()))
+    val orgPermissionsNamespace = orgPermissionsNamespaceCache.getOrElse(OrganizationPermissionsNamespaceKey(orgId))(Random.nextInt())
     orgPermissionsCache.getOrElse(OrganizationPermissionsKey(orgId, orgPermissionsNamespace, userIdOpt)) {
       computeOrganizationPermissions(orgId, userIdOpt)
     }
@@ -166,19 +166,18 @@ class PermissionCommanderImpl @Inject() (
   }
 }
 
-case class OrganizationPermissionsNamespace(value: Int) extends AnyVal
-case class OrganizationPermissionsNamespaceKey(orgId: Id[Organization]) extends Key[OrganizationPermissionsNamespace] {
+case class OrganizationPermissionsNamespaceKey(orgId: Id[Organization]) extends Key[Int] {
   override val version = 1
   val namespace = "org_permissions_namespace"
   def toKey(): String = orgId.id.toString
 }
 class OrganizationPermissionsNamespaceCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
-  extends PrimitiveCacheImpl[OrganizationPermissionsNamespaceKey, OrganizationPermissionsNamespace](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
+  extends PrimitiveCacheImpl[OrganizationPermissionsNamespaceKey, Int](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
 
-case class OrganizationPermissionsKey(orgId: Id[Organization], opn: OrganizationPermissionsNamespace, userIdOpt: Option[Id[User]]) extends Key[Set[OrganizationPermission]] {
+case class OrganizationPermissionsKey(orgId: Id[Organization], opn: Int, userIdOpt: Option[Id[User]]) extends Key[Set[OrganizationPermission]] {
   override val version = 1
   val namespace = "org_permissions"
-  def toKey(): String = orgId.id.toString + "_" + opn.value.toString + "_" + userIdOpt.map(x => x.id.toString).getOrElse("none")
+  def toKey(): String = orgId.id.toString + "_" + opn.toString + "_" + userIdOpt.map(x => x.id.toString).getOrElse("none")
 }
 
 class OrganizationPermissionsCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -427,9 +427,9 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
 
   @Provides @Singleton
   def orgPermissionsNamespaceCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
-    new OrganizationPermissionsNamespaceCache(stats, accessLog, (outerRepo, 7 days))
+    new OrganizationPermissionsNamespaceCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 7 days))
 
   @Provides @Singleton
   def orgPermissionsCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
-    new OrganizationPermissionsCache(stats, accessLog, (outerRepo, 7 days))
+    new OrganizationPermissionsCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -426,10 +426,10 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
     new BasicOrganizationIdCache(stats, accessLog, (outerRepo, 7 days))
 
   @Provides @Singleton
-  def orgPermissionsNamespaceCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
+  def orgPermissionsNamespaceCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new OrganizationPermissionsNamespaceCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 7 days))
 
   @Provides @Singleton
-  def orgPermissionsCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
+  def orgPermissionsCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new OrganizationPermissionsCache(stats, accessLog, (innerRepo, 5 minutes), (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -424,4 +424,12 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Provides @Singleton
   def basicOrganizationIdCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
     new BasicOrganizationIdCache(stats, accessLog, (outerRepo, 7 days))
+
+  @Provides @Singleton
+  def orgPermissionsNamespaceCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
+    new OrganizationPermissionsNamespaceCache(stats, accessLog, (outerRepo, 7 days))
+
+  @Provides @Singleton
+  def orgPermissionsCache(stats: CacheStatistics, accessLog: AccessLog, outerRepo: FortyTwoCachePlugin) =
+    new OrganizationPermissionsCache(stats, accessLog, (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationConfigurationRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationConfigurationRepo.scala
@@ -1,10 +1,10 @@
 package com.keepit.model
 
 import com.google.inject.{ ImplementedBy, Inject, Singleton }
+import com.keepit.commanders.{ OrganizationPermissionsNamespaceCache, OrganizationPermissionsNamespaceKey }
 import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
 import com.keepit.common.db.slick._
 import com.keepit.common.db.{ Id, State }
-import com.keepit.common.logging.Logging
 import com.keepit.common.time.Clock
 import org.joda.time.DateTime
 
@@ -16,11 +16,16 @@ trait OrganizationConfigurationRepo extends Repo[OrganizationConfiguration] {
 
 @Singleton
 class OrganizationConfigurationRepoImpl @Inject() (
+    orgPermissionsNamespaceCache: OrganizationPermissionsNamespaceCache,
     val db: DataBaseComponent,
     val clock: Clock) extends OrganizationConfigurationRepo with DbRepo[OrganizationConfiguration] {
 
-  override def deleteCache(orgMember: OrganizationConfiguration)(implicit session: RSession): Unit = {}
-  override def invalidateCache(orgMember: OrganizationConfiguration)(implicit session: RSession): Unit = {}
+  override def deleteCache(model: OrganizationConfiguration)(implicit session: RSession): Unit = {
+    orgPermissionsNamespaceCache.remove(OrganizationPermissionsNamespaceKey(model.organizationId))
+  }
+  override def invalidateCache(model: OrganizationConfiguration)(implicit session: RSession): Unit = {
+    orgPermissionsNamespaceCache.remove(OrganizationPermissionsNamespaceKey(model.organizationId))
+  }
 
   import db.Driver.simple._
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRepo.scala
@@ -1,6 +1,7 @@
 package com.keepit.model
 
 import com.google.inject.{ ImplementedBy, Inject, Provider, Singleton }
+import com.keepit.commanders.{ OrganizationPermissionsNamespaceKey, OrganizationPermissionsNamespaceCache, OrganizationPermissionsCache }
 import com.keepit.common.actor.ActorInstance
 import com.keepit.common.db._
 import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
@@ -27,7 +28,9 @@ class OrganizationRepoImpl @Inject() (
     val db: DataBaseComponent,
     val clock: Clock,
     orgCache: OrganizationCache,
-    basicOrgCache: BasicOrganizationIdCache) extends OrganizationRepo with DbRepo[Organization] with SeqNumberDbFunction[Organization] with Logging {
+    basicOrgCache: BasicOrganizationIdCache,
+    orgPermissionsNamespaceCache: OrganizationPermissionsNamespaceCache,
+    orgPermissionsCache: OrganizationPermissionsCache) extends OrganizationRepo with DbRepo[Organization] with SeqNumberDbFunction[Organization] with Logging {
 
   import DBSession._
   import db.Driver.simple._
@@ -52,10 +55,12 @@ class OrganizationRepoImpl @Inject() (
   override def deleteCache(model: Organization)(implicit session: RSession) {
     orgCache.remove(OrganizationKey(model.id.get))
     basicOrgCache.remove(BasicOrganizationIdKey(model.id.get))
+    orgPermissionsNamespaceCache.remove(OrganizationPermissionsNamespaceKey(model.id.get))
   }
   override def invalidateCache(model: Organization)(implicit session: RSession) {
     orgCache.set(OrganizationKey(model.id.get), model)
     basicOrgCache.remove(BasicOrganizationIdKey(model.id.get))
+    orgPermissionsNamespaceCache.remove(OrganizationPermissionsNamespaceKey(model.id.get))
   }
 
   override def save(model: Organization)(implicit session: RWSession): Organization = {


### PR DESCRIPTION
Kind of tricky to invalidate the cache for only one particular org. When an
org's settings change, we need to invalidate `(orgId, *)`. I implemented a
two-cache strategy.
  The first cache is `Id[Organization] => Int`
  The second cache is `(Id[Organization], Int, Id[User]) => Set[OrganizationPermission]`

To go from `(Id[Organization], Id[User]) => Set[OrganizationPermission]`, first
hit cache #1 to get the `Int` for that orgId, then use that "namespace key" to hit
cache #2.

To invalidate an entire org, just drop the orgId key from cache #1
