### PR TITLE
remove intent cookie when user exits auth flow

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/social/providers/SecureSocialControllers.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/providers/SecureSocialControllers.scala
@@ -80,12 +80,7 @@ object ProviderController extends Controller with Logging {
             user =>
               log.info(s"[handleAuth] user [${user.email} ${user.identityId}] found from provider - completing auth")
               completeAuthentication(user, request.session)
-          }) match {
-            case result if result.header.status == 400 =>
-              log.error(s"[handleAuth] ${result.header.status} response from IdentityProvider $provider, res body=${result.body}")
-              Redirect(RoutesHelper.login())
-            case result => result
-          }
+          })
         } catch {
           case ex: AccessDeniedException => {
             log.error("[handleAuth] Access Denied for user logging in")

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -8,6 +8,7 @@ import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, Use
 import com.keepit.common.crypto.{ PublicIdConfiguration, PublicId }
 import com.keepit.common.db.ExternalId
 import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.common.mail._
 import com.keepit.common.net.UserAgent
@@ -132,6 +133,7 @@ class AuthController @Inject() (
     config: FortyTwoConfig,
     userIdentityHelper: UserIdentityHelper,
     pathCommander: PathCommander,
+    airbrake: AirbrakeNotifier,
     implicit val secureSocialClientIds: SecureSocialClientIds,
     implicit val publicIdConfig: PublicIdConfiguration) extends UserActions with ShoeboxServiceController with Logging {
 
@@ -148,6 +150,9 @@ class AuthController @Inject() (
       authHelper.transformResult(res) { (_, session: Session) =>
         res.withSession(session + (SecureSocial.OriginalUrlKey -> routes.AuthController.afterLoginClosePopup.url))
       }
+    } else if (res.header.status == 400) {
+      airbrake.notify(s"[handleAuth] loginSocial failed due to ${res.header.status} response from $provider, body=${res.body}")
+      Redirect(RoutesHelper.login()).discardingCookies(PostRegIntent.discardingCookies: _*)
     } else {
       res
     }
@@ -186,7 +191,12 @@ class AuthController @Inject() (
           p.authenticate().fold(
             result => result,
             user => completeAuthentication(user, request.session)
-          )
+          ) match {
+              case result if result.header.status == 400 =>
+                airbrake.notify(s"[handleAuth] ${result.header.status} response from $provider, body=${result.body}")
+                Redirect(RoutesHelper.login()).discardingCookies(PostRegIntent.discardingCookies: _*)
+              case result => result
+            }
         } catch {
           case ex: AccessDeniedException => {
             Redirect(RoutesHelper.login()).flashing("error" -> Messages("securesocial.login.accessDenied"))
@@ -338,17 +348,22 @@ class AuthController @Inject() (
     publicOrgId: Option[String], orgAuthToken: Option[String],
     publicKeepId: Option[String], keepAuthToken: Option[String]) = Action.async(parse.anyContent) { implicit request =>
     val authRes = ProviderController.authenticate(provider)
-    authRes(request).map { result =>
-      authHelper.transformResult(result) { (_, sess: Session) =>
-        // TODO: set FORTYTWO_USER_ID instead of clearing it and then setting it on the next request?
-        val res = result.withSession((sess + (SecureSocial.OriginalUrlKey -> routes.AuthController.signupPage().url)).deleteUserId)
+    authRes(request).map {
+      case badResult if badResult.header.status == 400 =>
+        airbrake.notify(s"[handleAuth] signup failed because provider $provider returned status ${badResult.header.status} and body ${badResult.body}")
+        Redirect("/signup").discardingCookies(PostRegIntent.discardingCookies: _*)
+      case result =>
+        authHelper.transformResult(result) { (_, sess: Session) =>
+          // TODO: set FORTYTWO_USER_ID instead of clearing it and then setting it on the next request?
+          val res = result.withSession((sess + (SecureSocial.OriginalUrlKey -> routes.AuthController.signupPage().url)).deleteUserId)
 
-        // todo implement POST hook
-        // This could be a POST, url encoded body. If so, there may be a registration hook for us to add to their session.
-        // ie, auto follow library, auto friend, etc
-        val cookies = PostRegIntent.requestToCookies(request)
-        res.withCookies(cookies: _*)
-      }
+          // todo implement POST hook
+          // This could be a POST, url encoded body. If so, there may be a registration hook for us to add to their session.
+          // ie, auto follow library, auto friend, etc
+
+          val cookies = PostRegIntent.requestToCookies(request)
+          res.withCookies(cookies: _*)
+        }
     }
   }
 


### PR DESCRIPTION
@leogrim the bug where the slack intent cookie isn't deleted (and routes to slack auth even no matter how you auth) is highlighted now that users can press "cancel" on the slack auth page and go back to /login. I'm happy to just remove the intent if you press "cancel" or something goes wrong.
