### PR TITLE
When given an empty "data:," image, still add the look here.

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -983,7 +983,13 @@ api.port.on({
             rect.height);
         }
       }
-      respond(canvas.toDataURL('image/png'));
+      var dataUrl = 'data:,';
+      try {
+        dataUrl = canvas.toDataURL('image/png');
+      } catch (e) {
+        log('[screenshot] failed to render screenshot area %O', e);
+      }
+      respond(dataUrl);
     });
   },
   load_draft: function (data, respond, tab) {

--- a/packrat/scripts/snap.js
+++ b/packrat/scripts/snap.js
@@ -380,7 +380,7 @@ k.snap = k.snap || (function () {
     info.bounds = toJson(ranges.getBoundingClientRect(r, info.rects));
     api.port.emit('screen_capture', info, function (dataUrl) {
       var img = new Image();
-      $(img).on('load', finalizeLookHereLink.bind(img, info.bounds, href, title));
+      $(img).on('load error', finalizeLookHereLink.bind(img, info.bounds, href, title));
       img.src = dataUrl;
     });
     var href = 'x-kifi-sel:' + k.snapshot.ofRange(r);


### PR DESCRIPTION
Large look-here's sometimes return an empty data url. So
continue to load the look here in in the onerror handler
instead of choking when onload doesn't fire.

@andrewconner 
