### PR TITLE
Use plan.name != "free" instead of plan.name == "paid"

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationConfiguration.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationConfiguration.scala
@@ -3,7 +3,8 @@ package com.keepit.model
 import com.keepit.common.db._
 import com.keepit.common.time._
 import org.joda.time.DateTime
-import play.api.libs.json.{ Json, Writes }
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
 
 case class OrganizationConfiguration(
     id: Option[Id[OrganizationConfiguration]] = None,
@@ -24,15 +25,13 @@ case class OrganizationConfiguration(
 object OrganizationConfigurationStates extends States[OrganizationConfiguration]
 
 case class ExternalOrganizationConfiguration(
-  planName: String,
+  isPaid: Boolean,
   settings: OrganizationSettingsWithEditability)
 
 object ExternalOrganizationConfiguration {
-  implicit val writes: Writes[ExternalOrganizationConfiguration] = Writes { config =>
-    Json.obj(
-      "name" -> config.planName,
-      "settings" -> config.settings
-    )
-  }
+  implicit val writes = (
+    (__ \ 'isPaid).write[Boolean] and
+    (__ \ 'settings).write[OrganizationSettingsWithEditability]
+  )(unlift(ExternalOrganizationConfiguration.unapply))
 }
 

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/orgSelector/orgSelector.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/orgSelector/orgSelector.tpl.html
@@ -17,7 +17,7 @@
       on-click="onClickUpsellRelocate()"
       on-hover="onHoverUpsellRelocate()"
     >
-      <span ng-if="space.destination.config.name.toLowerCase().indexOf('free') === -1">
+      <span ng-if="space.destination.config.isPaid">
         <span ng-if="(space.destination.viewer.membership && space.destination.viewer.membership.role === 'admin') && space.destination.config.settings.remove_libraries.setting === ORG_SETTING_VALUE.DISABLED">
           No one can move libraries out of your team. Edit this in <a class="kf-link" ui-sref="orgProfile.settings({ handle: space.destination.handle })">settings</a>
         </span>
@@ -31,7 +31,7 @@
           Moving team libraries is disabled for {{ library.org.name }}
         </span>
       </span>
-      <span ng-if="space.destination.config.name.toLowerCase().indexOf('free') !== -1 && (space.destination.viewer.membership && space.destination.viewer.membership.role === 'admin')">
+      <span ng-if="!space.destination.config.isPaid && (space.destination.viewer.membership && space.destination.viewer.membership.role === 'admin')">
         Restrict who can move libraries outside of your team by <a class="kf-link" target="_self" href="https://www.kifi.com/teams">upgrading your plan</a>.
       </span>
     </span>

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/orgSelector/orgSelector.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/orgSelector/orgSelector.tpl.html
@@ -17,7 +17,7 @@
       on-click="onClickUpsellRelocate()"
       on-hover="onHoverUpsellRelocate()"
     >
-      <span ng-if="space.destination.config.name.toLowerCase().indexOf('paid') !== -1">
+      <span ng-if="space.destination.config.name.toLowerCase().indexOf('free') === -1">
         <span ng-if="(space.destination.viewer.membership && space.destination.viewer.membership.role === 'admin') && space.destination.config.settings.remove_libraries.setting === ORG_SETTING_VALUE.DISABLED">
           No one can move libraries out of your team. Edit this in <a class="kf-link" ui-sref="orgProfile.settings({ handle: space.destination.handle })">settings</a>
         </span>
@@ -31,7 +31,7 @@
           Moving team libraries is disabled for {{ library.org.name }}
         </span>
       </span>
-      <span ng-if="space.destination.config.name.toLowerCase().indexOf('paid') === -1 && (space.destination.viewer.membership && space.destination.viewer.membership.role === 'admin')">
+      <span ng-if="space.destination.config.name.toLowerCase().indexOf('free') !== -1 && (space.destination.viewer.membership && space.destination.viewer.membership.role === 'admin')">
         Restrict who can move libraries outside of your team by <a class="kf-link" target="_self" href="https://www.kifi.com/teams">upgrading your plan</a>.
       </span>
     </span>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryVisibilitySelector.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryVisibilitySelector.tpl.html
@@ -28,7 +28,7 @@
         on-click="onClickUpsellPublic()"
         on-hover="onHoverUpsellPublic()"
       >
-      <span ng-if="space.config.name.toLowerCase().indexOf('free') === -1">
+      <span ng-if="space.config.isPaid">
         <span ng-if="(space.viewer.membership && space.viewer.membership.role === 'admin') && space.config.settings.publish_libraries.setting === ORG_SETTING_VALUE.MEMBER">
           Any member can make libraries public. Edit this in <a class="kf-link" ui-sref="orgProfile.settings({ handle: space.handle })">settings</a>
         </span>
@@ -42,7 +42,7 @@
           Public libraries are disabled for {{ space.name }}. Edit this in <a class="kf-link" ui-sref="orgProfile.settings({ handle: space.handle })">settings</a>
         </span>
       </span>
-      <span ng-if="space.config.name.toLowerCase().indexOf('free') !== -1">
+      <span ng-if="!space.config.isPaid">
         Restrict who can make libraries public by <a class="kf-link" href="#">upgrading your plan</a>.
       </span>
     </label>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryVisibilitySelector.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryVisibilitySelector.tpl.html
@@ -28,7 +28,7 @@
         on-click="onClickUpsellPublic()"
         on-hover="onHoverUpsellPublic()"
       >
-      <span ng-if="space.config.name.toLowerCase().indexOf('paid') !== -1">
+      <span ng-if="space.config.name.toLowerCase().indexOf('free') === -1">
         <span ng-if="(space.viewer.membership && space.viewer.membership.role === 'admin') && space.config.settings.publish_libraries.setting === ORG_SETTING_VALUE.MEMBER">
           Any member can make libraries public. Edit this in <a class="kf-link" ui-sref="orgProfile.settings({ handle: space.handle })">settings</a>
         </span>
@@ -42,7 +42,7 @@
           Public libraries are disabled for {{ space.name }}. Edit this in <a class="kf-link" ui-sref="orgProfile.settings({ handle: space.handle })">settings</a>
         </span>
       </span>
-      <span ng-if="space.config.name.toLowerCase().indexOf('paid') === -1">
+      <span ng-if="space.config.name.toLowerCase().indexOf('free') !== -1">
         Restrict who can make libraries public by <a class="kf-link" href="#">upgrading your plan</a>.
       </span>
     </label>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
@@ -83,7 +83,7 @@
                 on-click="onClickUpsellIntegration()"
                 on-hover="onHoverUpsellIntegration()"
               >
-                <span ng-if="space.destination.config.name.toLowerCase().indexOf('free') === -1">
+                <span ng-if="space.destination.config.isPaid">
                   <span ng-if="(space.destination.viewer.membership && space.destination.viewer.membership.role === 'admin') && space.destination.config.settings.create_slack_integration.setting === ORG_SETTING_VALUE.DISABLED">
                     No member of yor team can create integrations. Edit this in <a class="kf-link" ui-sref="orgProfile.settings({ handle: space.destination.handle })">settings</a>
                   </span>
@@ -97,8 +97,8 @@
                     Integrations are disabled for {{ library.org.name }}
                   </span>
                 </span>
-                <span ng-if="space.destination.config.name.toLowerCase().indexOf('free') !== -1 && (space.destination.viewer.membership && space.destination.viewer.membership.role === 'admin')">
-                  Enable Slack integration by <a class="kf-link" target="_self" href="https://www.kifi.com/teams">Upgrading to Basic</a>
+                <span ng-if="!space.destination.config.isPaid && (space.destination.viewer.membership && space.destination.viewer.membership.role === 'admin')">
+                  Enable Slack integration by <a class="kf-link" target="_self" href="https://www.kifi.com/teams">upgrading your plan</a>.
                 </span>
               </span>
             </div>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
@@ -83,7 +83,7 @@
                 on-click="onClickUpsellIntegration()"
                 on-hover="onHoverUpsellIntegration()"
               >
-                <span ng-if="space.destination.config.name.toLowerCase().indexOf('paid') !== -1">
+                <span ng-if="space.destination.config.name.toLowerCase().indexOf('free') === -1">
                   <span ng-if="(space.destination.viewer.membership && space.destination.viewer.membership.role === 'admin') && space.destination.config.settings.create_slack_integration.setting === ORG_SETTING_VALUE.DISABLED">
                     No member of yor team can create integrations. Edit this in <a class="kf-link" ui-sref="orgProfile.settings({ handle: space.destination.handle })">settings</a>
                   </span>
@@ -97,7 +97,7 @@
                     Integrations are disabled for {{ library.org.name }}
                   </span>
                 </span>
-                <span ng-if="space.destination.config.name.toLowerCase().indexOf('paid') === -1 && (space.destination.viewer.membership && space.destination.viewer.membership.role === 'admin')">
+                <span ng-if="space.destination.config.name.toLowerCase().indexOf('free') !== -1 && (space.destination.viewer.membership && space.destination.viewer.membership.role === 'admin')">
                   Enable Slack integration by <a class="kf-link" target="_self" href="https://www.kifi.com/teams">Upgrading to Basic</a>
                 </span>
               </span>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/userProfileLibraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/userProfileLibraryCard.tpl.html
@@ -9,7 +9,7 @@
     on-hover="onHoverUpsellMembers()"
     class="kf-upl-card-upsell"
   >
-    <span ng-if="getMeOrg().config.name.toLowerCase().indexOf('paid') !== -1">
+    <span ng-if="getMeOrg().config.name.toLowerCase().indexOf('free') === -1">
       <span ng-if="getMeOrg().viewer.membership.role === 'admin' && getMeOrg().config.settings.force_edit_libraries.setting === ORG_SETTING_VALUE.DISABLED">
         Only library owners can edit library settings.<br />Change this in <a class="kf-link" ui-sref="orgProfile.settings.team({ handle: lib.org.handle })">settings</a>
       </span>
@@ -20,7 +20,7 @@
         All team members can edit library settings.<br />Change this in <a class="kf-link" ui-sref="orgProfile.settings.team({ handle: lib.org.handle })">settings</a>
       </span>
     </span>
-    <span ng-if="getMeOrg().config.name.toLowerCase().indexOf('paid') === -1">
+    <span ng-if="getMeOrg().config.name.toLowerCase().indexOf('free') !== -1">
       Enable admins or all team members to edit library settings by <a class="kf-link" target="_self" href="https://www.kifi.com/teams">upgrading your plan</a>.
     </span>
   </span>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/userProfileLibraryCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/userProfileLibraryCard.tpl.html
@@ -9,7 +9,7 @@
     on-hover="onHoverUpsellMembers()"
     class="kf-upl-card-upsell"
   >
-    <span ng-if="getMeOrg().config.name.toLowerCase().indexOf('free') === -1">
+    <span ng-if="getMeOrg().config.isPaid">
       <span ng-if="getMeOrg().viewer.membership.role === 'admin' && getMeOrg().config.settings.force_edit_libraries.setting === ORG_SETTING_VALUE.DISABLED">
         Only library owners can edit library settings.<br />Change this in <a class="kf-link" ui-sref="orgProfile.settings.team({ handle: lib.org.handle })">settings</a>
       </span>
@@ -20,7 +20,7 @@
         All team members can edit library settings.<br />Change this in <a class="kf-link" ui-sref="orgProfile.settings.team({ handle: lib.org.handle })">settings</a>
       </span>
     </span>
-    <span ng-if="getMeOrg().config.name.toLowerCase().indexOf('free') !== -1">
+    <span ng-if="!getMeOrg().config.isPaid">
       Enable admins or all team members to edit library settings by <a class="kf-link" target="_self" href="https://www.kifi.com/teams">upgrading your plan</a>.
     </span>
   </span>

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
@@ -47,7 +47,7 @@
               on-hover="onHoverUpsellInvite()"
               class="kf-oph-upsell-invite"
             >
-              <span ng-if="plan.name.toLowerCase().indexOf('paid') !== -1">
+              <span ng-if="plan.name.toLowerCase().indexOf('free') === -1">
                 <span ng-if="viewer.membership.role === 'admin' && plan.settings.invite_members.setting === ORG_SETTING_VALUE.MEMBER">
                   All team members are able to invite. Edit this in <a class="kf-link" ui-sref="orgProfile.settings.team({ handle: profile.handle })">settings</a>
                 </span>
@@ -55,7 +55,7 @@
                   Only admins are able to invite. Edit this in <a class="kf-link" ui-sref="orgProfile.settings.team({ handle: profile.handle })">settings</a>
                 </span>
               </span>
-              <span ng-if="plan.name.toLowerCase().indexOf('paid') === -1">
+              <span ng-if="plan.name.toLowerCase().indexOf('free') === -1">
                 Restrict who can invite new members by <a class="kf-link" href="#">upgrading your plan</a>.
               </span>
             </span>
@@ -87,7 +87,7 @@
               on-hover="onHoverUpsellMembers()"
               class="kf-oph-upsell-members"
             >
-              <span ng-if="plan.name.toLowerCase().indexOf('paid') !== -1">
+              <span ng-if="plan.name.toLowerCase().indexOf('free') === -1">
                 <span ng-if="viewer.membership.role === 'admin' && plan.settings.view_members.setting === ORG_SETTING_VALUE.ANYONE">
                   Your members page is publicly viewable.<br />Edit this in <button class="kf-link" ui-sref="orgProfile.settings.team({ handle: profile.handle })">settings</button>
                 </span>
@@ -95,7 +95,7 @@
                   Only members of {{ profile.name }} can view your team's member list.<br />Edit this in <button class="kf-link" ui-sref="orgProfile.settings.team({ handle: profile.handle })">settings</button>
                 </span>
               </span>
-              <span ng-if="plan.name.toLowerCase().indexOf('paid') === -1">
+              <span ng-if="plan.name.toLowerCase().indexOf('free') !== -1">
                 Restrict who can view your team's members by <button class="kf-link" target="_self" href="https://www.kifi.com/teams">upgrading your plan</button>.
               </span>
             </span>

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
@@ -47,7 +47,7 @@
               on-hover="onHoverUpsellInvite()"
               class="kf-oph-upsell-invite"
             >
-              <span ng-if="plan.name.toLowerCase().indexOf('free') === -1">
+              <span ng-if="plan.isPaid">
                 <span ng-if="viewer.membership.role === 'admin' && plan.settings.invite_members.setting === ORG_SETTING_VALUE.MEMBER">
                   All team members are able to invite. Edit this in <a class="kf-link" ui-sref="orgProfile.settings.team({ handle: profile.handle })">settings</a>
                 </span>
@@ -55,7 +55,7 @@
                   Only admins are able to invite. Edit this in <a class="kf-link" ui-sref="orgProfile.settings.team({ handle: profile.handle })">settings</a>
                 </span>
               </span>
-              <span ng-if="plan.name.toLowerCase().indexOf('free') === -1">
+              <span ng-if="!plan.isPaid">
                 Restrict who can invite new members by <a class="kf-link" href="#">upgrading your plan</a>.
               </span>
             </span>
@@ -87,7 +87,7 @@
               on-hover="onHoverUpsellMembers()"
               class="kf-oph-upsell-members"
             >
-              <span ng-if="plan.name.toLowerCase().indexOf('free') === -1">
+              <span ng-if="plan.isPaid">
                 <span ng-if="viewer.membership.role === 'admin' && plan.settings.view_members.setting === ORG_SETTING_VALUE.ANYONE">
                   Your members page is publicly viewable.<br />Edit this in <button class="kf-link" ui-sref="orgProfile.settings.team({ handle: profile.handle })">settings</button>
                 </span>
@@ -95,7 +95,7 @@
                   Only members of {{ profile.name }} can view your team's member list.<br />Edit this in <button class="kf-link" ui-sref="orgProfile.settings.team({ handle: profile.handle })">settings</button>
                 </span>
               </span>
-              <span ng-if="plan.name.toLowerCase().indexOf('free') !== -1">
+              <span ng-if="!plan.isPaid">
                 Restrict who can view your team's members by <button class="kf-link" target="_self" href="https://www.kifi.com/teams">upgrading your plan</button>.
               </span>
             </span>

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -159,7 +159,7 @@ class OrganizationCommanderImpl @Inject() (
     val config = orgConfigRepo.getByOrgId(orgId)
     val plan = planManagementCommander.currentPlanHelper(orgId)
 
-    ExternalOrganizationConfiguration(plan.name.name, OrganizationSettingsWithEditability(config.settings, plan.editableFeatures))
+    ExternalOrganizationConfiguration(plan.displayName, OrganizationSettingsWithEditability(config.settings, plan.editableFeatures))
   }
 
   def getOrganizationInfo(orgId: Id[Organization], viewerIdOpt: Option[Id[User]])(implicit session: RSession): OrganizationInfo = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -158,8 +158,8 @@ class OrganizationCommanderImpl @Inject() (
   def getExternalOrgConfigurationHelper(orgId: Id[Organization])(implicit session: RSession): ExternalOrganizationConfiguration = {
     val config = orgConfigRepo.getByOrgId(orgId)
     val plan = planManagementCommander.currentPlanHelper(orgId)
-
-    ExternalOrganizationConfiguration(plan.displayName, OrganizationSettingsWithEditability(config.settings, plan.editableFeatures))
+    val isPaid = !plan.displayName.toLowerCase.contains("free")
+    ExternalOrganizationConfiguration(isPaid, OrganizationSettingsWithEditability(config.settings, plan.editableFeatures))
   }
 
   def getOrganizationInfo(orgId: Id[Organization], viewerIdOpt: Option[Id[User]])(implicit session: RSession): OrganizationInfo = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
@@ -111,7 +111,7 @@ class PaymentsController @Inject() (
           case Right(response) =>
             val plan = db.readOnlyMaster { implicit session => paidPlanRepo.get(paidAccountRepo.getByOrgId(request.orgId).planId) }
             val result = ExternalOrganizationConfiguration(
-              plan.name.name,
+              plan.displayName,
               OrganizationSettingsWithEditability(response.config.settings, plan.editableFeatures)
             )
             Ok(Json.toJson(result))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
@@ -110,8 +110,9 @@ class PaymentsController @Inject() (
           case Left(fail) => fail.asErrorResponse
           case Right(response) =>
             val plan = db.readOnlyMaster { implicit session => paidPlanRepo.get(paidAccountRepo.getByOrgId(request.orgId).planId) }
+            val isPaid = !plan.displayName.toLowerCase.contains("free")
             val result = ExternalOrganizationConfiguration(
-              plan.displayName,
+              isPaid,
               OrganizationSettingsWithEditability(response.config.settings, plan.editableFeatures)
             )
             Ok(Json.toJson(result))

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidPlan.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidPlan.scala
@@ -59,11 +59,12 @@ case class PaidPlan(
 
   def fullName = {
     val cycleString = billingCycle.month match {
-      case 1 => "Monthly"
-      case 12 => "Annual"
-      case _ => "Custom"
+      case 0 => ""
+      case 1 => " Monthly"
+      case 12 => " Annual"
+      case _ => " Custom"
     }
-    displayName + " " + cycleString
+    displayName + cycleString
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidPlan.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidPlan.scala
@@ -37,8 +37,8 @@ case class PaidPlan(
     updatedAt: DateTime = currentDateTime,
     state: State[PaidPlan] = PaidPlanStates.ACTIVE,
     kind: PaidPlan.Kind,
-    name: Name[PaidPlan],
-    displayName: String,
+    name: Name[PaidPlan], // as is, deprecated. need to migrate the .displayName column values over to this column, then use .name instead of .displayName in-code
+    displayName: String, // not actually a display name, use fullName instead TODO: migrate this over to `.name`
     billingCycle: BillingCycle,
     pricePerCyclePerUser: DollarAmount,
     editableFeatures: Set[Feature],
@@ -59,12 +59,14 @@ case class PaidPlan(
 
   def fullName = {
     val cycleString = billingCycle.month match {
-      case 0 => ""
-      case 1 => " Monthly"
-      case 12 => " Annual"
-      case _ => " Custom"
+      case 1 => "Monthly"
+      case 12 => "Annual"
+      case _ => "Custom"
     }
-    displayName + cycleString
+    displayName match {
+      case freeName if freeName.toLowerCase.contains("free") => displayName
+      case _ => displayName + " " + cycleString
+    }
   }
 }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/PaymentsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/PaymentsControllerTest.scala
@@ -76,7 +76,7 @@ class PaymentsControllerTest extends Specification with ShoeboxTestInjector {
           val request = route.getAccountFeatureSettings(publicId)
           val response = controller.getAccountFeatureSettings(publicId)(request)
           val payload = contentAsJson(response).as[JsObject]
-          (payload \ "name").as[String] === "test"
+          (payload \ "name").as[String] === "Free"
           ((payload \ "settings").as[JsObject] \ "publish_libraries" \ "setting").as[String] === "members"
           ((payload \ "settings").as[JsObject] \ "publish_libraries" \ "editable").as[Boolean] === true
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/PaymentsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/PaymentsControllerTest.scala
@@ -76,7 +76,7 @@ class PaymentsControllerTest extends Specification with ShoeboxTestInjector {
           val request = route.getAccountFeatureSettings(publicId)
           val response = controller.getAccountFeatureSettings(publicId)(request)
           val payload = contentAsJson(response).as[JsObject]
-          (payload \ "name").as[String] === "Free"
+          (payload \ "isPaid").as[Boolean] === false
           ((payload \ "settings").as[JsObject] \ "publish_libraries" \ "setting").as[String] === "members"
           ((payload \ "settings").as[JsObject] \ "publish_libraries" \ "editable").as[Boolean] === true
         }


### PR DESCRIPTION
@cvializ

@andrewconner this weans us off of `PaidPlan.name`. it's not being used anywhere on the backend after this merges (except new plan creation, which is only done internally).

I still need to rename `displayName` to be either `name, group or shortName`, but not doing it (don't think I need to) until we can agree upon something.
