### PR TITLE
Bump to 3.4.8 to release star fix

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.4.7
+version=3.4.8


### PR DESCRIPTION
@andrewconner I QA'd the Firefox bookmarks changes (tags are correct, no default Firefox bookmarks, a large number are all kept) to make sure the new API is equivalent, but a second set of eyes couldn't hurt if you have time.
