### PR TITLE
slack welcome flow improvements

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/slackConfirm.styl
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/slackConfirm.styl
@@ -14,8 +14,8 @@
     text-align: center
 
   .kf-slack-confirm-copied
-    top: 42px
-    right: 5px
+    top: 13px
+    right: -56px
     color: #0aa
     font-size: 14px
     position: absolute

--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/slackConfirm.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/slackConfirm.tpl.html
@@ -8,7 +8,7 @@
   <div ng-if="hasInstalled">
     <div class="kf-container kf-container-toppad">
       <div class="kf-container-header"><span>Share the love with your team</span></div>
-      <p>Since you already have our browser extensions (high five!), encourage your team to get it as well so they can benefit from the links kept here. Send them to this link to sign up with Slack and automatically join this Kifi team:</p>
+      <p>Since you already have our browser extension (high five!), encourage your team to get it as well so they can benefit from the links kept here. Send them to this link to sign up with Slack and automatically join this Kifi team:</p>
       <div class="kf-slack-confirm-team-link-wrapper">
         <input type="text" ng-model="teamLink" class="kf-textbox kf-slack-confirm-team-link" clipboard readonly text="teamLink" ng-click="clickedCopy()">
         <div ng-if="showCopiedConfirm" class="kf-slack-confirm-copied">Copied!</div>

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/routing/SlackAuthRouter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/routing/SlackAuthRouter.scala
@@ -64,7 +64,7 @@ class SlackAuthRouter @Inject() (
           case _ =>
         }
         _ <- Some(true) if weWantThisUserToAuthWithSlack(request.userIdOpt, org, slackTeamId)
-      } yield redirectThroughSlackAuth(org, slackTeamId, userPath)) orElse userPathOpt.map(Redirect(_))
+      } yield redirectThroughSlackAuth(org, slackTeamId, userPath, userId = Some(extId))) orElse userPathOpt.map(Redirect(_))
     }.getOrElse(notFound(request))
   }
 


### PR DESCRIPTION
@cvializ @andrewconner 

the "copied!" flash was overflowing the bottom border, so I positioned it to the right of the input instead. also added `userId` to params to populate the welcome message.
![screen shot 2016-02-02 at 10 35 21 am](https://cloud.githubusercontent.com/assets/8929238/12759968/db248da6-c998-11e5-82b7-d1cf06f76617.png)
