### PR TITLE
use ADD_MESSAGE permission to guard deep links

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
@@ -83,7 +83,7 @@ class MessageFetchingCommander @Inject() (
           messages <- futureMessages
           discussionKeepOpt <- futureKeep
           discussionKeep <- discussionKeepOpt.map(Future.successful).getOrElse(Future.failed(DiscussionFail.INVALID_KEEP_ID))
-          _ <- Some(()).filter(_ => discussionKeep.permissions.contains(KeepPermission.VIEW_KEEP)).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INSUFFICIENT_PERMISSIONS))
+          _ <- Some(()).filter(_ => discussionKeep.permissions.contains(KeepPermission.ADD_MESSAGE)).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INSUFFICIENT_PERMISSIONS))
         } yield (BasicDiscussion(thread.url, thread.nUrl, messages.flatMap(_.participants).toSet, messages), discussionKeep)
       case None =>
         val futureDiscussionKeep = shoebox.getDiscussionKeepsByIds(userId, Set(keepId)).imap(_.get(keepId))
@@ -95,7 +95,7 @@ class MessageFetchingCommander @Inject() (
         for {
           discussionKeepOpt <- futureDiscussionKeep
           discussionKeep <- discussionKeepOpt.map(Future.successful).getOrElse(Future.failed(DiscussionFail.INVALID_KEEP_ID))
-          _ <- Some(()).filter(_ => discussionKeep.permissions.contains(KeepPermission.VIEW_KEEP)).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INSUFFICIENT_PERMISSIONS))
+          _ <- Some(()).filter(_ => discussionKeep.permissions.contains(KeepPermission.ADD_MESSAGE)).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INSUFFICIENT_PERMISSIONS))
           nUrl <- futureNormalizedUrl
         } yield (BasicDiscussion(discussionKeep.url, nUrl, discussionKeep.keptBy.map(BasicUserLikeEntity(_)).toSet, Seq.empty), discussionKeep)
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/routing/SlackAuthRouter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/routing/SlackAuthRouter.scala
@@ -113,11 +113,11 @@ class SlackAuthRouter @Inject() (
         .map(keepId => keepRepo.get(keepId)).filter(_.isActive)
         .map { keep =>
           val isLoggedIn = request.userIdOpt.isDefined
-          val hasPermission = permissionCommander.getKeepPermissions(keep.id.get, request.userIdOpt).contains(KeepPermission.VIEW_KEEP)
+          val hasMessagingPermission = permissionCommander.getKeepPermissions(keep.id.get, request.userIdOpt).contains(KeepPermission.ADD_MESSAGE)
           val keepPageUrl = pathCommander.pathForKeep(keep).absolute
-          if (!onKifi && hasPermission) {
+          if (!onKifi && hasMessagingPermission) {
             Ok(html.maybeExtDeeplink(DeepLinkRedirect(url = keep.url, externalLocator = Some(s"/messages/${pubId.id}")), noExtUrl = keep.url))
-          } else if (onKifi && isLoggedIn && hasPermission) {
+          } else if (onKifi && isLoggedIn && hasMessagingPermission) {
             Ok(html.maybeExtDeeplink(DeepLinkRedirect(url = keep.url, externalLocator = Some(s"/messages/${pubId.id}")), noExtUrl = keepPageUrl))
           } else if (onKifi && !isLoggedIn) {
             val orgIdOpt = keep.organizationId.orElse(slackTeamRepo.getBySlackTeamId(slackTeamId).flatMap(_.organizationId))


### PR DESCRIPTION
@ryanpbrewster @andrewconner 

yesterday we guarded against people deep linking to private discussions from magic links, but we also need to prevent people from opening the ext on keep notifs where they can't comment on the keep.

source: https://www.kifi.com/k/Announcing-Kifi-s-New-Deeper-Slack-Integ/k1RT5425cNve shouldn't be comment-able. guessing someone got the notification (following the library), then opened it from the ext (I can repro).
