### PR TITLE
limit people with 'create_team' experiment to one org on the front end.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/header/loggedInHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/header/loggedInHeader.js
@@ -152,7 +152,7 @@ angular.module('kifi')
     };
 
     $scope.shouldShowCreateTeam = function () {
-      return $scope.me.experiments.indexOf('admin') !== -1 || $scope.me.experiments.indexOf('create_team') !== -1;
+      return $scope.me.experiments.indexOf('admin') !== -1 || ($scope.me.experiments.indexOf('create_team') !== -1 && $scope.me.orgs.length === 0);
     };
 
     $scope.addKeeps = function () {

--- a/kifi-backend/modules/shoebox/angular/src/profile/profileWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profileWidget.js
@@ -24,7 +24,7 @@ angular.module('kifi')
         }
 
         scope.shouldShowCreateTeam = function () {
-          return scope.me.experiments.indexOf('admin') !== -1 || scope.me.experiments.indexOf('create_team') !== -1;
+          return scope.me.experiments.indexOf('admin') !== -1 || (scope.me.experiments.indexOf('create_team') !== -1 && scope.me.orgs.length === 0);
         };
 
         scope.registerEvent = function (action) {


### PR DESCRIPTION
@andrewconner @ryanpbrewster @camhashemi I believe this is not enforced on the backend, so if a user gets creative with the API endpoints they could create more than one org.
