### PR TITLE
Verify join permission

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationPermission.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationPermission.scala
@@ -23,6 +23,7 @@ object OrganizationPermission extends Enumerator[OrganizationPermission] {
   case object VIEW_MEMBERS extends OrganizationPermission("view_members")
   case object VIEW_ORGANIZATION extends OrganizationPermission("view_organization")
   case object VIEW_SETTINGS extends OrganizationPermission("view_settings")
+  case object VERIFY_TO_JOIN extends OrganizationPermission("verify_to_join")
 
   def all: Set[OrganizationPermission] = _all.toSet
 

--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationSettings.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationSettings.scala
@@ -159,4 +159,10 @@ object Feature extends Enumerator[Feature] {
     val permission = OrganizationPermission.VIEW_SETTINGS
     val settings: Set[FeatureSetting] = Set(ADMINS, MEMBERS)
   }
+
+  case object VerifyToJoin extends Feature with FeatureWithPermissions {
+    val value = OrganizationPermission.VERIFY_TO_JOIN.value
+    val permission = OrganizationPermission.VERIFY_TO_JOIN
+    val settings: Set[FeatureSetting] = Set(DISABLED, ANYONE)
+  }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/PaidPlanFactory.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/PaidPlanFactory.scala
@@ -21,7 +21,8 @@ object PaidPlanFactory {
     Feature.CreateSlackIntegration -> FeatureSetting.DISABLED,
     Feature.EditOrganization -> FeatureSetting.ADMINS,
     Feature.ExportKeeps -> FeatureSetting.ADMINS,
-    Feature.ViewSettings -> FeatureSetting.MEMBERS
+    Feature.ViewSettings -> FeatureSetting.MEMBERS,
+    Feature.VerifyToJoin -> FeatureSetting.ANYONE
   ))
 
   def paidPlan(): PartialPaidPlan = {


### PR DESCRIPTION
@ryanpbrewster @leogrim this is separated from the actual implementation because (please correct me if I'm wrong) I need to:

1) deploy this code, 
2) update `editable_features` and `default_settings` for all plans, 
3) fire `AdminOrganizationController.applyDefaultSettingsToOrgConfigs()` to propagate the permission, 
4) deploy the implementation code (reading this new setting/permission)

it's been a while but I'm pretty sure that'll be safe
