### PR TITLE
make keep comment actions independent from other dropdown menus

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comment/comment.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comment/comment.styl
@@ -91,12 +91,12 @@
 .kf-keep-comment-actions
   position: relative
 
-  .kf-dropdown-menu
+  .kf-keep-comment-actions-menu
     font-size: 14px
     transform-origin: 80% top
     transition: visibility 0s, opacity linear dur, transform dur ease-out
 
-  &:not(.kf-open)>.kf-dropdown-menu
+  &:not(.kf-open)>.kf-keep-comment-actions-menu
     dur = .08s
     visibility: hidden
     opacity: 0
@@ -104,7 +104,7 @@
     transition-duration: 0s, dur, dur
     transition-delay: dur, 0s, 0s
 
-.kf-dropdown-menu-item
+.kf-keep-comment-actions-item
   padding: 0 16px
   color: #556179
   white-space: nowrap
@@ -127,10 +127,12 @@
     width: 15px
     height: 15px
 
-.kf-feed-item .kf-dropdown-menu
-  left: 265px
-.kf-lib-content .kf-dropdown-menu
-  left: 205px
+.kf-feed-item .kf-keep-comment-actions-menu
+  left: 252px
+.kf-lib-content .kf-keep-comment-actions-menu
+  left: 190px
+.kf-keep-page .kf-keep-comment-actions-menu
+  left: 190px
 
 .kf-keep-comment-container:hover .kf-keep-comment-actions-button
 .kf-keep-comment-actions.kf-open .kf-keep-comment-actions-button

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comment/comment.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comment/comment.tpl.html
@@ -12,8 +12,8 @@
             ng-attr-datetime="{{::comment.sentAt}}" am-time-ago="::comment.sentAt"
             title="{{::comment.sentAt|localTime}}" ng-if="::comment.sentAt"></time>
       <span class="kf-keep-comment-actions" kf-click-menu ng-if="commentActionItems.length > 0  && canSeeCommentActions">
-        <menu class="kf-dropdown-menu">
-          <button class="kf-dropdown-menu-item"
+        <menu class="kf-dropdown-menu kf-keep-comment-actions-menu">
+          <button class="kf-dropdown-menu-item kf-keep-comment-actions-item"
             ng-click="item.action($event)"
             ng-repeat="item in commentActionItems"
             ng-bind="item.title">


### PR DESCRIPTION
@cvializ I'm working towards making that dropdown menu only relative to the dropdown button, not any other elements on the page. ideally this would make the position consistent across the board (different browsers / keep widths are giving me trouble). not sure how to do that yet.
