### PR TITLE
add catch all for typeahead filtering

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
@@ -448,7 +448,7 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
           users <- usersFut
           emails <- emailsFut
         } yield {
-          (users.map(_.userId), emails.map(_.info))
+          (users.collect { case hit if hit.userId != userId => hit.userId }, emails.collect { case hit if !hit.info.userId.contains(userId) => hit.info })
         }
     }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
@@ -325,6 +325,8 @@ class TypeaheadCommander @Inject() (
           val frOpt = frMap.get(bu.userId)
           Some(ConnectionWithInviteStatus(name, hit.score, snType.name, picUrl, s"fortytwo/${bu.externalId}", frOpt.map(_ => "requested").getOrElse("joined"), None, frOpt.map(_.createdAt)))
 
+        case _: RichContact | SocialUserBasicInfo | User | TypeaheadUserHit => None
+
         case _ =>
           airbrake.notify(new IllegalArgumentException(s"Unknown hit type: $hit"))
           None


### PR DESCRIPTION
@andrewconner @leogrim also added to hide yourself (and your emails) from org-invite typeaheads
