### PR TITLE
Fix broken dropdown arrow in Firefox. Also uses arrow consistent with…

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/components/button.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/components/button.styl
@@ -40,6 +40,27 @@
   padding: 0
   margin: 0
 
+.kf-button-image
+  background: 0
+  border: 0
+  padding: 0
+  margin: 0
+
+  &:not([disabled]):not(.disabled)
+    &:hover
+      background: 0
+      opacity: .65
+
+    &:active
+      background: 0
+      opacity: 1
+
+  &.disabled,
+  &[disabled]
+    background: 0
+    filter: grayscale(1)
+    opacity: .5
+
 .kf-button-error
   color: errorRed
   box-shadow: 0 0 2px 0 #f00

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
@@ -13,7 +13,9 @@
         <div class="kf-keep-top-menu-container" kf-click-menu
              ng-if="menuItems.length > 0">
           <!-- This controls who gets the controls -->
-          <button class="kf-keep-top-menu-btn"></button>
+          <button class="kf-keep-top-menu-btn kf-button kf-button-image">
+            <svg kf-symbol-sprite icon="dropdown-arrow"></svg>
+          </button>
           <menu class="kf-dropdown-menu">
             <button class="kf-dropdown-menu-item"
                     ng-click="item.action($event, keep)"
@@ -113,7 +115,9 @@
              is-first-item="::isFirstItem"></div>
         <div class="kf-keep-card-menu-container" kf-click-menu ng-if="menuItems.length > 0">
           <!-- This controls who gets the controls -->
-          <button class="kf-keep-top-menu-btn"></button>
+          <button class="kf-keep-top-menu-btn kf-button kf-button-image">
+            <svg kf-symbol-sprite icon="dropdown-arrow"></svg>
+          </button>
           <menu class="kf-dropdown-menu">
             <button class="kf-dropdown-menu-item"
                     ng-click="item.action($event, keep)"

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.styl
@@ -263,39 +263,10 @@ maxWidthForNarrowKeep = keepCardMaxWidth + 2 * (keepSidePad + appSidePad1) - 1 /
 
 .kf-keep-top-menu-btn
   position: relative
-  width: 18px
-  height: 13px
-  border: 0
-  background: transparent
+  padding: 5px
 
-  &::before
-  &::after
-    content: ''
-    position: absolute;
-    left: 50%
-    width: 3px;
-    top: 4px
-    bottom: 4px
-    border-top-left-radius: 2px
-    border-top-right-radius: 2px
-    background: #c7c7c7
-    font-size: 0
-
-  &::before
-    transform: translate(-4px) rotate(-45deg)
-
-  &::after
-    transform: translate(2px) rotate(45deg)
-
-  &:hover::before
-  &:hover::after
-  &:focus::before
-  &:focus::after
-    background: #aaa
-
-  &:active::before
-  &:active::after
-   background: #888
+  svg
+    fill: #c7c7c7
 
 .kf-keep-keeper-pic
   display: table-cell


### PR DESCRIPTION
… team member item

@andrewconner @DerekBurch it's on the compact card too

| Before | After |
| --- | --- |
| <img width="100%" src="https://cloud.githubusercontent.com/assets/2363700/11539841/25bebc7e-98de-11e5-9c02-2df706e74cd0.png"> | <img width="100%" src="https://cloud.githubusercontent.com/assets/2363700/11539867/3bf48136-98de-11e5-8a6e-3f7eba77729a.png"> |
