### PR TITLE
Fix slack attachments

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
@@ -14,6 +14,9 @@ package object json {
       def readIfPossible[T](implicit reads: Reads[T]): Reads[Option[T]] = {
         jsp.readNullable[T] orElse emptyReads
       }
+      def formatIfPossible[T](implicit reads: Reads[T], writes: Writes[T]): OFormat[Option[T]] = {
+        OFormat(readIfPossible, jsp.writeNullable)
+      }
     }
   }
   object EnumFormat {

--- a/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
@@ -7,6 +7,15 @@ import play.api.data.validation.ValidationError
 import scala.util.{Success, Failure, Try}
 
 package object json {
+  object ReadIfPossible {
+    def emptyReads[T] = Reads { j => JsSuccess(Option.empty[T]) }
+    implicit class PimpedJsPath(jsp: JsPath) {
+      // validation with readIfPossible ALWAYS succeeds, be careful when using it
+      def readIfPossible[T](implicit reads: Reads[T]): Reads[Option[T]] = {
+        jsp.readNullable[T] orElse emptyReads
+      }
+    }
+  }
   object EnumFormat {
     def reads[T](fromStr: (String => Option[T]), domain: Set[String] = Set.empty): Reads[T] = Reads { j =>
       def errMsg = if (domain.nonEmpty) s"$j is not one of these: $domain" else s"Could not recognize $j"

--- a/kifi-backend/modules/common/app/com/keepit/slack/models/SlackMessage.scala
+++ b/kifi-backend/modules/common/app/com/keepit/slack/models/SlackMessage.scala
@@ -90,22 +90,23 @@ object SlackAttachment {
     attachment.markdownIn: Option[Set[String]]
   ))
 
+  import com.keepit.common.json.ReadIfPossible._
   implicit val format: Format[SlackAttachment] = (
-    (__ \ 'fallback).formatNullable[String] and
-    (__ \ 'color).formatNullable[String] and
-    (__ \ 'pretext).formatNullable[String] and
-    (__ \ 'service_name).formatNullable[String] and
-    (__ \ 'author_name).formatNullable[String] and
-    (__ \ 'author_link).formatNullable[String] and
-    (__ \ 'author_icon).formatNullable[String] and
-    (__ \ 'title).formatNullable[String] and
-    (__ \ 'title_link).formatNullable[String] and
-    (__ \ 'text).formatNullable[String] and
-    (__ \ 'fields).formatNullable[Seq[SlackAttachment.Field]] and
-    (__ \ 'from_url).formatNullable[String] and
-    (__ \ 'image_url).formatNullable[String] and
-    (__ \ 'thumb_url).formatNullable[String] and
-    (__ \ 'mrkdwn_in).formatNullable[Set[String]]
+    (__ \ 'fallback).formatIfPossible[String] and
+    (__ \ 'color).formatIfPossible[String] and
+    (__ \ 'pretext).formatIfPossible[String] and
+    (__ \ 'service_name).formatIfPossible[String] and
+    (__ \ 'author_name).formatIfPossible[String] and
+    (__ \ 'author_link).formatIfPossible[String] and
+    (__ \ 'author_icon).formatIfPossible[String] and
+    (__ \ 'title).formatIfPossible[String] and
+    (__ \ 'title_link).formatIfPossible[String] and
+    (__ \ 'text).formatIfPossible[String] and
+    (__ \ 'fields).formatIfPossible[Seq[SlackAttachment.Field]] and
+    (__ \ 'from_url).formatIfPossible[String] and
+    (__ \ 'image_url).formatIfPossible[String] and
+    (__ \ 'thumb_url).formatIfPossible[String] and
+    (__ \ 'mrkdwn_in).formatIfPossible[Set[String]]
   )(applyFromSlack, unlift(unapplyToSlack))
 }
 


### PR DESCRIPTION
@leogrim @eishay Slack does not validate their input, and I sent them a badly formatted attachment a couple days ago. When we ingest my badly formatted attachment, we blow up (because we _do_ validate our input).

I'm making the SlackAttachment formatters way more resilient. Maybe I should add logging for this?
