### PR TITLE
Adding dump of request info endpoint for debugging

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/admin/ServiceController.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/admin/ServiceController.scala
@@ -1,5 +1,6 @@
 package com.keepit.common.admin
 
+import com.keepit.common.net.UserAgent
 import com.keepit.common.zookeeper.ServiceDiscovery
 import com.google.inject.Inject
 import com.keepit.common.logging.Logging
@@ -14,6 +15,24 @@ class ServiceController @Inject() (
     localCache: InMemoryCachePlugin) extends com.keepit.common.controller.ServiceController with Logging {
 
   override lazy val serviceType: ServiceType = service.currentService
+
+  def headersP = headers
+  def headers = Action { implicit request =>
+    val addr = request.remoteAddress
+    val id = request.id
+    val method = request.method
+    val path = request.path
+    val version = request.version
+    val ua = UserAgent.apply(request)
+
+    val qs = request.queryString
+    val all = request.headers.toMap.mkString("\n")
+    val body = request.body
+
+    val pnt = Seq(addr.toString, id.toString, method.toString, path.toString, version.toString, ua.toString, qs.toString, all.toString, body.toString).mkString("\n\n")
+
+    Ok(pnt)
+  }
 
   def forceRefresh = Action { implicit request =>
     serviceDiscovery.forceUpdate()

--- a/kifi-backend/modules/common/conf/commonService.routes
+++ b/kifi-backend/modules/common/conf/commonService.routes
@@ -13,6 +13,8 @@ GET     /assets/*file               controllers.Assets.at(path="/public", file)
 GET     /up/elb                               @com.keepit.common.admin.ServiceController.upForElb
 GET     /up/pingdom                           @com.keepit.common.admin.ServiceController.upForPingdom
 GET     /up/deployment                        @com.keepit.common.admin.ServiceController.upForDeployment
+GET     /up/headers                           @com.keepit.common.admin.ServiceController.headers
+POST    /up/headers                           @com.keepit.common.admin.ServiceController.headersP
 
 #deprecated, remove when all elbs are updated
 GET     /up                                   @com.keepit.common.admin.ServiceController.deprecatedUp


### PR DESCRIPTION
I don't believe there's any real security vulnerability here letting anyone who knows the endpoint to get request details (nothing they don't already know besides ELB IP).

Useful when trying to determine how the server sees a request that was sent.

@eishay @leogrim 
