### PR TITLE
updates to discussion emails

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaEmailCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaEmailCommander.scala
@@ -2,7 +2,7 @@ package com.keepit.eliza.commanders
 
 import com.google.inject.Inject
 import com.keepit.common.crypto.PublicIdConfiguration
-import com.keepit.common.mail.template.EmailToSend
+import com.keepit.common.mail.template.{ TemplateOptions, EmailToSend }
 import com.keepit.common.mail.template.helpers.discussionLink
 import com.keepit.rover.RoverServiceClient
 import com.keepit.rover.model.RoverUriSummary
@@ -245,7 +245,8 @@ class ElizaEmailCommander @Inject() (
         subject = protoEmail.pageTitle,
         htmlTemplate = htmlBodyMaker(protoEmail),
         category = category,
-        extraHeaders = Some(Map(PostOffice.Headers.REPLY_TO -> magicAddress.address))
+        extraHeaders = Some(Map(PostOffice.Headers.REPLY_TO -> magicAddress.address)),
+        templateOptions = Seq(TemplateOptions.CustomLayout).toMap
       )
       shoebox.processAndSendMail(email) map {
         case true => // all good

--- a/kifi-backend/modules/eliza/app/views/discussionEmail.scala.html
+++ b/kifi-backend/modules/eliza/app/views/discussionEmail.scala.html
@@ -192,7 +192,7 @@
                                   </td>
                                 </tr>
                                 @{messages.map(message =>
-                                  emailMessageBlock(message.imageUrl, message.senderShortName, message.senderFullName, message.segments)
+                                  emailMessageBlock(threadInfo, message.imageUrl, message.senderShortName, message.senderFullName, message.segments)
                                 )}
                               </table></td>
                             <td width="2" bgcolor="#f3f3f3"></td>
@@ -205,7 +205,7 @@
                   </table></td>
               </tr>
               <!-- //Content Part -->
-              @discussionEmailFooter(threadInfo.conversationStarter, threadInfo.muteUrl, threadInfo.unsubUrl, isUser)
+              @discussionEmailFooter(threadInfo, isUser)
             </table></td>
         </tr>
       </table></td>

--- a/kifi-backend/modules/eliza/app/views/discussionEmailFooter.scala.html
+++ b/kifi-backend/modules/eliza/app/views/discussionEmailFooter.scala.html
@@ -1,5 +1,6 @@
-@(conversationStarter: String, muteUrlOpt: Option[String], unsubUrlOpt: Option[String], isUser: Boolean)
-
+@import com.keepit.common.mail.template.helpers.discussionLink
+@(threadInfo: com.keepit.eliza.model.ThreadEmailInfo, isUser: Boolean)
+@keepPageLink = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, threadInfo.keepId)}
 <tr>
   <td height="34"></td>
 </tr>
@@ -11,7 +12,7 @@
             <tr>
               <td width="410" class="clear_both"><table width="100%" border="0" cellspacing="0" cellpadding="0">
                         <tr>
-                          <td width="34" valign="top"><img src="https://djty7jcqog9qu.cloudfront.net/assets/email-reply-arrow.jpg" width="34" height="20" style="display:block;" border="0" alt="" /></td>
+                          <td width="34" valign="top"><a href=@keepPageLink target="_blank"><img src="https://djty7jcqog9qu.cloudfront.net/assets/email-reply-arrow.jpg" width="34" height="20" style="display:block;" border="0" alt="" /></a></td>
                           <td width="8">&nbsp;</td>
                           <td style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#999999;line-height:18px;">Participate in this discussion simply by replying to this email </td>
                         </tr>
@@ -25,7 +26,7 @@
                         <td class="aside2"><table width="100%" border="0" cellspacing="0" cellpadding="0" align="center">
                             <tr>
                               <td height="20" valign="middle" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#999999;line-height:18px;">
-                                @muteUrlOpt.map{ muteUrl =>
+                                @threadInfo.muteUrl.map{ muteUrl =>
                                   <a href="@muteUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#999999;line-height:18px;text-decoration:underline;">Mute this conversation</a>
                                 }.getOrElse {
                                   <span style="font-family:Arial, Helvetica, sans-serif;font-size:13px;color:#999999;line-height:18px;text-decoration:underline;">Mute this conversation</span>
@@ -59,7 +60,7 @@
                     <tr>
                       <td width="23" align="center" valign="middle"><img src="https://djty7jcqog9qu.cloudfront.net/assets/email-heart.png" width="23" height="21" style="display:block;" border="0" alt="heart" /></td>
                        <td width="14" height="21">&nbsp;</td>
-                                  <td style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#ffffff;line-height:18px;">@conversationStarter used kifi to send this message. <a href="https://www.kifi.com/?utm_source=extmsg&utm_medium=vf_email&kcid=vf_email-extmsg" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#ffffff;line-height:18px;text-decoration:underline;">Learn more</a></td>
+                                  <td style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#ffffff;line-height:18px;">@{threadInfo.conversationStarter} used kifi to send this message. <a href="https://www.kifi.com/?utm_source=extmsg&utm_medium=vf_email&kcid=vf_email-extmsg" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#ffffff;line-height:18px;text-decoration:underline;">Learn more</a></td>
 
                     </tr>
                   </table></td>
@@ -102,8 +103,8 @@
         <tr>
           <td valign="top"><table width="100%" border="0" cellspacing="0" cellpadding="0">
             <tr>
-              <td class="center" style="font-family:Arial, Helvetica, sans-serif;font-size:12px;color:#333333;line-height:22px;">Sent by kifi 278 Hope Street Ste D, Mountain View, CA 94043, USA<br class="br" />
-                View our <a href="https://www.kifi.com/privacy?utm_source=extmsg&utm_medium=vf_email&kcid=vf_email-extmsg" target="_blank" style="color:#85a4ea;text-decoration:underline;">privacy policy</a>. Click to @unsubUrlOpt.map{ unsubUrl =>
+              <td class="center" style="font-family:Arial, Helvetica, sans-serif;font-size:12px;color:#333333;line-height:22px;">Sent by Kifi 278 Hope Street Ste D, Mountain View, CA 94043, USA<br class="br" />
+                View our <a href="https://www.kifi.com/privacy?utm_source=extmsg&utm_medium=vf_email&kcid=vf_email-extmsg" target="_blank" style="color:#85a4ea;text-decoration:underline;">privacy policy</a>. Click to @threadInfo.unsubUrl.map{ unsubUrl =>
                   <a href="@unsubUrl" target="_blank" style="color:#85a4ea;text-decoration:underline;">unsubscribe</a>
                 }.getOrElse {
                   <span style="color:#85a4ea;text-decoration:underline;">unsubscribe</span>

--- a/kifi-backend/modules/eliza/app/views/emailMessageBlock.scala.html
+++ b/kifi-backend/modules/eliza/app/views/emailMessageBlock.scala.html
@@ -1,4 +1,6 @@
-@(imageUrl: Option[String], shortName: String, fullName: String, segments: Seq[com.keepit.eliza.util.MessageSegment])
+@import com.keepit.common.mail.template.helpers.discussionLink
+@(threadInfo: com.keepit.eliza.model.ThreadEmailInfo, imageUrl: Option[String], shortName: String, fullName: String, segments: Seq[com.keepit.eliza.util.MessageSegment])
+@keepPageUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, threadInfo.keepId)}
   <tr>
     <td bgcolor="#f3f3f3"><table width="100%" border="0" cellspacing="0" cellpadding="0">
         <tr>
@@ -15,10 +17,10 @@
                     <tr>
                       <!-- Image -->
                       <td width="73" valign="top">@imageUrl.map{ iUrl =>
-                        <img src="https:@imageUrl" alt="@shortName" width="73" height="73" style="display:block;" border="0" />
+                        <a href=@keepPageUrl target="_blank" style="text-decoration: none;"><img src="https:@imageUrl" alt="@shortName" width="73" height="73" style="display:block;" border="0" /></a>
                       }.getOrElse{
-                        <div style="font-family: Arial; font-size: 62px; font-weight: 600; background-color: #DCD6D6; color: #ffffff; width: 73px; height: 73px; text-align: center; vertical-align: middle; border-radius: 3px;">
-                          @{shortName(0).toUpper}
+                        <div style="width: 73px; height: 73px; text-align: center; vertical-align: middle; border-radius: 3px;">
+                          <a href=@keepPageUrl target="_blank" style="font-family: Arial; font-size: 62px; font-weight: 600; background-color: #DCD6D6; color: #ffffff; text-decoration: none;">@{shortName(0).toUpper}</a>
                         </div>
                       }</td>
                       <!-- //Image -->
@@ -26,13 +28,13 @@
                       <!-- Content -->
                       <td valign="top"><table width="100%" border="0" cellspacing="0" cellpadding="0">
                           <tr>
-                            <td style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#333333;line-height:16px;font-weight:bold;text-decoration:none;">@fullName</td>
+                            <td><a href=@keepPageUrl target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#333333;line-height:16px;font-weight:bold;text-decoration:none;">@fullName</a></td>
                           </tr>
                           <tr>
                             <td height="16" style="line-height:1px;font-size:1px;">&nbsp;</td>
                           </tr>
                           <tr>
-                            <td style="font-family:Georgia, 'Times New Roman', Times, serif;font-size:18px;color:#333333;line-height:24px;">@segments.map(_.txt).mkString(" ")</td>
+                            <td><a href=@keepPageUrl target="_blank" style="font-family:Georgia, 'Times New Roman', Times, serif;font-size:18px;color:#333333;line-height:24px;text-decoration: none;">@segments.map(_.txt).mkString(" ")</a></td>
                           </tr>
                         </table></td>
                       <!-- //Content -->

--- a/kifi-backend/modules/eliza/app/views/pageDescriptionBig.scala.html
+++ b/kifi-backend/modules/eliza/app/views/pageDescriptionBig.scala.html
@@ -1,10 +1,10 @@
 @import com.keepit.common.mail.template.helpers.discussionLink
 
 @(threadInfo: com.keepit.eliza.model.ThreadEmailInfo)
-@visitThisPageUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, threadInfo.keepId, "clickedArticleVisitLink")}
-@articleTitleUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, threadInfo.keepId, "clickedArticleTitle")}
-@articleDomainUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, threadInfo.keepId, "clickedArticleDomain")}
-@articleImageUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, threadInfo.keepId, "clickedArticleImage")}
+@visitThisPageUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, None, "clickedArticleVisitLink")}
+@articleTitleUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, None, "clickedArticleTitle")}
+@articleDomainUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, None, "clickedArticleDomain")}
+@articleImageUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, None, "clickedArticleImage")}
 <table width="100%" border="0" cellspacing="0" cellpadding="0">
   @threadInfo.heroImageUrl.map{ heroImageUrl =>
     <tr>

--- a/kifi-backend/modules/eliza/app/views/pageDescriptionSmall.scala.html
+++ b/kifi-backend/modules/eliza/app/views/pageDescriptionSmall.scala.html
@@ -1,10 +1,10 @@
 @import com.keepit.common.mail.template.helpers.discussionLink
 
 @(threadInfo: com.keepit.eliza.model.ThreadEmailInfo)
-@visitThisPageUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, threadInfo.keepId, "clickedArticleVisitLink")}
-@articleTitleUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, threadInfo.keepId, "clickedArticleTitle")}
-@articleDomainUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, threadInfo.keepId, "clickedArticleDomain")}
-@articleImageUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, threadInfo.keepId, "clickedArticleImage")}
+@visitThisPageUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, None, "clickedArticleVisitLink")}
+@articleTitleUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, None, "clickedArticleTitle")}
+@articleDomainUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, None, "clickedArticleDomain")}
+@articleImageUrl = @{discussionLink(threadInfo.uriId, threadInfo.threadId.id, None, "clickedArticleImage")}
 <table width="100%" border="0" cellspacing="0" cellpadding="0">
   <tr>
     <td height="14" style="line-height:1px;font-size:1px;">&nbsp;</td>

--- a/kifi-backend/modules/shoebox/app/views/email/layouts/footer.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/layouts/footer.scala.html
@@ -15,7 +15,7 @@
                                         <tr>
                                             <td align="left" class="center1" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#333333;line-height:22px;">
                                                 <a href="@kifiFooterUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Kifi.com</a>
-                                                Your recommendations network<br/>Follow us on
+                                                Follow us on
                                                 <a href="@kifiTwitterUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Twitter</a>
                                                 &nbsp;
                                                 <a href="@kifiFacebookUrl" target="_blank" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#85a4ea;line-height:18px;text-decoration:underline;">Facebook</a>


### PR DESCRIPTION
@andrewconner @eishay @JRuff42 makes things more to-spec regarding the discussion email:
- link to keep page on message elements (commenter name, picture, comment text, "reply" button)
- link directly to content / extension on the keep image, title, or url
- remove default footer for discussion emails (there already is one)
