### PR TITLE
Appease our mozilla overlords. Consistent meta.js ordering

### DIFF
--- a/packrat/gulpfile.js
+++ b/packrat/gulpfile.js
@@ -25,6 +25,7 @@ var filenames = require('gulp-filenames');
 var sourcemaps = require('gulp-sourcemaps');
 var babel = require('gulp-babel');
 var explicitGlobals = require('explicit-globals');
+var pathSort = require('path-sort');
 
 var target = 'local';
 var listed = false;
@@ -474,10 +475,25 @@ gulp.task('meta', function () {
   var firefoxMeta = preMeta.pipe(clone())
     .pipe(map(function (code) {
       var data = JSON.parse(code.toString());
-      return 'exports.contentScripts =' + data[0] +
-        ';\nexports.styleDeps = ' + data[1] +
-        ';\nexports.scriptDeps = ' + data[2] +
-        ';\nexports.flatScriptDeps = ' + data[3] +
+      var contentScripts = data[0];
+      var styleDeps = JSON.parse(data[1]);
+      var scriptDeps = JSON.parse(data[2]);
+      var flatScriptDeps = JSON.parse(data[3]);
+
+      styleDeps = pathSort(Object.keys(styleDeps)).reduce(function (acc, k) {
+        acc[k] = pathSort(styleDeps[k]);
+        return acc;
+      }, {});
+      scriptDeps = pathSort(Object.keys(scriptDeps)).reduce(function (acc, k) {
+        acc[k] = pathSort(scriptDeps[k]);
+        return acc;
+      }, {});
+      flatScriptDeps = pathSort(flatScriptDeps);
+
+      return 'exports.contentScripts =' + contentScripts +
+        ';\nexports.styleDeps = ' + JSON.stringify(styleDeps, null, 2) +
+        ';\nexports.scriptDeps = ' + JSON.stringify(scriptDeps, null, 2) +
+        ';\nexports.flatScriptDeps = ' + JSON.stringify(flatScriptDeps, null, 2) +
         ";\nif (/^Mac/.test(require('sdk/system').platform)) {\n  exports.styleDeps['scripts/keeper_scout.js'] = ['styles/mac.css'];\n}\n";
     }))
     .pipe(gulp.dest(outDir + '/firefox/lib'));

--- a/packrat/package.json
+++ b/packrat/package.json
@@ -33,11 +33,12 @@
     "karma-jasmine": "~0.1.5",
     "lazypipe": "~0.2.2",
     "new-from": "0.0.3",
+    "path-sort": "^0.1.0",
     "plist": "^1.2.0",
     "run-sequence": "~0.3.6",
     "through2": "~0.5.1",
     "vinyl-map": "~1.0.1",
-    "xml2js": "^0.4.16",
-    "xar-js": "^0.2.0"
+    "xar-js": "^0.2.0",
+    "xml2js": "^0.4.16"
   }
 }


### PR DESCRIPTION
> **Mozilla Add-ons: Kifi - Connecting People with Knowledge 3.7.12 Fully Reviewed**
> 
> Reviewer:
> Philipp Kewisch
> 
> Comments:
> If lib/meta.js is generated, can you make sure the sorting is stable? The changes in that file seem to be a result of reordering lines. Thanks!"

@andrewconner this shouldn't affect Firefox module loading because deps are all loaded at once, and then they're initialized once they're `require()`d.

This only affects Firefox's `meta.js`
