### PR TITLE
Fixing client deleting of tags (which did nothing previously), exposing rename

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/CollectionCommander.scala
@@ -80,13 +80,6 @@ class CollectionCommander @Inject() (
     searchClient.updateKeepIndex()
   }
 
-  def undeleteCollection(collection: Collection)(implicit context: HeimdalContext): Unit = {
-    db.readWrite { implicit s =>
-      collectionRepo.save(collection.copy(state = CollectionStates.ACTIVE, createdAt = clock.now()))
-    }
-    searchClient.updateKeepIndex()
-  }
-
   def getBasicCollections(ids: Seq[Id[Collection]]): Seq[BasicCollection] = {
     db.readOnlyMaster { implicit session =>
       ids.map { id =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/KeepsController.scala
@@ -37,6 +37,7 @@ class KeepsController @Inject() (
   clock: Clock,
   heimdalContextBuilder: HeimdalContextBuilderFactory,
   airbrake: AirbrakeNotifier,
+  keepToCollectionRepo: KeepToCollectionRepo,
   implicit val publicIdConfig: PublicIdConfiguration)
     extends UserActions with ShoeboxServiceController {
 
@@ -131,18 +132,26 @@ class KeepsController @Inject() (
   def deleteCollection(id: ExternalId[Collection]) = UserAction { request =>
     db.readOnlyMaster { implicit s => collectionRepo.getByUserAndExternalId(request.userId, id) } map { coll =>
       implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
+      val keepIds = db.readOnlyReplica { implicit session =>
+        keepToCollectionRepo.getKeepsForTag(coll.id.get).toSet
+      }
       collectionCommander.deleteCollection(coll)
-      Ok(Json.obj("deleted" -> coll.name))
+      val cnt = keepsCommander.removeTagFromKeeps(keepIds, coll.name)
+      Ok(Json.obj("deleted" -> coll.name, "cnt" -> cnt))
     } getOrElse {
       NotFound(Json.obj("error" -> s"Collection not found for id $id"))
     }
   }
 
-  def undeleteCollection(id: ExternalId[Collection]) = UserAction { request =>
-    db.readOnlyMaster { implicit s => collectionRepo.getByUserAndExternalId(request.userId, id, Some(CollectionStates.ACTIVE)) } map { coll =>
+  def renameCollection(id: ExternalId[Collection]) = UserAction(parse.json) { request =>
+    val newTagName = (request.body \ "newTagName").as[String].trim
+    db.readOnlyMaster { implicit s => collectionRepo.getByUserAndExternalId(request.userId, id) } map { coll =>
       implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
-      collectionCommander.undeleteCollection(coll)
-      Ok(Json.obj("undeleted" -> coll.name))
+      val keepIds = db.readOnlyReplica { implicit session =>
+        keepToCollectionRepo.getKeepsForTag(coll.id.get).toSet
+      }
+      val cnt = keepsCommander.replaceTagOnKeeps(keepIds, coll.name, Hashtag(newTagName))
+      Ok(Json.obj("deleted" -> coll.name, "cnt" -> cnt))
     } getOrElse {
       NotFound(Json.obj("error" -> s"Collection not found for id $id"))
     }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -395,7 +395,7 @@ GET     /site/keeps/:id                  @com.keepit.controllers.website.KeepsCo
 
 GET     /site/collections/page      @com.keepit.controllers.website.KeepsController.page(sort: String ?= "used", offset : Int ?= 0, pageSize: Int ?= 0)
 POST    /site/collections/:id/delete @com.keepit.controllers.website.KeepsController.deleteCollection(id: ExternalId[Collection])
-POST    /site/collections/:id/undelete @com.keepit.controllers.website.KeepsController.undeleteCollection(id: ExternalId[Collection])
+POST    /site/collections/:id/rename @com.keepit.controllers.website.KeepsController.renameCollection(id: ExternalId[Collection])
 GET     /site/collections/search    @com.keepit.controllers.website.KeepsController.searchUserTags(query: String, limit: Option[Int] = None)
 
 #### Deprecated: use /site/user-or-org/:handle/libraries/:slug


### PR DESCRIPTION
Previously, deleting a tag just deleted the collection, but didn't bother to change keeps at all. Funny how long it's been broken.

Admin tag rename seems to work well, so might as well expose it. It does assume that KeepToCollection is accurate, so reprocessing note is needed for any tags in the note, but not in KeepToCollection.

@leogrim 
