### PR TITLE
Update the org profile click-to-edit. Other oph fixes.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.js
@@ -12,7 +12,6 @@ angular.module('kifi')
         inputPlaceholder: '=',
         onSave: '=',
         linkable: '=',
-        className: '=',
         readonly: '='
       },
       replace: true,
@@ -23,22 +22,8 @@ angular.module('kifi')
           textareaHeight: '',
           textareaWidth: ''
         };
+        $scope.focus = false;
         $scope.saveable = true;
-
-        var calculateHeight = function() {
-          var textarea = $element.find('textarea'),
-              span     = $element.find('span');
-          if (textarea && span) {
-            // Show an element that matches the textarea's styling to determine
-            // how high it should be to show all of textarea's text.
-            var tester = span[0];
-            tester.style.width = textarea.css('width');
-            $scope.view.textareaHeight = {'height': span.css('height') };
-          }
-        };
-
-        $scope.$watch('view.editableValue', function() { calculateHeight(); });
-        $scope.$evalAsync(function() { calculateHeight(); });
 
         $scope.editEvent = function($event) {
           if ($event.which === 27) {
@@ -73,11 +58,41 @@ angular.module('kifi')
         };
 
         $scope.onBlur = function () {
+          $scope.focus = false;
+
           if ($scope.saveable) {
             $scope.save();
             $scope.saveable = true;
           }
         };
+
+        $scope.onFocus = function () {
+          $scope.selectAll();
+          $scope.focus = true;
+        };
+
+        $scope.selectAll = function () {
+          var textarea = $element.find('textarea')[0];
+          if (!$scope.focus && textarea.selectionStart === textarea.selectionEnd) {
+            textarea.select();
+          }
+        };
+
+        function calculateHeight() {
+          var textarea = $element.find('textarea');
+          var span = $element.find('span');
+          if (textarea && span) {
+            // Show an element that matches the textarea's styling to determine
+            // how high it should be to show all of textarea's text.
+            var tester = span[0];
+            tester.style.width = textarea.css('width');
+            $scope.view.textareaHeight = {'height': span.css('height') };
+          }
+        }
+
+        $scope.$watch('view.editableValue', function () {
+          calculateHeight();
+        }, true);
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.styl
@@ -1,51 +1,51 @@
-editButtonWidth = 40px
+.kf-click-to-edit
+  ::selection
+    background: rgba(255, 255, 255, .33)
 
-.kf-click-to-edit:hover:before
-  position: absolute
-  right: 0
-  width: editButtonWidth
-  text-align: center
-  font-size: 0.85rem
-  font-weight: normal
-  pointer-events: none
-  display: inline-block
-  vertical-align: middle
-  color: white
+  ::-moz-selection
+    background: rgba(255, 255, 255, .33)
 
-.kf-click-to-edit 
+  p
+    margin: 0
+
   .kf-click-to-edit-textarea
   .kf-click-to-edit-p
-    width: 'calc(100% - %s)' % editButtonWidth
     box-sizing: border-box
+    width: 100%
+    min-height: 25px
     padding: 2px
     background: none
-    border-radius: 2px
+    border: 0
     color: inherit
+    text-decoration: inherit
     line-height: normal
-    min-height: 25px
-    border: 1px dashed transparent
     word-wrap: break-word
+    text-align: inherit
     resize: none
 
-  .kf-click-to-edit-p
-    margin-bottom: 0px
+  .kf-click-to-edit-p-a
+    color: inherit
+    text-decoration: inherit
 
-    + .kf-click-to-edit-p
-      margin-top: 5px
+  &.editable .kf-click-to-edit-wrapper
+    padding: 5px 10px
+    border: 2px dashed transparent
+    border-radius: 10px
+    cursor: pointer
+    color: inherit
+    text-decoration: inherit
 
-  &.editable
-    &:hover
-      textarea
-        border-color: rgba(255, 255, 255, 0.25)
+  &.editable:hover .kf-click-to-edit-wrapper
+    border-color: rgba(255, 255, 255, 0.25)
+    box-shadow: inset 0 0 15px rgba(255, 255, 255, .1)
 
-    &:focus,
-    &:hover:focus
-      border-color: #fff
+  &.editable.focus .kf-click-to-edit-wrapper
+    border-color: textLightGrey
+    box-shadow: inset 0 0 15px rgba(255, 255, 255, .1)
 
-.kf-click-to-edit
-  .kf-click-to-edit-textarea-tester
-    box-sizing: border-box
-    padding-left: 15px
-    position: absolute
-    top: -9999px
-    left: -9999px
+.kf-click-to-edit-textarea-tester
+  box-sizing: border-box
+  padding-left: 15px
+  position: absolute
+  top: -9999px
+  left: -9999px

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/clickToEdit/clickToEdit.tpl.html
@@ -1,15 +1,13 @@
-<div 
-  class="kf-click-to-edit" 
-  ng-class="{'editable': !readonly}"
+<div
+  class="kf-click-to-edit"
+  ng-class="{ 'editable': !readonly, 'focus': focus }"
 >
-  <div ng-show="!readonly">
-    <span class="kf-click-to-edit-textarea kf-click-to-edit-textarea-tester {{ className }}">{{view.editableValue}}</span>
-    <textarea placeholder="{{ inputPlaceholder }}" class="kf-click-to-edit-textarea {{ className }}" ng-model="view.editableValue" ng-keydown="editEvent($event)" ng-blur="onBlur()" ng-style="view.textareaHeight"></textarea>
+  <div ng-show="!readonly" class="kf-click-to-edit-wrapper" ng-click="selectAll()">
+    <span class="kf-click-to-edit-textarea kf-click-to-edit-textarea-tester" ng-bind="view.editableValue"></span>
+    <textarea ng-attr-placeholder="{{ inputPlaceholder }}" class="kf-click-to-edit-textarea" ng-model="view.editableValue" ng-keydown="editEvent($event)" ng-focus="onFocus()" ng-blur="onBlur()" ng-style="view.textareaHeight"></textarea>
   </div>
-  <p class="kf-click-to-edit-p" ng-if="readonly && !linkable">{{ view.editableValue }}</p>
+  <p class="kf-click-to-edit-p" ng-if="readonly && !linkable" ng-bind="view.editableValue"></p>
   <p class="kf-click-to-edit-p" ng-if="readonly && linkable">
-    <a ng-href="{{value}}" target="_blank">
-      {{ view.editableValue }}
-    </a>
+    <a class="kf-click-to-edit-p-a" ng-href="{{ value }}" target="_blank" ng-bind="view.editableValue"></a>
   </p>
 </div>

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfile.styl
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfile.styl
@@ -1,3 +1,4 @@
 .kf-org-profile
   margin: 0 auto
   text-align: center
+  overflow-x: hidden // TODO(carlos): investigate why this is needed to prevent scroll

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.styl
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.styl
@@ -4,7 +4,6 @@ ophImageWidth = 100px
 .kf-oph
   background: pageHeaderColor
   color: #fff
-  position: relative
 
 .kf-oph-wrapper
   wrapper()
@@ -15,17 +14,6 @@ ophImageWidth = 100px
   padding-top: 50px
   max-width: 480px
   margin: 0 auto
-  display: flex
-  flex-direction: column
-
-  textarea.kf-edit-field
-    background: transparent
-
-  &.kf-editing
-    textarea.kf-edit-field
-      background: white
-      color: textDarkGrey
-
 
   .profile-image-widget
     width: ophImageWidth
@@ -36,18 +24,21 @@ ophImageWidth = 100px
     margin-bottom: 15px
 
 .kf-oph-upper-right
-  position: absolute
-  top: 15px
-  right: 0
-  left: 0
-  margin: auto 10px
-  text-align: right
   color: rgba(255,255,255,0.8)
+  margin: 0 20px
+  padding: 10px
+  border-top: 1px solid textLightGrey
+  border-bottom: 1px solid textLightGrey
 
   @media (min-width: 480px)
-    right: 25px
-    left: auto
-    margin: 0
+    position: absolute
+    top: 15px
+    right: 0
+    left: 0
+    margin: auto 10px
+    padding: 0
+    border: 0
+    text-align: right
 
   .kf-oph-credit-banner
     margin-top: 10px
@@ -62,116 +53,56 @@ ophImageWidth = 100px
 .kf-oph-invite-button.kf-link
   color: rgba(255, 255, 255, 0.8)
 
-  svg
-    fill: rgba(255, 255, 255, 0.8)
-
   &:hover
-    color: white
+    color: #fff
 
-    svg
-      fill: white
+  svg
+    fill: currentColor
 
-.kf-oph-pic-wrapper
-  position: relative
-  overflow: hidden
-  border-radius: 10px
-  cursor: pointer
+.kf-oph-input
+  margin: 0 5px
 
-.kf-oph-pic-wrapper:hover:before
-  content: 'Upload Logo'
-  position: absolute
-  right: 0
-  bottom: 0
-  left: 0
-  height: 50px
-  line-height: 50px
-  color: #000
-  background-color: rgba(255, 255, 255, .5);
-
-.kf-oph-pic-wrapper:hover:before:hover
-  background-color: rgba(255, 255, 255, 1);
-
-.kf-oph-about
-  flex: 1
-  text-align: left
-
-  .kf-oph-input
-    width: 100%
-    text-align: center
-
-  .kf-click-to-edit .kf-click-to-edit-p
-    text-align: center
-    width: 100%
-
-.kf-oph-about-info
-  margin-bottom: 40px
+  + .kf-oph-input
+    margin-top: 2px
 
 .kf-oph-name
-  line-height: 31px
   font-size: 30px
-  font-weight: normal
-  color: inherit
-  box-sizing: border-box
-
 
 .kf-oph-description
   color: #d8d8d8
   line-height: 1.6em
   font-size: 0.9em
   font-smoothing: antialiased
-  word-break: break-word
-  width: 100%
-  margin-bottom: 10px
-
-  &>a[href]
-    color: inherit
-
-    &:hover
-      text-decoration: underline
 
 .kf-oph-admin-link
-  margin-top: -24px
-  display: block
+  position: absolute
 
 .kf-oph-url
-.kf-click-to-edit-p
-  margin-top: 0
   color: lighten(accentGreen, 15%)
-
-  textarea, a
-    font-size: 0.85rem
-    color: lighten(accentGreen, 15%)
-    text-decoration: underline
-
-  a
-    text-decoration: none
-
-    &:hover
-      text-decoration: underline
+  font-size: 0.85rem
+  text-decoration: underline
 
 .kf-oph-stats
   text-align: center
-  margin: 10px auto 0
+  margin: 25px auto 0
 
   @media (max-height: uphSmallMaxDim) and (max-width: uphSmallMaxDim)
     &::before
       transform: scale(1,.5)  // half-pixel border workaround crbug.com/236371
 
 .kf-oph-stats-a
-  display: inline-block
+  display: inline-flex
   margin: 0 1px
   padding: 6px 14px
-  color: #9fa3aa
   background-color: alpha(#fff, 5%)
   border-top-left-radius: 5px
   border-top-right-radius: 5px
+  color: #9fa3aa
+  font-size: 14px
+  line-height: 24px
 
-  &:not(.active)[href]:hover
+  &:hover:not(.active)
     background-color: alpha(#fff, 10%)
-
-  &:not([href])
-    color: accentGreen
-    cursor: default
 
   &:focus
     outline: none
@@ -180,51 +111,48 @@ ophImageWidth = 100px
     background: appBackgroundColor
     color: textBlackColor
 
-    .kf-oph-stats-count
-      color: inherit
+  > * + *
+    margin-left: 5px
 
-  .kf-oph-stats-count
-  .kf-oph-stats-name
-    display: inline-block
-    vertical-align: middle
+@keyframes pop-up
+  0%
+    bottom: -40px
+    transform: scaleY(.5)
 
-.kf-oph-stats-name
-  line-height: 24px
-  font-size: 14px
+  75%
+    transform: scaleY(1.1)
+    bottom: 0
 
-.kf-oph-stats-count
-  color: #fff
-  line-height: 24px
-  font-size: 14px
-  margin-right: 5px
-
-  :not([href])>&
-    color: inherit
+  100%
+    transform: scaleY(1)
 
 .profile-image.editable
   overflow: hidden
   position: relative
 
-  &.default-image
-    &:after
-      bottom: 0
-
   &:after
     content: 'Upload new'
     position: absolute
     right: 5%
+    bottom: -50px
     left: 5%
-    background: white
-    font-size: 0.85rem
     padding: 7px
     background: secondaryTextGray
     border-top-left-radius: defaultBorderRadius
     border-top-right-radius: defaultBorderRadius
-    bottom: -50px
+    font-size: 0.85rem
     transition: bottom 0.25s ease-out
 
+  // Show 'Upload new' on hover
   &:hover
     &:after
+      bottom: 0
+
+  // Animate in 'Upload new' when the logo is the default
+  &.default-image
+    &:after
+      transform-origin: bottom
+      animation: pop-up ease-in-out .75s
       bottom: 0
 
 .kf-oph-upsell-invite .kf-tooltip-body

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
@@ -15,26 +15,23 @@
   <div class="kf-oph-wrapper">
     <div class="kf-oph-top">
       <div kf-profile-image readonly="readonly" profile="profile" upload-url="{{'/organizations/' + profile.id + '/avatar/upload'}}" pic-url="profile | pic:200"></div>
+      <div ng-if="isKifiAdmin">
+        <a class="kf-oph-admin-link" ng-href="https://admin.kifi.com/admin/organization/{{profile.id}}">♡</a>
+      </div>
       <div class="kf-oph-about">
         <div class="kf-oph-about-info">
-          <div class="kf-oph-name" kf-click-to-edit on-save="save" value="profile.name" class-name="'kf-oph-input'" readonly="readonly"></div>
+          <div class="kf-oph-name kf-oph-input" kf-click-to-edit on-save="save" value="profile.name" readonly="readonly"></div>
           <div
-            class="kf-oph-description"
+            class="kf-oph-description kf-oph-input"
             kf-click-to-edit
             on-save="save"
-            class-name="'kf-oph-input'"
             input-placeholder="'Description'"
             value="profile.description"
             readonly="readonly"
             ng-if="!(readonly && !profile.description.length)"
           ></div>
-          <div ng-if="isKifiAdmin">
-            <a class="kf-oph-admin-link" ng-href="https://admin.kifi.com/admin/organization/{{profile.id}}">♡</a>
-          </div>
-          <p class="kf-oph-url">
-            <span kf-click-to-edit on-save="save" readonly="readonly" class-name="'kf-oph-input'" input-placeholder="'Link (e.g. http://example.com)'" linkable="true" value="profile.site"></span>
-          </p>
-          <div class="kf-oph-upper-right">
+          <span class="kf-oph-url kf-oph-input" kf-click-to-edit on-save="save" readonly="readonly" input-placeholder="'Link (e.g. http://example.com)'" linkable="true" value="profile.site"></span>
+          <div class="kf-oph-upper-right" ng-if="canInvite || (viewer.membership && plan.showUpsells && billingState !== null)">
             <button ng-if="canInvite" class="kf-link kf-oph-invite-button" ng-click="goToMemberInvite()">
               <svg
                 kf-symbol-sprite
@@ -79,8 +76,8 @@
             ng-click="onClickTrack($event, 'clickedProfileLibraries')"
             ng-class="{ 'active': state.current.activetab === 'libraries' }"
           >
-            <div class="kf-oph-stats-count">{{profile.numLibraries|num}}</div>
-            <div class="kf-oph-stats-name" ng-pluralize count="profile.numLibraries" when="{'1':'Library', 'other':'Libraries'}"></div>
+            <span ng-bind="profile.numLibraries | num"></span>
+            <span ng-pluralize count="profile.numLibraries" when="{ '1': 'Library', 'other': 'Libraries' }"></span>
           </a>
           <div class="kf-oph-stats-a-members">
             <span
@@ -109,8 +106,8 @@
               ng-click="onClickTrack($event, 'clickedProfileMembers')"
               ng-class="{ 'active': state.current.activetab === 'members' }"
             >
-              <div class="kf-oph-stats-count">{{profile.numMembers|num}}</div>
-              <div class="kf-oph-stats-name" ng-pluralize count="profile.numMembers" when="{'1': 'Member', 'other':'Members'}"></div>
+              <span ng-bind="profile.numMembers | num"></span>
+              <span ng-pluralize count="profile.numMembers" when="{ '1': 'Member', 'other': 'Members' }"></span>
             </a>
           </div>
           <a


### PR DESCRIPTION
@andrewconner ( @camhashemi )

| Before | After |
| --- | --- |
| <img src="https://cloud.githubusercontent.com/assets/2363700/11048567/8172c55e-86ed-11e5-8dc7-5aa39e566f2b.png" width="100%"> | <img src="https://cloud.githubusercontent.com/assets/2363700/11048570/86889c8a-86ed-11e5-8c31-148f772c02e3.png" width="100%"> |
| <img src="https://cloud.githubusercontent.com/assets/2363700/11048575/8deca160-86ed-11e5-9a6b-da1c09374140.png" width="100%"> | <img src="https://cloud.githubusercontent.com/assets/2363700/11048577/9210fa16-86ed-11e5-967f-e1ba417e3d79.png" width="100%"> |

The features in this PR are: 
1. New styling border around the click-to-edit boxes for the org info. It's consistent with the bio-box on user profiles
2. The first click on the click-to-edit selects all the text. Subsequent clicks behave normally.
3. I also added an animate-in for the "Upload new" tab on the profile image.

This PR has a lot of code-cleanup on the org profile header.
