### PR TITLE
Align the comment section with the card elements

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comments.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comments.styl
@@ -3,7 +3,7 @@
   width: 100%
   height: auto
   flex-direction: row
-  justify-content: space-around
+  justify-content: flex-end
 
   .kf-keep-comments
     display: flex
@@ -15,7 +15,8 @@
     border-bottom-left-radius: 5px
     border-bottom-right-radius: 5px
     background-color: #3e495508
-    padding: 10px
+    padding: 20px 20px 10px 15px
+    margin-top: -10px
 
     .kf-keep-comments-view-previous
       font-size: 14px
@@ -68,4 +69,3 @@
         padding-left: 10px
         color: #3e4955CC
         box-sizing: border-box
-


### PR DESCRIPTION
@DerekBurch @jaredpetker @andrewconner I thought I would align the UI elements in the comment area with the UI elements in the keeper card. What do you think?

| Before | After |
| --- | --- |
| <img width="100%" src="https://cloud.githubusercontent.com/assets/2363700/11518389/952afa94-9845-11e5-89ef-3b4ea60f3928.png"> | <img width="100%" src="https://cloud.githubusercontent.com/assets/2363700/11518388/9521ee54-9845-11e5-82dc-c6747f44a51a.png"> |
