### PR TITLE
Revert "try to send an invite even if you can't fetch users"

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/OrganizationInviteCommander.scala
@@ -465,19 +465,15 @@ class OrganizationInviteCommanderImpl @Inject() (db: Database,
           slackClient.getUsers(slackTeam.slackTeamId).flatMap { userInfos =>
             userInfos.find(_.name == username) match {
               case None => Future.failed(SlackFail.SlackUserNotFound(username, slackTeam.slackTeamId))
-              case Some(slackUser) => Future.successful((SlackChannelId.User(slackUser.id.value), Some(slackUser)))
+              case Some(slackUser) =>
+                val invite: OrganizationInvite = persistInvitation(OrganizationInvite(organizationId = orgId, inviterId = org.ownerId, userId = userIdOpt, emailAddress = slackUser.profile.emailAddress), force = true)
+                  .getOrElse(throw new Exception(s"can't create org (${orgId.id}) invite for ${slackUser.id} on slack team ${slackTeam.id.get.id}"))
+                val message = SlackMessageRequest.fromKifi {
+                  DescriptionElements.formatForSlack(DescriptionElements(s"Here's your invitation to join ${org.name} on Kifi!",
+                    "Click here to accept it" --> LinkElement(s"${pathCommander.pathForOrganization(org).absolute}?authToken=${invite.authToken}")))
+                }
+                slackClient.sendToSlackHoweverPossible(slackTeam.slackTeamId, SlackChannelId.User(slackUser.id.value), message).map(_ => ())
             }
-          }.recover {
-            case SlackFail.NoValidToken => (SlackChannelId.User(username.value), None)
-          }.flatMap {
-            case (channel, userInfoOpt) =>
-              val invite: OrganizationInvite = persistInvitation(OrganizationInvite(organizationId = orgId, inviterId = org.ownerId, userId = None, emailAddress = userInfoOpt.flatMap(_.profile.emailAddress)), force = true)
-                .getOrElse(throw new Exception(s"can't create org (${orgId.id}) invite for slack username $username on slack team ${slackTeam.id.get.id}"))
-              val message = SlackMessageRequest.fromKifi {
-                DescriptionElements.formatForSlack(DescriptionElements(s"Here's your invitation to join ${org.name} on Kifi!",
-                  "Click here to accept it" --> LinkElement(s"${pathCommander.pathForOrganization(org).absolute}?authToken=${invite.authToken}")))
-              }
-              slackClient.sendToSlackHoweverPossible(slackTeam.slackTeamId, channel, message).map(_ => ())
           }
       }
     }


### PR DESCRIPTION
Reverts kifi/keepit#20237

@leogrim there are lots of assumptions that a `SlackChannelId` has a prefix (usernames break it), I can talk with @ryanpbrewster tomorrow if we want to loosen those assumptions or we can just not fallback
