### PR TITLE
punting on 'add comment'

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/LibraryToSlackChannelPusher.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/LibraryToSlackChannelPusher.scala
@@ -127,14 +127,14 @@ class LibraryToSlackChannelPusherImpl @Inject() (
       case Some(post) =>
         DescriptionElements(
           keep.title.getOrElse(keep.url.abbreviate(KEEP_URL_MAX_DISPLAY_LENGTH)) --> LinkElement(keep.url), "from", s"#${post.channel.name.value}" --> LinkElement(post.permalink),
-          "was added to", lib.name --> LinkElement(pathCommander.libraryPageViaSlack(lib, slackTeamId).absolute), ".", "Add Comment" --> LinkElement(pathCommander.keepPageOnKifiViaSlack(keep, slackTeamId))
+          "was added to", lib.name --> LinkElement(pathCommander.libraryPageViaSlack(lib, slackTeamId).absolute), "."
         )
       case None =>
         DescriptionElements(
           getUser(keep.userId), "added",
           keep.title.getOrElse(keep.url.abbreviate(KEEP_URL_MAX_DISPLAY_LENGTH)) --> LinkElement(pathCommander.keepPageOnUrlViaSlack(keep, slackTeamId)),
           "to", lib.name --> LinkElement(pathCommander.libraryPageViaSlack(lib, slackTeamId).absolute),
-          keep.note.map(n => DescriptionElements("—", "_“", Hashtags.format(n), "”_")), ".", "Add Comment" --> LinkElement(pathCommander.keepPageOnKifiViaSlack(keep, slackTeamId))
+          keep.note.map(n => DescriptionElements("—", "_“", Hashtags.format(n), "”_")), "."
         )
     }
   }


### PR DESCRIPTION
I think we should try making this CTA an attachment, since it doesn't really flow with what the user really wants to see: "userX kept keepY in libraryZ". Punting on it to the weekend where I'll have more time to properly test and play with it.
