### PR TITLE
add routing to 'add comments' link in slack push notifs

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PathCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PathCommander.scala
@@ -82,8 +82,9 @@ class PathCommander @Inject() (
   private def keepPageViaSlack(keep: Keep, slackTeamId: SlackTeamId): Path = {
     Path(s"s/${slackTeamId.value}/k/${Keep.publicId(keep.id.get).id}/${UrlHash.hashUrl(keep.url).urlEncoded}")
   }
-  def keepPageOnKifiViaSlack(keep: Keep, slackTeamId: SlackTeamId) = keepPageViaSlack(keep, slackTeamId) + "/kifi"
-  def keepPageOnUrlViaSlack(keep: Keep, slackTeamId: SlackTeamId): String = keep.url // TODO(ryan): this should be a Kifi route at some point
+  def keepPageOnKifiViaSlack(keep: Keep, slackTeamId: SlackTeamId): Path = keepPageViaSlack(keep, slackTeamId) + "/kifi"
+  def keepPageOnUrlViaSlack(keep: Keep, slackTeamId: SlackTeamId): Path = keepPageViaSlack(keep, slackTeamId) + "/web"
+  def userPageViaSlack(basicUser: BasicUser, slackTeamId: SlackTeamId): Path = Path(s"s/${slackTeamId.value}/u/${basicUser.externalId.id}")
 
   /**
    * I'd prefer if you just didn't use these routes

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/LibraryToSlackChannelPusher.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/LibraryToSlackChannelPusher.scala
@@ -13,7 +13,7 @@ import com.keepit.common.performance.{ AlertingTimer, StatsdTiming }
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.common.strings._
 import com.keepit.common.time.{ Clock, DEFAULT_DATE_TIME_ZONE }
-import com.keepit.common.util.{ DescriptionElements, LinkElement }
+import com.keepit.common.util.{ LinkElement, DescriptionElements }
 import com.keepit.model._
 import com.keepit.slack.models._
 import com.keepit.social.BasicUser
@@ -127,14 +127,14 @@ class LibraryToSlackChannelPusherImpl @Inject() (
       case Some(post) =>
         DescriptionElements(
           keep.title.getOrElse(keep.url.abbreviate(KEEP_URL_MAX_DISPLAY_LENGTH)) --> LinkElement(keep.url), "from", s"#${post.channel.name.value}" --> LinkElement(post.permalink),
-          "was added to", lib.name --> LinkElement(pathCommander.libraryPageViaSlack(lib, slackTeamId).absolute), "."
+          "was added to", lib.name --> LinkElement(pathCommander.libraryPageViaSlack(lib, slackTeamId).absolute), ".", "Add Comment" --> LinkElement(pathCommander.keepPageOnKifiViaSlack(keep, slackTeamId))
         )
       case None =>
         DescriptionElements(
           getUser(keep.userId), "added",
           keep.title.getOrElse(keep.url.abbreviate(KEEP_URL_MAX_DISPLAY_LENGTH)) --> LinkElement(pathCommander.keepPageOnUrlViaSlack(keep, slackTeamId)),
           "to", lib.name --> LinkElement(pathCommander.libraryPageViaSlack(lib, slackTeamId).absolute),
-          keep.note.map(n => DescriptionElements("—", "_“", Hashtags.format(n), "”_")), "."
+          keep.note.map(n => DescriptionElements("—", "_“", Hashtags.format(n), "”_")), ".", "Add Comment" --> LinkElement(pathCommander.keepPageOnKifiViaSlack(keep, slackTeamId))
         )
     }
   }

--- a/kifi-backend/modules/shoebox/app/views/mobile/deepLinkRedirect.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/mobile/deepLinkRedirect.scala.html
@@ -6,7 +6,6 @@
 @deepLinkStr = @{UriEncoding.encodePathSegment(deepLinkData.toString(), "ascii")}
 
 <!DOCTYPE html>
-
 @if(r.externalLocator.isDefined) {
 <html data-kifi-deep-link='{"url":"@{r.url}","locator":"@{r.externalLocator.get}"}'>
 }


### PR DESCRIPTION
@ryanpbrewster @andrewconner 
https://app.asana.com/0/83234711497124/84792773514350

if the user has the extension, route to keep.url with ext open. else, route to the keep page with appropriate upsell params.
