### PR TITLE
Actually update the org profile when accepting an invite.

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.js
@@ -149,7 +149,7 @@ angular.module('kifi')
               .acceptOrgMemberInvite(scope.profile.id, $location.search().authToken)
               .then(function () {
                 scope.acknowledgedInvite = true;
-                $state.reload();
+                $state.reload('orgProfile');
               });
           }
         }

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileService.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileService.js
@@ -76,12 +76,12 @@ angular.module('kifi')
         .then(profileService.fetchMe);
       },
       removeOrgMember: function (orgId, removeFields) {
-
         return net
         .removeOrgMember(orgId, removeFields)
         .then(function () {
           invalidateOrgProfileCache();
-        });
+        })
+        .then(profileService.fetchMe);
       },
       transferOrgMemberOwnership: function (orgId, newOwner) {
         return net.transferOrgMemberOwnership(orgId, newOwner);


### PR DESCRIPTION
Jen noticed this wasn't working. You have to tell `ui-router` how far up the state tree you want it to reload. Fetching the new `me` object won't hurt either, since it has a list of full org objects on it.
