### PR TITLE
server-side amplitude events will passthrough the device_id from the client

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalContext.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/HeimdalContext.scala
@@ -1,5 +1,8 @@
 package com.keepit.heimdal
 
+import java.util.Base64
+
+import com.fasterxml.jackson.core.JsonParseException
 import com.keepit.common.logging.Logging
 import com.keepit.common.mail.template.EmailTrackingParam
 import org.joda.time.DateTime
@@ -152,10 +155,11 @@ class HeimdalContextBuilder extends Logging {
   }
 
   def addRequestInfo(request: RequestHeader): Unit = {
-    this += ("doNotTrack", request.headers.get("do-not-track").exists(_ == "1"))
+    this += ("doNotTrack", request.headers.get("do-not-track").contains("1"))
     addRemoteAddress(IpAddress.fromRequest(request).ip)
     addUserAgent(request.headers.get("User-Agent").getOrElse(""))
     addKifiClientAndVersion(request)
+    addDistinctId(request)
 
     request match {
       case userRequest: UserRequest[_] =>
@@ -164,6 +168,25 @@ class HeimdalContextBuilder extends Logging {
         addExperiments(userRequest.experiments)
         Try(SocialNetworkType(userRequest.identityOpt.get.identityId.providerId)).foreach { socialNetwork => this += ("identityProvider", socialNetwork.toString) }
       case _ =>
+    }
+  }
+
+  def addDistinctId(request: RequestHeader): Unit = {
+    request.cookies.get("amplitude_idkifi.com").foreach { cookie =>
+      try {
+        val json = new String(Base64.getDecoder.decode(cookie.value), "UTF-8")
+        val amplitudeCookieData = Json.parse(json)
+        amplitudeCookieData \ "deviceId" match {
+          case JsString(value) => this += ("distinct_id", value)
+          case _ =>
+        }
+      } catch {
+        // don't let these exceptions bubble up, but still log them
+        case iae: IllegalArgumentException => // base64 encode error
+          log.warn(s"HeimdalContextBuilder.addDistinctid(): amplitude_idkifi.com cookie is invalid: ${cookie.value}")
+        case je: JsonParseException =>
+          log.warn(s"HeimdalContextBuilder.addDistinctid(): amplitude_idkifi.com cookie is not valid json: ${cookie.value}")
+      }
     }
   }
 

--- a/kifi-backend/modules/common/test/com/keepit/common/controller/MidFlightRequestsTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/controller/MidFlightRequestsTest.scala
@@ -1,23 +1,13 @@
 package com.keepit.common.controller
 
-import org.specs2.mutable._
-import play.api.mvc.{ RequestHeader, Headers }
 import java.util.concurrent.atomic.AtomicLong
+
 import com.google.inject.util.Providers
 import com.keepit.common.amazon.MyInstanceInfo
-import com.keepit.common.zookeeper.DiscoveryModule
 import com.keepit.common.service.ServiceType
-
-case class DummyRequestHeader(id: Long, path: String) extends RequestHeader {
-  def tags = Map()
-  def uri = ""
-  def method = ""
-  def version = ""
-  def queryString = Map()
-  def remoteAddress = ""
-  def secure: Boolean = false
-  lazy val headers = new Headers { val data = Seq() }
-}
+import com.keepit.common.zookeeper.DiscoveryModule
+import com.keepit.test.DummyRequestHeader
+import org.specs2.mutable.Specification
 
 class MidFlightRequestsTest extends Specification {
 

--- a/kifi-backend/modules/common/test/com/keepit/test/DummyRequestHeader.scala
+++ b/kifi-backend/modules/common/test/com/keepit/test/DummyRequestHeader.scala
@@ -1,0 +1,38 @@
+package com.keepit.test
+
+import play.api.mvc.{ Cookie, Cookies, Headers, RequestHeader }
+
+import scala.collection.mutable
+
+case class DummyRequestHeader(id: Long, path: String) extends RequestHeader {
+  def tags = Map()
+
+  def uri = ""
+
+  def method = ""
+
+  def version = ""
+
+  def queryString = Map()
+
+  def remoteAddress = ""
+
+  def secure: Boolean = false
+
+  val mutableHeaders = mutable.ArrayBuffer[(String, Seq[String])]()
+  lazy val headers = new Headers {
+    override protected val data: Seq[(String, Seq[String])] = mutableHeaders
+  }
+
+  val mutableCookies = mutable.Map[String, String]()
+
+  override lazy val cookies: Cookies = new Cookies {
+    private def toCookie(name: String, value: String) = new Cookie(name, value)
+
+    override def get(name: String): Option[Cookie] = mutableCookies.get(name).map(value => toCookie(name, value))
+
+    override def foreach[U](f: (Cookie) => U): Unit = {
+      mutableCookies.toSeq.map { case (name, value) => toCookie(name, value) }.foreach(f)
+    }
+  }
+}


### PR DESCRIPTION
the `device_id` for user events has been "user_<id>" but this is redundant since we also send a separate `user_id` property and it also makes it difficult to link events between a visitor and a user after registration. this change will extract the device_id from a request cookie (if supplied) so events from a visitor that turns into a user will be linked to the same device id. this will also affect visitor events that pass through heimdal to ensure they set the client's device_id instead of the ip address (which is bad anyway).

@jaredpetker  For iOS/Android app events, is there a request header I can check for thats unique to the actual device?

@andrewconner 
