### PR TITLE
More admin migration for notes/tags

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxDataPipeController.scala
@@ -1,6 +1,7 @@
 package com.keepit.controllers.internal
 
 import com.keepit.classify.{ NormalizedHostname, DomainInfo, DomainRepo, Domain }
+import com.keepit.commanders.Hashtags
 import com.keepit.common.akka.SafeFuture
 import com.keepit.common.db.{ Id, SequenceNumber }
 import com.keepit.common.service.RequestConsolidator
@@ -189,7 +190,16 @@ class ShoeboxDataPipeController @Inject() (
         val changedKeeps = keepRepo.getBySequenceNumber(seqNum, fetchSize)
         val attributionById = sourceRepo.getByKeepIds(changedKeeps.flatMap(_.id).toSet)
         changedKeeps.map { keep =>
-          val (source, tags) = if (keep.isActive) (attributionById.get(keep.id.get), collectionRepo.getHashtagsByKeepId(keep.id.get)) else (None, Set.empty[Hashtag])
+          val tagsFromHashtags = Hashtags.findAllHashtagNames(keep.note.getOrElse("")).map(Hashtag.apply)
+          val tagsFromCollections = collectionRepo.getHashtagsByKeepId(keep.id.get)
+          if (tagsFromHashtags != tagsFromCollections) {
+            // For my own edification for now. Our data is messed up, so this will happen for most imported, tagged keeps.
+            // I want to read what sort of differences there are. Until I add an auto-fixer, just log it
+            // and let search benefit from the combined set.
+            log.info(s"[getKeepsAndTagsChanged] Tag mismatch for ${keep.id.get}: $tagsFromHashtags vs $tagsFromCollections")
+          }
+          val allTags = tagsFromHashtags ++ tagsFromCollections
+          val (source, tags) = if (keep.isActive) (attributionById.get(keep.id.get), allTags) else (None, Set.empty[Hashtag])
           KeepAndTags(keep, source, tags)
         }
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/CollectionRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/CollectionRepo.scala
@@ -134,19 +134,6 @@ class CollectionRepoImpl @Inject() (
 
   override def save(model: Collection)(implicit session: RWSession): Collection = {
     val newModel = model.copy(seq = deferredSeqNum())
-    session.onTransactionSuccess {
-      Try {
-        val tag = SendableTag.from(model.summary)
-        if (model.state == CollectionStates.INACTIVE) {
-          elizaServiceClient.sendToUser(model.userId, Json.arr("remove_tag", tag))
-        } else if (model.id == None) {
-          elizaServiceClient.sendToUser(model.userId, Json.arr("create_tag", tag))
-        } else {
-          //elizaServiceClient.sendToUser(model.userId, Json.arr("rename_tag", tag))
-          // Do not update clients right now.
-        }
-      }
-    }
     super.save(newModel)
   }
 
@@ -172,7 +159,7 @@ class CollectionRepoImpl @Inject() (
   }
 
   def getHashtagsByKeepIds(keepIds: Set[Id[Keep]])(implicit session: RSession): Map[Id[Keep], Seq[Hashtag]] = {
-    if (keepIds.size == 0) {
+    if (keepIds.nonEmpty) {
       Map.empty[Id[Keep], Seq[Hashtag]]
     } else {
       import com.keepit.common.db.slick.StaticQueryFixed.interpolation

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -594,7 +594,7 @@ GET     /admin/bookmarks/editWithUri @com.keepit.controllers.admin.AdminBookmark
 POST    /admin/uri/disable/:id      @com.keepit.controllers.admin.AdminBookmarksController.disableUrl(id: Id[NormalizedURI])
 POST    /admin/bookmarks/inactive   @com.keepit.controllers.admin.AdminBookmarksController.inactive(id: Id[Keep])
 POST    /admin/bookmarks/special    @com.keepit.controllers.admin.AdminBookmarksController.www$youtube$com$watch$v$otCpCn0l4Wo(id: Id[Keep])
-POST    /admin/bookmarks/reprocessNotes @com.keepit.controllers.admin.AdminBookmarksController.reprocessNotesOfKeeps()
+POST    /admin/bookmarks/reprocessNotes @com.keepit.controllers.admin.AdminBookmarksController.reprocessNotesOfKeeps(appendTagsToNote: Boolean)
 POST    /admin/bookmarks/replaceTags @com.keepit.controllers.admin.AdminBookmarksController.replaceTagOnKeeps()
 POST    /admin/bookmarks/removeTag  @com.keepit.controllers.admin.AdminBookmarksController.removeTagFromKeeps()
 GET     /admin/bookmarks/userKeywords @com.keepit.controllers.admin.AdminBookmarksController.userBookmarkKeywords


### PR DESCRIPTION
@leogrim Just an improved admin endpoint for me to fix tags.

Additionally, some logging in the data pipe controller for when tags between the note and Collection model mismatch, so I can get an idea how often which is wrong.
