### PR TITLE
Bad, defensive fix of us sending bad emails

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/EmailTestController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/EmailTestController.scala
@@ -53,7 +53,7 @@ class EmailTestController @Inject() (
     def verificationCode = request.getQueryString("code") getOrElse s"fake_verification_code_${currentDateTime.getMillis}"
 
     val emailOptF: Option[Future[ElectronicMail]] = Some(name) collect {
-      case "gratification" => emailSenderProvider.gratification(userId, Some(sendTo))
+      case "gratification" => emailSenderProvider.gratification(userId, Some(sendTo)).map(_.getOrElse(???))
       case "kifiInvite" => emailSenderProvider.kifiInvite(sendTo, userId, ExternalId[Invitation]())
       case "welcome" => emailSenderProvider.welcome.sendToUser(userId)
       case "resetPassword" => emailSenderProvider.resetPassword.sendToUser(userId, sendTo)

--- a/kifi-backend/modules/shoebox/app/views/email/black/gratification.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/black/gratification.scala.html
@@ -62,6 +62,6 @@ The Kifi Team<br>
 
 <p>P.S. We send these emails to inform you of new library views, followers, and keep views. You can update your email settings <a href="@unsubscribeUrl">here</a>.</p>
 
-<p>Kifi<br>709 N Shoreline Blvd<br>Mountain View, CA 94043</p>
+<p>Kifi<br>278 Hope St, Ste D<br>Mountain View, CA 94043</p>
 </body>
 </html>


### PR DESCRIPTION
@camhashemi For some reason, we're sending basically empty (content wise) emails to some users for the gratification email. Without really knowing how the filtering works, I'm throwing in this stop-gap so that we stop sending this (forwarded to you a week ago, it's still happening):

```
Hey Werdna,

We at Kifi hope you're having a great week.

Cheers,
The Kifi Team
P.S. We send these emails to inform you of new library views, followers, and keep views. You can update your email settings here.

Kifi
709 N Shoreline Blvd
Mountain View, CA 94043
```

I'm sure there's a one-liner and easy fix, but didn't see it.
