### PR TITLE
don't deep link from external message links

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/mail/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/package.scala
@@ -100,9 +100,9 @@ package object template {
 
     def libraryName(id: Id[Library]) = Tag1(tags.libraryName, id).toHtml
 
-    def discussionLink(id: Id[NormalizedURI], keepPubId: PublicId[Keep], accessToken: Option[String]) = Tag3(tags.discussionLink, id, keepPubId.id, accessToken).toHtml
-    def discussionLink(id: Id[NormalizedURI], keepPubId: PublicId[Keep], accessToken: Option[String], trackingContent: String) = {
-      Html(appendTrackingParams(Tag3(tags.discussionLink, id, keepPubId.id, accessToken) + "&", trackingContent, openInAppIfMobile = true))
+    def discussionLink(id: Id[NormalizedURI], keepPubId: PublicId[Keep], accessToken: Option[String], shouldDeepLink: Boolean) = Tag4(tags.discussionLink, id, keepPubId.id, accessToken, shouldDeepLink).toHtml
+    def discussionLink(id: Id[NormalizedURI], keepPubId: PublicId[Keep], accessToken: Option[String], shouldDeepLink: Boolean, trackingContent: String) = {
+      Html(appendTrackingParams(Tag4(tags.discussionLink, id, keepPubId.id, accessToken, shouldDeepLink) + "&", trackingContent, openInAppIfMobile = true))
     }
 
     def libraryLink(id: Id[Library], authToken: Option[String], content: String, openInAppIfMobile: Boolean = true) =

--- a/kifi-backend/modules/common/app/com/keepit/common/mail/template/Tag.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/mail/template/Tag.scala
@@ -39,6 +39,10 @@ case class Tag3[S, T, U](label: TagLabel, arg0: S, arg1: T, arg2: U)(implicit va
   def args = Seq(writerS.writes(arg0), writerT.writes(arg1), writerU.writes(arg2))
 }
 
+case class Tag4[S, T, U, V](label: TagLabel, arg0: S, arg1: T, arg2: U, arg3: V)(implicit val writerS: Writes[S], writerT: Writes[T], writerU: Writes[U], writerV: Writes[V]) extends Tag {
+  def args = Seq(writerS.writes(arg0), writerT.writes(arg1), writerU.writes(arg2), writerV.writes(arg3))
+}
+
 object TagLabel {
   implicit val format = new Format[TagLabel] {
     def reads(js: JsValue) = JsSuccess(TagLabel(js.as[JsString].value))

--- a/kifi-backend/modules/eliza/app/views/discussionEmail.scala.html
+++ b/kifi-backend/modules/eliza/app/views/discussionEmail.scala.html
@@ -166,7 +166,7 @@
                 <td height="20" style="line-height:1px;font-size:1px;">&nbsp;</td>
               </tr>
               <tr>
-                @discussionEmailHeader(threadInfo, messages, isAdded)
+                @discussionEmailHeader(threadInfo, messages, isAdded, isUser)
               </tr>
               <tr>
                 <td height="26"></td>
@@ -185,14 +185,14 @@
                                 <tr>
                                   <td class="aside">
                                     @if(isSmall) {
-                                      @pageDescriptionSmall(threadInfo)
+                                      @pageDescriptionSmall(threadInfo, isUser)
                                     } else {
-                                      @pageDescriptionBig(threadInfo)
+                                      @pageDescriptionBig(threadInfo, isUser)
                                     }
                                   </td>
                                 </tr>
                                 @{messages.map(message =>
-                                  emailMessageBlock(threadInfo, message.imageUrl, message.senderShortName, message.senderFullName, message.segments)
+                                  emailMessageBlock(threadInfo, message.imageUrl, message.senderShortName, message.senderFullName, message.segments, isUser)
                                 )}
                               </table></td>
                             <td width="2" bgcolor="#f3f3f3"></td>

--- a/kifi-backend/modules/eliza/app/views/discussionEmailFooter.scala.html
+++ b/kifi-backend/modules/eliza/app/views/discussionEmailFooter.scala.html
@@ -1,6 +1,6 @@
 @import com.keepit.common.mail.template.helpers.discussionLink
 @(threadInfo: com.keepit.eliza.model.ThreadEmailInfo, isUser: Boolean)
-@keepPageLink = @{discussionLink(threadInfo.uriId, threadInfo.keepId, threadInfo.nonUserAccessToken)}
+@keepPageLink = @{discussionLink(threadInfo.uriId, threadInfo.keepId, threadInfo.nonUserAccessToken, shouldDeepLink = isUser)}
 <tr>
   <td height="34"></td>
 </tr>

--- a/kifi-backend/modules/eliza/app/views/discussionEmailHeader.scala.html
+++ b/kifi-backend/modules/eliza/app/views/discussionEmailHeader.scala.html
@@ -1,6 +1,6 @@
 @import com.keepit.common.mail.template.helpers.discussionLink
-@(threadInfo: com.keepit.eliza.model.ThreadEmailInfo, messages: Seq[com.keepit.eliza.model.ExtendedThreadItem], isAdded: Boolean)
-@thisPageUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, threadInfo.nonUserAccessToken)}
+@(threadInfo: com.keepit.eliza.model.ThreadEmailInfo, messages: Seq[com.keepit.eliza.model.ExtendedThreadItem], isAdded: Boolean, isUser: Boolean)
+@thisPageUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, threadInfo.nonUserAccessToken, shouldDeepLink = isUser)}
 <td class="txt_p" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#999999;line-height:16px;">@if(isAdded) {
   @if(threadInfo.invitedByUser.nonEmpty){<span class="txt_p" style="font-family:Arial, Helvetica, sans-serif;font-size:14px;color:#333333;line-height:16px;font-weight:bold;">@threadInfo.invitedByUser.get.fullName</span> added you} else {You were added} to a discussion with
   @smartEmailParticipantsList(threadInfo.participants, threadInfo.invitedByUser.map(_.fullName).toSeq)

--- a/kifi-backend/modules/eliza/app/views/emailMessageBlock.scala.html
+++ b/kifi-backend/modules/eliza/app/views/emailMessageBlock.scala.html
@@ -1,6 +1,6 @@
 @import com.keepit.common.mail.template.helpers.discussionLink
-@(threadInfo: com.keepit.eliza.model.ThreadEmailInfo, imageUrl: Option[String], shortName: String, fullName: String, segments: Seq[com.keepit.eliza.util.MessageSegment])
-@keepPageUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, threadInfo.nonUserAccessToken)}
+@(threadInfo: com.keepit.eliza.model.ThreadEmailInfo, imageUrl: Option[String], shortName: String, fullName: String, segments: Seq[com.keepit.eliza.util.MessageSegment], isUser: Boolean)
+@keepPageUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, threadInfo.nonUserAccessToken, shouldDeepLink = isUser)}
   <tr>
     <td bgcolor="#f3f3f3"><table width="100%" border="0" cellspacing="0" cellpadding="0">
         <tr>

--- a/kifi-backend/modules/eliza/app/views/pageDescriptionBig.scala.html
+++ b/kifi-backend/modules/eliza/app/views/pageDescriptionBig.scala.html
@@ -1,10 +1,10 @@
 @import com.keepit.common.mail.template.helpers.discussionLink
 
-@(threadInfo: com.keepit.eliza.model.ThreadEmailInfo)
-@visitThisPageUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, "clickedArticleVisitLink")}
-@articleTitleUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, "clickedArticleTitle")}
-@articleDomainUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, "clickedArticleDomain")}
-@articleImageUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, "clickedArticleImage")}
+@(threadInfo: com.keepit.eliza.model.ThreadEmailInfo, isUser: Boolean)
+@visitThisPageUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, shouldDeepLink = isUser, "clickedArticleVisitLink")}
+@articleTitleUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, isUser, "clickedArticleTitle")}
+@articleDomainUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, isUser, "clickedArticleDomain")}
+@articleImageUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, isUser, "clickedArticleImage")}
 <table width="100%" border="0" cellspacing="0" cellpadding="0">
   @threadInfo.heroImageUrl.map{ heroImageUrl =>
     <tr>

--- a/kifi-backend/modules/eliza/app/views/pageDescriptionSmall.scala.html
+++ b/kifi-backend/modules/eliza/app/views/pageDescriptionSmall.scala.html
@@ -1,10 +1,10 @@
 @import com.keepit.common.mail.template.helpers.discussionLink
 
-@(threadInfo: com.keepit.eliza.model.ThreadEmailInfo)
-@visitThisPageUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, "clickedArticleVisitLink")}
-@articleTitleUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, "clickedArticleTitle")}
-@articleDomainUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, "clickedArticleDomain")}
-@articleImageUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, "clickedArticleImage")}
+@(threadInfo: com.keepit.eliza.model.ThreadEmailInfo, isUser: Boolean)
+@visitThisPageUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, shouldDeepLink = isUser, "clickedArticleVisitLink")}
+@articleTitleUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, isUser, "clickedArticleTitle")}
+@articleDomainUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, isUser, "clickedArticleDomain")}
+@articleImageUrl = @{discussionLink(threadInfo.uriId, threadInfo.keepId, None, isUser, "clickedArticleImage")}
 <table width="100%" border="0" cellspacing="0" cellpadding="0">
   <tr>
     <td height="14" style="line-height:1px;font-size:1px;">&nbsp;</td>

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/EmailTemplateProcessor.scala
@@ -238,8 +238,11 @@ class EmailTemplateProcessorImpl @Inject() (
           import com.keepit.common.core._
           val keepPubId = tagArgs(1)
           val accessTokenOpt = tagArgs(2).asOpt[String]
-          val data = Json.obj("t" -> "m", "uri" -> uri.externalId, "id" -> keepPubId, "at" -> accessTokenOpt).nonNullFields
-          config.applicationBaseUrl + "/redir?data=" + URLEncoder.encode(Json.stringify(data), "ascii")
+          val shouldDeepLink = tagArgs(3).as[Boolean]
+          if (shouldDeepLink) {
+            val data = Json.obj("t" -> "m", "uri" -> uri.externalId, "id" -> keepPubId, "at" -> accessTokenOpt).nonNullFields
+            config.applicationBaseUrl + "/redir?data=" + URLEncoder.encode(Json.stringify(data), "ascii")
+          } else uri.url
 
         case tags.organizationId => Organization.publicId(org.id.get).id
         case tags.organizationName => org.name

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateProcessorImplTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/emails/EmailTemplateProcessorImplTest.scala
@@ -202,7 +202,7 @@ class EmailTemplateProcessorImplTest extends Specification with ShoeboxTestInjec
           val keepPubId = Keep.publicId(keepId)(inject[PublicIdConfiguration])
 
           val deepLink = "http://dev.ezkeep.com:9000/redir?data=" + URLEncoder.encode(s"""{"t":"m","uri":"${uri.externalId}","id":"${keepPubId.id}"}""", "ascii")
-          val html = Html(s"""${discussionLink(uri.id.get, keepPubId, None)}""")
+          val html = Html(s"""${discussionLink(uri.id.get, keepPubId, None, false)}""")
           val processor = inject[EmailTemplateProcessorImpl]
           val emailToSend = EmailToSend(
             from = SystemEmailAddress.NOTIFICATIONS,


### PR DESCRIPTION
@andrewconner @eishay it's a bit more fragile than I would like, but I don't think we differentiate between discussion emails to users and non users any other way.
