### PR TITLE
Bump version to 3.6.0

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.5.10
+version=3.6.0


### PR DESCRIPTION
@andrewconner 

@leogrim releases the switch to `sources` instead of `source` for Google search results

@camhashemi releases the change that removes the guard for the keep page
