### PR TITLE
Unused field in UserThread

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaUserEmailNotifierActor.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/mail/ElizaUserEmailNotifierActor.scala
@@ -103,7 +103,7 @@ class ElizaUserEmailNotifierActor @Inject() (
 
     val result = if (extendedThreadItems.isEmpty) Future.successful(()) else {
       log.info(s"preparing to send email for thread ${thread.id}, user thread ${thread.id} of user ${userThread.user} " +
-        s"with notificationUpdatedAt=${userThread.notificationUpdatedAt} and notificationLastSeen=${userThread.notificationLastSeen} " +
+        s"with notificationUpdatedAt=${userThread.notificationUpdatedAt} " +
         s"with ${extendedThreadItems.size} items and unread=${userThread.unread} and notificationEmailed=${userThread.notificationEmailed}")
 
       val recipientUserId = userThread.user

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThread.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThread.scala
@@ -28,7 +28,6 @@ case class UserThread(
   muted: Boolean = false,
   lastMsgFromOther: Option[Id[ElizaMessage]],
   notificationUpdatedAt: DateTime = currentDateTime,
-  notificationLastSeen: Option[DateTime] = None,
   notificationEmailed: Boolean = false,
   lastActive: Option[DateTime] = None, //Contains the 'createdAt' timestamp of the last message this user sent on this thread
   startedBy: Id[User], // denormalized from MessageThread
@@ -41,7 +40,7 @@ case class UserThread(
 
   lazy val summary = s"UserThread[id = $id, created = $createdAt, update = $updatedAt, user = $user, keep = $keepId, " +
     s"uriId = $uriId, lastSeen = $lastSeen, unread = $unread, notificationUpdatedAt = $notificationUpdatedAt, " +
-    s"notificationLastSeen = $notificationLastSeen, notificationEmailed = $notificationEmailed]"
+    s"notificationEmailed = $notificationEmailed]"
 }
 
 object UserThreadStates extends States[UserThread]

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThreadRepo.scala
@@ -84,12 +84,11 @@ class UserThreadRepoImpl @Inject() (
     def muted = column[Boolean]("muted", O.NotNull)
     def lastMsgFromOther = column[Option[Id[ElizaMessage]]]("last_msg_from_other", O.Nullable)
     def notificationUpdatedAt = column[DateTime]("notification_updated_at", O.NotNull)
-    def notificationLastSeen = column[Option[DateTime]]("notification_last_seen", O.Nullable)
     def notificationEmailed = column[Boolean]("notification_emailed", O.NotNull)
     def lastActive = column[Option[DateTime]]("last_active", O.Nullable)
     def startedBy = column[Id[User]]("started_by", O.NotNull)
     def accessToken = column[ThreadAccessToken]("access_token", O.NotNull)
-    def * = (id.?, createdAt, updatedAt, state, user, keepId, uriId, lastSeen, unread, muted, lastMsgFromOther, notificationUpdatedAt, notificationLastSeen, notificationEmailed, lastActive, startedBy, accessToken) <> ((UserThread.apply _).tupled, UserThread.unapply _)
+    def * = (id.?, createdAt, updatedAt, state, user, keepId, uriId, lastSeen, unread, muted, lastMsgFromOther, notificationUpdatedAt, notificationEmailed, lastActive, startedBy, accessToken) <> ((UserThread.apply _).tupled, UserThread.unapply _)
   }
 
   def table(tag: Tag) = new UserThreadTable(tag)


### PR DESCRIPTION
@leogrim @camhashemi 

Looked through the db and I think there's room to clean up the `unread` vs `lastSeen` logic. I'd like to turn `unread` into a `def` that compares two timestamps (and possibly looks at `muted`). I feel that this would simplify the logic a lot.
