### PR TITLE
Separating credit code acceptance with email sending

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileCreateCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileCreateCtrl.js
@@ -49,6 +49,7 @@ angular.module('kifi')
         }
         function next() {
           profileService.fetchMe();
+          profileService.fetchPrefs(); // To invalidate credit code, if any.
           $state.go('orgProfile.libraries', { handle: org.handle, openInviteModal: true, addMany: true  });
         }
       })


### PR DESCRIPTION
@leogrim @ryanpbrewster Got a 500 from the frontend when trying to create an team then apply a code. It failed when sending the email. Error id `fb11487a-7d68-4f85-80ca-ae5687807b66` if you want to look into it, but this should at least let the credit be applied without doing a 500 in this case. Thoughts?
