### PR TITLE
use shoebox messaging endpoint for ext reply actions

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/discussion/Message.scala
+++ b/kifi-backend/modules/common/app/com/keepit/discussion/Message.scala
@@ -88,3 +88,27 @@ object DiscussionKeep {
   private implicit val libCardFormat = LibraryCardInfo.internalFormat
   implicit val format = Json.format[DiscussionKeep]
 }
+
+case class MessageSource(value: String)
+object MessageSource {
+  val CHROME = MessageSource("Chrome")
+  val FIREFOX = MessageSource("Firefox")
+  val EMAIL = MessageSource("Email")
+  val IPHONE = MessageSource("iPhone")
+  val IPAD = MessageSource("iPad")
+  val ANDROID = MessageSource("Android")
+  val SERVER = MessageSource("server")
+  val SITE = MessageSource("Kifi.com")
+
+  implicit val messageSourceFormat = new Format[MessageSource] {
+    def reads(json: JsValue): JsResult[MessageSource] = {
+      json.asOpt[String] match {
+        case Some(str) => JsSuccess(MessageSource(str))
+        case None => JsError()
+      }
+    }
+    def writes(kind: MessageSource): JsValue = {
+      JsString(kind.value)
+    }
+  }
+}

--- a/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
@@ -13,7 +13,7 @@ import com.keepit.common.routes.Eliza
 import com.keepit.common.service.{ServiceClient, ServiceType}
 import com.keepit.common.store.S3UserPictureConfig
 import com.keepit.common.zookeeper.ServiceCluster
-import com.keepit.discussion.{CrossServiceMessage, Discussion, Message}
+import com.keepit.discussion.{MessageSource, CrossServiceMessage, Discussion, Message}
 import com.keepit.eliza.model._
 import com.keepit.model._
 import com.keepit.notify.model.event.NotificationEvent
@@ -125,7 +125,7 @@ trait ElizaServiceClient extends ServiceClient {
   def getCrossServiceMessages(msgIds: Set[Id[Message]]): Future[Map[Id[Message], CrossServiceMessage]]
   def getDiscussionsForKeeps(keepIds: Set[Id[Keep]]): Future[Map[Id[Keep], Discussion]]
   def markKeepsAsReadForUser(userId: Id[User], lastSeenByKeep: Map[Id[Keep], Id[Message]]): Future[Map[Id[Keep], Int]]
-  def sendMessageOnKeep(userId: Id[User], text: String, keepId: Id[Keep]): Future[Message]
+  def sendMessageOnKeep(userId: Id[User], text: String, keepId: Id[Keep], source: Option[MessageSource]): Future[Message]
   def getMessagesOnKeep(keepId: Id[Keep], fromIdOpt: Option[Id[Message]], limit: Int): Future[Seq[Message]]
   def getChangedMessagesFromKeeps(keepIds: Set[Id[Keep]], seq: SequenceNumber[Message]): Future[Seq[CrossServiceMessage]]
   def getMessageCountsForKeeps(keepIds: Set[Id[Keep]]): Future[Map[Id[Keep], Int]]
@@ -340,9 +340,9 @@ class ElizaServiceClientImpl @Inject() (
       response.json.as[Response].unreadCount
     }
   }
-  def sendMessageOnKeep(userId: Id[User], text: String, keepId: Id[Keep]): Future[Message] = {
+  def sendMessageOnKeep(userId: Id[User], text: String, keepId: Id[Keep], source: Option[MessageSource]): Future[Message] = {
     import SendMessageOnKeep._
-    val request = Request(userId, text, keepId)
+    val request = Request(userId, text, keepId, source.getOrElse(MessageSource.SITE))
     call(Eliza.internal.sendMessageOnKeep(), body = Json.toJson(request)).map { response =>
       response.json.as[Response].msg
     }
@@ -436,7 +436,7 @@ object ElizaServiceClient {
     implicit val responseFormat: Format[Response] = Json.format[Response]
   }
   object SendMessageOnKeep {
-    case class Request(userId: Id[User], text: String, keepId: Id[Keep])
+    case class Request(userId: Id[User], text: String, keepId: Id[Keep], source: MessageSource)
     case class Response(msg: Message)
     implicit val requestFormat: Format[Request] = Json.format[Request]
     implicit val responseFormat: Format[Response] = Json.format[Response]

--- a/kifi-backend/modules/common/test/com/keepit/eliza/FakeElizaServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/eliza/FakeElizaServiceClientImpl.scala
@@ -7,7 +7,7 @@ import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.mail.EmailAddress
 import com.keepit.common.service.ServiceType
 import com.keepit.common.zookeeper.ServiceCluster
-import com.keepit.discussion.{CrossServiceMessage, Discussion, Message}
+import com.keepit.discussion.{MessageSource, CrossServiceMessage, Discussion, Message}
 import com.keepit.eliza.model._
 import com.keepit.model._
 import com.keepit.notify.model.event.NotificationEvent
@@ -104,7 +104,7 @@ class FakeElizaServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, schedul
   def getMessageCountsForKeeps(keepIds: Set[Id[Keep]]): Future[Map[Id[Keep], Int]] = Future.successful(keepIds.map(_ -> 1).toMap)
   def getElizaKeepStream(userId: Id[User], limit: Int, beforeId: Option[Id[Keep]], filter: ElizaFeedFilter) = ???
   def markKeepsAsReadForUser(userId: Id[User], lastSeen: Map[Id[Keep], Id[Message]]): Future[Map[Id[Keep],Int]] = ???
-  def sendMessageOnKeep(userId: Id[User], text: String, keepId: Id[Keep]): Future[Message] = ???
+  def sendMessageOnKeep(userId: Id[User], text: String, keepId: Id[Keep], source: Option[MessageSource]): Future[Message] = ???
   def keepHasThreadWithAccessToken(keepId: Id[Keep], accessToken: String): Future[Boolean] = Future.successful(true)
   def editParticipantsOnKeep(keepId: Id[Keep], editor: Id[User], newUsers: Set[Id[User]]): Future[Set[Id[User]]] = ???
   def getMessagesChanged(seqNum: SequenceNumber[Message], fetchSize: Int): Future[Seq[CrossServiceMessage]] = Future.successful(Seq.empty)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
@@ -10,7 +10,7 @@ import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.common.mail.BasicContact
 import com.keepit.common.time._
-import com.keepit.discussion.{ DiscussionFail, Discussion, Message }
+import com.keepit.discussion.{ MessageSource, DiscussionFail, Discussion, Message }
 import com.keepit.eliza.model._
 import com.keepit.heimdal.HeimdalContext
 import com.keepit.model._

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/EmailMessageProcessingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/EmailMessageProcessingCommander.scala
@@ -1,17 +1,15 @@
 package com.keepit.eliza.commanders
 
 import com.google.inject.Inject
+import com.keepit.discussion.MessageSource
 import com.keepit.eliza.model._
 import com.keepit.common.logging.Logging
 import com.kifi.franz.SQSQueue
 import com.keepit.eliza.mail.MailNotificationReply
-import com.keepit.common.db.Id
-import scala.Some
 import com.keepit.eliza.model.NonUserThread
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.util.{ Success, Failure }
-import com.keepit.common.db.slick.Database
 import com.keepit.heimdal.HeimdalContextBuilderFactory
 import scala.concurrent.duration._
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageWithBasicUser.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageWithBasicUser.scala
@@ -1,7 +1,7 @@
 package com.keepit.eliza.commanders
 
 import com.keepit.common.crypto.PublicId
-import com.keepit.discussion.Message
+import com.keepit.discussion.{ MessageSource, Message }
 import org.joda.time.DateTime
 
 import com.keepit.common.time._

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -15,7 +15,7 @@ import com.keepit.common.logging.Logging
 import com.keepit.common.mail.BasicContact
 import com.keepit.common.net.URI
 import com.keepit.common.time._
-import com.keepit.discussion.{ DiscussionKeep, Message }
+import com.keepit.discussion.{ MessageSource, DiscussionKeep, Message }
 import com.keepit.eliza.model._
 import com.keepit.eliza.model.SystemMessageData._
 import com.keepit.heimdal.{ HeimdalContext, HeimdalContextBuilder }
@@ -198,7 +198,6 @@ class MessagingCommander @Inject() (
   def sendNewMessage(from: Id[User], userRecipients: Seq[Id[User]], nonUserRecipients: Seq[NonUserParticipant], url: String, titleOpt: Option[String], messageText: String, source: Option[MessageSource])(implicit context: HeimdalContext): Future[(MessageThread, ElizaMessage)] = {
     updateMessageSearchHistoryWithEmailAddresses(from, nonUserRecipients)
     val userParticipants = (from +: userRecipients).distinct
-    val tStart = currentDateTime
 
     val uriFetch = URI.parse(url) match {
       case Success(parsed) =>

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/ext/ExtMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/ext/ExtMessagingController.scala
@@ -1,7 +1,7 @@
 package com.keepit.eliza.controllers.ext
 
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
-import com.keepit.discussion.{ DiscussionFail, Message }
+import com.keepit.discussion.{ MessageSource, DiscussionFail, Message }
 import com.keepit.eliza.model._
 import com.keepit.eliza.commanders.{ ElizaThreadInfo, ElizaDiscussionCommander, MessagingCommander, ElizaEmailCommander }
 import com.keepit.common.controller.{ ElizaServiceController, UserActions, UserActionsHelper }
@@ -79,7 +79,7 @@ class ExtMessagingController @Inject() (
         val contextBuilder = heimdalContextBuilder.withRequestInfo(request)
         contextBuilder += ("source", "extension")
         (o \ "extVersion").asOpt[String].foreach { version => contextBuilder += ("extensionVersion", version) }
-        contextBuilder.data.remove("remoteAddress") // To be removed when the extension if fixed to send the client's ip
+        contextBuilder.data.remove("remoteAddress") // To be removed when the extension if fixed to send the client's ip //
         discussionCommander.sendMessage(request.userId, text, keepId, source)(contextBuilder.build)
       }
     } yield {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaDiscussionController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaDiscussionController.scala
@@ -8,7 +8,7 @@ import com.keepit.common.db.{ SequenceNumber, Id }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
 import com.keepit.model.{ ElizaFeedFilter, User, Keep }
-import com.keepit.discussion.Message
+import com.keepit.discussion.{ MessageSource, Message }
 import com.keepit.eliza.commanders.ElizaDiscussionCommander
 import com.keepit.eliza.model._
 import com.keepit.heimdal._
@@ -78,7 +78,8 @@ class ElizaDiscussionController @Inject() (
     import SendMessageOnKeep._
     val input = request.body.as[Request]
     val contextBuilder = heimdalContextBuilder.withRequestInfo(request)
-    discussionCommander.sendMessage(input.userId, input.text, input.keepId, source = Some(MessageSource.SITE))(contextBuilder.build).map { msg =>
+    contextBuilder += ("source", input.source.value)
+    discussionCommander.sendMessage(input.userId, input.text, input.keepId, source = Some(input.source))(contextBuilder.build).map { msg =>
       val output = Response(msg)
       Ok(Json.toJson(output))
     }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
@@ -9,9 +9,8 @@ import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.mail.BasicContact
 import com.keepit.common.net.{ URISanitizer, UserAgent }
 import com.keepit.common.time._
-import com.keepit.discussion.{ DiscussionKeep, DiscussionFail, Message }
+import com.keepit.discussion.{ MessageSource, DiscussionFail, Message }
 import com.keepit.eliza.commanders._
-import com.keepit.eliza.model.MessageSource
 import scala.collection._
 import com.keepit.heimdal._
 import com.keepit.model.{ Keep, Organization, User }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
@@ -5,7 +5,7 @@ import com.keepit.common.cache.CacheStatistics
 import com.keepit.common.logging.AccessLog
 import com.keepit.common.json._
 import com.keepit.common.util.DescriptionElements
-import com.keepit.discussion.{ CrossServiceMessage, Message }
+import com.keepit.discussion.{ MessageSource, CrossServiceMessage, Message }
 import com.keepit.notify.model.Recipient
 import com.keepit.social.{ BasicUserLikeEntity, BasicUser }
 import org.joda.time.DateTime
@@ -78,30 +78,6 @@ object MessageSender {
 
   def toMessageSenderView(messageSender: MessageSender): MessageSenderView =
     messageSender.fold(MessageSenderSystemView(), MessageSenderUserView, nup => MessageSenderNonUserView(nup.identifier))
-}
-
-case class MessageSource(value: String)
-object MessageSource {
-  val CHROME = MessageSource("Chrome")
-  val FIREFOX = MessageSource("Firefox")
-  val EMAIL = MessageSource("Email")
-  val IPHONE = MessageSource("iPhone")
-  val IPAD = MessageSource("iPad")
-  val ANDROID = MessageSource("Android")
-  val SERVER = MessageSource("server")
-  val SITE = MessageSource("Kifi.com")
-
-  implicit val messageSourceFormat = new Format[MessageSource] {
-    def reads(json: JsValue): JsResult[MessageSource] = {
-      json.asOpt[String] match {
-        case Some(str) => JsSuccess(MessageSource(str))
-        case None => JsError()
-      }
-    }
-    def writes(kind: MessageSource): JsValue = {
-      JsString(kind.value)
-    }
-  }
 }
 
 sealed abstract class SystemMessageData(val kind: String)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessageRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessageRepo.scala
@@ -6,6 +6,7 @@ import com.keepit.common.db.slick._
 import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.plugin.{ SequencingActor, SchedulingProperties, SequencingPlugin }
+import com.keepit.discussion.MessageSource
 import org.joda.time.DateTime
 import com.keepit.common.time._
 import com.keepit.common.db.{ SequenceNumber, DbSequenceAssigner, Id }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessagingTypeMappers.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessagingTypeMappers.scala
@@ -1,8 +1,9 @@
 package com.keepit.eliza.model
 
-import com.keepit.common.db.{ Id }
+import com.keepit.common.db.Id
+import com.keepit.discussion.MessageSource
 import play.api.libs.json.{ Json, JsSuccess, JsArray, JsNumber }
-import com.keepit.model.{ NormalizedURI }
+import com.keepit.model.NormalizedURI
 import com.keepit.common.db.slick.DataBaseComponent
 
 case class InvalidDatabaseEncodingException(msg: String) extends java.lang.Throwable

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/commanders/NotificationDeliveryCommanderTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/commanders/NotificationDeliveryCommanderTest.scala
@@ -8,8 +8,8 @@ import com.keepit.common.crypto.FakeCryptoModule
 import com.keepit.common.db.Id
 import com.keepit.common.store.FakeElizaStoreModule
 import com.keepit.common.time._
+import com.keepit.discussion.MessageSource
 import com.keepit.eliza.FakeElizaServiceClientModule
-import com.keepit.eliza.model.MessageSource
 import com.keepit.heimdal.{ FakeHeimdalServiceClientModule, HeimdalContext }
 import com.keepit.model._
 import com.keepit.rover.FakeRoverServiceModule

--- a/kifi-backend/modules/shoebox/angular/src/common/services/net.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/net.js
@@ -111,7 +111,6 @@ angular.module('kifi')
       connectSlack: post(shoebox, '/organizations/:teamId/slack/connect?slackTeamId=:optSlackTeamId&slackState=:optSlackState'),
       createTeamFromSlack: post(shoebox, '/organizations/create/slack?slackTeamId=:optSlackTeamId&slackState=:optSlackState'),
 
-    // eliza
       addMessageToKeepDiscussion: post(shoebox, '/keeps/:id/messages'),
       // ?limit={{number}}&fromId={{Option(String))}}
       getMessagesForKeepDiscussion: get(shoebox, '/keeps/:id/messages?limit=:limit&fromId=:fromId'),

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepService.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepService.js
@@ -17,7 +17,7 @@ angular.module('kifi')
     var api = {
       addMessageToKeepDiscussion: function (keepId, text) {
         return net
-        .addMessageToKeepDiscussion(keepId, { text: text })
+        .addMessageToKeepDiscussion(keepId, { text: text, source: 'Kifi.com' }) // '/kifi-backend/modules/common/app/com/keepit/discussion/MessageSource'
         .then(getResponseData);
       },
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/DiscussionController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/DiscussionController.scala
@@ -2,15 +2,16 @@ package com.keepit.controllers.website
 
 import com.google.inject.{ Inject, Singleton }
 import com.keepit.commanders.DiscussionCommander
-import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper }
+import com.keepit.common.controller.{ UserRequest, ShoeboxServiceController, UserActions, UserActionsHelper }
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.json.{ TraversableFormat, KeyFormat }
-import com.keepit.discussion.{ DiscussionFail, Message }
+import com.keepit.discussion.{ MessageSource, DiscussionFail, Message }
 import com.keepit.eliza.ElizaServiceClient
+import com.keepit.heimdal.{ HeimdalContext, HeimdalContextBuilderFactory }
 import com.keepit.model._
-import play.api.libs.json.Json
+import play.api.libs.json.{ JsValue, Json }
 
 import scala.concurrent.{ Future, ExecutionContext }
 
@@ -21,6 +22,7 @@ class DiscussionController @Inject() (
   val userActionsHelper: UserActionsHelper,
   val db: Database,
   userRepo: UserRepo,
+  protected val heimdalContextBuilder: HeimdalContextBuilderFactory,
   implicit val publicIdConfig: PublicIdConfiguration,
   implicit val ec: ExecutionContext)
     extends UserActions with ShoeboxServiceController {
@@ -44,10 +46,11 @@ class DiscussionController @Inject() (
     }
   }
   def sendMessageOnKeep(pubId: PublicId[Keep]) = UserAction.async(parse.tolerantJson) { request =>
+    val source = (request.body \ "source").asOpt[MessageSource]
     (for {
       text <- (request.body \ "text").asOpt[String].map(Future.successful).getOrElse(Future.failed(DiscussionFail.MISSING_MESSAGE_TEXT))
       keepId <- Keep.decodePublicId(pubId).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INVALID_KEEP_ID))
-      msg <- discussionCommander.sendMessageOnKeep(request.userId, text, keepId)
+      msg <- discussionCommander.sendMessageOnKeep(request.userId, text, keepId, source)
     } yield {
       Ok(Json.toJson(msg))
     }).recover {

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1081,7 +1081,7 @@ api.port.on({
     data.extVersion = api.version;
     data.source = api.browser.name;
     data.eip = eip;
-    ajax('eliza', 'POST', '/eliza/messages/' + threadId, data, logAndRespond, logErrorAndRespond);
+    ajax('shoebox', 'POST', '/site/keeps/' + threadId + '/messages', data, logAndRespond, logErrorAndRespond);
     function logAndRespond(o) {
       log('[send_reply] resp:', o);
       respond(o);


### PR DESCRIPTION
@ryanpbrewster @andrewconner tested this in dev mode (prod server) and it worked fine. the backend stuff is just to accurately track the message source now that it's ambiguous.

@DerekBurch not sure if we have keep messaging permission leaks on mobile, but if there's a possibility of it we should migrate to `POST /site/keeps/:keepId/messages` for reply actions.
