### PR TITLE
show the slack promo based on the value of prefs

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/home/featureUpsell.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/home/featureUpsell.tpl.html
@@ -1,4 +1,4 @@
-<div class="kf-feature-upsell" ng-show="::showFeatureUpsell">
+<div class="kf-feature-upsell" ng-show="showFeatureUpsell">
   <div class="kf-fu-slack">
     <span class="kf-fu-header kf-flex-row"><span class="svg-slack kf-fu-slack-icon"></span><b>Integrate Kifi with Slack</b></span>
     <span class="kf-fu-body">Automatically keep URLs from Slack.</span>


### PR DESCRIPTION
@cvializ @andrewconner borrowing your trick from `orgProfileCreate.js`. it's bad that we should need to refetch `prefs` multiple times, but I'm not sure how to wait for the first call's values.
