### PR TITLE
Introduce KeepSourceAttribution.keepId

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/KeepSourceAttribution.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepSourceAttribution.scala
@@ -23,6 +23,7 @@ case class KeepSourceAttribution(
     id: Option[Id[KeepSourceAttribution]] = None,
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime,
+    keepId: Option[Id[Keep]],
     attribution: SourceAttribution,
     state: State[KeepSourceAttribution] = KeepSourceAttributionStates.ACTIVE) extends ModelWithState[KeepSourceAttribution] {
 

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/414.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/414.sql
@@ -1,0 +1,8 @@
+# SHOEBOX
+
+# --- !Ups
+
+ALTER TABLE keep_source_attribution ADD COLUMN keep_id BIGINT(20) DEFAULT NULL AFTER updated_at;
+insert into evolutions(name, description) values('414.sql', 'add keep_source_attribution.keep_id, remove bookmark.source_attribution_id');
+
+# --- !Downs

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepSourceAttributionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepSourceAttributionRepo.scala
@@ -32,18 +32,19 @@ class KeepSourceAttributionRepoImpl @Inject() (
 
   def unapplyToDbRow(attr: KeepSourceAttribution) = {
     val (attrType, js) = SourceAttribution.toJson(attr.attribution)
-    Some((attr.id, attr.createdAt, attr.updatedAt, attrType, js, attr.state))
+    Some((attr.id, attr.createdAt, attr.updatedAt, attr.keepId, attrType, js, attr.state))
   }
 
-  def applyFromDbRow(id: Option[Id[KeepSourceAttribution]], createdAt: DateTime, updatedAt: DateTime, attrType: KeepAttributionType, attrJson: JsValue, state: State[KeepSourceAttribution]) = {
+  def applyFromDbRow(id: Option[Id[KeepSourceAttribution]], createdAt: DateTime, updatedAt: DateTime, keepId: Option[Id[Keep]], attrType: KeepAttributionType, attrJson: JsValue, state: State[KeepSourceAttribution]) = {
     val attr = SourceAttribution.fromJson(attrType, attrJson).get
-    KeepSourceAttribution(id, createdAt, updatedAt, attr, state)
+    KeepSourceAttribution(id, createdAt, updatedAt, keepId, attr, state)
   }
 
   class KeepSourceAttributionTable(tag: Tag) extends RepoTable[KeepSourceAttribution](db, tag, "keep_source_attribution") {
+    def keepId = column[Option[Id[Keep]]]("keep_id", O.Nullable)
     def attributionType = column[KeepAttributionType]("attr_type", O.NotNull)
     def attributionJson = column[JsValue]("attr_json", O.NotNull)
-    def * = (id.?, createdAt, updatedAt, attributionType, attributionJson, state) <> ((applyFromDbRow _).tupled, unapplyToDbRow _)
+    def * = (id.?, createdAt, updatedAt, keepId, attributionType, attributionJson, state) <> ((applyFromDbRow _).tupled, unapplyToDbRow _)
   }
 
   def table(tag: Tag) = new KeepSourceAttributionTable(tag)

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepSourceAttributionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepSourceAttributionTest.scala
@@ -38,14 +38,14 @@ class KeepSourceAttributionTest extends Specification with ShoeboxTestInjector {
 
     "source attribtuion serialize" in {
       val attr = TwitterAttribution("505809542656303104", connerdelights)
-      val keepAttr = KeepSourceAttribution(attribution = attr)
+      val keepAttr = KeepSourceAttribution(keepId = None, attribution = attr)
       SourceAttribution.deprecatedWrites.writes(keepAttr) === Json.obj("twitter" -> Json.obj("idString" -> "505809542656303104", "screenName" -> connerdelights))
     }
 
     "twitter attribution persists in db" in {
       withDb() { implicit injector =>
         val attr = TwitterAttribution.fromRawTweetJson(tweetJs)
-        val keepAttr = KeepSourceAttribution(attribution = attr.get)
+        val keepAttr = KeepSourceAttribution(keepId = None, attribution = attr.get)
         val attrRepo = inject[KeepSourceAttributionRepo]
         db.readWrite { implicit s =>
           val saved = attrRepo.save(keepAttr)


### PR DESCRIPTION
@ryanpbrewster @andrewconner won't add a unique constraint just yet, will make it easy to backfill Twitter's attribution (now or later on, depending on priorities).
