### PR TITLE
Firefox tweaks

### DIFF
--- a/packrat/bin/deploy.sh
+++ b/packrat/bin/deploy.sh
@@ -4,48 +4,6 @@ set -o errexit
 
 pushd "$(dirname $0)/.." > /dev/null
 
-JSON_CMD=node_modules/json/lib/json.js
-AUTH_CMD=bin/getSignature.js
-
-function amo_upload() {
-  local URL="https://addons.mozilla.org/api/v3/addons/$1/versions/$2/"
-  local OUT=$( \
-    curl \
-    -qSsw '\n%{http_code}' \
-    -XPUT --form "upload=@$3" \
-    -H "Authorization: JWT $($AUTH_CMD)" \
-    $URL
-  )
-  local RET=$?
-
-  if [[ $RET -ne 0 ]]; then
-    echo "{ \"error\": \"$( echo "$OUT" | tail -n1 )\", \"code\": $RET }"
-    return $RET
-  fi
-
-  # Should print N lines, where N-1 are the response,
-  # and the last line is the HTTP code
-  echo "$OUT"
-}
-
-function amo_status() {
-  local URL="https://addons.mozilla.org/api/v3/addons/$1/versions/$2/"
-  local OUT=$(
-    curl \
-    -qSsw '\n%{http_code}' \
-    -H "Authorization: JWT $($AUTH_CMD)" \
-    $URL
-  )
-  local RET=$?
-
-  if [[ $RET -ne 0 ]]; then
-    echo "{ \"error\": \"$( echo "$OUT" | tail -n1 )\", \"code\": $RET }"
-    return $RET
-  fi
-
-  echo "$OUT"
-}
-
 if [[ ! -f FortyTwo.pem ]]; then
 
   echo $'\nERROR: need FortyTwo.pem in '$(pwd)' (ask Carlos or Andrew)'
@@ -77,116 +35,32 @@ elif [[ -f out/kifi.xpi && -f out/kifi.update.rdf ]]; then
   echo $'\nDeploying REAL Firefox extension to kifi.com'
   read -p 'Press Enter or Ctrl-C '
 
-  # TODO(carlos): When jpm 1.0.4+ is released (and hopefully not buggy),
-  # remove this mess and use `jpm sign` instead
-  if [[ ! -f out/kifi-signed.xpi ]]; then
+  bin/review.sh || REVIEW_STATUS_CODE=$?
 
-    ID=$(cat out/firefox/package.json | $JSON_CMD id)
-    VERSION=$(cat out/firefox/package.json | $JSON_CMD version)
-    UNSIGNED_XPI="out/kifi.xpi"
+  if [[ REVIEW_STATUS_CODE -ne 0 ]]; then
+    echo 'Firefox review failed. Exiting.'
+    echo '(if it failed after after validation go to addons.mozilla.org to download the signed xpi)'
+    echo '(then name it "kifi-signed.xpi", put it in "./out" and re-run this script to upload it to S3)'
+    exit $?
+  fi
 
-    # Step 1: Upload the unsigned XPI for validation and signing
-    UPLOAD_RESULT=$( amo_upload $ID $VERSION $UNSIGNED_XPI )
-    UPLOAD_RESULT_CODE=$?
+  if [[ -f out/kifi-signed.xpi ]]; then
 
-    UPLOAD_RESULT_JSON=$( echo "$UPLOAD_RESULT" | tail -r | tail +2 | tail -r ) # all but last line
-    UPLOAD_ERR=$(echo "$UPLOAD_RESULT_JSON" | $JSON_CMD error detail)
+    echo 'Uploading to S3...'
 
-    if [[ "$UPLOAD_RESULT_CODE" -ne 0 || -n "$UPLOAD_ERR" ]]; then
+    aws s3api put-object --bucket kifi-bin --key ext/firefox/kifi.xpi \
+      --content-type 'application/x-xpinstall' --body out/kifi-signed.xpi \
+      --cache-control 'no-cache, no-store'
+    aws s3api put-object --bucket kifi-bin --key ext/firefox/kifi.update.rdf \
+      --content-type 'application/rdf+xml' --body ./kifi.update.rdf \
+      --cache-control 'no-cache, no-store'
 
-      echo "Upload Error: $UPLOAD_ERR"
-      exit 1
+  else
 
-    fi
-
-    # Step 2: Check if processing has finished
-    # If not: poll
-    # If finished: check if valid
-    # If valid: proceed, else fail
-    #
-    # Continue polling until the file is present in the response
-    # Then save the URL and download it
-
-    STATUS_WAITING=''
-
-    printf "Fetching validation.."
-
-    while true; do
-
-      STATUS_RESULT=$( amo_status $ID $VERSION )
-      STATUS_RESULT_CODE=$?
-      STATUS_RESULT_JSON="$( echo "$STATUS_RESULT" | tail -r | tail +2 | tail -r )"
-
-      STATUS_PROCESSED="$(echo "$STATUS_RESULT_JSON" | $JSON_CMD processed)"
-      STATUS_ERR="$(echo "$STATUS_RESULT_JSON" | $JSON_CMD error detail)"
-      STATUS_VALID="$(echo "$STATUS_RESULT_JSON" | $JSON_CMD valid)"
-      STATUS_FILE_URL="$( echo "$STATUS_RESULT_JSON" | $JSON_CMD files | $JSON_CMD -c this.signed | $JSON_CMD 0.download_url )"
-
-      if [[ "$STATUS_RESULT_CODE" -ne 0 || -n "$STATUS_ERR" ]]; then # check for errors from cUrl
-
-        echo "Status Error: $STATUS_ERR"
-        exit 1
-
-      elif [ "$STATUS_PROCESSED" == "true" ]; then # check to see if validation has completed
-
-        if [ "$STATUS_VALID" != "true" ]; then # validation failed, quit
-
-          echo "Failed validation : ("
-          echo "$STATUS_RESULT_JSON" | $JSON_CMD validation_results
-          exit 1
-
-        else
-
-          if [ -n "$STATUS_FILE_URL" ]; then
-
-            # Validation passed, break out of the polling while-loop
-            printf $'\nPassed validation!'
-            break
-
-          else
-            if [ -z $STATUS_WAITING ]; then
-
-              STATUS_WAITING='WAITING'
-              printf $'\nPassed validation!'
-              printf $'\nBut the signed file isn\'t ready. It may take ~3 minutes to become available'
-              printf $'\n(Download the xpi from https://addons.mozilla.org/en-US/developers/addons if it fails)'
-              printf $'\nWaiting..'
-
-            fi
-            # continue to wait
-          fi
-
-        fi
-
-      fi
-      sleep 5 # it's not ready, so continue polling
-      printf "."
-    done
-
-    # Step 3: Download the file
-    printf $'\nDownloading signed file from '$STATUS_FILE_URL
-    curl \
-    -gqSsLw '\n%{http_code}\n' \
-    -o "out/kifi-signed.xpi" \
-    -H "Authorization: JWT $($AUTH_CMD)" \
-    "$STATUS_FILE_URL"
-
-    if [[ ! -f out/kifi-signed.xpi ]]; then
-
-      printf $'\nCouldn\'t find out/kifi-signed.xpi for upload. Exiting.'
-      exit 1
-
-    fi
+    echo 'Not uploading to S3: listed addons are hosted by Mozilla'
 
   fi
 
-  echo 'Uploading to S3...'
-  aws s3api put-object --bucket kifi-bin --key ext/firefox/kifi.xpi \
-    --content-type 'application/x-xpinstall' --body out/kifi-signed.xpi \
-    --cache-control 'no-cache, no-store'
-  aws s3api put-object --bucket kifi-bin --key ext/firefox/kifi.update.rdf \
-    --content-type 'application/rdf+xml' --body out/kifi.update.rdf \
-    --cache-control 'no-cache, no-store'
   echo $'Done.\n\n!! Please upload kifi.zip to the Chrome Web Store at https://chrome.google.com/webstore/developer/dashboard'
 
 elif [[ -f out/kifi-dev.crx && -f out/kifi-dev.xml && -f out/kifi-dev.xpi && -f out/kifi-dev.update.rdf ]]; then

--- a/packrat/bin/duplicateRdfDescription.js
+++ b/packrat/bin/duplicateRdfDescription.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+var runningAsScript = (require.main === module);
+var fs = require('fs');
+var es = require('event-stream');
+var xml2js = require('xml2js');
+var infile = process.argv[2];
+var outfile = process.argv[3];
+var unlisted = (process.argv[4] === 'unlisted');
+
+var inStream = (!infile || infile === '-' ? process.stdin : fs.createReadStream(infile, { flags: 'r' }));
+var outStream = (!outfile || outfile === '-' ? process.stdout : fs.createWriteStream(outfile));
+
+if (runningAsScript) {
+  inStream
+  .pipe(duplicateRdfDescription({ unlisted: unlisted }))
+  .pipe(outStream);
+}
+
+module.exports = duplicateDescription;
+
+function duplicateRdfDescription(options) {
+  options = options || {};
+  options.unlisted = unlisted || (typeof options.unlisted === 'boolean' ? options.unlisted : false);
+
+  return es.pipeline(
+    es.wait(),
+    es.map(parseXml),
+    es.map(duplicateDescription.bind(null, unlisted)),
+    es.map(buildXml)
+  );
+}
+
+function parseXml(rdfString, callback) {
+  var parser = new xml2js.Parser();
+  parser.parseString(rdfString, function (err, result) {
+    callback(err, err ? '' : JSON.stringify(result));
+  });
+}
+
+function duplicateDescription(unlisted, rdfJson, callback) {
+  var root = JSON.parse(rdfJson);
+  var descriptions = root.RDF.Description;
+  var originalDescription = descriptions[0];
+  var id = (unlisted ? 'kifi-unlisted@42go.com' : 'kifi@42go.com');
+  var copiedDescription;
+
+  if (descriptions.length === 1) {
+    copiedDescription = copyJson(originalDescription);
+    setDescriptionId(copiedDescription, id);
+    setDescriptionId(originalDescription, id);
+    copiedDescription.$.about = copiedDescription.$.about.replace(/kifi@42go\.com/g, 'kifi-unlisted@42go.com');
+    descriptions.push(copiedDescription);
+  }
+
+  callback(null, JSON.stringify(root));
+}
+
+function setDescriptionId(description, id) {
+  description['em:updates'][0].Seq[0].li[0].Description[0]['em:id'] = id;
+}
+
+function buildXml(rdfJson, callback) {
+  var rdfObj = JSON.parse(rdfJson);
+
+  var builder = new xml2js.Builder();
+  var xml = builder.buildObject(rdfObj);
+
+  callback(null, xml);
+}
+
+function copyJson(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/packrat/bin/review.sh
+++ b/packrat/bin/review.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# TODO(carlos): When `jpm sign` is mature (and hopefully not buggy),
+# remove this mess and use `jpm sign` instead
+
+JSON_CMD=node_modules/json/lib/json.js
+AUTH_CMD=bin/getSignature.js
+
+function amo_upload() {
+  local URL="https://addons.mozilla.org/api/v3/addons/$1/versions/$2/"
+  local OUT=$( \
+    curl \
+    -qSsw '\n%{http_code}' \
+    -XPUT --form "upload=@$3" \
+    -H "Authorization: JWT $($AUTH_CMD)" \
+    $URL
+  )
+  local RET=$?
+
+  if [[ $RET -ne 0 ]]; then
+    echo "{ \"error\": \"$( echo "$OUT" | tail -n1 )\", \"code\": $RET }"
+    return $RET
+  fi
+
+  # Should print N lines, where N-1 are the response,
+  # and the last line is the HTTP code
+  echo "$OUT"
+}
+
+function amo_status() {
+  local URL="https://addons.mozilla.org/api/v3/addons/$1/versions/$2/"
+  local OUT=$(
+    curl \
+    -qSsw '\n%{http_code}' \
+    -H "Authorization: JWT $($AUTH_CMD)" \
+    $URL
+  )
+  local RET=$?
+
+  if [[ $RET -ne 0 ]]; then
+    echo "{ \"error\": \"$( echo "$OUT" | tail -n1 )\", \"code\": $RET }"
+    return $RET
+  fi
+
+  echo "$OUT"
+}
+
+if [[ -f out/kifi-signed.xpi ]]; then
+
+  echo "The signed out/kifi-signed.xpi is present! Continuing..."
+
+else
+
+  ID=$(cat out/firefox/package.json | $JSON_CMD id)
+  VERSION=$(cat out/firefox/package.json | $JSON_CMD version)
+  UNSIGNED_XPI="out/kifi.xpi"
+
+  # Step 1: Upload the unsigned XPI for validation and signing
+  UPLOAD_RESULT=$( amo_upload $ID $VERSION $UNSIGNED_XPI )
+  UPLOAD_RESULT_CODE=$?
+
+  UPLOAD_RESULT_JSON=$( echo "$UPLOAD_RESULT" | tail -r | tail +2 | tail -r ) # all but last line
+  UPLOAD_ERR=$(echo "$UPLOAD_RESULT_JSON" | $JSON_CMD error detail)
+
+  if [[ "$UPLOAD_RESULT_CODE" -ne 0 || -n "$UPLOAD_ERR" ]]; then
+
+    echo "Upload Error: $UPLOAD_ERR"
+    exit 1
+
+  fi
+
+  # Step 2: If it's listed don't sign it.
+  # If not, check if processing has finished.
+  # If not: poll
+  # If finished: check if valid
+  # If valid: proceed, else fail
+  #
+  # Continue polling until the file is present in the response
+  # Then save the URL and download it
+
+  if [[ -n $( grep -n '<em:id>kifi@42go.com</em:id>' out/kifi.update.rdf ) ]]; then
+    # it's a listed addon
+
+    echo "Skipping signing for listed addon"
+    exit 0
+
+  else
+
+    STATUS_WAITING=''
+
+    printf "Fetching validation.."
+
+    while true; do
+
+      STATUS_RESULT=$( amo_status $ID $VERSION )
+      STATUS_RESULT_CODE=$?
+      STATUS_RESULT_JSON="$( echo "$STATUS_RESULT" | tail -r | tail +2 | tail -r )"
+
+      STATUS_PROCESSED="$(echo "$STATUS_RESULT_JSON" | $JSON_CMD processed)"
+      STATUS_ERR="$(echo "$STATUS_RESULT_JSON" | $JSON_CMD error detail)"
+      STATUS_VALID="$(echo "$STATUS_RESULT_JSON" | $JSON_CMD valid)"
+      STATUS_FILE_URL="$( echo "$STATUS_RESULT_JSON" | $JSON_CMD files | $JSON_CMD -c this.signed | $JSON_CMD 0.download_url )"
+
+      if [[ "$STATUS_RESULT_CODE" -ne 0 || -n "$STATUS_ERR" ]]; then # check for errors from cUrl
+
+        echo "Status Error: $STATUS_ERR"
+        exit 1
+
+      elif [ "$STATUS_PROCESSED" == "true" ]; then # check to see if validation has completed
+
+        if [ "$STATUS_VALID" != "true" ]; then # validation failed, quit
+
+          echo "Failed validation : ("
+          echo "$STATUS_RESULT_JSON" | $JSON_CMD validation_results
+          exit 1
+
+        else
+
+          if [ -n "$STATUS_FILE_URL" ]; then
+
+            # Validation passed, break out of the polling while-loop
+            printf $'\nPassed validation!'
+            break
+
+          else
+            if [ -z $STATUS_WAITING ]; then
+
+              STATUS_WAITING='WAITING'
+              printf $'\nPassed validation!'
+              printf $'\nBut the signed file isn\'t ready. It may take ~3 minutes to become available'
+              printf $'\n(Download the xpi from https://addons.mozilla.org/en-US/developers/addons if it fails)'
+              printf $'\nWaiting..'
+
+            fi
+            # continue to wait
+          fi
+
+        fi
+
+      fi
+      sleep 5 # it's not ready, so continue polling
+      printf "."
+    done
+
+  fi # rdf check
+
+  # Step 3: Download the file
+  printf $'\nDownloading signed file from '$STATUS_FILE_URL
+  curl \
+  -gqSsLw '\n%{http_code}\n' \
+  -o "out/kifi-signed.xpi" \
+  -H "Authorization: JWT $($AUTH_CMD)" \
+  "$STATUS_FILE_URL"
+
+  if [[ ! -f out/kifi-signed.xpi ]]; then
+
+    printf $'\nCouldn\'t find out/kifi-signed.xpi for upload. Exiting.'
+    exit 1
+
+  fi
+
+fi

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.7.1
+version=3.7.2

--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.7.0
+version=3.7.1

--- a/packrat/package.json
+++ b/packrat/package.json
@@ -32,6 +32,7 @@
     "new-from": "0.0.3",
     "run-sequence": "~0.3.6",
     "through2": "~0.5.1",
-    "vinyl-map": "~1.0.1"
+    "vinyl-map": "~1.0.1",
+    "xml2js": "^0.4.16"
   }
 }


### PR DESCRIPTION
@andrewconner 

Highlights:
- Factored out review code into bin/review.sh
- Added new Firefox extension with id `kifi-unlisted@42go.com`
- `kifi.update.rdf` has entries for both `kifi-unlisted@42go.com` and `kifi@42go.com`.
- We will host `kifi-unlisted@42go.com` at `https://www.kifi.com/extensions/firefox/kifi.xpi`
- Clients currently on the `kifi@42go.com` extension will automatically transition to `kifi-unlisted@42go.com` extension

Note:
- In the future when `kifi@42go.com` is reviewed and listed, clients will not be able to transition back to the unlisted extension

The build/deploy process will be the same as before. `gulp package` and `bin/deploy.sh`. If you need to manage the extension on addons.mozilla.org, know the difference between kifi-unlisted and kifi.

A `gulp package-listed` is in the gulpfile which will build a new version to the listed extension, and running `bin/deploy.sh` will deploy it.
