### PR TITLE
add last_activity_at to keep_to_library and keep_to_user

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
@@ -38,7 +38,7 @@ case class Keep(
   originalKeeperId: Option[Id[User]] = None,
   source: KeepSource,
   keptAt: DateTime = currentDateTime,
-  lastActivityAt: DateTime = currentDateTime,
+  lastActivityAt: DateTime = currentDateTime, // denormalized to KeepToUser and KeepToLibrary, modify using KeepCommander.updateLastActivityAtifLater
   messageSeq: Option[SequenceNumber[Message]] = None,
   connections: KeepConnections,
   libraryId: Option[Id[Library]], // deprecated, prefer connections.libraries
@@ -74,7 +74,9 @@ case class Keep(
   def withLibraries(libraries: Set[Id[Library]]): Keep = this.copy(connections = connections.withLibraries(libraries))
   def withParticipants(users: Set[Id[User]]): Keep = this.copy(connections = connections.withUsers(users))
 
+  // denormalized to KeepToUser and KeepToLibrary, use in KeepCommander.updateLastActivityAtifLater
   def withLastActivityAtIfLater(time: DateTime): Keep = if (lastActivityAt isBefore time) this.copy(lastActivityAt = time) else this
+
   def withMessageSeq(seq: SequenceNumber[Message]): Keep = if (messageSeq.exists(_ >= seq)) this else this.copy(messageSeq = Some(seq))
 
   def isActive: Boolean = state == KeepStates.ACTIVE

--- a/kifi-backend/modules/common/app/com/keepit/model/KeepToLibrary.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepToLibrary.scala
@@ -17,7 +17,8 @@ case class KeepToLibrary(
   uriId: Id[NormalizedURI],
   // and from Library
   visibility: LibraryVisibility,
-  organizationId: Option[Id[Organization]])
+  organizationId: Option[Id[Organization]],
+  lastActivityAt: DateTime = currentDateTime)
     extends ModelWithState[KeepToLibrary] {
 
   def withId(id: Id[KeepToLibrary]): KeepToLibrary = this.copy(id = Some(id))
@@ -28,6 +29,9 @@ case class KeepToLibrary(
   def withAddedAt(time: DateTime): KeepToLibrary = this.copy(addedAt = time)
   def withAddedBy(newOwnerId: Id[User]): KeepToLibrary = this.copy(addedBy = newOwnerId)
   def withUriId(newUriId: Id[NormalizedURI]) = this.copy(uriId = newUriId)
+
+  // denormalized from Keep.lastActivityAt, use in KeepCommander.updateLastActivityAtIfLater
+  def withLastActivityAt(time: DateTime): KeepToLibrary = this.copy(lastActivityAt = time)
 
   def isActive = state == KeepToLibraryStates.ACTIVE
   def isInactive = state == KeepToLibraryStates.INACTIVE

--- a/kifi-backend/modules/common/app/com/keepit/model/KeepToUser.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepToUser.scala
@@ -13,8 +13,10 @@ case class KeepToUser(
   userId: Id[User],
   addedAt: DateTime = currentDateTime,
   addedBy: Id[User],
-  // A denormalized field from Keep
-  uriId: Id[NormalizedURI])
+  // Denormalized fields from Keep
+  uriId: Id[NormalizedURI],
+  lastActivityAt: DateTime = currentDateTime)
+
     extends ModelWithState[KeepToUser] {
 
   def withId(id: Id[KeepToUser]): KeepToUser = this.copy(id = Some(id))
@@ -22,6 +24,9 @@ case class KeepToUser(
   def withState(newState: State[KeepToUser]): KeepToUser = this.copy(state = newState)
   def withUriId(newUriId: Id[NormalizedURI]) = this.copy(uriId = newUriId)
   def withAddedAt(time: DateTime) = this.copy(addedAt = time)
+
+  // denormalized from Keep.lastActivityAt, use in KeepCommander.updateLastActivityAtIfLater
+  def withLastActivityAt(time: DateTime): KeepToUser = this.copy(lastActivityAt = time)
 
   def isActive = state == KeepToUserStates.ACTIVE
   def isInactive = state == KeepToUserStates.INACTIVE

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/426.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/426.sql
@@ -1,0 +1,10 @@
+# SHOEBOX
+
+# --- !Ups
+
+alter table keep_to_library add column last_activity_at datetime not null;
+alter table keep_to_user add column last_activity_at datetime not null;
+
+insert into evolutions(name, description) values('426.sql', 'add last_activity_at to keep_to_library, keep_to_user');
+
+# --- !Downs

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
@@ -3,6 +3,7 @@ package com.keepit.controllers.admin
 import com.google.inject.Inject
 import com.keepit.commanders._
 import com.keepit.common.akka.SafeFuture
+import com.keepit.common.concurrent.ChunkedResponseHelper
 import com.keepit.common.controller.{ AdminUserActions, UserActionsHelper, UserRequest }
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.DBSession._
@@ -34,7 +35,8 @@ class AdminBookmarksController @Inject() (
   uriRepo: NormalizedURIRepo,
   userRepo: UserRepo,
   libraryRepo: LibraryRepo,
-  keepToLibraryRepo: KeepToLibraryRepo,
+  ktlRepo: KeepToLibraryRepo,
+  ktuRepo: KeepToUserRepo,
   keepImageCommander: KeepImageCommander,
   keywordSummaryCommander: KeywordSummaryCommander,
   keepCommander: KeepCommander,
@@ -315,7 +317,7 @@ class AdminBookmarksController @Inject() (
     val libraryId = (request.body \ "libraryId").as[Id[Library]]
 
     val keeps = db.readOnlyReplica { implicit session =>
-      keepToLibraryRepo.getAllByLibraryId(libraryId).map(_.keepId)
+      ktlRepo.getAllByLibraryId(libraryId).map(_.keepId)
     }
 
     db.readWrite(attempts = 5) { implicit session =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminLibraryController.scala
@@ -342,18 +342,4 @@ class AdminLibraryController @Inject() (
     val response = libraryCommander.unsafeModifyLibrary(lib, mods)
     Ok(Json.obj("lib" -> response.modifiedLibrary))
   }
-
-  def changeWhoCanComment = AdminUserAction(parse.tolerantJson) { implicit request =>
-    val okay = (request.body \ "okay").as[Boolean]
-    assert(okay)
-
-    val libs = db.readOnlyMaster { implicit s => libraryRepo.allActive() }
-    FutureHelpers.sequentialExec(libs.grouped(50000).toSeq) { batch =>
-      db.readWriteAsync { implicit s =>
-        batch.map(lib => libraryRepo.save(lib.copy(whoCanComment = LibraryCommentPermissions.ANYONE)))
-      }
-    }
-    Ok
-  }
-
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminOrganizationController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminOrganizationController.scala
@@ -5,25 +5,21 @@ import java.util.concurrent.atomic.AtomicInteger
 import com.google.inject.Inject
 import com.keepit.classify.NormalizedHostname
 import com.keepit.common.concurrent.ChunkedResponseHelper
-import com.keepit.common.core.futureExtensionOps
 import com.keepit.commanders._
 import com.keepit.common.controller._
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.db._
 import com.keepit.common.db.slick.Database
-import com.keepit.common.json.KeyFormat
-import com.keepit.heimdal.{ HeimdalContextBuilder, HeimdalContext }
+import com.keepit.heimdal.HeimdalContext
 import com.keepit.model._
-import com.keepit.payments.{ PaidPlanRepo, PaidAccountRepo, PaidPlanStates, PaidPlan }
-import play.api.libs.iteratee.{ Enumerator, Concurrent }
+import com.keepit.payments.{ PaidPlanRepo, PaidAccountRepo }
 import play.api.{ Mode, Play }
-import play.api.libs.json.{ JsValue, JsString, Json }
-import play.twirl.api.{ HtmlFormat, Html }
-import play.api.mvc.{ Action, AnyContent, Result }
+import play.api.libs.json.Json
+import play.twirl.api.HtmlFormat
+import play.api.mvc.{ Action, AnyContent }
 import views.html
 
-import scala.concurrent.{ Promise, ExecutionContext, Future }
-import com.keepit.common.time._
+import scala.concurrent.{ ExecutionContext, Future }
 
 import scala.util.Try
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/DiscussionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/DiscussionCommander.scala
@@ -101,7 +101,7 @@ class DiscussionCommanderImpl @Inject() (
       val keep = db.readWrite { implicit s =>
         val oldKeep = keepRepo.get(keepId)
         val allUsers = oldKeep.connections.users ++ newUsers + userId
-        keepCommander.persistKeep(oldKeep.withParticipants(allUsers))
+        keepCommander.addUsersToKeep(keepId, addedBy = userId, allUsers)
       }
       val elizaEdit = eliza.editParticipantsOnKeep(keepId, userId, newUsers)
       elizaEdit.onSuccess {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -79,6 +79,7 @@ trait KeepCommander {
   // Updating / managing
   def updateKeepTitle(keepId: Id[Keep], userId: Id[User], title: String)(implicit session: RWSession): Try[Keep]
   def updateKeepNote(userId: Id[User], oldKeep: Keep, newNote: String, freshTag: Boolean = true)(implicit session: RWSession): Keep
+  def updateLastActivityAtIfLater(keepId: Id[Keep], lastActivityAt: DateTime)(implicit session: RWSession): Keep
   def moveKeep(k: Keep, toLibrary: Library, userId: Id[User])(implicit session: RWSession): Either[LibraryError, Keep]
   def copyKeep(k: Keep, toLibrary: Library, userId: Id[User], withSource: Option[KeepSource] = None)(implicit session: RWSession): Either[LibraryError, Keep]
 
@@ -653,22 +654,36 @@ class KeepCommanderImpl @Inject() (
     require(k.connections.users.contains(k.userId), "keep owner is not one of the connected users")
     require(k.libraryId.toSet == k.connections.libraries, "ktls in 2 or more libraries are not supported")
 
-    val keep = keepRepo.save(k)
+    val oldKeepOpt = k.id.map(keepRepo.get)
+    val newKeep = keepRepo.save(k)
 
-    keep.connections.users.foreach { userId => ktuCommander.internKeepInUser(keep, userId, userId) }
+    if (oldKeepOpt.forall(_.connections.libraries != newKeep.connections.libraries)) {
+      val libraries = libraryRepo.getActiveByIds(newKeep.connections.libraries).values
+      libraries.foreach { lib => ktlCommander.internKeepInLibrary(newKeep, lib, newKeep.userId) }
+    }
 
-    val libraries = libraryRepo.getActiveByIds(keep.connections.libraries).values
-    libraries.foreach { lib => ktlCommander.internKeepInLibrary(keep, lib, keep.userId) }
+    val updatedKeepOpt = if (oldKeepOpt.forall(_.connections.users != newKeep.connections.users)) {
+      Some(addUsersToKeep(newKeep.id.get, addedBy = newKeep.userId, newKeep.connections.users))
+    } else None
 
-    keep
+    updatedKeepOpt.getOrElse(newKeep)
   }
   def addUsersToKeep(keepId: Id[Keep], addedBy: Id[User], newUsers: Set[Id[User]])(implicit session: RWSession): Keep = {
     val oldKeep = keepRepo.get(keepId)
     val newKeep = keepRepo.save(oldKeep.withParticipants(oldKeep.connections.users ++ newUsers))
 
     newUsers.foreach { userId => ktuCommander.internKeepInUser(newKeep, userId, addedBy) }
+    updateLastActivityAtIfLater(keepId, currentDateTime)
+  }
+  def updateLastActivityAtIfLater(keepId: Id[Keep], time: DateTime)(implicit session: RWSession): Keep = {
+    val oldKeep = keepRepo.get(keepId)
+    val newKeep = oldKeep.withLastActivityAtIfLater(time)
 
-    newKeep
+    if (newKeep.lastActivityAt != oldKeep.lastActivityAt) {
+      ktuRepo.getAllByKeepId(keepId).foreach(ktu => ktuRepo.save(ktu.withLastActivityAt(time)))
+      ktlRepo.getAllByKeepId(keepId).foreach(ktl => ktlRepo.save(ktl.withLastActivityAt(time)))
+      keepRepo.save(newKeep)
+    } else oldKeep
   }
   def refreshLibraries(keepId: Id[Keep])(implicit session: RWSession): Keep = {
     val keep = keepRepo.getNoCache(keepId)

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -831,7 +831,6 @@ POST    /admin/libraries/setLibraryOwner                @com.keepit.controllers.
 POST    /admin/libraries/forceAddMember                 @com.keepit.controllers.admin.AdminLibraryController.unsafeAddMember
 POST    /admin/libraries/forceMoveLibraryKeeps          @com.keepit.controllers.admin.AdminLibraryController.unsafeMoveLibraryKeeps
 POST    /admin/libraries/forceModify                    @com.keepit.controllers.admin.AdminLibraryController.unsafeModifyLibrary
-POST    /admin/libraries/changeWhoCanComment            @com.keepit.controllers.admin.AdminLibraryController.changeWhoCanComment()
 
 GET     /admin/typeahead                    @com.keepit.controllers.admin.TypeaheadAdminController.index
 GET     /admin/typeahead/userSearch         @com.keepit.controllers.admin.TypeaheadAdminController.userSearch(userId:Id[User], query:String ?= "")

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
@@ -49,9 +49,7 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
           userRepo.get(user.id.get) === user
           bookmarks.size === 1
           keepRepo.get(bookmarks.head.id.get).copy(
-            updatedAt = bookmarks.head.updatedAt,
-            lastActivityAt = bookmarks.head.lastActivityAt,
-            seq = bookmarks.head.seq
+            updatedAt = bookmarks.head.updatedAt
           ) === bookmarks.head
           keepRepo.all.size === 1
         }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
@@ -48,7 +48,11 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
         db.readWrite { implicit session =>
           userRepo.get(user.id.get) === user
           bookmarks.size === 1
-          keepRepo.get(bookmarks.head.id.get).copy(updatedAt = bookmarks.head.updatedAt) === bookmarks.head
+          keepRepo.get(bookmarks.head.id.get).copy(
+            updatedAt = bookmarks.head.updatedAt,
+            lastActivityAt = bookmarks.head.lastActivityAt,
+            seq = bookmarks.head.seq
+          ) === bookmarks.head
           keepRepo.all.size === 1
         }
       }


### PR DESCRIPTION
@ryanpbrewster @leogrim @andrewconner 

we need this to sort by `lastActivityAt` on the feed without doing joins between `bookmark` and `keep_to_user` or `keep_to_library`.

would do the migration tonight, estimated 25 min+ per table given @ryanpbrewster 's migration on `bookmark`
