### PR TITLE
Slack integrations settings page

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.js
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.js
@@ -8,44 +8,65 @@ angular.module('kifi')
 
     $scope.canEditIntegrations =  ($scope.viewer.permissions.indexOf(ORG_PERMISSION.CREATE_SLACK_INTEGRATION) !== -1);
     $scope.integrations = [];
+
     $scope.slackIntegrationReactionModel = {enabled: $scope.profile.config && $scope.profile.config.settings.slack_ingestion_reaction.setting === 'enabled'};
+    $scope.slackIntegrationDigestModel = {enabled: $scope.profile.config && $scope.profile.config.settings.slack_digest_notif.setting === 'enabled'};
+
     orgProfileService.getSlackIntegrationsForOrg($scope.profile)
-        .then(function(res) {
-          res.libraries.forEach(function(lib) {
-            if (lib.slack.integrations.length > 0) {
-              var integrations = lib.slack.integrations;
-              integrations.forEach(function(integration) {
-                lib.library.sortName = lib.library.name.replace(/[^\w\s]|_/g, '').toLowerCase();
-                $scope.integrations.push({
-                  library: lib.library,
-                  integration: integration,
-                  slackToKifi: integration.fromSlack && integration.fromSlack.status === 'on',
-                  kifiToSlack: integration.toSlack && integration.toSlack.status === 'on'
-                });
-              });
-            }
-          });
-          $scope.integrations.sort(function (a, b) {
-            return a.library.sortName.localeCompare(b.library.sortName);
+    .then(function(res) {
+      $scope.integrationsLoaded = true;
+      $scope.slackTeam = res.slackTeam;
+
+      res.libraries.forEach(function(lib) {
+        var integrations = lib.slack.integrations;
+        integrations.forEach(function(integration) {
+          lib.library.sortName = lib.library.name.replace(/[^\w\s]|_/g, '').toLowerCase();
+          $scope.integrations.push({
+            library: lib.library,
+            integration: integration,
+            slackToKifi: integration.fromSlack && integration.fromSlack.status === 'on',
+            slackToKifiMutable: integration.fromSlack && integration.fromSlack.isMutable,
+            kifiToSlack: integration.toSlack && integration.toSlack.status === 'on',
+            kifiToSlackMutable: integration.toSlack && integration.toSlack.isMutable
           });
         });
-
+      });
+      $scope.integrations.sort(function (a, b) {
+        return a.library.sortName.localeCompare(b.library.sortName);
+      });
+    });
 
     $scope.onSlackIntegrationReactionChanged = function() {
-        $scope.profile.config.settings.slack_ingestion_reaction.setting = $scope.slackIntegrationReactionModel.enabled ? 'enabled' : 'disabled';
-        orgProfileService.setOrgSettings($scope.profile.id, { slack_ingestion_reaction: $scope.profile.config.settings.slack_ingestion_reaction.setting });
+      $scope.profile.config.settings.slack_ingestion_reaction.setting = $scope.slackIntegrationReactionModel.enabled ? 'enabled' : 'disabled';
+      orgProfileService.setOrgSettings($scope.profile.id, { slack_ingestion_reaction: $scope.profile.config.settings.slack_ingestion_reaction.setting })
+      .then(onSave, onError);
+    };
 
+    $scope.onSlackIntegrationDigestChanged = function() {
+      $scope.profile.config.settings.slack_digest_notif.setting = $scope.slackIntegrationDigestModel.enabled ? 'enabled' : 'disabled';
+      orgProfileService.setOrgSettings($scope.profile.id, { slack_digest_notif: $scope.profile.config.settings.slack_digest_notif.setting })
+      .then(onSave, onError);
     };
 
     $scope.onKifiToSlackChanged = function(integration) {
-        integration.integration.toSlack.status = integration.kifiToSlack ? 'on' : 'off';
-        libraryService.modifySlackIntegrations(integration.library.id, [integration.integration.fromSlack, integration.integration.toSlack]);
+      integration.integration.toSlack.status = integration.kifiToSlack ? 'on' : 'off';
+      libraryService.modifySlackIntegrations(integration.library.id, [integration.integration.fromSlack, integration.integration.toSlack])
+      .then(onSave, onError);
     };
 
     $scope.onSlackToKifiChanged = function(integration) {
-        integration.integration.fromSlack.status = integration.slackToKifi ? 'on' : 'off';
-        libraryService.modifySlackIntegrations(integration.library.id, [integration.integration.fromSlack, integration.integration.toSlack]);
+      integration.integration.fromSlack.status = integration.slackToKifi ? 'on' : 'off';
+      libraryService.modifySlackIntegrations(integration.library.id, [integration.integration.fromSlack, integration.integration.toSlack])
+      .then(onSave, onError);
     };
+
+    function onSave() {
+      messageTicker({ text: 'Saved!', type: 'green' });
+    }
+
+    function onError() {
+      messageTicker({ text: 'Odd, that didn’t work. Try again?', type: 'red' });
+    }
 
 
     $scope.onClickedSyncAllSlackChannels = function() {
@@ -55,7 +76,7 @@ angular.module('kifi')
         $window.location = org.slack.link;
       } else {
         messageTicker({
-          text: 'Unable to retrieve Team information, please refresh and try again.',
+          text: 'Unable to retrieve team information, please refresh and try again.',
           type: 'red'
         });
       }

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.styl
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.styl
@@ -11,12 +11,24 @@
     color: #444
 
   .kf-ts-integrations-marketing-text
-    line-height: 24px
-    font-size: 18px
+    line-height: 22px
     margin-top: 15px
-    width: 500px
     color: #777
 
+    .kf-lib-slack-btn-sm
+      width: 110px
+      position: relative
+      display: inline-block
+
+      img
+        width: 110px
+        position: absolute
+        top: -21px
+
+  .kf-ts-integrations-fetch-date
+    color: #999
+    font-size: 12px
+    margin-top: 4px
 
   .kf-ts-integrations-checkrow
     display: flex
@@ -33,12 +45,8 @@
 
 
   .kf-ts-integrations-sync
-    margin-top: 15px
+    margin-top: 5px
     text-align: center
-
-    button
-      width: 150px
-
 
 .kf-ts-integrations-row
   margin-top: 8px

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.tpl.html
@@ -1,50 +1,89 @@
 <div>
-    <div ng-if="!canEditIntegrations" style="text-align: center">
-        Sadly, you are not allowed to be on this page, ask a team admin / owner for more information!
-    </div>
-    <div ng-if="canEditIntegrations">
-        <h1 class="kf-heading kf-ts-integrations-header">Slack Integrations</h1>
-        <div class="kf-ts-integrations">
+  <div ng-if="!canEditIntegrations" style="text-align: center">
+    Sadly, you are not allowed to be on this page, ask a team admin / owner for more information!
+  </div>
+  <div ng-if="canEditIntegrations">
+    <h1 class="kf-heading kf-ts-integrations-header">Slack Integrations</h1>
+    <div class="kf-ts-integrations">
 
-            <span>
-                Connect with <a href="https://slack.com/" target="_blank">Slack</a> to automatically save links messages or send new keeps to your Slack team.
-            </span>
+      <span>
+        Connect with <a href="https://slack.com/" target="_blank">Slack</a> to automatically save links messages or send new keeps to your Slack team.
+      </span>
 
-            <div class="kf-container kf-container-toppad">
-                <div class="kf-container-header"><span>Sync channels to Kifi</span></div>
-                <span class="kf-ts-integrations-marketing-text">Automatically keep links messaged in your channels. Kifi will create a library for each public (not private or direct message) Slack Channel. <a href="http://support.kifi.com/hc/en-us/articles/206873486-Getting-started-with-the-Kifi-Slack-Integeration" target="_blank">Learn more.</a></span>
-                <div class="kf-ts-integrations-sync"><button
-                        class="kf-button kf-button-large kf-action-button kf-button-cta-blue"
-                        tabindex="0"
-                        ng-click="onClickedSyncAllSlackChannels()"
-                        ng-bind="'Sync all Slack Channels'"></button></div>
+      <div class="kf-container kf-container-toppad" ng-if="integrationsLoaded && !slackTeam">
+        <div class="kf-container-header"><span>Connect your team to Slack</span></div>
+        <span class="kf-ts-integrations-marketing-text">Team members will be able to join your team using Slack, share links more easily, and sync Kifi libraries and Slack channels.</span>
+        <div class="kf-ts-integrations-sync"><button
+          class="kf-button kf-button-large kf-action-button kf-button-cta-blue"
+          tabindex="0"
+          ng-click="onClickedSyncAllSlackChannels()">Connect <span ng-bind="profile.name"></span> with Slack</button></div>
+      </div>
 
-            </div>
+      <div class="kf-container kf-container-toppad" ng-if="integrationsLoaded && !slackTeam.publicChannelsLastSyncedAt">
+        <div class="kf-container-header"><span>Sync channels to Kifi</span></div>
+        <span class="kf-ts-integrations-marketing-text">Automatically keep links messaged in your channels. Kifi will create a library for each public (not private or direct message) Slack Channel. <a href="http://support.kifi.com/hc/en-us/articles/206873486-Getting-started-with-the-Kifi-Slack-Integeration" target="_blank">Learn more.</a></span>
+        <div class="kf-ts-integrations-marketing-text">
+          To integrate one library or channel at a time, visit <a ui-sref="orgProfile.libraries">any library</a> and click the
+        <span class="kf-lib-slack-btn-sm"><img src="/img/add-to-slack.png" title="Add to Slack"></span> button.</div>
 
-            <div ng-if="integrations.length" class="kf-container kf-container-toppad">
-                <div class="kf-container-header"><span>Library Integrations</span></div>
-                <!--scroll-disabled="billingEvents === null || !hasMore()" scroll-next="fetch()"-->
-                <table class="kf-ts-integrations-table" smart-scroll scroll-distance="'100%'">
-                    <thead>
-                    <tr>
-                        <th style="text-align: left">Library &amp; Slack Channel</th>
-                        <th>Kifi → Slack</th>
-                        <th>Slack → Kifi</th>
-                    </tr>
-                    </thead>
-                    <tr ng-repeat="integration in integrations">
-                        <td style="text-align: left"><strong><a ng-href="{{integration.library.path}}">{{integration.library.name}}</a></strong> <span class="kf-ts-integrations-subtext">(Kifi)</span>  - <strong>{{integration.integration.channelName}}</strong> <span class="kf-ts-integrations-subtext">(Slack)</span></td>
-                        <td>
-                            <input ng-model="integration.kifiToSlack" ng-change="onKifiToSlackChanged(integration)"  type="checkbox" />
-                        </td>
-                        <td>
-                            <input ng-model="integration.slackToKifi" ng-change="onSlackToKifiChanged(integration)"  type="checkbox" />
-                        </td>
-                    </tr>
-                </table>
-
-            </div>
+        <div class="kf-ts-integrations-sync"><button
+          class="kf-button kf-button-large kf-action-button kf-button-cta-blue"
+          tabindex="0"
+          ng-click="onClickedSyncAllSlackChannels()">Sync all Slack Channels</button>
         </div>
+      </div>
 
+      <div class="kf-container kf-container-toppad" ng-if="integrationsLoaded && slackTeam.publicChannelsLastSyncedAt">
+        <div class="kf-container-header"><span>Fetch channels to sync</span></div>
+        <span class="kf-ts-integrations-marketing-text">
+          Refetch your Slack channels to automatically create Kifi libraries.
+          You can always connect one channel at a time with the
+          <span class="kf-lib-slack-btn-sm"><img src="/img/add-to-slack.png" title="Add to Slack"></span> button on your libraries.
+        </span>
+        <div class="kf-ts-integrations-sync">
+          <button
+            class="kf-button kf-button-large kf-action-button kf-button-cta-blue"
+            tabindex="0"
+            ng-click="onClickedSyncAllSlackChannels()">Sync new Slack channels</button>
+          <div class="kf-ts-integrations-fetch-date">Last fetched:&nbsp;<time am-time-ago="::slackTeam.publicChannelsLastSyncedAt" ng-if="slackTeam.publicChannelsLastSyncedAt"></time><span ng-if="!slackTeam.publicChannelsLastSyncedAt">never</span></div>
+        </div>
+      </div>
+
+      <div class="kf-container kf-container-toppad" ng-if="integrationsLoaded && slackTeam">
+        <div class="kf-container-header"><span>Slack settings</span></div>
+        <div class="kf-ts-integrations-checkrow">
+          <input ng-model="slackIntegrationReactionModel.enabled" ng-change="onSlackIntegrationReactionChanged()"  type="checkbox" />
+          <span>Show the emoji <strong>✓</strong> on links after they have been successfully saved in Kifi.</span>
+        </div>
+        <div class="kf-ts-integrations-checkrow">
+          <input ng-model="slackIntegrationDigestModel.enabled" ng-change="onSlackIntegrationDigestChanged()"  type="checkbox" />
+          <span>Recieve infrequent summary updates to channels.</span>
+        </div>
+      </div>
+
+      <div ng-if="integrations.length" class="kf-container kf-container-toppad">
+        <div class="kf-container-header"><span>Library Integrations</span></div>
+        <!--scroll-disabled="billingEvents === null || !hasMore()" scroll-next="fetch()"-->
+        <table class="kf-ts-integrations-table" smart-scroll scroll-distance="'100%'">
+          <thead>
+          <tr>
+            <th style="text-align: left">Library &amp; Slack Channel</th>
+            <th>Kifi → Slack</th>
+            <th>Slack → Kifi</th>
+          </tr>
+          </thead>
+          <tr ng-repeat="integration in integrations">
+            <td style="text-align: left"><strong><a ng-href="{{integration.library.path}}">{{integration.library.name}}</a></strong> <span class="kf-ts-integrations-subtext">(Kifi)</span>  - <strong>{{integration.integration.channelName}}</strong> <span class="kf-ts-integrations-subtext">(Slack)</span></td>
+            <td>
+              <input ng-model="integration.kifiToSlack" ng-change="onKifiToSlackChanged(integration)" type="checkbox" ng-disabled="!integration.kifiToSlackMutable" />
+            </td>
+            <td>
+              <input ng-model="integration.slackToKifi" ng-change="onSlackToKifiChanged(integration)" type="checkbox" ng-disabled="!integration.slackToKifiMutable" />
+            </td>
+          </tr>
+        </table>
+
+      </div>
     </div>
+  </div>
 </div>

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.tpl.html
@@ -19,7 +19,7 @@
           ng-click="onClickedSyncAllSlackChannels()">Connect <span ng-bind="profile.name"></span> with Slack</button></div>
       </div>
 
-      <div class="kf-container kf-container-toppad" ng-if="integrationsLoaded && !slackTeam.publicChannelsLastSyncedAt">
+      <div class="kf-container kf-container-toppad" ng-if="integrationsLoaded && slackTeam && !slackTeam.publicChannelsLastSyncedAt">
         <div class="kf-container-header"><span>Sync channels to Kifi</span></div>
         <span class="kf-ts-integrations-marketing-text">Automatically keep links messaged in your channels. Kifi will create a library for each public (not private or direct message) Slack Channel. <a href="http://support.kifi.com/hc/en-us/articles/206873486-Getting-started-with-the-Kifi-Slack-Integeration" target="_blank">Learn more.</a></span>
         <div class="kf-ts-integrations-marketing-text">
@@ -33,7 +33,7 @@
         </div>
       </div>
 
-      <div class="kf-container kf-container-toppad" ng-if="integrationsLoaded && slackTeam.publicChannelsLastSyncedAt">
+      <div class="kf-container kf-container-toppad" ng-if="integrationsLoaded && slackTeam && slackTeam.publicChannelsLastSyncedAt">
         <div class="kf-container-header"><span>Fetch channels to sync</span></div>
         <span class="kf-ts-integrations-marketing-text">
           Refetch your Slack channels to automatically create Kifi libraries.


### PR DESCRIPTION
@cvializ Big diff because the files were using 4 spaces instead of 2.

Screenshots of things that may show (depending on permissions):

![](http://acon.s3.amazonaws.com/sTvuJ.png)

![](http://acon.s3.amazonaws.com/3JcZj.png)

![](http://acon.s3.amazonaws.com/nwoQx.png)

Also, the list of integrations on that page respects permissions (thanks @ryanpbrewster)
