### PR TITLE
Make the Slack pusher robust to failure

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/concurrent/PimpedFuture.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/concurrent/PimpedFuture.scala
@@ -68,6 +68,12 @@ object FutureHelpers {
   def accumulateOneAtATime[I, T](items: Set[I])(f: I => Future[T])(implicit ec: ScalaExecutionContext): Future[Map[I, T]] = {
     foldLeft(items)(Map.empty[I,T]) { case (acc, nextItem) => f(nextItem).imap(res => acc + (nextItem -> res)) }
   }
+  def accumulateRobustly[I, T](items: Iterable[I])(f: I => Future[T])(implicit ec: ScalaExecutionContext): Future[Map[I, Either[Throwable, T]]] = {
+    foldLeft(items)(Map.empty[I, Either[Throwable, T]]) {
+      case (acc, nextItem) =>
+        f(nextItem).imap(Right(_)).recover { case fail => Left(fail) }.imap { res => acc + (nextItem -> res) }
+    }
+  }
 
   private val noopChunkCB: Int => Unit = _ => Unit
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
@@ -98,7 +98,7 @@ class PermissionCommanderImpl @Inject() (
 
   @StatsdTiming("PermissionCommander.getLibraryPermissions")
   def getLibraryPermissions(libId: Id[Library], userIdOpt: Option[Id[User]])(implicit session: RSession): Set[LibraryPermission] = {
-    getLibrariesPermissions(Set(libId), userIdOpt).get(libId).get
+    getLibrariesPermissions(Set(libId), userIdOpt).getOrElse(libId, Set.empty)
   }
 
   @StatsdTiming("PermissionCommander.getLibrariesPermissions")


### PR DESCRIPTION
@leogrim this fixes both issues (the exception for inactive libraries).
