### PR TITLE
Show activity attribution in feed and discussion attribution

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
@@ -251,6 +251,7 @@ angular.module('kifi')
           scope.displayTitle = keep.title || keep.summary && keep.summary.title || util.formatTitleFromUrl(keep.url);
           scope.defaultDescLines = 4;
           scope.me = profileService.me;
+          scope.showActivityAttribution = $state.is('home.feed') && profileService.hasExperiment('keep_nolib');
           scope.showOriginLibrary = scope.currentPageOrigin !== 'libraryPage' &&
             keep.library && keep.library.visibility !== 'discoverable' && keep.library.kind === 'system_secret';
           // Don't change until the link is updated to be a bit more secure:

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
@@ -6,6 +6,9 @@
         'mine': (keep.user.id === me.id)}">
 
     <div class="kf-keep-card kf-flex-column">
+      <div class="kf-keep-card-activity-attribution-container" ng-if="::showActivityAttribution">
+        <div kf-keep-card-activity-attribution keep="keep"></div>
+      </div>
       <div class="kf-keep-card-attribution-container">
         <div kf-keep-card-attribution
              keep="keep"

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCardActivityAttribution.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCardActivityAttribution.js
@@ -1,0 +1,27 @@
+'use strict';
+
+angular.module('kifi')
+
+.directive('kfKeepCardActivityAttribution', [
+  function () {
+    return {
+      scope: {
+        keep: '=keep'
+      },
+      replace: true,
+      restrict: 'A',
+      templateUrl: 'keep/keepCardActivityAttribution.tpl.html',
+      link: function (scope) {
+        var keep = scope.keep;
+        var messages = keep && keep.discussion && keep.discussion.messages;
+        var attribution = keep && keep.sourceAttribution;
+        var keeper = (attribution && attribution.kifi) || (keep && keep.user);
+        if (keeper && messages) {
+          scope.lastComment = messages.find(function (message) {
+            return message.sentBy && message.sentBy.id !== keeper.id;
+          });
+        }
+      }
+    };
+  }
+]);

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCardActivityAttribution.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCardActivityAttribution.styl
@@ -1,0 +1,20 @@
+.kf-keep-card-activity-attribution
+  display: flex
+  flex-direction: column
+  flex-grow: 1
+  align-items: center
+  font-size: 13px
+  color: textGreyColor
+  font-weight normal
+  font-smoothing: antialiased
+
+.kf-keep-card-activity-attribution-message
+  display: block
+  width: 100%
+
+.kf-keep-card-activity-attribution-divider
+  background: rgba(0,0,60,.141)
+  height: 1px
+  width: 100%
+  margin-bottom: 2px
+  margin-top: 6px

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCardActivityAttribution.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCardActivityAttribution.tpl.html
@@ -1,0 +1,15 @@
+<div class="kf-keep-card-activity-attribution" ng-show="lastComment">
+  <div class="kf-keep-card-activity-attribution-message">
+    <!--This is wrapped in a span to make sure there is a space after the name in safari :(-->
+    <span ng-if="::keep.user && !keep.sourceAttribution.slack"><a class="kf-link"
+       ng-href="{{::keep.user|profileUrl}}"
+       ng-bind="::lastComment.sentBy|name"/>
+    </a></span>
+    commented on this
+    <span ng-if="::lastComment.sentAt">·
+      <span><time ng-attr-datetime="{{::lastComment.sentAt}}" am-time-ago="::lastComment.sentAt"
+          title="{{::lastComment.sentAt|localTime}}"></time></span>
+    </span>
+  </div>
+  <div class="kf-keep-card-activity-attribution-divider"></div>
+</div>

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCardAttribution.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCardAttribution.js
@@ -2,8 +2,8 @@
 
 angular.module('kifi')
 
-.directive('kfKeepCardAttribution', [ '$state',
-  function ($state) {
+.directive('kfKeepCardAttribution', [ '$state', 'profileService',
+  function ($state, profileService) {
     return {
       scope: {
         keep: '=keep',
@@ -14,7 +14,11 @@ angular.module('kifi')
       restrict: 'A',
       templateUrl: 'keep/keepCardAttribution.tpl.html',
       link: function (scope) {
+        var keep = scope.keep;
+        var discussion = keep && keep.discussion;
         scope.showKeepPageLink = scope.keep.path && !$state.is('keepPage');
+        scope.showAsDiscussion = scope.keep && !scope.keep.libraryId && profileService.hasExperiment('keep_nolib');
+        scope.attributionTime = (scope.showAsDiscussion && discussion && discussion.startedAt) || (keep && keep.createdAt);
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCardAttribution.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCardAttribution.styl
@@ -31,7 +31,14 @@
   .kf-privacy-container
     display: inline-block
 
-//
+.kf-keep-card-attribution-discussion-members-list-item:after
+  content: ", "
+
+.kf-keep-card-attribution-discussion-members-list-item:last-child:after
+  content: ""
+
+.kf-keep-card-attribution-discussion-members-list-item:nth-last-child(2):after
+  content: " & "
 
 .kf-keep-card-attribution-message
   display: block

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCardAttribution.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCardAttribution.tpl.html
@@ -9,13 +9,23 @@
     <span ng-if="::keep.user && !keep.sourceAttribution.slack"><a class="kf-link"
        ng-href="{{::keep.user|profileUrl}}">{{::keep.user|name}}
     </a></span>
-    <span ng-if="::keep.sourceAttribution.slack">
+    <span ng-if="::keep.sourceAttribution.slack && !showAsDiscussion">
       <a class="kf-link" ng-href="{{keep.sourceAttribution.kifi | profileUrl}}" ng-if="keep.sourceAttribution.kifi"
         ng-bind="keep.sourceAttribution.kifi.firstName + ' ' + keep.sourceAttribution.kifi.lastName"></a>
       <a class="kf-link" ng-href="{{::keep.sourceAttribution.slack.message.permalink}}" ng-if="!keep.sourceAttribution.kifi" ng-bind="'@' + keep.sourceAttribution.slack.message.username"></a>
       added this
     </span>
-    <span ng-if="::!keep.sourceAttribution.slack">kept this</span>
+    <span ng-if="::!keep.sourceAttribution.slack && !showAsDiscussion">kept this</span>
+    <span ng-if="::showAsDiscussion">started a discussion</span>
+    <span ng-if="::showAsDiscussion && keep.participants.length > 1">with
+      <span class="kf-keep-card-attribution-discussion-members-list-item"
+            ng-repeat="participant in keep.participants | filter:({id: '!'+keep.user.id}) | limitTo: (keep.participants.length > 4 ? 2 : 3)">
+        <a class="kf-link" ng-href="{{::participant|profileUrl}}" ng-bind="participant.firstName"></a>
+      </span>
+      <span class="kf-keep-card-attribution-discussion-members-list-item"
+            ng-if="::keep.participants.length > 4"
+            ng-bind="(keep.participants.length - 3)+' others'"></span>
+    </span>
     <span ng-if="::showLibraryAttribution && keep.library && keep.library.visibility !== 'discoverable' && keep.library.path.slice(-7) !== '/secret'">
     into
     </span>
@@ -58,7 +68,7 @@
 
     <span class="kf-keep-card-attribution-slack" ng-if="::keep.sourceAttribution.slack">
       <a class="kf-link" ng-href="{{::keep.sourceAttribution.slack.message.permalink}}" target="_blank" ng-click="trackSlack()">
-        <span class="svg-slack kf-keep-card-attribution-slack-icon"></span>#<span ng-bind="keep.sourceAttribution.slack.message.channel.name">
+        <span class="svg-slack kf-keep-card-attribution-slack-icon"></span>#<span ng-bind="keep.sourceAttribution.slack.message.channel.name"></span>
       </a>
     </span>
 
@@ -70,12 +80,12 @@
     <span ng-if="isAdmin && keep.summary.hasContent">·</span>
     <span ng-if="isAdmin && keep.summary.hasContent"><a
       ng-href="https://www.kifi.com/k/cached?id={{keep.id}}" target="_blank">Saved</a></span>
-    <span ng-if="::keep.createdAt">·</span>
+    <span ng-if="::attributionTime">·</span>
     <a class="kf-keep-card-attribution-page-link kf-link" ng-if="showKeepPageLink" ng-href="{{::keep.path}}">
-      <time ng-attr-datetime="{{::keep.createdAt}}" am-time-ago="::keep.createdAt"
-            title="{{::keep.createdAt|localTime}}" ng-if="::keep.createdAt"></time>
+      <time ng-attr-datetime="{{::attributionTime}}" am-time-ago="::attributionTime"
+            title="{{attributionTime|localTime}}" ng-if="::attributionTime"></time>
     </a>
-    <time ng-attr-datetime="{{::keep.createdAt}}" am-time-ago="::keep.createdAt"
-           title="{{::keep.createdAt|localTime}}" ng-if="::keep.createdAt && !showKeepPageLink"></time>
+    <time ng-attr-datetime="{{::attributionTime}}" am-time-ago="::attributionTime"
+           title="{{attributionTime|localTime}}" ng-if="::attributionTime && !showKeepPageLink"></time>
   </div>
 </div>


### PR DESCRIPTION
- Allows keeps without library id's to have attribution text indicating that someone started a discussion (In place of the current "user kept this..." text)
- Also adds an additional activity attribution when keeps have comments (on the stream only). For now the activity attribution shows sender/time of the last comment.

This implements the asana task https://app.asana.com/0/67191066943880/78327651999195
