### PR TITLE
catch error response from SlackOAuthProvider

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/social/providers/SecureSocialControllers.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/providers/SecureSocialControllers.scala
@@ -80,7 +80,12 @@ object ProviderController extends Controller with Logging {
             user =>
               log.info(s"[handleAuth] user [${user.email} ${user.identityId}] found from provider - completing auth")
               completeAuthentication(user, request.session)
-          })
+          }) match {
+            case result if result.header.status == 400 =>
+              log.error(s"[handleAuth] ${result.header.status} response from IdentityProvider $provider, res body=${result.body}")
+              Redirect(RoutesHelper.login())
+            case result => result
+          }
         } catch {
           case ex: AccessDeniedException => {
             log.error("[handleAuth] Access Denied for user logging in")

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/oauth/SlackOAuthProvider.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/oauth/SlackOAuthProvider.scala
@@ -40,7 +40,9 @@ class SlackOAuthProviderImpl @Inject() (
     def getParameter(key: String) = request.queryString.get(key).flatMap(_.headOption)
     val REDIRECT_URI = BetterRoutesHelper.authenticate("slack").absoluteURL(true)
     getParameter("error") match {
-      case Some(errorCode) => Future.successful(Left(Results.BadRequest(errorCode)))
+      case Some(errorCode) =>
+        airbrake.notify(s"[SlackAuthError] error response from slack err=$errorCode, query string = ${request.rawQueryString}")
+        Future.successful(Left(Results.BadRequest(errorCode)))
       case None => getParameter("code") match {
         case None =>
           val slackTeamId = getParameter("slackTeamId").map(SlackTeamId(_))
@@ -51,7 +53,9 @@ class SlackOAuthProviderImpl @Inject() (
         case Some(code) => {
           getParameter("state").flatMap(state => slackStateCommander.getSlackAction(SlackAuthState(state))) match {
             case Some(Authenticate()) => slackClient.processAuthorizationResponse(SlackAuthorizationCode(code), REDIRECT_URI).imap(Right(_))
-            case _ => Future.successful(Left(SlackFail.InvalidAuthState.asResponse))
+            case _ =>
+              airbrake.notify(s"[SlackAuthError] invalid query param state, query string = ${request.rawQueryString}")
+              Future.successful(Left(SlackFail.InvalidAuthState.asResponse))
           }
         }
       }


### PR DESCRIPTION
@leogrim looks like `SlackOAuthProvider[43]` is where we get this https://www.kifi.com/authenticate/slack?error=access_denied&state=8ff5913a-0638-4d4f-933f-fc9ffd3157ea from. we just need to handle those responses appropriately (for now going back to /login)
