### PR TITLE
toggle slack digest notifications

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/426.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/426.sql
@@ -1,0 +1,10 @@
+# SHOEBOX
+
+# --- !Ups
+
+alter TABLE slack_channel_to_library add column mute_digest_notifications boolean NOT NULL DEFAULT false;
+alter TABLE slack_team add column mute_digest_notifications boolean NOT NULL DEFAULT false;
+
+insert into evolutions(name, description) values('426.sql', 'add mute_digest_notifications to slack_channel_to_library and slack_team');
+
+# --- !Downs

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SlackController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SlackController.scala
@@ -151,12 +151,12 @@ class SlackController @Inject() (
         }
 
         val libToSlackMods = mods.collect {
-          case ExternalSlackIntegrationModification(Left(ltsId), extSpace, status) =>
+          case ExternalSlackIntegrationModification(Left(ltsId), extSpace, status, _) =>
             LibraryToSlackChannel.decodePublicId(ltsId).get -> SlackIntegrationModification(extSpace.map(x => externalToInternalSpace(x)), status)
         }.toMap
         val slackToLibMods = mods.collect {
-          case ExternalSlackIntegrationModification(Right(stlId), extSpace, status) =>
-            SlackChannelToLibrary.decodePublicId(stlId).get -> SlackIntegrationModification(extSpace.map(externalToInternalSpace(_)), status)
+          case ExternalSlackIntegrationModification(Right(stlId), extSpace, status, muted) =>
+            SlackChannelToLibrary.decodePublicId(stlId).get -> SlackIntegrationModification(extSpace.map(externalToInternalSpace(_)), status, muted)
         }.toMap
 
         val libsUserNeedsToWriteTo = db.readOnlyMaster { implicit s =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackDigestNotifier.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackDigestNotifier.scala
@@ -88,7 +88,7 @@ class SlackDigestNotifierImpl @Inject() (
     for {
       org <- slackTeam.organizationId.flatMap(organizationInfoCommander.getBasicOrganizationHelper)
       librariesByChannel = {
-        val teamIntegrations = channelToLibRepo.getBySlackTeam(slackTeam.slackTeamId).filter(_.isWorking)
+        val teamIntegrations = channelToLibRepo.getBySlackTeam(slackTeam.slackTeamId).filter(stl => stl.isWorking && !stl.muteDigestNotifications)
         val teamChannelIds = teamIntegrations.flatMap(_.slackChannelId).toSet
         val librariesById = libRepo.getActiveByIds(teamIntegrations.map(_.libraryId).toSet)
         teamIntegrations.groupBy(_.slackChannelId).collect {

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/models/SlackIntegration.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/models/SlackIntegration.scala
@@ -58,18 +58,21 @@ case class SlackIntegrationCreateRequest(
 
 case class SlackIntegrationModification(
   space: Option[LibrarySpace] = None,
-  status: Option[SlackIntegrationStatus] = None)
+  status: Option[SlackIntegrationStatus] = None,
+  muted: Option[Boolean] = None)
 
 case class ExternalSlackIntegrationModification(
   id: Either[PublicId[LibraryToSlackChannel], PublicId[SlackChannelToLibrary]],
   space: Option[ExternalLibrarySpace],
-  status: Option[SlackIntegrationStatus])
+  status: Option[SlackIntegrationStatus],
+  muted: Option[Boolean])
 object ExternalSlackIntegrationModification {
   private implicit val eitherIdFormat = EitherFormat(LibraryToSlackChannel.formatPublicId, SlackChannelToLibrary.formatPublicId)
   implicit val format: Format[ExternalSlackIntegrationModification] = (
     (__ \ 'id).format[Either[PublicId[LibraryToSlackChannel], PublicId[SlackChannelToLibrary]]] and
     (__ \ 'space).formatNullable[ExternalLibrarySpace] and
-    (__ \ 'status).formatNullable[SlackIntegrationStatus]
+    (__ \ 'status).formatNullable[SlackIntegrationStatus] and
+    (__ \ 'muted).formatNullable[Boolean]
   )(ExternalSlackIntegrationModification.apply, unlift(ExternalSlackIntegrationModification.unapply))
 }
 


### PR DESCRIPTION
@leogrim @ryanpbrewster I'm trying to figure out the spec on this, it seems to make more sense to mute digest notifs on a per channel basis, but right now it's spec'd to mute on a per integration (i.e. library) basis. this one is to-spec, waiting on clarification. https://app.asana.com/0/32728208409723/80921334334285
