### PR TITLE
add null checks before querying last_activity_at

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepRepo.scala
@@ -710,8 +710,8 @@ class KeepRepoImpl @Inject() (
       case None => (tableName: String) => "true"
       case Some((keepId, before)) =>
         (tableName: String) => {
-          if (tableName == "k") s"last_activity_at < '$before' AND k.id < $keepId"
-          else s"last_activity_at < '$before' AND $tableName.keep_id < $keepId"
+          if (tableName == "k") s"last_activity_at is not null and last_activity_at < '$before' or (last_activity_at = '$before' and k.id < $keepId)"
+          else s"last_activity_at is not null and last_activity_at < '$before' or (last_activity_at = '$before' and $tableName.keep_id < $keepId)"
         }
     }
 
@@ -719,8 +719,8 @@ class KeepRepoImpl @Inject() (
       case None => (tableName: String) => "true"
       case Some((keepId, after)) =>
         (tableName: String) => {
-          if (tableName == "k") s"last_activity_at > '$after' AND k.id > $keepId"
-          else s"last_activity_at > '$after' AND $tableName.keep_id > $keepId"
+          if (tableName == "k") s"last_activity-at is not null and last_activity_at > '$after' or (last_activity_at = '$after' and k.id > $keepId)"
+          else s"last_activity_at is not null and last_activity_at > '$after' or (last_activity_at = '$after' and $tableName.keep_id > $keepId)"
         }
     }
 


### PR DESCRIPTION
@leogrim @ryanpbrewster @andrewconner 

we're not using any of the indices on `last_activity_at`. This may or may not help, `added_at` seems to have all the same indices, and the `not null` constraint, but either way it makes things more accurate. Perhaps the index used for nullable columns is different.

edit: this is a temporary fix that has improved the manual query a lot. going to test it behind the experiment, only three people on it. will run the migration to make `last_activity_at not null` tonight.
