### PR TITLE
Tracking who already has the extension on Slack confirmation page

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/teamSettings/slackConfirm.js
+++ b/kifi-backend/modules/shoebox/angular/src/teamSettings/slackConfirm.js
@@ -43,8 +43,11 @@ angular.module('kifi')
       }, 3000);
     };
 
-    $rootScope.$emit('trackOrgProfileEvent', 'view', {
-      type: 'org_profile:settings:integration_confirmation_slack'
-    });
+    $timeout(function () {
+      $rootScope.$emit('trackOrgProfileEvent', 'view', {
+        type: 'org_profile:settings:integration_confirmation_slack',
+        extensionInstalled: !!installService.installedVersion
+      });
+    }, 1000);
   }
 ]);


### PR DESCRIPTION
@cvializ Not sure if the timeout is needed, but shouldn't hurt anything. It's so that the extension has plenty of time to add it's attribute to the page.
