### PR TITLE
Center the slack icon relative to the rest of the text

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCardAttribution.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCardAttribution.styl
@@ -60,6 +60,8 @@
     margin-right: 6px
 
 .kf-keep-card-attribution-slack-icon
+  position: relative
+  top: 4px
   width: 20px
   height: 20px
   display: inline-block


### PR DESCRIPTION
@andrewconner another small change, but it's a detail that makes it look cleaner

| Before | After |
| --- | --- |
| <img width="100%" src="https://cloud.githubusercontent.com/assets/2363700/11569115/ea9361c8-99a4-11e5-9002-f9ee3d0b31c8.png"> | <img width="100%" src="https://cloud.githubusercontent.com/assets/2363700/11569166/3bcf8076-99a5-11e5-880b-57fd3a034ca1.png"> |
