### PR TITLE
Fixes drafts bug in ext

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -981,7 +981,10 @@ api.port.on({
     if (data.to) {
       respond(drafts[tab.nUri] || drafts[tab.url]);
     } else {
-      respond(drafts[currentThreadId(tab)]);
+      var threadId = currentThreadId(tab);
+      if (threadId) {
+        respond(drafts[threadId]);
+      }
     }
   },
   save_draft: function (data, _, tab) {
@@ -1824,7 +1827,7 @@ function forEachTabAtThreadList(f) {
   }
 }
 
-var threadLocatorRe = /^\/messages\/[a-z0-9-]+$/;
+var threadLocatorRe = /^\/messages\/[A-Za-z0-9-]+$/;
 function forEachThreadOpenInPane(f) {
   for (var loc in tabsByLocator) {
     if (threadLocatorRe.test(loc)) {
@@ -2386,6 +2389,7 @@ function storeDrafts(drafts) {
 
 function saveDraft(key, draft) {
   log('[saveDraft]', key);
+  if (!key) return;
   var now = draft.saved = Date.now();
   var drafts = loadDrafts();
   for (var k in drafts) {


### PR DESCRIPTION
@cvializ Fixes drafts bug. We had a regex that required IDs to be in basically UUID form (specifically, all lowercase). Not true anymore, so widen regex.

Since most people now have a thread keyed by `"undefined"`, refuse to read out `"undefined"` keys.

Your call, but since this PR is very simple, we may want to do some git magic and release a bugfix extension with this before we release the keep-notifcations-comment stuff (which is in master now). What do you think?
