### PR TITLE
Make OrganizationInfo use SlackTeamInfo instead of OrgSlackInfo

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
@@ -15,6 +15,7 @@ import com.keepit.common.db.slick._
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.common.mail.{ EmailAddress, _ }
+import com.keepit.common.performance.StatsdTiming
 import com.keepit.common.service.{ RequestConsolidator, IpAddress }
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.common.store.S3ImageStore
@@ -280,6 +281,7 @@ class UserCommanderImpl @Inject() (
     abookServiceClient.uploadContacts(userId, origin, payload)
   }
 
+  @StatsdTiming("UserCommander.getUserInfo")
   def getUserInfo(user: User): BasicUserInfo = {
     val (basicUser, biography, emails, pendingPrimary, notAuthed, numLibraries, numConnections, numFollowers, orgViews, pendingOrgViews, potentialOrgs, userSlackInfo) = db.readOnlyMaster { implicit session =>
       val basicUser = basicUserRepo.load(user.id.get)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/OrganizationView.scala
@@ -5,7 +5,7 @@ import com.keepit.common.db.ExternalId
 import com.keepit.common.net.URI
 import com.keepit.common.store.ImagePath
 import com.keepit.model.OrganizationModifications.SiteModification
-import com.keepit.slack.OrganizationSlackInfo
+import com.keepit.slack.{ OrganizationSlackTeamInfo, OrganizationSlackInfo }
 import com.keepit.social.BasicUser
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
@@ -22,7 +22,7 @@ case class OrganizationInfo(
     numMembers: Int,
     numLibraries: Int,
     config: Option[ExternalOrganizationConfiguration],
-    slack: Option[OrganizationSlackInfo]) {
+    slackTeam: Option[OrganizationSlackTeamInfo]) {
   def toBasicOrganization: BasicOrganization = BasicOrganization(this.orgId, this.ownerId, this.handle, this.name, this.description, this.avatarPath)
 }
 object OrganizationInfo {
@@ -38,7 +38,7 @@ object OrganizationInfo {
     (__ \ 'numMembers).write[Int] and
     (__ \ 'numLibraries).write[Int] and
     (__ \ 'config).writeNullable[ExternalOrganizationConfiguration] and
-    (__ \ 'slack).writeNullable[OrganizationSlackInfo]
+    (__ \ 'slack).writeNullable[OrganizationSlackTeamInfo]
   )(unlift(OrganizationInfo.unapply))
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackInfoCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackInfoCommander.scala
@@ -78,6 +78,7 @@ trait SlackInfoCommander {
 
   // For generating OrganizationInfo
   def getOrganizationSlackInfo(orgId: Id[Organization], viewerId: Id[User])(implicit session: RSession): OrganizationSlackInfo
+  def getOrganizationSlackTeam(orgId: Id[Organization], viewerId: Id[User])(implicit session: RSession): Option[OrganizationSlackTeamInfo]
 
   // For generating UserProfileStats
   def getUserSlackInfo(userId: Id[User], viewerId: Option[Id[User]])(implicit session: RSession): UserSlackInfo
@@ -212,6 +213,9 @@ class SlackInfoCommanderImpl @Inject() (
     }
   }
 
+  def getOrganizationSlackTeam(orgId: Id[Organization], viewerId: Id[User])(implicit session: RSession): Option[OrganizationSlackTeamInfo] = {
+    slackTeamRepo.getByOrganizationId(orgId).map(team => OrganizationSlackTeamInfo(team.slackTeamId, team.slackTeamName, team.publicChannelsLastSyncedAt))
+  }
   def getOrganizationSlackInfo(orgId: Id[Organization], viewerId: Id[User])(implicit session: RSession): OrganizationSlackInfo = {
     val (libIds, basicLibsById, integrationInfosByLib, slackTeam) = {
       val slackToLibs = channelToLibRepo.getIntegrationsByOrg(orgId)
@@ -229,7 +233,7 @@ class SlackInfoCommanderImpl @Inject() (
         }.toMap
       }
       val integrationInfosByLib = generateLibrarySlackIntegrationInfos(viewerId, slackToLibs, libToSlacks)
-      val slackTeamOpt = slackTeamRepo.getByOrganizationId(orgId).map(team => OrganizationSlackTeamInfo(team.slackTeamId, team.slackTeamName, team.publicChannelsLastSyncedAt))
+      val slackTeamOpt = getOrganizationSlackTeam(orgId, viewerId)
 
       (libIds, basicLibsById, integrationInfosByLib, slackTeamOpt)
     }


### PR DESCRIPTION
@cvializ this will change `slack.slackTeam` to `slackTeam` at the top level in the org object.
