### PR TITLE
use more accurate regex for slack webhooks

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -216,7 +216,7 @@ angular.module('kifi')
             if (!sub.name || sub.name.indexOf(' ') > -1) {
               sub.$error.name = true;
               scope.$error.general = 'Please enter a valid Slack channel name for each subscription.';
-            } else if (sub.info.url === '' || sub.info.url.match(/https:\/\/hooks.slack.com\/services\/.*\/.*\/.*/i) == null) {
+            } else if (sub.info.url === '' || sub.info.url.match(/^https:\/\/hooks.slack.com\/services\/.*\/.*\/.*[^\/]$/i) == null) {
               sub.$error.url = true;
               scope.$error.general = 'Please enter a valid webhook URL for each subscription.';
             }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -243,7 +243,7 @@ class LibraryCommanderImpl @Inject() (
 
     def validateIntegration(newSubscriptions: Option[Seq[LibrarySubscriptionKey]], oldSpace: LibrarySpace, newSpace: LibrarySpace): Option[LibraryFail] = {
       val areSubKeysValidOpt = newSubscriptions.map(subs => subs.forall {
-        case LibrarySubscriptionKey(name, info: SlackInfo, _) => name.length < 33 && "^https://hooks.slack.com/services/.*/.*/.*/?$".r.findFirstIn(info.url).isDefined
+        case LibrarySubscriptionKey(name, info: SlackInfo, _) => name.length < 33 && "^https://hooks.slack.com/services/.*/.*/.*[^/]$".r.findFirstIn(info.url).isDefined
         case _ => false // unsupported type
       })
 


### PR DESCRIPTION
@andrewconner 

the UI is highlighting disabled integrations now. this was an edge-case bug where if you append a `/` to a valid webhook, slack returns a 200 instead of a 400, even though the message doesn't go through (you get their integrations page actually, kind of weird). 

people who just copy and paste shouldn't have to worry about it, I'm guessing most of the trouble was getting the channel name matched up.
