### PR TITLE
This is awful, but stabbing in the dark.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
@@ -259,7 +259,12 @@ angular.module('kifi')
         } else if (profileService.prefs.auto_show_guide) {
           // guide
           extensionLiaison.triggerGuide();
-          profileService.savePrefs({auto_show_guide: null});
+          $timeout(function () {
+            extensionLiaison.triggerGuide();
+            $timeout(function () {
+              profileService.savePrefs({auto_show_guide: null});
+            }, 5000);
+          }, 1000);
           unregisterAutoShowGuide();
         } else if (profileService.isFakeUser() && showSlackCreateTeamPopup() && $state.current.name === 'home.feed') {
           profileService.savePrefs({show_slack_create_team_popup: false});


### PR DESCRIPTION
@cvializ It appears if you have multiple Kifi tabs open when the extension starts up, there's a race to open the guide, and the tabs cancel each other in a way. This basically a) tries twice to open it over a period of 1s, b) waits 5s to turn the "auto show guide" preference off.

I have some ext changes that help as well.
