### PR TITLE
remove team stuff from verification email

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationDomainOwnershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationDomainOwnershipCommander.scala
@@ -96,10 +96,10 @@ class OrganizationDomainOwnershipCommanderImpl @Inject() (
       }
     }
 
-    db.readWriteAsync { implicit session =>
-      val canVerifyToJoin = orgConfigurationRepo.getByOrgId(orgId).settings.settingFor(Feature.JoinByVerifying).contains(FeatureSetting.NONMEMBERS)
-      if (canVerifyToJoin) sendVerificationEmailsToAllPotentialMembers(ownership)
-    }
+    //    db.readWriteAsync { implicit session =>
+    //      val canVerifyToJoin = orgConfigurationRepo.getByOrgId(orgId).settings.settingFor(Feature.JoinByVerifying).contains(FeatureSetting.NONMEMBERS)
+    //      if (canVerifyToJoin) sendVerificationEmailsToAllPotentialMembers(ownership)
+    //    }
 
     ownership
   }
@@ -111,7 +111,7 @@ class OrganizationDomainOwnershipCommanderImpl @Inject() (
         !userEmail.address.address.contains("+test@kifi.com") && userEmail.lastVerificationSent.forall(lastSent => lastSent.plusDays(1).isBefore(currentDateTime)) &&
           !orgMembers.exists(_.userId == userEmail.userId) && !userValueRepo.getValue(userEmail.userId, UserValues.hideEmailDomainOrganizations).as[Set[Id[Organization]]].contains(ownership.organizationId)
       }
-    usersToEmail.foreach(userEmailAddressCommander.sendVerificationEmailHelper)
+    usersToEmail.foreach(???)
   }
 
   def removeDomainOwnership(request: OrganizationDomainRemoveRequest): Option[OrganizationFail] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -536,10 +536,7 @@ class AuthHelper @Inject() (
   }
 
   private def unsafeVerifyEmail(email: UserEmailAddress): Unit = {
-    db.readWrite(attempts = 3) { implicit s =>
-      userEmailAddressCommander.saveAsVerified(email)
-      orgDomainOwnershipCommander.autoJoinOrgViaEmail(email)
-    }
+    db.readWrite(attempts = 3)(implicit s => userEmailAddressCommander.saveAsVerified(email))
     orgDomainOwnershipCommander.addOwnershipsForPendingOrganizations(email.userId, email.address).map(_ => ())
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/EmailTestController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/EmailTestController.scala
@@ -75,7 +75,7 @@ class EmailTestController @Inject() (
         implicit val config = PublicIdConfiguration("secret key")
         val invite = LibraryInvite(libraryId = libraryId, inviterId = userId, emailAddress = Some(sendTo), userId = None, access = LibraryAccess.READ_ONLY, message = msg)
         emailSenderProvider.libraryInvite.sendInvite(invite).map(_.get)
-      case "confirm" => emailSenderProvider.confirmation.sendToUser(userId, sendTo, verificationCode, orgId.toSet)
+      case "confirm" => emailSenderProvider.confirmation.sendToUser(userId, sendTo, verificationCode)
       case "tip" if tip.isDefined =>
         val emailTip = EmailTip(tip.get).get
         testEmailTip(Left(userId), emailTip)

--- a/kifi-backend/modules/shoebox/app/views/email/verifyEmail.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/verifyEmail.scala.html
@@ -1,7 +1,5 @@
-@(toUserId: Id[User], verifyUrl: String, domainOwnerIds: Set[Id[Organization]])
+@(toUserId: Id[User], verifyUrl: String)
 @import com.keepit.common.mail.template.helpers._
-
-@orgNamesAndLinks = @{domainOwnerIds.map { orgId => (organizationName(orgId), organizationLink(orgId, None, "domainOwnerOrg")) } }
 
 <div style="color:#333;font:13px 'Helvetica Neue',Helvetica,Arial,sans-serif;padding:20px;">
 
@@ -10,13 +8,6 @@
 <p>To protect your privacy and security, please confirm your email address by clicking the link below:</p>
 
 <p><a href="@verifyUrl">@verifyUrl</a></p>
-
-@if(orgNamesAndLinks.nonEmpty) {
-<p>Upon confirmation, you'll be added to these teams:</p>
-@for(org <- orgNamesAndLinks) {
-<p><a href="@{org._2}">@{org._1}</a></p>
-}
-}
 
 <p>We look forward seeing you on Kifi,</p>
 

--- a/kifi-backend/modules/shoebox/app/views/email/verifyEmailText.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/verifyEmailText.scala.html
@@ -1,18 +1,10 @@
-@(toUserId: Id[User], verifyUrl: String, domainOwnerIds: Set[Id[Organization]])
+@(toUserId: Id[User], verifyUrl: String)
 @import com.keepit.common.mail.template.helpers._
-@orgNames = @{domainOwnerIds.map(orgId => organizationName(orgId))}
 
 Hi @firstName(toUserId),
 
 To protect your privacy and security, please confirm your email address by clicking the link below:
 @verifyUrl
-
-@if(orgNames.nonEmpty) {
-Upon confirmation, you'll become a member of these teams:
-@for(orgName <- orgNames) {
-  @orgName
-}
-}
 
 We look forward seeing you on Kifi,
 


### PR DESCRIPTION
@andrewconner @leogrim 

first part of https://app.asana.com/0/32728208409723/71155988168993

also stopped sending the email to everybody when you add a domain, until the new email is created and we decide how we want to go about that.
