### PR TITLE
add VIEW_SETTINGS permission for members to see the settings tab

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationPermission.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationPermission.scala
@@ -20,6 +20,7 @@ object OrganizationPermission {
   case object EXPORT_KEEPS extends OrganizationPermission("export_keeps")
   case object CREATE_SLACK_INTEGRATION extends OrganizationPermission("create_slack_integration")
   case object MANAGE_PLAN extends OrganizationPermission("manage_plan")
+  case object VIEW_SETTINGS extends OrganizationPermission("view_settings")
 
   def all: Set[OrganizationPermission] = Set(
     VIEW_ORGANIZATION,
@@ -35,7 +36,8 @@ object OrganizationPermission {
     GROUP_MESSAGING,
     EXPORT_KEEPS,
     CREATE_SLACK_INTEGRATION,
-    MANAGE_PLAN
+    MANAGE_PLAN,
+    VIEW_SETTINGS
   )
 
   implicit val format: Format[OrganizationPermission] =
@@ -61,6 +63,7 @@ object OrganizationPermission {
       case EXPORT_KEEPS.value => EXPORT_KEEPS
       case CREATE_SLACK_INTEGRATION.value => CREATE_SLACK_INTEGRATION
       case MANAGE_PLAN.value => MANAGE_PLAN
+      case VIEW_SETTINGS.value => VIEW_SETTINGS
     }
   }
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -656,8 +656,9 @@ class MessagingCommander @Inject() (
     val orgIds = validOrgRecipients.map(o => Organization.decodePublicId(o)).filter(_.isSuccess).map(_.get)
 
     val cantSendToOrgs = shoebox.getUserPermissionsByOrgId(orgIds.toSet, userId).map { permissionsByOrgId =>
-      permissionsByOrgId.exists { case (orgId, permissions) =>
-        !permissions.contains(OrganizationPermission.GROUP_MESSAGING).tap(if (_) airbrake.notify(s"user $userId was able to send to org $orgId without permissions!"))
+      permissionsByOrgId.exists {
+        case (orgId, permissions) =>
+          !permissions.contains(OrganizationPermission.GROUP_MESSAGING).tap(if (_) airbrake.notify(s"user $userId was able to send to org $orgId without permissions!"))
       }
     }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
@@ -136,13 +136,15 @@ class PermissionCommanderImpl @Inject() (
   def settinglessOrganizationPermissions(orgRoleOpt: Option[OrganizationRole]): Set[OrganizationPermission] = orgRoleOpt match {
     case None => Set.empty
     case Some(OrganizationRole.MEMBER) => Set(
-      OrganizationPermission.ADD_LIBRARIES
+      OrganizationPermission.ADD_LIBRARIES,
+      OrganizationPermission.VIEW_SETTINGS
     )
     case Some(OrganizationRole.ADMIN) => Set(
       OrganizationPermission.ADD_LIBRARIES,
       OrganizationPermission.MODIFY_MEMBERS,
       OrganizationPermission.REMOVE_MEMBERS,
-      OrganizationPermission.MANAGE_PLAN
+      OrganizationPermission.MANAGE_PLAN,
+      OrganizationPermission.VIEW_SETTINGS
     )
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
@@ -84,7 +84,7 @@ class PaymentsController @Inject() (
     }
   }
 
-  def getAccountFeatureSettings(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.MANAGE_PLAN) { request =>
+  def getAccountFeatureSettings(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.VIEW_SETTINGS) { request =>
     Ok(Json.toJson(orgCommander.getExternalOrgConfiguration(request.orgId)))
   }
 


### PR DESCRIPTION
@ryanpbrewster @leogrim 

@cvializ we have to enforce this on the front-end for it to be to-spec. members will get 403s whenever they try to do anything besides view the settings.
