### PR TITLE
revert to garbage user for system messages

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
@@ -51,7 +51,7 @@ class MessageFetchingCommander @Inject() (
       message.from match {
         case MessageSender.User(id) => Some(BasicUserLikeEntity(basicUserById(id)))
         case MessageSender.NonUser(nup) => Some(BasicUserLikeEntity(NonUserParticipant.toBasicNonUser(nup)))
-        case MessageSender.System => None
+        case MessageSender.System => Some(BasicUserLikeEntity(BasicUser(ExternalId[User]("42424242-4242-4242-4242-000000000001"), "Kifi", "", "0.jpg", Username("sssss"))))
       },
       participants
     )


### PR DESCRIPTION
@andrewconner 

when I set this to `None`, I only made the inbox compatible for it. I should have set `message.sender = undefined` immediately after the ext receives the message and QA'd that. will do that next.
