### PR TITLE
Error recovery for batch failure on keep note persistence

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -779,8 +779,9 @@ class KeepCommanderImpl @Inject() (
           val newNote = Hashtags.addHashtagsToString(keep.note.getOrElse(""), tagsFromCollections.toSeq)
           if (keep.note.getOrElse("").toLowerCase != newNote.toLowerCase) {
             log.info(s"[autoFixKeepNoteAndTags] (${keep.id.get}) Previous note: '${keep.note.getOrElse("")}', new: '$newNote'")
-            Try(updateKeepNote(keep.userId, keep, newNote, freshTag = false)).recover { case ex: Throwable =>
-              log.warn(s"[autoFixKeepNoteAndTags] (${keep.id.get}) Couldn't update note", ex)
+            Try(updateKeepNote(keep.userId, keep, newNote, freshTag = false)).recover {
+              case ex: Throwable =>
+                log.warn(s"[autoFixKeepNoteAndTags] (${keep.id.get}) Couldn't update note", ex)
             }
           }
         }


### PR DESCRIPTION
When batch fails, try a separate db transaction, since this is deadlock prone (renormalization, seq num changes, etc).
