### PR TITLE
fix slack test

### DIFF
--- a/kifi-backend/modules/shoebox/test/com/keepit/slack/SlackIngestionCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/slack/SlackIngestionCommanderTest.scala
@@ -46,7 +46,7 @@ class SlackIngestionCommanderTest extends TestKitSupport with SpecificationLike 
             val x = inject[SlackChannelToLibraryRepo].get(integration.id.get)
             x.lastIngestingAt must beNone
             x.lastIngestedAt must beNone
-            ktlRepo.getCountByLibraryId(lib.id.get) === 1
+            ktlRepo.getCountByLibraryId(lib.id.get) === 0
           }
 
           val query = Query(Query.in(integration.slackChannelName), Query.hasLink)


### PR DESCRIPTION
@leogrim @ryanpbrewster think this was a typo, didn't see any keeps stored beforehand.
