### PR TITLE
organization invite reminder emails (for internal testing only)

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/BasicOrganizationView.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/BasicOrganizationView.scala
@@ -40,6 +40,8 @@ object OrganizationInviteInfo {
   )(OrganizationInviteInfo.apply, unlift(OrganizationInviteInfo.unapply))
 
   def fromInvite(invite: OrganizationInvite, inviter: BasicUser): OrganizationInviteInfo = {
+    // TODO(josh) should this be changed to the following?
+    // OrganizationInviteInfo(inviter, invite.emailAddress, invite.lastReminderSentAt.getOrElse(invite.createdAt))
     OrganizationInviteInfo(inviter, invite.emailAddress, invite.createdAt)
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/model/NotificationCategory.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/NotificationCategory.scala
@@ -46,6 +46,7 @@ object NotificationCategory {
     val MANY_NEW_KEEPS = NotificationCategory("many_new_keeps")
 
     val ORGANIZATION_INVITATION = NotificationCategory("organization_invitation")
+    val ORGANIZATION_INVITATION_REMINDER = NotificationCategory("organization_invitation_reminder")
     val ORGANIZATION_JOINED = NotificationCategory("organization_joined")
     val REWARD_CREDIT_APPLIED = NotificationCategory("reward_credit_applied")
     val CREATE_TEAM = NotificationCategory("create_team")
@@ -57,7 +58,8 @@ object NotificationCategory {
 
     val reportToAnalytics = Set(ANNOUNCEMENT, MESSAGE, EMAIL_KEEP, EMAIL_CONFIRMATION, RESET_PASSWORD, FRIEND_REQUEST,
       FRIEND_ACCEPTED, WELCOME, APPROVED, WAITLIST, WHO_KEPT_MY_KEEP, CONTACT_JOINED, CONNECTION_MADE,
-      SOCIAL_FRIEND_JOINED, LIBRARY_FOLLOWING, LIBRARY_INVITATION, ORGANIZATION_INVITATION, DIGEST, ACTIVITY, CREATE_TEAM, JOIN_BY_VERIFYING)
+      SOCIAL_FRIEND_JOINED, LIBRARY_FOLLOWING, LIBRARY_INVITATION, ORGANIZATION_INVITATION, ORGANIZATION_INVITATION_REMINDER,
+      DIGEST, ACTIVITY, CREATE_TEAM, JOIN_BY_VERIFYING)
 
     // Parent Categories used in analytics
     val fromKifi = Set(ANNOUNCEMENT, WAITLIST, APPROVED, WELCOME, EMAIL_CONFIRMATION, RESET_PASSWORD, EMAIL_KEEP,
@@ -67,7 +69,7 @@ object NotificationCategory {
 
     // Formatting Categories used in the extension
     val triggered = Set(FRIEND_ACCEPTED, FRIEND_REQUEST, WHO_KEPT_MY_KEEP, CONTACT_JOINED, CONNECTION_MADE, SOCIAL_FRIEND_JOINED, LIBRARY_INVITATION, LIBRARY_FOLLOWED, NEW_KEEP, MANY_NEW_KEEPS,
-      ORGANIZATION_INVITATION, ORGANIZATION_JOINED)
+      ORGANIZATION_INVITATION, ORGANIZATION_INVITATION_REMINDER, ORGANIZATION_JOINED)
     val global = Set(ANNOUNCEMENT)
     val kifiMessageFormattingCategory = Map.empty ++ triggered.map(_ -> "triggered") ++ global.map(_ -> "global")
   }
@@ -89,6 +91,7 @@ object NotificationCategory {
     val DISCUSSION_UPDATES = NotificationCategory("discussion_updates")
     val LIBRARY_INVITATION = NotificationCategory("visitor_library_invitation")
     val ORGANIZATION_INVITATION = NotificationCategory("visitor_organization_invitation")
+    val ORGANIZATION_INVITATION_REMINDER = NotificationCategory("visitor_organization_invitation_reminder")
     val BILLING = NotificationCategory("billing")
 
     val INTEGRATION_WELCOME = NotificationCategory("integration_welcome")
@@ -102,7 +105,8 @@ object NotificationCategory {
     val SETTINGS_TOGGLE = NotificationCategory("settings_toggle")
     val BOT_SETTINGS_UPGRADE = NotificationCategory("bot_settings_upgrade_dm")
 
-    val reportToAnalytics = Set(INVITATION, DISCUSSION_STARTED, DISCUSSION_UPDATES, ADDED_TO_DISCUSSION, LIBRARY_INVITATION, ORGANIZATION_INVITATION, BILLING)
+    val reportToAnalytics = Set(INVITATION, DISCUSSION_STARTED, DISCUSSION_UPDATES, ADDED_TO_DISCUSSION, LIBRARY_INVITATION,
+      ORGANIZATION_INVITATION, ORGANIZATION_INVITATION_REMINDER, BILLING)
 
     // Formatting Categories used in the extension
     val fromFriends = Set(INVITATION, DISCUSSION_STARTED, ADDED_TO_DISCUSSION, DISCUSSION_UPDATES, LIBRARY_INVITATION)

--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationExperiment.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationExperiment.scala
@@ -62,9 +62,10 @@ object OrganizationExperimentType {
 
   val FAKE = OrganizationExperimentType("fake")
   val SLACK_PERSONAL_DIGESTS = OrganizationExperimentType("slack_personal_digests")
+  val ORG_INVITE_REMINDERS = OrganizationExperimentType("org_invite_reminders")
 
   val _ALL = List(
-    FAKE, SLACK_PERSONAL_DIGESTS
+    FAKE, SLACK_PERSONAL_DIGESTS, ORG_INVITE_REMINDERS
   )
 
   def get(str: String): OrganizationExperimentType = OrganizationExperimentType(str.toLowerCase.trim)

--- a/kifi-backend/modules/common/app/com/keepit/model/OrganizationInvite.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/OrganizationInvite.scala
@@ -6,7 +6,6 @@ import com.keepit.common.crypto.{ ModelWithPublicId, PublicIdGenerator }
 import com.keepit.common.db.{ Id, ModelWithState, State, States }
 import com.keepit.common.mail.EmailAddress
 import com.keepit.common.time._
-import com.keepit.model.InvitationDecision.ACCEPTED
 import com.kifi.macros.json
 import org.apache.commons.lang3.RandomStringUtils
 import org.joda.time.DateTime
@@ -25,7 +24,9 @@ case class OrganizationInvite(
     emailAddress: Option[EmailAddress] = None,
     role: OrganizationRole = OrganizationRole.MEMBER,
     message: Option[String] = None,
-    authToken: String = RandomStringUtils.randomAlphanumeric(16)) extends ModelWithPublicId[OrganizationInvite] with ModelWithState[OrganizationInvite] {
+    authToken: String = RandomStringUtils.randomAlphanumeric(16),
+    remindersSent: Int = 0,
+    lastReminderSentAt: Option[DateTime] = None) extends ModelWithPublicId[OrganizationInvite] with ModelWithState[OrganizationInvite] {
 
   def withId(id: Id[OrganizationInvite]): OrganizationInvite = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime): OrganizationInvite = this.copy(updatedAt = now)
@@ -72,7 +73,9 @@ object OrganizationInvite extends PublicIdGenerator[OrganizationInvite] {
     (__ \ 'emailAddress).format[Option[EmailAddress]] and
     (__ \ 'role).format[OrganizationRole] and
     (__ \ 'message).format[Option[String]] and
-    (__ \ 'authToken).format[String]
+    (__ \ 'authToken).format[String] and
+    (__ \ 'remindersSent).format[Int] and
+    (__ \ 'lastReminderSentAt).formatNullable(DateTimeJsonFormat)
   )(OrganizationInvite.apply, unlift(OrganizationInvite.unapply))
 
   implicit def ord: Ordering[OrganizationInvite] = new Ordering[OrganizationInvite] {

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/443.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/443.sql
@@ -1,0 +1,10 @@
+# SHOEBOX
+
+# --- !Ups
+
+ALTER TABLE organization_invite ADD COLUMN reminders_sent SMALLINT NOT NULL DEFAULT 0;
+ALTER TABLE organization_invite ADD COLUMN last_reminder_sent_at DATETIME NULL;
+
+INSERT INTO evolutions (name, description) VALUES ('443.sql', 'add reminder columns to organization_invite');
+
+# --- !Downs

--- a/kifi-backend/modules/common/test/com/keepit/model/OrganizationFactory.scala
+++ b/kifi-backend/modules/common/test/com/keepit/model/OrganizationFactory.scala
@@ -1,4 +1,5 @@
 package com.keepit.model
+
 import java.util.concurrent.atomic.AtomicLong
 
 import com.keepit.classify.NormalizedHostname

--- a/kifi-backend/modules/common/test/com/keepit/model/OrganizationInviteFactory.scala
+++ b/kifi-backend/modules/common/test/com/keepit/model/OrganizationInviteFactory.scala
@@ -1,0 +1,40 @@
+package com.keepit.model
+
+import java.util.concurrent.atomic.AtomicLong
+
+import com.keepit.common.db.Id
+import com.keepit.common.mail.EmailAddress
+import org.joda.time.DateTime
+
+object OrganizationInviteFactory {
+  private[this] val idx = new AtomicLong(System.currentTimeMillis() % 100)
+
+  def organizationInvite(): PartialOrganizationInvite = new PartialOrganizationInvite(OrganizationInvite(
+    organizationId = Id[Organization](idx.getAndIncrement()),
+    inviterId = Id[User](idx.getAndIncrement())
+  ))
+
+  def organizationInvites(count: Int): Seq[PartialOrganizationInvite] = List.fill(count)(organizationInvite())
+
+  case class PartialOrganizationInvite private[OrganizationInviteFactory] (orgInvite: OrganizationInvite) {
+    def withOrganization(org: Organization) = PartialOrganizationInvite(orgInvite.copy(organizationId = org.id.get))
+    def withOrganizationId(orgId: Id[Organization]) = PartialOrganizationInvite(orgInvite.copy(organizationId = orgId))
+    def withInviter(inviter: User) = PartialOrganizationInvite(orgInvite.copy(inviterId = inviter.id.get))
+    def withUser(user: User) = PartialOrganizationInvite(orgInvite.copy(userId = user.id))
+    def withEmailAddress(emailAddress: EmailAddress) = PartialOrganizationInvite(orgInvite.copy(emailAddress = Some(emailAddress)))
+    def withDecision(decision: InvitationDecision) = PartialOrganizationInvite(orgInvite.copy(decision = decision))
+    def withCreatedAt(date: DateTime) = PartialOrganizationInvite(orgInvite.copy(createdAt = date))
+    def get: OrganizationInvite = OrganizationInvite(
+      decision = orgInvite.decision,
+      organizationId = orgInvite.organizationId,
+      inviterId = orgInvite.inviterId,
+      userId = orgInvite.userId,
+      emailAddress = orgInvite.emailAddress,
+      createdAt = orgInvite.createdAt
+    )
+  }
+
+  implicit class PartialOrganizationInviteSeq(invites: Seq[PartialOrganizationInvite]) {
+    def get: Seq[OrganizationInvite] = invites.map(_.get)
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
@@ -1,12 +1,12 @@
 package com.keepit.commanders
 
-import com.google.inject.{ Provider, ImplementedBy, Inject, Singleton }
+import com.google.inject.{ ImplementedBy, Inject, Provider, Singleton }
 import com.keepit.abook.ABookServiceClient
 import com.keepit.abook.model.RichContact
 import com.keepit.commanders.emails.EmailTemplateSender
 import com.keepit.common.akka.SafeFuture
+import com.keepit.common.concurrent.ReactiveLock
 import com.keepit.common.controller.UserRequest
-import com.keepit.common.time._
 import com.keepit.common.core._
 import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.db.Id
@@ -18,9 +18,10 @@ import com.keepit.common.mail._
 import com.keepit.common.mail.template.EmailToSend
 import com.keepit.common.mail.template.TemplateOptions._
 import com.keepit.common.social.BasicUserRepo
+import com.keepit.common.time._
 import com.keepit.common.util.{ LinkElement, DescriptionElements }
 import com.keepit.eliza.{ OrgPushNotificationRequest, OrgPushNotificationCategory, ElizaServiceClient, PushNotificationExperiment, UserPushNotificationCategory }
-import com.keepit.heimdal.HeimdalContext
+import com.keepit.heimdal.{ ContextBoolean, ContextData, HeimdalContext }
 import com.keepit.model._
 import com.keepit.notify.model.Recipient
 import com.keepit.notify.model.event.{ OrgInviteAccepted, OrgNewInvite }
@@ -28,6 +29,7 @@ import com.keepit.search.SearchServiceClient
 import com.keepit.slack.{ SlackClientWrapper, SlackActionFail }
 import com.keepit.slack.models._
 import com.keepit.social.BasicUser
+import org.joda.time.ReadableDuration
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -46,6 +48,8 @@ trait OrganizationInviteCommander {
   def getViewerInviteInfo(orgId: Id[Organization], viewerIdOpt: Option[Id[User]], authTokenOpt: Option[String]): Option[OrganizationInviteInfo]
   def getInvitesByInviteeAndDecision(userId: Id[User], decision: InvitationDecision): Set[OrganizationInvite]
   def sendOrganizationInviteViaSlack(username: SlackUsername, orgId: Id[Organization], userIdOpt: Option[Id[User]]): Future[Unit]
+  def sendInviteReminders(durationOfNoResponse: ReadableDuration, maxRemindersSent: Int): Future[Seq[(Id[Organization], Int)]]
+  def sendInviteReminder(orgInvite: OrganizationInvite): Future[Option[ElectronicMail]]
 }
 
 @Singleton
@@ -73,6 +77,8 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
     slackChannelRepo: SlackChannelRepo,
     slackClient: SlackClientWrapper,
     pathCommander: PathCommander,
+    orgExperimentRepo: OrganizationExperimentRepo,
+    clock: Clock,
     implicit val publicIdConfig: PublicIdConfiguration) extends OrganizationInviteCommander with Logging {
 
   private def getValidationError(request: OrganizationInviteRequest)(implicit session: RSession): Option[OrganizationFail] = {
@@ -163,7 +169,7 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
 
   // return whether the invitation was persisted or not.
   private def persistInvitation(invite: OrganizationInvite, force: Boolean = false): Option[OrganizationInvite] = {
-    val OrganizationInvite(_, _, _, _, _, orgId, inviterId, recipientId, recipientEmail, _, _, _) = invite
+    val OrganizationInvite(_, _, _, _, _, orgId, inviterId, recipientId, recipientEmail, _, _, _, _, _) = invite
     val shouldInsert = force || db.readOnlyMaster { implicit s =>
       (recipientId, recipientEmail) match {
         case (Some(userId), _) =>
@@ -198,12 +204,7 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
   }
 
   def sendInvite(invite: OrganizationInvite, org: Organization): Future[Option[ElectronicMail]] = {
-    val toRecipientOpt: Option[Either[Id[User], EmailAddress]] =
-      if (invite.userId.isDefined) Some(Left(invite.userId.get))
-      else if (invite.emailAddress.isDefined) Some(Right(invite.emailAddress.get))
-      else None
-
-    toRecipientOpt map { toRecipient =>
+    getInviteRecipient(invite) map { toRecipient =>
       val trimmedInviteMsg = invite.message map (_.trim) filter (_.nonEmpty)
       val fromUserId = invite.inviterId
       val authToken = invite.authToken
@@ -225,6 +226,12 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
       airbrake.notify(s"OrganizationInvite does not have a recipient: $invite")
       Future.successful(None)
     }
+  }
+
+  def getInviteRecipient(invite: OrganizationInvite): Option[Either[Id[User], EmailAddress]] = {
+    if (invite.userId.isDefined) Some(Left(invite.userId.get))
+    else if (invite.emailAddress.isDefined) Some(Right(invite.emailAddress.get))
+    else None
   }
 
   def notifyInviteeAboutInvitationToJoinOrganization(org: Organization, orgOwner: BasicUser, inviter: User, invitees: Set[Id[User]]) {
@@ -478,6 +485,58 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
             log.info(s"[OrgDMInvite] sending to slack team ${slackTeamId.value}, user ${slackUserId.value}")
             slackClient.sendToSlackHoweverPossible(slackTeamId, slackUserId.asChannel, message).map(_ => ())
         }
+    }
+  }
+
+  def sendInviteReminders(durationOfNoResponse: ReadableDuration, maxRemindersSent: Int): Future[Seq[(Id[Organization], Int)]] = {
+    // do not send more than 1 email in parallel
+    val lock: ReactiveLock = new ReactiveLock
+    val maxLastReminderSentAt = clock.now().minus(durationOfNoResponse)
+
+    db.readOnlyReplica { implicit session =>
+      val orgsWithPendingInvites = organizationInviteRepo.getDecisionCountsGroupedByOrganization(Set(InvitationDecision.PENDING), OrganizationInviteStates.ACTIVE)
+
+      Future.sequence(orgsWithPendingInvites.map {
+        case (orgId, _) =>
+          if (orgExperimentRepo.hasExperiment(orgId, OrganizationExperimentType.ORG_INVITE_REMINDERS)) {
+            organizationInviteRepo.getAllByLastReminderSentAt(orgId, maxLastReminderSentAt, maxRemindersSent).foldLeft(Future.successful(0)) {
+              case (emailsSentF, invite) =>
+                emailsSentF.flatMap { emailsSent =>
+                  lock.withLockFuture { sendInviteReminder(invite).map(emailOpt => if (emailOpt.isDefined) emailsSent + 1 else emailsSent) }
+                }
+            }.map(emailsSent => orgId -> emailsSent)
+          } else Future.successful(orgId -> 0)
+      })
+    }
+  }
+
+  def sendInviteReminder(invite: OrganizationInvite): Future[Option[ElectronicMail]] = {
+    val fromUserId = invite.inviterId
+    db.readWrite { implicit session =>
+      organizationInviteRepo.save(invite.copy(remindersSent = invite.remindersSent + 1, lastReminderSentAt = Some(clock.now())))
+
+      getInviteRecipient(invite).map { toRecipient =>
+        val auxiliaryData = new HeimdalContext(Map[String, ContextData](("reminder", ContextBoolean(true))))
+        val emailToSend = EmailToSend(
+          fromName = Some(Right("Kifi")),
+          from = SystemEmailAddress.NOTIFICATIONS,
+          subject = s"Reminder", // TODO(josh)
+          to = toRecipient,
+          category = toRecipient.fold(
+            _ => NotificationCategory.User.ORGANIZATION_INVITATION_REMINDER,
+            _ => NotificationCategory.NonUser.ORGANIZATION_INVITATION_REMINDER),
+          htmlTemplate = views.html.email.organizationInvitationReminderPlain(toRecipient.left.toOption, fromUserId),
+          textTemplate = Some(views.html.email.organizationInvitationReminderText(toRecipient.left.toOption, fromUserId)),
+          templateOptions = Seq(CustomLayout).toMap,
+          auxiliaryData = Some(auxiliaryData),
+          campaign = Some("na"),
+          channel = Some("vf_email"),
+          source = Some("organization_invite_reminder") // TODO(josh)
+        )
+        emailTemplateSender.send(emailToSend).map(Some(_))
+      } getOrElse {
+        Future.successful(None)
+      }
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/cron/InviteReminderEmailCron.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/cron/InviteReminderEmailCron.scala
@@ -1,0 +1,59 @@
+package com.keepit.shoebox.cron
+
+import com.google.inject.Inject
+import com.keepit.commanders.{ OrganizationInviteCommander, UserEmailAddressCommander }
+import com.keepit.common.actor.ActorInstance
+import com.keepit.common.akka.FortyTwoActor
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.logging.Logging
+import com.keepit.common.plugin.{ SchedulerPlugin, SchedulingProperties }
+import com.keepit.common.time._
+import com.keepit.model.UserEmailAddressRepo
+import org.joda.time.Duration
+import us.theatr.akka.quartz.QuartzActor
+
+import scala.concurrent.ExecutionContext
+
+private[cron] object SendOrganizationInviteReminder
+
+class InviteReminderEmailActor @Inject() (
+    airbrake: AirbrakeNotifier,
+    db: Database,
+    userEmailAddressRepo: UserEmailAddressRepo,
+    userEmailAddressCommander: UserEmailAddressCommander,
+    organizationInviteCommander: OrganizationInviteCommander,
+    clock: Clock,
+    implicit val executionContext: ExecutionContext) extends FortyTwoActor(airbrake) with Logging {
+
+  def receive() = {
+    case SendOrganizationInviteReminder =>
+      val minDurationBetweenLastEmail = Duration.standardDays(3)
+      val maxRemindersSent = Int.MaxValue // todo(josh) should this be anything?
+
+      log.info(s"sending organization invite reminder emails")
+      organizationInviteCommander.sendInviteReminders(minDurationBetweenLastEmail, maxRemindersSent)
+  }
+}
+
+class InviteReminderEmailCron @Inject() (
+  actor: ActorInstance[InviteReminderEmailActor],
+  quartz: ActorInstance[QuartzActor],
+  val scheduling: SchedulingProperties)
+    extends SchedulerPlugin with Logging {
+
+  // plugin lifecycle methods
+  override def enabled: Boolean = true
+  override def onStart() {
+    // computes UTC hour for current 9am ET (EDT or EST)
+    val nowET = currentDateTime(zones.ET)
+    val offsetMillisToUtc = zones.ET.getOffset(nowET)
+    val offsetHoursToUtc = offsetMillisToUtc / 1000 / 60 / 60
+    val utcHourFor9amEasternTime = 9 + -offsetHoursToUtc
+
+    // <sec> <min> <hr> <day of mo> <mo> <day of wk> <yr>
+    val cronTime = s"0 0 $utcHourFor9amEasternTime ? * *" // 1pm UTC - send every day at 9am EDT / 6am PDT
+    // TODO(josh) uncomment when this is ready to test
+    // cronTaskOnLeader(quartz, actor.ref, cronTime, SendOrganizationInviteReminder)
+  }
+}

--- a/kifi-backend/modules/shoebox/app/views/email/organizationInvitationReminderPlain.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/organizationInvitationReminderPlain.scala.html
@@ -1,0 +1,13 @@
+@(inviteeId: Option[Id[User]], inviterId: Id[User])
+@import com.keepit.common.mail.template.helpers._
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+</head>
+<body>
+@* TODO(josh) *@
+Hi, this is a friendly reminder to join my team.
+</body>
+</html>

--- a/kifi-backend/modules/shoebox/app/views/email/organizationInvitationReminderPlain.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/organizationInvitationReminderPlain.scala.html
@@ -1,13 +1,38 @@
-@(inviteeId: Option[Id[User]], inviterId: Id[User])
+@(
+    inviteeId: Option[Id[User]],
+    inviterId: Id[User],
+    inviteMsg: Option[String],
+    orgId: Id[Organization],
+    authToken: String
+)
+
 @import com.keepit.common.mail.template.helpers._
+@orgLink = @{organizationLink(orgId, Some(authToken), "clickedOrgURL")}
+
+@* setting up message components that depend on conditionals *@
+@salutation = {
+@if(inviteeId.isEmpty) {
+<p>Hello,</p>
+} else {
+<p>Hi @firstName(inviteeId.get),</p>
+}
+}
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 </head>
-<body>
-@* TODO(josh) *@
-Hi, this is a friendly reminder to join my team.
+<p>
+@salutation
+<p>
+    @fullName(inviterId) is waiting your response to join the
+    <a href="@orgLink"><b>@organizationName(orgId)</b></a> team on Kifi,
+    so you can access and build our team's knowledge.
+</p>
+@if(inviteMsg.isDefined) {
+<br/>
+<p>"@inviteMsg.get" - @firstName(inviterId)</p>
+}
 </body>
 </html>

--- a/kifi-backend/modules/shoebox/app/views/email/organizationInvitationReminderText.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/email/organizationInvitationReminderText.scala.html
@@ -1,0 +1,4 @@
+@(inviteeId: Option[Id[User]], inviterId: Id[User])
+
+@* TODO(josh) *@
+Hi, this is a friendly to join my team.

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationInviteCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/OrganizationInviteCommanderTest.scala
@@ -2,22 +2,26 @@ package com.keepit.commanders
 
 import com.google.inject.Injector
 import com.keepit.abook.FakeABookServiceClientModule
-import com.keepit.abook.model.RichContact
 import com.keepit.common.actor.TestKitSupport
 import com.keepit.common.concurrent.FakeExecutionContextModule
 import com.keepit.common.db.Id
 import com.keepit.common.mail.EmailAddress
 import com.keepit.common.social.FakeSocialGraphModule
+import com.keepit.common.time._
 import com.keepit.heimdal.{ FakeHeimdalServiceClientModule, HeimdalContext }
+import com.keepit.model.NotificationCategory.fromElectronicMailCategory
 import com.keepit.model.OrganizationFactoryHelper._
+import com.keepit.model.OrganizationInviteFactory.organizationInvite
+import com.keepit.model.OrganizationInviteFactoryHelper._
 import com.keepit.model.UserFactoryHelper._
 import com.keepit.model.{ OrganizationFactory, _ }
 import com.keepit.social.BasicUser
 import com.keepit.test.ShoeboxTestInjector
+import org.joda.time.Duration.standardDays
 import org.specs2.mutable.SpecificationLike
 
 import scala.concurrent.Await
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 
 class OrganizationInviteCommanderTest extends TestKitSupport with SpecificationLike with ShoeboxTestInjector {
   implicit val context = HeimdalContext.empty
@@ -180,6 +184,79 @@ class OrganizationInviteCommanderTest extends TestKitSupport with SpecificationL
             orgInviteRepo.getByOrgAndUserId(org.id.get, invitee.id.get) must beEmpty
             permissionCommander.getOrganizationPermissions(org.id.get, Some(invitee.id.get)) must not contain (OrganizationPermission.VIEW_ORGANIZATION)
           }
+        }
+      }
+    }
+
+    "send invite reminder emails" in {
+      "sends the email on command" in withDb(modules: _*) { implicit injector =>
+        val orgInvite = db.readWrite { implicit session =>
+          val (org, owner, user) = setup
+          organizationInvite().withOrganization(org).withEmailAddress(EmailAddress("cam@panthers.com")).withInviter(owner).saved
+        }
+
+        orgInvite.remindersSent === 0
+        val emailOpt = Await.result(orgInviteCommander.sendInviteReminder(orgInvite), 5 seconds)
+        emailOpt must beSome
+
+        db.readOnlyMaster { implicit session =>
+          val updatedOrgInvite = orgInviteRepo.get(orgInvite.id.get)
+          updatedOrgInvite.remindersSent === 1
+          updatedOrgInvite.lastReminderSentAt must beSome
+          val Seq(email) = electronicMailRepo.all()
+          email === emailOpt.get
+          email.to === Seq(orgInvite.emailAddress.get)
+          email.htmlBody.value must contain("reminder to join my team")
+          fromElectronicMailCategory(email.category) === NotificationCategory.NonUser.ORGANIZATION_INVITATION_REMINDER
+        }
+      }
+
+      "sends reminder emails to those who have an old pending invite" in withDb(modules: _*) { implicit injector =>
+        val now = inject[Clock].now()
+        def daysAgo(n: Int) = now.minusDays(n)
+
+        val (org1, org2, invites) = db.readWrite { implicit session =>
+          val owner = UserFactory.user().withName("Roger", "Goodell").saved
+          val org1 = OrganizationFactory.organization().withName("Carolina Panthers").withOwner(owner).withHandle(OrganizationHandle("keeppounding")).withWeakMembers().saved
+          val org2 = OrganizationFactory.organization().withName("Denver Broncos").withOwner(owner).withHandle(OrganizationHandle("broncos")).withWeakMembers().saved
+
+          inject[OrganizationExperimentRepo].save(OrganizationExperiment(orgId = org1.id.get, experimentType = OrganizationExperimentType.ORG_INVITE_REMINDERS))
+
+          def invite = organizationInvite().withOrganization(org1).withInviter(owner)
+          val invites = Seq(
+            // 2 of these guys should get a reminder email, 2 should not b/c they were invited < 3 days ago
+            invite.withEmailAddress(EmailAddress("mtolbert@panthers.com")).withCreatedAt(daysAgo(2)).saved,
+            invite.withEmailAddress(EmailAddress("golsen@panthers.com")).withCreatedAt(daysAgo(3).plusMinutes(1)).saved,
+            invite.withEmailAddress(EmailAddress("jstewart@panthers.com")).withCreatedAt(daysAgo(4)).saved,
+            invite.withEmailAddress(EmailAddress("cnewton@panthers.com")).withCreatedAt(daysAgo(5)).saved,
+
+            // this org isn't in the ORG_INVITE_REMINDERS experiment, this shouldn't send a reminder
+            organizationInvite().withOrganization(org2).withCreatedAt(daysAgo(6)).saved
+          )
+
+          (org1, org2, invites)
+        }
+
+        val remindersSentByOrg = Await.result(orgInviteCommander.sendInviteReminders(standardDays(3), Int.MaxValue), 5 seconds)
+        remindersSentByOrg.size === 2
+        remindersSentByOrg.head === (org1.id.get, 2)
+        remindersSentByOrg(1) === (org2.id.get, 0)
+
+        def assertNotSentTo(inv: OrganizationInvite) = { inv.lastReminderSentAt must beNone; inv.remindersSent === 0 }
+        def assertSentTo(inv: OrganizationInvite) = { inv.lastReminderSentAt must beSome; inv.remindersSent === 1 }
+
+        db.readOnlyMaster { implicit session =>
+          val Seq(otherguy, newton, stewart, olsen, tolbert) = orgInviteRepo.all().sortBy(_.createdAt)
+          tolbert === invites.head
+          olsen === invites(1)
+
+          assertNotSentTo(tolbert)
+          assertNotSentTo(olsen)
+          assertNotSentTo(otherguy)
+          assertSentTo(stewart)
+          assertSentTo(newton)
+
+          electronicMailRepo.count === 2
         }
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationInviteFactoryHelper.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/OrganizationInviteFactoryHelper.scala
@@ -1,0 +1,13 @@
+package com.keepit.model
+
+import com.google.inject.Injector
+import com.keepit.common.db.slick.DBSession.RWSession
+import com.keepit.model.OrganizationInviteFactory.PartialOrganizationInvite
+
+object OrganizationInviteFactoryHelper {
+  implicit class OrganizationInvitePersister(partialOrgInvite: PartialOrganizationInvite) {
+    def saved(implicit injector: Injector, session: RWSession): OrganizationInvite = {
+      injector.getInstance(classOf[OrganizationInviteRepo]).save(partialOrgInvite.get.copy(id = None))
+    }
+  }
+}

--- a/tools/mixpanel_export/.gitignore
+++ b/tools/mixpanel_export/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 /logs/*.log
 /exports/
+/failed/


### PR DESCRIPTION
this is still a WIP (need content, rules for how often to send these emails, and additional requirements from @JRuff42), but this is the basic logic for sending organization invite reminder emails.

the basic logic thus far is: every morning a job will run that will lookup any invites that are pending & active and (created > 3 days ago OR last reminder sent > 3 days ago), and send the email (3 is variable of course).  there is also logic to not send a reminder email after so many have been sent already.

this is my first time working with organizations, so please review.  feedback appreciated

@andrewconner
