### PR TITLE
add last_activity_at and added_at single-col indices

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/429.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/429.sql
@@ -1,0 +1,14 @@
+# SHOEBOX
+
+# --- !Ups
+
+create index ktl_i_added_at on keep_to_library(added_at);
+create index ktu_i_added_at on keep_to_user(added_at);
+
+create index bookmark_i_last_activity_at on bookmark(last_activity_at);
+create index ktl_i_last_activity_at on keep_to_library(last_activity_at);
+create index ktu_i_last_activity_at on keep_to_user(last_activity_at);
+
+insert into evolutions (name, description) values('429.sql', 'add single-column last_activity_at and added_at indices on bookmark, ktl, and ktu');
+
+# --- !Downs


### PR DESCRIPTION
@leogrim @ryanpbrewster @andrewconner 

both of these columns are referenced many times in the `KeepRepo.getRecentKeeps` queries, but they don't have their own indices. Since we do sorts and aggregates on them, this could help.
