### PR TITLE
Always ask for SlackAuthScope.Identity explicitly

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackAuthenticationCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackAuthenticationCommander.scala
@@ -49,7 +49,7 @@ class SlackAuthenticationCommanderImpl @Inject() (
 
   def getAuthLink(action: SlackAuthenticatedAction, teamId: Option[SlackTeamId], scopes: Set[SlackAuthScope], redirectUri: String): SlackAPI.Route = {
     val state = setNewSlackState(action)
-    SlackAPI.OAuthAuthorize(scopes, state, teamId, redirectUri)
+    SlackAPI.OAuthAuthorize(scopes + SlackAuthScope.Identify, state, teamId, redirectUri)
   }
 
   def getSlackAction(state: SlackAuthState): Option[SlackAuthenticatedAction] = {


### PR DESCRIPTION
@ryanpbrewster all of `SlackAuthenticationCommander` is written under the assumption that we know your Slack identity. That can cause issues when someone tries to take an action that doesn't require any permissions and we don't know his / her Slack identity. 
