### PR TITLE
fix user profile library count

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/userProfile/userProfile.tpl.html
@@ -9,7 +9,7 @@
         ng-class="{ 'active': currentPageName === 'OwnedLibraries'}"
         ng-click="trackLibraryNav('own')"
       >
-        <div class="kf-up-tab-count">{{profile.numLibraries|num}}</div>
+        <div class="kf-up-tab-count">{{(profile.numLibraries + profile.numCollabLibraries)|num}}</div>
         <div class="kf-up-tab-name" >Libraries</div>
       </a>
       <a


### PR DESCRIPTION
@cvializ 

![screen shot 2016-02-26 at 4 23 57 pm](https://cloud.githubusercontent.com/assets/8929238/13369395/09c7c83a-dca9-11e5-86bd-531e304695ce.png)

cc @ryanpbrewster while there are one-off things that will make the backend return the right numbers, the underlying problem here is that we don't use `libraryMembership.listed` properly. We don't show any organization libraries on users' profiles, so `listed` should be false if `library.organizationId.isDefined` (not the case, we manually filter out org libs). I'm working on enforcing that low-priority.
