### PR TITLE
Hopefully fixing duplicate company names

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/profile/profileWidget.styl
+++ b/kifi-backend/modules/shoebox/angular/src/profile/profileWidget.styl
@@ -186,13 +186,14 @@
 
 
   .kf-pw-create-org
-    margin: 15px -16px -10px
-    padding: 15px
+    margin: 15px -16px 0px -16px
+    padding: 13px 0 0
     border-top: 1px solid borderLightGray
     cursor: pointer
 
   .kf-pw-create-org-wrapper
     display: flex
+    margin: 0 16px
     justify-content: space-around
 
     &:hover
@@ -205,7 +206,7 @@
     align-items: center
     width: 42px
     height: 42px
-    margin: 10px 0
+    margin: 0 0
     flex-shrink: 0
     border-radius: 50%
     border: 1px solid #fff
@@ -226,6 +227,7 @@
     max-width: 75%
     font-size: 20px
     margin-left: 2px
+    word-break: break-word
 
   .kf-pw-learn-more
     width: 100%


### PR DESCRIPTION
@camhashemi Looks like emails weren't checked for dupe names, and it also caused a refetch of preferences if `hide_company_name` is false and `company_name` is falsey.

Also made two small style changes. One was to trim long company names. The other is to tighten up the styling. New view:

![](http://acon.s3.amazonaws.com/H3T5I.png)
