### PR TITLE
add padding to bottom of keep comments on mobile web

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keeps/keeps.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keeps.styl
@@ -191,7 +191,7 @@ maxWidthForNarrowKeep = keepCardMaxWidth + 2 * (keepSidePad + appSidePad1) - 1 /
     border-top-left-radius: 0
 
   @media (max-width: maxWidthForNarrowKeep)
-    padding-bottom: 0
+    padding-bottom: 12px
 
     &>.kf-keep-body
       margin-left: -(keepSidePad)


### PR DESCRIPTION
@cvializ @andrewconner @eishay 

I'm guessing that the padding was set to 0 because we didn't have comments before, and the keep card already had it's own padding there. this fixes keep cards on the feed as well.
![screen shot 2015-12-08 at 10 12 28 am](https://cloud.githubusercontent.com/assets/8929238/11664101/a037986c-9d94-11e5-91cb-388751f6e671.png)
