### PR TITLE
AdminPayments activityOverview and Dashboard

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/AccountEventRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/AccountEventRepo.scala
@@ -24,6 +24,7 @@ trait AccountEventRepo extends Repo[AccountEvent] {
 
   def adminCountByKind(kinds: Set[AccountEventKind])(implicit session: RSession): Int
   def adminGetByKind(kinds: Set[AccountEventKind], pg: Paginator)(implicit session: RSession): Seq[AccountEvent]
+  def adminGetSince(time: DateTime)(implicit session: RSession): Set[AccountEvent]
 
   def deactivateAll(accountId: Id[PaidAccount])(implicit session: RWSession): Int
 }
@@ -112,6 +113,10 @@ class AccountEventRepoImpl @Inject() (
   def adminGetByKind(kinds: Set[AccountEventKind], pg: Paginator)(implicit session: RSession): Seq[AccountEvent] = {
     adminGetByKindHelper(kinds).sortBy(age).drop(pg.offset).take(pg.limit).list
   }
+  def adminGetSince(time: DateTime)(implicit session: RSession): Set[AccountEvent] = {
+    activeRows.filter(_.eventTime >= time).list.toSet
+  }
+
   def deactivateAll(accountId: Id[PaidAccount])(implicit session: RWSession): Int = {
     (for (row <- rows if row.accountId === accountId) yield (row.state, row.updatedAt)).update((AccountEventStates.INACTIVE, clock.now))
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidAccount.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/PaidAccount.scala
@@ -106,6 +106,8 @@ case class PaidAccount(
   def withEmailContacts(newContacts: Seq[EmailAddress]): PaidAccount = this.copy(emailContacts = newContacts)
 
   def withNewPlan(newPlanId: Id[PaidPlan]): PaidAccount = this.copy(planId = newPlanId)
+
+  def isActive: Boolean = state == PaidAccountStates.ACTIVE
 }
 
 object PaidAccountStates extends States[PaidAccount]

--- a/kifi-backend/modules/shoebox/app/views/admin/activityOverview.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/activityOverview.scala.html
@@ -1,0 +1,30 @@
+@import com.keepit.controllers.admin.AdminPaymentsActivityOverview
+@import com.keepit.common.controller.PaginatedRequest
+
+@(log: AdminPaymentsActivityOverview)(implicit request: com.keepit.common.controller.UserRequest[_])
+
+@views.html.admin.admin("Payments Dashboard", stylesheets = List("admin_user"), scripts = List("typeahead.bundle.min")) {
+    @views.html.admin.adminHelper.pagination(log.pgHelper.page, log.pgHelper.itemCount, log.pgHelper.pageSize, log.pgHelper.otherPagesRoute) {
+        <table class="table table-condensed table-striped">
+            <thead>
+            <th>Id</th><th>Organization</th><th>Action</th><th>Event Time</th><th>Who Done It?</th><th>Admin?</th><th>Credit Change</th><th>Payment Charge</th><th>Memo</th><th>Extra</th>
+            </thead>
+            <tbody>
+            @for(event <- log.events) {
+            <tr>
+                <td>@{event.id}</td>
+                <td>@adminHelper.orgDisplay(log.orgsByAccountId(event.accountId))</td>
+                <td><a href="@com.keepit.controllers.admin.routes.AdminPaymentsController.activityOverview(0, Some(event.action.eventType.value))">@{event.action.eventType}</a></td>
+                <td>@adminHelper.dateTimeDisplay(event.eventTime)</td>
+                <td>@event.whoDunnit.map(adminHelper.userDisplay(_)).getOrElse("none")</td>
+                <td>@event.adminInvolved.map(adminHelper.userDisplay(_)).getOrElse("none")</td>
+                <td>@{event.creditChange.toDollarString}</td>
+                <td>@{event.paymentCharge.map(_.toDollarString)}</td>
+                <td>@{event.memo.getOrElse("")}</td>
+                <td>@{event.action.toDbRow}</td>
+            </tr>
+            }
+            </tbody>
+        </table>
+    }
+}

--- a/kifi-backend/modules/shoebox/app/views/admin/admin.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/admin.scala.html
@@ -76,7 +76,8 @@
           <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:">Payments</a>
               <ul class="dropdown-menu" role="menu">
-                  <li><a href="@com.keepit.controllers.admin.routes.AdminPaymentsController.paymentsDashboard(0)">Dashboard</a>
+                  <li><a href="@com.keepit.controllers.admin.routes.AdminPaymentsController.paymentsDashboard">Dashboard</a>
+                  <li><a href="@com.keepit.controllers.admin.routes.AdminPaymentsController.activityOverview(0, None)">Activity Overview</a>
               </ul>
 
           <li class="dropdown">

--- a/kifi-backend/modules/shoebox/app/views/admin/paymentsDashboard.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/paymentsDashboard.scala.html
@@ -1,41 +1,35 @@
 @import com.keepit.controllers.admin.AdminPaymentsDashboard
 @import com.keepit.common.controller.PaginatedRequest
 
-@(dashboard: AdminPaymentsDashboard)(implicit request: com.keepit.common.controller.UserRequest[_])
+@(dash: AdminPaymentsDashboard)(implicit request: com.keepit.common.controller.UserRequest[_])
 
 @views.html.admin.admin("Payments Dashboard", stylesheets = List("admin_user"), scripts = List("typeahead.bundle.min")) {
-    @if(dashboard.frozenAccounts.nonEmpty) {
+
+    <h1>We are making @{dash.totalAmortizedIncomePerMonth.toDollarString} a month</h1>
+
+    <table class="table table-condensed table-striped">
+        <thead>
+        <th>Plan</th><th>Number of Accounts</th><th>Number of Active Users</th>
+        </thead>
+        <tbody>
+        @for((plan, (numAccounts, numUsers)) <- dash.planEnrollment) {
+        <tr>
+            <td>@{plan.displayName}</td>
+            <td>@numAccounts</td>
+            <td>@numUsers</td>
+        </tr>
+        }
+        </tbody>
+    </table>
+
+    @if(dash.frozenAccounts.nonEmpty) {
     <h2>Frozen Accounts!</h2>
     <ul>
-        @for(account <- dashboard.frozenAccounts) {
+        @for(account <- dash.frozenAccounts) {
             <li>
-                @adminHelper.orgDisplay(dashboard.orgsByAccountId(account.id.get))
+                @adminHelper.orgDisplay(account.organization)
             </li>
         }
     </ul>
-    }
-
-    @views.html.admin.adminHelper.pagination(dashboard.paginationHelper.page, dashboard.paginationHelper.itemCount, dashboard.paginationHelper.pageSize, dashboard.paginationHelper.otherPagesRoute) {
-        <table class="table table-condensed table-striped">
-            <thead>
-            <th>Id</th><th>Organization</th><th>Action</th><th>Event Time</th><th>Who Done It?</th><th>Admin?</th><th>Credit Change</th><th>Payment Charge</th><th>Memo</th><th>Extra</th>
-            </thead>
-            <tbody>
-            @for(event <- dashboard.recentEvents) {
-            <tr>
-                <td>@{event.id}</td>
-                <td>@adminHelper.orgDisplay(dashboard.orgsByAccountId(event.accountId))</td>
-                <td>@{event.action.eventType}</td>
-                <td>@adminHelper.dateTimeDisplay(event.eventTime)</td>
-                <td>@event.whoDunnit.map(adminHelper.userDisplay(_)).getOrElse("none")</td>
-                <td>@event.adminInvolved.map(adminHelper.userDisplay(_)).getOrElse("none")</td>
-                <td>@{event.creditChange.toDollarString}</td>
-                <td>@{event.paymentCharge.map(_.toDollarString)}</td>
-                <td>@{event.memo.getOrElse("")}</td>
-                <td>@{event.action.toDbRow}</td>
-            </tr>
-            }
-            </tbody>
-        </table>
     }
 }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -899,7 +899,8 @@ GET           /admin/payments/getAccountActivity           @com.keepit.controlle
 POST          /admin/payments/unfreezeAccount              @com.keepit.controllers.admin.AdminPaymentsController.unfreezeAccount(orgId: Id[Organization])
 POST          /admin/payments/backfillBillingContacts      @com.keepit.controllers.admin.AdminPaymentsController.addOrgOwnersAsBillingContacts
 
-GET           /admin/payments/dashboard  @com.keepit.controllers.admin.AdminPaymentsController.paymentsDashboard(page: Int ?= 0, kind: Option[String] ?= None)
+GET           /admin/payments/dashboard  @com.keepit.controllers.admin.AdminPaymentsController.paymentsDashboard
+GET           /admin/payments/activity   @com.keepit.controllers.admin.AdminPaymentsController.activityOverview(page: Int ?= 0, kind: Option[String] ?= None)
 
 
 ##########################################


### PR DESCRIPTION
Migrated the overview of account activity into AdminPaymentsActivityOverview
at /admin/payments/activity, and started the payments dashboard which has
more of a one-and-done strategy. Things like how much money we're making,
frozen accounts, and other things that you may want to see at-a-glance.

@eishay @JRuff42 
