### PR TITLE
Fixing eliza

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -37,7 +37,6 @@ trait OrganizationCommander {
   def getExternalOrgConfiguration(orgId: Id[Organization]): ExternalOrganizationConfiguration
   def getExternalOrgConfigurationHelper(orgId: Id[Organization])(implicit session: RSession): ExternalOrganizationConfiguration
   def getBasicOrganizations(orgIds: Set[Id[Organization]]): Map[Id[Organization], BasicOrganization]
-  def getBasicOrganization(orgId: Id[Organization])(implicit session: RSession): BasicOrganization
   def getOrganizationLibrariesVisibleToUser(orgId: Id[Organization], userIdOpt: Option[Id[User]], offset: Offset, limit: Limit): Seq[LibraryCardInfo]
   def createOrganization(request: OrganizationCreateRequest)(implicit eventContext: HeimdalContext): Either[OrganizationFail, OrganizationCreateResponse]
   def modifyOrganization(request: OrganizationModifyRequest)(implicit eventContext: HeimdalContext): Either[OrganizationFail, OrganizationModifyResponse]
@@ -107,39 +106,46 @@ class OrganizationCommanderImpl @Inject() (
   }
 
   def getBasicOrganizationViewHelper(orgId: Id[Organization], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String])(implicit session: RSession): BasicOrganizationView = {
-    val basicOrganization = basicOrganizationIdCache.getOrElse(BasicOrganizationIdKey(orgId))(getBasicOrganization(orgId))
+    // This function assumes that the org is active
+    val basicOrganization = basicOrganizationIdCache.getOrElse(BasicOrganizationIdKey(orgId))(getBasicOrganization(orgId).get)
     val membershipInfo = getMembershipInfoHelper(orgId, viewerIdOpt, authTokenOpt)
     BasicOrganizationView(basicOrganization, membershipInfo)
   }
 
   def getBasicOrganizations(orgIds: Set[Id[Organization]]): Map[Id[Organization], BasicOrganization] = {
-    db.readOnlyReplica { implicit session =>
+    val cacheFormattedMap = db.readOnlyReplica { implicit session =>
       basicOrganizationIdCache.bulkGetOrElse(orgIds.map(BasicOrganizationIdKey)) { missing =>
-        missing.map(_.id).map { orgId => orgId -> getBasicOrganization(orgId) }.toMap.map {
-          case (orgId, org) => (BasicOrganizationIdKey(orgId), org)
-        }
+        missing.map(_.id).map {
+          orgId => orgId -> getBasicOrganization(orgId) // grab all the Option[BasicOrganization]
+        }.collect {
+          case (orgId, Some(basicOrg)) => orgId -> basicOrg // take only the active orgs (inactive ones are None)
+        }.map {
+          case (orgId, org) => (BasicOrganizationIdKey(orgId), org) // format them so the cache can understand them
+        }.toMap
       }
-    }.map {
-      case (orgKey, org) => (orgKey.id, org)
     }
+    cacheFormattedMap.map { case (orgKey, org) => (orgKey.id, org) }
   }
 
-  def getBasicOrganization(orgId: Id[Organization])(implicit session: RSession): BasicOrganization = {
+  def getBasicOrganization(orgId: Id[Organization])(implicit session: RSession): Option[BasicOrganization] = {
     val org = orgRepo.get(orgId)
-    val orgHandle = org.handle
-    val orgName = org.name
-    val description = org.description
+    if (org.isInactive) None
+    else {
+      val orgHandle = org.handle
+      val orgName = org.name
+      val description = org.description
 
-    val ownerId = userRepo.get(org.ownerId).externalId
-    val avatarPath = organizationAvatarCommander.getBestImageByOrgId(orgId, ImageSize(200, 200)).imagePath
+      val ownerId = userRepo.get(org.ownerId).externalId
+      val avatarPath = organizationAvatarCommander.getBestImageByOrgId(orgId, ImageSize(200, 200)).imagePath
 
-    BasicOrganization(
-      orgId = Organization.publicId(orgId),
-      ownerId = ownerId,
-      handle = orgHandle,
-      name = orgName,
-      description = description,
-      avatarPath = avatarPath)
+      Some(BasicOrganization(
+        orgId = Organization.publicId(orgId),
+        ownerId = ownerId,
+        handle = orgHandle,
+        name = orgName,
+        description = description,
+        avatarPath = avatarPath))
+    }
   }
 
   def getOrganizationInfos(orgIds: Set[Id[Organization]], viewerIdOpt: Option[Id[User]]): Map[Id[Organization], OrganizationInfo] = {


### PR DESCRIPTION
So we have a few services that hold references to Shoebox models (Eliza notifications were the specific offender in this case). When they need those models, they make service calls to Shoebox. By that time, it's possible that the model has become inactive, and we really ought to be returning `Option[M]` instead of `M`.

This issue is difficult to solve without explicitly architecting code to handle it.

For now, I have simply dropped the inactive models from the batch request for `Map[Id[Organization], BasicOrganization]`. However, I would prefer to explicitly indicate that these models are inactive (and so the service making the call to Shoebox should probably clean up any references to that model). While `Option[M]` is "explicit", it's easy to mistakenly leave a model out on the Shoebox side. How do y'all feel about a `sealed abstract class ForeignModel[M]` that has `Active(model)` and `Inactive`, and as such behaves very much like an Option.

@leogrim @andrewconner @camhashemi 
