### PR TITLE
Added deep links to password reset emails

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -656,8 +656,9 @@ class MessagingCommander @Inject() (
     val orgIds = validOrgRecipients.map(o => Organization.decodePublicId(o)).filter(_.isSuccess).map(_.get)
 
     val cantSendToOrgs = shoebox.getUserPermissionsByOrgId(orgIds.toSet, userId).map { permissionsByOrgId =>
-      permissionsByOrgId.exists { case (orgId, permissions) =>
-        !permissions.contains(OrganizationPermission.GROUP_MESSAGING).tap(if (_) airbrake.notify(s"user $userId was able to send to org $orgId without permissions!"))
+      permissionsByOrgId.exists {
+        case (orgId, permissions) =>
+          !permissions.contains(OrganizationPermission.GROUP_MESSAGING).tap(if (_) airbrake.notify(s"user $userId was able to send to org $orgId without permissions!"))
       }
     }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
@@ -227,7 +227,8 @@ class EmailTemplateProcessorImpl @Inject() (
           config.applicationBaseUrl + libPathCommander.getPathForLibrary(library)
         case tags.libraryLink =>
           val data = Json.obj("t" -> "lv", "lid" -> Library.publicId(library.id.get).id)
-          config.applicationBaseUrl + "/redir?data=" + URLEncoder.encode(Json.stringify(data), "ascii")
+          val ans = config.applicationBaseUrl + "/redir?data=" + URLEncoder.encode(Json.stringify(data), "ascii")
+          ans
         case tags.libraryName => library.name
         case tags.libraryId => Library.publicId(library.id.get).id
         case tags.libraryOwnerFullName =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ResetPasswordEmailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ResetPasswordEmailSender.scala
@@ -5,15 +5,16 @@ import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
-import com.keepit.common.mail.{ EmailAddress, ElectronicMail, SystemEmailAddress }
 import com.keepit.common.mail.template.EmailToSend
-import com.keepit.controllers.core.routes
+import com.keepit.common.mail.{ ElectronicMail, EmailAddress, SystemEmailAddress }
+import com.keepit.controllers.website.DeepLinkRouter
 import com.keepit.inject.FortyTwoConfig
-import com.keepit.model.{ PasswordResetRepo, NotificationCategory, User }
+import com.keepit.model.{ NotificationCategory, PasswordResetRepo, User }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 class ResetPasswordEmailSender @Inject() (
+    deepLinkRouter: DeepLinkRouter,
     db: Database,
     emailTemplateSender: EmailTemplateSender,
     passwordResetRepo: PasswordResetRepo,
@@ -26,7 +27,7 @@ class ResetPasswordEmailSender @Inject() (
       passwordResetRepo.createNewResetToken(userId, resetEmailAddress)
     }
 
-    val resetUrl = config.applicationBaseUrl + routes.AuthController.setPasswordPage(reset.token)
+    val resetUrl = deepLinkRouter.passwordResetDeepLink(reset.token)
     val emailToSend = EmailToSend(
       fromName = Some(Right("Kifi Support")),
       from = SystemEmailAddress.SUPPORT,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/DeepLinkRouter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/DeepLinkRouter.scala
@@ -1,16 +1,20 @@
 package com.keepit.controllers.website
 
+import java.net.URLEncoder
+
 import com.google.inject.{ Inject, Singleton }
 import com.keepit.commanders.PathCommander
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.db.ExternalId
 import com.keepit.common.db.slick.Database
 import com.keepit.common.path.Path
+import com.keepit.inject.FortyTwoConfig
 import com.keepit.model._
-import play.api.libs.json.JsObject
+import play.api.libs.json.{ Json, JsObject }
 
 @Singleton
 class DeepLinkRouter @Inject() (
+    config: FortyTwoConfig,
     db: Database,
     userRepo: UserRepo,
     orgRepo: OrganizationRepo,
@@ -18,25 +22,58 @@ class DeepLinkRouter @Inject() (
     pathCommander: PathCommander,
     implicit val publicIdConfiguration: PublicIdConfiguration) {
 
+  private def passwordReset(authToken: String): JsObject = Json.obj("t" -> DeepLinkType.PasswordReset, DeepLinkField.AuthToken -> authToken)
+  def passwordResetDeepLink(authToken: String): String = deepLink(passwordReset(authToken))
+
+  def deepLink(data: JsObject): String = config.applicationBaseUrl + "/redir?data=" + URLEncoder.encode(Json.stringify(data), "ascii")
+
   def generateRedirectUrl(data: JsObject): Option[Path] = {
     (data \ "t").as[String] match {
-      case "vh" => Some(Path("")) // view home
-      case "vf" => Some(Path("friends")) // view friends
-      case "il" => Some(Path("/me/libraries/invited")) // view invited libraries
-      case "fr" => Some(Path("friends/requests"))
-      case "oi" => // org invite
-        val orgIdOpt = (data \ "oid").asOpt[PublicId[Organization]].flatMap(pubId => Organization.decodePublicId(pubId).toOption)
+      case DeepLinkType.ViewHomepage =>
+        Some(Path(""))
+      case DeepLinkType.ViewFriends =>
+        Some(Path("friends")) // view friends
+      case DeepLinkType.PasswordReset =>
+        val tokenOpt = (data \ DeepLinkField.AuthToken).asOpt[String]
+        tokenOpt.map(token => Path(s"password/$token"))
+      case DeepLinkType.InvitedLibraries =>
+        Some(Path("me/libraries/invited"))
+      case DeepLinkType.FriendRequest =>
+        Some(Path("friends/requests"))
+      case DeepLinkType.OrganizationInvite =>
+        val orgIdOpt = (data \ DeepLinkField.OrganizationId).asOpt[PublicId[Organization]].flatMap(pubId => Organization.decodePublicId(pubId).toOption)
         val orgOpt = orgIdOpt.map { orgId => db.readOnlyReplica { implicit session => orgRepo.get(orgId) } }
         orgOpt.map(org => pathCommander.pathForOrganization(org))
-      case "lr" | "li" | "lv" =>
-        val libIdOpt = (data \ "lid").asOpt[PublicId[Library]].flatMap(pubId => Library.decodePublicId(pubId).toOption)
+      case DeepLinkType.LibraryRecommendation | DeepLinkType.LibraryInvite | DeepLinkType.LibraryView =>
+        val libIdOpt = (data \ DeepLinkField.LibraryId).asOpt[PublicId[Library]].flatMap(pubId => Library.decodePublicId(pubId).toOption)
         val libOpt = libIdOpt.map { libId => db.readOnlyReplica { implicit session => libraryRepo.get(libId) } }
         libOpt.map(lib => pathCommander.pathForLibrary(lib))
-      case "nf" | "us" =>
-        val userIdOpt = (data \ "uid").asOpt[ExternalId[User]]
+      case DeepLinkType.NewFollower | DeepLinkType.UserView =>
+        val userIdOpt = (data \ DeepLinkField.UserId).asOpt[ExternalId[User]]
         val userOpt = userIdOpt.map { extId => db.readOnlyReplica { implicit session => userRepo.getByExternalId(extId) } }
         userOpt.map(user => pathCommander.pathForUser(user))
       case _ => None
     }
   }
+}
+
+object DeepLinkType {
+  val ViewHomepage = "vh"
+  val ViewFriends = "vf"
+  val PasswordReset = "pr"
+  val InvitedLibraries = "il"
+  val FriendRequest = "fr"
+  val OrganizationInvite = "oi"
+  val LibraryRecommendation = "lr"
+  val LibraryInvite = "li"
+  val LibraryView = "lv"
+  val NewFollower = "nf"
+  val UserView = "us"
+}
+
+object DeepLinkField {
+  val OrganizationId = "oid"
+  val LibraryId = "lid"
+  val UserId = "uid"
+  val AuthToken = "at"
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailSenderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailSenderTest.scala
@@ -365,14 +365,15 @@ class EmailSenderTest extends Specification with ShoeboxTestInjector {
         val token = tokens(0).token
         token.size === 8
 
+        val deepLink = "http://dev.ezkeep.com:9000/redir?data=" + URLEncoder.encode(s"""{"t":"pr","at":"$token"}""")
         val html = email.htmlBody.value
         html must contain("Hi Billy,")
-        html must contain(s"http://dev.ezkeep.com:9000/password/$token")
+        html must contain(deepLink)
         html must contain("utm_campaign=passwordReset")
 
         val text = email.textBody.get.value
         text must contain("Hi Billy,")
-        text must contain(s"http://dev.ezkeep.com:9000/password/$token")
+        text must contain(deepLink)
       }
     }
 


### PR DESCRIPTION
Made the DeepLinkRouter a little safer, and it now produces deep links (as well
as routing them). Only the Password Reset emails use this functionality, but
eventually all of the deep links should be produced there.

@leogrim @jaredpetker 
