### PR TITLE
Library ordering

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/Implicits.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/Implicits.scala
@@ -1,6 +1,7 @@
 package com.keepit.common
 
 import com.keepit.common.concurrent.ExecutionContext
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import play.api.libs.json._
 
 import scala.collection.IterableLike
@@ -34,6 +35,12 @@ final class TryExtensionOps[A](val x: scala.util.Try[A]) extends AnyVal {
   def fold[B](f: A => B, g: Throwable => B): B = x match {
     case scala.util.Success(t) => f(t)
     case scala.util.Failure(t) => g(t)
+  }
+  def safeOption(implicit airbrake: AirbrakeNotifier): Option[A] = x match {
+    case scala.util.Success(t) => Some(t)
+    case scala.util.Failure(f) =>
+      airbrake.notify(f)
+      None
   }
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
@@ -8,13 +8,17 @@ import scala.util.{Success, Failure, Try}
 
 package object json {
   object EnumFormat {
-    def reads[T](f: (String => Option[T]), domain: Set[String] = Set.empty): Reads[T] = Reads { j =>
+    def reads[T](fromStr: (String => Option[T]), domain: Set[String] = Set.empty): Reads[T] = Reads { j =>
       def errMsg = if (domain.nonEmpty) s"$j is not one of these: $domain" else s"Could not recognize $j"
       for {
         str <- j.validate[String]
-        v <- f(str).map(JsSuccess(_)).getOrElse(JsError(ValidationError(errMsg)))
+        v <- fromStr(str).map(JsSuccess(_)).getOrElse(JsError(ValidationError(errMsg)))
       } yield v
     }
+    def writes[T](toStr: T => String): Writes[T] = Writes { v => JsString(toStr(v)) }
+    def format[T](fromStr: (String => Option[T]), toStr: T => String, domain: Set[String] = Set.empty) = Format(
+      reads(fromStr, domain), writes(toStr)
+    )
   }
   object KeyFormat {
     def key1Reads[A](strA: String)(implicit aReads: Reads[A]): Reads[A] = Reads[A] {

--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -170,13 +170,14 @@ object Library extends PublicIdGenerator[Library] {
 }
 
 sealed abstract class SortDirection(val value: String)
-object SortDirection {
+object SortDirection extends Enumerator[SortDirection] {
   case object ASCENDING extends SortDirection("asc")
   case object DESCENDING extends SortDirection("desc")
-  def apply(value: String) = value match {
-    case ASCENDING.value => ASCENDING
-    case DESCENDING.value => DESCENDING
-  }
+  val all = _all.toSet
+  def fromStr(str: String): Option[SortDirection] = all.find(_.value == str)
+  def apply(str: String) = fromStr(str).get
+
+  implicit val format: Format[SortDirection] = EnumFormat.format(fromStr, _.value)
 
   implicit def queryStringBinder[T](implicit stringBinder: QueryStringBindable[String]) = new QueryStringBindable[SortDirection] {
     override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, SortDirection]] = {

--- a/kifi-backend/modules/common/app/com/keepit/model/UserExperiment.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserExperiment.scala
@@ -79,6 +79,7 @@ object UserExperimentType {
   val CREATE_TEAM = UserExperimentType("create_team")
   val SLACK = UserExperimentType("slack")
   val KEEP_COMMENTS = UserExperimentType("keep_comments")
+  val CUSTOM_LIBRARY_ORDERING = UserExperimentType("custom_library_ordering")
 
   val _ALL = ADMIN :: AUTO_GEN :: FAKE :: BYPASS_ABUSE_CHECKS :: VISITED :: NO_SEARCH_EXPERIMENTS ::
     DEMO :: EXTENSION_LOGGING :: SHOW_HIT_SCORES :: SHOW_DISCUSSIONS ::
@@ -86,7 +87,7 @@ object UserExperimentType {
     GRAPH_BASED_PEOPLE_TO_INVITE :: CORTEX_NEW_MODEL :: CURATOR_DIVERSE_TOPIC_RECOS ::
     ACTIVITY_EMAIL :: EXPLICIT_SOCIAL_POSTING :: RELATED_PAGE_INFO :: NEXT_GEN_RECOS ::
     RECO_FASTLANE :: RECO_SUBSAMPLE :: APPLY_RECO_FEEDBACK :: PLAIN_EMAIL :: SEARCH_LAB ::
-    NEW_NOTIFS_SYSTEM :: KEEP_MULTILIB :: CREATE_TEAM :: SLACK :: KEEP_COMMENTS :: Nil
+    NEW_NOTIFS_SYSTEM :: KEEP_MULTILIB :: CREATE_TEAM :: SLACK :: KEEP_COMMENTS :: CUSTOM_LIBRARY_ORDERING :: Nil
 
   // only the ExperimentTypes in this list will be tracked as user properties in analytics
   val _TRACK_FOR_ANALYTICS = Set(EXPLICIT_SOCIAL_POSTING, RELATED_PAGE_INFO, ACTIVITY_EMAIL)

--- a/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
@@ -93,6 +93,8 @@ object UserValueName {
   val HIDE_EMAIL_DOMAIN_ORGANIZATIONS = UserValueName("hide_email_domain_organizations")
   val PENDING_ORG_DOMAIN_OWNERSHIP_BY_EMAIL = UserValueName("pending_org_domain_ownership_by_email")
 
+  val DEFAULT_LIBRARY_ARRANGEMENT = UserValueName("default_library_arrangement")
+
   // Please use lower_underscore_case for new value names (and not lowerCamelCase)
 
   def bookmarkImportContextName(newImportId: String) = UserValueName(s"bookmark_import_${newImportId}_context")

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInfoCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInfoCommander.scala
@@ -1,6 +1,6 @@
 package com.keepit.commanders
 
-import com.google.inject.{ ImplementedBy, Inject }
+import com.google.inject.{ ImplementedBy, Inject, Singleton }
 import com.keepit.common.akka.SafeFuture
 import com.keepit.common.core._
 import com.keepit.common.crypto.PublicIdConfiguration
@@ -49,6 +49,7 @@ trait LibraryInfoCommander {
   def getLibrariesVisibleToUserHelper(orgId: Id[Organization], userIdOpt: Option[Id[User]], offset: Offset, limit: Limit)(implicit session: RSession): Seq[Library]
 }
 
+@Singleton
 class LibraryInfoCommanderImpl @Inject() (
     db: Database,
     libraryCardCommander: LibraryCardCommander,

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryQueryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryQueryCommander.scala
@@ -1,0 +1,72 @@
+package com.keepit.commanders
+
+import com.google.inject.{ Inject, ImplementedBy, Singleton }
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.DBSession.{ RWSession, RSession }
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.model._
+import com.keepit.common.core.tryExtensionOps
+import play.api.libs.json.{ Format, Json }
+
+import scala.util.Try
+
+case class LibraryQuery(
+    ownerId: Option[Id[User]] = None,
+    orgId: Option[Id[Organization]] = None,
+    arrangement: Option[LibraryQuery.Arrangement] = None,
+    fromId: Option[Id[Library]],
+    limit: Int) {
+  def withArrangement(newArrangement: LibraryQuery.Arrangement) = this.copy(arrangement = Some(newArrangement))
+}
+
+object LibraryQuery {
+  case class Arrangement(ordering: LibraryOrdering, direction: SortDirection)
+  object Arrangement {
+    implicit val format: Format[Arrangement] = Json.format[Arrangement]
+    val GLOBAL_DEFAULT = Arrangement(LibraryOrdering.LAST_KEPT_INTO, SortDirection.DESCENDING)
+  }
+
+  case class ExtraInfo(explicitlyAllowedLibraries: Set[Id[Library]], orgsWithVisibleLibraries: Set[Id[Organization]])
+}
+
+@ImplementedBy(classOf[LibraryQueryCommanderImpl])
+trait LibraryQueryCommander {
+  def setPreferredArrangement(userId: Id[User], arrangement: LibraryQuery.Arrangement)(implicit session: RWSession): Unit
+  def getLibraries(requester: Option[Id[User]], query: LibraryQuery)(implicit session: RSession): Seq[Id[Library]]
+}
+
+@Singleton
+class LibraryQueryCommanderImpl @Inject() (
+  db: Database,
+  userValueRepo: UserValueRepo,
+  libMembershipRepo: LibraryMembershipRepo,
+  orgMembershipRepo: OrganizationMembershipRepo,
+  libRepo: LibraryRepo,
+  implicit val airbrake: AirbrakeNotifier)
+    extends LibraryQueryCommander {
+
+  def setPreferredArrangement(userId: Id[User], arrangement: LibraryQuery.Arrangement)(implicit session: RWSession): Unit = {
+    userValueRepo.setValue(userId, UserValueName.DEFAULT_LIBRARY_ARRANGEMENT, Json.stringify(Json.toJson(arrangement)))
+  }
+
+  def getLibraries(requester: Option[Id[User]], query: LibraryQuery)(implicit session: RSession): Seq[Id[Library]] = {
+    val preferredArrangement = query.arrangement.orElse {
+      for {
+        userId <- requester
+        preferredArrangementStr <- userValueRepo.getUserValue(userId, UserValueName.DEFAULT_LIBRARY_ARRANGEMENT).map(_.value)
+        preferredArrangementJson <- Try(Json.parse(preferredArrangementStr)).safeOption
+        preferredArrangement <- Try(preferredArrangementJson.as[LibraryQuery.Arrangement]).safeOption
+      } yield preferredArrangement
+    }
+    val customizedQuery = preferredArrangement.map(query.withArrangement).getOrElse(query)
+
+    val extraInfo = LibraryQuery.ExtraInfo(
+      explicitlyAllowedLibraries = requester.map(userId => libMembershipRepo.getWithUserId(userId).map(_.libraryId).toSet).getOrElse(Set.empty),
+      orgsWithVisibleLibraries = requester.map(userId => orgMembershipRepo.getAllByUserId(userId).map(_.organizationId).toSet).getOrElse(Set.empty)
+    )
+    libRepo.getLibraryIdsForQuery(customizedQuery, extraInfo)
+  }
+
+}
+

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -2,14 +2,17 @@ package com.keepit.model
 
 import com.google.inject.{ ImplementedBy, Inject, Singleton, Provider }
 import com.keepit.commanders._
+import com.keepit.common.core.anyExtensionOps
 import com.keepit.common.actor.ActorInstance
 import com.keepit.common.db.slick.DBSession.{ RWSession, RSession }
 import com.keepit.common.db.slick._
 import com.keepit.common.db._
 import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.json.EnumFormat
 import com.keepit.common.logging.Logging
 import com.keepit.common.mail.EmailAddress
 import com.keepit.common.plugin.{ SchedulingProperties, SequencingActor, SequencingPlugin }
+import com.keepit.common.reflection.Enumerator
 import com.keepit.common.time._
 import com.keepit.common.util.Paginator
 import com.keepit.model.LibrarySpace.{ OrganizationSpace, UserSpace }
@@ -35,6 +38,8 @@ trait LibraryRepo extends Repo[Library] with SeqNumberFunction[Library] {
   def hasKindsByOwner(ownerId: Id[User], kinds: Set[LibraryKind], excludeState: Option[State[Library]] = Some(LibraryStates.INACTIVE))(implicit session: RSession): Boolean
   def countLibrariesForOrgByVisibility(orgId: Id[Organization], excludeState: State[Library] = LibraryStates.INACTIVE)(implicit session: RSession): Map[LibraryVisibility, Int]
 
+  // PSA: Please use this function going forward, it's nonsense to have a million single-purpose queries
+  def getLibraryIdsForQuery(query: LibraryQuery, extraInfo: LibraryQuery.ExtraInfo)(implicit session: RSession): Seq[Id[Library]]
   //
   // Profile Library Repo functions
   //
@@ -148,6 +153,8 @@ class LibraryRepoImpl @Inject() (
   def table(tag: Tag) = new LibraryTable(tag)
   initTable()
 
+  private def activeRows = rows.filter(_.state === LibraryStates.ACTIVE)
+
   def allActive()(implicit session: RSession): Seq[Library] = rows.filter(_.state === LibraryStates.ACTIVE).list
 
   override def save(library: Library)(implicit session: RWSession): Library = {
@@ -199,6 +206,60 @@ class LibraryRepoImpl @Inject() (
     space match {
       case UserSpace(userId) => getByUserId(userId, excludeState)
       case OrganizationSpace(orgId) => getByOrgId(orgId, excludeState)
+    }
+  }
+
+  def getLibraryIdsForQuery(query: LibraryQuery, extraInfo: LibraryQuery.ExtraInfo)(implicit session: RSession): Seq[Id[Library]] = {
+    import LibraryQuery._
+    val published: LibraryVisibility = LibraryVisibility.PUBLISHED
+    val orgVisible: LibraryVisibility = LibraryVisibility.ORGANIZATION
+    val arrangement = query.arrangement.getOrElse(Arrangement.GLOBAL_DEFAULT)
+
+    activeRows |> { rs => // Actually perform the query
+      query.ownerId.map(ownerId => rs.filter(_.ownerId === ownerId)).getOrElse(rs)
+    } |> { rs =>
+      query.orgId.map(orgId => rs.filter(_.orgId === orgId)).getOrElse(rs)
+    } |> { rs => // Now drop libraries that the viewer doesn't have access to
+      rs.filter { lib =>
+        lib.visibility === published ||
+          (lib.visibility === orgVisible && lib.orgId.inSet(extraInfo.orgsWithVisibleLibraries)) ||
+          lib.id.inSet(extraInfo.explicitlyAllowedLibraries)
+      }
+    } |> { rs => // then prepare to sort the libraries
+      query.fromId.map { fromId =>
+        val fromLib = get(fromId)
+        arrangement.ordering match {
+          case LibraryOrdering.ALPHABETICAL =>
+            val fromName = fromLib.name
+            arrangement.direction match {
+              case SortDirection.ASCENDING => rs.filter(_.name > fromName)
+              case SortDirection.DESCENDING => rs.filter(_.name < fromName)
+            }
+          case LibraryOrdering.LAST_KEPT_INTO =>
+            val fromLastKept = fromLib.lastKept
+            arrangement.direction match {
+              case SortDirection.ASCENDING => rs.filter(_.lastKept > fromLastKept)
+              case SortDirection.DESCENDING => rs.filter(_.lastKept < fromLastKept)
+            }
+          case LibraryOrdering.MEMBER_COUNT =>
+            val fromMemberCount = fromLib.memberCount
+            arrangement.direction match {
+              case SortDirection.ASCENDING => rs.filter(lib => lib.memberCount > fromMemberCount || (lib.memberCount === fromMemberCount && lib.id > fromId))
+              case SortDirection.DESCENDING => rs.filter(lib => lib.memberCount < fromMemberCount || (lib.memberCount === fromMemberCount && lib.id < fromId))
+            }
+        }
+      }.getOrElse(rs)
+    } |> { rs => // actually sort them
+      arrangement match {
+        case Arrangement(LibraryOrdering.ALPHABETICAL, SortDirection.ASCENDING) => rs.sortBy(lib => lib.name asc)
+        case Arrangement(LibraryOrdering.ALPHABETICAL, SortDirection.DESCENDING) => rs.sortBy(lib => lib.name asc)
+        case Arrangement(LibraryOrdering.LAST_KEPT_INTO, SortDirection.ASCENDING) => rs.sortBy(lib => lib.lastKept asc)
+        case Arrangement(LibraryOrdering.LAST_KEPT_INTO, SortDirection.DESCENDING) => rs.sortBy(lib => lib.lastKept desc)
+        case Arrangement(LibraryOrdering.MEMBER_COUNT, SortDirection.ASCENDING) => rs.sortBy(lib => (lib.memberCount asc, lib.id asc))
+        case Arrangement(LibraryOrdering.MEMBER_COUNT, SortDirection.DESCENDING) => rs.sortBy(lib => (lib.memberCount desc, lib.id desc))
+      }
+    } |> { rs => // then take the first page of the results
+      rs.map(_.id).take(query.limit).list
     }
   }
 
@@ -553,26 +614,21 @@ class LibrarySequencingPluginImpl @Inject() (
  */
 sealed abstract class LibraryOrdering(val value: String)
 
-object LibraryOrdering {
+object LibraryOrdering extends Enumerator[LibraryOrdering] {
   case object LAST_KEPT_INTO extends LibraryOrdering("last_kept_into")
   case object ALPHABETICAL extends LibraryOrdering("alphabetical")
   case object MEMBER_COUNT extends LibraryOrdering("member_count")
 
-  def fromStr(str: String): LibraryOrdering = {
-    str match {
-      case LAST_KEPT_INTO.value => LAST_KEPT_INTO
-      case ALPHABETICAL.value => ALPHABETICAL
-      case MEMBER_COUNT.value => MEMBER_COUNT
-    }
-  }
+  val all = _all
+  def fromStr(str: String): Option[LibraryOrdering] = all.find(_.value == str)
+  def apply(str: String): LibraryOrdering = fromStr(str).get
 
-  def all: Seq[LibraryOrdering] = Seq(LAST_KEPT_INTO, ALPHABETICAL, MEMBER_COUNT)
+  implicit val format: Format[LibraryOrdering] = EnumFormat.format(fromStr, _.value)
 
   implicit def queryStringBinder[T](implicit stringBinder: QueryStringBindable[String]) = new QueryStringBindable[LibraryOrdering] {
     override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, LibraryOrdering]] = {
       stringBinder.bind(key, params) map {
-        case Right(str) =>
-          Right(LibraryOrdering.fromStr(str))
+        case Right(str) => Right(LibraryOrdering(str))
         case _ => Left("Unable to bind a LibraryOrdering")
       }
     }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -462,6 +462,10 @@ POST    /site/libraries/:id/image/position  @com.keepit.controllers.website.Libr
 DELETE  /site/libraries/:id/image           @com.keepit.controllers.website.LibraryImageController.removeLibraryImage(id: PublicId[Library])
 GET     /site/libraries/:ids/images         @com.keepit.controllers.website.LibraryImageController.getLibraryImages(ids: String, is: Option[String] ?= None)
 
+## endpoints only for testing, should be deleted by 2016-01-10
+GET     /site/rpb/user/:userId/libraries   @com.keepit.controllers.website.UserController.rpbGetUserLibraries(userId: ExternalId[User], fromId: Option[String] ?= None, limit: Int ?= 10)
+GET     /site/rpb/org/:orgId/libraries     @com.keepit.controllers.website.UserController.rpbGetOrgLibraries(orgId: PublicId[Organization], fromId: Option[String] ?= None, limit: Int ?= 10)
+
 POST  /site/libraries/:id/slack/modify      @com.keepit.controllers.website.SlackController.modifyIntegrations(id: PublicId[Library])
 POST  /site/libraries/:id/slack/delete      @com.keepit.controllers.website.SlackController.deleteIntegrations(id: PublicId[Library])
 


### PR DESCRIPTION
@andrewconner  @camhashemi 

I _think_ that this will allow us to get rid of all of the myriad `LibraryRepo` methods of "getXXXLibrariesForYYY". Additionally, this allows users to save their preferred library arrangement (alphabetical/member count/last kept at).

I'm at least 80% that this shouldn't affect any existing systems, and the endpoints only work for users with a new "custom_library_ordering" experiment, so even if they're broken or don't obey privacy settings properly it shouldn't be too big of an issue.

Thoughts?
