### PR TITLE
use lastActivityAt = keptAt for new keeps

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -156,7 +156,7 @@ class KeepInternerImpl @Inject() (
       source = source,
       visibility = libraryOpt.map(_.visibility).getOrElse(LibraryVisibility.SECRET),
       libraryId = libraryOpt.map(_.id.get),
-      keptAt = keptAt,
+      keptAt = existingKeepOpt.map(_.keptAt).getOrElse(keptAt),
       note = kNote,
       originalKeeperId = existingKeepOpt.flatMap(_.userId) orElse userIdOpt,
       organizationId = libraryOpt.flatMap(_.organizationId),


### PR DESCRIPTION
@ryanpbrewster @leogrim for new keeps, use `lastActivityAt` = `keptAt`. this will ensure that slack keeps are backfilled into your feed, rather than pushed to the top upon every ingestion. https://app.asana.com/0/inbox/32728208409722/92839833687202/92839833687206
