### PR TITLE
Moved the admin org config endpoint to /admin/orgs

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationSettings.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationSettings.scala
@@ -7,10 +7,13 @@ import play.api.libs.json._
 import scala.util.{ Failure, Success, Try }
 
 case class OrganizationSettings(kvs: Map[Feature, FeatureSetting]) {
-  def setAll(newKvs: Map[Feature, FeatureSetting]): OrganizationSettings = {
-    this.copy(kvs = kvs ++ newKvs)
-  }
-  def withSettings(newKvs: (Feature, FeatureSetting)*): OrganizationSettings = setAll(newKvs.toMap)
+  def features: Set[Feature] = kvs.keySet
+  def settingFor(f: Feature): Option[FeatureSetting] = kvs.get(f)
+
+  def withFeatureSetTo(fs: (Feature, FeatureSetting)): OrganizationSettings = setAll(Map(fs._1 -> fs._2))
+  def setAll(newKvs: Map[Feature, FeatureSetting]): OrganizationSettings = this.copy(kvs = kvs ++ newKvs)
+  def overwriteWith(that: OrganizationSettings): OrganizationSettings = this.setAll(that.kvs)
+
   def extraPermissionsFor(roleOpt: Option[OrganizationRole]): Set[OrganizationPermission] = kvs.collect {
     case (feature: FeatureWithPermissions, setting: FeatureSetting) => feature.extraPermissionsFor(roleOpt, setting)
   }.toSet.flatten

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -743,6 +743,7 @@ POST    /admin/organizations/create                          @com.keepit.control
 POST    /admin/organizations/addOrCreateByUser/:userId       @com.keepit.controllers.admin.AdminOrganizationController.addCandidateOrCreateByName(userId: Id[User])
 POST    /admin/organizations/importOrgsFromLinkedIn          @com.keepit.controllers.admin.AdminOrganizationController.importOrgsFromLinkedIn()
 DELETE  /admin/organizations/deleteSystemLibrariesWithInactiveOrgs      @com.keepit.controllers.admin.AdminOrganizationController.deleteSystemLibrariesWithInactiveOrgs()
+POST    /admin/organizations/applyDefaultSettingsToOrgConfigs           @com.keepit.controllers.admin.AdminOrganizationController.applyDefaultSettingsToOrgConfigs()
 
 
 GET     /admin/topKeepersNotInOrg   @com.keepit.controllers.admin.AdminUserController.topKeepersNotInOrg
@@ -906,7 +907,6 @@ GET           /admin/payments/addCreditCard                @com.keepit.controlle
 POST          /admin/payments/addCreditCard                @com.keepit.controllers.admin.AdminPaymentsController.addCreditCard(orgId: Id[Organization])
 GET           /admin/payments/getAccountActivity           @com.keepit.controllers.admin.AdminPaymentsController.getAccountActivity(orgId: Id[Organization], page: Int)
 POST          /admin/payments/unfreezeAccount              @com.keepit.controllers.admin.AdminPaymentsController.unfreezeAccount(orgId: Id[Organization])
-POST          /admin/payments/applyDefaultSettingsToOrgConfigs      @com.keepit.controllers.admin.AdminPaymentsController.applyDefaultSettingsToOrgConfigs()
 
 ##########################################
 # Common Healthcheck / service routes

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -408,7 +408,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           libraryCommander.modifyLibrary(libraryId = lib.id.get, userId = libOwner.id.get, LibraryModifications(space = Some(org.id.get))) must beRight
 
           // However, if we give the admin force-edit permissions
-          val newSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.ForceEditLibraries -> FeatureSetting.ADMINS) }
+          val newSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.ForceEditLibraries -> FeatureSetting.ADMINS) }
           orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, orgOwner.id.get, newSettings)) must beRight
 
           // They still can't steal the library

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminOrganizationControllerTest.scala
@@ -89,7 +89,7 @@ class AdminOrganizationControllerTest extends Specification with ShoeboxTestInje
           1 === 1
         }
       }
-      "pass cam's test" in {
+      "work for both adding and removing features" in {
         withDb(modules: _*) { implicit injector =>
           val (org, owner) = db.readWrite { implicit session =>
             val owner = UserFactory.user().saved

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminOrganizationControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/admin/AdminOrganizationControllerTest.scala
@@ -2,19 +2,25 @@ package com.keepit.controllers.admin
 
 import com.google.inject.Injector
 import com.keepit.abook.FakeABookServiceClientModule
-import com.keepit.common.concurrent.WatchableExecutionContext
 import com.keepit.common.controller.FakeUserActionsHelper
+import com.keepit.common.db.Id
 import com.keepit.common.social.FakeSocialGraphModule
 import com.keepit.model.OrganizationFactoryHelper._
-import com.keepit.model.OrganizationPermission._
+import com.keepit.model.PaidPlanFactoryHelper._
 import com.keepit.model.UserFactoryHelper._
 import com.keepit.model._
+import com.keepit.payments.PaidPlan
 import com.keepit.test.ShoeboxTestInjector
 import org.specs2.mutable.Specification
-import play.api.libs.json.{ JsValue, Json }
-import play.api.mvc.Call
+import play.api.libs.iteratee.Iteratee
+import play.api.libs.json._
+import play.api.mvc.{ Result, Call }
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+
+import scala.concurrent.{ Future, Await }
+import scala.concurrent.duration.Duration
+import scala.util.Try
 
 class AdminOrganizationControllerTest extends Specification with ShoeboxTestInjector {
   implicit def createFakeRequest(route: Call) = FakeRequest(route.method, route.url)
@@ -26,5 +32,106 @@ class AdminOrganizationControllerTest extends Specification with ShoeboxTestInje
   )
 
   "AdminOrganizationController" should {
+    "propagate default plan settings to existing org configs" in {
+      def chunkedResultToJsArray(r: Result): Future[Try[JsArray]] = {
+        r.body.run(Iteratee.getChunks).map { chunks =>
+          Try {
+            val payloads = chunks.init.map { c =>
+              // This is my hella-ghetto way of dropping the obnoxious chunked HTTP headers
+              // Chunks things come in like this:
+              //     XYZ
+              //     <actual stuff>
+              //     XYZ
+              //     <actual stuff>
+              // The XYZ is some sort of indicator about the size of the chunk coming down
+              val s = new String(c).dropWhile(!_.isWhitespace)
+              Json.parse(s)
+            }
+            JsArray(payloads)
+          }
+        }
+      }
+      def chunkedResultAsJson(result: Future[Result]): JsArray = {
+        Await.result(result.flatMap(chunkedResultToJsArray), Duration.Inf).get
+      }
+      "work" in {
+        withDb(modules: _*) { implicit injector =>
+          val (plan, orgs, admin) = db.readWrite { implicit session =>
+            val admin = UserFactory.user().saved
+            val plan = PaidPlanFactory.paidPlan().saved
+            val orgs = OrganizationFactory.organizations(10).map(_.withOwner(admin)).saved
+
+            // Now break the org configs so we can see if this endpoint works
+            orgs.foreach { org =>
+              orgConfigRepo.save(orgConfigRepo.getByOrgId(org.id.get).withSettings(OrganizationSettings.empty))
+            }
+            (plan, orgs, admin)
+          }
+
+          // start with a bunch of orgs with incomplete settings
+          // hit the endpoint to bring them up-to-speed with the plan that they're on
+
+          inject[FakeUserActionsHelper].setUser(admin, Set(UserExperimentType.ADMIN))
+          val payload = Json.obj("confirmation" -> "really do it")
+          val request = route.applyDefaultSettingsToOrgConfigs().withBody(payload)
+          val result = controller.applyDefaultSettingsToOrgConfigs()(request)
+          status(result) === OK
+          val affectedOrgs = chunkedResultAsJson(result).value.map { jsv => (jsv \ "orgId").as[Id[Organization]] }.toSet
+          affectedOrgs === orgs.map(_.id.get).toSet
+
+          // check to make sure they're reached parity with the plan
+
+          db.readOnlyMaster { implicit session =>
+            orgs.foreach { org =>
+              orgConfigRepo.getByOrgId(org.id.get).settings === plan.defaultSettings
+            }
+          }
+          1 === 1
+        }
+      }
+      "pass cam's test" in {
+        withDb(modules: _*) { implicit injector =>
+          val (org, owner) = db.readWrite { implicit session =>
+            val owner = UserFactory.user().saved
+            val org = OrganizationFactory.organization().withOwner(owner).saved
+            (org, owner)
+          }
+          val newPlan1 = db.readWrite { implicit session =>
+            val oldPlan = paidPlanRepo.get(Id[PaidPlan](1))
+            val newFeatureSet = oldPlan.defaultSettings.kvs.keySet -- Set(Feature.CreateSlackIntegration, Feature.EditOrganization)
+            val newFeatureSettings = newFeatureSet.map { feature => feature -> oldPlan.defaultSettings.kvs(feature) }.toMap
+            paidPlanRepo.save(oldPlan.copy(editableFeatures = newFeatureSet, defaultSettings = OrganizationSettings(newFeatureSettings))) // mock db migration, remove features
+          }
+
+          inject[FakeUserActionsHelper].setUser(owner, Set(UserExperimentType.ADMIN))
+          val payload = Json.obj("confirmation" -> "really do it")
+          val request = route.applyDefaultSettingsToOrgConfigs().withBody(payload)
+          val response = controller.applyDefaultSettingsToOrgConfigs()(request)
+
+          status(response) === OK
+          chunkedResultAsJson(response).value.map { jsv => (jsv \ "orgId").as[Id[Organization]] }.toSet === Set(org.id.get)
+
+          val newConfig1 = db.readOnlyMaster(implicit s => orgConfigRepo.getByOrgId(org.id.get))
+          newConfig1.settings === newPlan1.defaultSettings
+
+          val newPlan2 = db.readWrite { implicit session =>
+            val oldPlan = paidPlanRepo.get(Id[PaidPlan](1))
+            val newFeatureSet = PaidPlanFactory.testPlanEditableFeatures
+            val newFeatureSettings = PaidPlanFactory.testPlanSettings
+            paidPlanRepo.save(oldPlan.copy(editableFeatures = newFeatureSet, defaultSettings = newFeatureSettings)) // mock db migration, add features
+          }
+
+          val response2 = controller.applyDefaultSettingsToOrgConfigs()(request)
+
+          chunkedResultAsJson(response2).value.map { jsv => (jsv \ "orgId").as[Id[Organization]] }.toSet === Set(org.id.get)
+
+          status(response2) === OK
+          val newConfig2 = db.readOnlyMaster(implicit s => orgConfigRepo.getByOrgId(org.id.get))
+          newConfig2.settings === newPlan2.defaultSettings
+
+          newConfig2.settings.kvs.keySet.diff(newConfig1.settings.kvs.keySet) === Set(Feature.CreateSlackIntegration, Feature.EditOrganization)
+        }
+      }
+    }
   }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/PaymentsControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/PaymentsControllerTest.scala
@@ -83,43 +83,6 @@ class PaymentsControllerTest extends Specification with ShoeboxTestInjector {
       }
     }
 
-    "apply new default settings to org configurations" in {
-      "apply migration properly" in {
-        withDb(controllerTestModules: _*) { implicit injector =>
-          val (org, owner) = setup()
-          val newPlan1 = db.readWrite { implicit session =>
-            val oldPlan = paidPlanRepo.get(Id[PaidPlan](1))
-            val newFeatureSet = oldPlan.defaultSettings.kvs.keySet -- Set(Feature.CreateSlackIntegration, Feature.EditOrganization)
-            val newFeatureSettings = newFeatureSet.map { feature => feature -> oldPlan.defaultSettings.kvs(feature) }.toMap
-            paidPlanRepo.save(oldPlan.copy(editableFeatures = newFeatureSet, defaultSettings = OrganizationSettings(newFeatureSettings))) // mock db migration, remove features
-          }
-
-          inject[FakeUserActionsHelper].setUser(owner, Set(UserExperimentType.ADMIN))
-          val request = adminRoute.applyDefaultSettingsToOrgConfigs()
-          val response = inject[AdminPaymentsController].applyDefaultSettingsToOrgConfigs()(request)
-
-          status(response) must equalTo(200)
-          val newConfig1 = db.readOnlyMaster(implicit s => orgConfigRepo.getByOrgId(org.id.get))
-          newConfig1.settings === newPlan1.defaultSettings
-
-          val newPlan2 = db.readWrite { implicit session =>
-            val oldPlan = paidPlanRepo.get(Id[PaidPlan](1))
-            val newFeatureSet = PaidPlanFactory.testPlanEditableFeatures
-            val newFeatureSettings = PaidPlanFactory.testPlanSettings
-            paidPlanRepo.save(oldPlan.copy(editableFeatures = newFeatureSet, defaultSettings = newFeatureSettings)) // mock db migration, add features
-          }
-
-          val response2 = inject[AdminPaymentsController].applyDefaultSettingsToOrgConfigs()(request)
-
-          status(response2) must equalTo(200)
-          val newConfig2 = db.readOnlyMaster(implicit s => orgConfigRepo.getByOrgId(org.id.get))
-          newConfig2.settings === newPlan2.defaultSettings
-
-          newConfig2.settings.kvs.keySet.diff(newConfig1.settings.kvs.keySet) === Set(Feature.CreateSlackIntegration, Feature.EditOrganization)
-        }
-      }
-    }
-
     "get active plans" in {
       withDb(controllerTestModules: _*) { implicit injector =>
         val (org, owner) = setup()

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
@@ -54,7 +54,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
       withDb(modules: _*) { implicit injector =>
         val (org, owner, admin, member, _) = setup()
 
-        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.PublishLibraries -> FeatureSetting.ADMINS) }
+        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.PublishLibraries -> FeatureSetting.ADMINS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, initOrgSettings)) must beRight
 
         // owner can create public libraries
@@ -83,7 +83,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         memberLibResponse3 must beLeft
 
         // admins can alter feature settings
-        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.PublishLibraries -> FeatureSetting.MEMBERS) }
+        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.PublishLibraries -> FeatureSetting.MEMBERS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, orgSettings)) must beRight
 
         val memberModifyRequest2 = LibraryModifications(visibility = Some(LibraryVisibility.PUBLISHED))
@@ -98,7 +98,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
       withDb(modules: _*) { implicit injector =>
         val (org, owner, admin, member, _) = setup()
 
-        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.InviteMembers -> FeatureSetting.ADMINS) }
+        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.InviteMembers -> FeatureSetting.ADMINS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, initOrgSettings)) must beRight
 
         val invitees = db.readWrite { implicit session => UserFactory.users(3).saved }
@@ -117,7 +117,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         memberInviteResponse1 must beLeft
 
         // admins can alter feature settings
-        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.InviteMembers -> FeatureSetting.MEMBERS) }
+        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.InviteMembers -> FeatureSetting.MEMBERS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, orgSettings)) must beRight
 
         val memberInviteRequest2 = OrganizationInviteSendRequest(org.id.get, member.id.get, targetEmails = Set.empty, targetUserIds = Set(invitees(2).id.get))
@@ -145,7 +145,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         libraryCommander.modifyLibrary(library.id.get, admin.id.get, adminModifyRequest) must beLeft
         libraryCommander.modifyLibrary(library.id.get, member.id.get, memberModifyRequest) must beLeft
 
-        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.ForceEditLibraries -> FeatureSetting.ADMINS) }
+        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.ForceEditLibraries -> FeatureSetting.ADMINS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, orgSettings)) must beRight
 
         libraryCommander.modifyLibrary(library.id.get, owner.id.get, ownerModifyRequest) must beRight
@@ -160,7 +160,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
       withDb(modules: _*) { implicit injector =>
         val (org, owner, admin, member, nonMember) = setup()
 
-        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.ViewMembers -> FeatureSetting.MEMBERS) }
+        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.ViewMembers -> FeatureSetting.MEMBERS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, initOrgSettings)) must beRight
 
         val testRoute = com.keepit.controllers.website.routes.OrganizationMembershipController.getMembers(Organization.publicId(org.id.get)).url
@@ -191,7 +191,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         status(nonMemberMobileResult1) must equalTo(FORBIDDEN)
         (contentAsJson(nonMemberMobileResult1) \ "error").as[String] must equalTo("insufficient_permissions")
 
-        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.ViewMembers -> FeatureSetting.ANYONE) }
+        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.ViewMembers -> FeatureSetting.ANYONE) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, orgSettings)) must beRight
 
         val nonMemberResult2 = organizationMembershipController.getMembers(Organization.publicId(org.id.get), 0, 30)(nonMemberRequest)
@@ -208,7 +208,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
       withDb(modules: _*) { implicit injector =>
         val (org, owner, admin, member, nonMember) = setup()
 
-        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.EditOrganization -> FeatureSetting.ADMINS) }
+        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.EditOrganization -> FeatureSetting.ADMINS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, initOrgSettings)) must beRight
 
         val organizationCommander = inject[OrganizationCommander]
@@ -223,7 +223,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         memberResponse must beLeft
         memberResponse.left.get must equalTo(OrganizationFail.INSUFFICIENT_PERMISSIONS)
 
-        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.EditOrganization -> FeatureSetting.MEMBERS) }
+        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.EditOrganization -> FeatureSetting.MEMBERS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, owner.id.get, orgSettings)) must beRight
 
         organizationCommander.modifyOrganization(memberModifyRequest) must beRight
@@ -237,7 +237,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         val (org, owner, admin, member, _) = setup()
 
         // Initially, removing libraries is completely disabled
-        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.RemoveLibraries -> FeatureSetting.DISABLED) }
+        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.RemoveLibraries -> FeatureSetting.DISABLED) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, initOrgSettings)) must beRight
 
         val (ownerLibrary, adminLibrary, memberLibrary) = db.readWrite { implicit session =>
@@ -256,14 +256,14 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         libraryCommander.modifyLibrary(adminLibrary.id.get, admin.id.get, adminModifyRequest) must beLeft
         libraryCommander.modifyLibrary(memberLibrary.id.get, member.id.get, memberModifyRequest) must beLeft
 
-        val orgSettings1 = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.RemoveLibraries -> FeatureSetting.ADMINS) }
+        val orgSettings1 = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.RemoveLibraries -> FeatureSetting.ADMINS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, orgSettings1)) must beRight
 
         libraryCommander.modifyLibrary(ownerLibrary.id.get, owner.id.get, ownerModifyRequest) must beRight
         libraryCommander.modifyLibrary(adminLibrary.id.get, admin.id.get, adminModifyRequest) must beRight
         libraryCommander.modifyLibrary(memberLibrary.id.get, member.id.get, memberModifyRequest) must beLeft
 
-        val orgSettings2 = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.RemoveLibraries -> FeatureSetting.MEMBERS) }
+        val orgSettings2 = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.RemoveLibraries -> FeatureSetting.MEMBERS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, orgSettings2)) must beRight
 
         libraryCommander.modifyLibrary(memberLibrary.id.get, member.id.get, memberModifyRequest) must beRight
@@ -277,7 +277,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         val (org, owner, admin, member, _) = setup()
 
         // Initially, only admins
-        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.CreateSlackIntegration -> FeatureSetting.ADMINS) }
+        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.CreateSlackIntegration -> FeatureSetting.ADMINS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, initOrgSettings)) must beRight
 
         val library = db.readWrite { implicit session => LibraryFactory.library().withOwner(owner).withCollaborators(Seq(admin, member)).withOrganization(org).saved }
@@ -300,7 +300,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         libraryCommander.modifyLibrary(library.id.get, admin.id.get, adminModifyRequest) must beRight
         libraryCommander.modifyLibrary(library.id.get, member.id.get, memberModifyRequest) must beLeft
 
-        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.CreateSlackIntegration -> FeatureSetting.MEMBERS) }
+        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.CreateSlackIntegration -> FeatureSetting.MEMBERS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, orgSettings)) must beRight
 
         libraryCommander.modifyLibrary(library.id.get, member.id.get, memberModifyRequest) must beRight
@@ -321,7 +321,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         val (org, owner, admin, member, _) = setup()
 
         // Initially, only admins
-        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.ExportKeeps -> FeatureSetting.ADMINS) }
+        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.ExportKeeps -> FeatureSetting.ADMINS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, initOrgSettings)) must beRight
 
         val keepExportCommander = inject[KeepExportCommander]
@@ -334,7 +334,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         Await.result(keepExportCommander.exportKeeps(adminExportRequest), Duration(3, SECONDS)) must beSuccessfulTry
         Await.result(keepExportCommander.exportKeeps(memberExportRequest), Duration(3, SECONDS)) must beFailedTry
 
-        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.ExportKeeps -> FeatureSetting.MEMBERS) }
+        val orgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.ExportKeeps -> FeatureSetting.MEMBERS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, orgSettings)) must beRight
 
         Await.result(keepExportCommander.exportKeeps(memberExportRequest), Duration(3, SECONDS)) must beSuccessfulTry
@@ -348,7 +348,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         val (org, owner, admin, member, nonMember) = setup()
 
         // Initially, totally disabled
-        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.GroupMessaging -> FeatureSetting.DISABLED) }
+        val initOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.GroupMessaging -> FeatureSetting.DISABLED) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, initOrgSettings)) must beRight
 
         val mobileRoute = com.keepit.controllers.mobile.routes.MobileContactsController.searchForAllContacts(query = None, limit = None).url
@@ -401,7 +401,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         } must beTrue
 
         // allow admins to send group messages
-        val orgSettings1 = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.GroupMessaging -> FeatureSetting.ADMINS) }
+        val orgSettings1 = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.GroupMessaging -> FeatureSetting.ADMINS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, orgSettings1)) must beRight
 
         inject[FakeUserActionsHelper].setUser(owner)
@@ -447,7 +447,7 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         } must beTrue
 
         // members can send group messages
-        val orgSettings2 = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withSettings(Feature.GroupMessaging -> FeatureSetting.MEMBERS) }
+        val orgSettings2 = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.GroupMessaging -> FeatureSetting.MEMBERS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, orgSettings2)) must beRight
 
         inject[FakeUserActionsHelper].setUser(owner)


### PR DESCRIPTION
And made it return a chunked response so it won't timeout when we call it.

Testing a chunked response turned out to be more complex than I thought. Kind
of neat the way that Play handles them.

@stkem @camhashemi 
