### PR TITLE
be more liberal with moving the keeper

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
@@ -146,21 +146,23 @@ class PageCommander @Inject() (
 
   @StatsdTiming("PageCommander.inferKeeperPosition")
   private def inferKeeperPosition(domainId: Id[Domain])(implicit session: RSession): Option[JsObject] = {
+    // if a domain has more than $minSamples users moving it in the past $since months, move the keeper to a popular location
     inferredKeeperPositionCache.getOrElseOpt(InferredKeeperPositionKey(domainId)) {
       val since = currentDateTime.minusMonths(6)
-      val roundToNearest = 50 // return value will vary in roundToNearest intervals
+      val roundToNearest = 100 // return value will vary in roundToNearest intervals
       val minSamples = 10
 
       val positions = userToDomainRepo.getPositionsForDomain(domainId, sinceOpt = Some(since))
       if (positions.size >= minSamples) {
-        // get mode of all positions rounded to the nearest 100 pixels, distances from "top" being negative
-        val positionMode = positions.foldLeft(Map.empty[Long, Int]) {
+        val countByPosition = positions.foldLeft(Map.empty[Long, Int]) {
           case (countByBucket, js) =>
             val bottomOpt = (js \ "bottom").asOpt[Double]
             val topOpt = (js \ "top").asOpt[Double]
             val position = Math.round(bottomOpt.orElse(topOpt.map(_ * -1)).getOrElse(0.0) / roundToNearest.toDouble) * roundToNearest
             countByBucket + (position -> (countByBucket.getOrElse(position, 0) + 1))
-        }.maxBy(_._2)._1
+        } - 0 // ignore default position
+
+        val (positionMode, _) = countByPosition.maxBy { case (position, count) => count }
 
         if (positionMode != 0) log.info(s"[inferKeeper] setting position on domain id=${domainId.id} to position=$positionMode")
 
@@ -265,7 +267,7 @@ class PageCommander @Inject() (
 }
 
 case class InferredKeeperPositionKey(id: Id[Domain]) extends Key[JsObject] {
-  override val version = 1
+  override val version = 2
   val namespace = "inferred_keeper_position"
   def toKey(): String = id.id.toString
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageMetaTagsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageMetaTagsCommander.scala
@@ -9,6 +9,7 @@ import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.common.store.{ S3ImageConfig, S3UserPictureConfig }
+import com.keepit.common.util.DescriptionElements
 import com.keepit.inject.FortyTwoConfig
 import com.keepit.model.LibraryVisibility.PUBLISHED
 import com.keepit.model._
@@ -275,7 +276,7 @@ class PageMetaTagsCommander @Inject() (
     } yield {
       val splitName = authorOpt.map(_.name.split(" "))
       val description = {
-        val shoeboxDescription = keep.note.map(Hashtags.format)
+        val shoeboxDescription = keep.note.map(note => DescriptionElements.formatPlain(Hashtags.format(note)))
         val roverDescription = summary.values.headOption.flatMap(_.description)
         Seq(shoeboxDescription, roverDescription).flatten.mkString(". ")
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PublicPageMetaTags.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PublicPageMetaTags.scala
@@ -37,7 +37,7 @@ class OrgMetadataCache(stats: CacheStatistics, accessLog: AccessLog, innermostPl
   extends JsonCacheImpl[OrgMetadataKey, String](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
 
 case class KeepMetadataKey(id: Id[Keep]) extends Key[String] {
-  override val version = 2
+  override val version = 3
   val namespace = "keep_metadata_by_id"
   def toKey(): String = s"${id.id.toString}"
 }


### PR DESCRIPTION
@andrewconner this is more aligned with what it seems @eishay and @JRuff42 wanted from this feature. If a significant number of (ten or more) people have moved the keeper on a domain, move it so they can see the FTUE. 
