### PR TITLE
Rewards apply to accounts, and coupons work

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/404.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/404.sql
@@ -9,6 +9,7 @@ CREATE TABLE credit_code_info (
 	state VARCHAR(20) NOT NULL,
 	code VARCHAR(128) NOT NULL,
 	kind VARCHAR(64) NOT NULL,
+	credit int(10) NOT NULL,
 	status VARCHAR(32) NOT NULL,
 	referrer_user_id BIGINT(20) DEFAULT NULL,
 	referrer_organization_id BIGINT(20) DEFAULT NULL,
@@ -37,7 +38,7 @@ CREATE TABLE credit_reward (
 
 	PRIMARY KEY(id),
 	UNIQUE KEY credit_reward_u_code_single_use (code, single_use),
-	UNIQUE KEY credit_reward_u_kind_unrepeatable (kind, unrepeatable),
+	UNIQUE KEY credit_reward_u_unrepeatable (unrepeatable),
 	CONSTRAINT credit_reward_f_code FOREIGN KEY (code) REFERENCES credit_code_info(code),
 	CONSTRAINT credit_reward_f_account_id FOREIGN KEY (account_id) REFERENCES paid_account(id),
 	CONSTRAINT credit_reward_f_account_id_applied_credit FOREIGN KEY (account_id, applied, credit) REFERENCES account_event(account_id, id, credit_change)

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/AccountEvent.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/AccountEvent.scala
@@ -51,6 +51,7 @@ object AccountEventKind {
     PaymentMethodAdded,
     PlanBilling,
     PlanChanged,
+    RewardCredit,
     SpecialCredit,
     UserAdded,
     UserRemoved

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditCode.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditCode.scala
@@ -2,7 +2,6 @@ package com.keepit.payments
 
 import java.net.URLEncoder
 
-import com.keepit.common.db.slick.DBSession.RWSession
 import com.keepit.common.db.slick._
 import com.keepit.common.db.{ Id, ModelWithState, State, States }
 import com.keepit.common.strings._
@@ -14,6 +13,7 @@ import play.api.http.Status._
 import play.api.mvc.Results.Status
 
 case class CreditCode(value: String) {
+  require(value == value.toLowerCase.trim, "CreditCode is not normalized!")
   def urlEncoded: String = URLEncoder.encode(value, UTF8)
 }
 
@@ -22,7 +22,7 @@ object CreditCode {
   implicit val format: Format[CreditCode] = Format(Reads.of[String].map(normalize(_)), Writes[CreditCode](code => JsString(code.value)))
   def columnType(db: DataBaseComponent) = {
     import db.Driver.simple._
-    MappedColumnType.base[CreditCode, String](_.value, CreditCode.apply)
+    MappedColumnType.base[CreditCode, String](_.value, CreditCode(_))
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditCode.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditCode.scala
@@ -44,17 +44,6 @@ object CreditCodeKind {
     case Some(validKind) => validKind
     case None => throw new IllegalArgumentException(s"Unknown CreditCodeKind: $kind")
   }
-
-  def creditValue(kind: CreditCodeKind) = kind match {
-    case Coupon => DollarAmount.dollars(42)
-    case OrganizationReferral => DollarAmount.dollars(19)
-    case Promotion => throw new IllegalArgumentException("Promotion credit codes do not have a defined value for the redeemer")
-  }
-  def referrerCreditValue(kind: CreditCodeKind) = kind match {
-    case Coupon => None
-    case OrganizationReferral => Some(DollarAmount.dollars(100))
-    case Promotion => throw new IllegalArgumentException("Promotion credit codes do not have a defined value for the referrer")
-  }
 }
 
 case class CreditCodeReferrer(userId: Id[User], organizationId: Option[Id[Organization]])
@@ -90,8 +79,6 @@ case class CreditCodeInfo(
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
 
   def isSingleUse: Boolean = CreditCodeKind.isSingleUse(kind)
-
-  def referrerCredit: Option[DollarAmount] = CreditCodeKind.referrerCreditValue(kind)
 }
 
 case class CreditCodeRewards(target: CreditReward, referrer: Option[CreditReward])

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditCode.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditCode.scala
@@ -83,6 +83,8 @@ case class CreditCodeInfo(
   def withId(id: Id[CreditCodeInfo]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
 
+  def isSingleUse: Boolean = CreditCodeKind.isSingleUse(kind)
+
   def credit: DollarAmount = CreditCodeKind.creditValue(kind)
   def referrerCredit: Option[DollarAmount] = CreditCodeKind.referrerCreditValue(kind)
 }
@@ -100,6 +102,7 @@ sealed abstract class CreditCodeFail(val status: Int, val message: String) exten
 object CreditCodeFail {
   case class UnavailableCreditCodeException(code: CreditCode) extends CreditCodeFail(CONFLICT, s"Credit code $code is unavailable")
   case class CreditCodeNotFoundException(code: CreditCode) extends CreditCodeFail(BAD_REQUEST, s"Credit code $code does not exist")
-  case class CreditCodeNotApplicable(req: CreditCodeApplyRequest) extends CreditCodeFail(BAD_REQUEST, s"Credit code ${req.code} cannot be applied by user ${req.applierId} in org ${req.orgId}")
+  case class CreditCodeAbuseException(req: CreditCodeApplyRequest) extends CreditCodeFail(BAD_REQUEST, s"Credit code ${req.code} cannot be applied by user ${req.applierId} in org ${req.orgId}")
+  case class CreditCodeAlreadyBurnedException(code: CreditCode) extends CreditCodeFail(BAD_REQUEST, s"Credit code $code has already been used")
   case class NoPaidAccountException(userId: Id[User], orgIdOpt: Option[Id[Organization]]) extends CreditCodeFail(BAD_REQUEST, s"User $userId in org $orgIdOpt has no paid account")
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditCode.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditCode.scala
@@ -2,6 +2,7 @@ package com.keepit.payments
 
 import java.net.URLEncoder
 
+import com.keepit.common.db.slick.DBSession.RWSession
 import com.keepit.common.db.slick._
 import com.keepit.common.db.{ Id, ModelWithState, State, States }
 import com.keepit.common.strings._

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditReward.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditReward.scala
@@ -176,4 +176,5 @@ case class CreditReward(
     code: Option[UsedCreditCode]) extends ModelWithState[CreditReward] {
   def withId(id: Id[CreditReward]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
+  def withAppliedEvent(event: AccountEvent) = this.copy(applied = Some(event.id.get))
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditReward.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditReward.scala
@@ -105,6 +105,12 @@ object RewardKind {
     val applicable: Used.type = Used
   }
 
+  case object Promotion extends RewardKind("promotion") with RewardStatus.WithEmptyInfo {
+    case object Used extends Status("used")
+    protected val allStatus: Set[S] = Set(Used)
+    val applicable: Used.type = Used
+  }
+
   case object OrganizationCreation extends RewardKind("org_creation") with RewardStatus.WithIndependentInfo[Id[Organization]] {
     val infoFormat = Id.format[Organization]
     case object Created extends Status("created")
@@ -120,7 +126,7 @@ object RewardKind {
     val applicable: Upgraded.type = Upgraded
   }
 
-  private val all: Set[RewardKind] = Set(Coupon, OrganizationCreation, OrganizationReferral)
+  private val all: Set[RewardKind] = Set(Coupon, OrganizationCreation, OrganizationReferral, Promotion)
 
   def apply(kind: String) = all.find(_.kind equalsIgnoreCase kind) match {
     case Some(validKind) => validKind
@@ -143,20 +149,17 @@ sealed trait UnrepeatableRewardKey {
 }
 
 object UnrepeatableRewardKey {
-  case class ForUser(userId: Id[User]) extends UnrepeatableRewardKey { def toKey = s"user|$userId" }
-  case class ForOrganization(orgId: Id[Organization]) extends UnrepeatableRewardKey { def toKey = s"org|$orgId" }
-  case class ForOrganizationMember(orgId: Id[Organization], userId: Id[User]) extends UnrepeatableRewardKey { def toKey = s"org|$orgId-user$userId" }
+  case class Referral(from: Id[Organization], to: Id[Organization]) extends UnrepeatableRewardKey { def toKey = s"refer|$from-$to" }
+  case class NewOrganization(orgId: Id[Organization]) extends UnrepeatableRewardKey { def toKey = s"newOrg|$orgId" }
 
   private object ValidLong {
     def unapply(id: String): Option[Long] = Try(id.toLong).toOption
   }
-  private val userKey = """^user\|(\d+)$""".r
-  private val organizationKey = """^org\|(\d+)$""".r
-  private val organizationMemberKey = """^org\|(\d+)\-user\|(\d+)$""".r
+  private val newOrg = """^newOrg\|(\d+)$""".r
+  private val referral = """^refer\|(\d+)-(\d+)$""".r
   def fromKey(key: String): UnrepeatableRewardKey = key match {
-    case userKey(ValidLong(userId)) => ForUser(Id(userId))
-    case organizationKey(ValidLong(orgId)) => ForOrganization(Id(orgId))
-    case organizationMemberKey(ValidLong(orgId), ValidLong(userId)) => ForOrganizationMember(Id(orgId), Id(userId))
+    case newOrg(ValidLong(orgId)) => NewOrganization(Id(orgId))
+    case referral(ValidLong(from), ValidLong(to)) => Referral(from = Id(from), to = Id(to))
     case _ => throw new IllegalArgumentException(s"Invalid reward key: $key")
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditRewardCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditRewardCommander.scala
@@ -32,6 +32,9 @@ class CreditRewardCommanderImpl @Inject() (
   implicit val defaultContext: ExecutionContext)
     extends CreditRewardCommander with Logging {
 
+  private val newOrgReferralCredit = DollarAmount.dollars(100)
+  private val orgReferrerCredit = DollarAmount.dollars(100)
+
   def getOrCreateReferralCode(orgId: Id[Organization]): CreditCode = {
     db.readWrite { implicit session =>
       val org = orgRepo.get(orgId)
@@ -40,7 +43,7 @@ class CreditRewardCommanderImpl @Inject() (
         val creditCodeInfo = CreditCodeInfo(
           code = CreditCode.normalize(RandomStringUtils.randomAlphanumeric(20)),
           kind = kind,
-          credit = CreditCodeKind.creditValue(kind),
+          credit = newOrgReferralCredit,
           status = CreditCodeStatus.Open,
           referrer = Some(CreditCodeReferrer.fromOrg(org))
         )
@@ -104,7 +107,7 @@ class CreditRewardCommanderImpl @Inject() (
 
           referrerCreditReward <- creditRewardRepo.create(CreditReward(
             accountId = accountId,
-            credit = creditCodeInfo.referrerCredit.get,
+            credit = orgReferrerCredit,
             applied = None,
             reward = referrerReward,
             unrepeatable = Some(UnrepeatableRewardKey.Referral(from = creditCodeInfo.referrer.get.organizationId.get, to = orgId.get)),

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditRewardCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditRewardCommander.scala
@@ -38,7 +38,7 @@ class CreditRewardCommanderImpl @Inject() (
       val creditCodeInfo = creditCodeInfoRepo.getByOrg(orgId).getOrElse {
         val kind = CreditCodeKind.OrganizationReferral
         val creditCodeInfo = CreditCodeInfo(
-          code = CreditCode(RandomStringUtils.randomAlphanumeric(20)),
+          code = CreditCode.normalize(RandomStringUtils.randomAlphanumeric(20)),
           kind = kind,
           credit = CreditCodeKind.creditValue(kind),
           status = CreditCodeStatus.Open,

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditRewardCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditRewardCommander.scala
@@ -2,12 +2,14 @@ package com.keepit.payments
 
 import com.google.inject.{ ImplementedBy, Inject, Singleton }
 import com.keepit.common.db.Id
+import com.keepit.common.db.slick.DBSession.RWSession
 import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
 import com.keepit.common.time._
-import com.keepit.model.{ OrganizationRepo, Organization }
-import com.keepit.payments.CreditCodeFail.{ CreditCodeNotApplicable, NoPaidAccountException, CreditCodeNotFoundException }
+import com.keepit.model.{ User, OrganizationRepo, Organization }
+import com.keepit.payments.CreditCodeFail.{ CreditCodeAlreadyBurnedException, CreditCodeAbuseException, NoPaidAccountException, CreditCodeNotFoundException }
 import org.apache.commons.lang3.RandomStringUtils
+import play.api.libs.json.JsNull
 
 import scala.concurrent.ExecutionContext
 import scala.util.{ Success, Failure, Try }
@@ -49,32 +51,70 @@ class CreditRewardCommanderImpl @Inject() (
     for {
       creditCodeInfo <- creditCodeInfoRepo.getByCode(req.code).map(Success(_)).getOrElse(Failure(CreditCodeNotFoundException(req.code)))
       accountId <- req.orgId.map(accountRepo.getAccountId(_)).map(Success(_)).getOrElse(Failure(NoPaidAccountException(req.applierId, req.orgId)))
-      appliable <- if (creditCodeInfo.referrer.exists(r => r.organizationId.isDefined && r.organizationId == req.orgId)) Failure(CreditCodeNotApplicable(req)) else Success(true)
+      _ <- if (creditCodeInfo.referrer.exists(r => r.organizationId.isDefined && r.organizationId == req.orgId)) Failure(CreditCodeAbuseException(req)) else Success(true)
+      _ <- if (creditCodeInfo.isSingleUse && creditRewardRepo.getByCreditCode(creditCodeInfo.code).nonEmpty) Failure(CreditCodeAlreadyBurnedException(req.code)) else Success(true)
     } yield {
       creditCodeInfo.kind match {
-        case CreditCodeKind.Coupon => ???
+        case CreditCodeKind.Coupon =>
+          val targetReward = Reward(RewardKind.Coupon)(RewardKind.Coupon.Used)(None)
+          val targetCreditReward = internCreditReward(CreditReward(
+            accountId = accountId,
+            credit = creditCodeInfo.credit,
+            applied = None,
+            reward = targetReward,
+            unrepeatable = None,
+            code = Some(UsedCreditCode(creditCodeInfo, req.applierId))
+          ), req.applierId)
+          CreditCodeRewards(target = targetCreditReward, referrer = None)
+
         case CreditCodeKind.OrganizationReferral =>
           val targetReward = Reward(RewardKind.OrganizationCreation)(RewardKind.OrganizationCreation.Created)(req.orgId.get)
-          val targetCreditReward = creditRewardRepo.save(CreditReward(
+          val targetCreditReward = internCreditReward(CreditReward(
             accountId = accountId,
             credit = creditCodeInfo.credit,
             applied = None,
             reward = targetReward,
             unrepeatable = req.orgId.map(UnrepeatableRewardKey.ForOrganization),
             code = Some(UsedCreditCode(creditCodeInfo, req.applierId))
-          ))
+          ), req.applierId)
 
           val referrerReward = Reward(RewardKind.OrganizationReferral)(RewardKind.OrganizationReferral.Created)(req.orgId.get)
-          val referrerCreditReward = Some(creditRewardRepo.save(CreditReward(
+          val referrerCreditReward = internCreditReward(CreditReward(
             accountId = accountId,
             credit = creditCodeInfo.referrerCredit.get,
             applied = None,
             reward = referrerReward,
             unrepeatable = req.orgId.map(UnrepeatableRewardKey.ForOrganization),
             code = Some(UsedCreditCode(creditCodeInfo, req.applierId))
-          )))
-          CreditCodeRewards(target = targetCreditReward, referrer = referrerCreditReward)
+          ), req.applierId)
+          CreditCodeRewards(target = targetCreditReward, referrer = Some(referrerCreditReward))
       }
+    }
+  }
+
+  def internCreditReward(cr: CreditReward, userAttribution: Id[User])(implicit session: RWSession): CreditReward = {
+    require(cr.id.isEmpty)
+    val creditReward = creditRewardRepo.save(cr)
+
+    val rewardNeedsToBeApplied = creditReward.reward.status == creditReward.reward.kind.applicable
+    if (!rewardNeedsToBeApplied) creditReward
+    else {
+      val account = accountRepo.get(creditReward.accountId)
+      accountRepo.save(account.withIncreasedCredit(creditReward.credit))
+      val rewardCreditEvent = eventCommander.track(AccountEvent(
+        eventTime = clock.now(),
+        accountId = account.id.get,
+        whoDunnit = Some(userAttribution),
+        whoDunnitExtra = JsNull,
+        kifiAdminInvolved = None,
+        action = AccountEventAction.RewardCredit(creditReward.id.get),
+        creditChange = creditReward.credit,
+        paymentMethod = None,
+        paymentCharge = None,
+        memo = None,
+        chargeId = None
+      ))
+      creditRewardRepo.save(creditReward.withAppliedEvent(rewardCreditEvent))
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/PaymentsIntegrityChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/PaymentsIntegrityChecker.scala
@@ -145,7 +145,7 @@ class PaymentsIntegrityChecker @Inject() (
     }
   }.getOrElse(Seq(PaymentsIntegrityError.CouldNotGetAccountLock("balance check")))
 
-  private def checkAccount(orgId: Id[Organization]): Seq[PaymentsIntegrityError] = {
+  def checkAccount(orgId: Id[Organization]): Seq[PaymentsIntegrityError] = {
     Seq(
       processMembershipsForAccount(orgId),
       processBalancesForAccount(orgId)

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/CreditRewardCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/CreditRewardCommanderTest.scala
@@ -125,7 +125,7 @@ class CreditRewardCommanderTest extends SpecificationLike with ShoeboxTestInject
             val coupon = creditCodeInfoRepo.create(CreditCodeInfo(
               kind = CreditCodeKind.Coupon,
               credit = CreditCodeKind.creditValue(CreditCodeKind.Coupon),
-              code = CreditCode(RandomStringUtils.randomAlphanumeric(20)),
+              code = CreditCode.normalize(RandomStringUtils.randomAlphanumeric(20)),
               status = CreditCodeStatus.Open,
               referrer = None)).get
             (owner, org, coupon)
@@ -155,7 +155,7 @@ class CreditRewardCommanderTest extends SpecificationLike with ShoeboxTestInject
             val coupon = creditCodeInfoRepo.create(CreditCodeInfo(
               kind = CreditCodeKind.Coupon,
               credit = CreditCodeKind.creditValue(CreditCodeKind.Coupon),
-              code = CreditCode(RandomStringUtils.randomAlphanumeric(20)),
+              code = CreditCode.normalize(RandomStringUtils.randomAlphanumeric(20)),
               status = CreditCodeStatus.Open,
               referrer = None)).get
             (owner, org1, org2, coupon)
@@ -186,7 +186,7 @@ class CreditRewardCommanderTest extends SpecificationLike with ShoeboxTestInject
             val promo = creditCodeInfoRepo.create(CreditCodeInfo(
               kind = CreditCodeKind.Promotion,
               credit = DollarAmount.dollars(42),
-              code = CreditCode("kifirocks-2015"),
+              code = CreditCode.normalize("kifirocks-2015"),
               status = CreditCodeStatus.Open,
               referrer = None)).get
             (org1, org2, promo)
@@ -221,7 +221,7 @@ class CreditRewardCommanderTest extends SpecificationLike with ShoeboxTestInject
               creditCodeInfoRepo.create(CreditCodeInfo(
                 kind = CreditCodeKind.Promotion,
                 credit = DollarAmount.dollars(42),
-                code = CreditCode(s"kifirocks-2015-$i"),
+                code = CreditCode.normalize(s"kifirocks-2015-$i"),
                 status = CreditCodeStatus.Open,
                 referrer = None)).get
             }

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/CreditRewardCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/CreditRewardCommanderTest.scala
@@ -4,7 +4,9 @@ import com.keepit.common.concurrent.FakeExecutionContextModule
 import com.keepit.model.OrganizationFactoryHelper.OrganizationPersister
 import com.keepit.model.UserFactoryHelper.UserPersister
 import com.keepit.model.{ OrganizationFactory, UserFactory }
+import com.keepit.payments.CreditCodeFail.CreditCodeAlreadyBurnedException
 import com.keepit.test.ShoeboxTestInjector
+import org.apache.commons.lang3.RandomStringUtils
 import org.specs2.mutable.SpecificationLike
 
 //things to test: add_user, remvove_user, change plan free to paid, all paths through charge processing
@@ -37,8 +39,8 @@ class CreditRewardCommanderTest extends SpecificationLike with ShoeboxTestInject
         }
       }
     }
-    "apply credit codes" in {
-      "apply org referral credit codes" in {
+    "apply referral codes" in {
+      "prevent invalid attempts at code application" in {
         withDb(modules: _*) { implicit injector =>
           val (owner, org1, org2) = db.readWrite { implicit session =>
             val owner = UserFactory.user().saved
@@ -53,16 +55,100 @@ class CreditRewardCommanderTest extends SpecificationLike with ShoeboxTestInject
           val badRequestsAndTheirFailures = Seq(
             CreditCodeApplyRequest(code, owner.id.get, None) -> CreditCodeFail.NoPaidAccountException(owner.id.get, None),
             CreditCodeApplyRequest(CreditCode("garbagecode"), owner.id.get, Some(org2.id.get)) -> CreditCodeFail.CreditCodeNotFoundException(CreditCode("garbagecode")),
-            CreditCodeApplyRequest(code, owner.id.get, Some(org1.id.get)) -> CreditCodeFail.CreditCodeNotApplicable(CreditCodeApplyRequest(code, owner.id.get, Some(org1.id.get)))
+            CreditCodeApplyRequest(code, owner.id.get, Some(org1.id.get)) -> CreditCodeFail.CreditCodeAbuseException(CreditCodeApplyRequest(code, owner.id.get, Some(org1.id.get)))
           )
           for ((badRequest, fail) <- badRequestsAndTheirFailures) {
             creditRewardCommander.applyCreditCode(badRequest) must beFailedTry(fail)
           }
-
-          val response = creditRewardCommander.applyCreditCode(CreditCodeApplyRequest(code, owner.id.get, Some(org2.id.get))).get
-          db.readOnlyMaster { implicit session =>
-            creditRewardRepo.all === Seq(response.target, response.referrer.get)
+          1 === 1
+        }
+      }
+      "apply org referral credit codes on org creation" in {
+        withDb(modules: _*) { implicit injector =>
+          val (owner, org1, org2) = db.readWrite { implicit session =>
+            val owner = UserFactory.user().saved
+            val org1 = OrganizationFactory.organization().withOwner(owner).saved
+            val org2 = OrganizationFactory.organization().withOwner(owner).saved
+            (owner, org1, org2)
           }
+
+          val code = creditRewardCommander.getOrCreateReferralCode(org1.id.get)
+          db.readOnlyMaster { implicit session => creditCodeInfoRepo.all.map(_.code) === Seq(code) }
+
+          val initialCredit = db.readOnlyMaster { implicit session => paidAccountRepo.getByOrgId(org2.id.get).credit }
+          val rewards = creditRewardCommander.applyCreditCode(CreditCodeApplyRequest(code, owner.id.get, Some(org2.id.get))).get
+          val finalCredit = db.readOnlyMaster { implicit session => paidAccountRepo.getByOrgId(org2.id.get).credit }
+          finalCredit - initialCredit === rewards.target.credit
+
+          db.readOnlyMaster { implicit session =>
+            creditRewardRepo.all === Seq(rewards.target, rewards.referrer.get)
+            val rewardCreditEvents = accountEventRepo.all.filter(_.action.eventType == AccountEventKind.RewardCredit)
+            rewardCreditEvents must haveSize(1)
+            rewardCreditEvents.head.creditChange === rewards.target.credit
+          }
+
+          paymentsChecker.checkAccount(org1.id.get) must beEmpty
+          paymentsChecker.checkAccount(org2.id.get) must beEmpty
+        }
+      }
+    }
+
+    "apply coupon codes" in {
+      "give an org credit if they apply a coupon code" in {
+        withDb(modules: _*) { implicit injector =>
+          val (owner, org, coupon) = db.readWrite { implicit session =>
+            val owner = UserFactory.user().saved
+            val org = OrganizationFactory.organization().withOwner(owner).saved
+            val coupon = creditCodeInfoRepo.create(CreditCodeInfo(
+              kind = CreditCodeKind.Coupon,
+              code = CreditCode(RandomStringUtils.randomAlphanumeric(20)),
+              status = CreditCodeStatus.Open,
+              referrer = None)).get
+            (owner, org, coupon)
+          }
+
+          val initialCredit = db.readOnlyMaster { implicit session => paidAccountRepo.getByOrgId(org.id.get).credit }
+          val rewards = creditRewardCommander.applyCreditCode(CreditCodeApplyRequest(coupon.code, owner.id.get, Some(org.id.get))).get
+          val finalCredit = db.readOnlyMaster { implicit session => paidAccountRepo.getByOrgId(org.id.get).credit }
+          finalCredit - initialCredit === rewards.target.credit
+
+          db.readOnlyMaster { implicit session =>
+            creditRewardRepo.all === Seq(rewards.target)
+            val rewardCreditEvents = accountEventRepo.all.filter(_.action.eventType == AccountEventKind.RewardCredit)
+            rewardCreditEvents must haveSize(1)
+            rewardCreditEvents.head.creditChange === rewards.target.credit
+          }
+
+          paymentsChecker.checkAccount(org.id.get) must beEmpty
+        }
+      }
+      "only let a one-time-use coupon be used once" in {
+        withDb(modules: _*) { implicit injector =>
+          val (owner, org1, org2, coupon) = db.readWrite { implicit session =>
+            val owner = UserFactory.user().saved
+            val org1 = OrganizationFactory.organization().withOwner(owner).saved
+            val org2 = OrganizationFactory.organization().withOwner(owner).saved
+            val coupon = creditCodeInfoRepo.create(CreditCodeInfo(
+              kind = CreditCodeKind.Coupon,
+              code = CreditCode(RandomStringUtils.randomAlphanumeric(20)),
+              status = CreditCodeStatus.Open,
+              referrer = None)).get
+            (owner, org1, org2, coupon)
+          }
+
+          creditRewardCommander.applyCreditCode(CreditCodeApplyRequest(coupon.code, owner.id.get, Some(org1.id.get))) must beSuccessfulTry
+
+          creditRewardCommander.applyCreditCode(CreditCodeApplyRequest(coupon.code, owner.id.get, Some(org1.id.get))) must beFailedTry(CreditCodeAlreadyBurnedException(coupon.code))
+          creditRewardCommander.applyCreditCode(CreditCodeApplyRequest(coupon.code, owner.id.get, Some(org2.id.get))) must beFailedTry(CreditCodeAlreadyBurnedException(coupon.code))
+
+          db.readOnlyMaster { implicit session =>
+            creditRewardRepo.count === 1
+            val rewardCreditEvents = accountEventRepo.all.filter(_.action.eventType == AccountEventKind.RewardCredit)
+            rewardCreditEvents must haveSize(1)
+          }
+
+          paymentsChecker.checkAccount(org1.id.get) must beEmpty
+          paymentsChecker.checkAccount(org2.id.get) must beEmpty
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/CreditRewardCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/CreditRewardCommanderTest.scala
@@ -9,6 +9,8 @@ import com.keepit.test.ShoeboxTestInjector
 import org.apache.commons.lang3.RandomStringUtils
 import org.specs2.mutable.SpecificationLike
 
+import scala.util.Random
+
 //things to test: add_user, remvove_user, change plan free to paid, all paths through charge processing
 
 class CreditRewardCommanderTest extends SpecificationLike with ShoeboxTestInjector {
@@ -124,7 +126,7 @@ class CreditRewardCommanderTest extends SpecificationLike with ShoeboxTestInject
             val org = OrganizationFactory.organization().withOwner(owner).saved
             val coupon = creditCodeInfoRepo.create(CreditCodeInfo(
               kind = CreditCodeKind.Coupon,
-              credit = CreditCodeKind.creditValue(CreditCodeKind.Coupon),
+              credit = DollarAmount.dollars(50 + Random.nextInt(50)),
               code = CreditCode.normalize(RandomStringUtils.randomAlphanumeric(20)),
               status = CreditCodeStatus.Open,
               referrer = None)).get
@@ -154,7 +156,7 @@ class CreditRewardCommanderTest extends SpecificationLike with ShoeboxTestInject
             val org2 = OrganizationFactory.organization().withOwner(owner).saved
             val coupon = creditCodeInfoRepo.create(CreditCodeInfo(
               kind = CreditCodeKind.Coupon,
-              credit = CreditCodeKind.creditValue(CreditCodeKind.Coupon),
+              credit = DollarAmount.dollars(50 + Random.nextInt(50)),
               code = CreditCode.normalize(RandomStringUtils.randomAlphanumeric(20)),
               status = CreditCodeStatus.Open,
               referrer = None)).get

--- a/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxInjectionHelpers.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/test/ShoeboxInjectionHelpers.scala
@@ -80,6 +80,7 @@ trait ShoeboxInjectionHelpers { self: TestInjectorProvider =>
   def libSubCommander(implicit injector: Injector) = inject[LibrarySubscriptionCommander].asInstanceOf[LibrarySubscriptionCommanderImpl]
   def deepLinkRouter(implicit injector: Injector) = inject[DeepLinkRouter].asInstanceOf[DeepLinkRouterImpl]
   def paidAccountRepo(implicit injector: Injector) = inject[PaidAccountRepo]
+  def accountEventRepo(implicit injector: Injector) = inject[AccountEventRepo]
   def creditCodeInfoRepo(implicit injector: Injector) = inject[CreditCodeInfoRepo]
   def creditRewardRepo(implicit injector: Injector) = inject[CreditRewardRepo]
   def creditRewardCommander(implicit injector: Injector) = inject[CreditRewardCommander]


### PR DESCRIPTION
When a CreditReward reaches it's applicable state, it is automatically applied
to the relevant account.

Coupon codes work once, and then are burned.

@leogrim I want to implement coupon codes that are not single-use (but are unrepeatable per org). Anything else that needs to be implemented before I hook this up to a controller and start testing it in production?
