### PR TITLE
Improving quick keep based on feedback

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/quickKeepsConfirmModal.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/quickKeepsConfirmModal.tpl.html
@@ -6,7 +6,7 @@
   <div ng-if="numKeepsProcessed > 0 && invalid.length > 0"><hr></div>
   <div ng-if="invalid.length > 0">
     Unfortunately, we had trouble with <span ng-bind="invalid.length"></span> of your links. Be sure to enter them one per line, and only include regular HTTP or HTTPs pages.
-    <div>One of the problematic links was:<br><code ng-bind="invalid[0]">/code></div>
+    <div>One of the problematic links was:<div><code ng-bind="invalid[0]"></code></div></div>
   </div>
   </div>
 </div>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/quickKeepsConfirmModal.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/quickKeepsConfirmModal.tpl.html
@@ -1,12 +1,12 @@
 <div kf-modal class="kf-quick-add-keeps">
   <div kf-basic-modal-content title="Add many keeps" action-text="Awesome!" action="">
   <div ng-if="numKeepsProcessed > 0">
-    Pulled out {{numKeepsProcessed}} links, and are munching on them now. They’ll be kept in your library very soon.
+    We pulled out <span ng-bind="numKeepsProcessed"></span> links, and are munching on them now. They’ll be kept in your library very soon.
   </div>
   <div ng-if="numKeepsProcessed > 0 && invalid.length > 0"><hr></div>
   <div ng-if="invalid.length > 0">
-    Unfortunately, we had trouble with {{invalid.length}} of your links. Be sure to enter them one per line, and only include regular HTTP or HTTPs pages.
-    <div>One of the problematic links was:<br><code>{{invalid[0]}}</code></div>
+    Unfortunately, we had trouble with <span ng-bind="invalid.length"></span> of your links. Be sure to enter them one per line, and only include regular HTTP or HTTPs pages.
+    <div>One of the problematic links was:<br><code ng-bind="invalid[0]">/code></div>
   </div>
   </div>
 </div>

--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -133,7 +133,8 @@ k.panes.notices = k.panes.notices || function () {
     var $box = $list.closest('.kifi-notices-box');
     $box.antiscroll({x: false});
     $(window).off('resize.notices').on('resize.notices', function () {
-      $box.data('antiscroll').refresh();
+      var antiscroll = $box.data('antiscroll');
+      antiscroll && antiscroll.refresh();
       $list.canScroll();
     });
 


### PR DESCRIPTION
@cvializ Thanks!

Also adding a bit of safety to ext's `notices.js`. While working for keep notifications, I noticed a JS error where `$box.data('antiscroll')` was undefined. I didn't figure out exactly what case causes that, but just added an extra check.
