### PR TITLE
use_strict broke firefox google inject

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.4.2
+version=3.4.3

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -25,7 +25,6 @@ $.fn.layout = function () {
 
 // We check the pattern because Chrome match/glob patterns aren't powerful enough. crbug.com/289057
 if (searchUrlRe.test(document.URL)) !function () {
-  'use strict';
   log('[google_inject]');
 
   var origin = location.origin;


### PR DESCRIPTION
@andrewconner not sure when this started, but strict-mode rules were causing SyntaxError exceptions in `google_inject.js` and Kifi wasn't showing in Google
