### PR TITLE
Send membership info back with keepable libraries

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCardCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCardCommander.scala
@@ -125,6 +125,7 @@ class LibraryCardCommanderImpl @Inject() (
       }
 
       val permissions = permissionCommander.getLibraryPermissions(lib.id.get, Some(viewerId))
+      val viewerMemInfoOpt = viewerMemOpt.map(miniMem => LibraryMembershipInfo(miniMem.access, miniMem.listed, miniMem.subscribed, permissions))
 
       val info = LibraryCardInfo(
         id = Library.publicId(lib.id.get),
@@ -143,7 +144,7 @@ class LibraryCardCommanderImpl @Inject() (
         collaborators = collabsSample,
         lastKept = lib.lastKept.getOrElse(lib.createdAt),
         following = None, // not needed
-        membership = None, // not needed
+        membership = viewerMemInfoOpt,
         invite = None, // not needed
         permissions = permissions,
         path = path,


### PR DESCRIPTION
@andrewconner @ryanpbrewster 

this saves us from doing weird checks on the front-end to know if you're a member. if you're not a collaborator of a keepable library, we'll send an invite accept request before keeping to it.
