### PR TITLE
Fixed a org transfer bug

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -462,7 +462,7 @@ class LibraryCommanderImpl @Inject() (
     libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, lib.ownerId).foreach { oldOwnerMembership =>
       libraryMembershipRepo.save(oldOwnerMembership.withAccess(LibraryAccess.READ_WRITE))
     }
-    val existingMembershipOpt = libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, newOwner)
+    val existingMembershipOpt = libraryMembershipRepo.getWithLibraryIdAndUserId(libraryId, newOwner, excludeState = None)
     val newMembershipTemplate = LibraryMembership(libraryId = libraryId, userId = newOwner, access = LibraryAccess.OWNER)
     libraryMembershipRepo.save(newMembershipTemplate.copy(id = existingMembershipOpt.map(_.id.get)))
     libraryRepo.save(lib.withOwner(newOwner))


### PR DESCRIPTION
@camhashemi you called it right.

I thought I was doing the smart thing (where you avoid integrity constraint violations by overwriting dead models), except I was implicitly excluding dead models. :100: 
