### PR TITLE
filter yourself from certain typeahead results

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/TypeaheadAdminController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/TypeaheadAdminController.scala
@@ -96,14 +96,15 @@ class TypeaheadAdminController @Inject() (
   }
 
   def contactSearch(userId: Id[User], query: String) = AdminUserAction.async { request =>
+
     abookServiceClient.prefixQuery(userId, query, None) map { hits =>
       log.info(s"[contactSearch($userId,$query)-LOCAL] res=(${hits.length});${hits.take(10).mkString(",")}")
       Ok(Json.toJson(hits))
     }
   }
 
-  def search(userId: Id[User], query: String, limit: Int, pictureUrl: Boolean, dedupEmail: Boolean) = AdminUserPage.async { request =>
-    typeaheadCommander.searchWithInviteStatus(userId, query, Some(limit), pictureUrl, dedupEmail) map { res => // hack
+  def search(userId: Id[User], query: String, limit: Int, pictureUrl: Boolean) = AdminUserPage.async { request =>
+    typeaheadCommander.searchWithInviteStatus(userId, query, Some(limit), pictureUrl) map { res => // hack
       Ok(
         Html("<table border=1><tr><td>label</td><td>networkType</td><td>score</td><td>status</td><td>value</td><td>image</td><td>email</td><td>inviteLastSentAt</td></tr>" +
           res.map(c => s"<tr><td>${c.label}</td><td>${c.networkType}</td><td>${c.score}</td><td>${c.status}</td><td>${c.value}</td><td>${c.image.getOrElse("")}</td><td>${c.email}</td><td>${c.inviteLastSentAt}</td></tr>").mkString("") +

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryMembershipCommander.scala
@@ -339,7 +339,7 @@ class LibraryMembershipCommanderImpl @Inject() (
 
   def suggestMembers(userId: Id[User], libraryId: Id[Library], query: Option[String], limit: Option[Int]): Future[Seq[MaybeLibraryMember]] = {
     val futureFriendsAndContacts = query.map(_.trim).filter(_.nonEmpty) match {
-      case Some(validQuery) => typeaheadCommander.searchFriendsAndContacts(userId, validQuery, limit)
+      case Some(validQuery) => typeaheadCommander.searchFriendsAndContacts(userId, validQuery, includeSelf = false, limit)
       case None => Future.successful(typeaheadCommander.suggestFriendsAndContacts(userId, limit))
     }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
@@ -241,7 +241,7 @@ class TypeaheadCommander @Inject() (
     }
   }
 
-  private def aggregate(userId: Id[User], q: String, limitOpt: Option[Int], dedupEmail: Boolean, contacts: Set[ContactType]): Future[Seq[NetworkTypeAndHit]] = {
+  private def aggregate(userId: Id[User], q: String, limitOpt: Option[Int], contacts: Set[ContactType]): Future[Seq[NetworkTypeAndHit]] = {
     implicit val prefix = LogPrefix(s"aggregate($userId,$q,$limitOpt)")
     // FB or LN
     val socialF = if (contacts.contains(ContactType.SOCIAL))
@@ -308,18 +308,18 @@ class TypeaheadCommander @Inject() (
 
     top flatMap {
       case (snType, hit) => hit.info match {
-        case e: RichContact =>
+        case e: RichContact if !e.userId.contains(userId) =>
           val (status, lastSentAt) = emailInvitesMap.get(e.email) map { inv => inviteStatus(inv) } getOrElse ("", None)
           Some(ConnectionWithInviteStatus(e.name.getOrElse(""), hit.score, SocialNetworks.EMAIL.name, None, emailId(e.email), status, None, lastSentAt))
 
-        case sci: SocialUserBasicInfo =>
+        case sci: SocialUserBasicInfo if !sci.userId.contains(userId) =>
           val (status, lastSentAt) = socialInvitesMap.get(sci.id) map { inv => inviteStatus(inv) } getOrElse ("", None)
           Some(ConnectionWithInviteStatus(sci.fullName, hit.score, sci.networkType.name, if (pictureUrl) sci.getPictureUrl(75, 75) else None, socialId(sci), status, None, lastSentAt))
 
-        case u: User =>
+        case u: User if !u.id.contains(userId) =>
           Some(ConnectionWithInviteStatus(u.fullName, hit.score, SocialNetworks.FORTYTWO.name, if (pictureUrl) u.pictureName.map(_ + ".jpg") else None, s"fortytwo/${u.externalId}", "joined"))
 
-        case bu: TypeaheadUserHit => // todo(Ray): uptake User API from search
+        case bu: TypeaheadUserHit if bu.userId != userId => // todo(Ray): uptake User API from search
           val name = s"${bu.firstName} ${bu.lastName}".trim // if not good enough, lookup User
           val picUrl = if (pictureUrl) Some(bu.pictureName) else None
           val frOpt = frMap.get(bu.userId)
@@ -332,7 +332,7 @@ class TypeaheadCommander @Inject() (
     }
   }
 
-  def searchWithInviteStatus(userId: Id[User], query: String, limit: Option[Int], pictureUrl: Boolean, dedupEmail: Boolean): Future[Seq[ConnectionWithInviteStatus]] = {
+  def searchWithInviteStatus(userId: Id[User], query: String, limit: Option[Int], pictureUrl: Boolean): Future[Seq[ConnectionWithInviteStatus]] = {
     implicit val prefix = LogPrefix(s"searchWIS($userId,$query,$limit)")
 
     val socialInvitesF = db.readOnlyMasterAsync { implicit ro =>
@@ -345,7 +345,7 @@ class TypeaheadCommander @Inject() (
     val q = query.trim
     if (q.length == 0) Future.successful(Seq.empty[ConnectionWithInviteStatus])
     else {
-      aggregate(userId, q, limit, dedupEmail, ContactType.getAll()) flatMap { top =>
+      aggregate(userId, q, limit, ContactType.getAll()) flatMap { top =>
         for {
           socialInvites <- socialInvitesF
           emailInvites <- emailInvitesF
@@ -377,8 +377,8 @@ class TypeaheadCommander @Inject() (
     (users, contacts)
   }
 
-  def searchFriendsAndContacts(userId: Id[User], query: String, limit: Option[Int]): Future[(Seq[(Id[User], BasicUser)], Seq[BasicContact])] = {
-    aggregate(userId, query, limit, true, Set(ContactType.KIFI_FRIEND, ContactType.EMAIL)).map { hits =>
+  def searchFriendsAndContacts(userId: Id[User], query: String, includeSelf: Boolean, limit: Option[Int]): Future[(Seq[(Id[User], BasicUser)], Seq[BasicContact])] = {
+    aggregate(userId, query, limit, Set(ContactType.KIFI_FRIEND, ContactType.EMAIL)).map { hits =>
       val (users, contacts) = hits.map(_._2.info).foldLeft((Seq.empty[User], Seq.empty[RichContact])) {
         case ((users, contacts), nextContact: RichContact) => (users, contacts :+ nextContact)
         case ((users, contacts), nextUser: User) => (users :+ nextUser, contacts)
@@ -386,17 +386,20 @@ class TypeaheadCommander @Inject() (
           airbrake.notify(new IllegalArgumentException(s"Unknown hit type: $nextHit"))
           (users, contacts)
       }
-      (users.map(user => user.id.get -> BasicUser.fromUser(user)), contacts.map(BasicContact.fromRichContact))
+      (
+        users.collect { case user if includeSelf || !user.id.contains(userId) => user.id.get -> BasicUser.fromUser(user) },
+        contacts.collect { case richContact if includeSelf || !richContact.userId.contains(userId) => BasicContact.fromRichContact(richContact) }
+      )
     }
   }
 
   def searchForContacts(userId: Id[User], query: String, limit: Option[Int]): Future[Seq[ContactSearchResult]] = {
     val friendsAndContactsF = query.trim match {
       case q if q.isEmpty =>
-        (Future.successful(suggestFriendsAndContacts(userId, limit)))
+        Future.successful(suggestFriendsAndContacts(userId, limit))
       case q =>
         // Start futures
-        val friends = searchFriendsAndContacts(userId, q, limit)
+        val friends = searchFriendsAndContacts(userId, q, includeSelf = true, limit)
 
         val startTime = System.currentTimeMillis()
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/TypeaheadController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/TypeaheadController.scala
@@ -18,8 +18,8 @@ class TypeaheadController @Inject() (
     commander: TypeaheadCommander,
     val userActionsHelper: UserActionsHelper) extends UserActions with ShoeboxServiceController with Logging {
 
-  def searchWithInviteStatus(query: Option[String], limit: Option[Int], pictureUrl: Boolean, dedupEmail: Boolean) = UserAction.async { request =>
-    commander.searchWithInviteStatus(request.userId, query.getOrElse(""), limit, pictureUrl, dedupEmail) map { res =>
+  def searchWithInviteStatus(query: Option[String], limit: Option[Int], pictureUrl: Boolean) = UserAction.async { request =>
+    commander.searchWithInviteStatus(request.userId, query.getOrElse(""), limit, pictureUrl) map { res =>
       Ok(Json.toJson(res))
     }
   }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -527,7 +527,7 @@ POST    /site/user/delighted/answer @com.keepit.controllers.website.UserControll
 POST    /site/user/delighted/cancel @com.keepit.controllers.website.UserController.cancelDelightedSurvey()
 POST    /site/user/close            @com.keepit.controllers.website.UserController.closeAccount()
 
-GET     /site/user/connections/all/search    @com.keepit.controllers.website.TypeaheadController.searchWithInviteStatus(query:Option[String], limit:Option[Int], pictureUrl:Boolean ?= true, dedupEmail:Boolean ?= true)
+GET     /site/user/connections/all/search    @com.keepit.controllers.website.TypeaheadController.searchWithInviteStatus(query:Option[String], limit:Option[Int], pictureUrl:Boolean ?= true)
 GET     /site/user/contacts/search  @com.keepit.controllers.website.TypeaheadController.searchForContacts(query:Option[String], limit:Option[Int])
 
 GET     /site/user/prefs            @com.keepit.controllers.website.UserController.getPrefs()
@@ -839,7 +839,7 @@ GET     /admin/typeahead                    @com.keepit.controllers.admin.Typeah
 GET     /admin/typeahead/userSearch         @com.keepit.controllers.admin.TypeaheadAdminController.userSearch(userId:Id[User], query:String ?= "")
 GET     /admin/typeahead/socialSearch       @com.keepit.controllers.admin.TypeaheadAdminController.socialSearch(userId:Id[User], query:String ?= "")
 GET     /admin/typeahead/contactSearch      @com.keepit.controllers.admin.TypeaheadAdminController.contactSearch(userId:Id[User], query:String ?= "")
-GET     /admin/typeahead/search             @com.keepit.controllers.admin.TypeaheadAdminController.search(userId:Id[User], query:String ?= "", limit:Int ?= 5, pictureUrl:Boolean ?= true, dedupEmail:Boolean ?= true)
+GET     /admin/typeahead/search             @com.keepit.controllers.admin.TypeaheadAdminController.search(userId:Id[User], query:String ?= "", limit:Int ?= 5, pictureUrl:Boolean ?= true)
 
 POST    /admin/typeahead/:filterType/refreshPrefixFilter        @com.keepit.controllers.admin.TypeaheadAdminController.refreshPrefixFilter(filterType:String)
 POST    /admin/typeahead/:filterType/refreshPrefixFiltersByIds  @com.keepit.controllers.admin.TypeaheadAdminController.refreshPrefixFiltersByIds(filterType:String)

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/TypeaheadControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/TypeaheadControllerTest.scala
@@ -89,8 +89,8 @@ class TypeaheadControllerTest extends Specification with ShoeboxTestInjector {
         inject[FakeUserActionsHelper].setUser(u1)
 
         @inline def search(query: String, limit: Int = 10): Seq[ConnectionWithInviteStatus] = {
-          val path = com.keepit.controllers.website.routes.TypeaheadController.searchWithInviteStatus(Some(query), Some(limit), false, true).url
-          val res = inject[TypeaheadController].searchWithInviteStatus(Some(query), Some(limit), false, true)(FakeRequest("GET", path))
+          val path = com.keepit.controllers.website.routes.TypeaheadController.searchWithInviteStatus(Some(query), Some(limit), false).url
+          val res = inject[TypeaheadController].searchWithInviteStatus(Some(query), Some(limit), false)(FakeRequest("GET", path))
           val s = contentAsString(res)
           Json.parse(s).as[Seq[ConnectionWithInviteStatus]] tap { res => log.info(s"[search($query,$limit)] res(len=${res.length}):$res") }
         }
@@ -169,8 +169,8 @@ class TypeaheadControllerTest extends Specification with ShoeboxTestInjector {
         inject[FakeUserActionsHelper].setUser(u1)
 
         @inline def search(query: String, limit: Int = 10): Seq[ConnectionWithInviteStatus] = {
-          val path = com.keepit.controllers.website.routes.TypeaheadController.searchWithInviteStatus(Some(query), Some(limit), false, true).url
-          val res = inject[TypeaheadController].searchWithInviteStatus(Some(query), Some(limit), false, true)(FakeRequest("GET", path))
+          val path = com.keepit.controllers.website.routes.TypeaheadController.searchWithInviteStatus(Some(query), Some(limit), false).url
+          val res = inject[TypeaheadController].searchWithInviteStatus(Some(query), Some(limit), false)(FakeRequest("GET", path))
           val s = contentAsString(res)
           Json.parse(s).as[Seq[ConnectionWithInviteStatus]] tap { res => log.info(s"[search($query,$limit)] res(len=${res.length}):$res") }
         }
@@ -239,8 +239,8 @@ class TypeaheadControllerTest extends Specification with ShoeboxTestInjector {
         inject[FakeUserActionsHelper].setUser(u1)
 
         @inline def search(query: String, limit: Int = 10): Seq[ConnectionWithInviteStatus] = {
-          val path = com.keepit.controllers.website.routes.TypeaheadController.searchWithInviteStatus(Some(query), Some(limit), false, true).url
-          val res = inject[TypeaheadController].searchWithInviteStatus(Some(query), Some(limit), false, true)(FakeRequest("GET", path))
+          val path = com.keepit.controllers.website.routes.TypeaheadController.searchWithInviteStatus(Some(query), Some(limit), false).url
+          val res = inject[TypeaheadController].searchWithInviteStatus(Some(query), Some(limit), false)(FakeRequest("GET", path))
           val s = contentAsString(res)
           Json.parse(s).as[Seq[ConnectionWithInviteStatus]] tap { res => log.info(s"[search($query,$limit)] res(len=${res.length}):$res") }
         }


### PR DESCRIPTION
@andrewconner @leogrim @ryanpbrewster  takes care of https://app.asana.com/0/32728208409723/61310533486775

I believe we want to keep your contacts / self-profile for the ext, this maintains that. But anything invite related should filter yourself.

![screen shot 2015-11-17 at 5 12 50 pm](https://cloud.githubusercontent.com/assets/8929238/11229874/c20db814-8d4e-11e5-8956-9afd9f3ba7f2.png)
