### PR TITLE
Fix empty sources area from showing when no sources available

### DIFF
--- a/packrat/html/search/google_hit.html
+++ b/packrat/html/search/google_hit.html
@@ -34,18 +34,20 @@
       {{/libraries}}
       <a class="kifi-res-libs-n" href="javascript:">{{librariesMore}}</a>
     {{/libraries.length}}
-    {{#sources}}
-      <span class="kifi-res-source">
-        {{#twitter.tweet}}
-          <span class="kifi-res-source-twitter-icon"></span>
-          <a class="kifi-res-source-tweet-user" href="https://www.twitter.com/{{user.screen_name}}/status/{{id_str}}">@{{user.screen_name}}</a>
-        {{/twitter.tweet}}
-        {{#slack.message}}
-          <span class="kifi-res-source-slack-icon"></span>
-          <a class="kifi-res-source-slack-channel" href="{{permalink}}">#{{channel.name}}</a>
-        {{/slack.message}}
-      </span>
-    {{/sources}}
+    {{#sources.length}}
+      {{#sources}}
+        <span class="kifi-res-source">
+          {{#twitter.tweet}}
+            <span class="kifi-res-source-twitter-icon"></span>
+            <a class="kifi-res-source-tweet-user" href="https://www.twitter.com/{{user.screen_name}}/status/{{id_str}}">@{{user.screen_name}}</a>
+          {{/twitter.tweet}}
+          {{#slack.message}}
+            <span class="kifi-res-source-slack-icon"></span>
+            <a class="kifi-res-source-slack-channel" href="{{permalink}}">#{{channel.name}}</a>
+          {{/slack.message}}
+        </span>
+      {{/sources}}
+    {{/sources.length}}
     {{#tags.length}}
       <span class="kifi-res-tags"></span>
       {{#tags}}

--- a/packrat/scripts/google_inject.js
+++ b/packrat/scripts/google_inject.js
@@ -915,7 +915,7 @@ if (searchUrlRe.test(document.URL)) !function () {
       librariesMore: hit.librariesOmitted || '',
       tags: hit.tags,
       tagsMore: hit.tagsOmitted || '',
-      sources: (hit.sources || [ hit.source ]).sort(prioritizeSlack),
+      sources: (hit.sources || []).sort(prioritizeSlack),
       origin: response.origin
     };
   }


### PR DESCRIPTION
@andrewconner I used a truthy-check on an array instead of on the array's length. left a " | " in the results without sources
