### PR TITLE
Moved getIdBySubsetAndModulus to PaidAccountRepo

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationRepo.scala
@@ -20,7 +20,6 @@ trait OrganizationRepo extends Repo[Organization] with SeqNumberFunction[Organiz
   def getOrgByName(name: String, state: State[Organization] = OrganizationStates.ACTIVE)(implicit session: RSession): Option[Organization]
   def searchOrgsByNameFuzzy(name: String, state: State[Organization] = OrganizationStates.ACTIVE)(implicit session: RSession): Seq[Organization]
   def getPotentialOrganizationsForUser(userId: Id[User])(implicit session: RSession): Seq[Organization]
-  def getIdSubsetByModulus(modulus: Int, partition: Int)(implicit session: RSession): Set[Id[Organization]]
   def getAllByState(state: State[Organization])(implicit session: RSession): Set[Organization]
 }
 
@@ -141,11 +140,6 @@ class OrganizationRepoImpl @Inject() (
         );""".as[Id[Organization]].list.toSet
 
     getByIds(orgIds).values.toSeq
-  }
-
-  def getIdSubsetByModulus(modulus: Int, partition: Int)(implicit session: RSession): Set[Id[Organization]] = {
-    import com.keepit.common.db.slick.StaticQueryFixed.interpolation
-    sql"""select id from organization where state='active' and frozen = false and MOD(id, $modulus)=$partition""".as[Id[Organization]].list.toSet
   }
 
   def getAllByState(state: State[Organization])(implicit session: RSession): Set[Organization] = rows.filter(row => row.state === state).list.toSet

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/PaymentsIntegrityChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/PaymentsIntegrityChecker.scala
@@ -147,7 +147,7 @@ class PaymentsIntegrityChecker @Inject() (
   def checkAccounts(modulus: Int = 7): Unit = {
     // we are going to process ~1/modulus of the orgs, based on the date
     val partition = clock.now.getDayOfYear % modulus
-    val orgIds = db.readOnlyReplica { implicit session => organizationRepo.getIdSubsetByModulus(modulus, partition) }
+    val orgIds = db.readOnlyReplica { implicit session => paidAccountRepo.getIdSubsetByModulus(modulus, partition) }
 
     orgIds.foreach { orgId =>
       Try(checkAccount(orgId)) match {


### PR DESCRIPTION
It is only used to find a specific subset of the paid accounts. I don't know
why we have such a strong desire to hide the fact that PaidAccount exists...
