### PR TITLE
Note fallbacks to Slack/Twitter messages

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/emojiService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/emojiService.js
@@ -852,6 +852,17 @@ angular.module('kifi')
         return encodeMap[m] || m;
       }
 
+      function isSupported() {
+        if (supported == null) {
+          var c = document.createElement('canvas').getContext('2d');
+          c.textBaseline = 'top';
+          c.font = '32px Arial';
+          c.fillText('😄', 0, 0);
+          supported = c.getImageData(16, 16, 1, 1).data[0] !== 0;
+        }
+        return supported;
+      }
+
       var supported;
 
       return {
@@ -859,18 +870,9 @@ angular.module('kifi')
           return s.replace(encodeRe, encodeReplace);
         },
         decode: function (s) {
-          return s.replace(decodeRe, decodeReplace);
+          return isSupported ? s.replace(decodeRe, decodeReplace) : s;
         },
-        supported: function () {
-          if (supported == null) {
-            var c = document.createElement('canvas').getContext('2d');
-            c.textBaseline = 'top';
-            c.font = '32px Arial';
-            c.fillText('😄', 0, 0);
-            supported = c.getImageData(16, 16, 1, 1).data[0] !== 0;
-          }
-          return supported;
-        }
+        supported: isSupported
       };
 
     }

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
@@ -5,10 +5,10 @@ angular.module('kifi')
 .directive('kfKeepCard', [
   '$state', '$analytics', '$q', 'extensionLiaison', 'util', 'installService', 'libraryService',
   'modalService', 'keepActionService', '$location', 'undoService', '$rootScope', 'profileService',
-  '$injector',
+  '$injector', '$filter',
   function ($state, $analytics, $q, extensionLiaison, util, installService, libraryService,
       modalService, keepActionService, $location, undoService, $rootScope, profileService,
-      $injector) {
+      $injector, $filter) {
 
     // constants for side-by-side layout image sizing heuristic, based on large screen stylesheet values
     var cardW = 496;
@@ -129,7 +129,7 @@ angular.module('kifi')
           if (!editor.length) {
             var noteEl = keepEl.find('.kf-keep-card-note');
             var keepLibraryId = keep.library && keep.library.id;
-            $injector.get('keepNoteForm').init(noteEl, keep.note, keepLibraryId, keep.pubId, function update(noteText) {
+            $injector.get('keepNoteForm').init(noteEl, scope.displayNote, keepLibraryId, keep.pubId, function update(noteText) {
               keep.note = noteText;
             });
           } else {
@@ -290,6 +290,30 @@ angular.module('kifi')
           // Don't change until the link is updated to be a bit more secure:
           scope.galleryView = scope.forceGalleryView || !profileService.prefs.use_minimal_keep_card;
           scope.globalGalleryView = scope.galleryView;
+          var updateNote = function () {
+            var noteMayHaveFallback = keep.sourceAttribution && (keep.sourceAttribution.twitter || keep.sourceAttribution.slack);
+            var noteHasSubstance = function (note) {
+              if (!note) { return false; }
+              var parts = note.split(/\[#((?:\\.|[^\]])*)\]/g); // splitting on hashtags
+              var textPortion = '';
+              for (var i = 0; i < parts.length; i += 2) { textPortion += parts[i].trim(); }
+              return textPortion.length > 0;
+            };
+
+            if (noteMayHaveFallback && !noteHasSubstance(keep.note) && !scope.noteAttribution) {
+              if (keep.sourceAttribution.twitter) {
+                scope.displayNote = keep.sourceAttribution.twitter.tweet.text;
+                scope.noteAttribution = 'Twitter';
+              } else if (keep.sourceAttribution.slack && $filter('slackText')(keep.sourceAttribution.slack.message.text)) {
+                scope.displayNote = keep.sourceAttribution.slack.message.text;
+                scope.noteAttribution = 'Slack';
+              }
+            } else {
+              scope.displayNote = keep.note;
+              scope.noteAttribution = '';
+            }
+          };
+          scope.$watch('keep.note', updateNote);
 
           var libraryPermissions = (keep.library && keep.library.permissions) || [];
           var keepPermissions = keep.permissions || [];
@@ -348,7 +372,7 @@ angular.module('kifi')
                 action: scope.editKeepTitle.bind(scope)
               });
               scope.menuItems.push({
-                title: keep.note ? 'Edit Note' : 'Add Note',
+                title: scope.displayNote ? 'Edit Note' : 'Add Note',
                 action: scope.editKeepNote.bind(scope)
               });
               var removeImageCallback = scope.removeImageCallback();

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
@@ -300,7 +300,7 @@ angular.module('kifi')
               return textPortion.length > 0;
             };
 
-            if (noteMayHaveFallback && !noteHasSubstance(keep.note) && !scope.noteAttribution) {
+            if (noteMayHaveFallback && !noteHasSubstance(keep.note)) {
               if (keep.sourceAttribution.twitter) {
                 scope.displayNote = keep.sourceAttribution.twitter.tweet.text;
                 scope.noteAttribution = 'Twitter';

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
@@ -304,9 +304,12 @@ angular.module('kifi')
               if (keep.sourceAttribution.twitter) {
                 scope.displayNote = keep.sourceAttribution.twitter.tweet.text;
                 scope.noteAttribution = 'Twitter';
-              } else if (keep.sourceAttribution.slack && $filter('slackText')(keep.sourceAttribution.slack.message.text)) {
-                scope.displayNote = keep.sourceAttribution.slack.message.text;
-                scope.noteAttribution = 'Slack';
+              } else if (keep.sourceAttribution.slack) {
+                var html = $filter('slackText')(keep.sourceAttribution.slack.message.text);
+                if (html) {
+                  scope.displayNote = html;
+                  scope.noteAttribution = 'Slack';
+                }
               }
             } else {
               scope.displayNote = keep.note;

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.styl
@@ -589,8 +589,10 @@ defaultBorderColorOverlayUsingBefore(borderWidth)  // slightly darkens an image'
     overflow: hidden
     text-overflow: ellipsis
 
-    &:not(:empty)
-      margin: noteMargin
+  .kf-keep-card-note-via
+    font-size: 13px
+    color: #aaa
+    white-space: nowrap
 
   .kf-keep-card-add-note
     border: 0

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
@@ -34,10 +34,12 @@
         </button>
       </div>
       <div class="kf-keep-card-note-container">
-        <div class="kf-keep-card-note" ng-bind-html="::keep.note|noteHtml"
-             ng-if="::keep.note || canEditKeep"></div>
+        <div class="kf-keep-card-note" ng-show="::displayNote && !noteAttribution" ng-bind-html="::displayNote|noteHtml"></div>
+        <div class="kf-keep-card-note" ng-if="::displayNote && noteAttribution === 'Slack'"><span ng-bind-html="::displayNote|slackText"></span> <span class="kf-keep-card-note-via">(via Slack)</span></div>
+        <div class="kf-keep-card-note" ng-if="::displayNote && noteAttribution === 'Twitter'"><span ng-bind="::displayNote"></span> <span class="kf-keep-card-note-via">(via Twitter)</span></div>
+
         <button class="kf-keep-card-add-note" ng-click="editKeepNote($event, keep)"
-                ng-if="canEditKeep && galleryView && !keep.note && keep.author.id === me.id">Add a note
+                ng-if="canEditKeep && galleryView && !displayNote && keep.author.id === me.id">Add a note
           (type # to add a tag)
         </button>
       </div>

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.tpl.html
@@ -35,7 +35,7 @@
       </div>
       <div class="kf-keep-card-note-container">
         <div class="kf-keep-card-note" ng-show="::displayNote && !noteAttribution" ng-bind-html="::displayNote|noteHtml"></div>
-        <div class="kf-keep-card-note" ng-if="::displayNote && noteAttribution === 'Slack'"><span ng-bind-html="::displayNote|slackText"></span> <span class="kf-keep-card-note-via">(via Slack)</span></div>
+        <div class="kf-keep-card-note" ng-if="::displayNote && noteAttribution === 'Slack'"><span ng-bind-html="::displayNote"></span> <span class="kf-keep-card-note-via">(via Slack)</span></div>
         <div class="kf-keep-card-note" ng-if="::displayNote && noteAttribution === 'Twitter'"><span ng-bind="::displayNote"></span> <span class="kf-keep-card-note-via">(via Twitter)</span></div>
 
         <button class="kf-keep-card-add-note" ng-click="editKeepNote($event, keep)"

--- a/kifi-backend/modules/shoebox/angular/src/keeps/keepNoteForm.js
+++ b/kifi-backend/modules/shoebox/angular/src/keeps/keepNoteForm.js
@@ -662,7 +662,7 @@ angular.module('kifi')
             .on('click', '.kf-knf-cancel', onCancelClick)
             .on('click', '.kf-knf-save', onSaveClick);
           var $note = $form.find('.kf-knf-editor')
-            .html($filter('noteHtml')(noteText))
+            .html($filter('noteHtml')(noteText, true))
             .data({
               libraryId: libraryId,
               keepId: keepId,


### PR DESCRIPTION
@cvializ Not completely done, but open for review.

For ingested links, we often don't have a note, but _do_ have the original message text. This exposes it. If the user edits the note, the edit will take over and the original text won't show.

![](http://acon.s3.amazonaws.com/0CXVP.png)

![](http://acon.s3.amazonaws.com/XoMyB.png)
