### PR TITLE
Unify shoebox internal endpoints

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -59,7 +59,7 @@ object ParamValue {
   implicit def dateTimeToParam(dateTime: DateTime) = ParamValue(Some(dateTime.toStandardTimeString))
 }
 
-abstract class Method(name: String)
+sealed abstract class Method(name: String)
 case object GET extends Method("GET")
 case object POST extends Method("POST")
 case object PUT extends Method("PUT")
@@ -84,6 +84,7 @@ object Shoebox extends Service {
     def internNormalizedURI() = ServiceRoute(POST, "/internal/shoebox/database/internNormalizedURI")
     def getUsers(ids: String) = ServiceRoute(GET, "/internal/shoebox/database/getUsers", Param("ids", ids))
     def getUserIdsByExternalIds(ids: String) = ServiceRoute(GET, "/internal/shoebox/database/userIdsByExternalIds", Param("ids", ids))
+    def getUserIdsByExternalIdsNew() = ServiceRoute(POST, "/internal/shoebox/database/userIdsByExternalIdsNew")
     def getBasicUsers() = ServiceRoute(POST, "/internal/shoebox/database/getBasicUsers")
     def getEmailAddressesForUsers() = ServiceRoute(POST, "/internal/shoebox/database/getEmailAddressesForUsers")
     def getEmailAddressForUsers() = ServiceRoute(POST, "/internal/shoebox/database/getEmailAddressForUsers")

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -360,6 +360,13 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, impli
     Future.successful(ids)
   }
 
+  def getUserIdsByExternalIdsNew(extIds: Set[ExternalId[User]]): Future[Map[ExternalId[User], Id[User]]] = {
+    val idMap = extIds.map { id =>
+      id -> allUserExternalIds.getOrElse(id, throw new Exception(s"can't find id $id in $allUserExternalIds")).id.get
+    }.toMap
+    Future.successful(idMap)
+  }
+
   def getBasicUsers(userIds: Seq[Id[User]]): Future[Map[Id[User], BasicUser]] = {
     val basicUsers = userIds.map { id =>
       val dummyUser = User(

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -405,7 +405,7 @@ class MessagingCommander @Inject() (
   }
 
   def addParticipantsToThread(adderUserId: Id[User], threadExtId: ExternalId[MessageThread], newParticipantsExtIds: Seq[ExternalId[User]], emailContacts: Seq[BasicContact], orgs: Seq[PublicId[Organization]])(implicit context: HeimdalContext): Future[Boolean] = {
-    val newUserParticipantsFuture = shoebox.getUserIdsByExternalIds(newParticipantsExtIds)
+    val newUserParticipantsFuture = shoebox.getUserIdsByExternalIdsNew(newParticipantsExtIds.toSet).map(_.values.toSeq)
     val newNonUserParticipantsFuture = constructNonUserRecipients(adderUserId, emailContacts)
 
     val orgIds = orgs.map(o => Organization.decodePublicId(o)).filter(_.isSuccess).map(_.get)
@@ -591,7 +591,7 @@ class MessagingCommander @Inject() (
     initContext: HeimdalContext): Future[(ElizaMessage, Option[ElizaThreadInfo], Seq[MessageWithBasicUser])] = {
     val tStart = currentDateTime
 
-    val userRecipientsFuture = shoebox.getUserIdsByExternalIds(userExtRecipients)
+    val userRecipientsFuture = shoebox.getUserIdsByExternalIdsNew(userExtRecipients.toSet).map(_.values.toSeq)
     val nonUserRecipientsFuture = constructNonUserRecipients(userId, nonUserRecipients)
 
     val orgIds = validOrgRecipients.map(o => Organization.decodePublicId(o)).filter(_.isSuccess).map(_.get)

--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/util/SearchControllerUtil.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/util/SearchControllerUtil.scala
@@ -93,7 +93,7 @@ trait SearchControllerUtil {
   }
   private def getUserScope(userIdStr: String): Future[UserScope] = {
     Try(ExternalId[User](userIdStr)) match {
-      case Success(extUserId) => shoeboxClient.getUserIdsByExternalIds(Seq(extUserId)).imap { case Seq(userId) => UserScope(userId) }
+      case Success(extUserId) => shoeboxClient.getUserIdsByExternalIdsNew(Set(extUserId)).imap { case idMap => UserScope(idMap.values.head) }
       case Failure(e) => Future.failed(e)
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -36,7 +36,7 @@ import securesocial.core.IdentityId
 
 import scala.concurrent.Future
 import scala.util.{ Try, Failure, Success }
-import com.keepit.common.json.{ EitherFormat, TupleFormat }
+import com.keepit.common.json.{ TraversableFormat, EitherFormat, TupleFormat }
 
 class ShoeboxController @Inject() (
   db: Database,
@@ -218,11 +218,17 @@ class ShoeboxController @Inject() (
   }
 
   def getUserIdsByExternalIds(ids: String) = Action { request =>
-    val extUserIds = ids.split(',').map(_.trim).filterNot(_.isEmpty).map(ExternalId[User](_))
+    val extUserIds = ids.split(',').map(_.trim).filterNot(_.isEmpty).map(ExternalId[User])
     val users = db.readOnlyMaster { implicit s => //using cache
-      extUserIds.map { userRepo.getOpt(_).map(_.id.get.id) }.flatten
+      extUserIds.flatMap(userRepo.getOpt(_).map(_.id.get.id))
     }
     Ok(Json.toJson(users))
+  }
+  def getUserIdsByExternalIdsNew() = Action(parse.tolerantJson) { request =>
+    implicit val extIdToIdMapFormat = TraversableFormat.mapFormat[ExternalId[User], Id[User]](_.id, s => Try(ExternalId[User](s)).toOption)
+    val extUserIds = request.body.as[Set[ExternalId[User]]]
+    val idMap = db.readOnlyMaster { implicit s => userRepo.convertExternalIds(extUserIds) }
+    Ok(Json.toJson(idMap))
   }
 
   def getBasicUsers() = Action(parse.tolerantJson) { request =>

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -935,6 +935,7 @@ POST    /internal/shoebox/database/getNormalizedUriByUrlOrPrenormalize @com.keep
 POST    /internal/shoebox/database/internNormalizedURI                 @com.keepit.controllers.internal.ShoeboxController.internNormalizedURI()
 GET     /internal/shoebox/database/getUsers                            @com.keepit.controllers.internal.ShoeboxController.getUsers(ids: String)
 GET     /internal/shoebox/database/userIdsByExternalIds                @com.keepit.controllers.internal.ShoeboxController.getUserIdsByExternalIds(ids: String)
+POST    /internal/shoebox/database/userIdsByExternalIdsNew             @com.keepit.controllers.internal.ShoeboxController.getUserIdsByExternalIdsNew()
 POST    /internal/shoebox/database/getBasicUsers                       @com.keepit.controllers.internal.ShoeboxController.getBasicUsers()
 POST    /internal/shoebox/database/getEmailAddressesForUsers           @com.keepit.controllers.internal.ShoeboxController.getEmailAddressesForUsers()
 POST    /internal/shoebox/database/getEmailAddressForUsers             @com.keepit.controllers.internal.ShoeboxController.getEmailAddressForUsers()

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/DbRepo.scala
@@ -279,6 +279,7 @@ trait SeqNumberDbFunction[M <: ModelWithSeqNumber[M]] extends SeqNumberFunction[
 trait ExternalIdColumnFunction[M <: ModelWithExternalId[M]] { self: Repo[M] =>
   def get(id: ExternalId[M])(implicit session: RSession): M
   def getOpt(id: ExternalId[M])(implicit session: RSession): Option[M]
+  def convertExternalIds(ids: Set[ExternalId[M]])(implicit session: RSession): Map[ExternalId[M], Id[M]]
 }
 
 trait ExternalIdColumnDbFunction[M <: ModelWithExternalId[M]] extends ExternalIdColumnFunction[M] { self: DbRepo[M] =>
@@ -295,6 +296,10 @@ trait ExternalIdColumnDbFunction[M <: ModelWithExternalId[M]] extends ExternalId
   }
 
   def getOpt(id: ExternalId[M])(implicit session: RSession): Option[M] = getByExtIdCompiled(id).firstOption
+
+  def convertExternalIds(ids: Set[ExternalId[M]])(implicit session: RSession): Map[ExternalId[M], Id[M]] = {
+    rowsWithExternalIdColumn.filter(r => r.externalId.inSet(ids)).map(r => (r.externalId, r.id)).list.toMap
+  }
 }
 
 /**


### PR DESCRIPTION
@andrewconner @leogrim 
Keeping the old endpoints alive so that the deploy is entirely painless.
    1. Deploy shoebox with the new endpoints
    2. Deploy other services that use the new endpoints
    3. Deploy shoebox, killing the old endpoint
