### PR TITLE
dynamically route org "Settings" tab depending on permissions

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.js
@@ -194,6 +194,8 @@ angular.module('kifi')
       scope.onCreditBannerEarnMore = function () {
         $state.go('orgProfile.settings.credits');
       };
+
+      scope.settingsRoute = scope.viewer.permissions.indexOf(ORG_PERMISSION.VIEW_SETTINGS) !== -1 ? 'orgProfile.settings.team' : 'orgProfile.settings.credits'
     }
   };
 }]);

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.tpl.html
@@ -112,7 +112,7 @@
           </div>
           <a
             class="kf-oph-stats-a kf-button-textonly"
-            ui-sref="orgProfile.settings.team"
+            ui-sref="{{ settingsRoute }}"
             ng-click="onClickTrack($event, 'clickedProfileSettings')"
             ng-class="{ 'active': state.current.activetab ==='settings'}"
             ng-if="viewer.permissions.indexOf(ORG_PERMISSION.REDEEM_CREDIT_CODE) !== -1"

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettings.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettings.tpl.html
@@ -6,7 +6,7 @@
           <h1>Settings</h1>
         </div>
         <ul>
-          <li class="kf-ops-nav-item" ng-class="{ 'kf-ops-nav-active': state.current.activenav === 'team-settings' }">
+          <li class="kf-ops-nav-item" ng-if="canViewPrivileges" ng-class="{ 'kf-ops-nav-active': state.current.activenav === 'team-settings' }">
             <a class="kf-link" ng-click="onClickTrack($event, 'clickPrivileges', 'main')" ui-sref="orgProfile.settings.team({ '#': 's-' })">Member Privileges</a>
           </li>
           <!-- sublisting -->

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettingsCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettingsCtrl.js
@@ -8,7 +8,8 @@ angular.module('kifi')
   function ($window, $rootScope, $scope, $timeout, $state,
             profileService, orgProfileService, ORG_PERMISSION, $location) {
     $scope.state = $state;
-    $scope.settings = $scope.settings.settings;
+    $scope.settings = ($scope.settings && $scope.settings.settings) || [];
+    $scope.canViewPrivileges = ($scope.viewer.permissions.indexOf(ORG_PERMISSION.VIEW_SETTINGS) !== -1);
     $scope.canExportKeeps = ($scope.viewer.permissions.indexOf(ORG_PERMISSION.EXPORT_KEEPS) !== -1);
     $scope.canManagePlan = ($scope.viewer.permissions.indexOf(ORG_PERMISSION.MANAGE_PLAN) !== -1);
     $scope.canRedeemCredit = ($scope.viewer.permissions.indexOf(ORG_PERMISSION.REDEEM_CREDIT_CODE) !== -1);
@@ -34,7 +35,7 @@ angular.module('kifi')
       $window.removeEventListener('hashchange', onHashChange);
     });
 
-    if (!$scope.viewer.membership || $scope.viewer.permissions.indexOf(ORG_PERMISSION.VIEW_SETTINGS) === -1) {
+    if (!$scope.viewer.membership) {
       $rootScope.$emit('errorImmediately');
     }
 


### PR DESCRIPTION
@cvializ @andrewconner 

found this while investigating what would break if the server didn't return `organization.config`, turns out this was already broken. users should be able to view "earn credits" even without the "view settings" permission (given by member privilege setting). right now they get a 404.
