### PR TITLE
Cleanup

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/messageTicker/messageTicker.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/messageTicker/messageTicker.js
@@ -70,7 +70,9 @@ angular.module('kifi')
       messageBar.classList.add('hide');
       return setTimeout(function() {
         messageBar.classList.remove('hide');
-        return messageBar.parentNode.removeChild(messageBar);
+        if (messageBar.parentNode) {
+          return messageBar.parentNode.removeChild(messageBar);
+        }
       }, 250);
     };
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -4,11 +4,11 @@ angular.module('kifi')
 
 .directive('kfManageLibrary', [
   '$window', '$rootScope', '$location', '$state', 'friendService',
-  'libraryService', 'modalService', 'profileService', 'util', 'LIB_PERMISSION',
-  'ORG_PERMISSION', 'ORG_SETTING_VALUE',
+  'libraryService', 'modalService', 'profileService', 'orgProfileService', 'util',
+  'LIB_PERMISSION', 'ORG_PERMISSION', 'ORG_SETTING_VALUE',
   function ($window, $rootScope, $location, $state, friendService,
-            libraryService, modalService, profileService, util, LIB_PERMISSION,
-            ORG_PERMISSION, ORG_SETTING_VALUE) {
+            libraryService, modalService, profileService, orgProfileService, util,
+            LIB_PERMISSION, ORG_PERMISSION, ORG_SETTING_VALUE) {
     return {
       restrict: 'A',
       require: '^kfModal',
@@ -190,6 +190,10 @@ angular.module('kifi')
               returnAction = null;
             }
 
+            if (scope.spaceIsOrg(scope.space.destination)) {
+              orgProfileService.invalidateOrgProfileCache();
+            }
+
             if (!returnAction) {
               $location.url(newLibrary.url || newLibrary.path);
             } else {
@@ -233,6 +237,10 @@ angular.module('kifi')
 
           submitting = true;
           libraryService.deleteLibrary(scope.library.id).then(function () {
+            if (scope.spaceIsOrg(scope.space.current)) {
+              orgProfileService.invalidateOrgProfileCache();
+            }
+
             // If we were on the deleted library's page,
             // return to the space it was in.
             if ($state.is('library.keeps') &&

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileLibrariesCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileLibrariesCtrl.js
@@ -22,7 +22,6 @@ angular.module('kifi')
 
     function resetAndFetchLibraries() {
       $scope.libraries = null;
-      orgProfileService.invalidateOrgProfileCache();
       newLibraryIds = {};
       libraryLazyLoader.reset();
       $scope.fetchLibraries();
@@ -31,9 +30,11 @@ angular.module('kifi')
     $scope.libraries = null;
 
     [
-      $rootScope.$on('$stateChangeSuccess', function (event, toState) {
-        if (/^orgProfile\.libraries/.test(toState.name)) {
-          resetAndFetchLibraries();
+      $rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
+        // ui-router wants to navigate to the userOrOrg route because the URL matches,
+        // so we tell it not to if we know we're staying in this space.
+        if (/^userOrOrg/.test(toState.name) && toParams.handle === fromParams.handle) {
+          event.preventDefault();
         }
       }),
 

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMemberManage.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMemberManage.js
@@ -77,6 +77,7 @@ angular.module('kifi')
       })
       .then(function success() {
         memberPageAnalytics({ action: 'clickedCancelInvite', orgMember: member.username });
+        orgProfileService.invalidateOrgProfileCache();
         removeMemberFromPage(member);
       })
       ['catch'](handleErrorResponse);
@@ -98,7 +99,6 @@ angular.module('kifi')
     $scope.me = profileService.me;
 
     function resetAndFetch() {
-      orgProfileService.invalidateOrgProfileCache();
       memberLazyLoader.reset();
       $scope.fetchMembers();
     }
@@ -157,6 +157,7 @@ angular.module('kifi')
       })
       .then(function () {
         memberPageAnalytics({ action: 'clickedInvite', orgMember: member.username });
+        orgProfileService.invalidateOrgProfileCache();
       })
       ['catch'](handleErrorResponse);
 
@@ -208,6 +209,7 @@ angular.module('kifi')
       })
       .then(function success() {
         member.role = role;
+        orgProfileService.invalidateOrgProfileCache();
       })
       ['catch'](handleErrorResponse);
     }

--- a/kifi-backend/modules/shoebox/angular/src/route.js
+++ b/kifi-backend/modules/shoebox/angular/src/route.js
@@ -135,6 +135,14 @@ angular.module('kifi')
         controller: 'OrgProfileSettingsCtrl',
         templateUrl: 'orgProfile/orgProfileSettings.tpl.html',
         activetab: 'settings',
+        resolve: {
+          billingState: [
+            'billingService', 'profile',
+            function (billingService, profile) {
+              return billingService.getBillingState(profile.organization.id);
+            }
+          ]
+        },
         'abstract': true
       })
       .state('orgProfile.settings.team', {
@@ -165,13 +173,7 @@ angular.module('kifi')
         activetab: 'settings',
         activenav: 'payment-plan',
         resolve: {
-          stripe: StripeCheckoutProvider.load,
-          billingState: [
-            'billingService', 'profile',
-            function (billingService, profile) {
-              return billingService.getBillingState(profile.organization.id);
-            }
-          ]
+          stripe: StripeCheckoutProvider.load
         }
       })
       .state('orgProfile.settings.activity', {

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/paymentPlan.js
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/paymentPlan.js
@@ -3,9 +3,16 @@
 angular.module('kifi')
 
 .controller('PaymentPlanCtrl', [
-  '$rootScope', '$scope', '$state',  '$filter', 'billingService', 'modalService', 'billingState','StripeCheckout',
-  function ($rootScope, $scope, $state, $filter, billingService, modalService, billingState, StripeCheckout) {
-    $scope.billingState = billingState;
+  '$window', '$rootScope', '$scope', '$state', '$filter', 'billingState', 'billingService',
+  'modalService', 'StripeCheckout', 'messageTicker',
+  function ($window, $rootScope, $scope, $state, $filter, billingState, billingService,
+            modalService, StripeCheckout, messageTicker) {
+    $scope.card = billingState.card;
+
+    $scope.plan = {
+      tier: 'free',
+      cycle: 1 //month
+    };
 
     var handler = StripeCheckout.configure({
       locale: 'auto'
@@ -38,6 +45,36 @@ angular.module('kifi')
         });
       });
     };
+
+    $scope.savePlanChanges = function () {
+      messageTicker({
+        text: 'Saved Successfully',
+        type: 'green'
+      });
+    };
+
+    $scope.changePlanToFree = function () {
+      $scope.plan.tier = 'free';
+    };
+
+    $scope.changePlanToStandard = function () {
+      $scope.plan.tier = 'standard';
+    };
+
+    $scope.$watch('plan', function (newValue, oldValue) {
+      if (newValue.tier === oldValue.tier &&
+          newValue.cycle === oldValue.cycle) {
+        return;
+      }
+
+      if (newValue.tier === 'enterprise') {
+        $window.open('mailto:billing@kifi.com');
+        newValue.tier = oldValue.tier;
+        return;
+      }
+
+      $scope.savePlanChanges();
+    }, true);
 
     // Close Checkout on page navigation
     [

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/paymentPlan.styl
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/paymentPlan.styl
@@ -2,13 +2,20 @@ freePlanColor = #8A74B9
 basicPlanColor = #1067BD
 enterprisePlanColor = #118730
 
+.kf-payment-plan
+  h2
+    font-size: 20px
+
+  p
+    font-size: 14px
+
 .kf-payment-plan-top-header
   margin-bottom: 10px
 
-.kf-team-plan-cards
+.kf-payment-plan-cards
   justify-content: space-around
 
-.kf-team-plan-card
+.kf-payment-plan-card
   box-sizing: border-box
   position: relative
   display: inline-block
@@ -18,28 +25,30 @@ enterprisePlanColor = #118730
   padding: 5px 10px
   border-radius: 12px
   box-shadow: 2px 2px 4px 0px rgba(0, 0, 0, .5)
-  font-size: 12px
-  text-align: center
   color: #fff
+  text-align: center
   font-smoothing: antialiased
-  transition: .33s ease-in-out
+  transition: transform .33s ease-in-out, box-shadow .33s ease-in-out
+
+  p
+    font-size: 12px
 
   &:hover
     box-shadow: 2px 2px 8px 4px rgba(0, 0, 0, .33)
     transform: scale(1.05, 1.05)
 
-.kf-team-plan-card-description
+.kf-payment-plan-card-description
   margin: 0
   font-smoothing: antialiased
 
-  + .kf-team-plan-card-description
+  + .kf-payment-plan-card-description
     margin-top: 5px
 
-.kf-team-plan-card-title
+.kf-payment-plan-card-title
   heading_lg()
   font-weight: bold
 
-.kf-team-plan-card-cost
+.kf-payment-plan-card-cost
   position: relative
   display: inline-block
   font-size: 36px
@@ -55,14 +64,14 @@ enterprisePlanColor = #118730
     right: 100%
     font-size: 24px
 
-.kf-team-plan-card-bottom
+.kf-payment-plan-card-bottom
   position: absolute
   right: 0
   bottom: 0
   left: 0
   margin-bottom: 10px
 
-.kf-team-plan-card-cta
+.kf-payment-plan-card-cta
   margin-top: 8px
   padding: 5px 10px
   background: none
@@ -82,22 +91,26 @@ enterprisePlanColor = #118730
     transition: none
     box-shadow: 0 0 4px 2px rgba(0, 0, 0, .15)
 
-.kf-team-plan-card-soon
+  &.ng-leave
+    transition: none
+
+
+.kf-payment-plan-card-soon
   width: 100%
   margin: 0 -10px
   padding: 18px 10px
   background-color: rgba(255, 255, 255, .25)
   font-size: 18px
 
-.kf-team-plan-card-free
+.kf-payment-plan-card-free
   background-color: freePlanColor
 
-.kf-team-plan-card-basic
+.kf-payment-plan-card-basic
   background-color: basicPlanColor
 
-.kf-team-plan-card-enterprise
+.kf-payment-plan-card-enterprise
   background-color: enterprisePlanColor
 
-.kf-team-plan-select
+.kf-payment-plan-select
   width: 100%
   padding: 10px

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/paymentPlan.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/paymentPlan.tpl.html
@@ -1,53 +1,56 @@
-<div class="kf-team-plan">
-  <h1 class="kf-payment-plan-top-header">Team Plan</h1>
+<div class="kf-payment-plan">
+  <h1 class="kf-payment-plan-top-header">Payment Plan</h1>
   <div class="kf-container">
     <div class="kf-container-header"><h2>Select your plan</h2></div>
-    <div class="kf-row kf-team-plan-cards">
-      <div class="kf-team-plan-card kf-team-plan-card-free">
-        <div class="kf-team-plan-card-title">Free</div>
-        <div class="kf-team-plan-card-cost">0</div>
-        <div class="kf-team-plan-card-bottom">
-          <p class="kf-team-plan-card-description"><a class="kf-link kf-link-white kf-link-underline" href="#">Details</a></p>
-          <button class="kf-team-plan-card-cta" style="visibility: hidden;">Change plan</button>
+    <div class="kf-row kf-payment-plan-cards">
+      <div class="kf-payment-plan-card kf-payment-plan-card-free">
+        <div class="kf-payment-plan-card-title">Free</div>
+        <div class="kf-payment-plan-card-cost">0</div>
+        <div class="kf-payment-plan-card-bottom">
+          <p class="kf-payment-plan-card-description"><a class="kf-link kf-link-white kf-link-underline" href="#">Details</a></p>
+          <button ng-if="plan.tier !== 'free'" class="kf-payment-plan-card-cta" ng-click="changePlanToFree()">Downgrade</button>
+          <p ng-if="plan.tier === 'free'">Your current plan</p>
         </div>
       </div>
-      <div class="kf-team-plan-card kf-team-plan-card-basic">
-        <div class="kf-team-plan-card-title">Standard</div>
-        <div class="kf-team-plan-card-cost">6.67</div>
-        <p class="kf-team-plan-card-description">per user per month when billed anually</p>
-        <p class="kf-team-plan-card-description">$8 billed monthly</p>
-        <div class="kf-team-plan-card-bottom">
-          <p class="kf-team-plan-card-description"><a class="kf-link kf-link-white kf-link-underline" href="#">Details</a></p>
-          <button class="kf-team-plan-card-cta">Upgrade now</button>
+      <div class="kf-payment-plan-card kf-payment-plan-card-basic">
+        <div class="kf-payment-plan-card-title">Standard</div>
+        <div class="kf-payment-plan-card-cost">6.67</div>
+        <p ng-if="plan.tier !== 'standard'" class="kf-payment-plan-card-description">per user per month when billed anually</p>
+        <p ng-if="plan.tier !== 'standard'" class="kf-payment-plan-card-description">$8 billed monthly</p>
+        <div class="kf-payment-plan-card-bottom">
+          <p class="kf-payment-plan-card-description"><a class="kf-link kf-link-white kf-link-underline" href="#">Details</a></p>
+          <p ng-if="plan.tier === 'standard'">Your current plan</p>
+          <button ng-if="plan.tier === 'free'" class="kf-payment-plan-card-cta" ng-click="changePlanToStandard()">Upgrade now</button>
         </div>
       </div>
-      <div class="kf-team-plan-card kf-team-plan-card-enterprise">
-        <div class="kf-team-plan-card-title">Enterprise</div>
-        <p class="kf-team-plan-card-soon">Coming Soon</p>
-        <div class="kf-team-plan-card-bottom">
-          <p class="kf-team-plan-card-description"><a class="kf-link kf-link-white kf-link-underline" href="#">Details</a></p>
-          <button class="kf-team-plan-card-cta">Contact us</button>
+      <div class="kf-payment-plan-card kf-payment-plan-card-enterprise">
+        <div class="kf-payment-plan-card-title">Enterprise</div>
+        <p class="kf-payment-plan-card-soon">Coming Soon</p>
+        <div class="kf-payment-plan-card-bottom">
+          <p class="kf-payment-plan-card-description"><a class="kf-link kf-link-white kf-link-underline" href="#">Details</a></p>
+          <a class="kf-payment-plan-card-cta kf-link kf-link-white" href="mailto:billing@kifi.com">Contact us</a>
         </div>
       </div>
     </div>
     <p>Select your team's plan. Get details on the plans we offer on the <a class="kf-link" href="#">pricing page</a></p>
     <div class="custom-select kf-button">
-    <select class="kf-team-plan-select">
-        <option>Free Plan</option>
-        <option>Standard Plan</option>
-        <option>Enterprise Plan</option>
+    <select ng-model="plan.tier" class="kf-payment-plan-select">
+        <option value="free">Free Plan</option>
+        <option value="standard">Standard Plan</option>
+        <option value="enterprise">Enterprise Plan - contact us</option>
       </select>
     </div>
     <h2 class="kf-heading">Choose your Payment Frequency</h2>
-    <p>You're paying for <span ng-bind="profile.numMembers"></span> users. With worry-free billing, we'll automatically charge or credit your account with a change in team members.</p>
+    <p>You're paying for <b ng-bind="profile.numMembers"></b> users. With worry-free billing, we'll automatically charge or credit your account with a change in team members.</p>
     <div class="custom-select kf-button">
-      <select class="kf-team-plan-select">
-        <option>Annual billing</option>
-        <option>Monthly billing</option>
+      <select ng-model="plan.cycle" class="kf-payment-plan-select">
+        <option value="12">Annual billing</option>
+        <option value="1">Monthly billing</option>
       </select>
     </div>
     <h2 class="kf-heading">Manage your Credit Card Information</h2>
-    <p>Your current card ends in {{ billingState.card }}</p>
+    <p ng-if="!card">You haven't added a card yet.</p>
+    <p ng-if="card">Your current card is <b ng-bind="card.brand"></b> ****<b ng-bind="card.last4"></b></p>
     <p>
       <button class="kf-button kf-button-large" ng-click="openStripeCheckout()">Update Payment Information</button>
     </p>

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.js
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.js
@@ -3,10 +3,12 @@
 angular.module('kifi')
 
 .controller('TeamSettingsCtrl', [
-  '$window', '$rootScope', '$scope', '$state', '$sce', 'orgProfileService', 'profileService',
-  'billingService', 'messageTicker', 'ORG_PERMISSION', 'ORG_SETTING_VALUE',
-  function ($window, $rootScope, $scope, $state, $sce, orgProfileService, profileService,
-            billingService, messageTicker, ORG_PERMISSION, ORG_SETTING_VALUE) {
+  '$window', '$rootScope', '$scope', '$state', '$sce', 'billingState',
+  'orgProfileService', 'profileService', 'billingService', 'messageTicker',
+  'ORG_PERMISSION', 'ORG_SETTING_VALUE',
+  function ($window, $rootScope, $scope, $state, $sce, billingState,
+            orgProfileService, profileService, billingService, messageTicker,
+            ORG_PERMISSION, ORG_SETTING_VALUE) {
     $scope.ORG_PERMISSION = ORG_PERMISSION;
     $scope.settingsSectionTemplateData = [
       {
@@ -194,11 +196,7 @@ angular.module('kifi')
     }
 
     if ($scope.viewer.membership && $scope.viewer.membership.role === 'admin') {
-      billingService
-      .getBillingState($scope.profile.id)
-      .then(function (stateData) {
-        $scope.billingState = stateData;
-      });
+      $scope.billingState = billingState;
     }
 
     $scope.kifiAdmin = (profileService.me.experiments.indexOf('admin') !== -1);

--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.js
@@ -1,3 +1,4 @@
+
 'use strict';
 
 angular.module('kifi')
@@ -9,7 +10,6 @@ angular.module('kifi')
   connections: 'Connections',
   followers: 'Followers'
 })
-
 
 .controller('UserProfileCtrl', [
   '$scope', '$analytics', '$location', '$rootScope', '$state', '$window', 'profile',
@@ -24,7 +24,7 @@ angular.module('kifi')
     $scope.showInvitedLibraries = function () {
       return $scope.profile && $scope.profile.numInvitedLibraries && $scope.viewingOwnProfile;
     };
-    
+
     //
     // Internal functions.
     //
@@ -70,14 +70,20 @@ angular.module('kifi')
 
       $analytics.eventTrack($rootScope.userLoggedIn ? 'user_clicked_page' : 'visitor_clicked_page', profileEventTrackAttributes);
     }
-    
 
     //
     // Watches and listeners.
     //
-    
- 
+
     [
+      $rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
+        // ui-router wants to navigate to the userOrOrg route because the URL matches,
+        // so we tell it not to if we know we're staying in this space.
+        if (/^userOrOrg/.test(toState.name) && toParams.handle === fromParams.handle) {
+          event.preventDefault();
+        }
+      }),
+
       $rootScope.$on('$stateChangeSuccess', function (event, toState, toParams, fromState, fromParams) {
         // When routing among the nested states, track page view again.
         if (/^userProfile/.test(toState.name) && /^userProfile/.test(fromState.name) && toParams.handle === fromParams.handle) {
@@ -86,7 +92,6 @@ angular.module('kifi')
         }
         if (/^userProfile\.libraries\./.test(toState.name)) {
           $scope.libraryType = toState.name.split('.').pop();
-          
         }
       }),
       $rootScope.$on('getCurrentLibrary', function (e, args) {


### PR DESCRIPTION
@andrewconner

@camhashemi - this fixes the flash when the user navigates from org members to org libraries and back and forth. It turns out, the `userOrOrg` state was matching on the `/:handle` url, so I added a check to prevent the state-change if we are navigating inside of the same org.
