### PR TITLE
Make library slugs optional during Lib Creation

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -473,9 +473,9 @@ class AdminUserController @Inject() (
     val visibilityOpt = request.body.get("visibility").flatMap(_.headOption).map(LibraryVisibility(_))
     val slugOpt = request.body.get("slug").flatMap(_.headOption)
 
-    (nameOpt, visibilityOpt, slugOpt) match {
-      case (Some(name), Some(visibility), Some(slug)) => {
-        val libraryAddRequest = LibraryInitialValues(name, visibility, slug)
+    (nameOpt, visibilityOpt) match {
+      case (Some(name), Some(visibility)) =>
+        val libraryAddRequest = LibraryInitialValues(name, visibility, slugOpt)
 
         implicit val context = heimdalContextBuilder.withRequestInfoAndSource(request, KeepSource.site).build
         val result: Either[LibraryFail, Library] = libraryCommander.createLibrary(libraryAddRequest, userId)
@@ -483,7 +483,6 @@ class AdminUserController @Inject() (
           case Left(fail) => BadRequest(fail.message)
           case Right(_) => Ok
         }
-      }
       case _ => BadRequest("All Fields are required.")
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -19,6 +19,7 @@ import com.keepit.model._
 import com.keepit.search.SearchServiceClient
 import com.keepit.slack.models.{ SlackChannelToLibraryRepo, LibraryToSlackChannelRepo, SlackChannelToLibrary }
 import com.kifi.macros.json
+import org.apache.commons.lang3.RandomStringUtils
 import org.joda.time.DateTime
 import play.api.http.Status._
 
@@ -114,21 +115,18 @@ class LibraryCommanderImpl @Inject() (
   def validateCreateRequest(libCreateReq: LibraryInitialValues, ownerId: Id[User])(implicit session: RSession): Option[LibraryFail] = {
     val targetSpace = libCreateReq.space.getOrElse(LibrarySpace.fromUserId(ownerId))
 
-    def invalidName = {
-      if (!Library.isValidName(libCreateReq.name)) {
-        Some(LibraryFail(BAD_REQUEST, "invalid_name"))
-      } else None
+    def invalidName = libCreateReq.name match {
+      case name if !Library.isValidName(name) => Some(LibraryFail(BAD_REQUEST, "invalid_name"))
+      case _ => None
     }
-    def invalidSlug = {
-      if (!LibrarySlug.isValidSlug(libCreateReq.slug) || LibrarySlug.isReservedSlug(libCreateReq.slug)) {
-        Some(LibraryFail(BAD_REQUEST, "invalid_slug"))
-      } else None
+    def invalidSlug = libCreateReq.slug match {
+      case Some(slug) if !LibrarySlug.isValidSlug(slug) || LibrarySlug.isReservedSlug(slug) => Some(LibraryFail(BAD_REQUEST, "invalid_slug"))
+      case None => None
     }
-    def slugCollision = {
-      libraryRepo.getBySpaceAndSlug(targetSpace, LibrarySlug(libCreateReq.slug)) match {
-        case Some(existingLibrary) => Some(LibraryFail(BAD_REQUEST, "library_slug_exists"))
-        case None => None
-      }
+    def slugCollision = libCreateReq.slug match {
+      case Some(slug) if libraryRepo.getBySpaceAndSlug(targetSpace, LibrarySlug(slug)).isDefined =>
+        Some(LibraryFail(BAD_REQUEST, "library_slug_exists"))
+      case None => None
     }
     def invalidSpace = {
       val canCreateLibraryInSpace = targetSpace match {
@@ -165,7 +163,15 @@ class LibraryCommanderImpl @Inject() (
       case UserSpace(_) => None
       case OrganizationSpace(orgId) => Some(orgId)
     }
-    val newSlug = LibrarySlug(libCreateReq.slug)
+    val newSlug = libCreateReq.slug match {
+      case Some(slug) => LibrarySlug(slug)
+      case None =>
+        val suffixes = "" +: Stream.continually("-" + RandomStringUtils.randomNumeric(2)).take(9)
+        val baseSlug = LibrarySlug.generateFromName(libCreateReq.name)
+        suffixes.map(suff => LibrarySlug(baseSlug + suff)).filter { slug =>
+          libraryRepo.getBySpaceAndSlug(targetSpace, slug).isEmpty
+        }.head
+    }
     val newColor = libCreateReq.color.orElse(Some(LibraryColor.pickRandomLibraryColor()))
     val newListed = libCreateReq.listed.getOrElse(true)
     val newKind = libCreateReq.kind.getOrElse(LibraryKind.USER_CREATED)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -119,14 +119,12 @@ class LibraryCommanderImpl @Inject() (
       case name if !Library.isValidName(name) => Some(LibraryFail(BAD_REQUEST, "invalid_name"))
       case _ => None
     }
-    def invalidSlug = libCreateReq.slug match {
-      case Some(slug) if !LibrarySlug.isValidSlug(slug) || LibrarySlug.isReservedSlug(slug) => Some(LibraryFail(BAD_REQUEST, "invalid_slug"))
-      case None => None
+    def invalidSlug = libCreateReq.slug.collect {
+      case slug if !LibrarySlug.isValidSlug(slug) || LibrarySlug.isReservedSlug(slug) => LibraryFail(BAD_REQUEST, "invalid_slug")
     }
-    def slugCollision = libCreateReq.slug match {
-      case Some(slug) if libraryRepo.getBySpaceAndSlug(targetSpace, LibrarySlug(slug)).isDefined =>
-        Some(LibraryFail(BAD_REQUEST, "library_slug_exists"))
-      case None => None
+    def slugCollision = libCreateReq.slug.collect {
+      case slug if libraryRepo.getBySpaceAndSlug(targetSpace, LibrarySlug(slug)).isDefined =>
+        LibraryFail(BAD_REQUEST, "library_slug_exists")
     }
     def invalidSpace = {
       val canCreateLibraryInSpace = targetSpace match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterWaitlistCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterWaitlistCommander.scala
@@ -113,7 +113,7 @@ class TwitterWaitlistCommanderImpl @Inject() (
         val addRequest = LibraryInitialValues(
           name = s"@$handle’s Twitter Links",
           visibility = LibraryVisibility.PUBLISHED,
-          slug = s"$handle-twitter-links",
+          slug = Some(s"$handle-twitter-links"),
           kind = Some(LibraryKind.USER_CREATED), // bad!
           description = Some(s"Interesting pages, articles, and links I've shared on Twitter: https://twitter.com/$handle"),
           color = Some(LibraryColor.pickRandomLibraryColor()),

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -103,14 +103,13 @@ class ExtLibraryController @Inject() (
         BadRequest(Json.obj("error" -> "badly_formatted_request", "details" -> errs.toString))
       case JsSuccess(externalCreateRequest, _) =>
         val libCreateRequest = db.readOnlyReplica { implicit session =>
-          val slug = externalCreateRequest.slug.getOrElse(LibrarySlug.generateFromName(externalCreateRequest.name))
           val space = externalCreateRequest.space map {
             case ExternalUserSpace(extId) => LibrarySpace.fromUserId(userRepo.getByExternalId(extId).id.get)
             case ExternalOrganizationSpace(pubId) => LibrarySpace.fromOrganizationId(Organization.decodePublicId(pubId).get)
           }
           LibraryInitialValues(
             name = externalCreateRequest.name,
-            slug = slug,
+            slug = externalCreateRequest.slug,
             visibility = externalCreateRequest.visibility,
             description = externalCreateRequest.description,
             color = externalCreateRequest.color,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -76,14 +76,13 @@ class MobileLibraryController @Inject() (
         BadRequest(Json.obj("error" -> "badly_formatted_request"))
       case JsSuccess(externalCreateRequest, _) =>
         val libCreateRequest = db.readOnlyReplica { implicit session =>
-          val slug = externalCreateRequest.slug.getOrElse(LibrarySlug.generateFromName(externalCreateRequest.name))
           val space = externalCreateRequest.space map {
             case ExternalUserSpace(extId) => LibrarySpace.fromUserId(userRepo.getByExternalId(extId).id.get)
             case ExternalOrganizationSpace(pubId) => LibrarySpace.fromOrganizationId(Organization.decodePublicId(pubId).get)
           }
           LibraryInitialValues(
             name = externalCreateRequest.name,
-            slug = slug,
+            slug = externalCreateRequest.slug,
             visibility = externalCreateRequest.visibility,
             description = externalCreateRequest.description,
             color = externalCreateRequest.color,

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -79,14 +79,13 @@ class LibraryController @Inject() (
         BadRequest(Json.obj("error" -> "badly_formatted_request", "details" -> errs.toString))
       case JsSuccess(externalCreateRequest, _) =>
         val libCreateRequest = db.readOnlyReplica { implicit session =>
-          val slug = externalCreateRequest.slug.getOrElse(LibrarySlug.generateFromName(externalCreateRequest.name))
           val space = externalCreateRequest.space map {
             case ExternalUserSpace(extId) => LibrarySpace.fromUserId(userRepo.getByExternalId(extId).id.get)
             case ExternalOrganizationSpace(pubId) => LibrarySpace.fromOrganizationId(Organization.decodePublicId(pubId).get)
           }
           LibraryInitialValues(
             name = externalCreateRequest.name,
-            slug = slug,
+            slug = externalCreateRequest.slug,
             visibility = externalCreateRequest.visibility,
             description = externalCreateRequest.description,
             color = externalCreateRequest.color,

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
@@ -52,7 +52,7 @@ case class ExternalLibraryInitialValues(
 case class LibraryInitialValues(
     name: String,
     visibility: LibraryVisibility,
-    slug: String,
+    slug: Option[String] = None,
     kind: Option[LibraryKind] = None,
     description: Option[String] = None,
     color: Option[LibraryColor] = None,
@@ -63,7 +63,7 @@ case class LibraryInitialValues(
   def asLibraryModifications: LibraryModifications = LibraryModifications(
     name = Some(name),
     visibility = Some(visibility),
-    slug = Some(slug),
+    slug = slug,
     description = description,
     color = color,
     listed = listed,
@@ -95,7 +95,7 @@ object LibraryInitialValues {
       name = "General",
       description = Some("This library is for keeps the entire team should know about.  All team members are in this library."),
       visibility = LibraryVisibility.ORGANIZATION,
-      slug = "general",
+      slug = Some("general"),
       kind = Some(LibraryKind.SYSTEM_ORG_GENERAL),
       space = Some(LibrarySpace.fromOrganizationId(org.id.get)),
       orgMemberAccess = Some(LibraryAccess.READ_WRITE)

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackTeamCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackTeamCommander.scala
@@ -140,7 +140,6 @@ class SlackTeamCommanderImpl @Inject() (
         case UserSpace(_) => LibraryVisibility.SECRET
         case OrganizationSpace(_) => LibraryVisibility.ORGANIZATION
       },
-      slug = LibrarySlug.generateFromName(libraryName),
       kind = Some(LibraryKind.SLACK_CHANNEL),
       description = channel.purpose.map(_.value) orElse channel.topic.map(_.value),
       space = Some(librarySpace)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/LibraryCommanderTest.scala
@@ -216,13 +216,13 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
             libraryRepo.count === 0
           }
 
-          val lib1Request = LibraryInitialValues(name = "Avengers Missions", slug = "avengers", visibility = LibraryVisibility.SECRET)
+          val lib1Request = LibraryInitialValues(name = "Avengers Missions", slug = Some("avengers"), visibility = LibraryVisibility.SECRET)
 
-          val lib2Request = LibraryInitialValues(name = "MURICA", slug = "murica", visibility = LibraryVisibility.PUBLISHED)
+          val lib2Request = LibraryInitialValues(name = "MURICA", slug = Some("murica"), visibility = LibraryVisibility.PUBLISHED)
 
-          val lib3Request = LibraryInitialValues(name = "Science and Stuff", slug = "science", visibility = LibraryVisibility.PUBLISHED, whoCanInvite = Some(LibraryInvitePermissions.OWNER))
+          val lib3Request = LibraryInitialValues(name = "Science and Stuff", slug = Some("science"), visibility = LibraryVisibility.PUBLISHED, whoCanInvite = Some(LibraryInvitePermissions.OWNER))
 
-          val lib4Request = LibraryInitialValues(name = "Invalid Param", slug = "", visibility = LibraryVisibility.SECRET)
+          val lib4Request = LibraryInitialValues(name = "Invalid Param", slug = Some(""), visibility = LibraryVisibility.SECRET)
 
           val libraryCommander = inject[LibraryCommander]
           val add1 = libraryCommander.createLibrary(lib1Request, userAgent.id.get)
@@ -234,7 +234,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           val add3 = libraryCommander.createLibrary(lib3Request, userIron.id.get)
           add3 must beRight
           add3.right.get.name === "Science and Stuff"
-          libraryCommander.createLibrary(lib4Request, userIron.id.get).isRight === false
+          libraryCommander.createLibrary(lib4Request, userIron.id.get) must beLeft
 
           db.readOnlyMaster { implicit s =>
             val allLibs = libraryRepo.all
@@ -273,7 +273,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           }
           val libraryCommander = inject[LibraryCommander]
 
-          val addRequest = LibraryInitialValues(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", space = Some(org.id.get))
+          val addRequest = LibraryInitialValues(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, space = Some(org.id.get))
           val addResponse = libraryCommander.createLibrary(addRequest, owner.id.get)
           addResponse must beRight
         }
@@ -288,7 +288,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           }
           val libraryCommander = inject[LibraryCommander]
 
-          val addRequest = LibraryInitialValues(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", space = Some(org.id.get))
+          val addRequest = LibraryInitialValues(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, space = Some(org.id.get))
           val addResponse = libraryCommander.createLibrary(addRequest, rando.id.get)
           addResponse must beLeft
         }
@@ -298,7 +298,7 @@ class LibraryCommanderTest extends TestKitSupport with SpecificationLike with Sh
           val user = db.readWrite { implicit session =>
             UserFactory.user().saved
           }
-          val addRequest = LibraryInitialValues(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, slug = "kifilib", space = Some(user.id.get))
+          val addRequest = LibraryInitialValues(name = "Kifi Library", visibility = LibraryVisibility.ORGANIZATION, space = Some(user.id.get))
           val addResponse = libraryCommander.createLibrary(addRequest, user.id.get)
           addResponse must beLeft
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/ext/ExtLibraryControllerTest.scala
@@ -139,13 +139,13 @@ class ExtLibraryControllerTest extends Specification with ShoeboxTestInjector wi
         }
 
         // duplicate name
-        status(createLibrary(user1, Json.obj("name" -> "Lib 1", "visibility" -> "secret"))) === BAD_REQUEST
+        status(createLibrary(user1, Json.obj("name" -> "Lib 1", "visibility" -> "secret"))) === OK
 
         // invalid name
         status(createLibrary(user1, Json.obj("name" -> "Lib/\" 3", "visibility" -> "secret"))) === BAD_REQUEST
 
         db.readOnlyMaster { implicit s =>
-          libraryRepo.count === 1
+          libraryRepo.count === 2
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/mobile/MobileLibraryControllerTest.scala
@@ -84,10 +84,10 @@ class MobileLibraryControllerTest extends Specification with ShoeboxTestInjector
         // add library with same title
         val jsBody2 = Json.obj("name" -> "Drones stuff", "visibility" -> "secret")
         val result2 = createLibrary(user, jsBody2)
-        status(result2) must equalTo(BAD_REQUEST)
+        status(result2) must equalTo(OK)
 
         db.readOnlyMaster { implicit s =>
-          libraryRepo.getAllByOwner(user.id.get).length === 1
+          libraryRepo.getAllByOwner(user.id.get).length === 2
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KifiSiteRouterTest.scala
@@ -182,7 +182,7 @@ class KifiSiteRouterTest extends Specification with ShoeboxApplicationInjector {
         // Libraries
         val libraryCommander = inject[LibraryCommander]
         val Right(library) = {
-          val libraryRequest = LibraryInitialValues(name = "Awesome Lib", visibility = LibraryVisibility.PUBLISHED, slug = "awesome-lib")
+          val libraryRequest = LibraryInitialValues(name = "Awesome Lib", visibility = LibraryVisibility.PUBLISHED)
           libraryCommander.createLibrary(libraryRequest, user1.id.get)
         }
         actionsHelper.unsetUser

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationFactoryHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationFactoryHelper.scala
@@ -46,7 +46,7 @@ object OrganizationFactoryHelper {
       val libraryRepo = injector.getInstance(classOf[LibraryRepo])
       val libraryMembershipRepo = injector.getInstance(classOf[LibraryMembershipRepo])
       val oglCR = LibraryInitialValues.forOrgGeneralLibrary(org)
-      val lib = libraryRepo.save(Library(ownerId = org.ownerId, name = oglCR.name, slug = LibrarySlug(oglCR.slug), kind = oglCR.kind.get, visibility = oglCR.visibility, organizationId = Some(org.id.get), memberCount = 1 + partialOrganization.admins.length + partialOrganization.members.length))
+      val lib = libraryRepo.save(Library(ownerId = org.ownerId, name = oglCR.name, slug = LibrarySlug(oglCR.slug.get), kind = oglCR.kind.get, visibility = oglCR.visibility, organizationId = Some(org.id.get), memberCount = 1 + partialOrganization.admins.length + partialOrganization.members.length))
       libraryMembershipRepo.save(LibraryMembership(libraryId = lib.id.get, userId = org.ownerId, access = LibraryAccess.OWNER))
       (partialOrganization.admins ++ partialOrganization.members).foreach { member =>
         libraryMembershipRepo.save(LibraryMembership(libraryId = lib.id.get, userId = member.id.get, access = LibraryAccess.READ_WRITE))

--- a/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/payments/PaidFeatureSettingsTest.scala
@@ -60,21 +60,21 @@ class PaidFeatureSettingsTest extends SpecificationLike with ShoeboxTestInjector
         orgCommander.setAccountFeatureSettings(OrganizationSettingsRequest(org.id.get, admin.id.get, initOrgSettings)) must beRight
 
         // owner can create public libraries
-        val ownerCreateRequest = LibraryInitialValues(name = "Alphabet Soup", slug = "alphabet", visibility = LibraryVisibility.PUBLISHED, space = Some(LibrarySpace(owner.id.get, org.id)))
+        val ownerCreateRequest = LibraryInitialValues(name = "Alphabet Soup", visibility = LibraryVisibility.PUBLISHED, space = Some(LibrarySpace(owner.id.get, org.id)))
         val ownerLibResponse = libraryCommander.createLibrary(ownerCreateRequest, owner.id.get)
         ownerLibResponse must beRight
 
         // admin can create public libraries
-        val adminCreateRequest = LibraryInitialValues(name = "Alphabetter Soup", slug = "alphabetter", visibility = LibraryVisibility.PUBLISHED, space = Some(LibrarySpace(admin.id.get, org.id)))
+        val adminCreateRequest = LibraryInitialValues(name = "Alphabetter Soup", visibility = LibraryVisibility.PUBLISHED, space = Some(LibrarySpace(admin.id.get, org.id)))
         val adminLibResponse = libraryCommander.createLibrary(adminCreateRequest, admin.id.get)
         adminLibResponse must beRight
 
         // member cannot create public libraries
-        val memberCreateRequest1 = LibraryInitialValues(name = "Alphabest Soup", slug = "alphabest", visibility = LibraryVisibility.PUBLISHED, space = Some(LibrarySpace(member.id.get, org.id)))
+        val memberCreateRequest1 = LibraryInitialValues(name = "Alphabest Soup", visibility = LibraryVisibility.PUBLISHED, space = Some(LibrarySpace(member.id.get, org.id)))
         val memberLibResponse1 = libraryCommander.createLibrary(memberCreateRequest1, member.id.get)
         memberLibResponse1 must beLeft
 
-        val memberCreateRequest2 = LibraryInitialValues(name = "Alphabest Soup", slug = "alphabest", visibility = LibraryVisibility.SECRET, space = Some(LibrarySpace(member.id.get, org.id)))
+        val memberCreateRequest2 = LibraryInitialValues(name = "Alphabest Soup", visibility = LibraryVisibility.SECRET, space = Some(LibrarySpace(member.id.get, org.id)))
         val memberLibResponse2 = libraryCommander.createLibrary(memberCreateRequest2, member.id.get)
         memberLibResponse2 must beRight
         val library = memberLibResponse2.right.get


### PR DESCRIPTION
If a library slug is not provided, we will generate a valid one on the backend (based on the name, with a random suffix to ensure no collisions).

@andrewconner @camhashemi @leogrim 
