### PR TITLE
Fixing tag removal / replacement bugs

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/tagManage/modifyTagProgressModal.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/modifyTagProgressModal.tpl.html
@@ -1,6 +1,6 @@
 <div kf-modal class="kf-rename-tag-confirm-modal">
   <div kf-basic-modal-content title="Modifying tag" action-text="Great!" action="">
-    <span ng-if="action === 'rename'">Renaming “<span ng-bind="name"></span>”. Depending on how many keeps have this tag, it may take a few minutes to rename it everywhere.</span>
-    <span ng-if="action === 'delete'">Renaming “<span ng-bind="name"></span>”. Depending on how many keeps have this tag, it may take a few minutes to finish removing it.</span>
+    <span ng-if="action === 'rename'">Renaming tag “<span ng-bind="name"></span>”. Depending on how many keeps have this tag, it may take a few minutes to rename it everywhere.</span>
+    <span ng-if="action === 'delete'">Deteting tag “<span ng-bind="name"></span>”. Depending on how many keeps have this tag, it may take a few minutes to finish removing it.</span>
   </div>
 </div>

--- a/kifi-backend/modules/shoebox/angular/src/tagManage/modifyTagProgressModal.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/modifyTagProgressModal.tpl.html
@@ -1,0 +1,6 @@
+<div kf-modal class="kf-rename-tag-confirm-modal">
+  <div kf-basic-modal-content title="Modifying tag" action-text="Great!" action="">
+    <span ng-if="action === 'rename'">Renaming “<span ng-bind="name"></span>”. Depending on how many keeps have this tag, it may take a few minutes to rename it everywhere.</span>
+    <span ng-if="action === 'delete'">Renaming “<span ng-bind="name"></span>”. Depending on how many keeps have this tag, it may take a few minutes to finish removing it.</span>
+  </div>
+</div>

--- a/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/tagManage.js
@@ -167,9 +167,15 @@ angular.module('kifi')
     };
 
     $scope.deleteTag = function () {
-      manageTagService.remove($scope.selectedTag).then(function () {
-        _.remove($scope.tagsToShow, $scope.selectedTag);
+      var _scope = $rootScope.$new();
+      _scope.action = 'delete';
+      _scope.name = $scope.selectedTag.name;
+      modalService.open({
+        template: 'tagManage/modifyTagProgressModal.tpl.html',
+        scope: _scope
       });
+      _.remove($scope.tagsToShow, $scope.selectedTag);
+      manageTagService.remove($scope.selectedTag);
     };
 
     $scope.showRenameTagModal = function (tag) {
@@ -183,9 +189,15 @@ angular.module('kifi')
     };
 
     $scope.renameTag = function () {
-      manageTagService.rename($scope.selectedTag).then(function () {
-        $scope.selectedTag.name = $scope.selectedTag.renamed;
+      var _scope = $rootScope.$new();
+      _scope.action = 'rename';
+      _scope.name = $scope.selectedTag.name;
+      modalService.open({
+        template: 'tagManage/modifyTagProgressModal.tpl.html',
+        scope: _scope
       });
+      $scope.selectedTag.name = $scope.selectedTag.renamed;
+      manageTagService.rename($scope.selectedTag);
     };
   }
 ]);

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/Hashtags.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/Hashtags.scala
@@ -34,11 +34,22 @@ object Hashtags {
   }
 
   def removeHashtagsFromString(str: String, hashtags: Set[Hashtag]): String = {
-    removeHashtagNamesFromString(str, hashtags.map(_.tag))
+    removeTagNamesFromString(str, hashtags.map(_.tag))
   }
 
-  def removeHashtagNamesFromString(str: String, hashtagNames: Set[String]): String = {
-    hashTagRe.replaceSomeIn(str, m => if (hashtagNames.contains(m.group(1))) Some("") else None).trim
+  def removeTagNamesFromString(str: String, hashtagNames: Set[String]): String = {
+    val normalizedTags = hashtagNames.map(Hashtag(_).normalized)
+    hashTagRe.replaceSomeIn(str, m => if (normalizedTags.contains(Hashtag(m.group(1)).normalized)) Some("") else None).trim
+  }
+
+  def replaceTagNameFromString(str: String, oldTag: String, newTag: String): String = {
+    val oldNormalized = Hashtag(oldTag).normalized
+    hashTagRe.replaceSomeIn(str, m =>
+      if (oldNormalized == Hashtag(m.group(1)).normalized) {
+        if (newTag.nonEmpty) Some("[#" + newTag + "]")
+        else Some("")
+      } else None
+    ).trim
   }
 
   def format(note: String): DescriptionElements = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -485,10 +485,17 @@ class KeepCommanderImpl @Inject() (
     db.readWrite { implicit session =>
       val updated = keepRepo.getByIds(keeps).flatMap {
         case ((_, k)) =>
-          val tags = Hashtags.findAllHashtagNames(k.note.getOrElse(""))
-          if (tags.contains(tag.tag)) {
-            val newTags = tags - tag.tag
-            Some(syncTagsToNoteAndSaveKeep(k.userId, k, newTags.toSeq))
+          val existingTags = Hashtags.findAllHashtagNames(k.note.getOrElse("")).map(Hashtag(_)).toSeq
+          val existingNormalized = existingTags.map(_.normalized)
+
+          if (k.isActive && existingNormalized.contains(tag.normalized)) {
+            val newTags = existingTags.filterNot(_.normalized == tag.normalized).map(_.tag)
+            Try(syncTagsToNoteAndSaveKeep(k.userId, k, newTags)) match { // Note will be updated here
+              case Success(r) => Some(r)
+              case Failure(ex) =>
+                log.warn(s"[removeTagFromKeeps] Failure removing tag for keep ${k.id.get} removing ${tag.tag}. Existing tags: ${k.note}, new tags: $newTags")
+                None
+            }
           } else None
       }
       updated.values.flatten.distinctBy(_.id).map { c =>
@@ -498,15 +505,33 @@ class KeepCommanderImpl @Inject() (
     }
   }
 
+  // Assumption that all keeps are owned by the same user
   def replaceTagOnKeeps(keeps: Set[Id[Keep]], oldTag: Hashtag, newTag: Hashtag): Int = {
-    db.readWrite { implicit session =>
+    if (keeps.nonEmpty && oldTag.normalized == newTag.normalized) { // Changing capitalization, etc
+      db.readWrite { implicit session =>
+        for {
+          firstKeepId <- keeps.headOption
+          keep = keepRepo.get(firstKeepId)
+          existing <- collectionRepo.getByUserAndName(keep.userId, oldTag)
+        } yield {
+          collectionRepo.save(existing.copy(name = newTag))
+        }
+      }
+    }
+    db.readWrite(attempts = 3) { implicit session =>
       val updated = keepRepo.getByIds(keeps).flatMap {
         case ((_, k)) =>
-          val tags = Hashtags.findAllHashtagNames(k.note.getOrElse(""))
-          if (tags.contains(oldTag.tag)) {
-            val newTags = tags - oldTag.tag + newTag.tag
-            val newNote = k.note.map(_.replaceAllLiterally("#" + oldTag, "#" + newTag))
-            Some(syncTagsToNoteAndSaveKeep(k.userId, k.withNote(newNote), newTags.toSeq))
+          val existingTags = Hashtags.findAllHashtagNames(k.note.getOrElse("")).map(Hashtag(_)).toSeq
+          val existingNormalized = existingTags.map(_.normalized)
+          if (k.isActive && existingNormalized.contains(oldTag.normalized)) {
+            val newTags = newTag.tag +: existingTags.filterNot(_.normalized == oldTag.normalized).map(_.tag)
+            val newNote = k.note.map(Hashtags.replaceTagNameFromString(_, oldTag.tag, newTag.tag))
+            Try(syncTagsToNoteAndSaveKeep(k.userId, k.withNote(newNote), newTags)) match {
+              case Success(r) => Some(r)
+              case Failure(ex) =>
+                log.warn(s"[replaceTagOnKeeps] Failure updating note for keep ${k.id.get} replacing ${oldTag.tag} with ${newTag.tag}. Existing note: ${k.note}, new note: $newNote")
+                None
+            }
           } else None
       }
       updated.values.flatten.distinctBy(_.id).map { c =>
@@ -551,7 +576,7 @@ class KeepCommanderImpl @Inject() (
     // find hashtags to remove & to append
     val hashtagsToRemove = hashtagsInNote.filterNot(hashtagsToPersistSet.contains(_))
     val hashtagsToAppend = allTagsKeepShouldHave.filterNot(hashtagsInNote.contains(_))
-    val noteWithHashtagsRemoved = Hashtags.removeHashtagNamesFromString(keepNote, hashtagsToRemove.toSet)
+    val noteWithHashtagsRemoved = Hashtags.removeTagNamesFromString(keepNote, hashtagsToRemove.toSet)
     val noteWithHashtagsAppended = Hashtags.addTagsToString(noteWithHashtagsRemoved, hashtagsToAppend)
     val finalNote = Some(noteWithHashtagsAppended.trim).filterNot(_.isEmpty)
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/HashtagsTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/HashtagsTest.scala
@@ -64,46 +64,40 @@ class HashtagsTest extends Specification {
     }
 
     "remove specific hashtags from a string" in {
-      Hashtags.removeHashtagNamesFromString("", Set("asdf")) === ""
-      Hashtags.removeHashtagNamesFromString("asdf", Set("asdf")) === "asdf"
-      Hashtags.removeHashtagNamesFromString("#[asdf]", Set("asdf")) === "#[asdf]"
-      Hashtags.removeHashtagNamesFromString("[\\#asdf]", Set("asdf")) === "[\\#asdf]"
-      Hashtags.removeHashtagNamesFromString("[#asdf]", Set("asdf")) === ""
-      Hashtags.removeHashtagNamesFromString("[#asdf]]", Set("asdf")) === "]"
-      Hashtags.removeHashtagNamesFromString("[#asdf\\]]", Set("asdf")) === "[#asdf\\]]" //'#asdf\]' does not match '#asdf'
-      Hashtags.removeHashtagNamesFromString("[#asd[f\\]]", Set("asdf")) === "[#asd[f\\]]" //'#asd[f\]' does not match '#asdf'
-      Hashtags.removeHashtagNamesFromString("[##asdf]", Set("asdf")) === "[##asdf]"
-      Hashtags.removeHashtagNamesFromString("[[#asdf]]", Set("asdf")) === "[]"
+      Hashtags.removeTagNamesFromString("", Set("asdf")) === ""
+      Hashtags.removeTagNamesFromString("asdf", Set("asdf")) === "asdf"
+      Hashtags.removeTagNamesFromString("#[asdf]", Set("asdf")) === "#[asdf]"
+      Hashtags.removeTagNamesFromString("[\\#asdf]", Set("asdf")) === "[\\#asdf]"
+      Hashtags.removeTagNamesFromString("[#asdf]", Set("asdf")) === ""
+      Hashtags.removeTagNamesFromString("[#asdf]]", Set("asdf")) === "]"
+      Hashtags.removeTagNamesFromString("[#asdf\\]]", Set("asdf")) === "[#asdf\\]]" //'#asdf\]' does not match '#asdf'
+      Hashtags.removeTagNamesFromString("[#asd[f\\]]", Set("asdf")) === "[#asd[f\\]]" //'#asd[f\]' does not match '#asdf'
+      Hashtags.removeTagNamesFromString("[##asdf]", Set("asdf")) === "[##asdf]"
+      Hashtags.removeTagNamesFromString("[[#asdf]]", Set("asdf")) === "[]"
 
-      Hashtags.removeHashtagNamesFromString("[#asdf] [#qwer]", Set("asdf")) === "[#qwer]"
-      Hashtags.removeHashtagNamesFromString("[#asdf] [#qwer]", Set("asdf", "qwer")) === ""
-      Hashtags.removeHashtagNamesFromString("[#asdf] a [#qwer]", Set("asdf", "qwer")) === "a"
-      Hashtags.removeHashtagNamesFromString("a [#asdf] b [#qwer] c", Set("asdf", "qwer")) === "a  b  c"
+      Hashtags.removeTagNamesFromString("[#asdf] [#qwer]", Set("asdf")) === "[#qwer]"
+      Hashtags.removeTagNamesFromString("[#asdf] [#qwer]", Set("asdf", "qwer")) === ""
+      Hashtags.removeTagNamesFromString("[#asdf] a [#qwer]", Set("asdf", "qwer")) === "a"
+      Hashtags.removeTagNamesFromString("a [#asdf] b [#qwer] c", Set("asdf", "qwer")) === "a  b  c"
     }
 
-    "remove all hashtags or unescape them for v1 mobile notes" in {
-      // text only
-      Hashtags.formatMobileNoteV1(None) === None
-      Hashtags.formatMobileNoteV1(Some("")) === None
-      Hashtags.formatMobileNoteV1(Some("hi there")) === Some("hi there")
-      Hashtags.formatMobileNoteV1(Some("[\\#asdf]")) === Some("[#asdf]")
+    "replace specific hashtags from a string" in {
+      Hashtags.replaceTagNameFromString("", "asdf", "dfgh") === ""
+      Hashtags.replaceTagNameFromString("asdf", "asdf", "") === "asdf"
+      Hashtags.replaceTagNameFromString("#[asdf]", "asdf", "dfgh") === "#[asdf]"
 
-      // tags only
-      Hashtags.formatMobileNoteV1(Some("[#\\asd\\]f]")) === None
-      Hashtags.formatMobileNoteV1(Some("[#asdf\\]]")) === None
-      Hashtags.formatMobileNoteV1(Some("[#asd[f\\]]")) === None
-      Hashtags.formatMobileNoteV1(Some("[##asdf]")) === None
-      Hashtags.formatMobileNoteV1(Some("[#asdf]")) === None
-      Hashtags.formatMobileNoteV1(Some("[#asdf] [#hjkl]")) === None
-      Hashtags.formatMobileNoteV1(Some(" [#asdf] [#hjkl] ")) === None
+      Hashtags.replaceTagNameFromString("[#asdf]", "Asdf", "dfgh") === "[#dfgh]"
+      Hashtags.replaceTagNameFromString("[#Asdf]", "asdf", "dfgh") === "[#dfgh]"
+      Hashtags.replaceTagNameFromString("[#asdf]", "asdf", "Asdf") === "[#Asdf]"
 
-      // text + tags
-      Hashtags.formatMobileNoteV1(Some("this is really useful [#tag1] [#tag2]")) === Some("this is really useful")
-      Hashtags.formatMobileNoteV1(Some("this is really [\\#useful] [#tag1] [#tag2]")) === Some("this is really [#useful]")
-      //Hashtags.formatMobileNoteV1(Some("i love [#scala]")) === Some("i love #scala")
-      //Hashtags.formatMobileNoteV1(Some("""i love [#\\asdf\]]""")) === Some("""i love #\asdf]""")
-      //Hashtags.formatMobileNoteV1(Some("[[#asdf]]")) === Some("[#asdf]")
-      //Hashtags.formatMobileNoteV1(Some("[#asdf]]")) === Some("#asdf]")
+      Hashtags.replaceTagNameFromString("[\\#asdf]", "asdf", "dfgh") === "[\\#asdf]"
+      Hashtags.replaceTagNameFromString("[#asdf]", "Asdf", "") === ""
+
+      Hashtags.replaceTagNameFromString("[#asdf] [#qwer]", "asdf", "dfgh") === "[#dfgh] [#qwer]"
+      Hashtags.replaceTagNameFromString("[#asdf] [#qwer]", "asdf", "qwer") === "[#qwer] [#qwer]"
+      Hashtags.replaceTagNameFromString("[#asdf] a [#qwer]", "asdf", "dfgh") === "[#dfgh] a [#qwer]"
+      Hashtags.replaceTagNameFromString("a [#asdf] b [#qwer] c", "asdf", "dfgh") === "a [#dfgh] b [#qwer] c"
     }
+
   }
 }


### PR DESCRIPTION
**Site**
• `modifyTagProgressModal` added, to tell people that bulk tag operations take a while. User thought it didn't work.
• Client side fakes removal and renaming immediately, to provide responsive experience to a slow task

**Backend**
• Removing tags from string now removes all matching tags, _after_ normalization. Previously, if your canonical tags was "Scala", you couldn't remove "scala"
• Replacing tag now replaces matching tags, _after_ normalization. Same as above.
• When replacing tag in string, if replacement is actually just a formatting change (Scala → scala), rename the actual `Collection#name` so that anywhere the name shows in UI, it's changed. User reported unable to change capitalization of tag.
• Added test for replacing tags in string
• If unable to save new note, log error, but continue. In these bulk operations, it's not usually an all-or-nothing proposition. Report to airbrake if errors occurred.

@leogrim @cvializ (small amount of site changes here)
