### PR TITLE
Fixing email-in-email bug

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/mail/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/package.scala
@@ -100,7 +100,7 @@ package object template {
 
     def discussionLink(id: Id[NormalizedURI], threadExtId: String) = Tag2(tags.discussionLink, id, threadExtId).toHtml
     def discussionLink(id: Id[NormalizedURI], threadExtId: String, trackingContent: String) = {
-      Html(appendTrackingParams(Tag2(tags.discussionLink, id, threadExtId) + "&", trackingContent, openInAppIfMobile = true))
+      htmlUrl(Tag2(tags.discussionLink, id, threadExtId) + "&", trackingContent, openInAppIfMobile = false)
     }
 
     def libraryLink(id: Id[Library], authToken: Option[String], content: String, openInAppIfMobile: Boolean = true) =

--- a/kifi-backend/modules/common/app/com/keepit/common/mail/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/package.scala
@@ -100,7 +100,7 @@ package object template {
 
     def discussionLink(id: Id[NormalizedURI], threadExtId: String) = Tag2(tags.discussionLink, id, threadExtId).toHtml
     def discussionLink(id: Id[NormalizedURI], threadExtId: String, trackingContent: String) = {
-      htmlUrl(Tag2(tags.discussionLink, id, threadExtId) + "&", trackingContent, openInAppIfMobile = false)
+      Html(appendTrackingParams(Tag2(tags.discussionLink, id, threadExtId) + "&", trackingContent, openInAppIfMobile = true))
     }
 
     def libraryLink(id: Id[Library], authToken: Option[String], content: String, openInAppIfMobile: Boolean = true) =

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaUserEmailNotifierActor.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaUserEmailNotifierActor.scala
@@ -6,7 +6,7 @@ import com.keepit.common.concurrent.FutureHelpers
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
-import com.keepit.common.mail.template.EmailToSend
+import com.keepit.common.mail.template.{ TemplateOptions, EmailToSend }
 import com.keepit.common.mail.{ EmailAddress, ElectronicMail, SystemEmailAddress }
 import com.keepit.common.store.ImageSize
 import com.keepit.eliza.commanders.{ ElizaEmailUriSummaryImageSizes, ElizaEmailCommander }
@@ -128,8 +128,9 @@ class ElizaUserEmailNotifierActor @Inject() (
                 fromName = Some(Right("Kifi Notifications")),
                 to = Right(destinationEmail),
                 subject = s"""New messages on "${threadEmailInfo.pageTitle}"""",
-                htmlTemplate = views.html.discussionEmail(threadEmailInfo, extendedThreadItems, true, false, true),
-                category = NotificationCategory.User.MESSAGE
+                htmlTemplate = views.html.discussionEmail(threadEmailInfo, extendedThreadItems, isUser = true, isAdded = false, isSmall = true),
+                category = NotificationCategory.User.MESSAGE,
+                templateOptions = Seq(TemplateOptions.CustomLayout).toMap
               )
           }
 


### PR DESCRIPTION
Found another bug, but not sure about the fix. Summoning @joshm1 

I notice that `com.keepit.common.mail.template.helpers.appendTrackingParams` does `&amp;` for the `&`s. How come? Why would a URL need that? If it's only for non-HTML urls, what about `htmlUrl`, which just wraps that in `Html()`? That seems to leave the `&amp;`s there.

Here's an example link we sent me (actually sent in prod): https://www.kifi.com/redir?data=%7B%22t%22%3A%22m%22%2C%22uri%22%3A%226c347c5d-3556-4372-840f-4ab4f79de0fc%22%2C%22id%22%3A%2263cfd7bf-7862-4087-9dc6-14287fb5de9e%22%7D&utm_source=fromFriends&amp;utm_medium=email&amp;utm_campaign=message&amp;utm_content=clickedArticleTitle&amp;kcid=message-email-fromFriends&amp;dat=eyJsIjoiY2xpY2tlZEFydGljbGVUaXRsZSIsImMiOltdLCJ0IjpbXX0=&amp;kma=1

Notice the &amps. Can I remove them? Or make `htmlUrl` not include them?

@ryanpbrewster 
