### PR TITLE
remove keep_nolib feature checks on frontend

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
@@ -276,7 +276,7 @@ angular.module('kifi')
           scope.$watch('keep.title', updateTitle);
           scope.defaultDescLines = 4;
           scope.me = profileService.me;
-          scope.showActivityAttribution = $state.is('home.feed') && profileService.hasExperiment('keep_nolib');
+          scope.showActivityAttribution = $state.is('home.feed');
           scope.showOriginLibrary = scope.currentPageOrigin !== 'libraryPage' &&
             keep.library && keep.library.visibility !== 'discoverable' && keep.library.kind === 'system_secret';
           // Don't change until the link is updated to be a bit more secure:

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCardAttribution.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCardAttribution.js
@@ -17,7 +17,7 @@ angular.module('kifi')
         var keep = scope.keep;
         var discussion = keep && keep.discussion;
         scope.showKeepPageLink = scope.keep.path && !$state.is('keepPage');
-        scope.showAsDiscussion = scope.keep && !scope.keep.libraryId && $state.is('home.feed') && profileService.hasExperiment('keep_nolib');
+        scope.showAsDiscussion = scope.keep && !scope.keep.libraryId && $state.is('home.feed');
         scope.attributionTime = (scope.showAsDiscussion && discussion && discussion.startedAt) || (keep && keep.createdAt);
       }
     };


### PR DESCRIPTION
This allows the front end to display headless keeps for all users
