### PR TITLE
add more org/user events and refresh lhr when they fire

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/leftHandNav/leftHandNav.js
+++ b/kifi-backend/modules/shoebox/angular/src/leftHandNav/leftHandNav.js
@@ -346,11 +346,22 @@ angular.module('kifi')
           maybeClose();
         };
 
+        var reload = function () { scope.reloadData(); };
         scope.reloadData(profileService.me);
         [
-          $rootScope.$on('refreshLeftHandNav', function() {
-            scope.reloadData();
-          })
+          $rootScope.$on('refreshLeftHandNav', reload),
+          $rootScope.$on('libraryCreated', reload),
+          $rootScope.$on('libraryModified', reload),
+          $rootScope.$on('libraryJoined', reload),
+          $rootScope.$on('libraryLeft', reload),
+          $rootScope.$on('libraryDeleted', reload),
+          $rootScope.$on('orgCreated', reload),
+          $rootScope.$on('orgMemberInviteAccepted', reload),
+          $rootScope.$on('orgMemberInviteDeclined', reload),
+          $rootScope.$on('orgMemberRemoved', reload),
+          $rootScope.$on('orgProfileUpdated', reload),
+          $rootScope.$on('orgAvatarUploaded', reload),
+          $rootScope.$on('orgOwnershipTransferred', reload)
         ].forEach(function (deregister) {
           scope.$on('$destroy', deregister);
         });

--- a/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/libraryService.js
@@ -176,7 +176,8 @@ angular.module('kifi')
           }
         }
 
-        return net.createLibrary(opts);
+        return net.createLibrary(opts)
+        .then(function (res) { $rootScope.$emit('libraryCreated', res); return res;});
       },
 
       modifyLibrary: function (opts, checkMissingFields) {
@@ -189,7 +190,8 @@ angular.module('kifi')
             return $q.reject({'error': 'missing fields: ' + missingFields.join(', ')});
           }
         }
-        return net.modifyLibrary(opts.id, opts);
+        return net.modifyLibrary(opts.id, opts)
+        .then(function (res) { $rootScope.$emit('libraryModified', opts.id, res); return res;});
       },
 
       getLibraryShareContacts: function (libId, query) {

--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.js
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileHeader.js
@@ -139,7 +139,6 @@ angular.module('kifi')
           click: function () {
             orgProfileService.declineOrgMemberInvite(scope.profile.id);
             scope.acknowledgedInvite = true;
-            scope.$emit('refreshLeftHandNav');
           }
         },
         {
@@ -150,7 +149,6 @@ angular.module('kifi')
               .acceptOrgMemberInvite(scope.profile.id, $location.search().authToken)
               .then(function () {
                 scope.acknowledgedInvite = true;
-                scope.$emit('refreshLeftHandNav');
                 $state.reload('orgProfile');
               });
           }


### PR DESCRIPTION
Potentially resolves https://app.asana.com/0/20751731968782/91307853307603
In the future, we may want to be smarter and not completely refresh the rail unless we have to (i.e on library delete just remove it from the lists without reloading).

@cvializ @andrewconner 
