### PR TITLE
Use the correct api for add/remove listener

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/followScroll.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/followScroll.js
@@ -64,12 +64,12 @@ angular.module('kifi')
         $timeout(function () {
           positionY = getAbsoluteBoundingRect(element).top;
 
-          desktopMq.addEventListener('change', updateMq);
+          desktopMq.addListener('change', updateMq);
           updateMq();
 
           $scope.$on('$destroy', function () {
             $window.removeEventListener('scroll', moveFloatMenu);
-            desktopMq.removeEventListener('change', updateMq);
+            desktopMq.removeListener('change', updateMq);
           });
         });
       }


### PR DESCRIPTION
@andrewconner Chrome exposes both addEventListener and the standard addListener, but Firefox does not.
