### PR TITLE
minor improvements to slack upsell widget

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
@@ -82,6 +82,7 @@ object UserValueName {
   val HAS_SEEN_FTUE = UserValueName("has_seen_ftue")
   val STORED_CREDIT_CODE = UserValueName("stored_credit_code")
   val SLACK_INT_PROMO = UserValueName("slack_int_promo")
+  val SLACK_UPSELL_WIDGET = UserValueName("slack_upsell_widget")
   val SHOW_SLACK_CREATE_TEAM_POPUP = UserValueName("show_slack_create_team_popup")
 
   val LAST_SMS_SENT = UserValueName("last_sms_sent")

--- a/kifi-backend/modules/shoebox/angular/src/home/featureUpsell.js
+++ b/kifi-backend/modules/shoebox/angular/src/home/featureUpsell.js
@@ -16,14 +16,13 @@ angular.module('kifi')
         scope.me = profileService.me;
         var hasFeatureUpsellExp = ((profileService.me.experiments || []).indexOf('slack_upsell_widget') !== -1);
         scope.userLoggedIn = $rootScope.userLoggedIn;
-
         var slackIntPromoP;
         if (Object.keys(profileService.prefs).length === 0 ) {
           slackIntPromoP = profileService.fetchPrefs().then(function(prefs) {
             return prefs.slack_int_promo;
           });
         } else {
-          slackIntPromoP = $q.when(profileService.prefs.slack_int_promo);
+          slackIntPromoP = $q.when(profileService.prefs.slack_upsell_widget);
         }
         slackIntPromoP.then(function(showPromo) {
           scope.showFeatureUpsell = hasFeatureUpsellExp && showPromo;
@@ -31,7 +30,7 @@ angular.module('kifi')
 
         scope.hide = function () {
           scope.showFeatureUpsell = false;
-          profileService.savePrefs({ slack_int_promo: false });
+          profileService.savePrefs({ slack_upsell_widget: false });
         };
 
         scope.clickedConnectSlack = function() {

--- a/kifi-backend/modules/shoebox/angular/src/home/featureUpsell.styl
+++ b/kifi-backend/modules/shoebox/angular/src/home/featureUpsell.styl
@@ -23,6 +23,9 @@ section-border-radius = 10px
   right: -5px
   opacity: 0
 
+  &:hover
+    cursor: pointer
+
 
 .kf-fu-header
   margin-top: 10px

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/UserCommander.scala
@@ -593,13 +593,13 @@ class UserCommanderImpl @Inject() (
   private def generateDynamicPrefs(prefSet: Set[UserValueName], userId: Id[User]): Map[UserValueName, JsValue] = {
     db.readOnlyReplica { implicit session =>
       prefSet.collect {
-        case SLACK_INT_PROMO =>
+        case pref if pref == SLACK_INT_PROMO || pref == SLACK_UPSELL_WIDGET =>
           val teamOpt = organizationMembershipRepo.getByUserId(userId, Limit(1), Offset(0)).headOption
           def hasIntegrations = {
             slackTeamMembershipRepo.getByUserId(userId).nonEmpty ||
               teamOpt.flatMap(team => slackChannelToLibraryRepo.getIntegrationsByOrg(team.organizationId).headOption).nonEmpty
           }
-          SLACK_INT_PROMO -> JsBoolean(teamOpt.nonEmpty && !hasIntegrations)
+          pref -> JsBoolean(teamOpt.nonEmpty && !hasIntegrations)
       }.toMap
     }
   }


### PR DESCRIPTION
@andrewconner  this makes it such that the widget can be shown / hidden independent of the pop-up we use when you create a team (which uses slack_int_promo)

![screen shot 2016-03-01 at 10 04 30 am](https://cloud.githubusercontent.com/assets/8929238/13437186/b9fbf410-df97-11e5-9ad5-3ef565392493.png)
