### PR TITLE
3.5.8: Improvement to tab handling during installation

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.5.7
+version=3.5.8

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -2880,7 +2880,23 @@ api.errors.wrap(authenticate.bind(null, function() {
   if (api.loadReason === 'install') {
     log('[main] fresh install');
     var baseUri = webBaseUri();
-    var tab = api.tabs.anyAt(baseUri + '/install') || api.tabs.anyAt(baseUri + '/');
+    var focused = api.tabs.getFocused();
+
+    var currentKifiTab;
+    if (focused && focused.url && focused.url.indexOf('https://www.kifi.com') === 0) {
+      currentKifiTab = focused;
+    }
+
+    var primaryKifiTab = api.tabs.anyAt(baseUri + '/install') || api.tabs.anyAt(baseUri + '/');
+
+    var otherKifiSiteTab;
+    api.tabs.each(function (tab) {
+      if (tab.url.indexOf('https://www.kifi.com') === 0) { // Order doesn't matter at this point, just grab one.
+        otherKifiSiteTab = tab;
+      }
+    });
+
+    var tab = currentKifiTab || primaryKifiTab || otherKifiSiteTab;
     if (tab) {
       api.tabs.select(tab.id);
     } else {

--- a/packrat/scripts/keeper_scout.js
+++ b/packrat/scripts/keeper_scout.js
@@ -181,7 +181,7 @@ k.tile = k.tile || function () {  // idempotent for Chrome
       var args = Array.prototype.slice.call(arguments);
       args.unshift(null);
       whenMeKnown.push(loadAndDo.bind(null, args));
-    } else if (!k.me) {
+    } else if (!k.me && name !== 'guide') {
       openLoginWindow();
     } else {
       var args = Array.prototype.slice.call(arguments, 2);


### PR DESCRIPTION
Here's the issue:
- Previously, if the ext was installed on a non-`/` page (or, `/install`, which doesn't run the angular app), weird things would happen.
- Multiple tabs would open, guide wouldn't open.

Now, we let the user start the guide on any `kifi.com` page. The logic about which tab to pick is as follows: a) if the focused tab is on a `kifi.com` page, use that, b) else, use any `kifi.com/` or `kifi.com/install` tab, c) else, use any other `kifi.com` tab (such as team slack settings).

A weird race can happen when the guide starts. When the extension first opens, it's possible for `keeper_scout` and the guide to fire before `me` is loaded in the ext. This should be largely fixed with a site change I made, where I made the site delay a second. But just in case, the guide can never trigger login now, which seems reasonable.

@cvializ 
