### PR TITLE
First step to get backend speaking right language to clients

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/integrations/slack/teamChooserCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/integrations/slack/teamChooserCtrl.js
@@ -31,7 +31,7 @@ angular.module('kifi')
     };
 
     $scope.onClickedCreateTeam = function() {
-      $window.location = 'https://kifi.com/site/organizations/create/slack?slackTeamId=' + $scope.params.slackTeamId;
+      $window.location = 'https://www.kifi.com/site/organizations/create/slack?slackTeamId=' + $scope.params.slackTeamId;
     };
 
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SlackController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SlackController.scala
@@ -16,7 +16,7 @@ import com.keepit.shoebox.controllers.{ LibraryAccessActions, OrganizationAccess
 import com.keepit.slack._
 import com.keepit.slack.models._
 import play.api.libs.json._
-import play.api.mvc.{ RequestHeader, Result }
+import play.api.mvc.{ Request, RequestHeader, Result }
 import com.keepit.common.core._
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -49,10 +49,10 @@ class SlackController @Inject() (
     implicit val publicIdConfig: PublicIdConfiguration,
     implicit val ec: ExecutionContext) extends UserActions with OrganizationAccessActions with LibraryAccessActions with ShoeboxServiceController {
 
-  private def redirectToLibrary(libraryId: Id[Library], showSlackDialog: Boolean): Result = {
+  private def redirectToLibrary(libraryId: Id[Library], showSlackDialog: Boolean): SlackResponse.RedirectClient = {
     val libraryUrl = deepLinkRouter.generateRedirect(DeepLinkRouter.libraryLink(Library.publicId(libraryId))).get.url
     val redirectUrl = if (showSlackDialog) libraryUrl + "?showSlackDialog" else libraryUrl
-    Redirect(redirectUrl, SEE_OTHER)
+    SlackResponse.RedirectClient(redirectUrl)
   }
 
   private def getOrgUrl(orgId: Id[Organization]): String = {
@@ -64,34 +64,39 @@ class SlackController @Inject() (
     implicit val context = heimdalContextBuilder.withRequestInfo(request).build
     val resultFut = for {
       code <- codeOpt.map(Future.successful).getOrElse(Future.failed(SlackAPIFailure.NoAuthCode))
-      action <- slackStateCommander.getSlackAction(SlackAuthState(state)).map(Future.successful(_)).getOrElse(Future.failed(SlackAPIFailure.InvalidAuthState))
+      action <- slackStateCommander.getSlackAction(SlackAuthState(state)).map(Future.successful).getOrElse(Future.failed(SlackAPIFailure.InvalidAuthState))
       slackAuth <- slackClient.processAuthorizationResponse(SlackAuthorizationCode(code), SlackController.REDIRECT_URI)
       slackIdentity <- slackClient.identifyUser(slackAuth.accessToken)
       result <- {
         slackCommander.registerAuthorization(request.userIdOpt, slackAuth, slackIdentity)
         processAuthorizedAction(request.userId, slackIdentity.teamId, slackIdentity.userId, action, slackAuth.incomingWebhook)
       }
-    } yield result
+    } yield {
+      result match {
+        case SlackResponse.RedirectClient(url) => Redirect(url, SEE_OTHER) // explicit error page?
+        case _ => Redirect("/", SEE_OTHER) // explicit error page?
+      }
+    }
 
     resultFut.recover {
       case fail: SlackAPIFailure => Redirect("/", SEE_OTHER) // we could have an explicit error page here
     }
   }
 
-  private def processAuthorizedAction(userId: Id[User], slackTeamId: SlackTeamId, slackUserId: SlackUserId, action: SlackAuthenticatedAction, incomingWebhook: Option[SlackIncomingWebhook])(implicit context: HeimdalContext): Future[Result] = {
+  private def processAuthorizedAction(userId: Id[User], slackTeamId: SlackTeamId, slackUserId: SlackUserId, action: SlackAuthenticatedAction, incomingWebhook: Option[SlackIncomingWebhook])(implicit context: HeimdalContext): Future[SlackResponse] = {
     action match {
       case SetupLibraryIntegrations(libId) => incomingWebhook match {
         case Some(webhook) =>
           slackIntegrationCommander.setupIntegrations(userId, libId, webhook, slackTeamId, slackUserId)
           Future.successful(redirectToLibrary(libId, showSlackDialog = true))
-        case _ => Future.successful(BadRequest("missing_webhook"))
+        case _ => Future.successful(SlackResponse.Error("missing_webhook"))
       }
 
       case TurnOnLibraryPush(integrationId) => incomingWebhook match {
         case Some(webhook) =>
           val libraryId = slackIntegrationCommander.turnOnLibraryPush(Id(integrationId), webhook, slackTeamId, slackUserId)
           Future.successful(redirectToLibrary(libraryId, showSlackDialog = true))
-        case _ => Future.successful(BadRequest("missing_webhook"))
+        case _ => Future.successful(SlackResponse.Error("missing_webhook"))
       }
 
       case TurnOnChannelIngestion(integrationId) => {
@@ -104,21 +109,21 @@ class SlackController @Inject() (
           slackTeam.organizationId match {
             case Some(orgId) =>
               slackTeamCommander.syncPublicChannels(userId, slackTeam.slackTeamId)
-              Redirect(getOrgUrl(orgId), SEE_OTHER)
-            case None => Redirect(s"/integrations/slack/teams?slackTeamId=${slackTeam.slackTeamId.value}", SEE_OTHER)
+              SlackResponse.RedirectClient(getOrgUrl(orgId))
+            case None => SlackResponse.RedirectClient(s"/integrations/slack/teams?slackTeamId=${slackTeam.slackTeamId.value}")
           }
         }
       }
 
       case AddSlackTeam() => slackTeamCommander.addSlackTeam(userId, slackTeamId).map { slackTeam =>
         slackTeam.organizationId match {
-          case Some(orgId) => Redirect(getOrgUrl(orgId), SEE_OTHER)
-          case None => Redirect(s"/integrations/slack/teams?slackTeamId=${slackTeam.slackTeamId.value}", SEE_OTHER)
+          case Some(orgId) => SlackResponse.RedirectClient(getOrgUrl(orgId))
+          case None => SlackResponse.RedirectClient(s"/integrations/slack/teams?slackTeamId=${slackTeam.slackTeamId.value}")
         }
       }
 
       case ConnectSlackTeam(orgId) => slackTeamCommander.connectSlackTeamToOrganization(userId, slackTeamId, orgId) match {
-        case Success(team) if team.organizationId.contains(orgId) => Future.successful(Redirect(getOrgUrl(orgId), SEE_OTHER))
+        case Success(team) if team.organizationId.contains(orgId) => Future.successful(SlackResponse.RedirectClient(getOrgUrl(orgId)))
         case teamMaybe =>
           val error = teamMaybe.map(team => new Exception(s"Something weird happen while connecting org $orgId with $team")).recover { case error => error }
           throw error.get
@@ -126,7 +131,7 @@ class SlackController @Inject() (
 
       case CreateSlackTeam() => slackTeamCommander.createOrganizationForSlackTeam(userId, slackTeamId).map { team =>
         team.organizationId match {
-          case Some(orgId) => Redirect(getOrgUrl(orgId), SEE_OTHER)
+          case Some(orgId) => SlackResponse.RedirectClient(getOrgUrl(orgId))
           case None => throw new Exception(s"Something weird happen while creating org for $team")
         }
       }
@@ -134,21 +139,21 @@ class SlackController @Inject() (
       case SyncPublicChannels() =>
         slackTeamCommander.syncPublicChannels(userId, slackTeamId).map {
           case (orgId, _) =>
-            Redirect(getOrgUrl(orgId), SEE_OTHER)
+            SlackResponse.RedirectClient(getOrgUrl(orgId))
         }
 
       case _ => throw new IllegalStateException(s"Action not handled by SlackController: $action")
     }
   }
 
-  private def processActionOrElseAuthenticate(userId: Id[User], slackTeamIdOpt: Option[SlackTeamId], action: SlackAuthenticatedAction)(implicit request: RequestHeader): Future[Result] = {
+  private def processActionOrElseAuthenticate(userId: Id[User], slackTeamIdOpt: Option[SlackTeamId], action: SlackAuthenticatedAction)(implicit request: RequestHeader): Future[SlackResponse] = {
     slackCommander.getIdentityAndMissingScopes(userId, slackTeamIdOpt)(action.helper).flatMap {
       case (Some((slackTeamId, slackUserId)), missingScopes) if missingScopes.isEmpty =>
         implicit val context = heimdalContextBuilder.withRequestInfo(request).build
         processAuthorizedAction(userId, slackTeamId, slackUserId, action, None)
       case (_, missingScopes) =>
         val authUrl = slackStateCommander.getAuthLink(action, slackTeamIdOpt, missingScopes, SlackController.REDIRECT_URI).url
-        Future.successful(Redirect(authUrl, SEE_OTHER))
+        Future.successful(SlackResponse.RedirectClient(authUrl))
     }
   }
 
@@ -211,14 +216,17 @@ class SlackController @Inject() (
 
   def addSlackTeam(slackTeamId: Option[String]) = UserAction.async { implicit request =>
     processActionOrElseAuthenticate(request.userId, slackTeamId.map(SlackTeamId(_)), AddSlackTeam())
+      .map(handleAsBrowserRequest)
   }
 
   def connectSlackTeam(organizationId: PublicId[Organization], slackTeamId: Option[String]) = OrganizationUserAction(organizationId, SlackCommander.slackSetupPermission).async { implicit request =>
     processActionOrElseAuthenticate(request.request.userId, slackTeamId.map(SlackTeamId(_)), ConnectSlackTeam(request.orgId))
+      .map(handleAsBrowserRequest)
   }
 
   def createSlackTeam(slackTeamId: Option[String]) = UserAction.async { implicit request =>
     processActionOrElseAuthenticate(request.userId, slackTeamId.map(SlackTeamId(_)), CreateSlackTeam())
+      .map(handleAsBrowserRequest)
   }
 
   def syncPublicChannels(organizationId: PublicId[Organization]) = OrganizationUserAction(organizationId, SlackCommander.slackSetupPermission).async { implicit request =>
@@ -226,6 +234,7 @@ class SlackController @Inject() (
       slackInfoCommander.getOrganizationSlackInfo(request.orgId, request.request.userId).slackTeams.toSeq
     }
     processActionOrElseAuthenticate(request.request.userId, Some(slackTeamId), SyncPublicChannels())
+      .map(handleAsBrowserRequest)
   }
 
   def getOrganizationsToConnectToSlackTeam() = UserAction { implicit request =>
@@ -268,6 +277,13 @@ class SlackController @Inject() (
 
   def setupLibraryIntegrations(libraryId: PublicId[Library]) = (UserAction andThen LibraryViewUserAction(libraryId)).async { implicit request =>
     processActionOrElseAuthenticate(request.userId, None, SetupLibraryIntegrations(Library.decodePublicId(libraryId).get))
+      .map(handleAsAPIRequest)
+  }
+
+  // Treats request as a browser request, not an API request. Remove when frontend updates.
+  def setupLibraryIntegrationsOld(libraryId: PublicId[Library]) = (UserAction andThen LibraryViewUserAction(libraryId)).async { implicit request =>
+    processActionOrElseAuthenticate(request.userId, None, SetupLibraryIntegrations(Library.decodePublicId(libraryId).get))
+      .map(handleAsBrowserRequest)
   }
 
   def turnOnLibraryPush(libraryId: PublicId[Library], integrationId: String) = (UserAction andThen LibraryViewUserAction(libraryId)).async { implicit request =>
@@ -276,7 +292,8 @@ class SlackController @Inject() (
         // todo(Léo): deal with broken webhook / missing write permissions ???
         val slackTeamId = db.readOnlyMaster { implicit session => libToSlackRepo.get(libToSlackId).slackTeamId }
         processActionOrElseAuthenticate(request.userId, Some(slackTeamId), TurnOnLibraryPush(libToSlackId.id))
-      case Failure(_) => Future.successful(BadRequest("invalid_integration_id"))
+          .map(handleAsBrowserRequest)
+      case Failure(_) => Future.successful(BadRequest("invalid_integration_id")) // Bad bad bad
     }
   }
 
@@ -285,7 +302,33 @@ class SlackController @Inject() (
       case Success(slackToLibId) =>
         val slackTeamId = db.readOnlyMaster { implicit session => slackToLibRepo.get(slackToLibId).slackTeamId }
         processActionOrElseAuthenticate(request.userId, Some(slackTeamId), TurnOnChannelIngestion(slackToLibId.id))
-      case Failure(_) => Future.successful(BadRequest("invalid_integration_id"))
+          .map(handleAsBrowserRequest)
+      case Failure(_) => Future.successful(BadRequest("invalid_integration_id")) // Bad bad bad
     }
   }
+
+  // Can elegantly handle redirects (to HTML pages), *never* speaks JSON, should not be on /site/ routes
+  private def handleAsBrowserRequest[T](implicit request: Request[T]) = { (response: SlackResponse) =>
+    response match {
+      case SlackResponse.RedirectClient(url) => Redirect(url, SEE_OTHER)
+      case SlackResponse.ActionPerformed => Redirect(request.headers.get(REFERER).getOrElse("/")) // Bad bad bad
+      case SlackResponse.Error(code) => Redirect("/") // Bad bad bad
+    }
+  }
+
+  // Always speaks JSON, should be on /site/ routes, cannot handle Redirects to HTML pages
+  private def handleAsAPIRequest[T](implicit request: Request[T]) = { (response: SlackResponse) =>
+    response match {
+      case SlackResponse.RedirectClient(url) => Ok(Json.obj("redirect" -> url))
+      case SlackResponse.ActionPerformed => Ok(Json.obj("success" -> true))
+      case SlackResponse.Error(code) => BadRequest(Json.obj("error" -> code))
+    }
+  }
+}
+
+private sealed trait SlackResponse
+private object SlackResponse {
+  final case class Error(code: String) extends SlackResponse
+  final case class RedirectClient(url: String) extends SlackResponse
+  case object ActionPerformed extends SlackResponse
 }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -466,9 +466,10 @@ POST    /site/rpb/setArrangement           @com.keepit.controllers.website.UserC
 GET     /site/rpb/user/:userId/libraries   @com.keepit.controllers.website.UserController.rpbGetUserLibraries(userId: ExternalId[User], fromId: Option[String] ?= None, limit: Int ?= 10)
 GET     /site/rpb/org/:orgId/libraries     @com.keepit.controllers.website.UserController.rpbGetOrgLibraries(orgId: PublicId[Organization], fromId: Option[String] ?= None, limit: Int ?= 10)
 
-GET   /site/libraries/:id/slack/add         @com.keepit.controllers.website.SlackController.setupLibraryIntegrations(id: PublicId[Library])
-GET   /site/libraries/:id/slack/push        @com.keepit.controllers.website.SlackController.turnOnLibraryPush(id: PublicId[Library], integrationId: String)
-GET   /site/libraries/:id/slack/ingest      @com.keepit.controllers.website.SlackController.turnOnChannelIngestion(id: PublicId[Library], integrationId: String)
+GET   /site/libraries/:id/slack/add         @com.keepit.controllers.website.SlackController.setupLibraryIntegrationsOld(id: PublicId[Library])
+POST  /site/libraries/:id/slack/add        @com.keepit.controllers.website.SlackController.setupLibraryIntegrations(id: PublicId[Library])
+POST  /site/libraries/:id/slack/push        @com.keepit.controllers.website.SlackController.turnOnLibraryPush(id: PublicId[Library], integrationId: String)
+POST  /site/libraries/:id/slack/ingest      @com.keepit.controllers.website.SlackController.turnOnChannelIngestion(id: PublicId[Library], integrationId: String)
 POST  /site/libraries/:id/slack/modify      @com.keepit.controllers.website.SlackController.modifyIntegrations(id: PublicId[Library])
 POST  /site/libraries/:id/slack/delete      @com.keepit.controllers.website.SlackController.deleteIntegrations(id: PublicId[Library])
 
@@ -555,11 +556,15 @@ GET           /site/organizations/:id/referralCode              @com.keepit.cont
 POST          /site/organizations/:id/redeemCode                @com.keepit.controllers.website.PaymentsController.redeemCreditCode(id: PublicId[Organization])
 GET           /site/organizations/:id/rewards                   @com.keepit.controllers.website.PaymentsController.getRewards(id: PublicId[Organization])
 
+# ↓ Take out of /site/
 GET           /site/slack/add                                   @com.keepit.controllers.website.SlackController.addSlackTeam(slackTeamId: Option[String] ?= None)
 GET           /site/slack/add/organizations                     @com.keepit.controllers.website.SlackController.getOrganizationsToConnectToSlackTeam()
+# ↓ Take out of /site/
 GET           /site/organizations/create/slack                  @com.keepit.controllers.website.SlackController.createSlackTeam(slackTeamId: Option[String] ?= None)
+# ↓ Take out of /site/
 GET           /site/organizations/:id/slack/connect             @com.keepit.controllers.website.SlackController.connectSlackTeam(id: PublicId[Organization], slackTeamId: Option[String] ?= None)
 GET           /site/organizations/:id/slack/list                @com.keepit.controllers.website.SlackController.getOrgIntegrations(id: PublicId[Organization])
+# ↓ Take out of /site/ OR change to be be JSON endpoint
 GET           /site/organizations/:id/slack/sync/public         @com.keepit.controllers.website.SlackController.syncPublicChannels(id: PublicId[Organization])
 
 # Slack POST routes are deprecated


### PR DESCRIPTION
Please help me verify that this makes no changes to current behavior. Next step, I'll move the site to use the POST /add endpoint, which speaks JSON.

For Ryan, problem was that requests come from two sources: things like browser clients (as if you typed in the URL and hit enter) and API clients (how the site's code talks to the backend). Browsers speak HTML, never speak JSON (because they'll just display it as text, and users get confused), and can deal with redirects to HTML. API endpoints speak JSON always, and cannot deal with redirects to HTML pages. As a rule, `/site/` routes are always the latter, for technical and convention reasons.

We accidentally had a little mix-and-match, which means sometimes users might see JSON, or our API gets confused why it's getting back HTML and barfs. This doesn't really fix anything, but lets me do the client side on the /add endpoint, and hopefully makes the code a bit more clear‽

@leogrim @ryanpbrewster Please read over, thanks.
