### PR TITLE
Fixing guice problem with our router

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -261,7 +261,7 @@ class AuthController @Inject() (
       case Some(info) =>
         val hasher = Registry.hashers.currentHasher
         val session = request.session
-        val home = com.keepit.controllers.website.routes.HomeController.home()
+        val home = com.keepit.controllers.website.HomeControllerRoutes.home()
         authCommander.getUserIdentity(IdentityId(info.email.address, SocialNetworks.EMAIL.authProvider)) match {
           case Some(identity @ UserIdentity(_, Some(userId))) => {
             val matches = hasher.matches(identity.passwordInfo.get, info.password)
@@ -274,7 +274,7 @@ class AuthController @Inject() (
                   error => Future.successful(Status(INTERNAL_SERVER_ERROR)("0")),
                   authenticator =>
                     Future.successful(
-                      Ok(Json.obj("uri" -> session.get(SecureSocial.OriginalUrlKey).getOrElse(home.url).asInstanceOf[String]))
+                      Ok(Json.obj("uri" -> session.get(SecureSocial.OriginalUrlKey).getOrElse(home).asInstanceOf[String]))
                         .withSession((session - SecureSocial.OriginalUrlKey).setUserId(userId))
                         .withCookies(authenticator.toCookie)
                     )
@@ -304,7 +304,7 @@ class AuthController @Inject() (
           Redirect(com.keepit.controllers.core.routes.AuthController.signupPage())
         } else if (userRequest.kifiInstallationId.isEmpty && !hasSeenInstall(userRequest)) {
           inviteCommander.markPendingInvitesAsAccepted(userRequest.user.id.get, userRequest.cookies.get("inv").flatMap(v => ExternalId.asOpt[Invitation](v.value)))
-          Redirect(com.keepit.controllers.website.routes.HomeController.install())
+          Redirect(com.keepit.controllers.website.HomeControllerRoutes.install())
         } else {
           userRequest.session.get(SecureSocial.OriginalUrlKey) map { url =>
             Redirect(url).withSession(userRequest.session - SecureSocial.OriginalUrlKey)
@@ -408,13 +408,13 @@ class AuthController @Inject() (
       case ur: UserRequest[_] =>
         Redirect("/")
       case request: NonUserRequest[_] =>
-        request.request.headers.get(USER_AGENT).map { agentString =>
+        request.request.headers.get(USER_AGENT).flatMap { agentString =>
           val agent = UserAgent(agentString)
           log.info(s"trying to log in via $agent. orig string: $agentString")
           if (agent.isOldIE) {
-            Some(Redirect(com.keepit.controllers.website.routes.HomeController.unsupported()))
+            Some(Redirect(com.keepit.controllers.website.HomeControllerRoutes.unsupported()))
           } else None
-        }.flatten.getOrElse(Ok(views.html.authMinimal.loginToKifi()))
+        }.getOrElse(Ok(views.html.authMinimal.loginToKifi()))
     }
   }
 
@@ -439,7 +439,7 @@ class AuthController @Inject() (
       UserAgent(agent)
     }
     if (agentOpt.exists(_.isOldIE)) {
-      Redirect(com.keepit.controllers.website.routes.HomeController.unsupported())
+      Redirect(com.keepit.controllers.website.HomeControllerRoutes.unsupported())
     } else {
       val cookieIntent = request.cookies.get("intent") // make sure everywhere handles this right
       val cookieModelPubId = request.cookies.get("modelPubId")
@@ -459,7 +459,7 @@ class AuthController @Inject() (
             // Complete user, they don't need to be here!
             log.info(s"[doSignupPage] ${ur.userId} already completed signup!")
 
-            val homeUrl = s"${com.keepit.controllers.website.routes.HomeController.home.url}?m=0"
+            val homeUrl = s"${com.keepit.controllers.website.HomeControllerRoutes.home}?m=0"
 
             val redirect = cookieIntent.map(_.value).map {
               case "follow" =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
@@ -1,34 +1,30 @@
 package com.keepit.controllers.website
 
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import com.keepit.commanders._
 import com.keepit.common.akka.SafeFuture
+import com.keepit.common.controller.KifiSession._
 import com.keepit.common.controller._
 import com.keepit.common.core._
 import com.keepit.common.db.slick._
 import com.keepit.common.http._
 import com.keepit.common.logging.Logging
-import com.keepit.common.net.UserAgent
-import com.keepit.common.service.FortyTwoServices
+import com.keepit.common.net.{RichRequestHeader, UserAgent}
+import com.keepit.common.time._
 import com.keepit.controllers.routing.KifiSiteRouter
 import com.keepit.heimdal._
-import com.keepit.inject.FortyTwoConfig
 import com.keepit.model._
-import com.keepit.social.SocialGraphPlugin
 import play.api.Play
 import play.api.Play.current
 import play.api.libs.iteratee.Enumerator
+import play.api.libs.json.Json
 import play.api.mvc._
 import play.twirl.api.Html
-import securesocial.core.{ Authenticator, SecureSocial }
-import play.api.libs.json.Json
-import com.keepit.common.time._
-import com.keepit.common.net.RichRequestHeader
+import securesocial.core.{Authenticator, SecureSocial}
 
-import KifiSession._
+import scala.concurrent.{ExecutionContext, Future}
 
-import scala.concurrent.{ ExecutionContext, Future }
-
+@Singleton
 class HomeController @Inject() (
   db: Database,
   userRepo: UserRepo,
@@ -224,4 +220,10 @@ class HomeController @Inject() (
     }
   }
 
+}
+
+object HomeControllerRoutes {
+  def home() = "/"
+  def install() = "/install"
+  def unsupported() = "/unsupported"
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/HomeController.scala
@@ -1,6 +1,6 @@
 package com.keepit.controllers.website
 
-import com.google.inject.{Inject, Singleton}
+import com.google.inject.{ Inject, Singleton }
 import com.keepit.commanders._
 import com.keepit.common.akka.SafeFuture
 import com.keepit.common.controller.KifiSession._
@@ -9,7 +9,7 @@ import com.keepit.common.core._
 import com.keepit.common.db.slick._
 import com.keepit.common.http._
 import com.keepit.common.logging.Logging
-import com.keepit.common.net.{RichRequestHeader, UserAgent}
+import com.keepit.common.net.{ RichRequestHeader, UserAgent }
 import com.keepit.common.time._
 import com.keepit.controllers.routing.KifiSiteRouter
 import com.keepit.heimdal._
@@ -20,9 +20,9 @@ import play.api.libs.iteratee.Enumerator
 import play.api.libs.json.Json
 import play.api.mvc._
 import play.twirl.api.Html
-import securesocial.core.{Authenticator, SecureSocial}
+import securesocial.core.{ Authenticator, SecureSocial }
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 @Singleton
 class HomeController @Inject() (


### PR DESCRIPTION
@leogrim So I don't know 100% what the issue was, but there was an infinite loop with the HomeController reverse router. What specifically, anyone's guess. I got a stack trace and profile, and couldn't see anything obvious.

Took a guess and removed all references to the HomeController reverse router, and presto, fixed. I don't like the solution, but at least tried to keep a single reference to the route paths, vs using `String`s. In a perfect world, I would write a test that would ensure they all actually exist in the real router. Maybe after PH.

(I need this fixed so I can test the new signup/login page changes)
