### PR TITLE
Filter bad Slack channel names

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/SourceAttribution.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/SourceAttribution.scala
@@ -95,10 +95,11 @@ object TwitterAttribution {
   implicit val format = Json.format[TwitterAttribution]
 }
 
-case class BasicSlackMessage(channel: SlackChannelIdAndName, userId: SlackUserId, username: SlackUsername, timestamp: SlackTimestamp, permalink: String, text: String)
+case class BasicSlackMessage(channel: SlackChannelIdAndPrettyName, userId: SlackUserId, username: SlackUsername, timestamp: SlackTimestamp, permalink: String, text: String)
 object BasicSlackMessage {
+
   implicit val format = Json.format[BasicSlackMessage]
-  def fromSlackMessage(message: SlackMessage): BasicSlackMessage = BasicSlackMessage(message.channel, message.userId, message.username, message.timestamp, message.permalink, message.text)
+  def fromSlackMessage(message: SlackMessage): BasicSlackMessage = BasicSlackMessage(SlackChannelIdAndPrettyName.from(message.channel), message.userId, message.username, message.timestamp, message.permalink, message.text)
 }
 
 case class SlackAttribution(message: BasicSlackMessage, teamId: SlackTeamId) extends SourceAttribution
@@ -107,7 +108,7 @@ object SlackAttribution {
 }
 
 case class SourceAttributionKeepIdKey(keepId: Id[Keep]) extends Key[SourceAttribution] {
-  override val version = 4
+  override val version = 5
   val namespace = "source_attribution_by_keep_id"
   def toKey(): String = keepId.id.toString
 }

--- a/kifi-backend/modules/common/app/com/keepit/slack/models/SlackChannelIdAndName.scala
+++ b/kifi-backend/modules/common/app/com/keepit/slack/models/SlackChannelIdAndName.scala
@@ -12,7 +12,6 @@ sealed abstract class SlackChannelId(prefix: String) {
   def value: String
 }
 
-
 object SlackChannelId {
   case class Public(value: String) extends SlackChannelId("C")
   case class Private(value: String) extends SlackChannelId("G")
@@ -41,10 +40,20 @@ object SlackChannelId {
   )
 }
 
-@json case class SlackChannelName(value: String) // broad sense, can be channel, group or DM
-@json case class SlackChannelIdAndName(id: SlackChannelId, name: SlackChannelName)
+@json case class SlackChannelName(value: String)
 @json case class SlackChannelTopic(value: String)
 @json case class SlackChannelPurpose(value: String)
+
+@json case class SlackChannelIdAndName(id: SlackChannelId, name: SlackChannelName)
+@json case class SlackChannelIdAndPrettyName(id: SlackChannelId, name: Option[SlackChannelName])
+object SlackChannelIdAndPrettyName {
+  def from(channelId: SlackChannelId, name: SlackChannelName): SlackChannelIdAndPrettyName = channelId match {
+    case SlackChannelId.Public(_) | SlackChannelId.Private(_) => SlackChannelIdAndPrettyName(channelId, Some(name))
+    case _ => SlackChannelIdAndPrettyName(channelId, None)
+  }
+
+  def from(channelIdAndName: SlackChannelIdAndName): SlackChannelIdAndPrettyName = SlackChannelIdAndPrettyName.from(channelIdAndName.id, channelIdAndName.name)
+}
 
 // There is more stuff than just this returned
 case class SlackPublicChannelInfo(

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryNewKeepsCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryNewKeepsCommander.scala
@@ -60,7 +60,10 @@ class LibraryNewKeepsCommander @Inject() (
           case (_, Some(kifiUser)) => s"${kifiUser.fullName} kept to $libTrunc" + titleString
           case (attr: SlackAttribution, _) =>
             val name = attr.message.username.value
-            s"$name added to #${attr.message.channel.name.value}" + titleString
+            attr.message.channel.name match {
+              case Some(prettyChannelName) => s"$name added to #$prettyChannelName" + titleString
+              case None => s"$name shared" + titleString
+            }
         } getOrElse {
           val keepAdded = keeperOpt match {
             case Some(bu) => s"${bu.fullName} kept to"

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/LibraryToSlackChannelPusher.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/LibraryToSlackChannelPusher.scala
@@ -174,10 +174,14 @@ class LibraryToSlackChannelPusherImpl @Inject() (
     }
 
     slackMessageOpt match {
-      case Some(post) =>
+      case Some(message) =>
+        val origin = message.channel.name match {
+          case Some(prettyChannelName) => s"#${prettyChannelName.value}"
+          case None => s"@${message.username.value}"
+        }
         DescriptionElements(
           keep.title.getOrElse(keep.url.abbreviate(KEEP_URL_MAX_DISPLAY_LENGTH)) --> keepLink,
-          "from", s"#${post.channel.name.value}" --> LinkElement(post.permalink),
+          "from", origin --> LinkElement(message.permalink),
           "was added to", lib.name --> libLink,
           addComment
         )

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPushingActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPushingActor.scala
@@ -364,10 +364,14 @@ class SlackPushingActor @Inject() (
     val libLink = LinkElement(pathCommander.libraryPageViaSlack(lib, slackTeamId).absolute)
 
     slackMessageOpt match {
-      case Some(post) =>
+      case Some(message) =>
+        val origin = message.channel.name match {
+          case Some(prettyChannelName) => s"#${prettyChannelName.value}"
+          case None => s"@${message.username.value}"
+        }
         DescriptionElements(
           keep.title.getOrElse(keep.url.abbreviate(KEEP_URL_MAX_DISPLAY_LENGTH)) --> keepLink,
-          "from", s"#${post.channel.name.value}" --> LinkElement(post.permalink),
+          "from", origin --> LinkElement(message.permalink),
           "was added to", lib.name --> libLink, addComment
         )
       case None =>


### PR DESCRIPTION
@ryanpbrewster @cvializ 
I'll wait to merge this until you can handle a missing channel name both in the tool tip and search.
An easy solution in search is probably to replace a missing channel name with the username.
