### PR TITLE
add Feature.SlackDigestNotification

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationSettings.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationSettings.scala
@@ -49,6 +49,7 @@ object OrganizationSettingsWithEditability {
 sealed trait Feature {
   val value: String
   def settings: Set[FeatureSetting]
+  val editableWith: OrganizationPermission
 
   private def toSetting(x: String): FeatureSetting = settings.find(_.value == x).getOrElse(throw new InvalidSettingForFeatureException(this, x))
   def settingReads: Reads[FeatureSetting] = Reads { j => j.validate[String].map(toSetting) }
@@ -101,76 +102,95 @@ object Feature extends Enumerator[Feature] {
     val value = OrganizationPermission.PUBLISH_LIBRARIES.value
     val permission = OrganizationPermission.PUBLISH_LIBRARIES
     val settings: Set[FeatureSetting] = Set(DISABLED, ADMINS, MEMBERS)
+    val editableWith = OrganizationPermission.MANAGE_PLAN
   }
 
   case object InviteMembers extends Feature with FeatureWithPermissions {
     val value = OrganizationPermission.INVITE_MEMBERS.value
     val permission = OrganizationPermission.INVITE_MEMBERS
     val settings: Set[FeatureSetting] = Set(DISABLED, ADMINS, MEMBERS)
+    val editableWith = OrganizationPermission.MANAGE_PLAN
   }
 
   case object GroupMessaging extends Feature with FeatureWithPermissions {
     val value = OrganizationPermission.GROUP_MESSAGING.value
     val permission = OrganizationPermission.GROUP_MESSAGING
     val settings: Set[FeatureSetting] = Set(DISABLED, ADMINS, MEMBERS)
+    val editableWith = OrganizationPermission.MANAGE_PLAN
   }
 
   case object ForceEditLibraries extends Feature with FeatureWithPermissions {
     val value = OrganizationPermission.FORCE_EDIT_LIBRARIES.value
     val permission = OrganizationPermission.FORCE_EDIT_LIBRARIES
     val settings: Set[FeatureSetting] = Set(DISABLED, ADMINS)
+    val editableWith = OrganizationPermission.MANAGE_PLAN
   }
 
   case object ViewOrganization extends Feature with FeatureWithPermissions {
     val value = OrganizationPermission.VIEW_ORGANIZATION.value
     val permission = OrganizationPermission.VIEW_ORGANIZATION
     val settings: Set[FeatureSetting] = Set(MEMBERS, ANYONE)
+    val editableWith = OrganizationPermission.MANAGE_PLAN
   }
 
   case object ViewMembers extends Feature with FeatureWithPermissions {
     val value = OrganizationPermission.VIEW_MEMBERS.value
     val permission = OrganizationPermission.VIEW_MEMBERS
     val settings: Set[FeatureSetting] = Set(DISABLED, ADMINS, MEMBERS, ANYONE)
+    val editableWith = OrganizationPermission.MANAGE_PLAN
   }
 
   case object RemoveLibraries extends Feature with FeatureWithPermissions {
     val value = OrganizationPermission.REMOVE_LIBRARIES.value
     val permission = OrganizationPermission.REMOVE_LIBRARIES
     val settings: Set[FeatureSetting] = Set(ADMINS, MEMBERS)
+    val editableWith = OrganizationPermission.MANAGE_PLAN
   }
 
   case object CreateSlackIntegration extends Feature with FeatureWithPermissions {
     val value = OrganizationPermission.CREATE_SLACK_INTEGRATION.value
     val permission = OrganizationPermission.CREATE_SLACK_INTEGRATION
-    val settings: Set[FeatureSetting] = Set(DISABLED, ANYONE, ADMINS, MEMBERS)
+    val settings: Set[FeatureSetting] = Set(DISABLED, ADMINS, MEMBERS)
+    val editableWith = OrganizationPermission.MANAGE_PLAN
   }
 
   case object EditOrganization extends Feature with FeatureWithPermissions {
     val value = OrganizationPermission.EDIT_ORGANIZATION.value
     val permission = OrganizationPermission.EDIT_ORGANIZATION
     val settings: Set[FeatureSetting] = Set(DISABLED, ADMINS, MEMBERS)
+    val editableWith = OrganizationPermission.MANAGE_PLAN
   }
 
   case object ExportKeeps extends Feature with FeatureWithPermissions {
     val value = OrganizationPermission.EXPORT_KEEPS.value
     val permission = OrganizationPermission.EXPORT_KEEPS
     val settings: Set[FeatureSetting] = Set(DISABLED, ADMINS, MEMBERS)
+    val editableWith = OrganizationPermission.MANAGE_PLAN
   }
 
   case object ViewSettings extends Feature with FeatureWithPermissions {
     val value = OrganizationPermission.VIEW_SETTINGS.value
     val permission = OrganizationPermission.VIEW_SETTINGS
     val settings: Set[FeatureSetting] = Set(ADMINS, MEMBERS)
+    val editableWith = OrganizationPermission.MANAGE_PLAN
   }
 
   case object JoinByVerifying extends Feature with FeatureWithPermissions {
     val value = OrganizationPermission.JOIN_BY_VERIFYING.value
     val permission = OrganizationPermission.JOIN_BY_VERIFYING
     val settings: Set[FeatureSetting] = Set(DISABLED, NONMEMBERS)
+    val editableWith = OrganizationPermission.MANAGE_PLAN
   }
 
   case object SlackIngestionReaction extends Feature {
     val value = "slack_ingestion_reaction"
     val settings: Set[FeatureSetting] = Set(DISABLED, ENABLED)
+    val editableWith = OrganizationPermission.CREATE_SLACK_INTEGRATION
+  }
+
+  case object SlackDigestNotification extends Feature {
+    val value = "slack_digest_notif"
+    val settings: Set[FeatureSetting] = Set(DISABLED, ENABLED)
+    val editableWith = OrganizationPermission.CREATE_SLACK_INTEGRATION
   }
 }

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/398.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/398.sql
@@ -26,9 +26,9 @@ CREATE TABLE organization_configuration (
 INSERT INTO `paid_plan` (`id`, `created_at`, `updated_at`, `state`, `name`, `billing_cycle`, `price_per_user_per_cycle`, `kind`, `editable_features`, `default_settings`)
 VALUES
   (1, '2015-08-19 21:50:48', '2015-08-19 21:50:48', 'active', 'Test', 1, 0, 'normal',
-  '["force_edit_libraries","invite_members","group_messaging","edit_organization","view_organization","remove_libraries","create_slack_integration","export_keeps","publish_libraries","view_members", "view_settings", "join_by_verifying", "slack_ingestion_reaction"]',
+  '["force_edit_libraries","invite_members","group_messaging","edit_organization","view_organization","remove_libraries","create_slack_integration","export_keeps","publish_libraries","view_members", "view_settings", "join_by_verifying", "slack_ingestion_reaction", "slack_digest_notif"]',
   '{"publish_libraries":"members","group_messaging":"members","force_edit_libraries":"disabled","export_keeps":"admins","view_members":"anyone","create_slack_integration":"disabled","edit_organization":"admins",
-  "remove_libraries":"members","invite_members":"members","view_organization":"anyone", "view_settings":"members", "join_by_verifying":"nonmembers", "slack_ingestion_reaction": "disabled" }'
+  "remove_libraries":"members","invite_members":"members","view_organization":"anyone", "view_settings":"members", "join_by_verifying":"nonmembers", "slack_ingestion_reaction": "disabled", "slack_digest_notif": "enabled" }'
   );
 
 insert into evolutions(name, description) values('398.sql', 'refactor org permissions: drop org_membership.permissions, drop org.base_permissions, paid_plan.features -> {paid_plan.editable_features, paid_plan.default_settings}, paid_account.feature_settings -> org_config.settings');

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.js
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/teamSettings.js
@@ -127,14 +127,14 @@ angular.module('kifi')
         heading: 'Integrations',
         fields: [
           {
-            title: 'Who can create a Slack integration with Kifi?',
+            title: 'Who can create and edit Slack integrations with Kifi?',
             description: (
-              'Select who is able to create a Slack integration with Kifi.' +
+              'Select who is able to create and edit Slack integrations with Kifi.' +
               ' Integrating with Slack will automatically send all keeps from' +
               ' a particular library to a Slack channel.'
             ),
             fieldKey: 'create_slack_integration',
-            selectOptions: getOptions(ORG_SETTING_VALUE.DISABLED, ORG_SETTING_VALUE.ADMIN, ORG_SETTING_VALUE.MEMBER, ORG_SETTING_VALUE.ANYONE),
+            selectOptions: getOptions(ORG_SETTING_VALUE.DISABLED, ORG_SETTING_VALUE.ADMIN, ORG_SETTING_VALUE.MEMBER),
             trackingValue: 'slack_integration_dropdown'
           },
           {

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/PaidPlanFactory.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/PaidPlanFactory.scala
@@ -9,6 +9,7 @@ import com.keepit.payments._
 object PaidPlanFactory {
   private[this] val idx = new AtomicLong(System.currentTimeMillis() % 100)
 
+  // tests will fail when adding new Features, update 398.sql with new features and their default settings
   val testPlanEditableFeatures = Feature.ALL -- Set(Feature.ViewOrganization, Feature.ViewSettings)
   val testPlanSettings: OrganizationSettings = OrganizationSettings.empty.setAll(Map(
     Feature.PublishLibraries -> FeatureSetting.MEMBERS,
@@ -18,12 +19,13 @@ object PaidPlanFactory {
     Feature.ViewOrganization -> FeatureSetting.ANYONE,
     Feature.ViewMembers -> FeatureSetting.ANYONE,
     Feature.RemoveLibraries -> FeatureSetting.MEMBERS,
-    Feature.CreateSlackIntegration -> FeatureSetting.ANYONE,
+    Feature.CreateSlackIntegration -> FeatureSetting.MEMBERS,
     Feature.EditOrganization -> FeatureSetting.ADMINS,
     Feature.ExportKeeps -> FeatureSetting.ADMINS,
     Feature.ViewSettings -> FeatureSetting.MEMBERS,
     Feature.JoinByVerifying -> FeatureSetting.NONMEMBERS,
-    Feature.SlackIngestionReaction -> FeatureSetting.DISABLED
+    Feature.SlackIngestionReaction -> FeatureSetting.DISABLED,
+    Feature.SlackDigestNotification -> FeatureSetting.ENABLED
   ))
 
   def paidPlan(): PartialPaidPlan = {


### PR DESCRIPTION
EDIT: don't listen to this, see below comment

this is my favorite of the three options I mentioned here: https://kifi.slack.com/archives/G0K0RKDKQ/p1453342261000025, because it fits in with the rest of our configurable permissions framework. 

team admins will choose who can edit slack integrations and their settings (cc @JRuff42, this is a new setting in /settings, the "who can create" doesn't make sense since it can be "anyone").
