### PR TITLE
Ghetto comments updater

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comments.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comments.js
@@ -49,10 +49,9 @@ angular.module('kifi')
           }
 
           $scope.comments = $scope.keep.discussion.messages.slice().sort(bySentAt); // don't mutate the original array, in case we need it later
-          $scope.numMessages = $scope.keep.discussion.numMessages; // Total number of known messages that exist for this keep
 
           $scope.visibleCount = Math.min(3, $scope.comments.length);
-          $scope.showViewPreviousComments = $scope.hasMoreToFetch = $scope.visibleCount < $scope.numMessages;
+          $scope.showViewPreviousComments = $scope.hasMoreToFetch = $scope.visibleCount < $scope.keep.discussion.numMessages;
 
           // listeners
 

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comments.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comments.js
@@ -102,7 +102,6 @@ angular.module('kifi')
           var readTimer;
           $scope.onInview = function (e, intoView) {
             if (intoView) {
-
               readTimer = $timeout(function () {
                 readTimer = null;
 

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comments.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comments.tpl.html
@@ -1,5 +1,5 @@
 <div class="kf-keep-comments-container">
-  <div class="kf-keep-comments" ng-if="visibleCount > 0 || canAddComments" ng-attr-kf-inview="{{ keep.discussion && numMessages ? 'onInview' : undefined }}">
+  <div class="kf-keep-comments" ng-if="visibleCount > 0 || canAddComments" ng-attr-kf-inview="{{ keep.discussion && keep.discussion.messages.length > 0 ? 'onInview' : undefined }}">
     <span class="kf-keep-comments-view-previous" ng-if="showViewPreviousComments" ng-click="onViewPreviousComments()">View Previous Comments</span>
     <div
       class="kf-keep-comments-comment"

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comments.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comments.tpl.html
@@ -1,6 +1,6 @@
 <div class="kf-keep-comments-container">
-  <div class="kf-keep-comments" ng-if="visibleCount > 0 || canAddComments" ng-attr-kf-inview="{{ keep.discussion && keep.discussion.numMessages ? 'onInview' : undefined }}">
-    <span class="kf-keep-comments-view-previous" ng-if="visibleCount < keep.discussion.numMessages" ng-click="onViewPreviousComments()">View Previous Comments</span>
+  <div class="kf-keep-comments" ng-if="visibleCount > 0 || canAddComments" ng-attr-kf-inview="{{ keep.discussion && numMessages ? 'onInview' : undefined }}">
+    <span class="kf-keep-comments-view-previous" ng-if="showViewPreviousComments" ng-click="onViewPreviousComments()">View Previous Comments</span>
     <div
       class="kf-keep-comments-comment"
       ng-repeat="comment in comments.slice(-visibleCount)"
@@ -15,7 +15,7 @@
       <div
         class="kf-keep-comments-input"
         contenteditable="true"
-        placeholder="write a comment..."
+        placeholder="Write a comment…"
         ng-keydown="keydown($event)"
         ng-keyup="keyup($event)"
       ></div>

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepService.js
@@ -33,9 +33,8 @@ angular.module('kifi')
         .then(getResponseData);
       },
 
-      markDiscussionAsRead: function (keep) {
+      markDiscussionAsRead: function (keepPubId, comments) {
         // readList = [ {"keep": <keepId1>,  "lastMessage": <msgId1>}, { "keep": <keepId2>, "lastMessage": <msgId2> } ]
-        var comments = keep.discussion && keep.discussion.messages;
 
         if (comments && comments.length) {
           comments = comments.slice(); // so our sort doesn't mutate the original
@@ -43,7 +42,7 @@ angular.module('kifi')
 
           return net
           .markDiscussionAsRead([{
-            keepId: keep.pubId,
+            keepId: keepPubId,
             lastMessage: mostRecentComment.id
           }])
           .then(getResponseData);


### PR DESCRIPTION
This is a very simple thread updater. It works by hijacking `markAsRead`, which returns how many new messages there are, given message last known ID. When we know there's some new messages, trigger a refetch of the latest batch.

This also refactors the code a bit. `$scope.comments` is all known comments, `$scope.keep.discussion` is no longer modified at all. `$scope.keep.discussion.numMessages` is no longer maintained / updated, because it broke anyways if the number of messages in a discussion changed externally. We now know if we should fetch the next batch based on the initial state, and whether the last batch fetched had messages.

This can become a bit more efficient because `comments` _should_ always be sorted, so we can contextually derive more information. But since the number of objects here is small, we're sorting again on every batch and being naïve.

I'm actually working on a real long-polling implementation, but @leogrim is doing something that makes the long poller way more efficient. So I'm waiting for that until his stuff is done.

@cvializ @camhashemi 
