### PR TITLE
Switching from logging to throwing

### DIFF
--- a/kifi-backend/modules/rover/app/com/keepit/rover/fetcher/apache/SecurityInterceptor.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/fetcher/apache/SecurityInterceptor.scala
@@ -11,8 +11,7 @@ trait SecurityInterceptor extends Logging {
   def throwIfBannedHost(host: String): Unit = {
     val trimmed = host.trim
     if (SecurityInterceptor.bannedHosts.exists(trimmed.startsWith)) {
-      //throw new HttpException(s"Tried to scrape banned domain ${host.toString}")
-      log.error(s"[SI] Blocking $trimmed")
+      throw new HttpException(s"Tried to scrape banned domain ${host.toString}")
     }
   }
 }


### PR DESCRIPTION
@leogrim Found a few keeps that make us scrape internal stuff, but it probably wasn't malicious.

Based on our convo a few weeks ago, we don't know what'll happen when we throw, but we assume that it'll throw on the fetch, which gets caught in `doFetch`. 
