### PR TITLE
attending to timeout we see from slack on both search api and user li…

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/slack/SlackClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/slack/SlackClient.scala
@@ -3,7 +3,7 @@ package com.keepit.slack
 import com.keepit.common.core._
 import com.keepit.common.json.readUnit
 import com.keepit.common.logging.Logging
-import com.keepit.common.net.{ DirectUrl, HttpClient, NonOKResponseException }
+import com.keepit.common.net._
 import com.keepit.slack.models._
 import play.api.http.Status
 import play.api.libs.json._
@@ -79,6 +79,8 @@ class SlackClientImpl(
   implicit val ec: ExecutionContext)
     extends SlackClient with Logging {
 
+  val longTimeout = CallTimeouts(responseTimeout = Some(30000), maxWaitTime = Some(30000), maxJsonParseTime = Some(30000))
+
   def pushToWebhook(url: String, msg: SlackMessageRequest): Future[Unit] = {
     log.info(s"About to post $msg to the Slack webhook at $url")
     httpClient.postFuture(DirectUrl(url), Json.toJson(msg)).flatMap { clientResponse =>
@@ -105,17 +107,24 @@ class SlackClientImpl(
   }
 
   private def slackCall[T](route: SlackAPI.Route)(implicit reads: Reads[T]): Future[T] = {
-    httpClient.getFuture(DirectUrl(route.url)).flatMap { clientResponse =>
-      (clientResponse.status, clientResponse.json) match {
-        case (Status.OK, payload) if (payload \ "ok").asOpt[Boolean].contains(true) =>
-          reads.reads(payload) match {
-            case JsSuccess(res, _) => Future.successful(res)
-            case errs: JsError => Future.failed(SlackFail.MalformedPayload(payload))
-          }
-        case (status, payload) => Future.failed(SlackAPIErrorResponse.ApiError(status, payload))
-      }
+    parseSlackResponse(httpClient.getFuture(DirectUrl(route.url)))
+  }
+
+  private def slackCall[T](route: SlackAPI.Route, callTimeouts: CallTimeouts)(implicit reads: Reads[T]): Future[T] = {
+    parseSlackResponse(httpClient.withTimeout(callTimeouts).getFuture(DirectUrl(route.url)))
+  }
+
+  private def parseSlackResponse[T](resp: Future[ClientResponse])(implicit reads: Reads[T]): Future[T] = resp.flatMap { clientResponse =>
+    (clientResponse.status, clientResponse.json) match {
+      case (Status.OK, payload) if (payload \ "ok").asOpt[Boolean].contains(true) =>
+        reads.reads(payload) match {
+          case JsSuccess(res, _) => Future.successful(res)
+          case errs: JsError => Future.failed(SlackFail.MalformedPayload(payload))
+        }
+      case (status, payload) => Future.failed(SlackAPIErrorResponse.ApiError(status, payload))
     }
   }
+
   def processAuthorizationResponse(code: SlackAuthorizationCode, redirectUri: String): Future[SlackAuthorizationResponse] = {
     slackCall[SlackAuthorizationResponse](SlackAPI.OAuthAccess(code, redirectUri))
   }
@@ -131,7 +140,7 @@ class SlackClientImpl(
   }
 
   def searchMessages(token: SlackUserAccessToken, request: SlackSearchRequest): Future[SlackSearchResponse] = {
-    slackCall[SlackSearchResponse](SlackAPI.SearchMessages(token, request))
+    slackCall[SlackSearchResponse](SlackAPI.SearchMessages(token, request), longTimeout)
   }
 
   def identifyUser(token: SlackAccessToken): Future[SlackIdentifyResponse] = {
@@ -162,7 +171,7 @@ class SlackClientImpl(
     slackCall[SlackTeamInfo](SlackAPI.TeamInfo(token))((__ \ 'team).read)
   }
   def getPublicChannels(token: SlackAccessToken, excludeArchived: Boolean): Future[Seq[SlackPublicChannelInfo]] = {
-    slackCall[Seq[SlackPublicChannelInfo]](SlackAPI.ChannelsList(token, excludeArchived))((__ \ 'channels).read)
+    slackCall[Seq[SlackPublicChannelInfo]](SlackAPI.ChannelsList(token, excludeArchived), longTimeout)((__ \ 'channels).read)
   }
   def getPublicChannelInfo(token: SlackAccessToken, channelId: SlackChannelId): Future[SlackPublicChannelInfo] = {
     slackCall[SlackPublicChannelInfo](SlackAPI.ChannelInfo(token, channelId))((__ \ 'channel).read)
@@ -173,6 +182,6 @@ class SlackClientImpl(
   }
 
   def getUsers(token: SlackAccessToken): Future[Seq[SlackUserInfo]] = {
-    slackCall[Seq[SlackUserInfo]](SlackAPI.UsersList(token))((__ \ 'members).read)
+    slackCall[Seq[SlackUserInfo]](SlackAPI.UsersList(token), longTimeout)((__ \ 'members).read)
   }
 }


### PR DESCRIPTION
…st. it seem to take them some time, the response json is large so it take long time to parse and we timeout with no need.

The standard timeout for that was 10sec, increasing few calls to 30sec (x3). Lets see how it goes for few days.

See 
https://fortytwo.airbrake.io/projects/91268/groups/1258110422457274197/notices/1629250396800506763
and 
https://fortytwo.airbrake.io/projects/91268/groups/1196766071605447655/notices/1629069207477845655
