### PR TITLE
Fix org checker (session-in-session issues)

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -34,9 +34,7 @@ object MarketingSuggestedLibrarySystemValue {
 trait LibraryCommander {
   def updateLastView(userId: Id[User], libraryId: Id[Library]): Unit
   def createLibrary(libCreateReq: LibraryInitialValues, ownerId: Id[User])(implicit context: HeimdalContext): Either[LibraryFail, Library]
-  def unsafeCreateLibrary(libCreateReq: LibraryInitialValues, ownerId: Id[User])(implicit session: RWSession): Library
   def modifyLibrary(libraryId: Id[Library], userId: Id[User], modifyReq: LibraryModifications)(implicit context: HeimdalContext): Either[LibraryFail, LibraryModifyResponse]
-  def unsafeModifyLibrary(library: Library, modifyReq: LibraryModifications): LibraryModifyResponse
   def deleteLibrary(libraryId: Id[Library], userId: Id[User])(implicit context: HeimdalContext): Option[LibraryFail]
   def internSystemGeneratedLibraries(userId: Id[User], generateNew: Boolean = true): (Library, Library)
   def createReadItLaterLibrary(userId: Id[User]): Library
@@ -48,7 +46,13 @@ trait LibraryCommander {
   def trackLibraryView(viewerId: Option[Id[User]], library: Library)(implicit context: HeimdalContext): Unit
   def updateLastEmailSent(userId: Id[User], keeps: Seq[Keep]): Unit
   def updateSubscribedToLibrary(userId: Id[User], libraryId: Id[Library], subscribedToUpdatesNew: Boolean): Either[LibraryFail, LibraryMembership]
+
+  // These are "fast" methods, so they can be transactional
+  def unsafeCreateLibrary(libCreateReq: LibraryInitialValues, ownerId: Id[User])(implicit session: RWSession): Library
   def unsafeTransferLibrary(libraryId: Id[Library], newOwner: Id[User])(implicit session: RWSession): Library
+
+  // These methods take forever (they have to fiddle with values denormalized onto keeps) so they're async
+  def unsafeModifyLibrary(library: Library, modifyReq: LibraryModifications): LibraryModifyResponse
   def unsafeAsyncDeleteLibrary(libraryId: Id[Library]): Future[Unit]
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/OrganizationChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/OrganizationChecker.scala
@@ -1,19 +1,19 @@
 package com.keepit.integrity
 
-import com.google.inject.{ Inject, Singleton }
+import com.google.inject.{Inject, Singleton}
 import com.keepit.commanders.LibraryCommander
-import com.keepit.common.db.slick.DBSession.RWSession
+import com.keepit.common.db.slick.DBSession.RSession
 import com.keepit.common.db.slick.Database
-import com.keepit.common.db.{ Id, SequenceNumber }
+import com.keepit.common.db.{Id, SequenceNumber}
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
-import com.keepit.common.performance.{ AlertingTimer, StatsdTiming }
-import com.keepit.common.time.{ Clock, _ }
+import com.keepit.common.performance.{AlertingTimer, StatsdTiming}
+import com.keepit.common.time.{Clock, _}
 import com.keepit.model._
-import com.keepit.payments.{ PlanManagementCommander, PaidAccountRepo, PaidAccountStates }
+import com.keepit.payments.{PaidAccountRepo, PaidAccountStates, PlanManagementCommander}
 
-import scala.concurrent.{ Future, ExecutionContext }
-import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.{Duration, SECONDS}
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 @Singleton
 class OrganizationChecker @Inject() (
@@ -38,61 +38,105 @@ class OrganizationChecker @Inject() (
 
   private[integrity] val ORGANIZATION_INTEGRITY_SEQ = Name[SequenceNumber[Organization]]("organization_integrity_plugin")
   private val ORG_FETCH_SIZE = 20
+  private val MAX_CHECK_TIME = Duration(10, SECONDS)
 
   @AlertingTimer(10 seconds)
   @StatsdTiming("OrganizationChecker.check")
   def check(): Unit = lock.synchronized {
-    db.readWrite { implicit s =>
+    val (allOrgs, brokenOrgs) = db.readOnlyReplica { implicit s =>
       val lastSeq = systemValueRepo.getSequenceNumber(ORGANIZATION_INTEGRITY_SEQ).getOrElse(SequenceNumber.ZERO[Organization])
-      val orgs = orgRepo.getBySequenceNumber(lastSeq, ORG_FETCH_SIZE)
-      if (orgs.nonEmpty) {
-        orgs.foreach { org =>
-          ensureStateIntegrity(org.id.get)
-          ensureOrgSystemLibraryIntegrity(org.id.get)
-        }
-        systemValueRepo.setSequenceNumber(ORGANIZATION_INTEGRITY_SEQ, orgs.map(_.seq).max)
+      val orgsToCheck = orgRepo.getBySequenceNumber(lastSeq, ORG_FETCH_SIZE).toSet
+      val brokenOrgs = orgsToCheck.filter { org => orgHasBrokenState(org.id.get) || orgHasBrokenSystemLibraries(org.id.get) }
+      (orgsToCheck, brokenOrgs)
+    }
+
+    if (allOrgs.nonEmpty) {
+      val maxSeq = allOrgs.map(_.seq).max
+      val tryToFixAllOrgsFut = Future.sequence { brokenOrgs.map(org => fixOrg(org.id.get)) }.map { _ => () }
+      Await.result(tryToFixAllOrgsFut, MAX_CHECK_TIME)
+      db.readWrite { implicit session =>
+        systemValueRepo.setSequenceNumber(ORGANIZATION_INTEGRITY_SEQ, maxSeq)
       }
     }
   }
 
-  private def ensureStateIntegrity(orgId: Id[Organization])(implicit session: RWSession) = {
+  def fixOrg(orgId: Id[Organization]): Future[Unit] = {
+    val fixes = Set(
+      ensureStateIntegrity(orgId),
+      ensureOrgSystemLibraryIntegrity(orgId)
+    )
+    Future.sequence(fixes).map { _ => () }
+  }
+
+  private def orgHasBrokenState(orgId: Id[Organization])(implicit session: RSession): Boolean = {
     val org = orgRepo.get(orgId)
-    if (org.isInactive) {
+    if (org.isActive) true
+    else {
       val zombieMemberships = orgMembershipRepo.getAllByOrgId(org.id.get, excludeState = Some(OrganizationMembershipStates.INACTIVE))
-      if (zombieMemberships.nonEmpty) {
-        airbrake.notify(s"[ORG-STATE-MATCH] Dead org $orgId has zombie memberships for these users: ${zombieMemberships.map(_.userId)}")
-        zombieMemberships.foreach(orgMembershipRepo.deactivate)
-      }
-
       val zombieCandidates = orgMembershipCandidateRepo.getAllByOrgId(org.id.get, states = Set(OrganizationMembershipCandidateStates.ACTIVE))
-      if (zombieCandidates.nonEmpty) {
-        airbrake.notify(s"[ORG-STATE-MATCH] Dead org $orgId has zombie candidates for these users: ${zombieCandidates.map(_.userId)}")
-        zombieCandidates.foreach(orgMembershipCandidateRepo.deactivate)
-      }
-
       val zombieInvites = orgInviteRepo.getAllByOrgId(org.id.get, state = OrganizationInviteStates.ACTIVE)
-      if (zombieInvites.nonEmpty) {
-        airbrake.notify(s"[ORG-STATE-MATCH] Dead org $orgId has zombie invites: ${zombieInvites.map(_.id.get)}")
-        zombieInvites.foreach(orgInviteRepo.deactivate)
-      }
-
       val zombiePaidAccount = paidAccountRepo.maybeGetByOrgId(org.id.get, excludeStates = Set(PaidAccountStates.INACTIVE))
-      if (zombiePaidAccount.isDefined) {
-        airbrake.notify(s"[ORG-STATE-MATCH] Dead org $orgId has zombie paid account: ${zombiePaidAccount.map(_.id.get)}")
-        planManagementCommander.deactivatePaidAccountForOrganization(org.id.get, session)
+      val zombieLibs = libraryRepo.getBySpace(org.id.get, excludeState = Some(LibraryStates.INACTIVE))
+
+      zombieMemberships.nonEmpty || zombieCandidates.nonEmpty || zombieInvites.nonEmpty || zombiePaidAccount.isDefined || zombieLibs.nonEmpty
+    }
+  }
+  private def ensureStateIntegrity(orgId: Id[Organization]): Future[Unit] = {
+    val org = db.readOnlyReplica { implicit session => orgRepo.get(orgId) }
+    if (org.isActive) Future.successful(())
+    else {
+      // There is some easy stuff that can be done synchronously
+      db.readWrite { implicit session =>
+        val zombieMemberships = orgMembershipRepo.getAllByOrgId(org.id.get, excludeState = Some(OrganizationMembershipStates.INACTIVE))
+        if (zombieMemberships.nonEmpty) {
+          airbrake.notify(s"[ORG-STATE-MATCH] Dead org $orgId has zombie memberships for these users: ${zombieMemberships.map(_.userId)}")
+          zombieMemberships.foreach(orgMembershipRepo.deactivate)
+        }
+
+        val zombieCandidates = orgMembershipCandidateRepo.getAllByOrgId(org.id.get, states = Set(OrganizationMembershipCandidateStates.ACTIVE))
+        if (zombieCandidates.nonEmpty) {
+          airbrake.notify(s"[ORG-STATE-MATCH] Dead org $orgId has zombie candidates for these users: ${zombieCandidates.map(_.userId)}")
+          zombieCandidates.foreach(orgMembershipCandidateRepo.deactivate)
+        }
+
+        val zombieInvites = orgInviteRepo.getAllByOrgId(org.id.get, state = OrganizationInviteStates.ACTIVE)
+        if (zombieInvites.nonEmpty) {
+          airbrake.notify(s"[ORG-STATE-MATCH] Dead org $orgId has zombie invites: ${zombieInvites.map(_.id.get)}")
+          zombieInvites.foreach(orgInviteRepo.deactivate)
+        }
+
+        val zombiePaidAccount = paidAccountRepo.maybeGetByOrgId(org.id.get, excludeStates = Set(PaidAccountStates.INACTIVE))
+        if (zombiePaidAccount.isDefined) {
+          airbrake.notify(s"[ORG-STATE-MATCH] Dead org $orgId has zombie paid account: ${zombiePaidAccount.map(_.id.get)}")
+          planManagementCommander.deactivatePaidAccountForOrganization(org.id.get, session)
+        }
       }
 
-      val zombieLibs = libraryRepo.getBySpace(org.id.get, excludeState = Some(LibraryStates.INACTIVE))
-      if (zombieLibs.nonEmpty) {
+      val zombieLibs = db.readOnlyReplica { implicit session =>
+        libraryRepo.getBySpace(org.id.get, excludeState = Some(LibraryStates.INACTIVE))
+      }
+      val libIntegrityFuts = if (zombieLibs.isEmpty) {
+        Set.empty[Future[Unit]]
+      } else {
         airbrake.notify(s"[ORG-STATE-MATCH] Dead org $orgId has zombie libraries: ${zombieLibs.map(_.id.get)}")
         zombieLibs.collect {
-          case lib if lib.canBeModified => libraryCommander.unsafeModifyLibrary(lib, LibraryModifications(space = Some(lib.ownerId)))
+          case lib if lib.canBeModified => libraryCommander.unsafeModifyLibrary(lib, LibraryModifications(space = Some(lib.ownerId))).keepChanges
           case lib if lib.isSystemLibrary => libraryCommander.unsafeAsyncDeleteLibrary(lib.id.get)
         }
       }
+      Future.sequence(libIntegrityFuts).map { _ => () }
     }
   }
-  private def ensureOrgSystemLibraryIntegrity(orgId: Id[Organization])(implicit session: RWSession) = {
+
+  private def orgHasBrokenSystemLibraries(orgId: Id[Organization])(implicit session: RSession): Boolean = {
+    val org = orgRepo.get(orgId)
+    if (org.isInactive) true
+    else {
+      val orgGeneralLibrary = libraryRepo.getBySpaceAndKind(org.id.get, LibraryKind.SYSTEM_ORG_GENERAL)
+      orgGeneralLibrary.size != 1
+    }
+  }
+  private def ensureOrgSystemLibraryIntegrity(orgId: Id[Organization]): Future[Unit] = db.readWriteAsync { implicit session =>
     val org = orgRepo.get(orgId)
     if (org.isActive) {
       val orgGeneralLibrary = libraryRepo.getBySpaceAndKind(org.id.get, LibraryKind.SYSTEM_ORG_GENERAL)


### PR DESCRIPTION
Library modify/delete is asynchronous, so it opens its own session. This is
an issue because the org checker was doing all of its modification in a single
monster read/write session. The fix involved splitting the single monster session
into multiple sessions.

This would be super expensive, so we first check all the orgs in a single
read session, pick out just the ones that are broken, then fix each broken
one independently. We block the thread to wait for the async library fixes
to complete.

@camhashemi @andrewconner 

There is some horrible stuff fiddling with `Future`, but otherwise I hope it's pretty straightforward.
