### PR TITLE
Migrating discussion permissions checking to Shoebox

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -256,7 +256,14 @@ object Eliza extends Service {
     def getSharedThreadsForGroupByWeek = ServiceRoute(POST, "/internal/eliza/sharedThreadsForGroupByWeek")
     def getAllThreadsForGroupByWeek = ServiceRoute(POST, "/internal/eliza/allThreadsForGroupByWeek")
     def getParticipantsByThreadExtId(threadExtId: String) = ServiceRoute(GET, "/internal/eliza/getParticipantsByThreadExtId", Param("threadId", threadExtId))
+
+    def getCrossServiceMessages = ServiceRoute(POST, "/internal/eliza/getCrossServiceMessages")
     def getDiscussionsForKeeps = ServiceRoute(POST, "/internal/eliza/getDiscussionsForKeeps")
+    def markKeepsAsReadForUser() = ServiceRoute(POST, "/internal/eliza/markKeepsAsReadForUser")
+    def sendMessageOnKeep() = ServiceRoute(POST, "/internal/eliza/sendMessageOnKeep")
+    def getMessagesOnKeep = ServiceRoute(POST, "/internal/eliza/getMessagesOnKeep")
+    def editMessage() = ServiceRoute(POST, "/internal/eliza/editMessage")
+    def deleteMessage() = ServiceRoute(POST, "/internal/eliza/deleteMessage")
   }
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/discussion/DiscussionFail.scala
+++ b/kifi-backend/modules/common/app/com/keepit/discussion/DiscussionFail.scala
@@ -15,6 +15,7 @@ object DiscussionFail extends Enumerator[DiscussionFail] {
   case object INSUFFICIENT_PERMISSIONS extends DiscussionFail(FORBIDDEN, "insufficient_permissions")
   case object INVALID_KEEP_ID extends DiscussionFail(BAD_REQUEST, "specified_keep_does_not_exist")
   case object INVALID_MESSAGE_ID extends DiscussionFail(BAD_REQUEST, "specified_message_does_not_exist")
+  case object MESSAGE_DOES_NOT_EXIST_ON_KEEP extends DiscussionFail(BAD_REQUEST, "message_does_not_exist_on_specified_keep")
 
   // The most generic input failure. As we create new endpoints we should create specific failures
   // This is here strictly because I'm lazy

--- a/kifi-backend/modules/common/app/com/keepit/discussion/DiscussionFail.scala
+++ b/kifi-backend/modules/common/app/com/keepit/discussion/DiscussionFail.scala
@@ -1,0 +1,24 @@
+package com.keepit.discussion
+
+import com.keepit.common.reflection.Enumerator
+import play.api.http.Status._
+import play.api.libs.json._
+import play.api.mvc.Results.Status
+
+import scala.util.control.NoStackTrace
+
+sealed abstract class DiscussionFail(val status: Int, val err: String) extends Exception(err) with NoStackTrace {
+  def asErrorResponse = Status(status)(Json.obj("error" -> err))
+}
+
+object DiscussionFail extends Enumerator[DiscussionFail] {
+  case object INSUFFICIENT_PERMISSIONS extends DiscussionFail(FORBIDDEN, "insufficient_permissions")
+  case object INVALID_KEEP_ID extends DiscussionFail(BAD_REQUEST, "specified_keep_does_not_exist")
+  case object INVALID_MESSAGE_ID extends DiscussionFail(BAD_REQUEST, "specified_message_does_not_exist")
+
+  // The most generic input failure. As we create new endpoints we should create specific failures
+  // This is here strictly because I'm lazy
+  case object COULD_NOT_PARSE extends DiscussionFail(BAD_REQUEST, "could_not_parse_request")
+  case object MISSING_MESSAGE_TEXT extends DiscussionFail(BAD_REQUEST, "no_text_provided")
+}
+

--- a/kifi-backend/modules/common/app/com/keepit/discussion/Message.scala
+++ b/kifi-backend/modules/common/app/com/keepit/discussion/Message.scala
@@ -5,7 +5,7 @@ import javax.crypto.spec.IvParameterSpec
 import com.keepit.common.crypto.{ PublicIdGenerator, ModelWithPublicId, PublicId }
 import com.keepit.common.db.{ Id, ExternalId }
 import com.keepit.common.store.ImagePath
-import com.keepit.model.{ Hashtag, LibraryCardInfo, DeepLocator, Keep }
+import com.keepit.model._
 import com.keepit.social.{ BasicUser, BasicUserLikeEntity }
 import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
@@ -26,6 +26,20 @@ object Message extends PublicIdGenerator[Message] {
     (__ \ 'sentBy).format[BasicUserLikeEntity] and
     (__ \ 'text).format[String]
   )(Message.apply, unlift(Message.unapply))
+}
+
+case class CrossServiceMessage(
+  id: Id[Message],
+  sentAt: DateTime,
+  sentBy: Option[Id[User]],
+  text: String)
+object CrossServiceMessage {
+  implicit val format: Format[CrossServiceMessage] = (
+    (__ \ 'id).format[Id[Message]] and
+    (__ \ 'sentAt).format[DateTime] and
+    (__ \ 'sentBy).formatNullable[Id[User]] and
+    (__ \ 'text).format[String]
+  )(CrossServiceMessage.apply, unlift(CrossServiceMessage.unapply))
 }
 
 case class Discussion(

--- a/kifi-backend/modules/common/app/com/keepit/discussion/Message.scala
+++ b/kifi-backend/modules/common/app/com/keepit/discussion/Message.scala
@@ -30,12 +30,14 @@ object Message extends PublicIdGenerator[Message] {
 
 case class CrossServiceMessage(
   id: Id[Message],
+  keep: Option[Id[Keep]],
   sentAt: DateTime,
   sentBy: Option[Id[User]],
   text: String)
 object CrossServiceMessage {
   implicit val format: Format[CrossServiceMessage] = (
     (__ \ 'id).format[Id[Message]] and
+    (__ \ 'keep).formatNullable[Id[Keep]] and
     (__ \ 'sentAt).format[DateTime] and
     (__ \ 'sentBy).formatNullable[Id[User]] and
     (__ \ 'text).format[String]

--- a/kifi-backend/modules/common/app/com/keepit/discussion/Message.scala
+++ b/kifi-backend/modules/common/app/com/keepit/discussion/Message.scala
@@ -11,6 +11,7 @@ import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
+// Exposed to clients
 case class Message(
   pubId: PublicId[Message],
   sentAt: DateTime,

--- a/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
@@ -441,4 +441,5 @@ object KeepPermission extends Enumerator[KeepPermission] {
   case object DELETE_OWN_MESSAGES extends KeepPermission("delete_own_messages")
   case object DELETE_OTHER_MESSAGES extends KeepPermission("delete_other_messages")
   case object DELETE_KEEP extends KeepPermission("delete_keep")
+  case object VIEW_MESSAGES extends KeepPermission("view_messages")
 }

--- a/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
@@ -3,6 +3,7 @@ package com.keepit.model
 import javax.crypto.spec.IvParameterSpec
 
 import com.keepit.common.path.Path
+import com.keepit.common.reflection.Enumerator
 import org.apache.commons.lang3.RandomStringUtils
 import play.api.mvc.PathBindable
 
@@ -433,3 +434,11 @@ case class BasicKeepIdKey(id: Id[Keep]) extends Key[BasicKeep] {
 
 class BasicKeepByIdCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
   extends ImmutableJsonCacheImpl[BasicKeepIdKey, BasicKeep](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
+
+sealed abstract class KeepPermission(val value: String)
+object KeepPermission extends Enumerator[KeepPermission] {
+  case object ADD_MESSAGE extends KeepPermission("add_message")
+  case object DELETE_OWN_MESSAGES extends KeepPermission("delete_own_messages")
+  case object DELETE_OTHER_MESSAGES extends KeepPermission("delete_other_messages")
+  case object DELETE_KEEP extends KeepPermission("delete_keep")
+}

--- a/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
@@ -115,7 +115,6 @@ object LibraryPermission extends Enumerator[LibraryPermission] {
   case object EXPORT_KEEPS extends LibraryPermission("export_keeps")
   case object CREATE_SLACK_INTEGRATION extends LibraryPermission("create_slack_integration")
   case object ADD_COMMENTS extends LibraryPermission("add_comments")
-  case object DELETE_COMMENTS extends LibraryPermission("delete_comments")
 
   private val soloReads = EnumFormat.reads(get, all.map(_.value))
   implicit val setReads: Reads[Set[LibraryPermission]] = TraversableFormat.safeSetReads[LibraryPermission](soloReads)

--- a/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/LibraryMembership.scala
@@ -115,6 +115,7 @@ object LibraryPermission extends Enumerator[LibraryPermission] {
   case object EXPORT_KEEPS extends LibraryPermission("export_keeps")
   case object CREATE_SLACK_INTEGRATION extends LibraryPermission("create_slack_integration")
   case object ADD_COMMENTS extends LibraryPermission("add_comments")
+  case object DELETE_COMMENTS extends LibraryPermission("delete_comments")
 
   private val soloReads = EnumFormat.reads(get, all.map(_.value))
   implicit val setReads: Reads[Set[LibraryPermission]] = TraversableFormat.safeSetReads[LibraryPermission](soloReads)
@@ -123,7 +124,6 @@ object LibraryPermission extends Enumerator[LibraryPermission] {
 
   def all = _all.toSet
   def get(str: String): Option[LibraryPermission] = all.find(_.value == str)
-  def apply(str: String): LibraryPermission = get(str).getOrElse(throw new Exception(s"Unknown LibraryPermission $str"))
 }
 
 sealed abstract class LibraryCommentPermissions(val value: String)

--- a/kifi-backend/modules/common/test/com/keepit/eliza/FakeElizaServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/eliza/FakeElizaServiceClientImpl.scala
@@ -102,10 +102,10 @@ class FakeElizaServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, schedul
   def getDiscussionsForKeeps(keepIds: Set[Id[Keep]]): Future[Map[Id[Keep], Discussion]] = {
     Future.successful(Map.empty)
   }
-  def deleteMessage(msgId: Id[Message]): Future[Discussion] = ???
-  def editMessage(msgId: Id[Message], newText: String): Future[Discussion] = ???
+  def deleteMessage(msgId: Id[Message]): Future[Unit] = ???
+  def editMessage(msgId: Id[Message], newText: String): Future[Message] = ???
   def getCrossServiceMessages(msgIds: Set[Id[Message]]): Future[Map[Id[Message],CrossServiceMessage]] = ???
   def getMessagesOnKeep(keepId: Id[Keep], fromIdOpt: Option[Id[Message]], limit: Int): Future[Seq[Message]] = ???
-  def markKeepsAsReadForUser(userId: Id[User], keepIds: Set[Id[Keep]]): Future[Map[Id[Keep],Int]] = ???
-  def sendMessageOnKeep(userId: Id[User], text: String, keepId: Id[Keep]): Future[Discussion] = ???
+  def markKeepsAsReadForUser(userId: Id[User], lastSeen: Map[Id[Keep], Id[Message]]): Future[Map[Id[Keep],Int]] = ???
+  def sendMessageOnKeep(userId: Id[User], text: String, keepId: Id[Keep]): Future[Message] = ???
 }

--- a/kifi-backend/modules/common/test/com/keepit/eliza/FakeElizaServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/eliza/FakeElizaServiceClientImpl.scala
@@ -1,6 +1,6 @@
 package com.keepit.eliza
 
-import com.keepit.discussion.{Discussion, Message}
+import com.keepit.discussion.{CrossServiceMessage, Discussion, Message}
 import com.keepit.model._
 import com.keepit.common.db.{ ExternalId, SequenceNumber, Id }
 import com.keepit.common.service.{ ServiceClient, ServiceType }
@@ -102,5 +102,10 @@ class FakeElizaServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, schedul
   def getDiscussionsForKeeps(keepIds: Set[Id[Keep]]): Future[Map[Id[Keep], Discussion]] = {
     Future.successful(Map.empty)
   }
-
+  def deleteMessage(msgId: Id[Message]): Future[Discussion] = ???
+  def editMessage(msgId: Id[Message], newText: String): Future[Discussion] = ???
+  def getCrossServiceMessages(msgIds: Set[Id[Message]]): Future[Map[Id[Message],CrossServiceMessage]] = ???
+  def getMessagesOnKeep(keepId: Id[Keep], fromIdOpt: Option[Id[Message]], limit: Int): Future[Seq[Message]] = ???
+  def markKeepsAsReadForUser(userId: Id[User], keepIds: Set[Id[Keep]]): Future[Map[Id[Keep],Int]] = ???
+  def sendMessageOnKeep(userId: Id[User], text: String, keepId: Id[Keep]): Future[Discussion] = ???
 }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
@@ -22,9 +22,12 @@ import scala.util.{ Failure, Success, Try }
 @ImplementedBy(classOf[ElizaDiscussionCommanderImpl])
 trait ElizaDiscussionCommander {
   def getMessagesOnKeep(keepId: Id[Keep], fromIdOpt: Option[Id[ElizaMessage]], limit: Int): Future[Seq[Message]]
+
+  def getDiscussionForKeep(keepId: Id[Keep]): Future[Discussion]
   def getDiscussionsForKeeps(keepIds: Set[Id[Keep]]): Future[Map[Id[Keep], Discussion]]
   def sendMessageOnKeep(userId: Id[User], txt: String, keepId: Id[Keep], source: Option[MessageSource] = None)(implicit context: HeimdalContext): Future[ElizaMessage]
   def markAsRead(userId: Id[User], keepId: Id[Keep], msgId: Id[ElizaMessage]): Option[Int]
+  def editMessage(messageId: Id[ElizaMessage], newText: String): ElizaMessage
   def deleteMessageOnKeep(userId: Id[User], keepId: Id[Keep], messageId: Id[ElizaMessage]): Try[Unit]
 }
 
@@ -79,6 +82,8 @@ class ElizaDiscussionCommanderImpl @Inject() (
       elizaMsgs.flatMap(em => extMessageMap.get(em.id.get))
     }
   }
+
+  def getDiscussionForKeep(keepId: Id[Keep]): Future[Discussion] = getDiscussionsForKeeps(Set(keepId)).imap(dm => dm(keepId))
   def getDiscussionsForKeeps(keepIds: Set[Id[Keep]]) = db.readOnlyReplica { implicit s =>
     val threadsByKeep = messageThreadRepo.getByKeepIds(keepIds)
     val threadIds = threadsByKeep.values.map(_.id.get).toSet
@@ -162,10 +167,19 @@ class ElizaDiscussionCommanderImpl @Inject() (
     }
   }
 
+  def editMessage(messageId: Id[ElizaMessage], newText: String): ElizaMessage = db.readWrite { implicit s =>
+    messageRepo.save(messageRepo.get(messageId).withText(newText))
+  }
+
   def deleteMessageOnKeep(userId: Id[User], keepId: Id[Keep], messageId: Id[ElizaMessage]): Try[Unit] = db.readWrite { implicit s =>
     for {
       msg <- Some(messageRepo.get(messageId)).filter(_.isActive).map(Success(_)).getOrElse(Failure(new Exception("message does not exist")))
       thread <- Some(messageThreadRepo.get(msg.thread)).filter(_.keepId.contains(keepId)).map(Success(_)).getOrElse(Failure(new Exception("wrong keep id!")))
+      // TODO(ryan): stop checking permissions in Eliza
+      // Three options that I can see, in order of how much I like them:
+      //  1. trust Shoebox to ask for reasonable things, only do simple sanity checks (i.e., pass in a KeepId and make sure the msg is on that keep)
+      //  2. asynchronously ask for permissions from Shoebox, do all checking here
+      //  3. pass in permissions (from Shoebox), double-check them here
       owner <- msg.from.asUser.filter(_ == userId).map(Success(_)).getOrElse(Failure(new Exception("wrong owner")))
     } yield messageRepo.deactivate(msg)
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaDiscussionController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaDiscussionController.scala
@@ -1,0 +1,70 @@
+package com.keepit.eliza.controllers.internal
+
+import com.keepit.common.crypto.{ PublicIdConfiguration, PublicId }
+import com.keepit.common.db.Id
+import com.keepit.common.json.{ TraversableFormat, KeyFormat, TupleFormat }
+import com.keepit.common.logging.Logging
+import com.keepit.discussion.Message
+import com.keepit.eliza.commanders.{ MessageFetchingCommander, ElizaDiscussionCommander, NotificationDeliveryCommander, MessagingCommander }
+import com.keepit.common.controller.ElizaServiceController
+import com.keepit.common.time._
+import com.keepit.eliza.model.{ ElizaMessage, MessageSource }
+import com.keepit.eliza.model.ElizaMessage._
+import com.keepit.heimdal._
+import com.keepit.model.{ User, Keep }
+import com.keepit.shoebox.ShoeboxServiceClient
+
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.libs.json._
+
+import com.google.inject.Inject
+import play.api.mvc.Action
+
+import scala.concurrent.Future
+import scala.util.{ Try, Success, Failure }
+
+class ElizaDiscussionController @Inject() (
+  notificationCommander: NotificationDeliveryCommander,
+  discussionCommander: ElizaDiscussionCommander,
+  messageFetchingCommander: MessageFetchingCommander,
+  shoebox: ShoeboxServiceClient,
+  implicit val publicIdConfig: PublicIdConfiguration,
+  heimdalContextBuilder: HeimdalContextBuilderFactory)
+    extends ElizaServiceController with Logging {
+
+  def getMessagesOnKeep(keepId: Id[Keep], limit: Int = 10, fromRawIdOpt: Option[Long] = None) = Action.async { request =>
+    val fromIdOpt = fromRawIdOpt.map(Id[Message]).map(ElizaMessage.fromCommon)
+    discussionCommander.getMessagesOnKeep(keepId, fromIdOpt, limit).map { msgs =>
+      Ok(Json.obj("messages" -> msgs))
+    }
+  }
+
+  def sendMessageOnKeep(authorId: Id[User], keepId: Id[Keep]) = Action.async(parse.tolerantJson) { request =>
+    val text = (request.body \ "text").as[String]
+    val contextBuilder = heimdalContextBuilder.withRequestInfo(request)
+    discussionCommander.sendMessageOnKeep(authorId, text, keepId, source = Some(MessageSource.SITE))(contextBuilder.build).map { msg =>
+      Ok(Json.obj("pubId" -> Message.publicId(ElizaMessage.toCommon(msg.id.get)), "sentAt" -> msg.createdAt))
+    }
+  }
+
+  def markKeepsAsRead() = Action(parse.tolerantJson) { request =>
+    implicit val inputReads = KeyFormat.key2Reads[Id[Keep], Id[Message]]("keepId", "lastMessage")
+    val outputWrites = TraversableFormat.mapWrites[Id[Keep], Int](_.id.toString)
+    val userId = (request.body \ "user").as[Id[User]]
+    val input = request.body.as[Seq[(Id[Keep], Id[Message])]]
+    val unreadMessagesByKeep = input.flatMap {
+      case (keepId, msgId) => discussionCommander.markAsRead(userId, keepId, ElizaMessage.fromCommon(msgId)).map { unreadMsgCount => keepId -> unreadMsgCount }
+    }.toMap
+    Ok(outputWrites.writes(unreadMessagesByKeep))
+  }
+
+  def deleteMessageOnKeep() = Action(parse.tolerantJson) { request =>
+    val inputReads = KeyFormat.key3Reads[Id[User], Id[Keep], Id[Message]]("userId", "keepId", "messageId")
+    val (userId, keepId, msgId) = request.body.as[(Id[User], Id[Keep], Id[Message])](inputReads)
+    discussionCommander.deleteMessageOnKeep(userId, keepId, ElizaMessage.fromCommon(msgId)).map { _ =>
+      NoContent
+    }.recover {
+      case fail: Exception => BadRequest(JsString(fail.getMessage))
+    }.get
+  }
+}

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/site/WebsiteMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/site/WebsiteMessagingController.scala
@@ -105,7 +105,7 @@ class WebsiteMessagingController @Inject() (
           case Some(messageId) =>
             val elizaMessageId = ElizaMessage.fromCommon(messageId)
             shoebox.canDeleteCommentOnKeep(request.userId, keepId).map { canDelete =>
-              if (canDelete && discussionCommander.deleteMessageOnKeep(request.userId, keepId, elizaMessageId)) Ok
+              if (canDelete && discussionCommander.deleteMessageOnKeep(request.userId, keepId, elizaMessageId).isSuccess) Ok
               else Forbidden(Json.obj("error" -> "insufficient_permissions"))
             }
         }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/site/WebsiteMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/site/WebsiteMessagingController.scala
@@ -73,7 +73,7 @@ class WebsiteMessagingController @Inject() (
                 val contextBuilder = heimdalContextBuilder.withRequestInfo(request)
                 for {
                   msg <- discussionCommander.sendMessageOnKeep(request.userId, text, keepId, source = Some(MessageSource.SITE))(contextBuilder.build)
-                } yield Ok(Json.obj("pubId" -> Message.publicId(ElizaMessage.toCommon(msg.id.get)), "sentAt" -> msg.createdAt))
+                } yield Ok(Json.toJson(msg))
               } else Future.successful(Forbidden)
             }
         }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
@@ -6,7 +6,7 @@ import com.keepit.common.db.slick.{ Repo, DbRepo, ExternalIdColumnFunction, Exte
 import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
 import com.keepit.common.cache.CacheStatistics
 import com.keepit.common.logging.AccessLog
-import com.keepit.discussion.Message
+import com.keepit.discussion.{ CrossServiceMessage, Message }
 import com.keepit.notify.model.Recipient
 import org.joda.time.DateTime
 import com.keepit.common.time._
@@ -126,9 +126,17 @@ case class ElizaMessage(
     extends ModelWithExternalId[ElizaMessage] {
   def withId(id: Id[ElizaMessage]): ElizaMessage = this.copy(id = Some(id))
   def withUpdateTime(updateTime: DateTime) = this.copy(updatedAt = updateTime)
+  def withText(newText: String) = this.copy(messageText = newText)
   def sanitizeForDelete = this.copy(state = ElizaMessageStates.INACTIVE)
 
   def isActive: Boolean = state == ElizaMessageStates.ACTIVE
+
+  def asCrossServiceMessage = CrossServiceMessage(
+    id = ElizaMessage.toCommon(id.get),
+    sentAt = createdAt,
+    sentBy = from.asUser,
+    text = messageText
+  )
 }
 object ElizaMessageStates extends States[ElizaMessage]
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
@@ -127,6 +127,8 @@ case class ElizaMessage(
   def withId(id: Id[ElizaMessage]): ElizaMessage = this.copy(id = Some(id))
   def withUpdateTime(updateTime: DateTime) = this.copy(updatedAt = updateTime)
   def sanitizeForDelete = this.copy(state = ElizaMessageStates.INACTIVE)
+
+  def isActive: Boolean = state == ElizaMessageStates.ACTIVE
 }
 object ElizaMessageStates extends States[ElizaMessage]
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
@@ -130,13 +130,6 @@ case class ElizaMessage(
   def sanitizeForDelete = this.copy(state = ElizaMessageStates.INACTIVE)
 
   def isActive: Boolean = state == ElizaMessageStates.ACTIVE
-
-  def asCrossServiceMessage = CrossServiceMessage(
-    id = ElizaMessage.toCommon(id.get),
-    sentAt = createdAt,
-    sentBy = from.asUser,
-    text = messageText
-  )
 }
 object ElizaMessageStates extends States[ElizaMessage]
 

--- a/kifi-backend/modules/eliza/conf/elizaService.routes
+++ b/kifi-backend/modules/eliza/conf/elizaService.routes
@@ -73,10 +73,13 @@ GET   /internal/eliza/connectedClientCount      @com.keepit.eliza.controllers.in
 GET   /internal/eliza/getUserThreadStats        @com.keepit.eliza.controllers.internal.ElizaController.getUserThreadStats(userId: Id[User])
 GET   /internal/eliza/sequenceNumber/renormalization @com.keepit.eliza.controllers.internal.ElizaController.getRenormalizationSequenceNumber()
 
-POST    /internal/eliza/keeps/markAsRead      @com.keepit.eliza.controllers.site.WebsiteMessagingController.markKeepsAsRead()
-POST    /internal/eliza/keeps/:id/message     @com.keepit.eliza.controllers.site.WebsiteMessagingController.sendMessageOnKeep(id: PublicId[Keep])
-GET     /internal/eliza/keeps/:id/messages    @com.keepit.eliza.controllers.site.WebsiteMessagingController.getMessagesOnKeep(id: PublicId[Keep], limit: Int ?= 10, fromId: Option[String] ?= None)
-POST    /internal/eliza/keeps/:id/deleteMessage @com.keepit.eliza.controllers.site.WebsiteMessagingController.deleteMessageOnKeep(id: PublicId[Keep])
+POST    /internal/eliza/getCrossServiceMessages  @com.keepit.eliza.controllers.internal.ElizaDiscussionController.getCrossServiceMessages
+POST    /internal/eliza/getDiscussionsForKeeps   @com.keepit.eliza.controllers.internal.ElizaDiscussionController.getDiscussionsForKeeps
+POST    /internal/eliza/markKeepsAsReadForUser   @com.keepit.eliza.controllers.internal.ElizaDiscussionController.markKeepsAsReadForUser()
+POST    /internal/eliza/sendMessageOnKeep        @com.keepit.eliza.controllers.internal.ElizaDiscussionController.sendMessageOnKeep()
+POST    /internal/eliza/getMessagesOnKeep        @com.keepit.eliza.controllers.internal.ElizaDiscussionController.getMessagesOnKeep
+POST    /internal/eliza/editMessage              @com.keepit.eliza.controllers.internal.ElizaDiscussionController.editMessage()
+POST    /internal/eliza/deleteMessage            @com.keepit.eliza.controllers.internal.ElizaDiscussionController.deleteMessage()
 
 GET   /internal/eliza/getThreadContentForIndexing  @com.keepit.eliza.controllers.internal.MessagingController.getThreadContentForIndexing(sequenceNumber: Long, maxBatchSize: Long)
 
@@ -90,7 +93,6 @@ POST  /internal/eliza/sharedThreadsForGroupByWeek         @com.keepit.eliza.cont
 POST  /internal/eliza/allThreadsForGroupByWeek         @com.keepit.eliza.controllers.internal.ElizaController.getAllThreadsForGroupByWeek
 
 GET   /internal/eliza/getParticipantsByThreadExtId      @com.keepit.eliza.controllers.internal.ElizaController.getParticipantsByThreadExtId(threadId: ExternalId[MessageThread])
-POST  /internal/eliza/getDiscussionsForKeeps            @com.keepit.eliza.controllers.internal.ElizaController.getDiscussionsForKeeps
 
 GET  /internal/eliza/getUnreadNotifications     @com.keepit.eliza.controllers.internal.MessagingController.getUnreadNotifications(userId: Id[User], howMany: Int)
 

--- a/kifi-backend/modules/eliza/conf/elizaService.routes
+++ b/kifi-backend/modules/eliza/conf/elizaService.routes
@@ -4,6 +4,10 @@
 
 POST    /eliza/site/chatter               @com.keepit.controllers.site.ChatterController.getChatter
 GET     /eliza/site/notifications         @com.keepit.eliza.controllers.site.WebsiteMessagingController.getNotifications(n: Int, before: Option[String] ?= None)
+
+
+# DEPRECATED ROUTES
+# There are equivalent Shoebox routes that should be called instead
 POST    /eliza/site/keeps/markAsRead      @com.keepit.eliza.controllers.site.WebsiteMessagingController.markKeepsAsRead()
 POST    /eliza/site/keeps/:id/message     @com.keepit.eliza.controllers.site.WebsiteMessagingController.sendMessageOnKeep(id: PublicId[Keep])
 GET     /eliza/site/keeps/:id/messages    @com.keepit.eliza.controllers.site.WebsiteMessagingController.getMessagesOnKeep(id: PublicId[Keep], limit: Int ?= 10, fromId: Option[String] ?= None)
@@ -68,6 +72,11 @@ POST  /internal/eliza/sendToAllUsers            @com.keepit.eliza.controllers.in
 GET   /internal/eliza/connectedClientCount      @com.keepit.eliza.controllers.internal.ElizaController.connectedClientCount
 GET   /internal/eliza/getUserThreadStats        @com.keepit.eliza.controllers.internal.ElizaController.getUserThreadStats(userId: Id[User])
 GET   /internal/eliza/sequenceNumber/renormalization @com.keepit.eliza.controllers.internal.ElizaController.getRenormalizationSequenceNumber()
+
+POST    /internal/eliza/keeps/markAsRead      @com.keepit.eliza.controllers.site.WebsiteMessagingController.markKeepsAsRead()
+POST    /internal/eliza/keeps/:id/message     @com.keepit.eliza.controllers.site.WebsiteMessagingController.sendMessageOnKeep(id: PublicId[Keep])
+GET     /internal/eliza/keeps/:id/messages    @com.keepit.eliza.controllers.site.WebsiteMessagingController.getMessagesOnKeep(id: PublicId[Keep], limit: Int ?= 10, fromId: Option[String] ?= None)
+POST    /internal/eliza/keeps/:id/deleteMessage @com.keepit.eliza.controllers.site.WebsiteMessagingController.deleteMessageOnKeep(id: PublicId[Keep])
 
 GET   /internal/eliza/getThreadContentForIndexing  @com.keepit.eliza.controllers.internal.MessagingController.getThreadContentForIndexing(sequenceNumber: Long, maxBatchSize: Long)
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/DiscussionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/DiscussionCommander.scala
@@ -1,0 +1,38 @@
+package com.keepit.commanders
+
+import com.google.inject.{ ImplementedBy, Inject, Singleton }
+import com.keepit.common.crypto.PublicId
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.logging.Logging
+import com.keepit.discussion.Message
+import com.keepit.eliza.ElizaServiceClient
+import com.keepit.model._
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+@ImplementedBy(classOf[DiscussionCommanderImpl])
+trait DiscussionCommander {
+  def markKeepsAsRead(userId: Id[User], lastSeenByKeep: Map[Id[Keep], Id[Message]]): Future[Map[Id[Keep], Int]]
+  def sendMessageOnKeep(userId: Id[User], text: String, keepId: Id[Keep]): Future[Message]
+  def getMessagesOnKeep(userId: Id[User], keepId: Id[Keep], limit: Int, fromId: Option[Id[Message]]): Future[Seq[Message]]
+  def editMessageOnKeep(userId: Id[User], keepId: Id[Keep], msgId: Id[Message], newText: String): Future[Message]
+  def deleteMessageOnKeep(userId: Id[User], keepId: Id[Keep], msgId: Id[Message]): Future[Unit]
+}
+
+@Singleton
+class DiscussionCommanderImpl @Inject() (
+  db: Database,
+  eliza: ElizaServiceClient,
+  permissionCommander: PermissionCommander,
+  airbrake: AirbrakeNotifier,
+  implicit val executionContext: ExecutionContext)
+    extends DiscussionCommander with Logging {
+
+  def markKeepsAsRead(userId: Id[User], lastSeenByKeep: Map[Id[Keep], Id[Message]]): Future[Map[Id[Keep], Int]] = ???
+  def sendMessageOnKeep(userId: Id[User], text: String, keepId: Id[Keep]): Future[Message] = ???
+  def getMessagesOnKeep(userId: Id[User], keepId: Id[Keep], limit: Int, fromId: Option[Id[Message]]): Future[Seq[Message]] = ???
+  def editMessageOnKeep(userId: Id[User], keepId: Id[Keep], msgId: Id[Message], newText: String): Future[Message] = ???
+  def deleteMessageOnKeep(userId: Id[User], keepId: Id[Keep], msgId: Id[Message]): Future[Unit] = ???
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/DiscussionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/DiscussionCommander.scala
@@ -1,12 +1,11 @@
 package com.keepit.commanders
 
 import com.google.inject.{ ImplementedBy, Inject, Singleton }
-import com.keepit.common.crypto.PublicId
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
-import com.keepit.discussion.Message
+import com.keepit.discussion.{ DiscussionFail, Message }
 import com.keepit.eliza.ElizaServiceClient
 import com.keepit.model._
 
@@ -30,9 +29,45 @@ class DiscussionCommanderImpl @Inject() (
   implicit val executionContext: ExecutionContext)
     extends DiscussionCommander with Logging {
 
-  def markKeepsAsRead(userId: Id[User], lastSeenByKeep: Map[Id[Keep], Id[Message]]): Future[Map[Id[Keep], Int]] = ???
-  def sendMessageOnKeep(userId: Id[User], text: String, keepId: Id[Keep]): Future[Message] = ???
-  def getMessagesOnKeep(userId: Id[User], keepId: Id[Keep], limit: Int, fromId: Option[Id[Message]]): Future[Seq[Message]] = ???
-  def editMessageOnKeep(userId: Id[User], keepId: Id[Keep], msgId: Id[Message], newText: String): Future[Message] = ???
-  def deleteMessageOnKeep(userId: Id[User], keepId: Id[Keep], msgId: Id[Message]): Future[Unit] = ???
+  def markKeepsAsRead(userId: Id[User], lastSeenByKeep: Map[Id[Keep], Id[Message]]): Future[Map[Id[Keep], Int]] = {
+    eliza.markKeepsAsReadForUser(userId, lastSeenByKeep)
+  }
+  def sendMessageOnKeep(userId: Id[User], text: String, keepId: Id[Keep]): Future[Message] = {
+    val errs = db.readOnlyReplica { implicit s =>
+      val userCanSendMessage = permissionCommander.getKeepPermissions(keepId, Some(userId)).contains(KeepPermission.ADD_MESSAGE)
+      Stream[Option[DiscussionFail]](
+        Some(DiscussionFail.INSUFFICIENT_PERMISSIONS).filter(_ => !userCanSendMessage)
+      ).flatten
+    }
+
+    errs.headOption.map(fail => Future.failed(fail)).getOrElse {
+      eliza.sendMessageOnKeep(userId, text, keepId)
+    }
+  }
+  def getMessagesOnKeep(userId: Id[User], keepId: Id[Keep], limit: Int, fromIdOpt: Option[Id[Message]]): Future[Seq[Message]] = {
+    val errs = db.readOnlyReplica { implicit s =>
+      val userCanViewMessages = permissionCommander.getKeepPermissions(keepId, Some(userId)).contains(KeepPermission.VIEW_MESSAGES)
+      Stream[Option[DiscussionFail]](
+        Some(DiscussionFail.INSUFFICIENT_PERMISSIONS).filter(_ => !userCanViewMessages)
+      ).flatten
+    }
+
+    errs.headOption.map(fail => Future.failed(fail)).getOrElse {
+      eliza.getMessagesOnKeep(keepId, fromIdOpt, limit)
+    }
+  }
+  def editMessageOnKeep(userId: Id[User], keepId: Id[Keep], msgId: Id[Message], newText: String): Future[Message] = {
+    for {
+      msg <- eliza.getCrossServiceMessages(Set(msgId)).map(_.values.head)
+      owner <- msg.sentBy.filter(_ == userId).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INSUFFICIENT_PERMISSIONS))
+      editedMsg <- eliza.editMessage(msgId, newText)
+    } yield editedMsg
+  }
+  def deleteMessageOnKeep(userId: Id[User], keepId: Id[Keep], msgId: Id[Message]): Future[Unit] = {
+    for {
+      msg <- eliza.getCrossServiceMessages(Set(msgId)).map(_.values.head)
+      owner <- msg.sentBy.filter(_ == userId).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INSUFFICIENT_PERMISSIONS))
+      res <- eliza.deleteMessage(msgId)
+    } yield res
+  }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
@@ -4,15 +4,10 @@ import com.google.inject.{ ImplementedBy, Inject, Singleton }
 import com.keepit.common.cache._
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.DBSession.RSession
-import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.{ AccessLog, Logging }
 import com.keepit.common.performance.StatsdTiming
 import com.keepit.model._
-import com.keepit.common.core.anyExtensionOps
-import com.keepit.payments.PaidAccount
-import play.api.libs.functional.syntax._
-import play.api.libs.json._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration
@@ -22,8 +17,12 @@ import scala.util.Random
 trait PermissionCommander {
   def getOrganizationsPermissions(orgIds: Set[Id[Organization]], userIdOpt: Option[Id[User]])(implicit session: RSession): Map[Id[Organization], Set[OrganizationPermission]]
   def getOrganizationPermissions(orgId: Id[Organization], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[OrganizationPermission]
-  def getLibraryPermissions(libId: Id[Library], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[LibraryPermission]
+
   def getLibrariesPermissions(libIds: Set[Id[Library]], userIdOpt: Option[Id[User]])(implicit session: RSession): Map[Id[Library], Set[LibraryPermission]]
+  def getLibraryPermissions(libId: Id[Library], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[LibraryPermission]
+
+  def getKeepsPermissions(keepIds: Set[Id[Keep]], userIdOpt: Option[Id[User]])(implicit session: RSession): Map[Id[Keep], Set[KeepPermission]]
+  def getKeepPermissions(keepId: Id[Keep], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[KeepPermission]
 }
 
 @Singleton
@@ -37,6 +36,10 @@ class PermissionCommanderImpl @Inject() (
     libraryRepo: LibraryRepo,
     libraryMembershipRepo: LibraryMembershipRepo,
     libraryInviteRepo: LibraryInviteRepo,
+    keepRepo: KeepRepo,
+    userRepo: UserRepo,
+    ktlRepo: KeepToLibraryRepo,
+    ktuRepo: KeepToUserRepo,
     airbrake: AirbrakeNotifier,
     implicit val executionContext: ExecutionContext) extends PermissionCommander with Logging {
 
@@ -251,6 +254,37 @@ class PermissionCommanderImpl @Inject() (
       OrganizationPermission.REDEEM_CREDIT_CODE,
       OrganizationPermission.REMOVE_MEMBERS
     )
+  }
+
+  def getKeepsPermissions(keepIds: Set[Id[Keep]], userIdOpt: Option[Id[User]])(implicit session: RSession): Map[Id[Keep], Set[KeepPermission]] = {
+    val librariesByKeep = ktlRepo.getAllByKeepIds(keepIds)
+    val usersByKeep = ktuRepo.getAllByKeepIds(keepIds)
+
+    val libIds = librariesByKeep.values.flatten.map(_.libraryId).toSet
+    val libraries = libraryRepo.getActiveByIds(libIds)
+    val libPermissions = getLibrariesPermissions(libIds, userIdOpt)
+    val keeps = keepRepo.getByIds(keepIds)
+
+    keeps.map {
+      case (kid, k) =>
+        val keepLibraries = librariesByKeep.getOrElse(kid, Seq.empty).map(_.libraryId)
+
+        val canAddMessage = keepLibraries.exists { libId =>
+          libPermissions.getOrElse(libId, Set.empty).contains(LibraryPermission.ADD_COMMENTS)
+        }
+        val canDeleteOwnMessages = true
+        val canDeleteOtherMessages = keepLibraries.flatMap(libraries.get).exists(lib => userIdOpt.contains(lib.ownerId))
+
+        kid -> List(
+          canAddMessage -> KeepPermission.ADD_MESSAGE,
+          canDeleteOwnMessages -> KeepPermission.DELETE_OWN_MESSAGES,
+          canDeleteOtherMessages -> KeepPermission.DELETE_OTHER_MESSAGES
+        ).collect { case (true, p) => p }.toSet[KeepPermission]
+    }
+  }
+
+  def getKeepPermissions(keepId: Id[Keep], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[KeepPermission] = {
+    getKeepsPermissions(Set(keepId), userIdOpt).getOrElse(keepId, Set.empty)
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
@@ -277,6 +277,13 @@ class PermissionCommanderImpl @Inject() (
           }
           viewerIsDirectlyConnectedToKeep || viewerIsConnectedToKeepByALibrary
         }
+        val canViewMessages = {
+          val viewerIsDirectlyConnectedToKeep = userIdOpt.exists(keepUsers.contains)
+          val viewerIsConnectedToKeepByALibrary = keepLibraries.exists { libId =>
+            libPermissions.getOrElse(libId, Set.empty).contains(LibraryPermission.VIEW_LIBRARY)
+          }
+          viewerIsDirectlyConnectedToKeep || viewerIsConnectedToKeepByALibrary
+        }
         val canDeleteOwnMessages = true
         val canDeleteOtherMessages = {
           // This seems like a pretty strange operational definition...
@@ -287,7 +294,8 @@ class PermissionCommanderImpl @Inject() (
         kid -> List(
           canAddMessage -> KeepPermission.ADD_MESSAGE,
           canDeleteOwnMessages -> KeepPermission.DELETE_OWN_MESSAGES,
-          canDeleteOtherMessages -> KeepPermission.DELETE_OTHER_MESSAGES
+          canDeleteOtherMessages -> KeepPermission.DELETE_OTHER_MESSAGES,
+          canViewMessages -> KeepPermission.VIEW_MESSAGES
         ).collect { case (true, p) => p }.toSet[KeepPermission]
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
@@ -287,8 +287,9 @@ class PermissionCommanderImpl @Inject() (
         val canDeleteOwnMessages = true
         val canDeleteOtherMessages = {
           // This seems like a pretty strange operational definition...
+          val viewerOwnsTheKeep = userIdOpt.contains(k.userId)
           val viewerOwnsOneOfTheKeepLibraries = keepLibraries.flatMap(libraries.get).exists(lib => userIdOpt.contains(lib.ownerId))
-          viewerOwnsOneOfTheKeepLibraries
+          viewerOwnsTheKeep || viewerOwnsOneOfTheKeepLibraries
         }
 
         kid -> List(

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/DiscussionController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/DiscussionController.scala
@@ -1,21 +1,23 @@
 package com.keepit.controllers.website
 
 import com.google.inject.{ Inject, Singleton }
+import com.keepit.commanders.DiscussionCommander
 import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper }
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
 import com.keepit.common.json.{ TraversableFormat, KeyFormat }
-import com.keepit.discussion.Message
+import com.keepit.discussion.{ DiscussionFail, Message }
 import com.keepit.eliza.ElizaServiceClient
 import com.keepit.model._
 import play.api.libs.json.Json
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ Future, ExecutionContext }
 
 @Singleton
 class DiscussionController @Inject() (
   eliza: ElizaServiceClient,
+  discussionCommander: DiscussionCommander,
   val userActionsHelper: UserActionsHelper,
   val db: Database,
   implicit val publicIdConfig: PublicIdConfiguration,
@@ -23,38 +25,74 @@ class DiscussionController @Inject() (
     extends UserActions with ShoeboxServiceController {
 
   def markKeepsAsRead() = UserAction.async(parse.tolerantJson) { request =>
-    eliza.markKeepsAsReadForUser(request.userId, request.body.as[Set[Id[Keep]]]).map { res =>
-      val ans = res.map {
-        case (kid, unread) => Keep.publicId(kid) -> unread
-      }
+    implicit val inputFormat = KeyFormat.key2Reads[PublicId[Keep], PublicId[Message]]("keepId", "lastMessage")
+    (for {
+      parsedInput <- request.body.validate[Seq[(PublicId[Keep], PublicId[Message])]].map(Future.successful).getOrElse(Future.failed(DiscussionFail.COULD_NOT_PARSE))
+      input = parsedInput.map {
+        case (keepPubId, msgPubId) => Keep.decodePublicId(keepPubId).get -> Message.decodePublicId(msgPubId).get
+      }.toMap
+      unreadCountsByKeep <- discussionCommander.markKeepsAsRead(request.userId, input)
+    } yield {
       val outputWrites = TraversableFormat.mapWrites[PublicId[Keep], Int](_.id)
-      Ok(Json.toJson(ans)(outputWrites))
+      val res = unreadCountsByKeep.map {
+        case (kid, unreadCount) => Keep.publicId(kid) -> unreadCount
+      }
+      Ok(Json.toJson(res)(outputWrites))
+    }).recover {
+      case fail: DiscussionFail => fail.asErrorResponse
     }
   }
-  def sendMessageOnKeep(keepId: PublicId[Keep]) = UserAction.async(parse.tolerantJson) { request =>
-    eliza.sendMessageOnKeep(request.userId, (request.body \ "text").as[String], Keep.decodePublicId(keepId).get).map { res =>
-      Ok(Json.toJson(res))
+  def sendMessageOnKeep(pubId: PublicId[Keep]) = UserAction.async(parse.tolerantJson) { request =>
+    (for {
+      text <- (request.body \ "text").asOpt[String].map(Future.successful).getOrElse(Future.failed(DiscussionFail.MISSING_MESSAGE_TEXT))
+      keepId <- Keep.decodePublicId(pubId).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INVALID_KEEP_ID))
+      msg <- discussionCommander.sendMessageOnKeep(request.userId, text, keepId)
+    } yield {
+      Ok(Json.toJson(msg))
+    }).recover {
+      case fail: DiscussionFail => fail.asErrorResponse
     }
   }
-  def getMessagesOnKeep(keepId: PublicId[Keep], limit: Int, fromId: Option[String]) = UserAction.async(parse.tolerantJson) { request =>
-    eliza.getMessagesOnKeep(Keep.decodePublicId(keepId).get, fromId.map(s => Message.decodePublicId(PublicId(s)).get), limit).map { res =>
-      Ok(Json.obj("messages" -> res))
+  def getMessagesOnKeep(pubId: PublicId[Keep], limit: Int, fromPubIdOpt: Option[String]) = UserAction.async(parse.tolerantJson) { request =>
+    val fromIdOptFut = fromPubIdOpt.filter(_.nonEmpty) match {
+      case None => Future.successful(None)
+      case Some(fromPubId) =>
+        Message.decodePublicId(PublicId(fromPubId)).map(x => Future.successful(Some(x))).getOrElse(Future.failed(DiscussionFail.INVALID_MESSAGE_ID))
+    }
+    (for {
+      keepId <- Keep.decodePublicId(pubId).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INVALID_KEEP_ID))
+      fromIdOpt <- fromIdOptFut
+      msgs <- discussionCommander.getMessagesOnKeep(request.userId, keepId, limit, fromIdOpt)
+    } yield {
+      Ok(Json.obj("messages" -> msgs))
+    }).recover {
+      case fail: DiscussionFail => fail.asErrorResponse
     }
   }
-  def editMessageOnKeep(keepId: PublicId[Keep]) = UserAction.async(parse.tolerantJson) { request =>
-    // TODO(ryan): validate request
+  def editMessageOnKeep(pubId: PublicId[Keep]) = UserAction.async(parse.tolerantJson) { request =>
     val inputReads = KeyFormat.key2Reads[PublicId[Message], String]("messageId", "newText")
-    val (msgId, newText) = request.body.as[(PublicId[Message], String)](inputReads)
-    eliza.editMessage(Message.decodePublicId(msgId).get, newText).map { res =>
-      Ok(Json.toJson(res))
+    (for {
+      keepId <- Keep.decodePublicId(pubId).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INVALID_KEEP_ID))
+      (msgPubId, newText) <- request.body.validate[(PublicId[Message], String)](inputReads).map(Future.successful).getOrElse(Future.failed(DiscussionFail.COULD_NOT_PARSE))
+      msgId <- Message.decodePublicId(msgPubId).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INVALID_MESSAGE_ID))
+      editedMsg <- discussionCommander.editMessageOnKeep(request.userId, keepId, msgId, newText)
+    } yield {
+      Ok(Json.toJson(editedMsg))
+    }).recover {
+      case fail: DiscussionFail => fail.asErrorResponse
     }
   }
-  def deleteMessageOnKeep(keepId: PublicId[Keep]) = UserAction.async(parse.tolerantJson) { request =>
-    // TODO(ryan): validate request
+  def deleteMessageOnKeep(pubId: PublicId[Keep]) = UserAction.async(parse.tolerantJson) { request =>
     val inputReads = KeyFormat.key1Reads[PublicId[Message]]("messageId")
-    val msgId = request.body.as[PublicId[Message]](inputReads)
-    eliza.deleteMessage(Message.decodePublicId(msgId).get).map { res =>
-      Ok(Json.toJson(res))
+    (for {
+      keepId <- Keep.decodePublicId(pubId).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INVALID_KEEP_ID))
+      msgPubId <- request.body.validate[PublicId[Message]](inputReads).map(Future.successful).getOrElse(Future.failed(DiscussionFail.COULD_NOT_PARSE))
+      msgId <- Message.decodePublicId(msgPubId).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INVALID_MESSAGE_ID))
+      delete <- discussionCommander.deleteMessageOnKeep(request.userId, keepId, msgId)
+    } yield {
+      NoContent
+    }).recover {
+      case fail: DiscussionFail => fail.asErrorResponse
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/DiscussionController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/DiscussionController.scala
@@ -33,11 +33,11 @@ class DiscussionController @Inject() (
       }.toMap
       unreadCountsByKeep <- discussionCommander.markKeepsAsRead(request.userId, input)
     } yield {
-      val outputWrites = TraversableFormat.mapWrites[PublicId[Keep], Int](_.id)
+      implicit val outputWrites = TraversableFormat.mapWrites[PublicId[Keep], Int](_.id)
       val res = unreadCountsByKeep.map {
         case (kid, unreadCount) => Keep.publicId(kid) -> unreadCount
       }
-      Ok(Json.toJson(res)(outputWrites))
+      Ok(Json.obj("unreadCounts" -> res))
     }).recover {
       case fail: DiscussionFail => fail.asErrorResponse
     }
@@ -77,7 +77,7 @@ class DiscussionController @Inject() (
       msgId <- Message.decodePublicId(msgPubId).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INVALID_MESSAGE_ID))
       editedMsg <- discussionCommander.editMessageOnKeep(request.userId, keepId, msgId, newText)
     } yield {
-      Ok(Json.toJson(editedMsg))
+      Ok(Json.obj("message" -> editedMsg))
     }).recover {
       case fail: DiscussionFail => fail.asErrorResponse
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/DiscussionController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/DiscussionController.scala
@@ -1,49 +1,60 @@
 package com.keepit.controllers.website
 
 import com.google.inject.{ Inject, Singleton }
-import com.keepit.commanders.{ LibraryAccessCommander, LibraryMembershipCommander, PermissionCommander }
 import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper }
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
+import com.keepit.common.db.Id
 import com.keepit.common.db.slick.Database
-import com.keepit.common.json.EitherFormat
+import com.keepit.common.json.{ TraversableFormat, KeyFormat }
 import com.keepit.discussion.Message
-import com.keepit.model.ExternalLibrarySpace.{ ExternalOrganizationSpace, ExternalUserSpace }
-import com.keepit.model.LibrarySpace.{ OrganizationSpace, UserSpace }
+import com.keepit.eliza.ElizaServiceClient
 import com.keepit.model._
-import com.keepit.slack.models._
-import com.keepit.slack.{ LibraryToSlackChannelPusher, SlackClient, SlackCommander }
-import play.api.libs.json.{ JsObject, JsSuccess, Json, JsError }
+import play.api.libs.json.Json
 
-import scala.concurrent.{ Future, ExecutionContext }
-import scala.util.{ Success, Failure }
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class DiscussionController @Inject() (
-  slackClient: SlackClient,
-  slackCommander: SlackCommander,
-  libraryAccessCommander: LibraryAccessCommander,
-  deepLinkRouter: DeepLinkRouter,
-  slackToLibRepo: SlackChannelToLibraryRepo,
-  userRepo: UserRepo,
+  eliza: ElizaServiceClient,
   val userActionsHelper: UserActionsHelper,
   val db: Database,
   implicit val publicIdConfig: PublicIdConfiguration,
   implicit val ec: ExecutionContext)
     extends UserActions with ShoeboxServiceController {
 
-  def markKeepsAsRead() = UserAction(parse.tolerantJson) { request =>
-    ???
+  def markKeepsAsRead() = UserAction.async(parse.tolerantJson) { request =>
+    eliza.markKeepsAsReadForUser(request.userId, request.body.as[Set[Id[Keep]]]).map { res =>
+      val ans = res.map {
+        case (kid, unread) => Keep.publicId(kid) -> unread
+      }
+      val outputWrites = TraversableFormat.mapWrites[PublicId[Keep], Int](_.id)
+      Ok(Json.toJson(ans)(outputWrites))
+    }
   }
-  def sendMessageOnKeep(keepId: PublicId[Keep]) = UserAction(parse.tolerantJson) { request =>
-    ???
+  def sendMessageOnKeep(keepId: PublicId[Keep]) = UserAction.async(parse.tolerantJson) { request =>
+    eliza.sendMessageOnKeep(request.userId, (request.body \ "text").as[String], Keep.decodePublicId(keepId).get).map { res =>
+      Ok(Json.toJson(res))
+    }
   }
-  def getMessagesOnKeep(keepId: PublicId[Keep], limit: Int, fromId: Option[String]) = UserAction(parse.tolerantJson) { request =>
-    ???
+  def getMessagesOnKeep(keepId: PublicId[Keep], limit: Int, fromId: Option[String]) = UserAction.async(parse.tolerantJson) { request =>
+    eliza.getMessagesOnKeep(Keep.decodePublicId(keepId).get, fromId.map(s => Message.decodePublicId(PublicId(s)).get), limit).map { res =>
+      Ok(Json.obj("messages" -> res))
+    }
   }
-  def editMessageOnKeep(keepId: PublicId[Keep]) = UserAction(parse.tolerantJson) { request =>
-    ???
+  def editMessageOnKeep(keepId: PublicId[Keep]) = UserAction.async(parse.tolerantJson) { request =>
+    // TODO(ryan): validate request
+    val inputReads = KeyFormat.key2Reads[PublicId[Message], String]("messageId", "newText")
+    val (msgId, newText) = request.body.as[(PublicId[Message], String)](inputReads)
+    eliza.editMessage(Message.decodePublicId(msgId).get, newText).map { res =>
+      Ok(Json.toJson(res))
+    }
   }
-  def deleteMessageOnKeep(keepId: PublicId[Keep]) = UserAction(parse.tolerantJson) { request =>
-    ???
+  def deleteMessageOnKeep(keepId: PublicId[Keep]) = UserAction.async(parse.tolerantJson) { request =>
+    // TODO(ryan): validate request
+    val inputReads = KeyFormat.key1Reads[PublicId[Message]]("messageId")
+    val msgId = request.body.as[PublicId[Message]](inputReads)
+    eliza.deleteMessage(Message.decodePublicId(msgId).get).map { res =>
+      Ok(Json.toJson(res))
+    }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/DiscussionController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/DiscussionController.scala
@@ -1,0 +1,49 @@
+package com.keepit.controllers.website
+
+import com.google.inject.{ Inject, Singleton }
+import com.keepit.commanders.{ LibraryAccessCommander, LibraryMembershipCommander, PermissionCommander }
+import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper }
+import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
+import com.keepit.common.db.slick.Database
+import com.keepit.common.json.EitherFormat
+import com.keepit.discussion.Message
+import com.keepit.model.ExternalLibrarySpace.{ ExternalOrganizationSpace, ExternalUserSpace }
+import com.keepit.model.LibrarySpace.{ OrganizationSpace, UserSpace }
+import com.keepit.model._
+import com.keepit.slack.models._
+import com.keepit.slack.{ LibraryToSlackChannelPusher, SlackClient, SlackCommander }
+import play.api.libs.json.{ JsObject, JsSuccess, Json, JsError }
+
+import scala.concurrent.{ Future, ExecutionContext }
+import scala.util.{ Success, Failure }
+
+@Singleton
+class DiscussionController @Inject() (
+  slackClient: SlackClient,
+  slackCommander: SlackCommander,
+  libraryAccessCommander: LibraryAccessCommander,
+  deepLinkRouter: DeepLinkRouter,
+  slackToLibRepo: SlackChannelToLibraryRepo,
+  userRepo: UserRepo,
+  val userActionsHelper: UserActionsHelper,
+  val db: Database,
+  implicit val publicIdConfig: PublicIdConfiguration,
+  implicit val ec: ExecutionContext)
+    extends UserActions with ShoeboxServiceController {
+
+  def markKeepsAsRead() = UserAction(parse.tolerantJson) { request =>
+    ???
+  }
+  def sendMessageOnKeep(keepId: PublicId[Keep]) = UserAction(parse.tolerantJson) { request =>
+    ???
+  }
+  def getMessagesOnKeep(keepId: PublicId[Keep], limit: Int, fromId: Option[String]) = UserAction(parse.tolerantJson) { request =>
+    ???
+  }
+  def editMessageOnKeep(keepId: PublicId[Keep]) = UserAction(parse.tolerantJson) { request =>
+    ???
+  }
+  def deleteMessageOnKeep(keepId: PublicId[Keep]) = UserAction(parse.tolerantJson) { request =>
+    ???
+  }
+}

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -394,6 +394,12 @@ POST    /site/keeps/personalExport       @com.keepit.controllers.website.KeepsCo
 POST    /site/keeps/organizationExport   @com.keepit.controllers.website.KeepsController.exportOrganizationKeeps()
 GET     /site/keeps/:id                  @com.keepit.controllers.website.KeepsController.getKeepInfo(id: InternalOrExternalId[Keep])
 
+POST    /site/keeps/markAsRead              @com.keepit.controllers.website.DiscussionController.markKeepsAsRead()
+POST    /site/keeps/:keepId/messages        @com.keepit.controllers.website.DiscussionController.sendMessageOnKeep(keepId: PublicId[Keep])
+GET     /site/keeps/:keepId/messages        @com.keepit.controllers.website.DiscussionController.getMessagesOnKeep(keepId: PublicId[Keep], limit: Int ?= 10, fromId: Option[String] ?= None)
+POST    /site/keeps/:keepId/messages/edit   @com.keepit.controllers.website.DiscussionController.editMessageOnKeep(keepId: PublicId[Keep])
+POST    /site/keeps/:keepId/messages/delete @com.keepit.controllers.website.DiscussionController.deleteMessageOnKeep(keepId: PublicId[Keep])
+
 GET     /site/collections/page      @com.keepit.controllers.website.KeepsController.pageCollections(sort: String ?= "last_kept", offset : Int ?= 0, pageSize: Int ?= 0)
 POST    /site/collections/delete    @com.keepit.controllers.website.KeepsController.deleteCollectionByTag(tag: String)
 POST    /site/collections/rename    @com.keepit.controllers.website.KeepsController.renameCollectionByTag()


### PR DESCRIPTION
If the user wants to do something like comment on a keep, or get some messages on a keep, they ask Shoebox. Shoebox validates that the user is allowed to perform the requested action and then fires off an internal request to Eliza. Eliza blindly carries out that request to the best of its ability and reports back.

@camhashemi @leogrim @andrewconner 

This PR compiles and passes tests, but I'm like 95% sure it would break in production. I'll look over it tomorrow with a fine-toothed comb.
