### PR TITLE
use https for page metadata

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageMetaTagsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageMetaTagsCommander.scala
@@ -60,7 +60,11 @@ class PageMetaTagsCommander @Inject() (
 
   private def imageUrl(image: KeepImage): String = addProtocol(keepImageCommander.getUrl(image))
 
-  private def addProtocol(url: String): String = if (url.startsWith("http:") || url.startsWith("https:")) url else s"http:$url"
+  private def addProtocol(url: String): String = {
+    if (url.startsWith("https:")) url
+    else if (url.startsWith("http:")) url.replaceFirst("http", "https")
+    else s"https:$url"
+  }
 
   private def relatedLibrariesLinks(library: Library): Future[Seq[String]] = relatedLibraryCommander.suggestedLibraries(library.id.get, None) map { relatedLibs =>
     val libs = relatedLibs.filterNot(_.kind == RelatedLibraryKind.POPULAR).take(6).map(_.library)


### PR DESCRIPTION
@andrewconner adding it for library images as well, shouldn't hurt right?
