### PR TITLE
fix look here: use strict breaks top-level var becoming a global

### DIFF
--- a/packrat/adapters/safari/scripts/ranges.js
+++ b/packrat/adapters/safari/scripts/ranges.js
@@ -1,8 +1,11 @@
-var ranges = {
-  getClientRects: function (r) {
-    return r.getClientRects();
-  },
-  getBoundingClientRect: function (r) {
-    return r.getBoundingClientRect();
-  }
-};
+window.ranges = window.ranges || (function () {
+  'use strict';
+  return {
+    getClientRects: function (r) {
+      return r.getClientRects();
+    },
+    getBoundingClientRect: function (r) {
+      return r.getBoundingClientRect();
+    }
+  };
+}());


### PR DESCRIPTION
@andrewconner a Babel plugin was adding top-level `"use strict";`s to Safari files, which changes the semantics of top-level vars such that they don't become global variables. So explicitly adding ranges to the `window` object resolves the problem with the "look here" creation breaking.
