### PR TITLE
get/set feed filters via query params

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/route.js
+++ b/kifi-backend/modules/shoebox/angular/src/route.js
@@ -31,9 +31,10 @@ angular.module('kifi')
         'abstract': true
       })
       .state('home.feed', {
-        url: '',
+        url: '?filter&handle',
         controller: 'FeedCtrl',
-        templateUrl: 'feed/feed.tpl.html'
+        templateUrl: 'feed/feed.tpl.html',
+        reloadOnSearch: false
       })
       .state('getStarted', {
           url: '/getstarted',


### PR DESCRIPTION
@cvializ @eishay @andrewconner 

allows users to deep link to "kifi.com/?filter=Kifi" with that team's filter pre-populated. went with whitespace-omitted team names instead of org ids so that it looks nicer.

![screen shot 2016-01-19 at 3 39 29 pm](https://cloud.githubusercontent.com/assets/8929238/12435883/4692fc00-bec5-11e5-84b2-8585aa413aa0.png)
