### PR TITLE
Kill SlackAuthenticatedAction SetupSlackTeam + clean up `OrganizationSlackInfo`

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/slack/SlackAuthStateCommander.scala
+++ b/kifi-backend/modules/common/app/com/keepit/slack/SlackAuthStateCommander.scala
@@ -60,13 +60,6 @@ object TurnOnChannelIngestion extends SlackAuthenticatedActionHelper[TurnOnChann
   def helper = TurnOnChannelIngestion
 }
 
-// Deprecated
-object SetupSlackTeam extends SlackAuthenticatedActionHelper[SetupSlackTeam]("setup_slack_team")
-@json case class SetupSlackTeam(organizationId: Option[Id[Organization]]) extends SlackAuthenticatedAction {
-  type A = SetupSlackTeam
-  def helper = SetupSlackTeam
-}
-
 object AddSlackTeam extends SlackAuthenticatedActionHelper[AddSlackTeam]("add_slack_team")
 case class AddSlackTeam() extends SlackAuthenticatedAction {
   type A = AddSlackTeam
@@ -107,7 +100,6 @@ object SlackAuthenticatedActionHelper {
     SetupLibraryIntegrations,
     TurnOnLibraryPush,
     TurnOnChannelIngestion,
-    SetupSlackTeam,
     AddSlackTeam,
     ConnectSlackTeam,
     CreateSlackTeam,
@@ -127,7 +119,6 @@ object SlackAuthenticatedActionHelper {
     case SetupLibraryIntegrations => implicitly[Format[SetupLibraryIntegrations]]
     case TurnOnLibraryPush => implicitly[Format[TurnOnLibraryPush]]
     case TurnOnChannelIngestion => implicitly[Format[TurnOnChannelIngestion]]
-    case SetupSlackTeam => implicitly[Format[SetupSlackTeam]]
     case AddSlackTeam => formatPure(AddSlackTeam())
     case ConnectSlackTeam => implicitly[Format[ConnectSlackTeam]]
     case CreateSlackTeam => formatPure(CreateSlackTeam())
@@ -139,7 +130,6 @@ object SlackAuthenticatedActionHelper {
     case SetupLibraryIntegrations => SlackAuthScope.integrationSetup
     case TurnOnLibraryPush => SlackAuthScope.push
     case TurnOnChannelIngestion => SlackAuthScope.ingest
-    case SetupSlackTeam => SlackAuthScope.syncPublicChannels
     case AddSlackTeam => SlackAuthScope.teamSetup
     case ConnectSlackTeam => SlackAuthScope.teamSetup
     case CreateSlackTeam => SlackAuthScope.teamSetup

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackInfoCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackInfoCommander.scala
@@ -51,10 +51,7 @@ case class LibrarySlackInfo(
 case class OrganizationSlackTeamInfo(id: SlackTeamId, name: SlackTeamName, publicChannelsLastSyncedAt: Option[DateTime])
 
 case class OrganizationSlackInfo(
-  link: String,
-  slackTeamId: Option[SlackTeamId], // deprecated
   slackTeam: Option[OrganizationSlackTeamInfo],
-  slackTeams: Set[SlackTeamId], // deprecated
   libraries: Seq[(BasicLibrary, LibrarySlackInfo)])
 
 object OrganizationSlackInfo {
@@ -249,14 +246,8 @@ class SlackInfoCommanderImpl @Inject() (
 
     val slackTeam = slackTeams.headOption
     val librarySlackInfosByLib = assembleLibrarySlackInfos(libIds, integrationInfosByLib)
-    val action = SetupSlackTeam(Some(orgId))
-    val missingScopes = action.helper.getMissingScopes(Set.empty)
-    val link = slackStateCommander.getAuthLink(action, slackTeam.map(_.id), missingScopes, SlackController.REDIRECT_URI).url
     OrganizationSlackInfo(
-      link,
-      slackTeam.map(_.id),
       slackTeam,
-      slackTeams.map(_.id),
       libraries = libIds.toList.sorted.collect {
         case libId if canViewLib(libId) => (basicLibsById(libId), librarySlackInfosByLib(libId))
       }


### PR DESCRIPTION
@andrewconner merging whenever you merged and `OrganizationSlackInfo.slackTeams` is no longer used in the front-end.
