### PR TITLE
Groundwork for immediate charging when a new card is added (and prevous charge failed)

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminPaymentsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminPaymentsController.scala
@@ -142,11 +142,12 @@ class AdminPaymentsController @Inject() (
       data("cvc").head.trim,
       data("cardholderName").head.trim
     )
-    stripeClient.getPermanentToken(cardDetails, s"Manually Entered through admin ${request.userId} for org $orgId").map { token =>
+    stripeClient.getPermanentToken(cardDetails, s"Manually Entered through admin ${request.userId} for org $orgId").flatMap { token =>
       val lastFour = cardDetails.number.takeRight(4)
       val pm = planCommander.addPaymentMethod(orgId, token, ActionAttribution(user = None, admin = Some(request.userId)), lastFour)
-      val event = planCommander.changeDefaultPaymentMethod(orgId, pm.id.get, ActionAttribution(user = None, admin = Some(request.userId)), lastFour)
-      Ok(event.toString)
+      planCommander.changeDefaultPaymentMethod(orgId, pm.id.get, ActionAttribution(user = None, admin = Some(request.userId)), lastFour).map { event =>
+        Ok(event.toString)
+      }
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidAccount.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidAccount.scala
@@ -83,6 +83,8 @@ case class PaidAccount(
   def withNewPlan(newPlanId: Id[PaidPlan]): PaidAccount = this.copy(planId = newPlanId)
 
   def withCycleStart(newCycleStart: DateTime): PaidAccount = this.copy(billingCycleStart = newCycleStart)
+
+  def lastBillingFailed: Boolean = false //I believe Ryan is working on tracking that in this model (per github comment) so this should be filled in or replaced when that is done
 }
 
 object PaidAccountStates extends States[PaidAccount]


### PR DESCRIPTION
@leogrim @andrewconner @ryanpbrewster @camhashemi 
The only part that is missing is actually sending the result down to the client (it makes it all the way into the controller but is dropped there right now) because I don't know what the desired format is.'
(In addition to easy "last charge failed" detection, which I believe @ryanpbrewster is working on based on a PR comment from yesterday)
