### PR TITLE
add user value to know if user signed up (no intent) via slack

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
@@ -82,6 +82,7 @@ object UserValueName {
   val HAS_SEEN_FTUE = UserValueName("has_seen_ftue")
   val STORED_CREDIT_CODE = UserValueName("stored_credit_code")
   val SLACK_INT_PROMO = UserValueName("slack_int_promo")
+  val SHOW_SLACK_CREATE_TEAM_POPUP = UserValueName("show_slack_create_team_popup")
 
   val LAST_SMS_SENT = UserValueName("last_sms_sent")
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -6,10 +6,10 @@ import com.keepit.commanders.emails.ResetPasswordEmailSender
 import com.keepit.common.crypto.{ PublicIdGenerator, PublicIdConfiguration, PublicId }
 import com.keepit.common.net.UserAgent
 import com.google.inject.Inject
-import com.keepit.common.oauth.{ OAuth1ProviderRegistry, ProviderIds, OAuth2ProviderRegistry }
+import com.keepit.common.oauth.{ SlackIdentity, OAuth1ProviderRegistry, ProviderIds, OAuth2ProviderRegistry }
 import com.keepit.common.service.IpAddress
 import com.keepit.payments.CreditCode
-import com.keepit.slack.models.SlackTeamId
+import com.keepit.slack.models.{ SlackTeamMembershipRepo, SlackTeamId }
 import play.api.Mode._
 import play.api.mvc._
 import play.api.http.{ Status, HeaderNames }
@@ -63,6 +63,7 @@ class AuthHelper @Inject() (
     userValueRepo: UserValueRepo,
     kifiInstallationRepo: KifiInstallationRepo, // todo: factor out
     orgRepo: OrganizationRepo,
+    slackMembershipRepo: SlackTeamMembershipRepo,
     ktlRepo: KeepToLibraryRepo,
     s3ImageStore: S3ImageStore,
     libPathCommander: PathCommander,
@@ -252,6 +253,7 @@ class AuthHelper @Inject() (
               userCommander.sendWelcomeEmail(user.id.get, withVerification = !emailConfirmedAlready, Some(emailAddress))
             }
           }
+          if (slackMembershipRepo.getByUserId(user.id.get).nonEmpty) userValueRepo.setValue(user.id.get, UserValueName.SHOW_SLACK_CREATE_TEAM_POPUP, true)
           val completedSignupEvent = UserEvent(user.id.get, context, UserEventTypes.COMPLETED_SIGNUP)
           heimdal.trackEvent(completedSignupEvent)
         }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/UserController.scala
@@ -334,7 +334,8 @@ class UserController @Inject() (
       COMPANY_NAME,
       HIDE_COMPANY_NAME,
       STORED_CREDIT_CODE,
-      SLACK_INT_PROMO
+      SLACK_INT_PROMO,
+      SHOW_SLACK_CREATE_TEAM_POPUP
     )
   }
 


### PR DESCRIPTION
@leogrim @andrewconner @DerekBurch 

we need to show a popup after "normal" slack auth signup. this could probably be done several ways but decided not to get into the `intent` mess since this is a standard flow, now sets a `pref` in `finishSignup`. crossing my fingers.

alternatively, we could pass (then destroy a cookie) to the home page whenever someone completes signup, to do ftue-related stuff.
