### PR TITLE
add keep to users where appropriate

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -180,6 +180,7 @@ object Shoebox extends Service {
     def getIntegrationsBySlackChannel() = ServiceRoute(POST, "/internal/shoebox/database/getIntegrationsBySlackChannel")
     def getSourceAttributionForKeeps() = ServiceRoute(POST, "/internal/shoebox/database/getSourceAttributionForKeeps")
     def internKeep() = ServiceRoute(POST, "/internal/shoebox/database/internKeep")
+    def addUsersToKeep(adderId: Id[User], keepId: Id[Keep]) = ServiceRoute(POST, "/internal/shoebox/database/addUsersToKeep", Param("adderId", adderId), Param("keepId", keepId))
   }
 }
 

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -136,6 +136,7 @@ trait ShoeboxServiceClient extends ServiceClient {
 
   // TODO(ryan): kill this once clients stop trying to create discussions through Eliza
   def internKeep(creator: Id[User], users: Set[Id[User]], uriId: Id[NormalizedURI], url: String, title: Option[String], note: Option[String]): Future[CrossServiceKeep]
+  def addUsersToKeep(adderId: Id[User], keepId: Id[Keep], newUsers: Set[Id[User]]): Future[Unit]
 }
 
 case class ShoeboxCacheProvider @Inject() (
@@ -865,6 +866,11 @@ class ShoeboxServiceClientImpl @Inject() (
       response.json.as[CrossServiceKeep]
     }
   }
+
+  def addUsersToKeep(adderId: Id[User], keepId: Id[Keep], newUsers: Set[Id[User]]): Future[Unit] = {
+    call(Shoebox.internal.addUsersToKeep(adderId, keepId), body = Json.obj("users" -> newUsers)).map(_ => ())
+  }
+
 }
 
 object ShoeboxServiceClient {

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -712,4 +712,6 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, impli
       note = note
     ))
   }
+
+  def addUsersToKeep(adderId: Id[User], keepId: Id[Keep], newUsers: Set[Id[User]]): Future[Unit] = Future.successful(())
 }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -455,6 +455,7 @@ class MessagingCommander @Inject() (
             sentOnUrl = None,
             sentOnUriId = None
           ))
+          shoebox.addUsersToKeep(adderUserId, keepId, actuallyNewUsers.toSet)
 
           Some((actuallyNewUsers, actuallyNewNonUsers, message, thread))
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/AuthCommander.scala
@@ -470,8 +470,7 @@ class AuthCommander @Inject() (
     val hasPermission = db.readOnlyMaster(implicit s => permissionCommander.getKeepPermissions(keepId, Some(userId)).contains(KeepPermission.ADD_MESSAGE))
     if (hasPermission) {
       db.readWrite { implicit s =>
-        val keep = keepRepo.get(keepId)
-        keepCommander.persistKeep(keep.withConnections(keep.connections.plusUser(userId)))
+        keepCommander.addUsersToKeep(keepId, userId, Set(userId))
       }
     }
     // user may not have explicit permission to be added, but implicit via access token from email participation. add them.
@@ -481,8 +480,7 @@ class AuthCommander @Inject() (
           db.readWrite { implicit s =>
             emailOpt.map(email => emailAddressCommander.saveAsVerified(UserEmailAddress.create(userId = userId, address = email)))
             addedByOpt.map { addedBy => // addedByOpt = None if no NonUserThread found for access token
-              val keep = keepRepo.get(keepId)
-              keepCommander.persistKeep(keep.withConnections(keep.connections.plusUser(userId)))
+              keepCommander.addUsersToKeep(keepId, addedBy, Set(userId))
             }
           }
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/DiscussionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/DiscussionCommander.scala
@@ -44,6 +44,9 @@ class DiscussionCommanderImpl @Inject() (
     }
 
     errs.headOption.map(fail => Future.failed(fail)).getOrElse {
+      db.readWrite { implicit s =>
+        keepCommander.addUsersToKeep(keepId, userId, Set(userId))
+      }
       eliza.sendMessageOnKeep(userId, text, keepId)
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -74,6 +74,7 @@ trait KeepCommander {
   def keepOne(rawBookmark: RawBookmarkRepresentation, userId: Id[User], libraryId: Id[Library], source: KeepSource, socialShare: SocialShare)(implicit context: HeimdalContext): (Keep, Boolean)
   def keepMultiple(rawBookmarks: Seq[RawBookmarkRepresentation], libraryId: Id[Library], userId: Id[User], source: KeepSource)(implicit context: HeimdalContext): (Seq[KeepInfo], Seq[String])
   def persistKeep(k: Keep)(implicit session: RWSession): Keep
+  def addUsersToKeep(keepId: Id[Keep], addedBy: Id[User], newUsers: Set[Id[User]])(implicit session: RWSession): Keep
 
   // Updating / managing
   def updateKeepTitle(keepId: ExternalId[Keep], libId: Id[Library], userId: Id[User], title: Option[String])(implicit context: HeimdalContext): Either[(Int, String), Keep]
@@ -663,12 +664,20 @@ class KeepCommanderImpl @Inject() (
 
     val keep = keepRepo.save(k)
 
-    keep.connections.users.foreach { userId => ktuCommander.internKeepInUser(keep, userId, keep.userId) }
+    keep.connections.users.foreach { userId => ktuCommander.internKeepInUser(keep, userId, userId) }
 
     val libraries = libraryRepo.getActiveByIds(keep.connections.libraries).values
     libraries.foreach { lib => ktlCommander.internKeepInLibrary(keep, lib, keep.userId) }
 
     keep
+  }
+  def addUsersToKeep(keepId: Id[Keep], addedBy: Id[User], newUsers: Set[Id[User]])(implicit session: RWSession): Keep = {
+    val oldKeep = keepRepo.get(keepId)
+    val newKeep = keepRepo.save(oldKeep.withParticipants(oldKeep.connections.users ++ newUsers))
+
+    newUsers.foreach { userId => ktuCommander.internKeepInUser(newKeep, userId, addedBy) }
+
+    newKeep
   }
   def refreshLibraries(keepId: Id[Keep])(implicit session: RWSession): Keep = {
     val keep = keepRepo.getNoCache(keepId)


### PR DESCRIPTION
@ryanpbrewster @leogrim @andrewconner 

adding participants to a created thread doesn't create a KTU, neither does commenting on a keep. this should do it.

@ryanpbrewster I think we should create a specific method for updating KTU + keep.connections, since we're losing `addedBy` here. It'd be similar to `persistKeep` but only for updating users, and asking for `addedBy`.
