### PR TITLE
Replace ghetto rate-limiting with timer-based deboucning

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/util/Debouncing.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/Debouncing.scala
@@ -1,48 +1,42 @@
 package com.keepit.common.util
 
-import org.joda.time.{ DateTime, Period }
-import scala.collection.concurrent.TrieMap
-import scala.collection.mutable
-import com.keepit.common.time.{ currentDateTime, DEFAULT_DATE_TIME_ZONE }
+import java.util.concurrent.TimeUnit
 
+import com.keepit.common.time.{ DEFAULT_DATE_TIME_ZONE, currentDateTime }
+import org.jboss.netty.util.{ HashedWheelTimer, Timeout, TimerTask }
+import org.joda.time.DateTime
+
+import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
+import scala.concurrent.duration.Duration
 import scala.util.Try
 
 object Debouncing {
   class Dropper[T] {
     private val onCooldownUntil: mutable.Map[String, DateTime] = mutable.Map.empty
-    def debounce(key: String, cooldown: Period)(fn: => T): Option[T] = {
+    def debounce(key: String, cooldown: Duration)(fn: => T): Option[T] = {
       val now = currentDateTime
       onCooldownUntil.get(key) match {
         case Some(threshold) if now.isBefore(threshold) => None
         case _ =>
-          onCooldownUntil.put(key, now.plus(cooldown))
+          onCooldownUntil.put(key, now.plusMillis(cooldown.toMillis.toInt))
           Some(fn)
       }
     }
   }
 
   class Buffer[T] {
-    private val onCooldownUntil: mutable.Map[String, DateTime] = mutable.Map.empty
-    private val bufferMap: mutable.Map[String, ListBuffer[T]] = mutable.Map.empty
+    private val bufMap: mutable.Map[String, ListBuffer[T]] = mutable.Map.empty
+    private val timer = new HashedWheelTimer(1, TimeUnit.MILLISECONDS)
     private val lock = new Object
-
-    def debounce(key: String, cooldown: Period)(item: T)(action: List[T] => Unit): Unit = lock.synchronized {
-      Try {
-        val now = currentDateTime
-        if (!bufferMap.isDefinedAt(key)) bufferMap.put(key, ListBuffer.empty)
-
-        val buffer = bufferMap(key)
-        buffer.prepend(item)
-        onCooldownUntil.get(key) match {
-          case Some(threshold) if now isBefore threshold =>
-          case _ =>
-            onCooldownUntil.put(key, now plus cooldown)
-            val input = buffer.toList
-            buffer.clear()
-            action(input)
-        }
+    def debounce(key: String, cooldown: Duration)(item: T)(action: List[T] => Unit): Unit = Try(lock.synchronized {
+      if (!bufMap.isDefinedAt(key)) {
+        bufMap.put(key, ListBuffer.empty)
+        timer.newTimeout(new TimerTask {
+          override def run(timeout: Timeout): Unit = lock.synchronized { bufMap.remove(key).foreach(buf => action(buf.toList)) }
+        }, cooldown.toMillis, TimeUnit.MILLISECONDS)
       }
-    }
+      bufMap(key).prepend(item)
+    })
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/util/Debouncing.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/Debouncing.scala
@@ -12,6 +12,7 @@ import scala.concurrent.duration.Duration
 import scala.util.Try
 
 object Debouncing {
+  private val timer = new HashedWheelTimer(100, TimeUnit.MILLISECONDS)
   class Dropper[T] {
     private val onCooldownUntil: mutable.Map[String, DateTime] = mutable.Map.empty
     def debounce(key: String, cooldown: Duration)(fn: => T): Option[T] = {
@@ -24,10 +25,8 @@ object Debouncing {
       }
     }
   }
-
   class Buffer[T] {
     private val bufMap: mutable.Map[String, ListBuffer[T]] = mutable.Map.empty
-    private val timer = new HashedWheelTimer(1, TimeUnit.MILLISECONDS)
     private val lock = new Object
     def debounce(key: String, cooldown: Duration)(item: T)(action: List[T] => Unit): Unit = Try(lock.synchronized {
       if (!bufMap.isDefinedAt(key)) {

--- a/kifi-backend/modules/common/test/com/keepit/common/util/DebouncingTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/util/DebouncingTest.scala
@@ -1,10 +1,9 @@
 package com.keepit.common.util
 
-import org.joda.time.Period
 import org.specs2.mutable.Specification
 
-import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
 
 class DebouncingTest extends Specification {
   private class LoudYapper {
@@ -19,7 +18,7 @@ class DebouncingTest extends Specification {
     var count = 0
     var value = 0
     val debouncer = new Debouncing.Dropper[Unit]
-    def trigger() = debouncer.debounce("trigger", Period.millis(1)) {
+    def trigger() = debouncer.debounce("trigger", 1 milli) {
       value += 1
       count += 1
     }
@@ -28,7 +27,7 @@ class DebouncingTest extends Specification {
     var count = 0
     var value = 0
     val debouncer = new Debouncing.Buffer[Int]
-    def trigger() = debouncer.debounce("trigger", Period.millis(1))(1) { buf =>
+    def trigger() = debouncer.debounce("trigger", 1 milli)(1) { buf =>
       value += buf.sum
       count += 1
     }
@@ -52,8 +51,7 @@ class DebouncingTest extends Specification {
 
       // The buffered one will always get to the correct value right after it actually triggers
       Thread.sleep(5)
-      buffered.trigger()
-      buffered.value === n + 1
+      buffered.value === n
     }
     "be thread-safe" in {
       val n = 1000
@@ -72,8 +70,7 @@ class DebouncingTest extends Specification {
       buffered.value must beCloseTo(n, n / 5)
 
       Thread.sleep(5)
-      buffered.trigger()
-      buffered.value === n + 1
+      buffered.value === n
     }
   }
 }

--- a/kifi-backend/modules/common/test/com/keepit/common/util/DebouncingTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/util/DebouncingTest.scala
@@ -46,11 +46,9 @@ class DebouncingTest extends Specification {
       quiet.count must beBetween(1, n / 5)
       quiet.value must beBetween(1, n / 5)
 
+      // The buffered one will always get to the correct value eventually
+      Thread.sleep(100)
       buffered.count must beBetween(1, n / 5)
-      buffered.value must beCloseTo(n, n / 5)
-
-      // The buffered one will always get to the correct value right after it actually triggers
-      Thread.sleep(5)
       buffered.value === n
     }
     "be thread-safe" in {
@@ -66,10 +64,8 @@ class DebouncingTest extends Specification {
       quiet.count must beBetween(1, n / 5)
       quiet.value must beBetween(1, n / 5)
 
+      Thread.sleep(100)
       buffered.count must beBetween(1, n / 5)
-      buffered.value must beCloseTo(n, n / 5)
-
-      Thread.sleep(5)
       buffered.value === n
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/logging/SlackLog.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/logging/SlackLog.scala
@@ -4,7 +4,8 @@ import com.keepit.common.util.{ Debouncing, DescriptionElements }
 import com.keepit.macros.Location
 import com.keepit.slack.models.{ SlackAttachment, SlackMessageRequest }
 import com.keepit.slack.{ InhouseSlackChannel, InhouseSlackClient }
-import org.joda.time.Period
+
+import scala.concurrent.duration._
 
 class SlackLog(loggingDestination: InhouseSlackChannel)(implicit inhouseSlackClient: InhouseSlackClient) {
   private val debouncer = new Debouncing.Buffer[SlackAttachment]
@@ -14,7 +15,7 @@ class SlackLog(loggingDestination: InhouseSlackChannel)(implicit inhouseSlackCli
   def error(elements: DescriptionElements*)(implicit sourceCodeLocation: Location): Unit = sendLog(sourceCodeLocation, elements, "danger")
 
   private def sendLog(fromLine: Location, text: DescriptionElements, color: String): Unit = {
-    debouncer.debounce(fromLine.location, Period.seconds(5))(
+    debouncer.debounce(fromLine.location, 5 seconds)(
       item = SlackAttachment(color = Some(color), text = Some(DescriptionElements.formatForSlack(text)))
     ) { attachments =>
         val msg = SlackMessageRequest.inhouse(

--- a/kifi-backend/modules/shoebox/app/com/keepit/integrity/KeepChecker.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/integrity/KeepChecker.scala
@@ -11,10 +11,11 @@ import com.keepit.common.performance.{ AlertingTimer, StatsdTiming }
 import com.keepit.common.time.{ Clock, _ }
 import com.keepit.common.util.Debouncing
 import com.keepit.model._
-import org.joda.time.Period
+import org.joda.time.{ Period }
 import com.keepit.common.core._
 
 import scala.concurrent.{ Future, ExecutionContext }
+import scala.concurrent.duration._
 import scala.util.Try
 
 @Singleton
@@ -98,13 +99,13 @@ class KeepChecker @Inject() (
     if (keep.isInactive) {
       val zombieKtus = ktuRepo.getAllByKeepId(keepId, excludeStateOpt = Some(KeepToUserStates.INACTIVE))
       for (ktu <- zombieKtus) {
-        debouncer.debounce(ktu.userId.id.toString, Period.minutes(1)) { airbrake.notify(s"[KTU-STATE-MATCH] KTU ${ktu.id.get} (keep ${ktu.keepId} --- user ${ktu.userId}) is a zombie!") }
+        debouncer.debounce(ktu.userId.id.toString, 1 minute) { airbrake.notify(s"[KTU-STATE-MATCH] KTU ${ktu.id.get} (keep ${ktu.keepId} --- user ${ktu.userId}) is a zombie!") }
         ktuCommander.deactivate(ktu)
       }
 
       val zombieKtls = ktlRepo.getAllByKeepId(keepId, excludeStateOpt = Some(KeepToLibraryStates.INACTIVE))
       for (ktl <- zombieKtls) {
-        debouncer.debounce(ktl.libraryId.toString, Period.minutes(1)) { airbrake.notify(s"[KTL-STATE-MATCH] KTL ${ktl.id.get} (keep ${ktl.keepId} --- lib ${ktl.libraryId}) is a zombie!") }
+        debouncer.debounce(ktl.libraryId.toString, 1 minute) { airbrake.notify(s"[KTL-STATE-MATCH] KTL ${ktl.id.get} (keep ${ktl.keepId} --- lib ${ktl.libraryId}) is a zombie!") }
         ktlCommander.deactivate(ktl)
       }
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackClientWrapper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackClientWrapper.scala
@@ -8,10 +8,10 @@ import com.keepit.common.logging.Logging
 import com.keepit.common.time.{ Clock, DEFAULT_DATE_TIME_ZONE }
 import com.keepit.common.util.{ Debouncing, Ord }
 import com.keepit.slack.models._
-import org.joda.time.Period
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Success, Try, Failure }
+import scala.concurrent.duration._
 
 sealed abstract class SlackChannelMagnet
 object SlackChannelMagnet {
@@ -221,7 +221,7 @@ class SlackClientWrapperImpl @Inject() (
         slackTeamMembershipRepo.deactivate(stm)
       }
     }
-    case Failure(otherFail) => debouncer.debounce("after-token", Period.seconds(5)) { airbrake.notify(otherFail) }
+    case Failure(otherFail) => debouncer.debounce("after-token", 5 seconds) { airbrake.notify(otherFail) }
   }
 
   def getTeamInfo(token: SlackAccessToken): Future[SlackTeamInfo] = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackOnboarder.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackOnboarder.scala
@@ -15,10 +15,10 @@ import com.keepit.model._
 import com.keepit.slack.SlackOnboarder.TeamOnboardingAgent
 import com.keepit.slack.models._
 import com.keepit.social.BasicUser
-import org.joda.time.Period
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
+import scala.concurrent.duration._
 
 @ImplementedBy(classOf[SlackOnboarderImpl])
 trait SlackOnboarder {
@@ -75,7 +75,7 @@ class SlackOnboarderImpl @Inject() (
       generateOnboardingMessageForIntegration(integ)
     }.flatMap { welcomeMsg =>
       log.info(s"[SLACK-ONBOARD] Generated this message: " + welcomeMsg)
-      debouncer.debounce(s"${integ.slackTeamId.value}_${integ.slackChannelName.value}", Period.minutes(10)) {
+      debouncer.debounce(s"${integ.slackTeamId.value}_${integ.slackChannelName.value}", 10 minutes) {
         slackLog.info(s"Sent a welcome message to channel ${integ.slackChannelName} saying", welcomeMsg.text)
         slackClient.sendToSlack(integ.slackUserId, integ.slackTeamId, (integ.slackChannelName, integ.slackChannelId), welcomeMsg)
       }


### PR DESCRIPTION
@andrewconner this seems way more reasonable to me than the existing logic. Thoughts?

I'm specifically a little concerned about using a hashed wheel timer with a tick of 1 millisecond. Only a little, because the computational overhead is pretty small, and 1 millisecond is actually a lot of time for a CPU, but still...
