### PR TITLE
use keep to populate pane when there is no notification

### DIFF
--- a/packrat/html/keeper/message_participants.html
+++ b/packrat/html/keeper/message_participants.html
@@ -1,6 +1,6 @@
 <div class="kifi-message-participants{{#isOverflowed}} kifi-overflow{{/isOverflowed}}" data-kifi-participants="{{participantCount}}">
   <div class="kifi-message-participants-1">
-    <div class="kifi-message-participants-title">Notes</div>
+    <div class="kifi-message-participants-title">{{#onKeep}}Comments{{/onKeep}}{{^onKeep}}Notes{{/onKeep}}</div>
   </div>
   <div class="kifi-message-participants-2">
     <div class="kifi-message-participants-title">A {{#onKeep}}keep by{{/onKeep}}{{^onKeep}}discussion with{{/onKeep}}</div>

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1102,9 +1102,13 @@ api.port.on({
     } else {
       // TODO: remember that this tab needs this thread info until it gets it or its pane changes?
       socket.send(['get_one_thread', id], function (th) {
-        standardizeNotification(th);
-        updateIfJustRead(th);
-        notificationsById[th.thread] = th;
+        if (th) { 
+          standardizeNotification(th);
+          updateIfJustRead(th);
+          notificationsById[th.thread] = th;
+        } else { // th = null if the thread has no notif (e.g. deeplink to user's own keep)
+          th = { thread: id };
+        }
         emitThreadInfoToTab(th, keep, tab);
       });
     }
@@ -1314,7 +1318,6 @@ api.port.on({
       if (!contacts.some(idIs(SUPPORT.id)) && (data.q ? sf.filter(data.q, [SUPPORT], getName).length : contacts.length < data.n)) {
         appendUserResult(contacts, data.n, SUPPORT);
       }
-      //debugger;
       var results = contacts
         .filter(function (elem) { return data.exclude.indexOf(elem.id || elem.email) === -1; })
         .slice(0, data.n)


### PR DESCRIPTION
@andrewconner @cvializ @leogrim 

everything works with "Add comment" unless the conversation doesn't exist, and especially when the keep is your own (since fetching a notification explodes). this has the server return `null` when there is no notification (not exploding), so that the ext can use the `keep` and `threadId` to populate the pane.

one remaining bug is that `add_participants` doesn't return a response when there's no thread (even though it creates a thread and adds the participants), so there's no immediate feedback, that's next. but this should get the feature 95% working.
