### PR TITLE
allow non-team-admins to see /integrations

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.js
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.js
@@ -6,7 +6,7 @@ angular.module('kifi')
   '$scope', '$window', '$analytics', 'orgProfileService', 'messageTicker', 'libraryService', 'ORG_PERMISSION',
   function ($scope, $window, $analytics, orgProfileService, messageTicker, libraryService, ORG_PERMISSION) {
 
-    $scope.canEditIntegrations =  ($scope.viewer.permissions.indexOf(ORG_PERMISSION.MANAGE_PLAN) !== -1);
+    $scope.canEditIntegrations =  ($scope.viewer.permissions.indexOf(ORG_PERMISSION.CREATE_SLACK_INTEGRATION) !== -1);
     $scope.integrations = [];
     $scope.slackIntegrationReactionModel = {enabled: $scope.profile.config && $scope.profile.config.settings.slack_ingestion_reaction.setting === 'enabled'};
     orgProfileService.getSlackIntegrationsForOrg($scope.profile)


### PR DESCRIPTION
@andrewconner @cvializ this should do it. the spec is more agreed upon now so this should be the case across the board (I changed the copy for the setting in a previous PR).
