### PR TITLE
allow non-admins to edit slack_ingestion_reaction setting

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -64,7 +64,10 @@ class OrganizationCommanderImpl @Inject() (
 
       case OrganizationSettingsRequest(orgId, requesterId, settings) =>
         val permissions = permissionCommander.getOrganizationPermissions(orgId, Some(requesterId))
-        if (!permissions.contains(MANAGE_PLAN)) Some(OrganizationFail.INSUFFICIENT_PERMISSIONS)
+
+        val canEditSlackFeatures = permissions.contains(OrganizationPermission.CREATE_SLACK_INTEGRATION) && settings.features == Set(Feature.SlackIngestionReaction)
+
+        if (!canEditSlackFeatures && !permissions.contains(OrganizationPermission.CREATE_SLACK_INTEGRATION)) Some(OrganizationFail.INSUFFICIENT_PERMISSIONS)
         else validateOrganizationSettings(orgId, settings)
 
       case OrganizationDeleteRequest(requesterId, orgId) =>


### PR DESCRIPTION
@ryanpbrewster @leogrim 

talked with @JRuff42 about who can edit settings within `/kifi/settings/integrations`, and this is the spec. that means `create_slack_integrations` now means `edit_slack_integrations`.

If this pattern continues (where one feature setting determines whether you can modify another), we can add a field `Feature.editableWith: OrganizationPermission` that we can use to determine this for any set of features and permissions.
