### PR TITLE
fix /integrations bugs

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.js
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.js
@@ -6,9 +6,9 @@ angular.module('kifi')
   '$scope', '$window', '$analytics', 'orgProfileService', 'messageTicker', 'libraryService', 'ORG_PERMISSION',
   function ($scope, $window, $analytics, orgProfileService, messageTicker, libraryService, ORG_PERMISSION) {
 
-    $scope.canEditIntegrations =  ($scope.viewer.permissions.indexOf(ORG_PERMISSION.CREATE_SLACK_INTEGRATION) !== -1);
+    $scope.canEditIntegrations =  ($scope.viewer.permissions.indexOf(ORG_PERMISSION.MANAGE_PLAN) !== -1);
     $scope.integrations = [];
-    $scope.slackIntegrationReactionModel = {enabled: $scope.profile.config.settings.slack_ingestion_reaction.setting === 'enabled'};
+    $scope.slackIntegrationReactionModel = {enabled: $scope.profile.config && $scope.profile.config.settings.slack_ingestion_reaction.setting === 'enabled'};
     orgProfileService.getSlackIntegrationsForOrg($scope.profile)
         .then(function(res) {
           res.libraries.forEach(function(lib) {


### PR DESCRIPTION
@cvializ @jaredpetker 

reproduced whenever I wasn't able to see the page (/settings/integrations) for an org I'm not a member of. that's why the `config` object isn't there, but seems like we should error before generating the controller?

also changed a permission since it's up in the air right now
