### PR TITLE
Fixing single slack integration

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/libraries/modals/librarySlackIntegrationModal.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/modals/librarySlackIntegrationModal.tpl.html
@@ -114,7 +114,7 @@
       </div>
       </div>
 
-      <a class="kf-library-slack-integration-modal-add-channel" ng-href="{{getSlackLink()}}">+
+      <a class="kf-library-slack-integration-modal-add-channel" ng-href="{{getSlackLink()}}" target="_self">+
         <span>Add a channel</span></a>
     </div>
   </div>

--- a/kifi-backend/modules/shoebox/angular/src/libraries/quickKeep.styl
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/quickKeep.styl
@@ -65,7 +65,7 @@
   color: red
 
 .kf-quick-add-keep-get-extension
-  margin: 20px -20px -20px -20px
+  margin: 20px -16px -20px -16px
   font-size: 14px
   background-color: #FEF8B8
   border-radius: 0px 0px 8px 8px


### PR DESCRIPTION
@leogrim I'm not sure all what was broken, this fixes the "+ Add a channel" link. We should still change the URLs, though.
