### PR TITLE
use LibraryCardInfo for LibraryController.getKeepableLibraries

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -155,7 +155,6 @@ angular.module('kifi')
             orgMemberAccess: scope.library.orgMemberAccess,
             space: owner
           }, true).then(function (resp) {
-            // libraryService.fetchLibraryInfos(true);
 
             var newLibrary = resp.data.library;
             newLibrary.listed = resp.data.listed || (resp.data.library.membership && resp.data.library.membership.listed) || true;

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInfoCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInfoCommander.scala
@@ -351,7 +351,7 @@ class LibraryInfoCommanderImpl @Inject() (
       // Include org libs that user is invited to
       val libsInvitedToInOrgs = if (includeOrgLibraries) {
         libraryInviteRepo.getByUser(userId, Set(LibraryInviteStates.DECLINED, LibraryInviteStates.ACCEPTED, LibraryInviteStates.INACTIVE)).collect {
-          case ((invite, lib)) if !memberOrOpenOrgLibIds.contains(lib.id.get) && lib.organizationId.isDefined =>
+          case ((invite, lib)) if invite.isCollaborator && !memberOrOpenOrgLibIds.contains(lib.id.get) && lib.organizationId.isDefined =>
             lib
         }
       } else Seq.empty

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -675,15 +675,12 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
         status(result1) === OK
         val payload1 = contentAsJson(result1)
         (payload1 \ "libraries").as[Seq[JsValue]].length === directLibs.size
-        (payload1 \ "libraries").as[Seq[JsObject]].count { _.keys.contains("membership") } === directLibs.size
 
         val request2 = createFakeRequest(route.getKeepableLibraries(includeOrgLibraries = true))
         val result2 = controller.getKeepableLibraries(includeOrgLibraries = true)(request2)
         status(result2) === OK
         val payload2 = contentAsJson(result2)
         (payload2 \ "libraries").as[Seq[JsValue]].length === (directLibs ++ indirectLibs).size
-        (payload2 \ "libraries").as[Seq[JsObject]].count { _.keys.contains("membership") } === directLibs.size
-        (payload2 \ "libraries").as[Seq[JsObject]].count { !_.keys.contains("membership") } === indirectLibs.size
       }
     }
 


### PR DESCRIPTION
@ryanpbrewster @andrewconner @leogrim 

this allows us to return org-keepable libraries to the site without breaking things (keeping the same objects as used elsewhere). this endpoint isn't being used anywhere, going to deploy this then dev-mode QA the front-end.
