### PR TITLE
Feature/ext team attr

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.7.13
+version=3.7.14

--- a/packrat/html/keeper/keepers.html
+++ b/packrat/html/keeper/keepers.html
@@ -1,6 +1,9 @@
 <kifi class="kifi-root kifi-keepers {{cssClass}}">
   {{#sources.length}}
-    <div class="kifi-keepers-h">In {{#oneSource}}This Channel{{/oneSource}}{{^oneSource}}These Channels{{/oneSource}}</div>
+    <div class="kifi-keepers-h">
+      In {{#oneSource}}This Channel{{/oneSource}}{{^oneSource}}These Channels{{/oneSource}}
+      {{^noCloseButton}}<a class="kifi-keepers-h-close" href="javascript:"></a>{{/noCloseButton}}
+    </div>
     <div class="kifi-keepers-sources">
     {{#sources}}
       {{#twitter.tweet}}

--- a/packrat/html/keeper/keepers.html
+++ b/packrat/html/keeper/keepers.html
@@ -32,7 +32,11 @@
               {{#channel.name}}#{{channel.name}}{{/channel.name}}
               {{^channel.name}}@{{username}}{{/channel.name}}
             </span>
-            <p class="kifi-keepers-source-context">{{#channel.name}}@{{username}}: {{/channel.name}}{{#text}}{{text}}{{/text}}{{^text}} shared this page{{/text}}</p>
+            <p class="kifi-keepers-source-context">
+              {{#channel.name}}@{{username}}{{/channel.name}}{{!
+            }}{{#text}}{{#channel.name}}: {{/channel.name}}{{text}}{{/text}}{{!
+            }}{{^text}} shared this page{{/text}}
+            </p>
           </div>
         </a>
       {{/slack.message}}

--- a/packrat/html/search/google_hit.html
+++ b/packrat/html/search/google_hit.html
@@ -43,7 +43,10 @@
           {{/twitter.tweet}}
           {{#slack.message}}
             <span class="kifi-res-source-slack-icon"></span>
-            <a class="kifi-res-source-slack-channel" href="{{permalink}}">#{{channel.name}}</a>
+            <a class="kifi-res-source-slack-channel" href="{{permalink}}">
+              {{#channel.name}}#{{channel.name}}{{/channel.name}}
+              {{^channel.name}}@{{username}}{{/channel.name}}
+            </a>
           {{/slack.message}}
         </span>
       {{/sources}}

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -2123,21 +2123,24 @@ function kififyWithPageData(tab, d) {
 
   // consider triggering automatic keeper behavior on page to engage user (only once)
   if (!tab.engaged) {
-    tab.engaged = true;
     if (!d.kept && !hide) {
       if (urlPatterns && urlPatterns.some(reTest(tab.url))) {
         log('[initTab]', tab.id, 'restricted');
+        tab.engaged = true;
       } else if (d.shown) {
         log('[initTab]', tab.id, 'shown before');
+        tab.engaged = true;
       } else if (d.keepers.length || d.libraries.length || d.sources.length) {
-        tab.keepersSec = 20;
+        tab.keepersSec = d.sources.filter(isSlack).length ? 0 : 20;
         if (api.tabs.isFocused(tab)) {
           scheduleAutoEngage(tab, 'keepers');
+          tab.engaged = true;
         }
       }
     }
   }
 }
+function isSlack(o) { return o.slack; }
 
 function gotPageDetailsFor(url, tab, resp) {
   var tabIsOld = api.tabs.get(tab.id) !== tab || url.split('#', 1)[0] !== tab.url.split('#', 1)[0];

--- a/packrat/scripts/keeper.js
+++ b/packrat/scripts/keeper.js
@@ -689,7 +689,7 @@ k.keeper = k.keeper || function () {  // idempotent for Chrome
                   ignoreWheel: true
                 });
 
-                if (o.sources.filter(isSlack).length) {
+                if (o.sources.filter(isSlack).length === 0) {
                   socialTooltipTimeout = setTimeout(function () {
                     $tile.hoverfu('hide')
                   }, 3000 + 1800 * o.libraries.length);

--- a/packrat/scripts/keeper.js
+++ b/packrat/scripts/keeper.js
@@ -155,7 +155,8 @@ k.keeper = k.keeper || function () {  // idempotent for Chrome
         if (o.libraries.length || o.keepers.length || o.sources.length) {
           var params = setSocialParams(o, {
             cssClass: 'kifi-keepers-hover',
-            kept: o.kept
+            kept: o.kept,
+            noCloseButton: true
           });
           k.render('html/keeper/keepers', params, function (html) {
             configureHover(attachSocialToolTipHandlers($(html), params, 'keepButton'), {
@@ -366,9 +367,9 @@ k.keeper = k.keeper || function () {  // idempotent for Chrome
   }
 
   function attachSocialToolTipHandlers($tip, params, subsource) {
-    return $tip.on('click', '.kifi-keepers-pic,.kifi-keepers-lib,.kifi-keepers-source', function () {
+    return $tip.on('click', '.kifi-keepers-pic,.kifi-keepers-lib,.kifi-keepers-source,.kifi-keepers-h-close', function () {
       var a = this, url = a.href;
-      if (url.indexOf('?') < 0) {
+      if (url && url.indexOf('?') < 0) {
         a.href = url + '?o=xst';
         setTimeout(function () {
           a.href = url;
@@ -379,9 +380,13 @@ k.keeper = k.keeper || function () {  // idempotent for Chrome
         action = 'clickedSource';
       } else if (a.classList.contains('kifi-keepers-lib')) {
         action = 'clickedLibrary';
-      } else {
+      } else if (a.classList.contains('kifi-keepers-pic')) {
         action = 'clickedFriend';
+      } else if (a.classList.contains('kifi-keepers-h-close')) {
+        action = 'clickedClose';
+        $tip.hoverfu('hide');
       }
+
       api.port.emit('track_notification_click', {
         category: 'socialToolTip',
         action: action,
@@ -665,6 +670,7 @@ k.keeper = k.keeper || function () {  // idempotent for Chrome
           if ((o.keepers.length || o.libraries.length || o.sources.length) && !lastCreatedAt) {
             $tile.hoverfu(function (configureHover) {
               // TODO: preload friend pictures
+              var socialTooltipTimeout;
               var params = setSocialParams(o, {cssClass: 'kifi-keepers-promo'});
               k.render('html/keeper/keepers', params, function (html) {
                 if (lastCreatedAt) return;
@@ -675,11 +681,19 @@ k.keeper = k.keeper || function () {  // idempotent for Chrome
                   $libs.css('width', $libs[0].offsetWidth);
                   $promo.detach();
                 }
-                configureHover($promo, {parent: $tile, mustHoverFor: 0, canLeaveFor: 1e9, ignoreWheel: true});
+                configureHover($promo, {
+                  parent: $tile,
+                  mustHoverFor: 0,
+                  canLeaveFor: 1e9,
+                  canLeaveAnywhere: true,
+                  ignoreWheel: true
+                });
 
-                var socialTooltipTimeout = setTimeout(function () {
-                  $tile.hoverfu('hide')
-                }, 3000 + 1800 * o.libraries.length);
+                if (o.sources.filter(isSlack).length) {
+                  socialTooltipTimeout = setTimeout(function () {
+                    $tile.hoverfu('hide')
+                  }, 3000 + 1800 * o.libraries.length);
+                }
 
                 attachSocialToolTipHandlers($promo, params, 'tile')
                 .data('timeout', socialTooltipTimeout)

--- a/packrat/scripts/lib/jquery-hoverfu.js
+++ b/packrat/scripts/lib/jquery-hoverfu.js
@@ -214,13 +214,18 @@
       if (data.opts.hideAfter) {
         clearTimeout(data.hide), delete data.hide;
       }
-      if (data.opts.canLeaveFor && (edge = between(this, this === a ? h : a, e.clientX, e.clientY))) {
+
+      edge = between(this, this === a ? h : a, e.clientX, e.clientY);
+      if (data.opts.canLeaveFor && (edge || data.opts.canLeaveAnywhere)) {
         data.hide = setTimeout(function () {
           hide.call(a);
         }, data.opts.canLeaveFor);
-        data.x = e.clientX;
-        data.y = e.clientY;
-        $(doc).on("mousemove.hoverfu", onMouseMoveMaybeHide.bind(a, edge, data));
+
+        if (!data.opts.canLeaveAnywhere) {
+          data.x = e.clientX;
+          data.y = e.clientY;
+          $(doc).on("mousemove.hoverfu", onMouseMoveMaybeHide.bind(a, edge, data));
+        }
       } else {
         hide.call(a);
       }

--- a/packrat/styles/keeper/keeper.less
+++ b/packrat/styles/keeper/keeper.less
@@ -320,6 +320,23 @@
     background-color: @keepers-h-bg-color;
   }
 }
+.kifi-keepers-h-close {
+  float: right;
+  padding: 0 10px;
+  margin-right: -10px;
+  cursor: pointer;
+  color: #999;
+
+  &:hover {
+    color: #333;
+  }
+  &:active {
+    color: #999
+  }
+  &:before {
+    content: 'X';
+  }
+}
 .kifi-keepers-sources,
 .kifi-keepers-libs {
   min-width: 200px;


### PR DESCRIPTION
@andrewconner could you pull and test this locally please? it affects the social tooltip on every page.
Expected behavior is: if it has a slack attribution, it should open immediately and it should stay open until the user opens the keeper or clicks the X to close.

@leogrim once this is deployed search will be able to handle null channel names

@JRuff42 
