### PR TITLE
allow organization settings to be changed incrementally

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationSettings.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationSettings.scala
@@ -19,7 +19,7 @@ case class OrganizationSettings(kvs: Map[Feature, FeatureSetting]) {
 
   def diff(that: OrganizationSettings): Set[Feature] = {
     this.kvs.collect {
-      case (feature, setting) if that.kvs(feature) != setting => feature
+      case (feature, setting) if !that.kvs.get(feature).contains(setting) => feature
     }.toSet
   }
 }


### PR DESCRIPTION
@ryanpbrewster eventually want to be able to add a Feature/FeatureSetting "slack_ingestion_reaction", and definitely don't want to have to send up and down all of an org's config to toggle it (it's not in the same UI page as "Team Settings"). should be fine to do, this throws an exception though.
