### PR TITLE
Detecting UA a bit better for MessageSource

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/net/UserAgent.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/net/UserAgent.scala
@@ -13,15 +13,19 @@ case class UserAgent(
     possiblyBot: Boolean,
     typeName: String,
     version: String) {
-  lazy val isKifiIphoneApp: Boolean = typeName == UserAgent.KifiIphoneAppTypeName
-  lazy val isKifiAndroidApp: Boolean = operatingSystemFamily == "Android" // TODO: use a custom User-Agent header in our Android app
-  lazy val isIphone: Boolean = (operatingSystemFamily == "iOS" && userAgent.contains("CPU iPhone OS")) || isKifiIphoneApp
-  lazy val isAndroid: Boolean = operatingSystemFamily == "Android" || isKifiAndroidApp
-  lazy val isMobile: Boolean = UserAgent.MobileOses.contains(operatingSystemFamily) || isKifiIphoneApp || isKifiAndroidApp
-  lazy val isMobileWeb: Boolean = UserAgent.MobileOses.contains(operatingSystemFamily)
-  lazy val isMobileApp: Boolean = isKifiIphoneApp || isKifiAndroidApp
-  lazy val canRunExtensionIfUpToDate: Boolean = !isMobile && UserAgent.ExtensionBrowserNames.contains(name)
-  lazy val isOldIE: Boolean = name == "IE" && (try { version.toDouble.toInt } catch { case _: NumberFormatException => Double.MaxValue }) < 10
+  val isKifiIphoneApp: Boolean = typeName == UserAgent.KifiIphoneAppTypeName
+  val isKifiAndroidApp: Boolean = operatingSystemFamily == "Android" && this.toString.contains(UserAgent.KifiMarker)
+  val isIphone: Boolean = (operatingSystemFamily == "iOS" && userAgent.contains("CPU iPhone OS")) || isKifiIphoneApp
+  val isAndroid: Boolean = operatingSystemFamily == "Android" || isKifiAndroidApp
+  val isMobile: Boolean = UserAgent.MobileOses.contains(operatingSystemFamily) || isKifiIphoneApp || isKifiAndroidApp
+  val isMobileWeb: Boolean = UserAgent.MobileOses.contains(operatingSystemFamily)
+  val isMobileApp: Boolean = isKifiIphoneApp || isKifiAndroidApp
+  val canRunExtensionIfUpToDate: Boolean = !isMobile && UserAgent.ExtensionBrowserNames.contains(name)
+  val isOldIE: Boolean = name == "IE" && (try { version.toDouble.toInt } catch { case _: NumberFormatException => Double.MaxValue }) < 10
+
+  override def toString = {
+    s"""UserAgent($userAgent, $name, $operatingSystemFamily, $operatingSystemName, $possiblyBot, $typeName, $version;; $isKifiIphoneApp,$isKifiAndroidApp,$isIphone, $isAndroid, $isMobile, $isMobileWeb, $canRunExtensionIfUpToDate, $isOldIE)"""
+  }
 }
 
 object UserAgent extends Logging {
@@ -29,6 +33,7 @@ object UserAgent extends Logging {
   val UnknownUserAgent = UserAgent("", "", "", "", true, "", "")
 
   val KifiIphoneAppTypeName = "kifi iphone app"
+  val KifiMarker = "Kifi"
 
   private val MobileOses = Set("Android", "iOS", "Bada", "DangerOS", "Firefox OS", "Mac OS", "Palm OS", "BlackBerry OS", "Symbian OS", "webOS")
   private val TabletIndicators = Set("iPad", "Tablet")


### PR DESCRIPTION
@leogrim @eishay Previously, clients had to send who they were. We should already know.

However, turns out previous Android app detection was broken.
