### PR TITLE
Flushing client caches when org is created.

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -1006,4 +1006,8 @@ class AdminUserController @Inject() (
     abookClient.hideOrganizationRecommendationForUser(userId, orgId)
     Redirect(com.keepit.controllers.admin.routes.AdminUserController.userView(userId))
   }
+
+  def flushClients(id: Id[User]) = AdminUserPage.async { implicit request =>
+    eliza.flush(id).map(_ => Ok)
+  }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -321,6 +321,10 @@ class OrganizationCommanderImpl @Inject() (
           val orgGeneralLibrary = libraryCommander.unsafeCreateLibrary(LibraryInitialValues.forOrgGeneralLibrary(org), org.ownerId)
           organizationAnalytics.trackOrganizationEvent(org, userRepo.get(request.requesterId), request)
 
+          session.onTransactionSuccess {
+            eliza.flush(request.requesterId)
+          }
+
           val orgView = getOrganizationViewHelper(org.id.get, Some(request.requesterId), None)
           Right(OrganizationCreateResponse(request, org, orgGeneralLibrary, orgView))
       }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -704,6 +704,7 @@ POST    /admin/user/:id/deactivate  @com.keepit.controllers.admin.AdminUserContr
 GET     /admin/user/:id/mixpanel/reset    @com.keepit.controllers.admin.AdminUserController.resetMixpanelProfile(id: Id[User])
 POST    /admin/user/:id/uservalue   @com.keepit.controllers.admin.AdminUserController.userValue(id: Id[User])
 POST    /admin/user/:id/username   @com.keepit.controllers.admin.AdminUserController.setUsername(id: Id[User])
+GET     /admin/user/:id/clientFlush @com.keepit.controllers.admin.AdminUserController.flushClients(id: Id[User])
 POST    /admin/unimpersonate        @com.keepit.controllers.admin.AdminAuthController.unimpersonate()
 GET    /admin/users/bumpSeq          @com.keepit.controllers.admin.AdminUserController.bumpUserSeq()
 GET     /admin/users/bumpConnSeq     @com.keepit.controllers.admin.AdminUserController.bumpUpSeqNumForConnections()

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -445,9 +445,6 @@ var socketHandlers = {
     } else {
       lightFlush();
     }
-    authenticate(function () {
-      log('[socket:flush] we\'re back');
-    });
   },
   experiments: function (exp) {
     log('[socket:experiments]', exp);


### PR DESCRIPTION
@eishay @leogrim 

Also exposes an admin endpoint to flush remotely, if we ever need to.
