### PR TITLE
When ContentType throws, use a sane default

### DIFF
--- a/kifi-backend/modules/rover/app/com/keepit/rover/fetcher/apache/ApacheFetchResponse.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/fetcher/apache/ApacheFetchResponse.scala
@@ -7,12 +7,15 @@ import org.apache.http.StatusLine
 import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.util.EntityUtils
 import org.apache.http.entity.ContentType
+import org.apache.http.Consts.UTF_8
+
+import scala.util.Try
 
 class ApacheFetchResponse(response: CloseableHttpResponse) {
   def getStatusLine: StatusLine = response.getStatusLine
 
   def info: FetchResponseInfo = {
-    val contentType = ContentType.getOrDefault(response.getEntity)
+    val contentType = Try(ContentType.getOrDefault(response.getEntity)).getOrElse(new ContentType("text/html", UTF_8))
     FetchResponseInfo(
       getStatusLine.getStatusCode,
       getStatusLine.toString,

--- a/kifi-backend/modules/rover/app/com/keepit/rover/fetcher/apache/ApacheFetchResponse.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/fetcher/apache/ApacheFetchResponse.scala
@@ -15,7 +15,7 @@ class ApacheFetchResponse(response: CloseableHttpResponse) {
   def getStatusLine: StatusLine = response.getStatusLine
 
   def info: FetchResponseInfo = {
-    val contentType = Try(ContentType.getOrDefault(response.getEntity)).getOrElse(new ContentType("text/html", UTF_8))
+    val contentType = Try(ContentType.getOrDefault(response.getEntity)).getOrElse(ContentType.create("text/html", UTF_8))
     FetchResponseInfo(
       getStatusLine.getStatusCode,
       getStatusLine.toString,

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
@@ -540,7 +540,6 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         val newOrgSettings = db.readOnlyMaster { implicit session => orgConfigRepo.getByOrgId(org.id.get).settings.withFeatureSetTo(Feature.JoinByVerifying -> FeatureSetting.NONMEMBERS) }
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, owner.id.get, newOrgSettings)) must beRight
 
-
         val response2 = authController.verifyEmail(userEmail.verificationCode.get, Some(orgPubId.id))(request)
         Await.ready(response2, Duration(5, "seconds"))
 


### PR DESCRIPTION
@leogrim Seems like this happens, and it's nearly always because of weird charsets. Examples:

throws `IllegalCharsetNameException` because of `UTF-8'` (with the extra quote)
throws `UnsupportedCharsetException` because of `pl` (Polish isn't a standard charset)

Just falling back to `UTF-8` and `text/html` so it doesn't blow the whole doc. Would you prefer `test/plain`? That's Apache's default, but I _imagine_ most of these are html.
