### PR TITLE
Revert "Revert "wrap slack search result links with tracking redirects""

### DIFF
--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/slack/SlackSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/slack/SlackSearchController.scala
@@ -166,7 +166,7 @@ class SlackSearchController @Inject() (
         libraries <- futureLibraries
       } yield {
         val attachments = relevantHits.map { hit =>
-          val url = hit.url
+          val url = convertUrlToKifiRedirect(hit.url, command, "clickedResultUrl")
           val uriId = Id[NormalizedURI](hit.id)
           val summary = summaries.get(uriId)
           val title = Some(hit.title).filter(_.nonEmpty) orElse summary.flatMap(_.article.title.filter(_.nonEmpty)) getOrElse url
@@ -174,18 +174,21 @@ class SlackSearchController @Inject() (
           val imageOpt = (keepId.flatMap(keepImages.get) orElse summary.map(_.images)).flatMap(_.get(idealImageSize))
           val pretext = {
             val attribution = keepId.flatMap(sourceAttributions.get).map {
-              case TwitterAttribution(tweet) => Elements("via", "@" + tweet.user.screenName.value --> LinkElement(tweet.getUrl), "on Twitter")
+              case TwitterAttribution(tweet) =>
+                val tweetUrl = convertUrlToKifiRedirect(tweet.getUrl, command, "clickedTweetUrl")
+                Elements("via", "@" + tweet.user.screenName.value --> LinkElement(tweetUrl), "on Twitter")
               case SlackAttribution(message) => Elements("via", "@" + message.username.value, "in", "#" + message.channel.name.value, "·", message.timestamp.toDateTime --> LinkElement(message.permalink))
             }
             val library = hit.libraryId.flatMap(id => libraries.get(Id(id)))
             val domain = DomainToNameMapper.getNameFromUrl(url)
-            Elements.formatForSlack(Elements(domain, library.map(lib => Elements("kept in", lib.name --> LinkElement(lib.url))), attribution))
+            Elements.formatForSlack(Elements(domain, library.map(lib => Elements("kept in", lib.name --> LinkElement(convertUrlToKifiRedirect(lib.url.absolute, command, "clickedLibraryUrl")))), attribution))
           }
+          val thumbUrl = imageOpt.map(image => convertUrlToKifiRedirect("https:" + image.path.getUrl, command, "clickedResultImage"))
           SlackAttachment(
             pretext = Some(pretext),
             title = Some(SlackAttachment.Title(title, Some(url))),
             text = summary.flatMap(_.article.description),
-            thumbUrl = imageOpt.map("https:" + _.path.getUrl),
+            thumbUrl = thumbUrl,
             color = Some("good")
           )
         }

--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/slack/SlackSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/slack/SlackSearchController.scala
@@ -166,7 +166,7 @@ class SlackSearchController @Inject() (
         libraries <- futureLibraries
       } yield {
         val attachments = relevantHits.map { hit =>
-          val url = convertUrlToKifiRedirect(hit.url, command, "clickedResultUrl")
+          val url = hit.url
           val uriId = Id[NormalizedURI](hit.id)
           val summary = summaries.get(uriId)
           val title = Some(hit.title).filter(_.nonEmpty) orElse summary.flatMap(_.article.title.filter(_.nonEmpty)) getOrElse url
@@ -184,9 +184,10 @@ class SlackSearchController @Inject() (
             Elements.formatForSlack(Elements(domain, library.map(lib => Elements("kept in", lib.name --> LinkElement(convertUrlToKifiRedirect(lib.url.absolute, command, "clickedLibraryUrl")))), attribution))
           }
           val thumbUrl = imageOpt.map(image => convertUrlToKifiRedirect("https:" + image.path.getUrl, command, "clickedResultImage"))
+          val resultUrl = convertUrlToKifiRedirect(url, command, "clickedResultUrl")
           SlackAttachment(
             pretext = Some(pretext),
-            title = Some(SlackAttachment.Title(title, Some(url))),
+            title = Some(SlackAttachment.Title(title, Some(resultUrl))),
             text = summary.flatMap(_.article.description),
             thumbUrl = thumbUrl,
             color = Some("good")


### PR DESCRIPTION
Reverts kifi/keepit#19413

@leogrim @andrewconner trying again, will revert if anything fishy comes up. wrapping all links except for domain names and message permalinks.
