### PR TITLE
remove nested db sessions from OrganizationChecker

### DIFF
--- a/kifi-backend/modules/heimdal/test/com/keepit/heimdal/AmplitudeClientTest.scala
+++ b/kifi-backend/modules/heimdal/test/com/keepit/heimdal/AmplitudeClientTest.scala
@@ -4,7 +4,6 @@ import com.google.inject.Module
 import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.net.{ FakeHttpClientModule, ProdHttpClientModule }
 import com.keepit.common.time._
-import com.keepit.heimdal.ContextStringData
 import com.keepit.model.{ User, UserExperimentType }
 import com.keepit.shoebox.{ FakeShoeboxServiceModule, FakeShoeboxServiceClientModule }
 import com.keepit.social.NonUserKinds

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
@@ -384,8 +384,10 @@ class AdminLibraryController @Inject() (
   def unsafeModifyLibrary = AdminUserAction(parse.tolerantJson) { implicit request =>
     val libId = (request.body \ "libraryId").as[Id[Library]]
     val mods = (request.body \ "modifications").as[LibraryModifications](LibraryModifications.adminReads)
-    val lib = db.readOnlyMaster { implicit session => libraryRepo.get(libId) }
-    val response = libraryCommander.unsafeModifyLibrary(lib, mods)
+    val response = db.readWrite { implicit session =>
+      val lib = libraryRepo.get(libId)
+      libraryCommander.unsafeModifyLibrary(lib, mods)
+    }
     Ok(Json.obj("lib" -> response.modifiedLibrary))
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -885,7 +885,7 @@ class AdminUserController @Inject() (
     val ownedLibraries = libraryRepo.getAllByOwner(userId).map(_.id.get)
     val ownsCollaborativeLibs = libraryMembershipRepo.getCollaboratorsByLibrary(ownedLibraries.toSet).exists { case (_, collaborators) => collaborators.size > 1 }
     assert(!ownsCollaborativeLibs, "cannot deactivate a user if they own a library with collaborators: either delete the library or transfer its ownership")
-    FutureHelpers.sequentialExec(ownedLibraries)(libraryCommander.unsafeAsyncDeleteLibrary)
+    ownedLibraries.foreach(libraryCommander.unsafeDeleteLibrary)
 
     // Personal Info
     userSessionRepo.invalidateByUser(userId) // User Session

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -377,8 +377,10 @@ class OrganizationCommanderImpl @Inject() (
         // Modifying an org opens its own DB session. Do these separately from the rest of the logic
         val returningLibsFut = Future {
           libsToReturn.foreach { libId =>
-            val lib = db.readOnlyReplica { implicit session => libraryRepo.get(libId) }
-            libraryCommander.unsafeModifyLibrary(lib, LibraryModifications(space = Some(lib.ownerId)))
+            val lib = db.readWrite { implicit session =>
+              val lib = libraryRepo.get(libId)
+              libraryCommander.unsafeModifyLibrary(lib, LibraryModifications(space = Some(lib.ownerId)))
+            }
           }
         }
         Right(OrganizationDeleteResponse(request, returningLibsFut, deletingLibsFut))

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/OrganizationChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/OrganizationChecker.scala
@@ -87,7 +87,7 @@ class OrganizationChecker @Inject() (
         airbrake.notify(s"[ORG-STATE-MATCH] Dead org $orgId has zombie libraries: ${zombieLibs.map(_.id.get)}")
         zombieLibs.collect {
           case lib if lib.canBeModified => libraryCommander.unsafeModifyLibrary(lib, LibraryModifications(space = Some(lib.ownerId)))
-          case lib if lib.isSystemLibrary => libraryCommander.unsafeAsyncDeleteLibrary(lib.id.get)
+          case lib if lib.isSystemLibrary => libraryCommander.unsafeDeleteLibrary(lib.id.get)
         }
       }
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryInviteRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryInviteRepo.scala
@@ -1,7 +1,7 @@
 package com.keepit.model
 
 import com.google.inject.{ Inject, Singleton, ImplementedBy }
-import com.keepit.common.db.slick.DBSession.RSession
+import com.keepit.common.db.slick.DBSession.{ RWSession, RSession }
 import com.keepit.common.db.{ State, Id }
 import com.keepit.common.db.slick._
 import com.keepit.common.logging.Logging
@@ -27,6 +27,7 @@ trait LibraryInviteRepo extends Repo[LibraryInvite] with RepoWithDelete[LibraryI
   def getLastSentByLibraryIdAndUserId(libraryId: Id[Library], userId: Id[User], includeStates: Set[State[LibraryInvite]])(implicit session: RSession): Option[LibraryInvite]
   def getLastSentByLibraryIdAndInviterIdAndUserId(libraryId: Id[Library], inviterId: Id[User], userId: Id[User], includeStates: Set[State[LibraryInvite]])(implicit session: RSession): Option[LibraryInvite]
   def getLastSentByLibraryIdAndInviterIdAndEmail(libraryId: Id[Library], inviterId: Id[User], email: EmailAddress, includeStates: Set[State[LibraryInvite]])(implicit session: RSession): Option[LibraryInvite]
+  def deactivate(model: LibraryInvite)(implicit session: RWSession): Unit
 }
 
 @Singleton
@@ -189,4 +190,6 @@ class LibraryInviteRepoImpl @Inject() (
   def getLastSentByLibraryIdAndUserId(libraryId: Id[Library], userId: Id[User], includeStates: Set[State[LibraryInvite]])(implicit session: RSession): Option[LibraryInvite] = {
     getLastSentByLibraryIdAndUserIdCompiled(libraryId, userId, includeStates).firstOption
   }
+
+  def deactivate(model: LibraryInvite)(implicit session: RWSession): Unit = save(model.withState(LibraryInviteStates.INACTIVE))
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryMembershipRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryMembershipRepo.scala
@@ -50,6 +50,7 @@ trait LibraryMembershipRepo extends Repo[LibraryMembership] with RepoWithDelete[
   def countsWithUserIdAndAccesses(userId: Id[User], accesses: Set[LibraryAccess])(implicit session: RSession): Map[LibraryAccess, Int]
   def getCollaboratorsByLibrary(libIds: Set[Id[Library]])(implicit session: RSession): Map[Id[Library], Set[Id[User]]]
   def getCollaborators(userId: Id[User])(implicit session: RSession): Set[Id[User]]
+  def deactivate(model: LibraryMembership)(implicit session: RWSession): Unit
 
   //
   // Profile Library Repo functions
@@ -433,6 +434,8 @@ class LibraryMembershipRepoImpl @Inject() (
   def getCollaborators(userId: Id[User])(implicit session: RSession): Set[Id[User]] = {
     getCollaboratorsCompiled(userId).run.toSet
   }
+
+  def deactivate(model: LibraryMembership)(implicit session: RWSession): Unit = save(model.withState(LibraryMembershipStates.INACTIVE))
 }
 
 trait LibraryMembershipSequencingPlugin extends SequencingPlugin


### PR DESCRIPTION
@ryanpbrewster @andrewconner turns out `unsafeModifyLibrary` also had sessions-in-sessions. it used a batch query at some point, which I had to remove. but like we said, better to be slow than wrong.
