### PR TITLE
Fixing /connect missing slackTeamId, moving off deprecated GET routes, kill them.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/net.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/net.js
@@ -102,7 +102,7 @@ angular.module('kifi')
       getKifiOrgsForSlackIntegration: get(shoebox, '/slack/add/organizations'),
       getAddSlackIntegrationLink: post(shoebox, '/libraries/:libraryId/slack/add'),
       publicSyncSlack: post(shoebox, '/organizations/:teamId/slack/sync/public'),
-      connectSlack: post(shoebox, '/organizations/:teamId/slack/connect'),
+      connectSlack: post(shoebox, '/organizations/:teamId/slack/connect?slackTeamId=:optSlackTeamId'),
 
     // eliza
       addMessageToKeepDiscussion: post(shoebox, '/keeps/:id/messages'),

--- a/kifi-backend/modules/shoebox/angular/src/common/services/slackService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/slackService.js
@@ -28,8 +28,8 @@ angular.module('kifi')
         return net.publicSyncSlack(teamId).then(dataLens);
       },
       // Returns a link that we should send the client to if they want to connect Slack to a team
-      connectTeam: function (teamId) {
-        return net.connectSlack(teamId).then(dataLens);
+      connectTeam: function (teamId, optSlackTeamId) {
+        return net.connectSlack(teamId, optSlackTeamId).then(dataLens);
       }
     };
     return api;

--- a/kifi-backend/modules/shoebox/angular/src/integrations/slack/teamChooserCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/integrations/slack/teamChooserCtrl.js
@@ -19,15 +19,18 @@ angular.module('kifi')
     });
 
     $scope.onClickedOrg = function(org) {
-      // do something
       $scope.selectedOrg = org;
     };
 
-      //createOrganizationForSlackTeam: post(shoebox, '/organizations/create/slack?slackTeamId=:slackTeamId'),
-      //    connectSlackTeamToOrganization: post(shoebox, '/organizations/:id/slack/connect?slackTeamId=:slackTeamId'),
     $scope.onClickedDone = function() {
-      $window.location = 'https://kifi.com/site/organizations/' + $scope.selectedOrg.id
-                            + '/slack/connect?slackTeamId=' + $scope.params.slackTeamId;
+      slackService.connectTeam($scope.selectedOrg.id).then(function (resp) {
+        if (resp.redirect) {
+          $window.location = resp.redirect;
+        } else {
+          // uh... how could this happen?
+          return;
+        }
+      });
     };
 
     $scope.onClickedCreateTeam = function() {

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -562,19 +562,9 @@ GET           /site/slack/add/organizations                     @com.keepit.cont
 # ↓ Take out of /site/
 GET           /site/organizations/create/slack                  @com.keepit.controllers.website.SlackController.createSlackTeam(slackTeamId: Option[SlackTeamId] ?= None)
 GET           /site/organizations/:id/slack/list                @com.keepit.controllers.website.SlackController.getOrgIntegrations(id: PublicId[Organization])
-
-# ↓ Treats requests as browser visits, remove when frontend updates ↓
-GET           /site/organizations/:id/slack/sync/public         @com.keepit.controllers.website.SlackController.syncPublicChannelsOld(id: PublicId[Organization])
-GET           /site/organizations/:id/slack/connect             @com.keepit.controllers.website.SlackController.connectSlackTeamOld(id: PublicId[Organization], slackTeamId: Option[SlackTeamId] ?= None)
-# ↑ Treats requests as browser visits, remove when frontend updates ↑
-
 POST          /site/organizations/:id/slack/connect             @com.keepit.controllers.website.SlackController.connectSlackTeam(id: PublicId[Organization], slackTeamId: Option[SlackTeamId] ?= None)
 POST          /site/organizations/:id/slack/sync/public         @com.keepit.controllers.website.SlackController.syncPublicChannels(id: PublicId[Organization])
 
-
-# Slack POST routes are deprecated
-POST          /site/organizations/create/slack                  @com.keepit.controllers.website.SlackController.createOrganizationForSlackTeam(slackTeamId: SlackTeamId)
-POST          /site/organizations/:id/slack/connect             @com.keepit.controllers.website.SlackController.connectOrganizationToSlackTeam(id: PublicId[Organization], slackTeamId: SlackTeamId)
 
 GET           /site/user-or-org/:handle                   @com.keepit.controllers.website.UserOrOrganizationController.getByHandle(handle: Handle, authToken: Option[String] ?= None)
 GET           /site/user-or-org/:handle/libraries         @com.keepit.controllers.website.UserOrOrganizationController.getLibrariesByHandle(handle: Handle, page: Int ?= 0, size: Int ?= 12, filter: String ?= "own")


### PR DESCRIPTION
@leogrim @cvializ @ryanpbrewster 
