### PR TITLE
Taking out Slack "create team" upsell page-load hook

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/layout/main/MainCtrl.js
@@ -240,17 +240,10 @@ angular.module('kifi')
       $rootElement.find('body').addClass('mac');
     }
 
-    function showSlackCreateTeamPopup() {
-      return profileService.prefs.show_slack_create_team_popup === true && profileService.me.slack &&
-        !profileService.me.slack.memberships.some(function (slackTeamInfo) {
-          return !!slackTeamInfo.orgId;
-        });
-    }
-
     var unregisterAutoShowGuide = $rootScope.$watch(function () {
       var newInstall = installService.installedVersion && profileService.prefs.auto_show_guide;
       var ftue = profileService.prefs.has_seen_ftue === false;
-      return newInstall || ftue || showSlackCreateTeamPopup();
+      return newInstall || ftue;
     }, function (show) {
       if (show) {
         if (profileService.prefs.has_seen_ftue === false) {
@@ -265,15 +258,6 @@ angular.module('kifi')
             }, 2000);
           }, 1000);
           unregisterAutoShowGuide();
-        } else if (profileService.isFakeUser() && showSlackCreateTeamPopup() && $state.current.name === 'home.feed') {
-          profileService.savePrefs({show_slack_create_team_popup: false});
-          modalService.open({
-            template: 'slack/newSlackUserTeamUpsellModal.tpl.html',
-            modalData: {}
-          });
-          unregisterAutoShowGuide();
-        } else if (profileService.prefs.show_slack_create_team_popup) {
-          profileService.savePrefs({show_slack_create_team_popup: false});
         }
       }
 


### PR DESCRIPTION
We're not going to deploy it today. This sort of logic should not be handled on the frontend, and is very fragile. Also a bit weird that slack memberships are included in `me` like that.

Currently, if `show_slack_create_team_popup` in the db is believed, just from users created today (UTC), 63 users have it set to true, but only 2 of those people are not in teams.

@camhashemi We'll revisit after the PH spike.
