### PR TITLE
If we cannot push a digest, try again later instead of immediately

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/slack/models/SlackFail.scala
+++ b/kifi-backend/modules/common/app/com/keepit/slack/models/SlackFail.scala
@@ -39,6 +39,7 @@ object SlackErrorCode {
   val CHANNEL_NOT_FOUND = "channel_not_found"
   val INVALID_AUTH = "invalid_auth"
   val NOT_IN_CHANNEL = "not_in_channel"
+  val RESTRICTED_ACTION = "restricted_action"
   val TOKEN_REVOKED = "token_revoked"
   val WEBHOOK_REVOKED = "webhook_revoked"
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackClientWrapper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackClientWrapper.scala
@@ -98,7 +98,7 @@ class SlackClientWrapperImpl @Inject() (
         }
         FutureHelpers.collectFirst(slackTeamMembers) { slackUserId =>
           sendToSlackViaUser(slackUserId, slackTeamId, slackChannel.map(ch => SlackChannelMagnet.fromBoth(ch.idAndName)) getOrElse slackChannelId, msg).map(v => Some(v)).recover {
-            case SlackFail.NoValidWebhooks | SlackFail.NoValidToken | SlackErrorCode(NOT_IN_CHANNEL) | SlackErrorCode(CHANNEL_NOT_FOUND) => None
+            case SlackFail.NoValidWebhooks | SlackFail.NoValidToken | SlackErrorCode(NOT_IN_CHANNEL) | SlackErrorCode(CHANNEL_NOT_FOUND) | SlackErrorCode(RESTRICTED_ACTION) => None
           }
         }.flatMap {
           case Some(v) => Future.successful(v)


### PR DESCRIPTION
Only if we think we can't recover (e.g.: slack explicitly says none of our tokens or webhooks are good).
