### PR TITLE
Introduce SlackController.{turnChannelIngestion, turnLibraryPush}

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/slack/models/SlackAuth.scala
+++ b/kifi-backend/modules/common/app/com/keepit/slack/models/SlackAuth.scala
@@ -41,7 +41,7 @@ object SlackAuthScope {
   val UsersRead = SlackAuthScope("users:read")
   val UsersWrite = SlackAuthScope("users:write")
 
-  val brokenPush: Set[SlackAuthScope] = Set(Commands, ChatWriteBot)
+  val brokenPush: Set[SlackAuthScope] = Set(Commands, ChatWriteBot) + ChannelsRead // adding ChannelsReads *temporarily* as an attempt to backfill some of the missing channel ids
   val newPush: Set[SlackAuthScope] = Set(Commands, IncomingWebhook)
   val ingest: Set[SlackAuthScope] = Set(SearchRead, ReactionsWrite, Commands)
   val integrationSetup = newPush

--- a/kifi-backend/modules/common/app/com/keepit/slack/models/SlackAuth.scala
+++ b/kifi-backend/modules/common/app/com/keepit/slack/models/SlackAuth.scala
@@ -41,9 +41,10 @@ object SlackAuthScope {
   val UsersRead = SlackAuthScope("users:read")
   val UsersWrite = SlackAuthScope("users:write")
 
-  val push: Set[SlackAuthScope] = Set(Commands)
+  val brokenPush: Set[SlackAuthScope] = Set(Commands, ChatWriteBot)
+  val newPush: Set[SlackAuthScope] = Set(Commands, IncomingWebhook)
   val ingest: Set[SlackAuthScope] = Set(SearchRead, ReactionsWrite, Commands)
-  val integrationSetup = Set(IncomingWebhook) ++ push
+  val integrationSetup = newPush
 
   val pushAnywhere: Set[SlackAuthScope] = Set(ChannelsRead, ChatWriteBot, Commands)
   val ingestAnywhere: Set[SlackAuthScope] = ingest + ChannelsRead

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackAuthenticationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackAuthenticationCommander.scala
@@ -78,15 +78,15 @@ class SlackAuthenticationCommanderImpl @Inject() (
         case _ => Future.failed(SlackActionFail.MissingWebhook(userId))
       }
 
-      case TurnOnLibraryPush(integrationId) => incomingWebhook match {
+      case TurnLibraryPush(integrationId, _, turnOn) => incomingWebhook match {
         case Some(webhook) =>
-          val libraryId = slackIntegrationCommander.turnOnLibraryPush(Id(integrationId), webhook, slackTeamId, slackUserId)
+          val libraryId = slackIntegrationCommander.turnLibraryPush(Id(integrationId), slackTeamId, slackUserId, turnOn)
           Future.successful(redirectToLibrary(libraryId, showSlackDialog = true))
         case _ => Future.failed(SlackActionFail.MissingWebhook(userId))
       }
 
-      case TurnOnChannelIngestion(integrationId) =>
-        val libraryId = slackIntegrationCommander.turnOnChannelIngestion(Id(integrationId), slackTeamId, slackUserId)
+      case TurnChannelIngestion(integrationId, turnOn) =>
+        val libraryId = slackIntegrationCommander.turnChannelIngestion(Id(integrationId), slackTeamId, slackUserId, turnOn)
         Future.successful(redirectToLibrary(libraryId, showSlackDialog = true))
 
       case AddSlackTeam(andThen) => slackTeamCommander.addSlackTeam(userId, slackTeamId).flatMap {

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackInfoCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackInfoCommander.scala
@@ -171,7 +171,7 @@ class SlackInfoCommanderImpl @Inject() (
           val authLink = {
             // todo(Léo): kill this authLink and have the front-end always call SlackController.turnOnChannelIngestion
             val existingScopes = teamMembershipMap.get(fs.slackUserId, fs.slackTeamId).flatMap(_.tokenWithScopes.map(_.scopes)) getOrElse Set.empty
-            val action = TurnOnChannelIngestion(fs.id.get.id)
+            val action = TurnChannelIngestion(fs.id.get.id, turnOn = true)
             val missingScopes = action.getMissingScopes(existingScopes)
             if (missingScopes.isEmpty) None
             else Some(slackStateCommander.getAuthLink(action, Some(fs.slackTeamId), missingScopes, SlackOAuthController.REDIRECT_URI).url)
@@ -184,7 +184,7 @@ class SlackInfoCommanderImpl @Inject() (
           val authLink = {
             // todo(Léo): kill this authLink and have the front-end always call SlackController.turnOnLibraryPush
             val existingScopes = teamMembershipMap.get(ts.slackUserId, ts.slackTeamId).flatMap(_.tokenWithScopes.map(_.scopes)) getOrElse Set.empty
-            val action = TurnOnLibraryPush(ts.id.get.id)
+            val action = TurnLibraryPush(ts.id.get.id, isBroken = false, turnOn = true)
             val missingScopes = action.getMissingScopes(existingScopes)
             if (missingScopes.isEmpty) None
             else Some(slackStateCommander.getAuthLink(action, Some(ts.slackTeamId), missingScopes, SlackOAuthController.REDIRECT_URI).url)

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackIntegrationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackIntegrationCommander.scala
@@ -232,7 +232,7 @@ class SlackIntegrationCommanderImpl @Inject() (
       case (userId, teamId, channelName) =>
         log.info(s"Fetching channelId for Slack channel $channelName via user $userId in team $teamId")
         tokensWithScopesByUserIdAndTeamId(userId, teamId) match {
-          case Some((token, scopes)) if scopes.contains(SlackAuthScope.SearchRead) => slackClient.getChannelId(token, channelName).map {
+          case Some((token, scopes)) if scopes intersect Set(SlackAuthScope.SearchRead, SlackAuthScope.ChannelsRead) nonEmpty => slackClient.getChannelId(token, channelName).map {
             case Some(channelId) =>
               log.info(s"Found channelId $channelId for Slack channel $channelName via user $userId in team $teamId")
               db.readWrite { implicit session =>

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -471,6 +471,8 @@ GET     /site/rpb/org/:orgId/libraries     @com.keepit.controllers.website.UserC
 
 POST  /site/libraries/:id/slack/add         @com.keepit.controllers.website.SlackController.setupLibraryIntegrations(id: PublicId[Library])
 POST  /site/libraries/:id/slack/modify      @com.keepit.controllers.website.SlackController.modifyIntegrations(id: PublicId[Library])
+POST  /site/libraries/:id/slack/push/:ltsId        @com.keepit.controllers.website.SlackController.pushLibrary(id: PublicId[Library], ltsId: String, turnOn: Boolean)
+POST  /site/libraries/:id/slack/ingest/:stlId      @com.keepit.controllers.website.SlackController.ingestChannel(id: PublicId[Library], stlId: String, turnOn: Boolean)
 POST  /site/libraries/:id/slack/delete      @com.keepit.controllers.website.SlackController.deleteIntegrations(id: PublicId[Library])
 
 GET     /site/user/me               @com.keepit.controllers.website.UserController.currentUser()

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/SlackFactories.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/SlackFactories.scala
@@ -31,7 +31,7 @@ object SlackTeamMembershipFactory {
       slackTeamId = SlackTeamId(ran(10)),
       slackTeamName = SlackTeamName(ran(10)),
       token = Some(SlackAccessToken(ran(30))),
-      scopes = SlackAuthScope.push ++ SlackAuthScope.ingest,
+      scopes = SlackAuthScope.newPush ++ SlackAuthScope.ingest,
       slackUser = None
     ))
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/slack/SlackCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/slack/SlackCommanderTest.scala
@@ -30,7 +30,7 @@ class SlackCommanderTest extends TestKitSupport with SpecificationLike with Shoe
           }
           val slackUser = SlackUserFactory.user()
           val ident = SlackIdentifyResponse("http://www.rando.slack.com/", slackTeam.slackTeamName, slackUser.username, slackTeam.slackTeamId, slackUser.userId)
-          val auth = SlackAuthorizationResponse(SlackAccessToken(RandomStringUtils.randomAlphanumeric(30)), SlackAuthScope.push, slackTeam.slackTeamName, slackTeam.slackTeamId, None)
+          val auth = SlackAuthorizationResponse(SlackAccessToken(RandomStringUtils.randomAlphanumeric(30)), SlackAuthScope.newPush, slackTeam.slackTeamName, slackTeam.slackTeamId, None)
 
           db.readOnlyMaster { implicit s => inject[SlackTeamMembershipRepo].all must beEmpty }
           slackCommander.registerAuthorization(Some(user1.id.get), auth, ident)


### PR DESCRIPTION
@andrewconner 
We should use these endpoints instead of `SlackController.modifyIntegration` on both org Slack settings and library Slack settings pages.

Additionally on the library Slack settings page, we should no longer let people toggle the library space (we can leave it for now).

Which means we should no longer use `SlackController.modifyIntegration` anywhere
