### PR TITLE
ignore 'localhost' for NormalizedHostname airbrakes

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/classify/Domain.scala
+++ b/kifi-backend/modules/common/app/com/keepit/classify/Domain.scala
@@ -77,9 +77,9 @@ object NormalizedHostname extends Logging {
     Try(NormalizedHostname(IDN.toASCII(hostname).toLowerCase)).toOption
       .filter { hostname =>
         val isValidHostname = isValid(hostname.value)
-        if (!isValidHostname)  AirbrakeNotifierStatic.notify(s"found an invalid hostname $hostname, make sure this isn't stored in the DB as normalized", new Exception)
+        if (!isValidHostname && hostname.value != "localhost") AirbrakeNotifierStatic.notify(s"found an invalid hostname $hostname, make sure this isn't stored in the DB as normalized", new Exception)
         isValidHostname
-    }
+      }
   }
 
   implicit val format: Format[NormalizedHostname] = new Format[NormalizedHostname] {


### PR DESCRIPTION
@ryanpbrewster @leogrim 

I added this airbrake since it seems like our `NormalizedHostname` normalizer has been too lenient (no regex validation) and I want to make sure our data is clean. might be over-aggressive, let's see if we find anything.
