### PR TITLE
Fixing always making suggested searches tags

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/filter.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/filter.js
@@ -46,6 +46,19 @@ angular.module('kifi')
   };
 })
 
+.filter('searchTerm', function () {
+  return function (term) {
+    var q;
+    if (_.startsWith(term, '#')) {
+      term = term.slice(1);
+      q = 'tag:' + encodeURIComponent(term.indexOf(' ') >= 0 ? '"' + term + '"' : term);
+    } else {
+      q = encodeURIComponent(term);
+    }
+    return '/find?q=' + q;
+  };
+})
+
 .filter('profileUrl', function () {
   return function (userOrOrg, sub) {
     if (userOrOrg) {

--- a/kifi-backend/modules/shoebox/angular/src/libraries/suggestedSearches.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/suggestedSearches.tpl.html
@@ -2,7 +2,7 @@
   <h2 class="kf-lss-title">Suggested Searches</h2>
   <ul>
     <li class="kf-lss-query" ng-repeat="query in library.suggestedSearches | limitTo: 10">
-      <a class="kf-lss-query-a" ng-href="{{library.url}}{{query | tagUrl}}">{{query}}</a>
+      <a class="kf-lss-query-a" ng-href="{{library.url}}{{query | searchTerm}}">{{query}}</a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
@cvializ Previously, we used the `tagUrl` filter, which took "a string" and translated it to a `tag:"a string"` tag query. For suggested searches, it's not always tags. This tries to be a bit smarter. If it starts with `#`, then treat it as a tag. Otherwise, normal search.
