### PR TITLE
don't overwrite added_at when interning a keep_to_user

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToUserCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepToUserCommander.scala
@@ -39,8 +39,7 @@ class KeepToUserCommanderImpl @Inject() (
 
   def internKeepInUser(keep: Keep, userId: Id[User], addedBy: Id[User])(implicit session: RWSession): KeepToUser = {
     ktuRepo.getByKeepIdAndUserId(keep.id.get, userId, excludeStateOpt = None) match {
-      case Some(existingKtu) if existingKtu.isActive =>
-        ktuRepo.save(existingKtu.withAddedAt(clock.now))
+      case Some(existingKtu) if existingKtu.isActive => existingKtu
       case existingKtuOpt =>
         val newKtuTemplate = KeepToUser(
           keepId = keep.id.get,


### PR DESCRIPTION
@ryanpbrewster @leogrim this leads to some weird behavior on the feed, where when we re-ingest keeps we overwrite `ktu.added_at` to be the later time, even though the `ktu` already existed. I'd prefer `added_at` to be equal to `kept_at` if you're the owner of the keep, less tricky to reason about.
