### PR TITLE
Compile-time safety against session-in-session issues

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/RPBExampleCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/RPBExampleCommander.scala
@@ -1,0 +1,53 @@
+package com.keepit.commanders
+
+import com.google.inject.{ Inject, Singleton }
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.DBSession.RSession
+import com.keepit.common.db.slick._
+import com.keepit.model._
+
+sealed trait DBContext
+object DBContext {
+  case class NoSession(dummy: Int) extends DBContext
+  case class YesSession(session: RSession) extends DBContext
+}
+
+@Singleton
+class RPBExampleCommander @Inject() (
+    db: Database,
+    keepRepo: KeepRepo) {
+
+  // For the purposes of this example, pretend that our repos used this convention
+  def safeDb[T](f: DBContext.YesSession => T)(implicit ctx: DBContext.NoSession) = db.readOnlyMaster { s => f(DBContext.YesSession(s)) }
+  def getKeep(keepId: Id[Keep])(implicit ctx: DBContext.YesSession) = keepRepo.get(keepId)(ctx.session)
+  def getCount()(implicit ctx: DBContext.YesSession) = keepRepo.count(ctx.session)
+
+  // If a method opens a session, you must declare it as such
+  def openSession(keepId: Id[Keep])(implicit ctx: DBContext.NoSession): Keep = {
+    safeDb { implicit s =>
+      getKeep(keepId)
+    }
+  }
+
+  def deferSession(keepId: Id[Keep])(implicit ctx: DBContext.NoSession): Keep = {
+    safeDb { implicit s =>
+      useDeferredSession(keepId)
+    }
+  }
+  def useDeferredSession(keepId: Id[Keep])(implicit ctx: DBContext.YesSession): Keep = {
+    doSomethingThatSeemsSafe()
+    getKeep(keepId)
+  }
+  def doSomethingThatSeemsSafe()(implicit ctx: DBContext.YesSession): Unit = {
+    println("i am totally safe")
+    println("when I was written, no one assumed I would misbehave ever")
+    println("but now I am angsty and want to do my own thing")
+    // Try to uncomment these lines
+    /*
+    safeDb { implicit s =>
+      println("ha, take that dad")
+      println(getCount)
+    }
+    */
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/RPBExampleCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/RPBExampleCommander.scala
@@ -2,49 +2,45 @@ package com.keepit.commanders
 
 import com.google.inject.{ Inject, Singleton }
 import com.keepit.common.db.Id
-import com.keepit.common.db.slick.DBSession.RSession
 import com.keepit.common.db.slick._
 import com.keepit.model._
 
-sealed trait DBContext
-object DBContext {
-  case class NoSession(dummy: Int) extends DBContext
-  case class YesSession(session: RSession) extends DBContext
-}
-
 @Singleton
 class RPBExampleCommander @Inject() (
-    db: Database,
+    db: SafeDatabase,
     keepRepo: KeepRepo) {
 
   // For the purposes of this example, pretend that our repos used this convention
-  def safeDb[T](f: DBContext.YesSession => T)(implicit ctx: DBContext.NoSession) = db.readOnlyMaster { s => f(DBContext.YesSession(s)) }
-  def getKeep(keepId: Id[Keep])(implicit ctx: DBContext.YesSession) = keepRepo.get(keepId)(ctx.session)
-  def getCount()(implicit ctx: DBContext.YesSession) = keepRepo.count(ctx.session)
+  def getKeep(keepId: Id[Keep])(implicit ctx: DBContext.Read) = keepRepo.get(keepId)(ctx.session)
+  def getCount()(implicit ctx: DBContext.Read) = keepRepo.count(ctx.session)
 
   // If a method opens a session, you must declare it as such
-  def openSession(keepId: Id[Keep])(implicit ctx: DBContext.NoSession): Keep = {
-    safeDb { implicit s =>
+  def openSession(keepId: Id[Keep])(implicit ctx: DBContext.Clean): Keep = {
+    db.read { implicit s =>
       getKeep(keepId)
     }
   }
 
-  def deferSession(keepId: Id[Keep])(implicit ctx: DBContext.NoSession): Keep = {
-    safeDb { implicit s =>
+  def deferSession(keepId: Id[Keep])(implicit ctx: DBContext.Clean): Keep = {
+    db.read { implicit s =>
       useDeferredSession(keepId)
     }
   }
-  def useDeferredSession(keepId: Id[Keep])(implicit ctx: DBContext.YesSession): Keep = {
+  def useDeferredSession(keepId: Id[Keep])(implicit ctx: DBContext.Read): Keep = {
+    doSomethingThatIsActuallySafe()
     doSomethingThatSeemsSafe()
     getKeep(keepId)
   }
-  def doSomethingThatSeemsSafe()(implicit ctx: DBContext.YesSession): Unit = {
-    println("i am totally safe")
+  def doSomethingThatIsActuallySafe(): Unit = {
+    println("i am really safe")
+  }
+  def doSomethingThatSeemsSafe()(implicit ctx: DBContext.Read): Unit = {
+    println("i am definitely unsafe")
     println("when I was written, no one assumed I would misbehave ever")
     println("but now I am angsty and want to do my own thing")
     // Try to uncomment these lines
     /*
-    safeDb { implicit s =>
+    db.write { implicit s =>
       println("ha, take that dad")
       println(getCount)
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/RPBExampleCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/RPBExampleCommanderTest.scala
@@ -1,0 +1,30 @@
+package com.keepit.commanders
+
+import com.keepit.common.actor.TestKitSupport
+import com.keepit.common.db.slick.{ DBContext, SafeDatabase }
+import com.keepit.model.KeepFactory
+import com.keepit.model.KeepFactoryHelper.KeepPersister
+import com.keepit.test.ShoeboxTestInjector
+import org.specs2.mutable.SpecificationLike
+
+class RPBExampleCommanderTest extends TestKitSupport with SpecificationLike with ShoeboxTestInjector {
+  val modules = Seq()
+  "RPBExampleCommander" should {
+    "let me do awesome things" in {
+      withDb() { implicit injector =>
+        implicit val thisCanTotallyBeAbused = DBContext.takeResponsibility("rpb")
+        val rpb = inject[RPBExampleCommander]
+        val sdb = inject[SafeDatabase]
+        val keep = db.readWrite { implicit s => KeepFactory.keep().saved }
+
+        // All fine
+        rpb.openSession(keep.id.get) === keep
+        rpb.deferSession(keep.id.get) === keep
+        sdb.read { implicit s => rpb.getKeep(keep.id.get) } === keep
+
+        // Not fine, but will compile because of `thisCanTotallyBeAbused`
+        sdb.read { implicit s => rpb.openSession(keep.id.get) } === keep
+      }
+    }
+  }
+}

--- a/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/SafeDatabase.scala
+++ b/kifi-backend/modules/sqldb/app/com/keepit/common/db/slick/SafeDatabase.scala
@@ -1,0 +1,20 @@
+package com.keepit.common.db.slick
+
+import com.google.inject.Inject
+import com.keepit.common.db.slick.DBSession.{ RWSession, RSession }
+
+sealed trait DBContext
+object DBContext {
+  def takeResponsibility(who: String): Clean = Clean(who)
+
+  case class Clean(signature: String) extends DBContext
+  case class Read(session: RSession) extends DBContext
+  case class Write(session: RWSession) extends DBContext
+
+  implicit def writeToRead(w: Write): Read = Read(w.session)
+}
+
+class SafeDatabase @Inject() (db: Database) {
+  def read[T](fn: DBContext.Read => T)(implicit ctx: DBContext.Clean): T = db.readOnlyMaster { s => fn(DBContext.Read(s)) }
+  def write[T](fn: DBContext.Write => T)(implicit ctx: DBContext.Clean): T = db.readWrite { s => fn(DBContext.Write(s)) }
+}


### PR DESCRIPTION
@andrewconner here's what I've got.

The basic idea is that we can get a some safety by asserting not just when things _do_ take in a session, but also when they explicitly _don't_.

If we do that then we can make the database require "proof" that we're not in a db session before it will open one. The rules for passing around contexts aren't too bad, but it does require every method that is going to eventually access the db to declare it. In many ways it reminds me of `IO` in Haskell. The advantage for dealing with all of this bullshit is that we get compile-time assurance that there aren't any session-in-session issues.

I put in a "backdoor", so to speak (basically required for any reasonable use) where you can force the compiler to let you open a db session.

Thoughts?

@leogrim @camhashemi 
