### PR TITLE
Stripe's documentation is outdated, found other domains they require.…

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/controller/HeaderAugmentor.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/controller/HeaderAugmentor.scala
@@ -39,11 +39,11 @@ private object Security extends Augmentor {
               s"style-src d1dwdv9wd966qu.cloudfront.net fonts.googleapis.com 'unsafe-inline'; " +
               s"script-src d1dwdv9wd966qu.cloudfront.net ssl.google-analytics.com d24n15hnbwhuhn.cloudfront.net cdn.mxpnl.com connect.facebook.net platform.twitter.com js.stripe.com checkout.stripe.com 'unsafe-eval' 'nonce-$nonce' $dev; " +
               s"font-src fonts.gstatic.com; " +
-              s"img-src data: d1dwdv9wd966qu.cloudfront.net djty7jcqog9qu.cloudfront.net ssl.google-analytics.com stats.g.doubleclick.net static.xx.fbcdn.net $dev; " +
+              s"img-src data: d1dwdv9wd966qu.cloudfront.net djty7jcqog9qu.cloudfront.net ssl.google-analytics.com stats.g.doubleclick.net static.xx.fbcdn.net q.stripe.com $dev; " +
               s"form-action www.kifi.com api.kifi.com $dev; " +
-              s"frame-src www.kifi.com *.facebook.com js.stripe.com; " + // to support Safari 9
-              s"child-src www.kifi.com *.facebook.com js.stripe.com; " +
-              s"connect-src www.kifi.com api.kifi.com search.kifi.com eliza.kifi.com api.mixpanel.com api.amplitude.com d1dwdv9wd966qu.cloudfront.net api.stripe.com $dev; " +
+              s"frame-src www.kifi.com *.facebook.com *.stripe.com; " + // to support Safari 9
+              s"child-src www.kifi.com *.facebook.com *.stripe.com; " +
+              s"connect-src www.kifi.com api.kifi.com search.kifi.com eliza.kifi.com api.mixpanel.com api.amplitude.com d1dwdv9wd966qu.cloudfront.net *.stripe.com $dev; " +
               "report-uri https://www.kifi.com/up/report"
 
           //val report = if (request.rawQueryString.contains("--report-csp")) "; report-uri https://www.kifi.com/up/report" else ""


### PR DESCRIPTION
Casting wider net.

@cvializ FYI. They made requests to q.stripe.com. Their docs don't mention checkout.stripe.com, but obviously that's needed because that's the script we include. Looks like they've moved some APIs to that domains as well.
