### PR TITLE
Made a bunch of library code a bit safer

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
@@ -137,11 +137,11 @@ class AdminLibraryController @Inject() (
         val allLibraryIds = pagedLibrariesById.keySet ++ topDailyFollower.map(_._1) ++ topDailyKeeps.map(_._1) ++ hotToday.map(_._1)
         val librariesById = {
           val missingLibraryIds = allLibraryIds -- pagedLibrariesById.keys
-          val missingLibraries = if (missingLibraryIds.nonEmpty) libraryRepo.getLibraries(missingLibraryIds) else Map.empty
+          val missingLibraries = if (missingLibraryIds.nonEmpty) libraryRepo.getActiveByIds(missingLibraryIds) else Map.empty
           pagedLibrariesById ++ missingLibraries
         }
         val usersById = userRepo.getAllUsers(librariesById.values.map(_.ownerId).toSeq)
-        librariesById.mapValues(lib => buildLibStatistic(lib, usersById(lib.ownerId)))
+        librariesById.map { case (libId, lib) => libId -> buildLibStatistic(lib, usersById(lib.ownerId)) }
       }
 
       val hotTodayWithStats = hotToday.map { case (libId, _, _, growth) => (growth, statsByLibraryId(libId)) }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -733,7 +733,7 @@ class KeepCommanderImpl @Inject() (
     val keep = keepRepo.save(k.withLibraries(libraryIds).withParticipants(userIds))
 
     userIds.foreach { userId => ktuCommander.internKeepInUser(keep, userId, keep.userId) }
-    val libraries = libraryRepo.getLibraries(libraryIds).values
+    val libraries = libraryRepo.getActiveByIds(libraryIds).values
     libraries.foreach { lib => ktlCommander.internKeepInLibrary(keep, lib, keep.userId) }
 
     keep

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
@@ -67,7 +67,7 @@ class KeepDecoratorImpl @Inject() (
       val entitiesFutures = augmentationFuture.map { augmentationInfos =>
         val idToLibrary = {
           val librariesShown = augmentationInfos.flatMap(_.libraries.map(_._1)).toSet ++ keepsSeq.flatMap(_.libraryId).toSet
-          db.readOnlyMaster { implicit s => libraryRepo.getLibraries(librariesShown) } //cached
+          db.readOnlyMaster { implicit s => libraryRepo.getActiveByIds(librariesShown) } //cached
         }
 
         val basicOrgByLibId = {
@@ -84,10 +84,11 @@ class KeepDecoratorImpl @Inject() (
           val keepers = keeps.map(_.userId).toSet // is this needed? need to double check, it may be redundant
           db.readOnlyMaster { implicit s => basicUserRepo.loadAll(keepersShown ++ libraryContributorsShown ++ libraryOwners ++ keepers) } //cached
         }
-        val idToBasicLibrary = idToLibrary.mapValues { library =>
-          val orgOpt = basicOrgByLibId.get(library.id.get)
-          val user = idToBasicUser(library.ownerId)
-          BasicLibrary(library, user, orgOpt.map(_.handle))
+        val idToBasicLibrary = idToLibrary.map {
+          case (libId, library) =>
+            val orgOpt = basicOrgByLibId.get(libId)
+            val user = idToBasicUser(library.ownerId)
+            libId -> BasicLibrary(library, user, orgOpt.map(_.handle))
         }
         val libraryCardByLibId = {
           val libraries = keeps.flatMap(_.libraryId.map(idToLibrary(_)))
@@ -133,7 +134,7 @@ class KeepDecoratorImpl @Inject() (
         val keepsInfo = (keeps zip colls, augmentationInfos, pageInfos zip sourceAttrs).zipped.map {
           case ((keep, collsForKeep), augmentationInfoForKeep, (pageInfoForKeep, sourceAttrOpt)) =>
             val keepers = perspectiveUserIdOpt.map { userId => augmentationInfoForKeep.keepers.filterNot(_._1 == userId) } getOrElse augmentationInfoForKeep.keepers
-            val keeps = allMyKeeps.get(keep.uriId) getOrElse Set.empty
+            val keeps = allMyKeeps.getOrElse(keep.uriId, Set.empty)
             val libraries = {
               def doShowLibrary(libraryId: Id[Library]): Boolean = {
                 // ensuring consistency of libraries returned by search with the user's latest database data (race condition)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepExportCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepExportCommander.scala
@@ -101,7 +101,7 @@ class KeepExportCommanderImpl @Inject() (
 
     val libIdsByKeep = ktlRepo.getAllByKeepIds(keeps.map(_.id.get).toSet).mapValues(ktls => ktls.map(_.libraryId))
     val idToLib = libraryRepo.getActiveByIds(libIdsByKeep.values.flatten.toSet)
-    val libsByKeepId = keeps.map { keep => keep.id.get -> libIdsByKeep(keep.id.get).map(idToLib(_)) }.toMap
+    val libsByKeepId = keeps.map { keep => keep.id.get -> libIdsByKeep(keep.id.get).flatMap(idToLib.get) }.toMap
     KeepExportResponse(keeps.sortBy(_.keptAt), tagsByKeepId, libsByKeepId)
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCardCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCardCommander.scala
@@ -201,7 +201,7 @@ class LibraryCardCommanderImpl @Inject() (
 
       val libIds = systemValueLibraries.keySet
       val libs = db.readOnlyReplica { implicit s =>
-        libraryRepo.getLibraries(libIds).values.toSeq.filter(_.visibility == LibraryVisibility.PUBLISHED)
+        libraryRepo.getActiveByIds(libIds).values.toSeq.filter(_.visibility == LibraryVisibility.PUBLISHED)
       }
       val infos: ParSeq[LibraryCardInfo] = db.readOnlyMaster { implicit s =>
         val owners = basicUserRepo.loadAll(libs.map(_.ownerId).toSet)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
@@ -142,7 +142,7 @@ class PageCommander @Inject() (
     val otherLibraryIds = libraries.filterNot(_._2 == userId).map(_._1)
     val memberLibraryIds = libraryMembershipRepo.getWithLibraryIdsAndUserId(otherLibraryIds.toSet, userId).filter(lm => lm._2.isDefined).keys
     val libraryIds = otherLibraryIds.diff(memberLibraryIds.toSeq)
-    val libraryMap = libraryRepo.getLibraries(libraryIds.toSet).filter(_._2.state == LibraryStates.ACTIVE)
+    val libraryMap = libraryRepo.getActiveByIds(libraryIds.toSet).filter(_._2.state == LibraryStates.ACTIVE)
     libraryIds.flatMap(libraryMap.get)
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/RecommendationsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/RecommendationsCommander.scala
@@ -68,14 +68,8 @@ class RecommendationsCommander @Inject() (
       val json = systemValueRepo.getValue(MarketingSuggestedLibrarySystemValue.systemValueName).get
       Json.fromJson[Seq[MarketingSuggestedLibrarySystemValue]](Json.parse(json)).get.map(lib => lib.id)
     }
-
-    val curatedLibraries = {
-      val libraryById = db.readOnlyReplica { implicit session => libRepo.getLibraries(curatedLibIds.toSet) }
-      curatedLibIds.map(libraryById)
-    }.filter { lib =>
-      lib.visibility == LibraryVisibility.PUBLISHED
-    }
-    curatedLibraries
+    val libraryById = db.readOnlyReplica { implicit session => libRepo.getActiveByIds(curatedLibIds.toSet) }
+    curatedLibIds.flatMap(libraryById.get).filter(_.visibility == LibraryVisibility.PUBLISHED)
   }
 
   def curatedPublicLibraryRecos(userId: Id[User]): Future[Seq[(Id[Library], FullLibRecoInfo)]] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/activity/UserLibrariesByRecentFollowersComponent.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/activity/UserLibrariesByRecentFollowersComponent.scala
@@ -27,7 +27,7 @@ class UserLibrariesByRecentFollowersComponent @Inject() (
 
   private def librariesToMembers(toUserId: Id[User], since: DateTime) = db.readOnlyReplica { implicit session =>
     val mostMembersLibraries = membershipRepo.mostMembersSinceForUser(10, since, toUserId).toMap
-    val libraries = libraryRepo.getLibraries(mostMembersLibraries.map(_._1).toSet)
+    val libraries = libraryRepo.getActiveByIds(mostMembersLibraries.keySet)
     val libToMembers = libraryInfoCommander.sortAndSelectLibrariesWithTopGrowthSince(mostMembersLibraries, since, (id: Id[Library]) => libraries(id).memberCount)
     (libToMembers, libraries)
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryImageController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryImageController.scala
@@ -91,7 +91,7 @@ class MobileLibraryImageController @Inject() (
     val libIds = idStrings.split('.').flatMap(id => Library.decodePublicId(PublicId[Library](id)).toOption)
     if (libIds.nonEmpty) {
       val accessibleLibIds = db.readOnlyReplica { implicit session =>
-        libraryRepo.getLibraries(libIds.toSet)
+        libraryRepo.getActiveByIds(libIds.toSet)
       } filter {
         case (_, lib) => libraryAccessCommander.canViewLibrary(request.userIdOpt, lib)
       } keySet

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/FeedController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/FeedController.scala
@@ -50,7 +50,7 @@ class FeedController @Inject() (
           db.readOnlyMaster { implicit ro => keepRepo.getCountByLibrary(libId) >= 3 } // if needed, can also filter by memberCount
       } map (_._1)
       val libMap = db.readOnlyReplica { implicit ro =>
-        libraryRepo.getLibraries(libIds.toSet)
+        libraryRepo.getActiveByIds(libIds.toSet)
       }
 
       val libs = libIds.map(libMap(_))

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryImageController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryImageController.scala
@@ -90,7 +90,7 @@ class LibraryImageController @Inject() (
     val libIds = idStrings.split('.').flatMap(id => Library.decodePublicId(PublicId[Library](id)).toOption)
     if (libIds.nonEmpty) {
       val accessibleLibIds = db.readOnlyReplica { implicit session =>
-        libraryRepo.getLibraries(libIds.toSet)
+        libraryRepo.getActiveByIds(libIds.toSet)
       } filter {
         case (_, lib) => libraryAccessCommander.canViewLibrary(request.userIdOpt, lib)
       } keySet

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/LibraryChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/LibraryChecker.scala
@@ -148,7 +148,7 @@ class LibraryChecker @Inject() (val airbrake: AirbrakeNotifier,
 
       val newLibraryKeepCount = keepRepo.getCountsByLibrary(libraryIds)
       val latestKeptAtMap = keepRepo.latestKeptAtByLibraryIds(libraryIds)
-      val librariesNeedingUpdate = libraryRepo.getLibraries(libraryIds)
+      val librariesNeedingUpdate = libraryRepo.getActiveByIds(libraryIds)
       (nextSeqNum, librariesNeedingUpdate, newLibraryKeepCount, latestKeptAtMap)
     }
     // sync library lastKept with most recent keep.lastKept
@@ -192,7 +192,7 @@ class LibraryChecker @Inject() (val airbrake: AirbrakeNotifier,
       val nextSeqNum = if (members.isEmpty) None else Some(members.map(_.seq).max)
       val libraryIds = members.map(_.libraryId).toSet
 
-      val libraries = libraryRepo.getLibraries(libraryIds)
+      val libraries = libraryRepo.getActiveByIds(libraryIds)
       val libraryMemberCounts = libraryMembershipRepo.countByLibraryId(libraryIds)
       (nextSeqNum, libraries, libraryMemberCounts)
     }


### PR DESCRIPTION
We shouldn't do things with inactive libraries. Somehow these ids are leaking
out, and there is code that is trying to use them. I made most of this code
more robust: where possible, it assumes that some of the library ids it has
could be invalid, and it does a `libraryIds.flatMap(libraryRepo.getActive)`
thing that drops the inactive ids.

@andrewconner @leogrim @camhashemi 
