### PR TITLE
Bugfix/safari compose sticky

### DIFF
--- a/packrat/adapters/safari/api.js
+++ b/packrat/adapters/safari/api.js
@@ -167,6 +167,7 @@ var api = api || (function () {
     var loadsLeft = (scriptPaths || []).length;// + (stylePaths || []).length;
     var scripts = [];
     var styles = [];
+    var paths = scriptPaths.concat(stylePaths);
     scriptPaths.forEach(function (p) {
       loadContent(p, function (text) {
         scripts.push(text);
@@ -182,9 +183,9 @@ var api = api || (function () {
 
     function done() {
       if (loadsLeft === 0) {
-        page._port.postMessage('api:inject', { scripts, styles });
+        page._port.postMessage('api:inject', { scripts, styles, paths });
         if (callback) {
-          callback({ scripts, styles });
+          callback({ scripts, styles, paths });
         }
       } else {
         loadsLeft--;

--- a/packrat/adapters/safari/scripts/api.js
+++ b/packrat/adapters/safari/scripts/api.js
@@ -50,7 +50,7 @@ var api = api || (function () {
         break;
       case 'api:inject':
         injectContentScript(msg[1], msg[2]);
-        markInjected(msg[1]);
+        markInjected(msg[2].paths);
         break;
       case 'api:log':
         var enable = msg[1], buf = log.buffer;
@@ -197,8 +197,8 @@ var api = api || (function () {
       if (typeof paths === 'string') {
         paths = [paths];
       }
-      api.port.emit('api:require', { paths, injected }, function (paths) {
-        markInjected(paths.scripts.concat(paths.styles));
+      api.port.emit('api:require', { paths, injected }, function (data) {
+        markInjected(data.paths);
         callback();
       });
     },

--- a/packrat/scripts/compose_toaster.js
+++ b/packrat/scripts/compose_toaster.js
@@ -36,7 +36,8 @@ k.toaster = k.toaster || (function () {
       show($parent, trigger, guided, recipient);
     },
     hideIfBlank: function () {
-      if ($toast && $toast.data('compose').isBlank()) {
+      var compose = $toast && $toast.data('compose');
+      if (compose && compose.isBlank && compose.isBlank()) {
         hide();
       } else {
         log('[toaster:hideIfBlank] no-op');

--- a/packrat/scripts/keeper.js
+++ b/packrat/scripts/keeper.js
@@ -257,7 +257,7 @@ k.keeper = k.keeper || function () {  // idempotent for Chrome
       $slider
       .off('transitionend')
       .on('transitionend', function (e) {
-        if (e.target === this) {
+        if (e.target === this && e.originalEvent.propertyName === 'opacity') {
           hideSlider2();
         }
       })


### PR DESCRIPTION
@andrewconner I accidentally used the scripts' content instead of their path as the key for marking them as already injected. Transposition error from Chrome's `api.js` :frowning: 
