### PR TITLE
eliminate double visitor/user viewed page events and introduce user_completed_signup event

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/heimdal/EventType.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/EventType.scala
@@ -15,6 +15,7 @@ object UserEventTypes {
   // Growth
   val JOINED = EventType("joined")
   val INVITED = EventType("invited")
+  val COMPLETED_SIGNUP = EventType("completed_signup")
 
   // Activity
   val CONNECTED = EventType("connected")


### PR DESCRIPTION
@andrewconner @leogrim 

basically what this intends to do is stop sending ANY `visitor_viewed_page` event when for a logged-in user.  It's my understanding that these exist because of limitations in the what events were recorded between during a user signup and how to track this non-user events to user registration in the analytics funnel

Note that that existing mixpanel funnels that depend on `visitor_viewed_page` events will be broken. So, let's not merge until a plan with @JRuff42  is in place for this
