### PR TITLE
Making failed images show the link text instead

### DIFF
--- a/packrat/scripts/formatting.js
+++ b/packrat/scripts/formatting.js
@@ -109,7 +109,7 @@ var formatMessage = (function () {
       var escapedUri = Mustache.escape(uri);
       var escapedUrl = (scheme ? '' : 'http://') + escapedUri;
       parts[i] = '<a target="_blank" href="' + escapedUrl + '">' +
-        (imageUrlRe.test(uri) ? '<img class="kifi-image-in-message" src="' + escapedUrl + '"/>' : escapedUri);
+        (imageUrlRe.test(uri) ? '<img class="kifi-image-in-message" onerror="this.outerHTML=this.src" src="' + escapedUrl + '"/>' : escapedUri);
       parts[i+1] = '</a>';
     }
     for (i = 0; i < parts.length; i += 3) {


### PR DESCRIPTION
@cvializ Kind of a fun little hack. We embed images in messages, but at times, they fail to load because it wasn't an image to begin with (evernote is guilty of this). This basically replaces the image with text (it'll be linked because of the outer `<a>`). Should be safe because src is already escaped.
