### PR TITLE
Convert to internal ids ASAP.

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/Implicits.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/Implicits.scala
@@ -76,6 +76,13 @@ final class TraversableExtensionOps[A](xs: Traversable[A]) {
   def countAll: Map[A, Int] = countBy(identity)
 }
 
+final class EitherExtensionOps[A, B](xs: Traversable[Either[A, B]]) {
+  def partitionEithers = xs.foldLeft(Seq.empty[A], Seq.empty[B]) {
+    case ((as, bs), Left(a)) => (a +: as, bs)
+    case ((as, bs), Right(b)) => (as, b +: bs)
+  }
+}
+
 final class JsObjectExtensionOps(x: JsObject) {
   def nonNullFields: JsObject = JsObject(x.fields.filter { case (_, b) => b != JsNull })
 }
@@ -98,6 +105,7 @@ trait Implicits {
   implicit def iterableExtensionOps[A, Repr](xs: IterableLike[A, Repr]): IterableExtensionOps[A, Repr] = new IterableExtensionOps(xs)
   implicit def traversableOnceExtensionOps[A](xs: TraversableOnce[A]): TraversableOnceExtensionOps[A] = new TraversableOnceExtensionOps(xs)
   implicit def traversableExtensionOps[A](xs: Traversable[A]): TraversableExtensionOps[A] = new TraversableExtensionOps(xs)
+  implicit def eitherExtensionOps[A, B](xs: Traversable[Either[A, B]]): EitherExtensionOps[A, B] = new EitherExtensionOps(xs)
   implicit def jsObjectExtensionOps[A](x: JsObject): JsObjectExtensionOps = new JsObjectExtensionOps(x)
   implicit def jsValueExtensionOps[A](x: JsValue): JsValueExtensionOps = new JsValueExtensionOps(x)
 }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -410,11 +410,10 @@ class MessagingCommander @Inject() (
     }
   }
 
-  def addParticipantsToThread(adderUserId: Id[User], keepId: Id[Keep], newParticipantsExtIds: Seq[ExternalId[User]], emailContacts: Seq[BasicContact], orgs: Seq[PublicId[Organization]])(implicit context: HeimdalContext): Future[Boolean] = {
-    val newUserParticipantsFuture = shoebox.getUserIdsByExternalIds(newParticipantsExtIds.toSet).map(_.values.toSeq)
+  def addParticipantsToThread(adderUserId: Id[User], keepId: Id[Keep], newUsers: Seq[Id[User]], emailContacts: Seq[BasicContact], orgIds: Seq[Id[Organization]])(implicit context: HeimdalContext): Future[Boolean] = {
+    val newUserParticipantsFuture = Future.successful(newUsers)
     val newNonUserParticipantsFuture = constructNonUserRecipients(adderUserId, emailContacts)
 
-    val orgIds = orgs.map(o => Organization.decodePublicId(o)).filter(_.isSuccess).map(_.get)
     val newOrgParticipantsFuture = Future.sequence(orgIds.map { oid =>
       shoebox.hasOrganizationMembership(oid, adderUserId).flatMap {
         case true => shoebox.getOrganizationMembers(oid)

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
@@ -149,7 +149,7 @@ class MessagingTest extends Specification with ElizaTestInjector {
         waitFor(notificationCommander.getLatestSendableNotifications(user3, 1, includeUriSummary = false)).length === 0
 
         val user3ExtId = Await.result(shoebox.getUser(user3), Duration(4, "seconds")).get.externalId
-        messagingCommander.addParticipantsToThread(user1, thread.keepId, Seq(user3ExtId), Seq.empty, Seq.empty)
+        messagingCommander.addParticipantsToThread(user1, thread.keepId, Seq(user3), Seq.empty, Seq.empty)
         inject[WatchableExecutionContext].drain()
         waitFor(notificationCommander.getLatestSendableNotifications(user3, 1, includeUriSummary = false)).length === 1
       }


### PR DESCRIPTION
This cleans up commander methods and separates concerns.
