### PR TITLE
add error banners for slack failures

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/messageTicker/messageTicker.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/messageTicker/messageTicker.styl
@@ -10,7 +10,7 @@
   transform: translateY(0px)
 
   &.hide
-    transform: translateY(-40px)
+    transform: translateY(-80px)
 
   .message_bar-message
     background: noticeYellow

--- a/kifi-backend/modules/shoebox/angular/src/home/homeCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/home/homeCtrl.js
@@ -3,8 +3,23 @@
 angular.module('kifi')
 
 .controller('HomeCtrl', [
-  '$rootScope', '$scope', '$stateParams', 'profileService',
-  function($rootScope, $scope, $stateParams, profileService) {
+  '$rootScope', '$scope', '$stateParams', 'profileService', 'messageTicker',
+  function($rootScope, $scope, $stateParams, profileService, messageTicker) {
+
+    var error = $stateParams.error;
+    if (error) {
+      var text;
+      switch (error) {
+        case 'slack_team_already_connected':
+          text = 'That Slack team is already connected to another Kifi team.' +
+            ' Please try a different Slack team or contact support@kifi.com to resolve any conflicts.';
+          break;
+        default:
+          text = 'An error occurred. Please contact support@kifi.com if this error persists.';
+          break;
+      }
+      messageTicker({ text: text, type: 'red', delay: 5000 });
+    }
 
     $scope.showDelightedSurvey = profileService.prefs.show_delighted_question;
 

--- a/kifi-backend/modules/shoebox/angular/src/route.js
+++ b/kifi-backend/modules/shoebox/angular/src/route.js
@@ -25,7 +25,7 @@ angular.module('kifi')
     // Set up the states.
     $stateProvider
       .state('home', {
-        url: '/?openImportModal',
+        url: '/?openImportModal&error',
         controller: 'HomeCtrl',
         templateUrl: 'home/home.tpl.html',
         'abstract': true


### PR DESCRIPTION
@cvializ @andrewconner LHF for handling slack errors. without this, we just return to the home page and don't say anything.
