### PR TITLE
ansible - shoebox instance-size specifc JVM parameters

### DIFF
--- a/provisioning/roles/kifi.common/vars/shoebox/c3.2xlarge.yml
+++ b/provisioning/roles/kifi.common/vars/shoebox/c3.2xlarge.yml
@@ -1,0 +1,4 @@
+# c3.2xlarge has 15 GiB
+---
+service_jvm_Xms: 7G
+service_jvm_Xmx: 7G

--- a/provisioning/roles/kifi.common/vars/shoebox/m3.2xlarge.yml
+++ b/provisioning/roles/kifi.common/vars/shoebox/m3.2xlarge.yml
@@ -1,0 +1,4 @@
+# m3.2xlarge has 30 GiB
+---
+service_jvm_Xms: 7G
+service_jvm_Xmx: 7G

--- a/provisioning/roles/kifi.common/vars/shoebox/m3_xlarge.yml
+++ b/provisioning/roles/kifi.common/vars/shoebox/m3_xlarge.yml
@@ -1,0 +1,4 @@
+# m3.xlarge has 15 GiB
+---
+service_jvm_Xms: 7G
+service_jvm_Xmx: 7G


### PR DESCRIPTION
@andrewconner as we discussed, there's a lot of room to increase `m3.2xlarge` but it might not be necessary. I added the files for the instance types shoebox uses.  

new instances will automatically set the Xmx/Xms based on what's in these files
