### PR TITLE
add tests for getRecentKeepsByActivity, massage SQL query

### DIFF
--- a/kifi-backend/modules/common/test/com/keepit/model/KeepFactory.scala
+++ b/kifi-backend/modules/common/test/com/keepit/model/KeepFactory.scala
@@ -24,7 +24,8 @@ object KeepFactory {
       libraryId = None,
       note = None,
       connections = KeepConnections(Set.empty, Set(userId)),
-      originalKeeperId = Some(userId)
+      originalKeeperId = Some(userId),
+      lastActivityAt = currentDateTime.minusYears(10).plusMinutes(idx.incrementAndGet().toInt)
     ))
   }
 
@@ -55,6 +56,7 @@ object KeepFactory {
     def withURIId(id: Id[NormalizedURI]) = this.copy(keep = keep.copy(uriId = id))
     def withUri(uri: NormalizedURI) = this.copy(keep = keep.copy(uriId = uri.id.get, url = uri.url))
     def withUrl(url: String) = this.copy(keep = keep.copy(url = url))
+    def withLastActivityAt(time: DateTime) = this.copy(keep = keep.copy(lastActivityAt = time))
     def get: Keep = keep
   }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
@@ -126,13 +126,22 @@ class KeepRepoTest extends Specification with ShoeboxTestInjector {
     "most recent from followed libraries" in { //tests only that the query interpolates correctly
       withDb() { implicit injector =>
         db.readWrite { implicit s =>
+          import com.keepit.common.core._
+          val keepRepo = inject[KeepRepo]
           val user1 = user().saved
           val library = LibraryFactory.library().withOwner(user1).saved
-          val keep = KeepFactory.keep().withUser(user1).withLibrary(library).saved
+          val keeps = KeepFactory.keeps(50).map(_.withUser(user1).withLibrary(library).saved)
           inject[LibraryMembershipRepo]
-          inject[KeepRepo].getRecentKeeps(user1.id.get, 10, None, None, None)
-          inject[KeepRepo].getRecentKeeps(user1.id.get, 10, Some(keep.externalId), None, None)
-          inject[KeepRepo].getRecentKeeps(user1.id.get, 10, None, Some(keep.externalId), None)
+          keepRepo.getRecentKeeps(user1.id.get, 10, None, None, None)
+          keepRepo.getRecentKeeps(user1.id.get, 10, Some(keeps.head.externalId), None, None)
+          keepRepo.getRecentKeeps(user1.id.get, 10, None, Some(keeps.head.externalId), None)
+
+          val firstPage = keepRepo.getRecentKeepsByActivity(user1.id.get, 10, None, None, None)
+          val secondPage = keepRepo.getRecentKeepsByActivity(user1.id.get, 10, Some(firstPage.last._1.externalId), None, None)
+          secondPage.forall { case (_, time) => time.getMillis < firstPage.last._2.getMillis } === true
+          val thirdPage = keepRepo.getRecentKeepsByActivity(user1.id.get, 10, Some(secondPage.last._1.externalId), None, None)
+          thirdPage.forall { case (_, time) => time.getMillis < secondPage.last._2.getMillis } === true
+          secondPage.forall { case (_, time) => time.getMillis > thirdPage.head._2.getMillis } === true
           1 === 1
         }
       }


### PR DESCRIPTION
@leogrim @ryanpbrewster 

this is a bit messier than I'd like, but works (in test). I'm not sure how we get away with it in the current prod query, but it doesn't compile in test (after replacing `added_at` with `last_activity_at`).
