### PR TITLE
don't tighten the number of integrations someone can make

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/manageLibrary.js
@@ -339,9 +339,7 @@ angular.module('kifi')
           scope.emptySlug = false;
           scope.modalTitle = scope.library.name;
           scope.library.subscriptions = scope.library.subscriptions || [];
-          if (scope.library.subscriptions.length < 3) {
-            scope.library.subscriptions.push(scope.newBlankSub());
-          }
+          scope.library.subscriptions.push(scope.newBlankSub());
         } else {
           scope.library = {
             'name': '',


### PR DESCRIPTION
@andrewconner not sure why this was implemented, maybe at some point we wanted to limit the number of integrations someone could make (which isn't really what this does). the backend doesn't do it, don't think we should, this makes the UI nicer.
