### PR TITLE
add admin endpoint to sync PaidPlan.defaultSettings and OrgConfig.settings

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationSettings.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationSettings.scala
@@ -88,7 +88,8 @@ object Feature {
     RemoveLibraries,
     CreateSlackIntegration,
     EditOrganization,
-    ExportKeeps
+    ExportKeeps,
+    ViewSettings
   )
   def apply(str: String): Feature = ALL.find(_.value == str).get
 
@@ -156,5 +157,11 @@ object Feature {
     val value = OrganizationPermission.EXPORT_KEEPS.value
     val permission = OrganizationPermission.EXPORT_KEEPS
     val settings: Set[FeatureSetting] = Set(DISABLED, ADMINS, MEMBERS)
+  }
+
+  case object ViewSettings extends Feature with FeatureWithPermissions {
+    val value = OrganizationPermission.VIEW_SETTINGS.value
+    val permission = OrganizationPermission.VIEW_SETTINGS
+    val settings: Set[FeatureSetting] = Set(ADMINS, MEMBERS)
   }
 }

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/398.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/398.sql
@@ -27,7 +27,7 @@ INSERT INTO `paid_plan` (`id`, `created_at`, `updated_at`, `state`, `name`, `bil
 VALUES
   (1, '2015-08-19 21:50:48', '2015-08-19 21:50:48', 'active', 'Test', 1, 0, 'normal',
   '["force_edit_libraries","invite_members","group_messaging","edit_organization","view_organization","remove_libraries","create_slack_integration","export_keeps","publish_libraries","view_members"]',
-  '{"publish_libraries":"members","group_messaging":"members","force_edit_libraries":"disabled","export_keeps":"admins","view_members":"anyone","create_slack_integration":"disabled","edit_organization":"admins","remove_libraries":"members","invite_members":"members","view_organization":"anyone"}'
+  '{"publish_libraries":"members","group_messaging":"members","force_edit_libraries":"disabled","export_keeps":"admins","view_members":"anyone","create_slack_integration":"disabled","edit_organization":"admins","remove_libraries":"members","invite_members":"members","view_organization":"anyone", "view_settings":"members"}'
   );
 
 insert into evolutions(name, description) values('398.sql', 'refactor org permissions: drop org_membership.permissions, drop org.base_permissions, paid_plan.features -> {paid_plan.editable_features, paid_plan.default_settings}, paid_account.feature_settings -> org_config.settings');

--- a/kifi-backend/modules/shoebox/angular/src/profile/profileWidget.styl
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profileWidget.styl
@@ -160,10 +160,10 @@
         margin-right: auto
         margin-left: auto
         color: white
-        background-color: alpha(red, .65)
+        background-color: alpha(gray, .85)
 
         &:hover:not(:active)
-          background-color: red
+          background-color: gray
 
       &.org-inv-btn-accept
         margin-right: auto

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
@@ -99,7 +99,7 @@ class PaymentsController @Inject() (
     Ok(Json.toJson(orgCommander.getExternalOrgConfiguration(request.orgId)))
   }
 
-  def setAccountFeatureSettings(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.MANAGE_PLAN)(parse.tolerantJson) { request =>
+  def setAccountFeatureSettings(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.VIEW_SETTINGS, OrganizationPermission.MANAGE_PLAN)(parse.tolerantJson) { request =>
     request.body.validate[OrganizationSettings](OrganizationSettings.siteFormat) match {
       case JsError(errs) => BadRequest(Json.obj("error" -> "could_not_parse", "details" -> errs.toString))
       case JsSuccess(settings, _) =>

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -906,7 +906,7 @@ GET           /admin/payments/addCreditCard                @com.keepit.controlle
 POST          /admin/payments/addCreditCard                @com.keepit.controllers.admin.AdminPaymentsController.addCreditCard(orgId: Id[Organization])
 GET           /admin/payments/getAccountActivity           @com.keepit.controllers.admin.AdminPaymentsController.getAccountActivity(orgId: Id[Organization], page: Int)
 POST          /admin/payments/unfreezeAccount              @com.keepit.controllers.admin.AdminPaymentsController.unfreezeAccount(orgId: Id[Organization])
-
+POST          /admin/payments/applyDefaultSettingsToOrgConfigs      @com.keepit.controllers.admin.AdminPaymentsController.applyDefaultSettingsToOrgConfigs()
 
 ##########################################
 # Common Healthcheck / service routes

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/PaymentsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/PaymentsControllerTest.scala
@@ -4,7 +4,9 @@ import com.google.inject.Injector
 import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.common.controller.FakeUserActionsHelper
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
+import com.keepit.common.db.Id
 import com.keepit.common.social.FakeSocialGraphModule
+import com.keepit.controllers.admin.AdminPaymentsController
 import com.keepit.heimdal.FakeHeimdalServiceClientModule
 import com.keepit.model.OrganizationFactoryHelper._
 import com.keepit.model.UserFactoryHelper._
@@ -22,6 +24,7 @@ class PaymentsControllerTest extends Specification with ShoeboxTestInjector {
   implicit def publicIdConfig(implicit injector: Injector) = inject[PublicIdConfiguration]
   private def controller(implicit injector: Injector) = inject[PaymentsController]
   private def route = com.keepit.controllers.website.routes.PaymentsController
+  private def adminRoute = com.keepit.controllers.admin.routes.AdminPaymentsController
 
   val controllerTestModules = Seq(
     FakeHeimdalServiceClientModule(),
@@ -60,7 +63,7 @@ class PaymentsControllerTest extends Specification with ShoeboxTestInjector {
         (planJson \ "name").as[String] must beEqualTo("Free")
         (planJson \ "pricePerUser").as[DollarAmount] must beEqualTo(DollarAmount(10000))
         (planJson \ "cycle").as[Int] must beEqualTo(1)
-        (planJson \ "features").as[Set[Feature]] must beEqualTo(Feature.ALL)
+        (planJson \ "features").as[Set[Feature]] must beEqualTo(PaidPlanFactory.testPlanEditableFeatures)
       }
     }
 
@@ -73,10 +76,46 @@ class PaymentsControllerTest extends Specification with ShoeboxTestInjector {
           val request = route.getAccountFeatureSettings(publicId)
           val response = controller.getAccountFeatureSettings(publicId)(request)
           val payload = contentAsJson(response).as[JsObject]
-
           (payload \ "name").as[String] === "test"
           ((payload \ "settings").as[JsObject] \ "publish_libraries" \ "setting").as[String] === "members"
           ((payload \ "settings").as[JsObject] \ "publish_libraries" \ "editable").as[Boolean] === true
+        }
+      }
+    }
+
+    "apply new default settings to org configurations" in {
+      "apply migration properly" in {
+        withDb(controllerTestModules: _*) { implicit injector =>
+          val (org, owner) = setup()
+          val newPlan1 = db.readWrite { implicit session =>
+            val oldPlan = paidPlanRepo.get(Id[PaidPlan](1))
+            val newFeatureSet = oldPlan.defaultSettings.kvs.keySet -- Set(Feature.CreateSlackIntegration, Feature.EditOrganization)
+            val newFeatureSettings = newFeatureSet.map { feature => feature -> oldPlan.defaultSettings.kvs(feature) }.toMap
+            paidPlanRepo.save(oldPlan.copy(editableFeatures = newFeatureSet, defaultSettings = OrganizationSettings(newFeatureSettings))) // mock db migration, remove features
+          }
+
+          inject[FakeUserActionsHelper].setUser(owner, Set(UserExperimentType.ADMIN))
+          val request = adminRoute.applyDefaultSettingsToOrgConfigs()
+          val response = inject[AdminPaymentsController].applyDefaultSettingsToOrgConfigs()(request)
+
+          status(response) must equalTo(200)
+          val newConfig1 = db.readOnlyMaster(implicit s => orgConfigRepo.getByOrgId(org.id.get))
+          newConfig1.settings === newPlan1.defaultSettings
+
+          val newPlan2 = db.readWrite { implicit session =>
+            val oldPlan = paidPlanRepo.get(Id[PaidPlan](1))
+            val newFeatureSet = PaidPlanFactory.testPlanEditableFeatures
+            val newFeatureSettings = PaidPlanFactory.testPlanSettings
+            paidPlanRepo.save(oldPlan.copy(editableFeatures = newFeatureSet, defaultSettings = newFeatureSettings)) // mock db migration, add features
+          }
+
+          val response2 = inject[AdminPaymentsController].applyDefaultSettingsToOrgConfigs()(request)
+
+          status(response2) must equalTo(200)
+          val newConfig2 = db.readOnlyMaster(implicit s => orgConfigRepo.getByOrgId(org.id.get))
+          newConfig2.settings === newPlan2.defaultSettings
+
+          newConfig2.settings.kvs.keySet.diff(newConfig1.settings.kvs.keySet) === Set(Feature.CreateSlackIntegration, Feature.EditOrganization)
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/PaidPlanFactory.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/PaidPlanFactory.scala
@@ -9,7 +9,7 @@ import org.apache.commons.lang3.RandomStringUtils.random
 object PaidPlanFactory {
   private[this] val idx = new AtomicLong(System.currentTimeMillis() % 100)
 
-  val testPlanEditableFeatures = Feature.ALL
+  val testPlanEditableFeatures = Feature.ALL -- Set(Feature.ViewOrganization, Feature.ViewSettings)
   val testPlanSettings: OrganizationSettings = OrganizationSettings.empty.setAll(Map(
     Feature.PublishLibraries -> FeatureSetting.MEMBERS,
     Feature.InviteMembers -> FeatureSetting.MEMBERS,
@@ -20,7 +20,8 @@ object PaidPlanFactory {
     Feature.RemoveLibraries -> FeatureSetting.MEMBERS,
     Feature.CreateSlackIntegration -> FeatureSetting.DISABLED,
     Feature.EditOrganization -> FeatureSetting.ADMINS,
-    Feature.ExportKeeps -> FeatureSetting.ADMINS
+    Feature.ExportKeeps -> FeatureSetting.ADMINS,
+    Feature.ViewSettings -> FeatureSetting.MEMBERS
   ))
 
   def paidPlan(): PartialPaidPlan = {


### PR DESCRIPTION
@ryanpbrewster @andrewconner 

the problem was that I took `view_settings` out of our "setting-less permissions` (i.e. in-memory permissions) before it was in the db, demanding a quick migration. this PR adds the feature without removing the setting-less permission, so we can run the migration safely/patiently. a second PR will remove the setting-less permission and bump the permissions cache.
