### PR TITLE
migrate inactive org configs as well

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminOrganizationController.scala
@@ -431,7 +431,7 @@ class AdminOrganizationController @Inject() (
   def applyDefaultSettingsToOrgConfigs() = AdminUserAction(parse.tolerantJson) { implicit request =>
     require((request.body \ "confirmation").as[String] == "really do it")
     val deprecatedSettings = (request.body \ "deprecatedSettings").asOpt[OrganizationSettings](OrganizationSettings.dbFormat).getOrElse(OrganizationSettings.empty)
-    val allOrgIds = db.readOnlyMaster { implicit s => orgRepo.allActive.map(_.id.get) }
+    val allOrgIds = db.readOnlyMaster { implicit s => orgRepo.all().map(_.id.get) }
     val response = ChunkedResponseHelper.chunked(allOrgIds) { orgId =>
       db.readWrite { implicit s =>
         val account = paidAccountRepo.getByOrgId(orgId)


### PR DESCRIPTION
@ryanpbrewster invalid (read: explosive) org configs can be handled in a number of different ways, I'm not sure what's best. Ideally we should never fetch them, but each new model with an `organization_id` tests that. I'm going to run the migration on all org configs for the time being.
