### PR TITLE
The Kifi icon wasn't showing in the Firefox extensions tab

### DIFF
--- a/packrat/adapters/firefox/package.json
+++ b/packrat/adapters/firefox/package.json
@@ -8,8 +8,8 @@
   "version": "see build.properties",
   "main": "lib/main.js",
   "id": "kifi@42go.com",
-  "icon": "data/icons/kifi.48.png",
-  "icon64": "data/icons/kifi.64.png",
+  "icon": "icon.png",
+  "icon64": "icon64.png",
   "permissions": {
     "cross-domain-content": ["https://www.kifi.com"]
   }

--- a/packrat/gulpfile.js
+++ b/packrat/gulpfile.js
@@ -420,8 +420,10 @@ gulp.task('xpi-firefox', ['build', 'config'], function () {
     .pipe(gulp.dest('.'))
     .pipe(shell([
       // TODO: verify jpm version before using it
+      // TODO(carlos): remove the line copying icons when https://bugzilla.mozilla.org/show_bug.cgi?id=1141839 and https://github.com/mozilla-jetpack/jpm/issues/341 are fixed
       // TODO(carlos): remove the line with sed when https://github.com/mozilla-jetpack/jpm/issues/409 is resolved
       (target === 'dev' ? 'cp icons/dev/kifi.??.png out/firefox/data/icons/ && ' : '') + '\
+      cp icons/kifi.48.png out/firefox/icon.png && cp icons/kifi.64.png out/firefox/icon64.png && \
       cd ' + path.join(outDir + '/firefox') + ' && \
       jpm xpi && \
       sed -i ".bak" -e \'s/"urn:mozilla:kifi/"urn:mozilla:extension:kifi/g\' kifi\@42go.com-*.*.*.update.rdf && \


### PR DESCRIPTION
I copied what Adblock Plus was doing to make their icons show. Apparently if you put the icons in the default place where Firefox looks you don't need to do anything special.
