### PR TITLE
Supporting Slack extension redirects

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/route.js
+++ b/kifi-backend/modules/shoebox/angular/src/route.js
@@ -325,7 +325,7 @@ angular.module('kifi')
         controller: 'KeepPageCtrl'
       })
       .state('slackIntegrationTeamChooser', {
-        url : '/integrations/slack/teams?slackTeamId',
+        url : '/integrations/slack/teams?slackTeamId&slackState',
         templateUrl: 'integrations/slack/teamChooser.tpl.html',
         controller: 'SlackIntegrationTeamChooserCtrl'
       })

--- a/packrat/adapters/chrome/manifest.json
+++ b/packrat/adapters/chrome/manifest.json
@@ -47,7 +47,8 @@
       ],
       "exclude_matches": [
         "*://*/r/*",
-        "*://*/s/*"
+        "*://*/s/*",
+        "*://*/redir/*"
       ],
       "run_at": "document_start"
     },
@@ -60,7 +61,9 @@
         "*://www.kifi.com/r/*",
         "*://dev.ezkeep.com/r/*",
         "*://www.kifi.com/s/*",
-        "*://dev.ezkeep.com/s/*"
+        "*://dev.ezkeep.com/s/*",
+        "*://www.kifi.com/redir/*",
+        "*://dev.ezkeep.com/redir/*"
       ],
       "run_at": "document_start"
     },

--- a/packrat/adapters/chrome/manifest.json
+++ b/packrat/adapters/chrome/manifest.json
@@ -46,7 +46,8 @@
         "*://dev.ezkeep.com/*"
       ],
       "exclude_matches": [
-        "*://*/r/*"
+        "*://*/r/*",
+        "*://*/s/*"
       ],
       "run_at": "document_start"
     },
@@ -57,7 +58,9 @@
       ],
       "matches": [
         "*://www.kifi.com/r/*",
-        "*://dev.ezkeep.com/r/*"
+        "*://dev.ezkeep.com/r/*",
+        "*://www.kifi.com/s/*",
+        "*://dev.ezkeep.com/s/*"
       ],
       "run_at": "document_start"
     },

--- a/packrat/scripts/deep_link_redirect.js
+++ b/packrat/scripts/deep_link_redirect.js
@@ -1,4 +1,4 @@
-// @match /^https?:\/\/(dev\.ezkeep\.com:9\d{3}|www\.kifi\.com)\/(r\/|redir).*/
+// @match /^https?:\/\/(dev\.ezkeep\.com:9\d{3}|www\.kifi\.com)\/(r\/|redir|s\/).*/
 // @require scripts/api.js
 // @asap
 


### PR DESCRIPTION
@cvializ Not sure if you've seen how our deep linking works. Currently, some email links are `https://www.kifi.com/r/some-uuid`. That url delivers basically a blank page, that attempts to inject data into the extension using a `data-kifi-deep-link` attribute populated with JSON. The extension listens on these URLs, and if it finds that attribute, redirects the browser and knows what to do next. If nothing happens in `x`ms, there's a `window.location = ...` on the page that completes the redirect.

This supports `/s`/ links too, which are redirects from Slack (the reason we're not using `/r/` is backend technical... the bit after the `/r/` is an id).

@camhashemi 
