### PR TITLE
Maybe fixing issue Eishay's having.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.js
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.js
@@ -9,8 +9,11 @@ angular.module('kifi')
     $scope.canEditIntegrations =  ($scope.viewer.permissions.indexOf(ORG_PERMISSION.CREATE_SLACK_INTEGRATION) !== -1);
     $scope.integrations = [];
 
-    $scope.slackIntegrationReactionModel = {enabled: $scope.profile.config && $scope.profile.config.settings.slack_ingestion_reaction.setting === 'enabled'};
-    $scope.slackIntegrationDigestModel = {enabled: $scope.profile.config && $scope.profile.config.settings.slack_digest_notif.setting === 'enabled'};
+    var settings = $scope.profile && $scope.profile.config && $scope.profile.config.settings;
+    var reactionSetting = settings && settings.slack_ingestion_reaction.setting;
+    var notifSetting = settings && settings.slack_digest_notif.setting;
+    $scope.slackIntegrationReactionModel = {enabled: reactionSetting === 'enabled'};
+    $scope.slackIntegrationDigestModel = {enabled: notifSetting === 'enabled'};
 
     orgProfileService.getSlackIntegrationsForOrg($scope.profile)
     .then(function(res) {


### PR DESCRIPTION
His error was that `config` had no `settings`. I can't figure out why `$scope.profile` could be assumed to magically be there. It's not passed in as a dependency, this is not a directive (so no isolate scope).
