### PR TITLE
unset as primary inactivated keeps

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -771,7 +771,7 @@ class KeepCommanderImpl @Inject() (
   }
   def changeUri(keep: Keep, newUri: NormalizedURI)(implicit session: RWSession): Unit = {
     if (keep.isInactive) {
-      val newKeep = keepRepo.save(keep.withNormUriId(newUri.id.get))
+      val newKeep = keepRepo.save(keep.withNormUriId(newUri.id.get).withPrimary(false))
       ktlCommander.syncKeep(newKeep)
       ktuCommander.syncKeep(newKeep)
     } else {


### PR DESCRIPTION
@andrewconner @leogrim @ryanpbrewster seems like this will fix https://fortytwo.airbrake.io/projects/91268/groups/1081513854301130421/notices/1555526903015163758

it already finds a primary for that uri/lib, we need to set one of the keeps to be inactive
