### PR TITLE
SlackAttachment.Field.short is optional

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/slack/models/SlackMessage.scala
+++ b/kifi-backend/modules/common/app/com/keepit/slack/models/SlackMessage.scala
@@ -47,7 +47,7 @@ case class SlackAttachment(
 object SlackAttachment {
   case class Author(name: String, link: Option[String], icon: Option[String])
   case class Title(value: String, link: Option[String])
-  @json case class Field(title: String, value: String, short: Boolean)
+  @json case class Field(title: String, value: String, short: Option[Boolean])
 
   def fromTitleAndImage(title: Title, thumbUrl: Option[String], color: String) = SlackAttachment(
     fallback = None,


### PR DESCRIPTION
@andrewconner this is the issue, I think.

@leogrim 
