### PR TITLE
Fix keeper-sender from appearing as their own chat partner

### DIFF
--- a/packrat/scripts/message_participants.js
+++ b/packrat/scripts/message_participants.js
@@ -246,7 +246,10 @@ k.messageParticipants = k.messageParticipants || (function ($, win) {
 			var other = participants.length <= 2 ? participants.filter(function (user) {
 				return user.id !== k.me.id;
 			})[0] : null;
-			var attr = (this.parent.keep && this.parent.keep.keptBy) || other;
+
+			var keptBy = (this.parent.keep && this.parent.keep.keptBy);
+			var attr = (keptBy && keptBy.id !== k.me.id ? keptBy : other);
+
 			return {
 				onKeep: onKeep,
 				participantName: attr ? this.getFullName(attr) : null,


### PR DESCRIPTION
@andrewconner It looks like the header was preferring to show the discussion's keep's keeper as the participant, even if it was you. So it looked weird when sending a new message to see that you're having a conversation with yourself. Reported by Dafna

| Before | After |
| --- | --- |
| <img width="100%" src="https://cloud.githubusercontent.com/assets/2363700/12435037/a9b2a160-bebf-11e5-8695-01a9e20f256e.png"> | <img width="100%" src="https://cloud.githubusercontent.com/assets/2363700/12435036/a9b0ec08-bebf-11e5-8a7e-a689e8be64e8.png"> |
