### PR TITLE
don't update last activity at as a side effect

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -684,19 +684,19 @@ class KeepCommanderImpl @Inject() (
       libraries.foreach { lib => ktlCommander.internKeepInLibrary(newKeep, lib, newKeep.userId) }
     }
 
-    val updatedKeepOpt = if (oldKeepOpt.forall(_.connections.users != newKeep.connections.users)) {
+    if (oldKeepOpt.forall(_.connections.users != newKeep.connections.users)) {
       val newUsers = oldKeepOpt.map(oldKeep => newKeep.connections.users -- oldKeep.connections.users).getOrElse(newKeep.connections.users)
-      Some(addUsersToKeep(newKeep.id.get, addedBy = newKeep.userId, newUsers))
-    } else None
+      addUsersToKeep(newKeep.id.get, addedBy = newKeep.userId, newUsers)
+    }
 
-    updatedKeepOpt.getOrElse(newKeep)
+    newKeep
   }
   def addUsersToKeep(keepId: Id[Keep], addedBy: Option[Id[User]], newUsers: Set[Id[User]])(implicit session: RWSession): Keep = {
     val oldKeep = keepRepo.get(keepId)
     val newKeep = keepRepo.save(oldKeep.withParticipants(oldKeep.connections.users ++ newUsers))
 
     newUsers.foreach { userId => ktuCommander.internKeepInUser(newKeep, userId, addedBy) }
-    updateLastActivityAtIfLater(keepId, currentDateTime)
+    newKeep
   }
   def updateLastActivityAtIfLater(keepId: Id[Keep], time: DateTime)(implicit session: RWSession): Keep = {
     val oldKeep = keepRepo.get(keepId)

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepInternerTest.scala
@@ -49,7 +49,8 @@ class KeepInternerTest extends Specification with ShoeboxTestInjector {
           userRepo.get(user.id.get) === user
           bookmarks.size === 1
           keepRepo.get(bookmarks.head.id.get).copy(
-            updatedAt = bookmarks.head.updatedAt
+            updatedAt = bookmarks.head.updatedAt,
+            seq = bookmarks.head.seq
           ) === bookmarks.head
           keepRepo.all.size === 1
         }


### PR DESCRIPTION
@ryanpbrewster @leogrim 

this decouples feed-bumping logic from everything else (fixing a bug where slack keeps are pushed to the top regardless of their recency). right now we only bump last_activity_at when adding messages (including add_participants messages). if we want to do so for other events we can explicitly append `updateLastActivityAtIfLater` to the handler.
