### PR TITLE
add "intent" cookie when processing "slackTeamId" in auth

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/social/providers/SecureSocialControllers.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/providers/SecureSocialControllers.scala
@@ -111,9 +111,9 @@ object ProviderController extends Controller with Logging {
     Authenticator.create(userIdentity) match {
       case Right(authenticator) => {
         log.info(s"[completeAuthentication] Authentication [${authenticator.identityId}] completed for [${userIdentity.email}]")
-        val slackTeamIdCookie = IdentityHelpers.parseSlackIdMaybe(userIdentity.identityId).toOption.map {
-          case (slackTeamId, _) => Cookie("slackTeamId", slackTeamId.value)
-        }
+        val slackTeamIdCookies = IdentityHelpers.parseSlackIdMaybe(userIdentity.identityId).toOption.map {
+          case (slackTeamId, _) => Seq(Cookie("slackTeamId", slackTeamId.value), Cookie("intent", "slack"))
+        }.getOrElse(Seq.empty)
         val kifiCookies = Seq(
           request.cookies.get("intent"),
           request.cookies.get("publicOrgId"),
@@ -121,9 +121,8 @@ object ProviderController extends Controller with Logging {
           request.cookies.get("publicLibraryId"),
           request.cookies.get("libAuthToken"),
           request.cookies.get("publicKeepId"),
-          request.cookies.get("keepAuthToken"),
-          slackTeamIdCookie
-        ).flatten
+          request.cookies.get("keepAuthToken")
+        ).flatten ++ slackTeamIdCookies
         Redirect(toUrl(sess)).withSession(sess -
           SecureSocial.OriginalUrlKey -
           IdentityProvider.SessionId -

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthController.scala
@@ -597,7 +597,7 @@ class AuthController @Inject() (
         val slackTeamIdThatWasAroundForSomeMysteriousReason = slackTeamId orElse slackTeamIdFromCookie
         Redirect(com.keepit.controllers.website.routes.SlackOAuthController.addSlackTeam(slackTeamIdThatWasAroundForSomeMysteriousReason).url, SEE_OTHER).discardingCookies(discardedCookie).withSession(request.session)
       case nonUserRequest: NonUserRequest[_] =>
-        val signupUrl = com.keepit.controllers.core.routes.AuthController.signup(provider = "slack", slackTeamId = slackTeamId.map(_.value)).url
+        val signupUrl = com.keepit.controllers.core.routes.AuthController.signup(provider = "slack", intent = slackTeamId.map(_ => PostRegIntent.Slack.intentValue), slackTeamId = slackTeamId.map(_.value)).url
         Redirect(signupUrl, SEE_OTHER).withSession(request.session)
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/core/AuthHelper.scala
@@ -90,7 +90,7 @@ object PostRegIntent {
 
   val intentKey = "intent"
   val onFailUrlKey = "onFailUrl"
-  val discardingCookies = Set(Set(intentKey), AutoFollowLibrary.cookieKeys, AutoJoinOrganization.cookieKeys, AutoJoinKeep.cookieKeys, Slack.cookieKeys, ApplyCreditCode.cookieKeys).flatten.map(DiscardingCookie(_)).toSeq
+  val discardingCookies = Set(Set(intentKey, onFailUrlKey), AutoFollowLibrary.cookieKeys, AutoJoinOrganization.cookieKeys, AutoJoinKeep.cookieKeys, Slack.cookieKeys, ApplyCreditCode.cookieKeys).flatten.map(DiscardingCookie(_)).toSeq
 
   def fromCookies(cookies: Set[Cookie])(implicit config: PublicIdConfiguration): PostRegIntent = {
     val cookieByName = cookies.groupBy(_.name).mapValuesStrict(_.head)


### PR DESCRIPTION
@leogrim this gets things working again in dev mode. moving forward, we may want to just get rid of `intent` and infer intent(s) from whatever cookies / params are there.

we can keep `intent` around for things like `JoinTwitterWaitlist` which don't have any other cookies of interest, and for whenever the intent is ambiguous from just the `id` and `authToken` cookies. 
