### PR TITLE
don't reset OriginalUrlKey from /signup

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -355,14 +355,14 @@ class AuthController @Inject() (
       case result =>
         authHelper.transformResult(result) { (_, sess: Session) =>
           // TODO: set FORTYTWO_USER_ID instead of clearing it and then setting it on the next request?
-          val res = result.withSession((sess + (SecureSocial.OriginalUrlKey -> routes.AuthController.signupPage().url)).deleteUserId)
+          val maybeUpdatedSession = if (sess.get(SecureSocial.OriginalUrlKey).isEmpty) sess + (SecureSocial.OriginalUrlKey -> routes.AuthController.signupPage().url) else sess
 
           // todo implement POST hook
           // This could be a POST, url encoded body. If so, there may be a registration hook for us to add to their session.
           // ie, auto follow library, auto friend, etc
 
           val cookies = PostRegIntent.requestToCookies(request)
-          res.withCookies(cookies: _*)
+          result.withCookies(cookies: _*).withSession(maybeUpdatedSession.deleteUserId())
         }
     }
   }


### PR DESCRIPTION
@leogrim @andrewconner this is preventing (slack) auth flows from returning to where they came from upon error.
