### PR TITLE
Easier to handle this way

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.js
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/integrations.js
@@ -75,10 +75,10 @@ angular.module('kifi')
     $scope.onClickedSyncAllSlackChannels = function() {
       $analytics.eventTrack('user_clicked_pane', { type: 'orgProfileIntegrations', action: 'syncAllChannels' });
       slackService.publicSync($scope.profile.id).then(function (resp) {
-        if (resp.redirect) {
-          $window.location = resp.redirect;
-        } else if (resp.success) {
+        if (resp.success) {
           messageTicker({ text: 'Syncing!', type: 'green' });
+        } else if (resp.redirect) {
+          $window.location = resp.redirect;
         }
       });
     };
@@ -86,10 +86,10 @@ angular.module('kifi')
     $scope.onClickedConnectSlack = function() {
       $analytics.eventTrack('user_clicked_pane', { type: 'orgProfileIntegrations', action: 'connectSlack' });
       slackService.connectTeam($scope.profile.id).then(function (resp) {
-        if (resp.redirect) {
-          $window.location = resp.redirect;
-        } else if (resp.success) {
+        if (resp.success) {
           messageTicker({ text: 'Slack connected!', type: 'green' });
+        } else if (resp.redirect) {
+          $window.location = resp.redirect;
         }
       });
 

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/slackConfirm.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/slackConfirm.tpl.html
@@ -1,46 +1,39 @@
 <div>
-  <!--
 
-  Section 1
-  Visible to everyone
-  "We're ingesting all of your teams links ..... blah blah this may take a few minutes
+  <div class="kf-container kf-container-toppad">
+    <h2>😻 Congrats, we’re syncing your channels now 😻</h2>
 
-  Section 2
-  If the user is currently in Chrome or FFX with an installed extension >  hide this section
-  If the user is in Chrome or FFX and no installed extension >  Buttons to install  (I don't care if they ever installed in the past, only if they are currently on a browser with it)
-  If the user is in IE, Safari, etc then buttons to download Chrome or FFX mentioning our awesome extension (same buttons we have on the /install page when you hit it on IE)
-
-  Section 3
-  Visible to everyone
-  Button to visit newly sync'd team (ideally less obvious than the install CTA).
-
-  -->
-
-  <h2>😻 Congrats, we’re syncing your channels now 😻</h2>
-
-  <p>We’re pulling in content to ​the <a ui-sref="orgProfile.libraries"><span ng-bind="profile.organization.name"></span> team page</a> — it make take a bit. Full search may take up to an hour because we’re downloading all your links so you can search them.</p>
+    <p>We’re pulling in content to ​the <a ui-sref="orgProfile.libraries"><span ng-bind="profile.organization.name"></span> team page</a> — it make take a bit. Full search may take up to an hour because we’re downloading all your links so you can search them.</p>
+  </div>
 
   <div ng-if="hasInstalled">
-    <p>Since you already have our browser extensions (high five!), encourage your team to get it as well so they can benefit from the links kept here. Send them to this link to sign up with Slack and automatically join this Kifi team:</p>
-    <div class="kf-slack-confirm-team-link-wrapper">
-      <input type="text" ng-model="teamLink" class="kf-textbox kf-slack-confirm-team-link" clipboard readonly text="teamLink" ng-click="showCopied()">
-      <div ng-if="showCopiedConfirm" class="kf-slack-confirm-copied">Copied!</div>
+    <div class="kf-container kf-container-toppad">
+      <div class="kf-container-header"><span>Share the love with your team</span></div>
+      <p>Since you already have our browser extensions (high five!), encourage your team to get it as well so they can benefit from the links kept here. Send them to this link to sign up with Slack and automatically join this Kifi team:</p>
+      <div class="kf-slack-confirm-team-link-wrapper">
+        <input type="text" ng-model="teamLink" class="kf-textbox kf-slack-confirm-team-link" clipboard readonly text="teamLink" ng-click="showCopied()">
+        <div ng-if="showCopiedConfirm" class="kf-slack-confirm-copied">Copied!</div>
+      </div>
     </div>
   </div>
 
   <div ng-if="!hasInstalled">
-    <p>Don’t miss the best part of Kifi: our browser extension integrates your keeps with Google Search and allows you to talk <i>on pages</i> with your team.</p>
+    <div class="kf-container kf-container-toppad">
+      <div class="kf-container-header"><span>Get our browser add-on</span></div>
+      <p>Don’t miss the best part of Kifi: our browser extension integrates your keeps with Google Search and allows you to talk <i>on pages</i> with your team.</p>
+      <p ng-if="!canInstall">We currently support Chrome and Firefox, and will support Safari soon. Hang tight!</p>
+      <p ng-if="canInstall">
+        <button class="kf-button kf-button-large kf-action-button kf-button-cta-blue kf-slack-confirm-ext-btn" ng-click="installExt()">Get the <span ng-bind="platform"></span> extension</button>
+      </p>
+    </div>
 
-    <p ng-if="!canInstall">We currently support Chrome and Firefox, and will support Safari soon. Hang tight!</p>
-
-    <p ng-if="canInstall">
-      <button class="kf-button kf-button-large kf-action-button kf-button-cta-blue kf-slack-confirm-ext-btn" ng-click="installExt()">Get the <span ng-bind="platform"></span> extension</button>
-    </p>
-
-    <p>After you explore around, you can quickly get your team on Kifi by sending them this link:</p>
-    <div class="kf-slack-confirm-team-link-wrapper">
-      <input type="text" ng-model="teamLink" class="kf-textbox kf-slack-confirm-team-link" clipboard readonly text="teamLink" ng-click="showCopied()">
-      <div ng-if="showCopiedConfirm" class="kf-slack-confirm-copied">Copied!</div>
+    <div class="kf-container kf-container-toppad">
+      <div class="kf-container-header"><span>Share the love with your team</span></div>
+      <p>After you explore around, you can quickly get your team on Kifi by sending them this link:</p>
+      <div class="kf-slack-confirm-team-link-wrapper">
+        <input type="text" ng-model="teamLink" class="kf-textbox kf-slack-confirm-team-link" clipboard readonly text="teamLink" ng-click="showCopied()">
+        <div ng-if="showCopiedConfirm" class="kf-slack-confirm-copied">Copied!</div>
+      </div>
     </div>
   </div>
 </div>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SlackController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SlackController.scala
@@ -305,7 +305,7 @@ class SlackController @Inject() (
   private def handleAsAPIRequest[T](implicit request: Request[T]) = { (response: SlackResponse) =>
     response match {
       case SlackResponse.RedirectClient(url) => Ok(Json.obj("redirect" -> url))
-      case SlackResponse.ActionPerformed(urlOpt) => Ok(Json.obj("success" -> true, "url" -> urlOpt))
+      case SlackResponse.ActionPerformed(urlOpt) => Ok(Json.obj("success" -> true, "redirect" -> urlOpt))
       case SlackResponse.Error(code) => BadRequest(Json.obj("error" -> code))
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SlackController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/SlackController.scala
@@ -306,7 +306,9 @@ class SlackController @Inject() (
     response match {
       case SlackResponse.RedirectClient(url) => Ok(Json.obj("redirect" -> url))
       case SlackResponse.ActionPerformed(urlOpt) => Ok(Json.obj("success" -> true, "redirect" -> urlOpt))
-      case SlackResponse.Error(code) => BadRequest(Json.obj("error" -> code))
+      case SlackResponse.Error(code) =>
+        log.warn(s"[SlackController#handleAsAPIRequest] Error: $code")
+        BadRequest(Json.obj("error" -> code))
     }
   }
 }


### PR DESCRIPTION
It's easier if both cases with redirects use the same URL. I check for `success` first, and if not, redirect. That way, if I cannot do anything statically/locally, I always redirect using the same URL.
