### PR TITLE
Fix markAsRead behavior, and return ids for comments

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
@@ -151,13 +151,11 @@ class ElizaDiscussionCommanderImpl @Inject() (
     } yield {
       val unreadCount = messageRepo.countByThread(mt.id.get, Some(msgId), SortDirection.ASCENDING)
 
-      // Marking a user thread as read is sort of insane
-      // userThreadRepo.markRead does 2 things: updates the "lastActive" time for a user thread, and sets ut.unread = false
-      // The only problem is that there might be new messages. If there are, the user thread ISN'T unread; the user is wrong
-      val msg = messageRepo.get(msgId)
-      userThreadRepo.markRead(userId, mt.id.get, msg) // TODO(ryan): rework this method so that it does a sane thing
-      if (unreadCount != 0) userThreadRepo.markUnread(userId, mt.id.get)
-
+      // TODO(ryan): drop UserThread.unread and instead have a `UserThread.lastSeenMessageId` and compare to `messageRepo.getLatest(threadId)`
+      // Then you can just set it and forget it
+      if (unreadCount == 0) {
+        userThreadRepo.markRead(userId, mt.id.get, messageRepo.get(msgId))
+      }
       unreadCount
     }
   }


### PR DESCRIPTION
@andrewconner @cvializ 
I don't have time today to make the messaging endpoint return the full message object. Right now it just gives back the public id of the message it created (so you can push that).
