### PR TITLE
allow add_participants sytem message to create notifs

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationDeliveryCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationDeliveryCommander.scala
@@ -311,8 +311,8 @@ class NotificationDeliveryCommander @Inject() (
     message.createdAt
   }
 
-  def getSendableNotification(userId: Id[User], keepId: Id[Keep], includeUriSummary: Boolean): Future[NotificationJson] = {
-    getNotificationsByUser(userId, UserThreadQuery(keepIds = Some(Set(keepId)), limit = 1), includeUriSummary).map(_.head)
+  def getSendableNotification(userId: Id[User], keepId: Id[Keep], includeUriSummary: Boolean): Future[Option[NotificationJson]] = {
+    getNotificationsByUser(userId, UserThreadQuery(keepIds = Some(Set(keepId)), limit = 1), includeUriSummary).map(_.headOption)
   }
 
   def getUnreadThreadNotifications(userId: Id[User]): Seq[UserThreadNotification] = {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
@@ -126,9 +126,9 @@ class SharedWsMessagingController @Inject() (
       case JsNumber(requestId) +: JsString(keepIdStr) +: _ =>
         Keep.decodePublicIdStr(keepIdStr).foreach { keepId =>
           (for {
-            json <- notificationDeliveryCommander.getSendableNotification(socket.userId, keepId, needsPageImages(socket))
+            jsonOpt <- notificationDeliveryCommander.getSendableNotification(socket.userId, keepId, needsPageImages(socket))
           } yield {
-            socket.channel.push(Json.arr(requestId.toLong, json.obj))
+            socket.channel.push(Json.arr(requestId.toLong, jsonOpt.map(_.obj).getOrElse[JsValue](JsNull)))
           }).onFailure {
             case f =>
               airbrake.notify(f)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PermissionCommander.scala
@@ -275,7 +275,6 @@ class PermissionCommanderImpl @Inject() (
           }
           viewerIsDirectlyConnectedToKeep || viewerCanAddMessageViaLibrary
         }
-        Option
         val canAddParticipants = canAddMessage
         val canDeleteOwnMessages = true
         val canDeleteOtherMessages = {


### PR DESCRIPTION
@andrewconner @leogrim tested adding participants with "new keep added" notifs, and when the thread doesn't have messages on it the notif doesn't send and they can't see the thread. hopefully this takes care of that.

also realized that we don't check any permissions on these either, something to think about.
