### PR TITLE
Don't allow members to force_edit_libraries

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.js
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.js
@@ -47,8 +47,7 @@ angular.module('kifi')
             fieldKey: 'force_edit_libraries',
             selectOptions: getOptions(
               { label: 'Library owner only', value: ORG_SETTING_VALUE.DISABLED },
-              ORG_SETTING_VALUE.ADMIN,
-              ORG_SETTING_VALUE.MEMBER
+              ORG_SETTING_VALUE.ADMIN
             )
           },
           {


### PR DESCRIPTION
@andrewconner / @camhashemi / ( @ryanpbrewster ?) This will make the select box show with blank selected if an org has the "members" value selected for force_edit_library. Is that acceptable, or should I wait for the backend to modify those orgs' values?
