### PR TITLE
Fix keep card comment on search page. Center all keep columns

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.styl
@@ -8,6 +8,8 @@ maxWidthForNarrowKeep = 559px // see derivation in keeps.styl
 minWidthForBoxed = maxWidthForNarrowKeep + 1px
 
 .kf-keep-container
+  display: inline-block
+  margin: 0 auto
   margin-bottom: 15px
 
 .kf-keep-body

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.styl
@@ -9,6 +9,7 @@ minWidthForBoxed = maxWidthForNarrowKeep + 1px
 
 .kf-keep-container
   display: inline-block
+  width: 100%
   margin: 0 auto
   margin-bottom: 15px
 

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.styl
@@ -7,6 +7,9 @@ maxWidthForNarrowKeep = keepCardMaxWidth + 2 * (keepSidePad + appSidePad1) - 1 /
 .kf-main-keeps
   position: relative
   padding-top: 10px
+  display: flex
+  align-items: center
+  flex-flow: column wrap
 
   @media (min-width: 480px)
     padding-top: 14px


### PR DESCRIPTION
@andrewconner @DerekBurch 

This should make the library page and search feel more responsive to users

| Before | After |
| --- | --- |
| <img width="100%" src="https://cloud.githubusercontent.com/assets/2363700/11540456/b09fad3c-98e1-11e5-8be5-7f2370986ed9.png"> | <img width="100%" src="https://cloud.githubusercontent.com/assets/2363700/11540457/b0a30888-98e1-11e5-86b9-ca8e9b858385.png"> |
