### PR TITLE
Introduce and maintain PaidAccount.planRenewal

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/406.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/406.sql
@@ -1,0 +1,9 @@
+# SHOEBOX
+
+# --- !Ups
+
+ALTER TABLE paid_account ADD COLUMN plan_renewal datetime NOT NULL AFTER credit;
+CREATE INDEX paid_account_i_plan_renewal on paid_account(plan_renewal);
+insert into evolutions(name, description) values('406.sql', 'add column paid_account.plan_renewal');
+
+# --- !Downs

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/AccountEvent.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/AccountEvent.scala
@@ -108,7 +108,7 @@ object AccountEventAction { //There is probably a deeper type hierarchy that can
     def toDbRow = eventType -> Json.toJson(this)
   }
 
-  @json
+  @json // deprecated
   case class PlanBilling(plan: Id[PaidPlan], cycle: BillingCycle, price: DollarAmount, activeUsers: Int, startDate: DateTime) extends AccountEventAction {
     def eventType = AccountEventKind.PlanBilling
     def toDbRow = eventType -> Json.toJson(this)
@@ -118,6 +118,19 @@ object AccountEventAction { //There is probably a deeper type hierarchy that can
     def from(plan: PaidPlan, account: PaidAccount): PlanBilling = {
       if (plan.id.get != account.planId) throw new InvalidArgumentException(s"Account ${account.id.get} is on plan ${account.planId}, not on plan ${plan.id.get}")
       PlanBilling(plan.id.get, plan.billingCycle, plan.pricePerCyclePerUser, account.activeUsers, account.billingCycleStart)
+    }
+  }
+
+  @json
+  case class PlanRenewal(plan: Id[PaidPlan], cycle: BillingCycle, price: DollarAmount, activeUsers: Int, renewalDate: DateTime) extends AccountEventAction {
+    def eventType = AccountEventKind.PlanBilling
+    def toDbRow = eventType -> Json.toJson(this)
+  }
+
+  object PlanRenewal {
+    def from(plan: PaidPlan, account: PaidAccount): PlanBilling = {
+      if (plan.id.get != account.planId) throw new InvalidArgumentException(s"Account ${account.id.get} is on plan ${account.planId}, not on plan ${plan.id.get}")
+      PlanBilling(plan.id.get, plan.billingCycle, plan.pricePerCyclePerUser, account.activeUsers, account.planRenewal)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/ActivityLogCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/ActivityLogCommander.scala
@@ -60,6 +60,7 @@ class ActivityLogCommanderImpl @Inject() (
         case SpecialCredit() => Elements("Special credit was granted to your team by Kifi Support", maybeUser.map(Elements("thanks to", _)))
         case ChargeBack() => s"A ${event.creditChange.toDollarString} refund was issued to your card"
         case PlanBilling(planId, _, _, _, _) => s"Your ${paidPlanRepo.get(planId)} plan was renewed."
+        case PlanRenewal(planId, _, _, _, _) => s"Your ${paidPlanRepo.get(planId)} plan was renewed."
         case Charge() =>
           val invoiceText = s"Invoice ${event.chargeId.map("#" + _).getOrElse(s"not found, please contact ${SystemEmailAddress.BILLING}")}"
           s"Your card was charged ${event.creditChange.toDollarString} for your current balance. [$invoiceText]"

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidAccount.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidAccount.scala
@@ -64,6 +64,7 @@ case class PaidAccount(
     orgId: Id[Organization],
     planId: Id[PaidPlan],
     credit: DollarAmount,
+    planRenewal: DateTime,
     paymentDueAt: Option[DateTime] = None,
     paymentStatus: PaymentStatus = PaymentStatus.Ok,
     userContacts: Seq[Id[User]],
@@ -76,6 +77,7 @@ case class PaidAccount(
   def withId(id: Id[PaidAccount]): PaidAccount = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime): PaidAccount = this.copy(updatedAt = now)
   def withState(state: State[PaidAccount]): PaidAccount = this.copy(state = state)
+  def withPlanRenewal(renewal: DateTime): PaidAccount = this.copy(planRenewal = renewal)
   def withPaymentStatus(status: PaymentStatus): PaidAccount = this.copy(paymentStatus = status)
   def withPaymentDueAt(dueAt: Option[DateTime]): PaidAccount = this.copy(paymentDueAt = dueAt)
   def freeze: PaidAccount = this.copy(frozen = true) //a frozen account will not be charged anything by the payment processor until unfrozen by an admin. Intended for automatically detected data integrity issues.

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidAccountRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidAccountRepo.scala
@@ -43,6 +43,7 @@ class PaidAccountRepoImpl @Inject() (
     def orgId = column[Id[Organization]]("org_id", O.NotNull)
     def planId = column[Id[PaidPlan]]("plan_id", O.NotNull)
     def credit = column[DollarAmount]("credit", O.NotNull)
+    def planRenewal = column[DateTime]("plan_renewal", O.NotNull)
     def paymentDueAt = column[Option[DateTime]]("payment_due_at", O.Nullable)
     def paymentStatus = column[PaymentStatus]("payment_status", O.NotNull)
     def userContacts = column[Seq[Id[User]]]("user_contacts", O.NotNull)
@@ -51,7 +52,7 @@ class PaidAccountRepoImpl @Inject() (
     def frozen = column[Boolean]("frozen", O.NotNull)
     def activeUsers = column[Int]("active_users", O.NotNull)
     def billingCycleStart = column[DateTime]("billing_cycle_start", O.NotNull)
-    def * = (id.?, createdAt, updatedAt, state, orgId, planId, credit, paymentDueAt, paymentStatus, userContacts, emailContacts, lockedForProcessing, frozen, activeUsers, billingCycleStart) <> ((PaidAccount.apply _).tupled, PaidAccount.unapply _)
+    def * = (id.?, createdAt, updatedAt, state, orgId, planId, credit, planRenewal, paymentDueAt, paymentStatus, userContacts, emailContacts, lockedForProcessing, frozen, activeUsers, billingCycleStart) <> ((PaidAccount.apply _).tupled, PaidAccount.unapply _)
   }
 
   def table(tag: Tag) = new PaidAccountTable(tag)

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/PaidAccountFactory.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/PaidAccountFactory.scala
@@ -13,7 +13,7 @@ object PaidAccountFactory {
 
   def paidAccount(): PartialPaidAccount = {
     new PartialPaidAccount(PaidAccount(id = Some(Id[PaidAccount](idx.incrementAndGet())), orgId = Id[Organization](idx.incrementAndGet()),
-      planId = Id[PaidPlan](idx.incrementAndGet()), credit = DollarAmount(0), userContacts = Seq.empty, emailContacts = Seq.empty, activeUsers = 0, billingCycleStart = currentDateTime))
+      planId = Id[PaidPlan](idx.incrementAndGet()), credit = DollarAmount(0), userContacts = Seq.empty, emailContacts = Seq.empty, activeUsers = 0, billingCycleStart = currentDateTime, planRenewal = currentDateTime))
   }
 
   def paidAccounts(count: Int): Seq[PartialPaidAccount] = List.fill(count)(paidAccount())
@@ -26,6 +26,7 @@ object PaidAccountFactory {
     def withCredit(amount: DollarAmount) = new PartialPaidAccount(account.copy(credit = amount))
     def withStatus(status: PaymentStatus) = new PartialPaidAccount(account.copy(paymentStatus = status))
     def withBillingCycleStart(billingCycleStart: DateTime) = new PartialPaidAccount(account.copy(billingCycleStart = billingCycleStart))
+    def withPlanRenewal(renewal: DateTime) = new PartialPaidAccount(account.copy(planRenewal = renewal))
     def withActiveUsers(activeUsers: Int) = new PartialPaidAccount(account.copy(activeUsers = activeUsers))
     def withFrozen(frozen: Boolean) = new PartialPaidAccount(account.copy(frozen = frozen))
     def withPaymentDueAt(dueAt: DateTime) = new PartialPaidAccount(account.copy(paymentDueAt = Some(dueAt)))

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/PlanManagementTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/PlanManagementTest.scala
@@ -59,7 +59,7 @@ class PlanManagementTest extends SpecificationLike with ShoeboxTestInjector {
           account.lockedForProcessing === false
 
           //"fast forward" to test proration
-          accountRepo.save(account.copy(billingCycleStart = account.billingCycleStart.minusDays(12)))
+          accountRepo.save(account.copy(billingCycleStart = account.billingCycleStart.minusDays(12), planRenewal = account.planRenewal.minusDays(12)))
 
           (account, plan)
         }
@@ -103,7 +103,7 @@ class PlanManagementTest extends SpecificationLike with ShoeboxTestInjector {
         //"fast forward" again to test proration of plan change cost
         db.readWrite { implicit session =>
           val currentAccount = accountRepo.get(accountId)
-          accountRepo.save(currentAccount.copy(billingCycleStart = currentAccount.billingCycleStart.minusDays(5)))
+          accountRepo.save(currentAccount.copy(billingCycleStart = currentAccount.billingCycleStart.minusDays(5), planRenewal = account.planRenewal.minusDays(5)))
         }
 
         commander.changePlan(orgId, plan.id.get, actionAttribution)


### PR DESCRIPTION
@andrewconner 
This only maintains the correctness of `PaidAccount.planRenewal`, no logic relies on it.
Once I have deployed this and updated `plan_renewal` for existing accounts in the database, I'll drop `billingCycleStart` and use it instead.
