### PR TITLE
Safereads for Sets of {Feature, OrgPermission}

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Organization.scala
@@ -69,9 +69,6 @@ object Organization extends ModelWithPublicIdCompanion[Organization] {
   protected val publicIdPrefix = "o"
   protected val publicIdIvSpec = new IvParameterSpec(Array(62, 91, 74, 34, 82, -77, 19, -35, -118, 3, 112, -59, -70, 94, 101, -115))
 
-  val totallyInvisiblePermissions: BasePermissions =
-    BasePermissions(OrganizationRole.allOpts.map(_ -> Set.empty[OrganizationPermission]).toMap)
-
   implicit val format: Format[Organization] = (
     (__ \ 'id).formatNullable[Id[Organization]] and
     (__ \ 'createdAt).format[DateTime] and

--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationInfo.scala
@@ -2,6 +2,7 @@ package com.keepit.model
 
 import com.keepit.common.crypto.PublicId
 import com.keepit.common.db.ExternalId
+import com.keepit.common.json.TraversableFormat
 import com.keepit.common.store.ImagePath
 import com.keepit.social.BasicUser
 import org.joda.time.DateTime

--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationPermission.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationPermission.scala
@@ -1,5 +1,6 @@
 package com.keepit.model
 
+import com.keepit.common.json.TraversableFormat
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
@@ -42,10 +43,14 @@ object OrganizationPermission {
     VIEW_SETTINGS
   )
 
-  implicit val format: Format[OrganizationPermission] =
+  val format: Format[OrganizationPermission] =
     Format(__.read[String].map(OrganizationPermission(_)), new Writes[OrganizationPermission] {
       def writes(o: OrganizationPermission) = JsString(o.value)
     })
+
+  implicit val writes = Writes(format.writes)
+  val reads = Reads(format.reads)
+  implicit val safeSetReads = TraversableFormat.safeSetReads[OrganizationPermission](reads)
 
   def apply(str: String): OrganizationPermission = {
     str match {
@@ -67,100 +72,6 @@ object OrganizationPermission {
       case VIEW_MEMBERS.value => VIEW_MEMBERS
       case VIEW_ORGANIZATION.value => VIEW_ORGANIZATION
       case VIEW_SETTINGS.value => VIEW_SETTINGS
-    }
-  }
-
-}
-case class BasePermissions(permissionsMap: PermissionsMap) {
-  def forRole(role: OrganizationRole): Set[OrganizationPermission] = permissionsMap(Some(role))
-  def forNonmember: Set[OrganizationPermission] = permissionsMap(None)
-
-  def withPermissions(roleAndPermissions: (Option[OrganizationRole], Set[OrganizationPermission])*): BasePermissions =
-    this.copy(permissionsMap overwriteWith PermissionsMap(roleAndPermissions.toMap))
-
-  // Return a BasePermissions where "role" has added and removed permissions
-  def modified(roleOpt: Option[OrganizationRole], added: Set[OrganizationPermission], removed: Set[OrganizationPermission]): BasePermissions =
-    this.copy(permissionsMap ++ PermissionsMap.just(roleOpt -> added) -- PermissionsMap.just(roleOpt -> removed))
-
-  def applyPermissionsDiff(pdiff: PermissionsDiff): BasePermissions =
-    this.copy(permissionsMap ++ pdiff.added -- pdiff.removed)
-
-  def addPermission(kv: (Option[OrganizationRole], OrganizationPermission)) =
-    this.applyPermissionsDiff(PermissionsDiff(added = PermissionsMap.just(kv._1 -> Set(kv._2))))
-
-  def removePermission(kv: (Option[OrganizationRole], OrganizationPermission)) =
-    this.applyPermissionsDiff(PermissionsDiff(removed = PermissionsMap.just(kv._1 -> Set(kv._2))))
-
-  def diff(that: BasePermissions): PermissionsDiff = PermissionsDiff(added = this.permissionsMap -- that.permissionsMap, that.permissionsMap -- this.permissionsMap)
-}
-object BasePermissions {
-  def apply(pm: Map[Option[OrganizationRole], Set[OrganizationPermission]]): BasePermissions = BasePermissions(PermissionsMap(pm))
-  def apply(kvs: (Option[OrganizationRole], Set[OrganizationPermission])*): BasePermissions = BasePermissions(PermissionsMap(kvs.toMap))
-  implicit val format: Format[BasePermissions] =
-    Format(__.read[PermissionsMap].map(BasePermissions(_)), new Writes[BasePermissions] {
-      def writes(bp: BasePermissions) = Json.toJson(bp.permissionsMap)
-    })
-}
-
-case class PermissionsDiff(added: PermissionsMap = PermissionsMap.empty, removed: PermissionsMap = PermissionsMap.empty)
-object PermissionsDiff {
-  val empty = PermissionsDiff()
-  implicit val format: Format[PermissionsDiff] = (
-    (__ \ 'add).formatNullable[PermissionsMap] and
-    (__ \ 'remove).formatNullable[PermissionsMap]
-  )(PermissionsDiff.fromOptions, PermissionsDiff.toOptions)
-
-  def justAdd(kvs: (Option[OrganizationRole], Set[OrganizationPermission])*): PermissionsDiff = PermissionsDiff(added = PermissionsMap(kvs.toMap))
-  def justRemove(kvs: (Option[OrganizationRole], Set[OrganizationPermission])*): PermissionsDiff = PermissionsDiff(removed = PermissionsMap(kvs.toMap))
-
-  def fromOptions(addedOpt: Option[PermissionsMap], removedOpt: Option[PermissionsMap]): PermissionsDiff =
-    PermissionsDiff(addedOpt.getOrElse(PermissionsMap.empty), removedOpt.getOrElse(PermissionsMap.empty))
-
-  def toOptions(pdiff: PermissionsDiff): (Option[PermissionsMap], Option[PermissionsMap]) =
-    (if (pdiff.added.isEmpty) None else Some(pdiff.added),
-      if (pdiff.removed.isEmpty) None else Some(pdiff.removed))
-}
-
-case class PermissionsMap(pm: Map[Option[OrganizationRole], Set[OrganizationPermission]]) {
-  def ++(that: PermissionsMap) = {
-    val allKeys = pm.keySet ++ that.pm.keySet
-    val newPM = allKeys.map { k => k -> (find(k) ++ that.find(k)) }.toMap
-    PermissionsMap(newPM)
-  }
-  def --(that: PermissionsMap) = {
-    val allKeys = pm.keySet ++ that.pm.keySet
-    val newPM = allKeys.map { k => k -> (find(k) -- that.find(k)) }.toMap
-    PermissionsMap(newPM)
-  }
-  def overwriteWith(that: PermissionsMap) = {
-    PermissionsMap(pm ++ that.pm)
-  }
-
-  def find(roleOpt: Option[OrganizationRole]): Set[OrganizationPermission] = pm.getOrElse(roleOpt, Set.empty)
-  def apply(roleOpt: Option[OrganizationRole]) = find(roleOpt)
-  def isEmpty: Boolean = pm.isEmpty
-}
-object PermissionsMap {
-  val empty: PermissionsMap = PermissionsMap(Map.empty[Option[OrganizationRole], Set[OrganizationPermission]])
-  def just(kvs: (Option[OrganizationRole], Set[OrganizationPermission])*): PermissionsMap = PermissionsMap(kvs.toMap)
-  implicit val format: Format[PermissionsMap] = new Format[PermissionsMap] {
-    def reads(json: JsValue): JsResult[PermissionsMap] = {
-      json.validate[JsObject].map { obj =>
-        val pm = (for ((k, v) <- obj.value) yield {
-          val roleOpt = if (k == "none") None else Some(OrganizationRole(k))
-          val permissions = v.as[Set[OrganizationPermission]]
-          roleOpt -> permissions
-        }).toMap
-        PermissionsMap(pm)
-      }
-    }
-    def writes(permissionsMap: PermissionsMap): JsValue = {
-      val jsonMap = for ((roleOpt, permissions) <- permissionsMap.pm) yield {
-        val k = roleOpt.map(_.value).getOrElse("none")
-        val v = Json.toJson(permissions)
-        k -> v
-      }
-      JsObject(jsonMap.toSeq)
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidPlanRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidPlanRepo.scala
@@ -29,7 +29,7 @@ class PaidPlanRepoImpl @Inject() (
   implicit val kindColumnType = MappedColumnType.base[PaidPlan.Kind, String](_.name, PaidPlan.Kind(_))
   implicit val featureSetTypeMapper = MappedColumnType.base[Set[Feature], String](
     { obj => Json.stringify(Json.toJson(obj)) },
-    { str => Json.parse(str).as[Set[Feature]](TraversableFormat.safeSetReads[Feature]) }
+    { str => Json.parse(str).as[Set[Feature]] }
   )
 
   type RepoImpl = PaidPlanTable


### PR DESCRIPTION
The only way to deserialize (easily) a Set[Feature] or
Set[OrganizationPermission] is safely. I also killed `BasePermissions` and all the associated code.

@camhashemi @andrewconner 
