### PR TITLE
display broken slack integrations in red

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -112,28 +112,7 @@ angular.module('kifi')
 
           scope.$error = {};
 
-          scope.library.subscriptions.forEach(function(sub) {
-
-            if (sub.name === '' && sub.info.url === '') {
-              return;
-            }
-
-            if (sub.name) { // slack channels can't have uppercase letters
-              sub.name = sub.name.toLowerCase();
-            }
-
-            if (!sub.name || sub.name.indexOf(' ') > -1) {
-              sub.$error = sub.$error || {};
-              sub.$error.name = true;
-              scope.$error.general = 'Please enter a valid Slack channel name for each subscription.';
-            }
-
-            if (sub.info.url === '' || sub.info.url.match(/https:\/\/hooks.slack.com\/services\/.*\/.*/i) == null) {
-              sub.$error = sub.$error || {};
-              sub.$error.url = true;
-              scope.$error.general = 'Please enter a valid webhook URL for each subscription.';
-            }
-          });
+          validateSubscriptions();
 
           if (scope.$error.general) {
             return;
@@ -222,6 +201,31 @@ angular.module('kifi')
             }
           });
         };
+
+        function validateSubscriptions() {
+          scope.library.subscriptions.forEach(function(sub) {
+
+            if (sub.name === '' && sub.info.url === '') {
+              return;
+            }
+
+            if (sub.name) { // slack channels can't have uppercase letters
+              sub.name = sub.name.toLowerCase();
+            }
+
+            sub.$error = sub.$error || {};
+            if (!sub.name || sub.name.indexOf(' ') > -1) {
+              sub.$error.name = true;
+              scope.$error.general = 'Please enter a valid Slack channel name for each subscription.';
+            } else if (sub.info.url === '' || sub.info.url.match(/https:\/\/hooks.slack.com\/services\/.*\/.*/i) == null) {
+              sub.$error.url = true;
+              scope.$error.general = 'Please enter a valid webhook URL for each subscription.';
+            } else if (sub.disabled) {
+              sub.$error.disabled = true;
+              scope.$error.general = 'This library has subscriptions with invalid info. Please edit or delete those subscriptions.";
+            }
+          });
+        }
 
         scope.openDeleteLibraryModal = function () {
           modalService.open({

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -217,7 +217,7 @@ angular.module('kifi')
             if (!sub.name || sub.name.indexOf(' ') > -1) {
               sub.$error.name = true;
               scope.$error.general = 'Please enter a valid Slack channel name for each subscription.';
-            } else if (sub.info.url === '' || sub.info.url.match(/https:\/\/hooks.slack.com\/services\/.*\/.*/i) == null) {
+            } else if (sub.info.url === '' || sub.info.url.match(/https:\/\/hooks.slack.com\/services\/.*\/.*\/.*/i) == null) {
               sub.$error.url = true;
               scope.$error.general = 'Please enter a valid webhook URL for each subscription.';
             }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -213,16 +213,13 @@ angular.module('kifi')
               sub.name = sub.name.toLowerCase();
             }
 
-            sub.$error = sub.$error || {};
+            sub.$error = {};
             if (!sub.name || sub.name.indexOf(' ') > -1) {
               sub.$error.name = true;
               scope.$error.general = 'Please enter a valid Slack channel name for each subscription.';
             } else if (sub.info.url === '' || sub.info.url.match(/https:\/\/hooks.slack.com\/services\/.*\/.*/i) == null) {
               sub.$error.url = true;
               scope.$error.general = 'Please enter a valid webhook URL for each subscription.';
-            } else if (sub.disabled) {
-              sub.$error.disabled = true;
-              scope.$error.general = 'This library has subscriptions with invalid info. Please edit or delete those subscriptions.";
             }
           });
         }

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
@@ -597,8 +597,13 @@ textarea.manage-lib-sub-input
   vertical-align: top
   placeholder secondaryTextGray
 
-  &:focus
+  &:focus:not(.ng-invalid)
     border: 1px solid blueColor
+
+  &.ng-invalid
+    border: 1px solid redColor
+    color: redColor
+    placeholder: redColor
 
 //
 // Delete library confirm modal

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.styl
@@ -597,7 +597,7 @@ textarea.manage-lib-sub-input
   vertical-align: top
   placeholder secondaryTextGray
 
-  &:focus:not(.ng-invalid)
+  &:focus
     border: 1px solid blueColor
 
   &.ng-invalid

--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.tpl.html
@@ -115,16 +115,16 @@
                 <li>Log into Slack, then <a href="https://slack.com/services/new/incoming-webhook" target="_blank">go to this page</a>.</li>
                 <li>Choose a default channel, then click "Add Incoming WebHooks Integration"</li>
                 <li>Copy the Webhook URL, and paste it in the URL fields below.</li>
-                <li>Enter the name of the #channel, @person, or group you want updates sent to, then "Save".</li>
+                <li>Enter the name of the #channel or @mention you want updates sent to, then "Save".</li>
               </ol>
-              <p>All new keeps added to this library will now appear in your Slack channel as well!</p>
+              <p>All new keeps added to this library will now appear in Slack!</p>
             </div>
 
             <form name="slackForm">
               <table class="manage-lib-subs-table">
                 <tr ng-repeat="subscription in library.subscriptions">
-                  <td class="manage-lib-sub-name-input" ng-keydown="preventNewline($event)"><input class="manage-lib-input manage-lib-sub-input ng-pristine ng-valid" ng-class="{'manage-lib-input-error': subscription.$error && subscription.$error.name}" ng-model="subscription.name" type="text" name="name" placeholder="#channel, @mention" autocomplete="off" novalidate></td>
-                  <td class="manage-lib-sub-url-input" ng-keydown="preventNewline($event)"><input class="manage-lib-input manage-lib-sub-input ng-pristine ng-valid" ng-class="{'manage-lib-input-error': subscription.$error && subscription.$error.url}" ng-model="subscription.info.url" placeholder="Webhook Url" autocomplete="off" novalidate></td>
+                  <td class="manage-lib-sub-name-input" ng-keydown="preventNewline($event)"><input class="manage-lib-input manage-lib-sub-input ng-pristine" ng-class="{ 'ng-valid' : !(subscription.$error && subscription.$error.name) || !subscription.disabled,  'ng-invalid': (subscription.$error && subscription.$error.name) || subscription.disabled }" ng-model="subscription.name" type="text" name="name" placeholder="#channel, @mention" autocomplete="off" novalidate></td>
+                  <td class="manage-lib-sub-url-input" ng-keydown="preventNewline($event)"><input class="manage-lib-input manage-lib-sub-input ng-pristine" ng-class="{ 'ng-valid' : !(subscription.$error && subscription.$error.url) || !subscription.disabled,  'ng-invalid': (subscription.$error && subscription.$error.url) || subscription.disabled }" ng-model="subscription.info.url" placeholder="Webhook Url" autocomplete="off" novalidate></td>
                   <td><a class="manage-lib-sub-remove-x" ng-if="$index != (library.subscriptions.length-1) || library.subscriptions.length == 3" ng-click="removeSubscription($index)"></a><a class="manage-lib-sub-add-x" ng-if="$index == (library.subscriptions.length-1) && (library.subscriptions.length != 3)" ng-click="addSubscription()"></a></td>
                 </tr>
               </table>

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -243,8 +243,7 @@ class LibraryCommanderImpl @Inject() (
 
     def validateIntegration(newSubscriptions: Option[Seq[LibrarySubscriptionKey]], oldSpace: LibrarySpace, newSpace: LibrarySpace): Option[LibraryFail] = {
       val areSubKeysValidOpt = newSubscriptions.map(subs => subs.forall {
-        case LibrarySubscriptionKey(name, info: SlackInfo, false) => name.length < 33 && "^https://hooks.slack.com/services/.*/.*/?$".r.findFirstIn(info.url).isDefined
-        case LibrarySubscriptionKey(_, _, true) => false // broken subscription wasn't fixed
+        case LibrarySubscriptionKey(name, info: SlackInfo, _) => name.length < 33 && "^https://hooks.slack.com/services/.*/.*/?$".r.findFirstIn(info.url).isDefined
         case _ => false // unsupported type
       })
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -243,7 +243,8 @@ class LibraryCommanderImpl @Inject() (
 
     def validateIntegration(newSubscriptions: Option[Seq[LibrarySubscriptionKey]], oldSpace: LibrarySpace, newSpace: LibrarySpace): Option[LibraryFail] = {
       val areSubKeysValidOpt = newSubscriptions.map(subs => subs.forall {
-        case LibrarySubscriptionKey(name, info: SlackInfo) => name.length < 33 && "^https://hooks.slack.com/services/.*/.*/?$".r.findFirstIn(info.url).isDefined
+        case LibrarySubscriptionKey(name, info: SlackInfo, false) => name.length < 33 && "^https://hooks.slack.com/services/.*/.*/?$".r.findFirstIn(info.url).isDefined
+        case LibrarySubscriptionKey(_, _, true) => false // broken subscription wasn't fixed
         case _ => false // unsupported type
       })
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -243,7 +243,7 @@ class LibraryCommanderImpl @Inject() (
 
     def validateIntegration(newSubscriptions: Option[Seq[LibrarySubscriptionKey]], oldSpace: LibrarySpace, newSpace: LibrarySpace): Option[LibraryFail] = {
       val areSubKeysValidOpt = newSubscriptions.map(subs => subs.forall {
-        case LibrarySubscriptionKey(name, info: SlackInfo, _) => name.length < 33 && "^https://hooks.slack.com/services/.*/.*/?$".r.findFirstIn(info.url).isDefined
+        case LibrarySubscriptionKey(name, info: SlackInfo, _) => name.length < 33 && "^https://hooks.slack.com/services/.*/.*/.*/?$".r.findFirstIn(info.url).isDefined
         case _ => false // unsupported type
       })
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibrarySubscriptionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibrarySubscriptionCommander.scala
@@ -69,12 +69,10 @@ class LibrarySubscriptionCommanderImpl @Inject() (
 
   def sendNewKeepMessage(keep: Keep, library: Library): Seq[Future[ClientResponse]] = {
 
-    val (subscriptions, keeper, handle) = db.readOnlyReplica { implicit session =>
+    val (subscriptions, keeper) = db.readOnlyReplica { implicit session =>
       val subscriptions = librarySubscriptionRepo.getByLibraryIdAndTrigger(library.id.get, SubscriptionTrigger.NEW_KEEP)
       val keeper = userRepo.get(keep.userId)
-      val owner = userRepo.get(library.ownerId)
-      val handle = library.organizationId.map(organizationRepo.get).map(_.handle.value).getOrElse(owner.username.value)
-      (subscriptions, keeper, handle)
+      (subscriptions, keeper)
     }
 
     subscriptions.map { subscription =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
@@ -30,7 +30,7 @@ object LibraryError {
 case class LibraryFail(status: Int, message: String) extends Exception(message)
 
 @json
-case class LibrarySubscriptionKey(name: String, info: SubscriptionInfo)
+case class LibrarySubscriptionKey(name: String, info: SubscriptionInfo, disabled: Boolean)
 
 case class ExternalLibraryInitialValues(
   name: String,

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibrarySubscription.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibrarySubscription.scala
@@ -35,7 +35,7 @@ object LibrarySubscription {
   )(LibrarySubscription.apply, unlift(LibrarySubscription.unapply))
 
   def toSubKey(sub: LibrarySubscription): LibrarySubscriptionKey = {
-    LibrarySubscriptionKey(name = sub.name, info = sub.info)
+    LibrarySubscriptionKey(name = sub.name, info = sub.info, sub.state == LibrarySubscriptionStates.DISABLED)
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibrarySubscriptionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibrarySubscriptionRepo.scala
@@ -13,9 +13,9 @@ import scala.slick.lifted.Tag
 
 @ImplementedBy(classOf[LibrarySubscriptionRepoImpl])
 trait LibrarySubscriptionRepo extends Repo[LibrarySubscription] {
-  def getByLibraryId(libraryId: Id[Library], excludeStates: Set[State[LibrarySubscription]] = Set(LibrarySubscriptionStates.INACTIVE, LibrarySubscriptionStates.DISABLED))(implicit session: RSession): Seq[LibrarySubscription]
-  def getByLibraryIdAndName(libraryId: Id[Library], name: String, excludeStates: Set[State[LibrarySubscription]] = Set(LibrarySubscriptionStates.INACTIVE, LibrarySubscriptionStates.DISABLED))(implicit session: RSession): Option[LibrarySubscription]
-  def getByLibraryIdAndTrigger(libraryId: Id[Library], trigger: SubscriptionTrigger, excludeStates: Set[State[LibrarySubscription]] = Set(LibrarySubscriptionStates.INACTIVE, LibrarySubscriptionStates.DISABLED))(implicit session: RSession): Seq[LibrarySubscription]
+  def getByLibraryId(libraryId: Id[Library], excludeStates: Set[State[LibrarySubscription]] = Set(LibrarySubscriptionStates.INACTIVE))(implicit session: RSession): Seq[LibrarySubscription]
+  def getByLibraryIdAndName(libraryId: Id[Library], name: String, excludeStates: Set[State[LibrarySubscription]] = Set(LibrarySubscriptionStates.INACTIVE))(implicit session: RSession): Option[LibrarySubscription]
+  def getByLibraryIdAndTrigger(libraryId: Id[Library], trigger: SubscriptionTrigger, excludeStates: Set[State[LibrarySubscription]] = Set(LibrarySubscriptionStates.INACTIVE))(implicit session: RSession): Seq[LibrarySubscription]
 }
 
 @Singleton

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibrarySubscriptionCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibrarySubscriptionCommanderTest.scala
@@ -37,7 +37,7 @@ class LibrarySubscriptionCommanderTest extends Specification with ShoeboxTestInj
     "save subscription given a subscription key" in {
       withDb() { implicit injector =>
         val (user, library) = setup()
-        val subKey = LibrarySubscriptionKey("competitors", SlackInfo("http://www.fakewebhook.com"))
+        val subKey = LibrarySubscriptionKey("competitors", SlackInfo("http://www.fakewebhook.com"), disabled = false)
 
         val newSub = db.readWrite { implicit session =>
           libSubCommander.saveSubByLibIdAndKey(library.id.get, subKey)
@@ -56,8 +56,8 @@ class LibrarySubscriptionCommanderTest extends Specification with ShoeboxTestInj
           librarySubscriptionRepo.save(LibrarySubscription(libraryId = library.id.get, name = "competitors2", trigger = SubscriptionTrigger.NEW_KEEP, info = SlackInfo("http://www.fakewebhook2.com/")))
         }
 
-        val subKeys = Seq(LibrarySubscriptionKey("competitors1", SlackInfo("http://www.fakewebhook.com")),
-          LibrarySubscriptionKey("competitors3", SlackInfo("http://www.fakewebhook3.com")))
+        val subKeys = Seq(LibrarySubscriptionKey("competitors1", SlackInfo("http://www.fakewebhook.com"), disabled = false),
+          LibrarySubscriptionKey("competitors3", SlackInfo("http://www.fakewebhook3.com"), disabled = false))
 
         val (newSubs, didSubsChange) = db.readWrite { implicit s =>
           val oldSubs = librarySubscriptionRepo.getByLibraryId(library.id.get)

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
@@ -289,16 +289,16 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         val libraryCommander = inject[LibraryCommander]
         val libraryController = inject[LibraryController]
 
-        val ownerModifyRequest = LibraryModifications(subscriptions = Some(Seq(LibrarySubscriptionKey("#general", SlackInfo("https://hooks.slack.com/services/kk/kk")))))
+        val ownerModifyRequest = LibraryModifications(subscriptions = Some(Seq(LibrarySubscriptionKey("#general", SlackInfo("https://hooks.slack.com/services/kk/kk"), disabled = false))))
 
         val adminModifyRequest = LibraryModifications(subscriptions = Some(Seq(
-          LibrarySubscriptionKey("#general", SlackInfo("https://hooks.slack.com/services/kk/kk")),
-          LibrarySubscriptionKey("#eng", SlackInfo("https://hooks.slack.com/services/ok/ok")))))
+          LibrarySubscriptionKey("#general", SlackInfo("https://hooks.slack.com/services/kk/kk"), disabled = false),
+          LibrarySubscriptionKey("#eng", SlackInfo("https://hooks.slack.com/services/ok/ok"), disabled = false))))
 
         val memberModifyRequest = LibraryModifications(subscriptions = Some(Seq(
-          LibrarySubscriptionKey("#general", SlackInfo("https://hooks.slack.com/services/kk/kk")),
-          LibrarySubscriptionKey("#eng", SlackInfo("https://hooks.slack.com/services/ok/ok")),
-          LibrarySubscriptionKey("#product", SlackInfo("https://hooks.slack.com/services/ko/ko")))))
+          LibrarySubscriptionKey("#general", SlackInfo("https://hooks.slack.com/services/kk/kk"), disabled = false),
+          LibrarySubscriptionKey("#eng", SlackInfo("https://hooks.slack.com/services/ok/ok"), disabled = false),
+          LibrarySubscriptionKey("#product", SlackInfo("https://hooks.slack.com/services/ko/ko"), disabled = false))))
 
         libraryCommander.modifyLibrary(library.id.get, owner.id.get, ownerModifyRequest) must beRight
         libraryCommander.modifyLibrary(library.id.get, admin.id.get, adminModifyRequest) must beRight


### PR DESCRIPTION
@andrewconner @cvializ @ryanpbrewster 

minimal improvements to the slack integration. we were previously swallowing broken webhook+name combos, now we return them and highlight in red as to give a minimal warning of why an integration isn't working.
