### PR TITLE
Harsh timeout for discussion decoration. Time for a cache?

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/akka/TimeoutFuture.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/akka/TimeoutFuture.scala
@@ -8,7 +8,7 @@ import org.jboss.netty.util.Timeout
 import com.keepit.common.core._
 
 object TimeoutFuture {
-  val timer = new HashedWheelTimer(10, TimeUnit.MILLISECONDS)
+  private val timer = new HashedWheelTimer(10, TimeUnit.MILLISECONDS)
   def apply[T](future: Future[T], onTimeout: => Unit = Unit)(implicit ec: ExecutionContext, after: Duration): Future[T] = {
     val promise = Promise[T]()
     val timeout = timer.newTimeout(new TimerTask {

--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeError.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeError.scala
@@ -145,7 +145,7 @@ case class AirbrakeError(
 object AirbrakeError {
   import scala.collection.JavaConverters._
 
-  val MaxMessageSize = 20 * 1024 //20KB
+  val MaxMessageSize = 10 * 1024 //10KB
   val MaxStackTrace = 50
 
   def incoming(request: RequestHeader, exception: Throwable = new DefaultAirbrakeException(), message: String = "", user: Option[User] = None, aggregateOnly: Boolean = false): AirbrakeError =

--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeNotifier.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/AirbrakeNotifier.scala
@@ -129,7 +129,7 @@ class AirbrakeSender @Inject() (
 
     futureResult.onFailure {
       case exception =>
-        log.error(s"error sending airbrake json: $json", exception)
+        log.error(s"error sending airbrake json: ${json.toString.take(500)}", exception)
     }
   }
 }
@@ -192,7 +192,7 @@ class AirbrakeNotifierImpl(actor: ActorInstance[AirbrakeNotifierActor], isCanary
     if (!isCanary) { // can filter out panic later
       actor.ref ! AirbrakeErrorNotice(error.cleanError)
     }
-    log.error(error.toString())
+    log.error(error.toString().take(2048))
     error
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
@@ -1,6 +1,7 @@
 package com.keepit.commanders
 
 import com.google.inject.{ ImplementedBy, Inject, Provider, Singleton }
+import com.keepit.common.akka.TimeoutFuture
 import com.keepit.common.core._
 import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.db.Id
@@ -19,6 +20,7 @@ import com.keepit.search.SearchServiceClient
 import com.keepit.search.augmentation.{ AugmentableItem, LimitedAugmentationInfo }
 import com.keepit.social.BasicUser
 import org.joda.time.DateTime
+import scala.concurrent.duration._
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -127,12 +129,16 @@ class KeepDecoratorImpl @Inject() (
           airbrake.notify(s"[KEEP-DECORATOR] Failed to get discussions for keeps $keepIds", fail)
           Map.empty[Id[Keep], Discussion]
       }
+      val discussionsWithStrictTimeout = TimeoutFuture(discussionsByKeepFut)(executionContext, 2.seconds).recover { case _ =>
+        log.warn(s"[KEEP-DECORATOR] Timed out fetching discussions for keeps $keepIds")
+        Map.empty[Id[Keep], Discussion]
+      }
 
       for {
         augmentationInfos <- augmentationFuture
         pageInfos <- pageInfosFuture
         (idToBasicUser, idToBasicLibrary, idToLibraryCard, idToBasicOrg) <- entitiesFutures
-        discussionsByKeep <- discussionsByKeepFut
+        discussionsByKeep <- discussionsWithStrictTimeout
       } yield {
 
         val keepsInfo = (keeps zip colls, augmentationInfos, pageInfos zip sourceAttrs).zipped.map {


### PR DESCRIPTION
@leogrim @ryanpbrewster I'm seeing 10s timeouts, which sucks (that eliza can take 10 seconds), but also means keep responses take that long as well. This sets a much more aggressive timeline. We'll still get airbrakes when it times out.
