### PR TITLE
allow ext to handle notices with no author (system notifs)

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
@@ -51,7 +51,7 @@ class MessageFetchingCommander @Inject() (
       message.from match {
         case MessageSender.User(id) => Some(BasicUserLikeEntity(basicUserById(id)))
         case MessageSender.NonUser(nup) => Some(BasicUserLikeEntity(NonUserParticipant.toBasicNonUser(nup)))
-        case MessageSender.System => Some(BasicUserLikeEntity(BasicUser(ExternalId[User]("42424242-4242-4242-4242-000000000001"), "Kifi", "", "0.jpg", Username("sssss"))))
+        case MessageSender.System => None
       },
       participants
     )

--- a/packrat/scripts/notices.js
+++ b/packrat/scripts/notices.js
@@ -204,15 +204,14 @@ k.panes.notices = k.panes.notices || function () {
       notice.title = notice.title || formatTitleFromUrl(notice.url);
       var participants = notice.participants;
       var nParticipants = participants.length;
-      notice.author = notice.author || notice.participants[0];
       if (notice.authors === 1) {
-        notice[nParticipants === 1 ? 'isSelf' : notice.author.id === k.me.id ? 'isSent' : 'isReceived'] = true;
+        notice[nParticipants === 1 ? 'isSelf' : (notice.author && notice.author.id) === k.me.id ? 'isSent' : 'isReceived'] = true;
       } else if (notice.firstAuthor > 1) {
         participants.splice(1, 0, participants.splice(notice.firstAuthor, 1)[0]);
       }
       var nPicsMax = 3;
       notice.picturedParticipants = nParticipants <= nPicsMax ?
-        notice.isReceived && nParticipants === 2 ? [notice.author] : participants :
+        notice.isReceived && nParticipants === 2 ? notice.author && [notice.author] || [] : participants :
         participants.slice(0, nPicsMax);
       notice.picIndex = notice.picturedParticipants.length === 1 ? 0 : counter();
       var nNamesMax = 4;
@@ -246,12 +245,12 @@ k.panes.notices = k.panes.notices || function () {
         notice.nameIndex = counter();
         notice.nameSeriesLength = notice.namedParticipants.length + (notice.otherParticipants ? 1 : 0);
       }
-      if (notice.author.id === k.me.id) {
+      if (notice.author && notice.author.id === k.me.id) {
         if (notice.isSelf) {
           notice.multiple = notice.messages > 1;
         }
         notice.authorShortName = 'Me';
-      } else if (nParticipants > 2) {
+      } else if (notice.author && nParticipants > 2) {
         notice.authorShortName = notice.author.firstName;
       }
       notice.picturedParticipants.map(formatParticipant);


### PR DESCRIPTION
@andrewconner @cvializ system notifications are sent to the ext inbox now, and currently the author is some garbage user named "Kifi". to fix that bug, I'm going to make `notice.author = undefined` on the backend, so this will be needed to get the desired behavior.
