### PR TITLE
Finally got things working.

### DIFF
--- a/kifi-backend/modules/common/test/com/keepit/common/reflection/EnumeratorTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/reflection/EnumeratorTest.scala
@@ -5,16 +5,26 @@ import org.specs2.mutable.Specification
 sealed abstract class Foo(val value: String)
 object Foo extends Enumerator[Foo] {
   case object A extends Foo("a")
-  case object B extends Foo("b")
-  case object C extends Foo("c")
-  def all = _all.toSet
+  object Bar extends Enumerator[Foo] {
+    case object B extends Foo("b")
+    object Baz {
+      case object C extends Foo("c")
+    }
+    case class Obstacle(y: String)
+    def all: Set[Foo] = _all.toSet
+  }
+  case class Rando(x: Int)
+  def all: Set[Foo] = _all.toSet
 }
 
 class EnumeratorTest extends Specification {
   "EnumeratorTest" should {
-    "retrieve all of a sealed trait's subclasses" in {
+    "retrieve all of an trait's subclasses enclosed within a given object" in {
       Foo.all must haveSize(3)
       Foo.all.map(_.value) === Set("a", "b", "c")
+
+      Foo.Bar.all must haveSize(2)
+      Foo.Bar.all.map(_.value) === Set("b", "c")
     }
   }
 }

--- a/kifi-backend/modules/common/test/com/keepit/common/reflection/EnumeratorTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/reflection/EnumeratorTest.scala
@@ -9,6 +9,7 @@ object Foo extends Enumerator[Foo] {
     case object B extends Foo("b")
     object Baz {
       case object C extends Foo("c")
+      case object D { val value: String = "d" }
     }
     case class Obstacle(y: String)
     def all: Set[Foo] = _all.toSet
@@ -16,6 +17,8 @@ object Foo extends Enumerator[Foo] {
   case class Rando(x: Int)
   def all: Set[Foo] = _all.toSet
 }
+
+case object E extends Foo("e") // ACHTUNG!!! This will not be caught by the _all because it is not enclosed within `object Foo`
 
 class EnumeratorTest extends Specification {
   "EnumeratorTest" should {
@@ -25,6 +28,9 @@ class EnumeratorTest extends Specification {
 
       Foo.Bar.all must haveSize(2)
       Foo.Bar.all.map(_.value) === Set("b", "c")
+
+      // Sadly, the macro does not work via sealedness, it just looks within a namespace
+      Foo.all.map(_.value) must not contain "e"
     }
   }
 }


### PR DESCRIPTION
@leogrim @andrewconner: I figured out how to work with macros.

Extending `Enumerator[T]` will inject a method `_all: Seq[T]` that contains every `object` that is a subclass of `T` _and that is defined within the given scope_. It does not work based on sealed traits (apparently this is a persistent issue due to Scala's compiler architecture).
