### PR TITLE
Bump keep sequence number immediately

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -641,7 +641,7 @@ class ShoeboxController @Inject() (
     import RegisterMessageOnKeep._
     val input = request.body.as[Request]
     val keep = db.readWrite { implicit s =>
-      keepRepo.save(keepRepo.get(input.keepId).withMessageSeq(input.msg.seq))
+      keepRepo.saveAndIncrementSequenceNumber(keepRepo.get(input.keepId).withMessageSeq(input.msg.seq))
     }
     libToSlackPusher.schedule(keep.connections.libraries)
     NoContent


### PR DESCRIPTION
instead of using a deferred seq number and hoping that the assigner plugin
runs in time

@leogrim 
