### PR TITLE
Expose search ordering to the front end

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/route.js
+++ b/kifi-backend/modules/shoebox/angular/src/route.js
@@ -62,7 +62,7 @@ angular.module('kifi')
         controller: 'ProfileCtrl'
       })
       .state('search', {
-        url: '/find?q&f',
+        url: '/find?q&f&o',
         templateUrl: 'search/search.tpl.html',
         controller: 'SearchCtrl',
         resolve: {
@@ -366,7 +366,7 @@ angular.module('kifi')
         errorView: 'kf-contact-admin'
       })
       .state('library.search', {
-        url: '/find?q&f',
+        url: '/find?q&f&o',
         templateUrl: 'search/matchingKeeps.tpl.html',
         controller: 'SearchCtrl',
         reloadOnSearch: false  // controller handles search query changes itself

--- a/kifi-backend/modules/shoebox/angular/src/search/matchingKeeps.styl
+++ b/kifi-backend/modules/shoebox/angular/src/search/matchingKeeps.styl
@@ -31,6 +31,11 @@
     padding-left: 10px
     margin-left: 10px
 
+.kf-smk-order-by-option
+  margin: 2px 0px
+  width: auto
+  text-align: center
+
 .kf-smk-top
   display: flex
   flex-direction: row
@@ -42,6 +47,30 @@
   .kf-card-style-selector
     float: right
     padding-left: 10px
+
+  .kf-smk-dropdown-parent
+    position: relative
+    display: inline-block
+
+    .kf-dropdown-menu
+      left: -14px
+      right: -14px
+
+    &:not(.kf-open)>.kf-dropdown-menu
+      dur = .16s
+      visibility: hidden
+      opacity: 0
+      transform: scale(.9)
+      transition-duration: 0s, dur, dur
+      transition-delay: dur, 0s, 0s
+
+    &.kf-open::before
+      content: ''
+      position: absolute
+      top: 'calc(100% - %s)' % menuGap
+      left: -10px
+      right: -10px
+      height: 20px
 
 .kf-smk-heading
   color: #999

--- a/kifi-backend/modules/shoebox/angular/src/search/matchingKeeps.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/search/matchingKeeps.tpl.html
@@ -7,8 +7,17 @@
     </div>
     <div class="kf-smk-top">
       <span class="kf-smk-heading" ng-if="loading">Searching...</span>
-      <span class="kf-smk-heading" ng-if="!loading" ng-pluralize count="resultKeeps.length" when="{0: 'No matching keeps', 1: '1 matching keep', other: 'Top {} results'}"></span>
-
+      <span class="kf-smk-heading" ng-if="!loading">
+        <span ng-pluralize count="resultKeeps.length" when="{0: 'No matching keeps', 1: '1 matching keep', other: 'Top {} results'}"></span>
+        <span ng-if="resultKeeps.length">ordered by</span>
+        <span class="kf-smk-dropdown-parent" kf-click-menu toggle-open="true" ng-if="resultKeeps.length">
+          <span class="kf-link" ng-bind="isOrderBySelected('recency') ? 'more recent' : 'most relevant'"></span>
+          <menu class="kf-dropdown-menu">
+            <span class="kf-link kf-smk-order-by-option" ng-click="setOrderBy('relevancy')">most relevant</span>
+            <span class="kf-link kf-smk-order-by-option" ng-click="setOrderBy('recency')">more recent</span>
+          </menu>
+        </span>
+      </span>
       <div class="kf-smk-bulk-add kf-flex-row" ng-click="edit.enabled = !edit.enabled" ng-if="$root.userLoggedIn && resultKeeps.length > 1">
         <svg kf-symbol-sprite
              icon="pencil"

--- a/kifi-backend/modules/shoebox/angular/src/search/search.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/search.js
@@ -16,7 +16,7 @@ angular.module('kifi')
     var context;
     var renderTimeout;
     var smoothScrollStep;  // used to ensure that only one smooth scroll animation happens at a time
-
+    var orderBy;
 
     //
     // Scope data.
@@ -54,6 +54,7 @@ angular.module('kifi')
       queryCount++;
       query = $stateParams.q || '';
       filter = $stateParams.f || 'a';
+      orderBy = $stateParams.o || (_.startsWith(query, 'tag:') ? 'recency' : 'relevancy');
 
       if (!query) {
         $state.go(library ? 'library.keeps' : 'home.feed');
@@ -137,7 +138,7 @@ angular.module('kifi')
 
       $scope.loading = true;
       var firstBatch = !context;
-      searchActionService.find(query, filter, library, context, $rootScope.userLoggedIn).then(function (queryNumber, result) {
+      searchActionService.find(query, filter, orderBy, library, context, $rootScope.userLoggedIn).then(function (queryNumber, result) {
         if (queryNumber !== queryCount) {  // results are for an old query
           return;
         }
@@ -235,12 +236,20 @@ angular.module('kifi')
       $location.search('f', newSearchFilter);
     };
 
+    $scope.isOrderBySelected = function (type) {
+      return orderBy === type;
+    };
+
+    $scope.setOrderBy = function (newOrderBy) {
+      $location.search('o', newOrderBy).replace();
+    };
+
 
     //
     // Watches and event listeners.
     //
     function newSearch() {
-      _.assign($stateParams, _.pick($location.search(), 'q', 'f'));
+      _.assign($stateParams, _.pick($location.search(), 'q', 'f', 'o'));
       init();
     }
 

--- a/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
+++ b/kifi-backend/modules/shoebox/angular/src/search/searchActionService.js
@@ -101,11 +101,12 @@ angular.module('kifi')
     //
     // Exposed API methods.
     //
-    function find(query, filter, library, context, userLoggedIn) {
+    function find(query, filter, orderBy, library, context, userLoggedIn) {
       var params = {
         q: query,
         f: filter || [],
         l: library && library.id || [],
+        orderBy: orderBy || [],
         disablePrefixSearch: 1,
         maxUris: 5,
         maxLibraries: context ? [] : 6,


### PR DESCRIPTION
This adds a way to change the search ordering between relevancy and recency.
Task: https://app.asana.com/0/20751731968782/86770238016779

We can tweak the UI for it, but I went with the following.
![image](https://cloud.githubusercontent.com/assets/3202346/13266640/df24b520-da2d-11e5-988f-dc5ebf3852a6.png)
