### PR TITLE
Formalizing the hack a bit

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
@@ -258,7 +258,6 @@ angular.module('kifi')
           $state.go('getStarted.followLibraries');
         } else if (profileService.prefs.auto_show_guide) {
           // guide
-          extensionLiaison.triggerGuide();
           $timeout(function () {
             extensionLiaison.triggerGuide();
             $timeout(function () {

--- a/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
@@ -258,11 +258,11 @@ angular.module('kifi')
           $state.go('getStarted.followLibraries');
         } else if (profileService.prefs.auto_show_guide) {
           // guide
-          $timeout(function () {
+          $timeout(function () { // Let the dust settle a bit before starting guide.
             extensionLiaison.triggerGuide();
-            $timeout(function () {
+            $timeout(function () { // If any other tabs may show the guide, let them load before turning it off.
               profileService.savePrefs({auto_show_guide: null});
-            }, 5000);
+            }, 2000);
           }, 1000);
           unregisterAutoShowGuide();
         } else if (profileService.isFakeUser() && showSlackCreateTeamPopup() && $state.current.name === 'home.feed') {


### PR DESCRIPTION
- No need to open it _immediately_. It's busy loading `me` and such, and barfs if things move too quickly.
- We do need to un-register it sooner, because if we wait too long, it'll never be turned off and we'll prompt them to open the guide _again_.

@cvializ I'd like to let the ext turn off `auto_show_guide`, because it actually knows what happened. Right now, the site is having to infer, which leads to these races since the communication is all fire-and-forget.
