### PR TITLE
Did some really dumb stuff to get external reward serialization to work

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryMembershipCommander.scala
@@ -321,7 +321,7 @@ class LibraryMembershipCommanderImpl @Inject() (
           category = pushCat)
       }
     }
-    
+
     if (lib.kind != LibraryKind.SYSTEM_ORG_GENERAL) {
       access match {
         case LibraryAccess.READ_WRITE =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/CreditRewardCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/CreditRewardCommanderTest.scala
@@ -250,6 +250,24 @@ class CreditRewardCommanderTest extends SpecificationLike with ShoeboxTestInject
         }
       }
     }
+
+    "let me do awesome things" in {
+      withDb(modules: _*) { implicit injector =>
+        val (org1, org2) = db.readWrite { implicit session =>
+          (
+            OrganizationFactory.organization().withOwner(UserFactory.user().saved).saved,
+            OrganizationFactory.organization().withOwner(UserFactory.user().saved).saved
+          )
+        }
+
+        val referralCode = creditRewardCommander.getOrCreateReferralCode(org1.id.get)
+        val rewards = creditRewardCommander.applyCreditCode(CreditCodeApplyRequest(referralCode, org2.ownerId, Some(org2.id.get))).get
+
+        println(rewards.target.reward.dump(creditRewardCommander))
+        println(rewards.referrer.get.reward.dump(creditRewardCommander))
+        1 === 1
+      }
+    }
   }
 
 }


### PR DESCRIPTION
@leogrim this is the first thing I've done with `Reward` that has made me sad.

How do you serialize a `CreditReward` to the outside world? We need to translate a `Id[Organization] => BasicOrganization` (or `BasicOrganizationView`???), a `Id[User] => BasicUser`, etc.

The only thing I could get to work is define a method on `RewardStatus` with type `(info: I, db: Database) => JsValue`, and inside every reward status you have to define how to get the relevant entity out of the db and serialize it. ((In reality I just defined shitty methods directly in `CreditRewardCommander` since that's the first piece of code I had around)).
