### PR TITLE
Return keep id for threads on notifications marked as read

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationMessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationMessagingCommander.scala
@@ -68,7 +68,8 @@ class NotificationMessagingCommander @Inject() (
     val updated = notificationCommander.setNotificationUnreadTo(notif.id.get, unread)
     if (updated) {
       val nUrl = ""
-      webSocketRouter.sendToUser(userId, Json.arr(if (unread) "message_unread" else "message_read", nUrl, notif.externalId, item.eventTime, item.externalId))
+      val thread = notificationJsonFormat.getNotificationThreadStr(notif, item)
+      webSocketRouter.sendToUser(userId, Json.arr(if (unread) "message_unread" else "message_read", nUrl, thread, item.eventTime, item.externalId))
       if (unread) {
         messagingAnalytics.clearedNotification(userId, Left(notif.externalId), Left(item.externalId), context)
       }

--- a/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/NotificationJsonFormat.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/NotificationJsonFormat.scala
@@ -39,15 +39,19 @@ class NotificationJsonFormat @Inject() (
     case PublicImage(url) => url
   }
 
+  def getNotificationThreadStr(notification: Notification, item: NotificationItem): String = {
+    item.event match {
+      case newKeep: LibraryNewKeep => Keep.publicId(newKeep.keepId).id
+      case _ => notification.externalId.id
+    }
+  }
+
   def basicJson(notifWithInfo: NotificationWithInfo): Future[NotificationWithJson] = notifWithInfo match {
     case NotificationWithInfo(notif, items, info) =>
       val relevantItem = notifWithInfo.relevantItem
       notifWithInfo.info match {
         case info: StandardNotificationInfo =>
-          val thread = relevantItem.event match {
-            case newKeep: LibraryNewKeep => Keep.publicId(newKeep.keepId).id
-            case _ => notif.externalId.id
-          }
+          val thread = getNotificationThreadStr(notif, relevantItem)
           Future.successful(NotificationWithJson(notif, items, Json.obj(
             "id" -> relevantItem.externalId,
             "time" -> relevantItem.eventTime,


### PR DESCRIPTION
@andrewconner that should do the job
@ryanpbrewster I have a feeling that we may want to drop `Notification.externalId` and use `Notification.groupIdentifier` instead. Thoughts?
