### PR TITLE
dont use paidPlan.name

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/AccountEventCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/AccountEventCommander.scala
@@ -114,7 +114,7 @@ object SimpleAccountEventInfo {
 
     implicit def fromBasicUser(user: BasicUser): BasicElement = user.fullName -> user.path.absolute
     implicit def fromEmailAddress(email: EmailAddress): BasicElement = email.address
-    implicit def fromPaidPlanAndUrl(plan: PaidPlan)(implicit orgHandle: OrganizationHandle): BasicElement = plan.name.name -> s"/$orgHandle/settings/plan"
+    implicit def fromPaidPlanAndUrl(plan: PaidPlan)(implicit orgHandle: OrganizationHandle): BasicElement = plan.fullName -> s"/$orgHandle/settings/plan"
 
     private def flatten(description: DescriptionElements): Seq[BasicElement] = description match {
       case SequenceOfElements(elements) => elements.map(flatten).flatten


### PR DESCRIPTION
@leogrim we need to use `fullName` to append the billing cycle string. regardless, `PaidPlan` needs a migration and `name` is useless (and not used).
