### PR TITLE
Add keptAt to KeepInfo.libraries

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -357,7 +357,7 @@ object BasicLibrary {
     val path = LibraryPathHelper.formatLibraryPath(owner, orgHandle, library.slug)
     BasicLibrary(Library.publicId(library.id.get), library.name, path, library.visibility, library.color)
   }
-  implicit val libraryWrites = Writes[BasicLibrary] { library =>
+  implicit val libraryWrites = OWrites[BasicLibrary] { library =>
     Json.obj("id" -> library.id, "name" -> library.name, "path" -> library.path, "visibility" -> library.visibility, "color" -> library.color, "secret" -> library.isSecret) //todo(Léo): remove secret field
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
@@ -135,7 +135,7 @@ class KeepDecoratorImpl @Inject() (
                 lazy val publicId = Library.publicId(libraryId)
                 !librariesWithWriteAccess.contains(libraryId) || keeps.exists(_.libraryId == publicId)
               }
-              augmentationInfoForKeep.libraries.collect { case (libraryId, contributorId, _) if doShowLibrary(libraryId) => (idToBasicLibrary(libraryId), idToBasicUser(contributorId)) }
+              augmentationInfoForKeep.libraries.collect { case (libraryId, contributorId, keptAt) if doShowLibrary(libraryId) => (BasicLibraryWithKeptAt(idToBasicLibrary(libraryId), keptAt), idToBasicUser(contributorId)) }
             }
 
             val keptAt = if (withKeepTime) {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileRecommendationsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileRecommendationsController.scala
@@ -99,7 +99,7 @@ class MobileRecommendationsController @Inject() (
         title = keep.title,
         url = keep.url,
         keepers = keep.keepers.getOrElse(Seq.empty),
-        libraries = keep.libraries.map(_.map { case (lib, user) => RecoLibraryInfo(user, lib.id, lib.name, lib.path, lib.color.map(_.hex)) } toSeq).getOrElse(Seq.empty),
+        libraries = keep.libraries.map(_.map { case (BasicLibraryWithKeptAt(lib, _), user) => RecoLibraryInfo(user, lib.id, lib.name, lib.path, lib.color.map(_.hex)) } toSeq).getOrElse(Seq.empty),
         others = Math.max(0, keep.keepersTotal.getOrElse(0) - keep.keepers.map(_.size).getOrElse(0)),
         siteName = keep.siteName,
         summary = keep.summary.get), explain = None)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepInfo.scala
@@ -1,13 +1,21 @@
 package com.keepit.model
 
-import com.keepit.common.time._
 import com.keepit.commanders.BasicCollection
 import com.keepit.common.crypto.{ PublicIdConfiguration, PublicId }
 import com.keepit.common.db.ExternalId
 import com.keepit.common.json.TupleFormat
 import com.keepit.social.BasicUser
 import org.joda.time.DateTime
-import play.api.libs.json.{ JsNull, Json, Writes }
+import com.keepit.common.time._
+import play.api.libs.json.{ OWrites, Json, Writes }
+
+case class BasicLibraryWithKeptAt(library: BasicLibrary, keptAt: DateTime)
+object BasicLibraryWithKeptAt {
+  implicit val writes: OWrites[BasicLibraryWithKeptAt] = OWrites[BasicLibraryWithKeptAt] {
+    case BasicLibraryWithKeptAt(library, keptAt) =>
+      BasicLibrary.libraryWrites.writes(library) + ("keptAt" -> Json.toJson(keptAt))
+  }
+}
 
 case class KeepInfo(
   id: Option[ExternalId[Keep]] = None,
@@ -20,7 +28,7 @@ case class KeepInfo(
   keepers: Option[Seq[BasicUser]] = None,
   keepersOmitted: Option[Int] = None,
   keepersTotal: Option[Int] = None,
-  libraries: Option[Seq[(BasicLibrary, BasicUser)]] = None,
+  libraries: Option[Seq[(BasicLibraryWithKeptAt, BasicUser)]] = None,
   librariesOmitted: Option[Int] = None,
   librariesTotal: Option[Int] = None,
   collections: Option[Set[String]] = None, // deprecated
@@ -40,7 +48,7 @@ object KeepInfo {
   val maxLibrariesShown = 10
 
   implicit val writes = {
-    implicit val libraryWithContributorWrites = TupleFormat.tuple2Writes[BasicLibrary, BasicUser]
+    implicit val libraryWithContributorWrites = TupleFormat.tuple2Writes[BasicLibraryWithKeptAt, BasicUser]
     new Writes[KeepInfo] {
       import com.keepit.common.core._
       def writes(o: KeepInfo) = Json.obj(


### PR DESCRIPTION
@andrewconner @jaredpetker 

@ryanpbrewster this tuple actually represents a keep today, so I didn't go with `addedAt` or tried to make it like a `KeepToLibrary`. I'm assuming we'll revamp the whole API at that point, a good opportunity to do so and it probably deserves it.
