### PR TITLE
add logging to prenormalized uri queries

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/InhouseSlackClient.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/InhouseSlackClient.scala
@@ -26,4 +26,5 @@ object InhouseSlackChannel extends Enumerator[InhouseSlackChannel] {
   case object SLACK_ALERTS extends InhouseSlackChannel("#slack-alerts", "https://hooks.slack.com/services/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")
   case object IP_CLUSTERS extends InhouseSlackChannel("#ip-clusters", "https://hooks.slack.com/services/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")
   case object TEST_RYAN extends InhouseSlackChannel("#test-ryan", "https://hooks.slack.com/services/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")
+  case object TEST_CAM extends InhouseSlackChannel("#test-cam", "https://hooks.slack.com/services/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")
 }


### PR DESCRIPTION
@ryanpbrewster I was able to mock all the way up to this line, and everything looked fine (the prenormalized uri was equivalent to the persisted uri, so the query should have been successful). I'm guessing something is getting tweaked here such that the query fails, unless there's some code whomp I'm not seeing.
