### PR TITLE
add Keep.path to DiscussionKeep

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/discussion/Message.scala
+++ b/kifi-backend/modules/common/app/com/keepit/discussion/Message.scala
@@ -64,6 +64,7 @@ object Discussion {
 case class DiscussionKeep(
   id: PublicId[Keep],
   url: String,
+  path: String,
   title: Option[String],
   note: Option[String],
   tags: Set[Hashtag],

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepInfo.scala
@@ -49,6 +49,7 @@ case class KeepInfo(
   def asDiscussionKeep: DiscussionKeep = DiscussionKeep(
     id = pubId.get,
     url = url,
+    path = path,
     title = title,
     note = note,
     tags = hashtags.getOrElse(Set.empty),


### PR DESCRIPTION
@ryanpbrewster @leogrim 

@cvializ now you can get the absolute path to the keep page by doing `"https://www.kifi.com/" + keep.path`
