### PR TITLE
Do not double-open the keep view.

### DIFF
--- a/packrat/adapters/safari/scripts/repair_transitionend.js
+++ b/packrat/adapters/safari/scripts/repair_transitionend.js
@@ -94,8 +94,12 @@
       var beforeTransitionProperties = getSingleTransitionProperties(element, ':before');
       var afterTransitionProperties = getSingleTransitionProperties(element, ':after');
       var allProperties = elementTransitionProperties.concat(beforeTransitionProperties).concat(afterTransitionProperties);
-
-      return unique(allProperties);
+      var uniqueProps = unique(allProperties);
+      var indexOfAll = uniqueProps.indexOf('all');
+      if (uniqueProps.length > 1 && indexOfAll > -1) {
+        uniqueProps.splice(indexOfAll, 1);
+      }
+      return uniqueProps;
     }
 
     function getTransitionEvent(element, property, duration) {

--- a/packrat/scripts/keep_box.js
+++ b/packrat/scripts/keep_box.js
@@ -235,7 +235,7 @@ k.keepBox = k.keepBox || (function () {
 
     $cart.addClass('kifi-animated').layout().addClass('kifi-roll')
     .on('transitionend', function end(e) {
-      if (e.target === this) {
+      if (e.target === this && e.originalEvent.propertyName === 'transform') {
         if (!back) {
           $cart.removeClass('kifi-animated kifi-back kifi-forward');
         }


### PR DESCRIPTION
Also ignore "all" if there are multiple transition props

@andrewconner this fixes Apple's complaint with our Safari extension.
