### PR TITLE
open the members invite modal upon team creation

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileCreateCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileCreateCtrl.js
@@ -16,7 +16,7 @@ angular.module('kifi')
       .createOrg(this.orgName)
       .then(function(handle) {
         profileService.fetchMe(); // update the me object
-        $state.go('orgProfile.members', { handle: handle, openInviteModal: true, addMany: true  });
+        $state.go('orgProfile.libraries', { handle: handle, openInviteModal: true, addMany: true  });
       })
       ['catch'](function () {
         modalService.openGenericErrorModal();

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileCreateCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileCreateCtrl.js
@@ -16,7 +16,7 @@ angular.module('kifi')
       .createOrg(this.orgName)
       .then(function(handle) {
         profileService.fetchMe(); // update the me object
-        $state.go('orgProfile.libraries', { handle: handle });
+        $state.go('orgProfile.members', { handle: handle, openInviteModal: true, addMany: true  });
       })
       ['catch'](function () {
         modalService.openGenericErrorModal();

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileLibrariesCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileLibrariesCtrl.js
@@ -98,6 +98,27 @@ angular.module('kifi')
 
     $scope.canCreateLibraries = ($scope.viewer.permissions.indexOf(ORG_PERMISSION.ADD_LIBRARIES) !== -1);
 
+    $scope.openInviteModal = function () {
+      if (!$scope.canInvite) {
+        return;
+      }
+
+      modalService.open({
+        template: 'orgProfile/orgProfileInviteSearchModal.tpl.html',
+        modalData: {
+          organization: organization,
+          addMany: $stateParams.addMany,
+          returnAction: function (inviteData) {
+            var invitees = inviteData.invitees || [];
+            var flattenedInvitees = invitees.map(function(invitee) {
+                return invitee.id || invitee.email;
+             });
+            orgProfileService.trackEvent('user_clicked_page', organization, { type: 'orgLibraries' , action: 'clickedInvite', orgInvitees: flattenedInvitees });
+          }
+        }
+      });
+    };
+
     $scope.shouldShowMoveCard = function () {
       return $scope.canCreateLibraries && ($scope.libraries && $scope.libraries.length < 10) && libraryLazyLoader.hasLoaded();
     };
@@ -115,6 +136,8 @@ angular.module('kifi')
 
     if ($stateParams.openCreateLibrary) {
       $scope.openCreateLibrary();
+    } else if ($stateParams.openInviteModal === 'true') {
+      $scope.openInviteModal();
     }
 
     resetAndFetchLibraries();

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMemberManage.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileMemberManage.js
@@ -245,6 +245,7 @@ angular.module('kifi')
         modalData: {
           organization: organization,
           inviteType: inviteType,
+          addMany: $stateParams.addMany,
           currentPageOrigin: 'organizationPage',
           returnAction: function (inviteData) {
             var invitees = inviteData.invitees || [];

--- a/kifi-backend/modules/shoebox/angular/src/route.js
+++ b/kifi-backend/modules/shoebox/angular/src/route.js
@@ -125,7 +125,7 @@ angular.module('kifi')
         activetab: 'members'
       })
       .state('orgProfile.libraries', {
-        url: '',
+        url: '?openInviteModal&addMany',
         controller: 'OrgProfileLibrariesCtrl',
         templateUrl: 'orgProfile/orgProfileLibraries.tpl.html',
         activetab: 'libraries'

--- a/kifi-backend/modules/shoebox/angular/src/route.js
+++ b/kifi-backend/modules/shoebox/angular/src/route.js
@@ -119,7 +119,7 @@ angular.module('kifi')
         'abstract': true
       })
       .state('orgProfile.members', {
-        url: '/members?openInviteModal',
+        url: '/members?openInviteModal&addMany',
         controller: 'OrgProfileMemberManageCtrl',
         templateUrl: 'orgProfile/orgProfileMemberManage.tpl.html',
         activetab: 'members'


### PR DESCRIPTION
@cvializ @andrewconner 

@JRuff42 this isn't exactly to-spec. the members invite modal is really easy to open from the /members page. would be extra work to get it to open from the boards page. so I'm just linking to the /members page upon team creation. maybe @cvializ knows a workaround?
