### PR TITLE
use integrations/slack/start for auth instead of /link

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSlack.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSlack.tpl.html
@@ -4,7 +4,7 @@
     <p class="kf-org-profile-slack-title">Get access to your Slack team's libraries of links on Kifi</p>
     <a
       class="kf-button kf-button-large kf-org-profile-slack-button"
-      href="https://www.kifi.com/link/slack"
+      href="https://www.kifi.com/integrations/slack/start"
       target="_self"
       ng-click="linkSlack($event)"
     >


### PR DESCRIPTION
@leogrim seems like it works, I'm going to QA a bit more before merging
