### PR TITLE
release feed filters v1

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/feed/feed.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/feed/feed.tpl.html
@@ -1,6 +1,6 @@
 <main class="kf-feed-items kf-main-pane" smart-scroll scroll-distance="scrollDistance" scroll-disabled="!hasMoreKeeps()" scroll-next="fetchKeeps()">
   <div class="kf-feed-header-container">
-    <div kf-feed-filter filter="feedFilter" update-callback="updateFeedFilter()" ng-if="isAdmin"></div>
+    <div kf-feed-filter filter="feedFilter" update-callback="updateFeedFilter()"></div>
     <div kf-card-style-selector ></div>
   </div>
 

--- a/kifi-backend/modules/shoebox/angular/src/feed/feedCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/feed/feedCtrl.js
@@ -43,10 +43,16 @@ angular.module('kifi')
     var orgFilterOptions = orgs.map(function(org) {
       return { value: 'org', id: org.id, text: org.name, handle: org.handle };
     });
+
+    var messageFilters = [
+      { value: 'unread', text: 'Unread' },
+      { value: 'sent', text: 'Sent' }
+    ];
+
     $scope.feedFilter.options = [
       { value: '', text: 'Your Stream' },
       { value: 'own', text: 'Your Keeps' }
-    ].concat(orgFilterOptions);
+    ].concat($scope.isAdmin ? messageFilters : []).concat(orgFilterOptions);
 
     function getFilterFromUrl() {
       return $scope.feedFilter.options.filter(function (filter) {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -840,7 +840,7 @@ class KeepCommanderImpl @Inject() (
           db.readOnlyReplica { implicit session =>
             // Grab 2x the required number because we're going to be dropping some
             val hasNoLibExperiment = userExperimentRepo.hasExperiment(userId, UserExperimentType.KEEP_NOLIB)
-            keepRepo.getRecentKeeps(userId, 2 * limit, beforeExtId, afterExtId, shoeboxFilterOpt).filter { case (k, _) => k.libraryId.isDefined || (k.connections.libraries.isEmpty && hasNoLibExperiment) }
+            keepRepo.getRecentKeeps(userId, 3 * limit, beforeExtId, afterExtId, shoeboxFilterOpt).filter { case (k, _) => k.libraryId.isDefined || (k.connections.libraries.isEmpty && hasNoLibExperiment) }
           }.distinctBy { case (k, addedAt) => k.uriId }.take(limit)
         }
     }


### PR DESCRIPTION
@ryanpbrewster @cvializ @andrewconner 

releasing feed filters from the admin exp per @JRuff42. puts message filters "unread, sent" behind the admin experiment.

quick-fixes a bug where Jen had 20 consecutive library-less keeps (rare), leading to her feed ending prematurely (since we drop library-less keeps post-query). I didn't notice any performance issues when increasing the limit from the frontend, so this should be fine until we remove the experiment.
