### PR TITLE
Don't be as aggressive reporting search memory usage

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/healthcheck/MemoryUsageModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/healthcheck/MemoryUsageModule.scala
@@ -13,7 +13,7 @@ case class ProdMemoryUsageModule() extends MemoryUsageModule {
   @Provides
   def memoryUsageMonitorProvider(airbrakeNotifierProvider: Provider[AirbrakeNotifier]): MemoryUsageMonitor = {
     MemoryUsageMonitor { (pool, threshold, maxHeapSize, count) =>
-      if (count > 1) { // at least two incidents in a row
+      if (count % 10 == 2) { // at least two incidents in a row, only notify every 10 incidents
         airbrakeNotifierProvider.get.notify(s"LOW MEMORY!!! - pool=[${pool.getName}] threshold=$threshold maxHeapSize=$maxHeapSize count=$count")
       }
     }


### PR DESCRIPTION
@ryanpbrewster @eishay reckon that's just breaking the thermometer. I have two hypotheses for the underlying issue:

the index is simply getting too large for the search-spot-2
Slack / Twitter payloads that I've added earlier this month are generating a lot of garbage and need to be trimmed (they should be anyway)
For now I'll see if this stops PagerDuties and get back to Slack.
