### PR TITLE
Rework Firefox's script loading to comply with addon review

### DIFF
--- a/packrat/adapters/firefox/data/scripts/ranges.js
+++ b/packrat/adapters/firefox/data/scripts/ranges.js
@@ -1,3 +1,5 @@
+// @module
+
 var ranges = {
   getClientRects: function (r) {
     return r.getClientRects();

--- a/packrat/adapters/firefox/data/scripts/repair_inputs.js
+++ b/packrat/adapters/firefox/data/scripts/repair_inputs.js
@@ -1,3 +1,5 @@
+// @module
+
 $.fn.repairInputs = function () {
   'use strict';
   return this;

--- a/packrat/adapters/firefox/data/scripts/selectionchange.js
+++ b/packrat/adapters/firefox/data/scripts/selectionchange.js
@@ -1,3 +1,5 @@
+// @module
+
 // github.com/2is10/selectionchange-polyfill
 
 var selectionchange = (function (undefined) {

--- a/packrat/adapters/shared/listeners.js
+++ b/packrat/adapters/shared/listeners.js
@@ -24,4 +24,6 @@ Object.defineProperty(Listeners.prototype, 'dispatch', {
 
 if (this.exports) {
   this.exports.Listeners = Listeners;
+} else {
+  this.Listeners = Listeners;
 }

--- a/packrat/gulpfile.js
+++ b/packrat/gulpfile.js
@@ -87,7 +87,7 @@ var chromeInjectionFooter = lazypipe()
 
 var firefoxExplicitGlobals = lazypipe()
   .pipe(function () {
-    return gulpif(['**/scripts/**/*.js', '!**/iframes/**', '!**/lib/**'], map(function (code, filename) {
+    return gulpif(['**/scripts/**/*.js', '!**/lib/**'], map(function (code, filename) {
       return explicitGlobals(code.toString());
     }));
   });
@@ -108,7 +108,7 @@ function wrapWithModuleCode(code, filename, relative) {
 
 var firefoxInjectionModule = lazypipe()
   .pipe(function () {
-    return gulpif(['**/scripts/**/*.js', '!**iframes/**'], map(function (code, filename) {
+    return gulpif(['**/scripts/**/*.js'], map(function (code, filename) {
       if (code.toString().indexOf('api.identify(') !== -1) {
         return code;
       } else {
@@ -120,8 +120,9 @@ var firefoxInjectionModule = lazypipe()
 var firefoxAdapterInjectionModule = lazypipe()
   .pipe(function () {
     return gulpif(['**/scripts/**/*.js'], map(function (code, filename) {
-      if (code.toString().indexOf('@module') !== -1) {
-        return wrapWithModuleCode(code, filename, 'adapters/firefox/data');
+      var codeString = code.toString();
+      if (codeString.indexOf('@module') !== -1) {
+        return wrapWithModuleCode(explicitGlobals(codeString), filename, 'adapters/firefox/data');
       } else {
         return code;
       }

--- a/packrat/gulpfile.js
+++ b/packrat/gulpfile.js
@@ -31,6 +31,7 @@ var chromeAdapterFiles = ['adapters/chrome/**', '!adapters/chrome/manifest.json'
 var firefoxAdapterFiles = ['adapters/firefox/**', '!adapters/firefox/package.json'];
 var sharedAdapterFiles = ['adapters/shared/*.js', 'adapters/shared/*.min.map'];
 var resourceFiles = ['icons/url_*.png', 'images/**', 'media/**', 'scripts/**', '!scripts/lib/rwsocket.js'];
+var firefoxScriptModuleFiles = ['**/scripts/**/*.js', '!scripts/lib/jquery.js', '!scripts/lib/mustache.js', '!scripts/lib/underscore.js'];
 var rwsocketScript = 'scripts/lib/rwsocket.js';
 var backgroundScripts = [
   'main.js',
@@ -108,7 +109,7 @@ function wrapWithModuleCode(code, filename, relative) {
 
 var firefoxInjectionModule = lazypipe()
   .pipe(function () {
-    return gulpif(['**/scripts/**/*.js'], map(function (code, filename) {
+    return gulpif(firefoxScriptModuleFiles, map(function (code, filename) {
       if (code.toString().indexOf('api.identify(') !== -1) {
         return code;
       } else {
@@ -119,7 +120,7 @@ var firefoxInjectionModule = lazypipe()
 
 var firefoxAdapterInjectionModule = lazypipe()
   .pipe(function () {
-    return gulpif(['**/scripts/**/*.js'], map(function (code, filename) {
+    return gulpif(firefoxScriptModuleFiles, map(function (code, filename) {
       var codeString = code.toString();
       if (codeString.indexOf('@module') !== -1) {
         return wrapWithModuleCode(explicitGlobals(codeString), filename, 'adapters/firefox/data');

--- a/packrat/gulpfile.js
+++ b/packrat/gulpfile.js
@@ -20,6 +20,8 @@ var remember = require('gulp-remember');
 var livereload = require('gulp-livereload');
 var gutil = require('gulp-util');
 var map = require('./gulp/vinyl-map.js');
+var filenames = require('gulp-filenames');
+var explicitGlobals = require('explicit-globals');
 
 var target = 'local';
 
@@ -83,6 +85,49 @@ var chromeInjectionFooter = lazypipe()
     }));
   });
 
+var firefoxExplicitGlobals = lazypipe()
+  .pipe(function () {
+    return gulpif(['**/scripts/**/*.js', '!**/iframes/**', '!**/lib/**'], map(function (code, filename) {
+      return explicitGlobals(code.toString());
+    }));
+  });
+
+function wrapWithModuleCode(code, filename, relative) {
+  if (relative) {
+    filename = path.relative(relative, filename);
+  }
+  var top = '\
+  \nvar init_module = init_module || {}; \
+  \ninit_module[\'' + filename + '\'] = function () { \
+  \ninit_module[\'' + filename + '\'] = function () {}; \
+  \n';
+  var bottom = '\n};\n'
+
+  return top + code.toString() + bottom;
+}
+
+var firefoxInjectionModule = lazypipe()
+  .pipe(function () {
+    return gulpif(['**/scripts/**/*.js', '!**iframes/**'], map(function (code, filename) {
+      if (code.toString().indexOf('api.identify(') !== -1) {
+        return code;
+      } else {
+        return wrapWithModuleCode(code, filename);
+      }
+    }));
+  });
+
+var firefoxAdapterInjectionModule = lazypipe()
+  .pipe(function () {
+    return gulpif(['**/scripts/**/*.js'], map(function (code, filename) {
+      if (code.toString().indexOf('@module') !== -1) {
+        return wrapWithModuleCode(code, filename, 'adapters/firefox/data');
+      } else {
+        return code;
+      }
+    }));
+  });
+
 gulp.task('clean', function () {
   return gulp.src(outDir, {read: false})
     .pipe(rimraf());
@@ -106,8 +151,11 @@ gulp.task('copy', function () {
 
   var firefoxAdapters = gulp.src(firefoxAdapterFiles, {base: './adapters'})
     .pipe(cache('firefox-adapters'))
+    .pipe(rename(function () {}))
+    .pipe(firefoxAdapterInjectionModule())
     .pipe(map(removeMostJsComments))
-    .pipe(gulp.dest(outDir));
+    .pipe(gulp.dest(outDir))
+    .pipe(filenames('firefox-deps'));
 
   var sharedAdapters = gulp.src(sharedAdapterFiles)
     .pipe(cache('shared-adapters'))
@@ -119,7 +167,11 @@ gulp.task('copy', function () {
     .pipe(cache('resources'));
 
   var firefoxResources = resources.pipe(clone())
-    .pipe(gulp.dest(outDir + '/firefox/data'));
+    .pipe(rename(function () {}))
+    .pipe(firefoxExplicitGlobals())
+    .pipe(firefoxInjectionModule())
+    .pipe(gulp.dest(outDir + '/firefox/data'))
+    .pipe(filenames('firefox-deps'));
 
   var chromeResources = resources.pipe(clone())
     .pipe(rename(function () {})) // very obscure way to make sure filenames use a relative path
@@ -143,7 +195,8 @@ gulp.task('copy', function () {
     .pipe(cache('background'))
     .pipe(map(removeMostJsComments))
     .pipe(gulp.dest(outDir + '/chrome'))
-    .pipe(gulp.dest(outDir + '/firefox/lib'));
+    .pipe(gulp.dest(outDir + '/firefox/lib'))
+    .pipe(filenames('firefox-deps'));
 
   return es.merge(
     chromeAdapters, firefoxAdapters, sharedAdapters,
@@ -169,10 +222,13 @@ gulp.task('html2js', function () {
     .pipe(rename(function (path) {
       path.extname = '.js';
       path.dirname = 'scripts/' + path.dirname;
-    }));
+    }))
+    .pipe(filenames('firefox-deps'));
 
   var firefox = common.pipe(clone())
-    .pipe(gulp.dest(outDir + '/firefox/data'));
+    .pipe(firefoxExplicitGlobals())
+    .pipe(firefoxInjectionModule())
+    .pipe(gulp.dest(outDir + '/firefox/data'))
 
   var chrome = common.pipe(clone())
     .pipe(chromeInjectionFooter())
@@ -290,7 +346,10 @@ gulp.task('meta', function () {
       if (type === 'contentScripts') {
         var payloadMatch = payload.match(contentScriptRe);
         var asap = payloadMatch[1], regex = payloadMatch[2];
-        contentScriptItems.push('["' + filename + '", ' + regex + ', ' + asap + ']');
+        contentScriptItems.push({
+          data: [ filename, regex, asap ],
+          string: '["' + filename + '", ' + regex + ', ' + asap + ']'
+        });
       } else {
         if (type === 'styleDeps') {
           styleDeps[filename] = styleDeps[filename] || [];
@@ -301,14 +360,32 @@ gulp.task('meta', function () {
         }
       }
     }
+
+    var flatScriptDeps = [
+      rwsocketScript
+    ].concat(filenames.get('firefox-deps')
+    .filter(function (dep) {
+      return (
+        dep.slice(-3) === '.js' && // only script files
+        ~dep.indexOf('scripts/') && // make sure it's in the scripts folder
+        !~dep.indexOf('firefox/lib/') && // but not in the backend-script lib folder
+        contentScriptItems.map(function (csi) { return csi.data[0]; }).indexOf(dep) === -1 // and don't add top-level scripts to the deps
+      );
+    })
+    .map(function (dep) {
+      return dep.replace(/firefox\/data\//g, '');
+    }));
+
     return JSON.stringify([
-      ' [\n  ' + contentScriptItems.join(',\n  ') + ']',
+      ' [\n  ' + contentScriptItems.map(function (csi) { return csi.string; }).join(',\n  ') + ']',
       JSON.stringify(styleDeps, undefined, 2),
-      JSON.stringify(scriptDeps, undefined, 2)
+      JSON.stringify(scriptDeps, undefined, 2),
+      JSON.stringify(flatScriptDeps, undefined, 2)
     ]);
   };
 
   var preMeta = gulp.src(tabScripts, {base: './'})
+    .pipe(filenames('firefox-deps'))
     .pipe(cache('meta'))
     .pipe(map(extractMetadata))
     .pipe(remember('meta'))
@@ -331,6 +408,7 @@ gulp.task('meta', function () {
       return 'exports.contentScripts =' + data[0] +
         ';\nexports.styleDeps = ' + data[1] +
         ';\nexports.scriptDeps = ' + data[2] +
+        ';\nexports.flatScriptDeps = ' + data[3] +
         ";\nif (/^Mac/.test(require('sdk/system').platform)) {\n  exports.styleDeps['scripts/keeper_scout.js'] = ['styles/mac.css'];\n}\n";
     }))
     .pipe(gulp.dest(outDir + '/firefox/lib'));

--- a/packrat/package.json
+++ b/packrat/package.json
@@ -10,6 +10,7 @@
     "gulp-cached": "~1.0.1",
     "gulp-clone": "~1.0.0",
     "gulp-concat": "~2.3.4",
+    "gulp-filenames": "^2.0.0",
     "gulp-if": "~1.2.2",
     "gulp-json-editor": "~2.0.2",
     "gulp-jsvalidate": "^2.1.0",

--- a/packrat/package.json
+++ b/packrat/package.json
@@ -6,6 +6,7 @@
     "bl": "~0.9.0",
     "css": "~2.0.0",
     "event-stream": "~3.1.5",
+    "explicit-globals": "cvializ/explicit-globals",
     "gulp": "~3.8.6",
     "gulp-cached": "~1.0.1",
     "gulp-clone": "~1.0.0",

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -6,6 +6,7 @@
 // @require scripts/lib/jquery.js
 // @require scripts/lib/jquery-ui-position.min.js
 // @require scripts/lib/jquery-hoverfu.js
+// @require scripts/lib/mustache.js
 // @require scripts/render.js
 // @require scripts/title_from_url.js
 // @require scripts/html/search/google.js
@@ -17,7 +18,22 @@ api.identify('googleInject');
 // Google inject regex accurate as of 2015-08-21. This is helpful: https://en.wikipedia.org/wiki/List_of_Google_domains
 // (same as match pattern above)
 var searchUrlRe = /^https?:\/\/www\.google\.(?:com|com\.(?:a[fgiru]|b[dhnorz]|c[ouy]|do|e[cgt]|fj|g[hit]|hk|jm|k[hw]|l[bcy]|m[mtxy]|n[afgip]|om|p[aeghkry]|qa|s[abglv]|t[jnrw]|u[ay]|v[cn])|co\.(?:ao|bw|c[kr]|i[dln]|jp|k[er]|ls|m[az]|pn|nz|t[hz]|u[gkz]|v[ei]|z[amw])|a[cdelmstz]|b[aefgijsty]|cat|c[acdfghilmnvz]|d[ejkmz]|e[es]|f[imr]|g[aefglmpry]|h[nrtu]|i[emqsto]|j[eo]|k[giz]|l[aiktuv]|m[degklnsuvw]|n[eloru]|p[lnstosuw]|r[osuw]|s[cehikmnot]|t[dgklmnot]|v[gu]|ws)\/(?:|search|webhp)(?:[?#].*)?$/;
+// line comment to kill regex syntax highlighting
+
 var pageSession = Math.random().toString(16).slice(2);
+
+api.require([
+  'scripts/api.js',
+  'scripts/lib/jquery.js',
+  'scripts/lib/jquery-ui-position.min.js',
+  'scripts/lib/jquery-hoverfu.js',
+  'scripts/lib/mustache.js',
+  'scripts/render.js',
+  'scripts/title_from_url.js',
+  'scripts/html/search/google.js',
+  'scripts/html/search/google_hits.js',
+  'scripts/html/search/google_hit.js'
+], function () {
 
 $.fn.layout = function () {
   return this.each(function () {this.clientHeight});  // forces layout
@@ -1181,3 +1197,5 @@ if (searchUrlRe.test(document.URL)) !function () {
     return String(n).replace(insertCommasRe, '$1,');
   }
 }();
+
+});

--- a/packrat/scripts/installed.js
+++ b/packrat/scripts/installed.js
@@ -52,6 +52,6 @@ api.identify('installed');
       }
     }
   }
-}(this.chrome && chrome.runtime && chrome.runtime.getManifest().version ||
-  this.self && self.options && self.options.version ||
+}(typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.getManifest().version ||
+  typeof self !== 'undefined' && self.options && self.options.version ||
   true));


### PR DESCRIPTION
@andrewconner This should remove the biggest obstacle to putting Kifi in the Mozilla addon site.

It removes the need to eval the lazy loaded scripts by wrapping the dependencies in module functions, loading the scripts, then calling the modules functions instead of evaling the code.

Wrapping the files in module functions would violate the script's expectations of setting globals with `var`, so I wrote a tool that reads the files for globals, then directly prepends a `window.` to explicitly reference these as globals.

The main changes are to the `gulpfile`, so the risk should be low, and it doesn't affect the Chrome extension at all. Let me know what you think
