### PR TITLE
Factored out credit reward serialization

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/PaymentsController.scala
@@ -161,6 +161,6 @@ class PaymentsController @Inject() (
   }
 
   def getRewards(pubId: PublicId[Organization]) = OrganizationUserAction(pubId, OrganizationPermission.MANAGE_PLAN) { request =>
-    Ok(Json.obj("rewards" -> creditRewardInfoCommander.getRewardsByOrg(request.orgId)))
+    Ok(Json.toJson(creditRewardInfoCommander.getRewardsByOrg(request.orgId)))
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/ActivityLogCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/ActivityLogCommander.scala
@@ -61,7 +61,7 @@ class ActivityLogCommanderImpl @Inject() (
     val description: DescriptionElements = {
       import com.keepit.payments.{ DescriptionElements => Elements }
       event.action match {
-        case RewardCredit(id) => creditRewardInfoCommander.getDescription(id)
+        case RewardCredit(id) => creditRewardInfoCommander.getDescription(creditRewardRepo.get(id))
         case IntegrityError(err) => Elements("Found and corrected an error in the account.") // this is intentionally vague to avoid sending dangerous information to clients
         case SpecialCredit() => Elements("Special credit was granted to your team by Kifi Support", maybeUser.map(Elements("thanks to", _)), ".")
         case Refund(_, _) => Elements("A", event.creditChange, "refund was issued to your card.")

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditRewardCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditRewardCommander.scala
@@ -2,19 +2,19 @@ package com.keepit.payments
 
 import com.google.inject.{ ImplementedBy, Inject, Singleton }
 import com.keepit.common.db.Id
-import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
+import com.keepit.common.db.slick.DBSession.RWSession
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
-import com.keepit.common.mail.{ SystemEmailAddress, LocalPostOffice, ElectronicMail }
+import com.keepit.common.mail.{ ElectronicMail, LocalPostOffice, SystemEmailAddress }
 import com.keepit.common.time._
-import com.keepit.model.{ OrganizationExperimentType, OrganizationExperiment, OrganizationExperimentRepo, NotificationCategory, UserEmailAddressRepo, OrganizationRole, OrganizationMembershipRepo, User, OrganizationRepo, Organization }
+import com.keepit.model.{ NotificationCategory, Organization, OrganizationMembershipRepo, OrganizationRepo, OrganizationRole, User, UserEmailAddressRepo }
 import com.keepit.payments.CreditRewardFail._
 import org.apache.commons.lang3.RandomStringUtils
 import play.api.libs.json.JsNull
 
 import scala.concurrent.ExecutionContext
-import scala.util.{ Success, Failure, Try }
+import scala.util.{ Failure, Success, Try }
 
 @ImplementedBy(classOf[CreditRewardCommanderImpl])
 trait CreditRewardCommander {
@@ -43,7 +43,6 @@ class CreditRewardCommanderImpl @Inject() (
   eventCommander: AccountEventTrackingCommander,
   accountLockHelper: AccountLockHelper,
   postOffice: LocalPostOffice,
-  orgExpRepo: OrganizationExperimentRepo,
   airbrake: AirbrakeNotifier,
   implicit val defaultContext: ExecutionContext)
     extends CreditRewardCommander with Logging {

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditRewardInfoCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditRewardInfoCommander.scala
@@ -8,11 +8,8 @@ import com.keepit.common.db.slick.DBSession.RSession
 import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
 import com.keepit.common.social.BasicUserRepo
-import com.keepit.common.time._
 import com.keepit.model._
 import com.keepit.social.BasicUser
-
-import scala.concurrent.ExecutionContext
 
 @ImplementedBy(classOf[CreditRewardInfoCommanderImpl])
 trait CreditRewardInfoCommander {
@@ -23,15 +20,11 @@ trait CreditRewardInfoCommander {
 @Singleton
 class CreditRewardInfoCommanderImpl @Inject() (
   db: Database,
-  orgRepo: OrganizationRepo,
   creditCodeInfoRepo: CreditCodeInfoRepo,
   creditRewardRepo: CreditRewardRepo,
   accountRepo: PaidAccountRepo,
   basicUserRepo: BasicUserRepo,
   orgCommander: OrganizationCommander,
-  clock: Clock,
-  orgExpRepo: OrganizationExperimentRepo,
-  implicit val defaultContext: ExecutionContext,
   implicit val publicIdConfig: PublicIdConfiguration)
     extends CreditRewardInfoCommander with Logging {
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditRewardInfoCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/payments/CreditRewardInfoCommander.scala
@@ -16,8 +16,8 @@ import scala.concurrent.ExecutionContext
 
 @ImplementedBy(classOf[CreditRewardInfoCommanderImpl])
 trait CreditRewardInfoCommander {
-  def getRewardsByOrg(orgId: Id[Organization]): Seq[ExternalCreditReward]
-  def getDescription(id: Id[CreditReward])(implicit session: RSession): DescriptionElements
+  def getRewardsByOrg(orgId: Id[Organization]): CreditRewardsView
+  def getDescription(creditReward: CreditReward)(implicit session: RSession): DescriptionElements
 }
 
 @Singleton
@@ -35,25 +35,45 @@ class CreditRewardInfoCommanderImpl @Inject() (
   implicit val publicIdConfig: PublicIdConfiguration)
     extends CreditRewardInfoCommander with Logging {
 
-  def getRewardsByOrg(orgId: Id[Organization]): Seq[ExternalCreditReward] = db.readOnlyMaster { implicit session =>
-    val creditRewards = creditRewardRepo.getByAccount(accountRepo.getByOrgId(orgId).id.get)
-      .toSeq.sortBy(_.applied.nonEmpty)
-    creditRewards.map { cr =>
-      ExternalCreditReward(
-        applied = cr.applied.map(eventId => AccountEvent.publicId(eventId))
-      )
+  def getRewardsByOrg(orgId: Id[Organization]): CreditRewardsView = db.readOnlyMaster { implicit session =>
+    val rewards = creditRewardRepo.getByAccount(accountRepo.getByOrgId(orgId).id.get).toSeq
+    val categorizedRewards = RewardCategory.all.map { category =>
+      category -> rewards.filter(_.reward.kind.category == category).sortBy(_.applied.isDefined)
+    }.toMap
+    val externalCategorizedRewards = categorizedRewards.map {
+      case (category, crs) => category -> crs.map { cr =>
+        ExternalCreditReward(
+          description = getDescription(cr),
+          applied = cr.applied.map(eventId => AccountEvent.publicId(eventId))
+        )
+      }
     }
+    CreditRewardsView(externalCategorizedRewards)
   }
 
   private def getUser(id: Id[User])(implicit session: RSession): BasicUser = basicUserRepo.load(id)
   private def getOrg(id: Id[Organization])(implicit session: RSession): BasicOrganization = orgCommander.getBasicOrganizationHelper(id).getOrElse(throw new Exception(s"Tried to build event info for dead org: $id"))
-  def getDescription(id: Id[CreditReward])(implicit session: RSession): DescriptionElements = {
-    val creditReward = creditRewardRepo.get(id)
+  def getDescription(creditReward: CreditReward)(implicit session: RSession): DescriptionElements = {
+    if (creditReward.applied.isDefined) describeAppliedReward(creditReward)
+    else describeUnearnedReward(creditReward)
+  }
+  private def describeUnearnedReward(creditReward: CreditReward)(implicit session: RSession): DescriptionElements = {
+    val trigger = creditReward.reward match {
+      case Reward(kind, _, _) if kind == RewardKind.OrganizationDescriptionAdded =>
+        DescriptionElements("you tell us about your team.")
+      case Reward(kind, _, referredOrgId: Id[Organization] @unchecked) if kind == RewardKind.OrganizationReferral =>
+        DescriptionElements(getOrg(referredOrgId), "upgrades to a pro account.")
+    }
+    DescriptionElements("You will get", creditReward.credit, "when", trigger)
+  }
+  private def describeAppliedReward(creditReward: CreditReward)(implicit session: RSession): DescriptionElements = {
     val reason = creditReward.reward match {
       case Reward(kind, _, _) if kind == RewardKind.Coupon =>
         DescriptionElements(getUser(creditReward.code.get.usedBy), "redeemed the coupon code", creditReward.code.get.code, ".")
       case Reward(kind, _, _) if kind == RewardKind.OrganizationCreation =>
         DescriptionElements("you created a team on Kifi. Thanks for being awesome! :)")
+      case Reward(kind, _, _) if kind == RewardKind.OrganizationDescriptionAdded =>
+        DescriptionElements("you told us about your team.")
       case Reward(kind, _, referredOrgId: Id[Organization] @unchecked) if kind == RewardKind.OrganizationReferral =>
         DescriptionElements("you referred", getOrg(referredOrgId), ". Thank you!")
       case Reward(kind, _, _) if kind == RewardKind.ReferralApplied =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/ActivityLogCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/ActivityLogCommanderTest.scala
@@ -20,7 +20,7 @@ class ActivityLogCommanderTest extends SpecificationLike with ShoeboxTestInjecto
 
   "ActivityLogCommanderTest" should {
     def display(event: AccountEvent)(implicit injector: Injector): String = {
-      DescriptionElements.flatWrites.writes(activityLogCommander.buildSimpleEventInfo(event).description).as[Seq[JsObject]].map(obj => (obj \ "text").as[String]).mkString
+      DescriptionElements.formatPlain(activityLogCommander.buildSimpleEventInfo(event).description)
     }
     "display events in a sane way" in {
       def setup()(implicit injector: Injector): Seq[AccountEvent] = db.readWrite { implicit session =>
@@ -71,7 +71,7 @@ class ActivityLogCommanderTest extends SpecificationLike with ShoeboxTestInjecto
         events.map(_.action.eventType).toSet === AccountEventKind.activityLog
 
         // events.foreach(display _ andThen println)
-        val e = events.toIterator
+        val e = events.iterator
         display(e.next()) === "The Org team was created by Owner and enrolled in the Free plan."
         display(e.next()) === "Your card was charged $0.00 for your balance. [Invoice not found, please contact billing@kifi.com]"
         display(e.next()) === "A $0.00 refund was issued to your card."

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/CreditRewardInfoCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/CreditRewardInfoCommanderTest.scala
@@ -1,0 +1,74 @@
+package com.keepit.payments
+
+import com.keepit.common.concurrent.FakeExecutionContextModule
+import com.keepit.common.db.Id
+import com.keepit.heimdal.HeimdalContext
+import com.keepit.model.{ OrganizationFactory, UserFactory }
+import com.keepit.model.OrganizationFactoryHelper.OrganizationPersister
+import com.keepit.model.UserFactoryHelper.UserPersister
+import com.keepit.test.ShoeboxTestInjector
+import org.specs2.mutable.SpecificationLike
+
+class CreditRewardInfoCommanderTest extends SpecificationLike with ShoeboxTestInjector {
+  implicit val ctxt = HeimdalContext.empty
+  val modules = Seq(
+    FakeExecutionContextModule(),
+    FakeStripeClientModule()
+  )
+
+  "CreditRewardInfoCommanderTest" should {
+    "describe credit rewards appropriately" in {
+      withDb(modules: _*) { implicit injector =>
+        val (org, account, owner) = db.readWrite { implicit s =>
+          val owner = UserFactory.user().withName("Owner", "OwnerLN").saved
+          val org = OrganizationFactory.organization().withName("Team").withOwner(owner).saved
+          val account = paidAccountRepo.getByOrgId(org.id.get)
+          (org, account, owner)
+        }
+
+        val Seq(couponCode, promoCode, refCode) = db.readWrite { implicit s =>
+          Seq(
+            creditCodeInfoRepo.create(CreditCodeInfo(kind = CreditCodeKind.Coupon, code = CreditCode.normalize("coupon"), credit = DollarAmount.dollars(42), status = CreditCodeStatus.Open, referrer = None)).get,
+            creditCodeInfoRepo.create(CreditCodeInfo(kind = CreditCodeKind.Promotion, code = CreditCode.normalize("promo"), credit = DollarAmount.dollars(42), status = CreditCodeStatus.Open, referrer = None)).get,
+            creditCodeInfoRepo.create(CreditCodeInfo(kind = CreditCodeKind.OrganizationReferral, code = CreditCode.normalize("ref"), credit = DollarAmount.dollars(42), status = CreditCodeStatus.Open, referrer = Some(CreditCodeReferrer(org.ownerId, org.id, DollarAmount.dollars(42))))).get
+          )
+        }
+        def makeReward(r: Reward, code: Option[CreditCode] = None) = CreditReward(
+          accountId = account.id.get,
+          credit = DollarAmount.dollars(42),
+          applied = if (r.status == r.kind.applicable) Some(Id(1)) else None, // throw in a fake account event
+          reward = r,
+          unrepeatable = Some(UnrepeatableRewardKey.WasCreated(org.id.get)),
+          code = code.map(c => UsedCreditCode(c, singleUse = false, owner.id.get))
+        )
+
+        val rewards = Seq(
+          makeReward(Reward(RewardKind.Coupon)(RewardKind.Coupon.Used)(None), Some(couponCode.code)) ->
+            "You earned $42.00 because Owner redeemed the coupon code COUPON.",
+          makeReward(Reward(RewardKind.OrganizationCreation)(RewardKind.OrganizationCreation.Created)(None)) ->
+            "You earned $42.00 because you created a team on Kifi. Thanks for being awesome! :)",
+          makeReward(Reward(RewardKind.OrganizationDescriptionAdded)(RewardKind.OrganizationDescriptionAdded.Started)(org.id.get)) ->
+            "You will get $42.00 when you tell us about your team.",
+          makeReward(Reward(RewardKind.OrganizationDescriptionAdded)(RewardKind.OrganizationDescriptionAdded.Achieved)(org.id.get)) ->
+            "You earned $42.00 because you told us about your team.",
+          makeReward(Reward(RewardKind.OrganizationReferral)(RewardKind.OrganizationReferral.Created)(org.id.get)) ->
+            "You will get $42.00 when Team upgrades to a pro account.",
+          makeReward(Reward(RewardKind.OrganizationReferral)(RewardKind.OrganizationReferral.Upgraded)(org.id.get)) ->
+            "You earned $42.00 because you referred Team. Thank you!",
+          makeReward(Reward(RewardKind.ReferralApplied)(RewardKind.ReferralApplied.Applied)(promoCode.code), Some(promoCode.code)) ->
+            "You earned $42.00 because Owner applied the code PROMO.",
+          makeReward(Reward(RewardKind.ReferralApplied)(RewardKind.ReferralApplied.Applied)(refCode.code), Some(refCode.code)) ->
+            "You earned $42.00 because Owner applied the code REF from Team."
+        )
+
+        db.readOnlyMaster { implicit s =>
+          rewards.foreach {
+            case (input, output) => DescriptionElements.formatPlain(inject[CreditRewardInfoCommander].getDescription(input)) === output
+          }
+        }
+        1 === 1
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
CreditRewardInfoCommander generates the DescriptionElements for credit rewards
now (the ActivityLogCommander defers to it).

The endpoint /site/organizations/:id/rewards serializes a CreditRewardsView,
which presents all of an organization's rewards (both applied and unearned),
along with descriptions of them. For applied rewards, this will look exactly
like the activity log. For unearned rewards, this contains information about
how to go about earning them (and how much will be earned upon completion).

@cvializ @leogrim 
