### PR TITLE
Revamped the SlackClientWrapper

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/concurrent/PimpedFuture.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/concurrent/PimpedFuture.scala
@@ -124,7 +124,7 @@ object FutureHelpers {
   }
 
   def doUntil(body: => Future[Boolean])(implicit ec: ScalaExecutionContext): Future[Unit] = {
-    foldLeftUntil(Stream.continually(()))(()) { case (_, _) => body.imap(done => ((), done)) }
+    foldLeftUntil(Stream.continually(()))(()) { case _ => body.imap(done => ((), done)) }
   }
 
   def whilef(f: => Future[Boolean], p: Promise[Unit] = Promise[Unit]())(body: => Unit)(implicit ec: ScalaExecutionContext): Future[Unit] = {

--- a/kifi-backend/modules/common/app/com/keepit/common/concurrent/PimpedFuture.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/concurrent/PimpedFuture.scala
@@ -127,6 +127,12 @@ object FutureHelpers {
     foldLeftUntil(Stream.continually(()))(()) { case _ => body.imap(done => ((), done)) }
   }
 
+  def doUntilAttempts(body: => Future[Boolean], maxAttempts: Int = 5)(implicit ec: ScalaExecutionContext): Future[Unit] = {
+    foldLeftUntil(Stream.continually(()))(1) {
+      case (attemptsSoFar, _) => body.imap(success => (attemptsSoFar + 1, success || attemptsSoFar > maxAttempts))
+    }.imap{ _ => () }
+  }
+
   def whilef(f: => Future[Boolean], p: Promise[Unit] = Promise[Unit]())(body: => Unit)(implicit ec: ScalaExecutionContext): Future[Unit] = {
     f.onComplete {
       case Success(true) => {

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackClientWrapper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackClientWrapper.scala
@@ -1,6 +1,7 @@
 package com.keepit.slack
 
 import com.google.inject.{ ImplementedBy, Inject, Singleton }
+import com.keepit.common.concurrent.FutureHelpers
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
@@ -10,9 +11,17 @@ import com.keepit.slack.models._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Success, Try, Failure }
 
+sealed abstract class SlackChannelMagnet
+object SlackChannelMagnet {
+  case class Id(id: SlackChannelId) extends SlackChannelMagnet
+  case class Name(name: SlackChannelName) extends SlackChannelMagnet
+  implicit def fromChannelId(id: SlackChannelId): SlackChannelMagnet = Id(id)
+  implicit def fromChannelName(name: SlackChannelName): SlackChannelMagnet = Name(name)
+}
+
 @ImplementedBy(classOf[SlackClientWrapperImpl])
 trait SlackClientWrapper {
-  def sendToSlack(webhook: SlackIncomingWebhook, msg: SlackMessageRequest): Future[Unit]
+  def sendToSlack(slackUserId: SlackUserId, slackTeamId: SlackTeamId, slackChannel: SlackChannelMagnet, msg: SlackMessageRequest): Future[Unit]
   def searchMessages(token: SlackAccessToken, request: SlackSearchRequest): Future[SlackSearchResponse]
   def addReaction(token: SlackAccessToken, reaction: SlackReaction, channelId: SlackChannelId, messageTimestamp: SlackMessageTimestamp): Future[Unit]
   def getChannelId(token: SlackAccessToken, channelName: SlackChannelName): Future[Option[SlackChannelId]]
@@ -32,24 +41,68 @@ class SlackClientWrapperImpl @Inject() (
   implicit val executionContext: ExecutionContext)
     extends SlackClientWrapper with Logging {
 
-  def sendToSlack(webhook: SlackIncomingWebhook, msg: SlackMessageRequest): Future[Unit] = {
+  def sendToSlack(slackUserId: SlackUserId, slackTeamId: SlackTeamId, slackChannel: SlackChannelMagnet, msg: SlackMessageRequest): Future[Unit] = {
     val now = clock.now
-    slackClient.pushToWebhook(webhook.url, msg).andThen {
-      case Success(()) =>
-        db.readWrite { implicit s =>
-          slackIncomingWebhookInfoRepo.getByWebhook(webhook).foreach { whi =>
-            slackIncomingWebhookInfoRepo.save(whi.withCleanSlate.withLastPostedAt(now))
+    slackChannel match {
+      case SlackChannelMagnet.Id(channelId) => pushToSlackUsingToken(slackUserId, slackTeamId, channelId, msg)
+      case SlackChannelMagnet.Name(channelName) => pushToSlackViaWebhook(slackUserId, slackTeamId, channelName, msg)
+    }
+  }
+
+  private def pushToSlackViaWebhook(slackUserId: SlackUserId, slackTeamId: SlackTeamId, slackChannelName: SlackChannelName, msg: SlackMessageRequest): Future[Unit] = {
+    FutureHelpers.doUntil {
+      val workingWebhooks = db.readOnlyMaster { implicit s =>
+        slackIncomingWebhookInfoRepo.getForChannelByName(slackUserId, slackTeamId, slackChannelName)
+      }
+      workingWebhooks match {
+        case Seq() => Future.failed(SlackAPIFailure.NoValidWebhooks)
+        case webhookInfo +: _ =>
+          val now = clock.now
+          val pushFut = slackClient.pushToWebhook(webhookInfo.webhook.url, msg).andThen {
+            case Success(_: Unit) => db.readWrite { implicit s =>
+              slackIncomingWebhookInfoRepo.save(
+                slackIncomingWebhookInfoRepo.get(webhookInfo.id.get).withCleanSlate.withLastPostedAt(now)
+              )
+            }
+            case Failure(fail: SlackAPIFailure) => db.readWrite { implicit s =>
+              slackIncomingWebhookInfoRepo.save(
+                slackIncomingWebhookInfoRepo.get(webhookInfo.id.get).withLastFailedAt(now).withLastFailure(fail)
+              )
+            }
+            case Failure(other) =>
+              // TODO(ryan): this is bad, if we ever get an unparseable error we're going to blow up continually forever
+              airbrake.notify("Got an unparseable error while pushing to Slack.", other)
           }
+
+          pushFut.map(_ => true).recover { case fail: SlackAPIFailure => false }
+      }
+    }
+  }
+
+  private def pushToSlackUsingToken(slackUserId: SlackUserId, slackTeamId: SlackTeamId, slackChannelId: SlackChannelId, msg: SlackMessageRequest): Future[Unit] = {
+    FutureHelpers.doUntil {
+      val workingToken = db.readOnlyMaster { implicit s =>
+        slackTeamMembershipRepo.getBySlackTeamAndUser(slackTeamId, slackUserId).collect {
+          case stm if stm.token.isDefined && stm.scopes.contains(SlackAuthScope.ChatWriteBot) => stm.token.get
         }
-      case Failure(fail: SlackAPIFailure) =>
-        log.error(s"[SLACK-CLIENT-WRAPPER] Caught a SlackAPIFailure ($fail) when posting, marking the webhook as broken")
-        db.readWrite { implicit s =>
-          slackIncomingWebhookInfoRepo.getByWebhook(webhook).foreach { whi =>
-            slackIncomingWebhookInfoRepo.save(whi.withLastFailedAt(now).withLastFailure(fail))
+      }
+      workingToken match {
+        case None => Future.failed(SlackAPIFailure.NoValidToken)
+        case Some(token) =>
+          val pushFut = slackClient.postToChannel(token, slackChannelId, msg).andThen {
+            case Success(_: Unit) => // If we ever kept track of successes for tokens, here is where we would note the success
+            case Failure(fail: SlackAPIFailure) => db.readWrite { implicit s =>
+              slackTeamMembershipRepo.getByToken(token).foreach { stm =>
+                slackTeamMembershipRepo.save(stm.revoked)
+              }
+            }
+            case Failure(other) =>
+              // TODO(ryan): this is bad, if we ever get an unparseable error we're going to blow up continually forever
+              airbrake.notify("Got an unparseable error while pushing to Slack.", other)
           }
-        }
-      case Failure(other) =>
-        log.error(s"[SLACK-CLIENT-WRAPPER] Caught a garbage error when posting, marking the webhook as broken")
+
+          pushFut.map(_ => true).recover { case fail: SlackAPIFailure => false }
+      }
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackCommander.scala
@@ -141,13 +141,11 @@ class SlackCommanderImpl @Inject() (
           "Keeps from", lib.name --> LinkElement(pathCommander.pathForLibrary(lib).absolute), "will be posted to this channel."
         )
       }
-      slackClient.sendToSlack(webhook, SlackMessageRequest.fromKifi(DescriptionElements.formatForSlack(welcomeMsg)).quiet) andThen {
-        case Success(()) =>
-          libToSlackPusher.pushUpdatesToSlack(libId) andThen {
-            case Success(_) =>
-              fetchMissingChannelIds()
-          }
-      }
+      slackClient.sendToSlack(identity.userId, identity.teamId, webhook.channelName, SlackMessageRequest.fromKifi(DescriptionElements.formatForSlack(welcomeMsg)).quiet)
+        .foreach { _ =>
+          libToSlackPusher.pushUpdatesToSlack(libId)
+            .foreach { _ => fetchMissingChannelIds() }
+        }
 
       val inhouseMsg = db.readOnlyReplica { implicit s =>
         import DescriptionElements._

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackInfoCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackInfoCommander.scala
@@ -119,7 +119,7 @@ class SlackInfoCommanderImpl @Inject() (
           case (key, Seq(ts)) =>
             val tsId = LibraryToSlackChannel.publicId(ts.id.get)
             val authLink = {
-              val hasValidWebhook = slackIncomingWebhookInfoRepo.getForIntegration(ts).nonEmpty
+              val hasValidWebhook = slackIncomingWebhookInfoRepo.getForChannelByName(ts.slackUserId, ts.slackTeamId, ts.slackChannelName).nonEmpty
               lazy val existingScopes = teamMembershipMap.get(ts.slackUserId, ts.slackTeamId).toSet[SlackTeamMembership].flatMap(_.scopes)
               val requiredScopes = SlackAuthScope.push
               if (hasValidWebhook && (requiredScopes subsetOf existingScopes)) None

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/models/LibraryToSlackChannel.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/models/LibraryToSlackChannel.scala
@@ -53,6 +53,8 @@ case class LibraryToSlackChannel(
   }
 
   def withSpace(newSpace: LibrarySpace) = this.copy(space = newSpace)
+
+  def channel: (SlackChannelName, Option[SlackChannelId]) = (slackChannelName, slackChannelId)
 }
 
 object LibraryToSlackChannelStates extends States[LibraryToSlackChannel]

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/models/SlackAPIFailure.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/models/SlackAPIFailure.scala
@@ -26,5 +26,7 @@ object SlackAPIFailure {
   val TokenRevoked = SlackAPIFailure(Status.NOT_FOUND, SlackAPIFailure.Error.tokenRevoked, JsNull)
   val WebhookRevoked = SlackAPIFailure(Status.NOT_FOUND, SlackAPIFailure.Error.webhookRevoked, JsNull)
   val NoAuthCode = SlackAPIFailure(Status.BAD_REQUEST, SlackAPIFailure.Error.noAuthCode, JsNull)
+  val NoValidWebhooks = SlackAPIFailure(Status.BAD_REQUEST, "no_valid_webhooks", JsNull)
+  val NoValidToken = SlackAPIFailure(Status.BAD_REQUEST, "no_valid_token", JsNull)
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/models/SlackIncomingWebhook.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/models/SlackIncomingWebhook.scala
@@ -48,8 +48,8 @@ object SlackIncomingWebhookInfoStates extends States[SlackIncomingWebhookInfo]
 
 @ImplementedBy(classOf[SlackIncomingWebhookInfoRepoImpl])
 trait SlackIncomingWebhookInfoRepo extends Repo[SlackIncomingWebhookInfo] {
-  def getForIntegration(int: SlackIntegration)(implicit session: RSession): Seq[SlackIncomingWebhookInfo]
-  def getByWebhook(wh: SlackIncomingWebhook)(implicit session: RSession): Option[SlackIncomingWebhookInfo]
+  def getForChannelByName(user: SlackUserId, teamId: SlackTeamId, name: SlackChannelName)(implicit session: RSession): Seq[SlackIncomingWebhookInfo]
+
   def getWithMissingChannelId()(implicit session: RSession): Set[(SlackUserId, SlackTeamId, SlackChannelName)]
   def fillInMissingChannelId(userId: SlackUserId, teamId: SlackTeamId, channelName: SlackChannelName, channelId: SlackChannelId)(implicit session: RWSession): Int
 }
@@ -147,11 +147,8 @@ class SlackIncomingWebhookInfoRepoImpl @Inject() (
     ))
   }
 
-  def getForIntegration(int: SlackIntegration)(implicit session: RSession): Seq[SlackIncomingWebhookInfo] = {
-    workingRows.filter(row => row.slackTeamId === int.slackTeamId && row.slackUserId === int.slackUserId && row.slackChannelName === int.slackChannelName).list
-  }
-  def getByWebhook(wh: SlackIncomingWebhook)(implicit session: RSession): Option[SlackIncomingWebhookInfo] = {
-    workingRows.filter(_.url === wh.url).firstOption
+  def getForChannelByName(userId: SlackUserId, teamId: SlackTeamId, channelName: SlackChannelName)(implicit session: RSession): Seq[SlackIncomingWebhookInfo] = {
+    workingRows.filter(row => row.slackUserId === userId && row.slackTeamId === teamId && row.slackChannelName === channelName).list
   }
 
   def getWithMissingChannelId()(implicit session: RSession): Set[(SlackUserId, SlackTeamId, SlackChannelName)] = {


### PR DESCRIPTION
It will now take a (SlackUserId, SlackTeamId, SlackChannel) and figure out
a way to push something to that channel. It will automatically go through
all the relevant webhooks, marking them as revoked as necessary, until
it finds one that works.

If it is given a SlackChannelName to identify the channel, it will use webhooks
If it is given a SlackChannelId, it will try and find a SlackAccessToken
  with the chat:write:bot scope

@leogrim 
