### PR TITLE
fix mysql syntax error in getRecentKeepsByActivity

### DIFF
--- a/kifi-backend/modules/common/test/com/keepit/model/KeepFactory.scala
+++ b/kifi-backend/modules/common/test/com/keepit/model/KeepFactory.scala
@@ -24,7 +24,8 @@ object KeepFactory {
       libraryId = None,
       note = None,
       connections = KeepConnections(Set.empty, Set(userId)),
-      originalKeeperId = Some(userId)
+      originalKeeperId = Some(userId),
+      lastActivityAt = currentDateTime.minusYears(10).plusMinutes(idx.incrementAndGet().toInt)
     ))
   }
 
@@ -35,6 +36,7 @@ object KeepFactory {
     def withUser(user: User) = this.copy(keep = keep.copy(userId = user.id.get, connections = keep.connections.withUsers(Set(user.id.get))))
     def withCreatedAt(time: DateTime) = this.copy(keep = keep.copy(createdAt = time))
     def withKeptAt(time: DateTime) = this.copy(keep = keep.copy(keptAt = time))
+    def withLastActivityAt(time: DateTime) = this.copy(keep = keep.copy(lastActivityAt = time))
     def withId(id: Id[Keep]) = this.copy(keep = keep.copy(id = Some(id)))
     def withId(id: Int) = this.copy(keep = keep.copy(id = Some(Id[Keep](id))))
     def withId(id: ExternalId[Keep]) = this.copy(keep = keep.copy(externalId = id))

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
@@ -693,7 +693,7 @@ class KeepRepoImpl @Inject() (
       } yield (keepId, lastActivityAtForKeep)
     }
 
-    val last_activity_at_BEFORE = beforeIdOpt.flatMap(getKeepIdAndLastActivityAt).filter(_ => false) match {
+    val last_activity_at_BEFORE = beforeIdOpt.flatMap(getKeepIdAndLastActivityAt) match {
       case None => "true"
       case Some((keepId, before)) => s"last_activity_at < '$before' OR (last_activity_at = '$before' AND k.id < $keepId)"
     }


### PR DESCRIPTION
@leogrim @ryanpbrewster this was throwing an exception whenever `beforeIdOpt` was defined. this passes tests, so going to test it in prod (behind an exp).
