### PR TITLE
Team-visible icon was missing in firefox with border-radius rule

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibraries.styl
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfileLibraries.styl
@@ -333,13 +333,8 @@ lockRadius = 14px
 .kf-upl-card-public
 .kf-upl-card-org-private
   display: inline-block
-  vertical-align: middle
   width: 22px
   height: 22px
-  border-radius: 50%
-  background-position: center 6px
-  background-size: auto 14px
-  background-repeat: no-repeat
   fill: white
 
   &:not(:first-child)


### PR DESCRIPTION
found only in firefox nightly, but these rules aren't needed any more anyway
