### PR TITLE
Only persist valid sites

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationCommander.scala
@@ -94,11 +94,7 @@ class OrganizationCommanderImpl @Inject() (
 
   private def validateModifications(modifications: OrganizationModifications): Option[OrganizationFail] = {
     val badName = modifications.name.exists(_.isEmpty)
-    val normalizedSiteUrl = modifications.site.map { url =>
-      if (url.startsWith("http://") || url.startsWith("https://")) url
-      else "http://" + url
-    }
-    val badSiteUrl = normalizedSiteUrl.exists(URI.parse(_).isFailure)
+    val badSiteUrl = modifications.site.exists(URI.parse(_).isFailure)
 
     Stream(
       badName -> OrganizationFail.INVALID_MODIFY_NAME,

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackTeamCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackTeamCommander.scala
@@ -117,7 +117,7 @@ class SlackTeamCommanderImpl @Inject() (
                     case Some((_, imageUrl)) => orgAvatarCommander.persistRemoteOrganizationAvatars(orgId, imageUrl).imap(_ => ())
                   }
                   teamInfo.emailDomains.exists { domain =>
-                    orgCommander.modifyOrganization(OrganizationModifyRequest(userId, orgId, OrganizationModifications(site = Some(domain.value)))).isRight
+                    orgCommander.modifyOrganization(OrganizationModifyRequest(userId, orgId, OrganizationModifications(rawSite = Some(domain.value)))).isRight
                   }
                   val connectedTeamMaybe = connectSlackTeamToOrganization(userId, slackTeamId, orgId)
                   futureAvatar.flatMap { _ =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationCommanderTest.scala
@@ -137,7 +137,7 @@ class OrganizationCommanderTest extends TestKitSupport with SpecificationLike wi
 
           // An owner can do whatever they want
           val ownerModifyRequest = OrganizationModifyRequest(orgId = org.id.get, requesterId = owner.id.get,
-            modifications = OrganizationModifications(name = Some("The view is nice from up here"), site = Some("www.kifi.com")))
+            modifications = OrganizationModifications(name = Some("The view is nice from up here"), rawSite = Some("www.kifi.com")))
           val ownerModifyResponse = orgCommander.modifyOrganization(ownerModifyRequest)
           ownerModifyResponse must beRight
           ownerModifyResponse.right.get.request === ownerModifyRequest


### PR DESCRIPTION
We were trying to fix the modifications if they were invalid, but only in the validation method. Once we actually got to the modification method itself we reverted to using the bad data.

Best to construct the "best effort valid modifications" before validating.
