### PR TITLE
don't allow users to steal your unverified primary email

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/profile/profileService.js
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profileService.js
@@ -211,7 +211,6 @@ angular.module('kifi')
         return invalidEmailValidationResult();
       case 403: // belongs to another user
         return failureInputActionResult(
-          'This email address is already taken',
           'This email address belongs to another user.<br>Please enter another email address.'
         );
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserEmailAddressCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserEmailAddressCommander.scala
@@ -75,7 +75,7 @@ class UserEmailAddressCommanderImpl @Inject() (db: Database,
 
   def intern(userId: Id[User], address: EmailAddress, verified: Boolean = false)(implicit session: RWSession): Try[(UserEmailAddress, Boolean)] = {
     userEmailAddressRepo.getByAddress(address, excludeState = None) match {
-      case Some(email) if email.verified && email.userId != userId => Failure(new UnavailableEmailAddressException(email, userId))
+      case Some(email) if (email.verified || email.primary) && email.userId != userId => Failure(new UnavailableEmailAddressException(email, userId))
       case Some(email) if email.state != UserEmailAddressStates.INACTIVE => Success {
         val isNew = email.userId != userId
         val updatedEmail = if (isNew) email.copy(userId = userId).withAddress(address).clearVerificationCode else email.withAddress(address)


### PR DESCRIPTION
@andrewconner @leogrim @ryanpbrewster 

userX can swallow userY's account by adding userY's unverified primary email (even without userX verifying). from then on, entering that email will allow userX to log in, not userY. Pretty bad, this is just a band-aid. We have a uniqueness constraint on email hash's (so two people can't have the same unverified email), seems like we should have a uniqueness constraint on (email hash, verified).
