### PR TITLE
Making successful redirects more clear.

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SlackController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SlackController.scala
@@ -62,12 +62,12 @@ class SlackController @Inject() (
   private def redirectToOrganization(organizationId: Id[Organization], showSlackDialog: Boolean): SlackResponse.ActionPerformed = {
     val organizationUrl = getOrgUrl(organizationId)
     val redirectUrl = if (showSlackDialog) organizationUrl + "?showSlackDialog" else organizationUrl
-    SlackResponse.ActionPerformed(redirectUrl)
+    SlackResponse.ActionPerformed(Some(redirectUrl))
   }
 
   private def redirectToOrganizationIntegrations(organizationId: Id[Organization]): SlackResponse.ActionPerformed = {
     val redirectUrl = getOrgUrl(organizationId) + "/settings/integrations"
-    SlackResponse.ActionPerformed(redirectUrl)
+    SlackResponse.ActionPerformed(Some(redirectUrl))
   }
 
   def registerSlackAuthorization(codeOpt: Option[String], state: String) = UserAction.async { implicit request =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SlackController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SlackController.scala
@@ -139,7 +139,7 @@ class SlackController @Inject() (
       case SyncPublicChannels() =>
         slackTeamCommander.syncPublicChannels(userId, slackTeamId).map {
           case (orgId, _) =>
-            SlackResponse.ActionPerformed(getOrgUrl(orgId)) // This is a success case (action is done). Should actually return: SlackResponse.ActionPerformed. Can't yet for backwards compatibility.
+            SlackResponse.ActionPerformed(Some(getOrgUrl(orgId)))
         }
 
       case _ => throw new IllegalStateException(s"Action not handled by SlackController: $action")
@@ -282,7 +282,7 @@ class SlackController @Inject() (
     response match {
       case SlackResponse.RedirectClient(url) => Redirect(url, SEE_OTHER)
       case SlackResponse.ActionPerformed(urlOpt) =>
-        val url = urlOpt.OrElse(request.headers.get(REFERER).filter(_.startsWith("https://www.kifi.com")).getOrElse("/"))
+        val url = urlOpt.orElse(request.headers.get(REFERER).filter(_.startsWith("https://www.kifi.com"))).getOrElse("/")
         Redirect(url)
       case SlackResponse.Error(code) =>
         log.warn(s"[SlackController#handleAsBrowserRequest] Error: $code")


### PR DESCRIPTION
Technically, `redirectToOrganization` and `redirectToOrganizationIntegrations` should just return paths, and the consumer should pick what it means (action performed? redirect?) @leogrim @ryanpbrewster 
