### PR TITLE
Fix airbrake on invalid hash (from fb integration?)

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettingsCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSettingsCtrl.js
@@ -17,13 +17,21 @@ angular.module('kifi')
     $scope.canEditIntegrations = ($scope.viewer.permissions.indexOf(ORG_PERMISSION.CREATE_SLACK_INTEGRATION) !== -1);
 
     function onHashChange() {
-      var anchor = angular.element($window.location.hash.slice(0, -1))[0];
+      var scrollSettingsAnchorRe = /[a-zA-Z0-9-]+/g; // one or more alpha, hyphens (and numbers just to follow POLS)
+      var hash = $window.location.hash.slice(0, -1);
+
+      if (!scrollSettingsAnchorRe.test(hash)) {
+        return;
+      }
+
+      var anchor = angular.element(hash)[0];
+      var headerHeightIsh = 70; // TODO(carlos): find an elegant way to compute this
       var headingTop;
       var scrollDestination;
 
       if (anchor) {
         headingTop = anchor.getBoundingClientRect().top - $window.document.body.getBoundingClientRect().top;
-        scrollDestination = headingTop - 70; // make room for header
+        scrollDestination = headingTop - headerHeightIsh; // make room for header
 
         angular.element('html, body').animate({
           scrollTop: scrollDestination


### PR DESCRIPTION
@andrewconner fixed an airbrake when we have a hash of `#_=_` on the settings pages. Could be set by a social network on return to Kifi (see http://stackoverflow.com/questions/7131909/facebook-callback-appends-to-return-url)

https://fortytwo.airbrake.io/projects/113130/groups/1610942515712534049/notices/1610942512814494722
