### PR TITLE
don't prepend @ for twitter names

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/social/Author.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/Author.scala
@@ -89,7 +89,7 @@ object BasicAuthor {
     )
     case TwitterAttribution(tweet) => TwitterUser(
       id = tweet.user.id.id.toString,
-      name = s"@${tweet.user.name}",
+      name = tweet.user.name,
       picture = ImageUrls.TWITTER_LOGO,
       url = tweet.permalink
     )


### PR DESCRIPTION
I see that we use their actual name from twitter, not their handle. so this was wrong.
