### PR TITLE
Client-facing SlackMessages get prettied data

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/SourceAttribution.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/SourceAttribution.scala
@@ -58,7 +58,7 @@ object SourceAttribution {
     val updatedValue = for {
       obj <- value.validate[JsObject]
       tweeterObj <- (value \ "twitter").validate[JsObject]
-      tweet <- (tweeterObj \ "tweet").validate(BasicTweet.format)
+      tweet <- (tweeterObj \ "tweet").validate(PrettyTweet.format)
     } yield {
       (obj - "twitter") + ("twitter" -> (tweeterObj ++ Json.obj("idString" -> tweet.id.id.toString, "screenName" -> tweet.user.screenName.value)))
     }
@@ -66,8 +66,8 @@ object SourceAttribution {
   }
 }
 
-case class BasicTweet(id: TwitterStatusId, user: RawTweet.User, permalink: String, text: String)
-object BasicTweet {
+case class PrettyTweet(id: TwitterStatusId, user: RawTweet.User, permalink: String, text: String)
+object PrettyTweet {
   private val userFormat: Format[RawTweet.User] = (
     (__ \ 'name).format[String] and
     (__ \ 'screen_name).format[TwitterHandle] and
@@ -80,23 +80,22 @@ object BasicTweet {
     (__ \ 'user).format(userFormat) and
     (__ \ 'permalink).format[String] and
     (__ \ 'text).format[String]
-  )(BasicTweet.apply _, unlift((BasicTweet.unapply)))
+  )(PrettyTweet.apply _, unlift((PrettyTweet.unapply)))
 
-  def fromRawTweet(tweet: RawTweet): BasicTweet = BasicTweet(tweet.id, tweet.user, tweet.getUrl, tweet.text)
+  def fromRawTweet(tweet: RawTweet): PrettyTweet = PrettyTweet(tweet.id, tweet.user, tweet.getUrl, tweet.text)
 }
 
-case class TwitterAttribution(tweet: BasicTweet) extends SourceAttribution
+case class TwitterAttribution(tweet: PrettyTweet) extends SourceAttribution
 object TwitterAttribution {
   implicit val format = Json.format[TwitterAttribution]
 }
 
-case class BasicSlackMessage(channel: SlackChannelIdAndPrettyName, userId: SlackUserId, username: SlackUsername, timestamp: SlackTimestamp, permalink: String, text: String)
-object BasicSlackMessage {
-
-  implicit val format = Json.format[BasicSlackMessage]
+case class PrettySlackMessage(channel: SlackChannelIdAndPrettyName, userId: SlackUserId, username: SlackUsername, timestamp: SlackTimestamp, permalink: String, text: String)
+object PrettySlackMessage {
+  implicit val format = Json.format[PrettySlackMessage]
 }
 
-case class SlackAttribution(message: BasicSlackMessage, teamId: SlackTeamId) extends SourceAttribution
+case class SlackAttribution(message: PrettySlackMessage, teamId: SlackTeamId) extends SourceAttribution
 object SlackAttribution {
   implicit val format = Json.format[SlackAttribution]
 }

--- a/kifi-backend/modules/common/app/com/keepit/model/SourceAttribution.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/SourceAttribution.scala
@@ -28,11 +28,6 @@ object SourceAttribution {
     }
   }
 
-  def fromRawSourceAttribution(source: RawSourceAttribution): SourceAttribution = source match {
-    case RawTwitterAttribution(tweet) => TwitterAttribution(BasicTweet.fromRawTweet(tweet))
-    case RawSlackAttribution(message, teamId) => SlackAttribution(BasicSlackMessage.fromSlackMessage(message), teamId)
-  }
-
   val internalFormat = new OFormat[SourceAttribution] {
     def writes(source: SourceAttribution) = {
       val (attrType, attrJs) = toJson(source)
@@ -99,7 +94,6 @@ case class BasicSlackMessage(channel: SlackChannelIdAndPrettyName, userId: Slack
 object BasicSlackMessage {
 
   implicit val format = Json.format[BasicSlackMessage]
-  def fromSlackMessage(message: SlackMessage): BasicSlackMessage = BasicSlackMessage(SlackChannelIdAndPrettyName.from(message.channel), message.userId, message.username, message.timestamp, message.permalink, message.text)
 }
 
 case class SlackAttribution(message: BasicSlackMessage, teamId: SlackTeamId) extends SourceAttribution
@@ -108,7 +102,7 @@ object SlackAttribution {
 }
 
 case class SourceAttributionKeepIdKey(keepId: Id[Keep]) extends Key[SourceAttribution] {
-  override val version = 5
+  override val version = 6
   val namespace = "source_attribution_by_keep_id"
   def toKey(): String = keepId.id.toString
 }

--- a/kifi-backend/modules/search/app/com/keepit/search/index/graph/keep/KeepIndexable.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/graph/keep/KeepIndexable.scala
@@ -49,7 +49,6 @@ object KeepFields {
   object Source {
     def apply(teamId: SlackTeamId, channelId: SlackChannelId): String = s"slack|${channelId.value}" // TODO(Léo): this should be "slack|teamId_channelId"
     def apply(handle: TwitterHandle): String = s"twitter|${handle.value}"
-    def apply(source: RawSourceAttribution): String = Source(SourceAttribution.fromRawSourceAttribution(source))
     def apply(source: SourceAttribution): String = source match {
       case TwitterAttribution(tweet) => Source(tweet.user.screenName)
       case SlackAttribution(message, teamId) => Source(teamId, message.channel.id)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepSourceCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepSourceCommander.scala
@@ -101,9 +101,9 @@ class KeepSourceAugmentor @Inject() (
       case Right(identifier) =>
         val whole = identifier.group(1)
         val id = whole.substring(2, whole.length - 1)
-        id.headOption.collect {
-          case 'U' => slackTeamMembershipRepo.getBySlackTeamAndUser(teamId, SlackUserId(id)).map(s => "<@" + s.slackUsername.value + ">")
-          case 'C' => slackChannelRepo.getByChannelId(teamId, SlackChannelId(id)).map(s => "<#" + s.slackChannelName.value + ">")
+        Option(SlackChannelId(id)).collect {
+          case SlackChannelId.User(username) => slackTeamMembershipRepo.getBySlackTeamAndUser(teamId, SlackUserId(username)).map(s => "<@" + s.slackUsername.value + ">")
+          case channel: SlackChannelId => slackChannelRepo.getByChannelId(teamId, channel).map(s => "<#" + s.slackChannelName.value + ">")
         }.getOrElse {
           log.warn(s"[genBasicSlackMessage] Unknown Slack id $whole")
           ""

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepSourceCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepSourceCommander.scala
@@ -101,7 +101,7 @@ class KeepSourceAugmentor @Inject() (
       case Right(identifier) =>
         val whole = identifier.group(1)
         val id = whole.substring(2, whole.length - 1)
-        Option(SlackChannelId(id)).collect {
+        SlackChannelId.parse[SlackChannelId](id).toOption.collect {
           case SlackChannelId.User(username) => slackTeamMembershipRepo.getBySlackTeamAndUser(teamId, SlackUserId(username)).map(s => "<@" + s.slackUsername.value + ">")
           case channel: SlackChannelId => slackChannelRepo.getByChannelId(teamId, channel).map(s => "<#" + s.slackChannelName.value + ">")
         }.getOrElse {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepSourceCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepSourceCommander.scala
@@ -5,11 +5,12 @@ import com.keepit.common.concurrent.FutureHelpers
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.DBSession.RSession
 import com.keepit.common.db.slick.Database
+import com.keepit.common.logging.Logging
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.common.core.mapExtensionOps
-import com.keepit.common.util.MapHelpers
+import com.keepit.common.core._
 import com.keepit.model._
-import com.keepit.slack.models.{ SlackTeamId, SlackUserId, SlackTeamMembershipRepo }
+import com.keepit.slack.models._
 import com.keepit.social.{ Author, BasicUser, SocialNetworks, SocialId }
 import com.keepit.social.twitter.TwitterUserId
 
@@ -34,7 +35,7 @@ class KeepSourceCommanderImpl @Inject() (
   keepRepo: KeepRepo,
   keepCommander: KeepCommander,
   implicit val defaultContext: ExecutionContext)
-    extends KeepSourceCommander {
+    extends KeepSourceCommander with Logging {
 
   // Get the source attribution for the provided keeps
   // then look at the a couple of tables to see if any of those attributions can be re-assigned to an actual Kifi user
@@ -81,5 +82,34 @@ class KeepSourceCommanderImpl @Inject() (
         }
       }
     }.toSet
+  }
+}
+
+@Singleton
+class KeepSourceAugmentor @Inject() (
+    slackTeamMembershipRepo: SlackTeamMembershipRepo,
+    slackChannelRepo: SlackChannelRepo) extends Logging {
+
+  def rawToSourceAttribution(source: RawSourceAttribution)(implicit session: RSession): SourceAttribution = source match {
+    case RawTwitterAttribution(tweet) => TwitterAttribution(BasicTweet.fromRawTweet(tweet))
+    case RawSlackAttribution(message, teamId) => SlackAttribution(genBasicSlackMessage(teamId, message), teamId)
+  }
+
+  private val slackIdentifier = """<[@#][A-Z].*?>""".r
+  private def genBasicSlackMessage(teamId: SlackTeamId, message: SlackMessage)(implicit session: RSession) = {
+    val improvedText = slackIdentifier.findMatchesAndInterstitials(message.text).map {
+      case Right(identifier) =>
+        val whole = identifier.group(1)
+        val id = whole.substring(2, whole.length - 1)
+        id.headOption.collect {
+          case 'U' => slackTeamMembershipRepo.getBySlackTeamAndUser(teamId, SlackUserId(id)).map(s => "<@" + s.slackUsername.value + ">")
+          case 'C' => slackChannelRepo.getByChannelId(teamId, SlackChannelId(id)).map(s => "<#" + s.slackChannelName.value + ">")
+        }.getOrElse {
+          log.warn(s"[genBasicSlackMessage] Unknown Slack id $whole")
+          ""
+        }
+      case Left(literal) => literal
+    }.mkString("")
+    BasicSlackMessage(SlackChannelIdAndPrettyName.from(message.channel), message.userId, message.username, message.timestamp, message.permalink, improvedText)
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepSourceCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepSourceCommander.scala
@@ -91,7 +91,7 @@ class KeepSourceAugmentor @Inject() (
     slackChannelRepo: SlackChannelRepo) extends Logging {
 
   def rawToSourceAttribution(source: RawSourceAttribution)(implicit session: RSession): SourceAttribution = source match {
-    case RawTwitterAttribution(tweet) => TwitterAttribution(BasicTweet.fromRawTweet(tweet))
+    case RawTwitterAttribution(tweet) => TwitterAttribution(PrettyTweet.fromRawTweet(tweet))
     case RawSlackAttribution(message, teamId) => SlackAttribution(genBasicSlackMessage(teamId, message), teamId)
   }
 
@@ -110,6 +110,6 @@ class KeepSourceAugmentor @Inject() (
         }
       case Left(literal) => literal
     }.mkString("")
-    BasicSlackMessage(SlackChannelIdAndPrettyName.from(message.channel), message.userId, message.username, message.timestamp, message.permalink, improvedText)
+    PrettySlackMessage(SlackChannelIdAndPrettyName.from(message.channel), message.userId, message.username, message.timestamp, message.permalink, improvedText)
   }
 }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepSourceAttributionTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepSourceAttributionTest.scala
@@ -37,7 +37,7 @@ class KeepSourceAttributionTest extends Specification with ShoeboxTestInjector {
     }
 
     "twitter source attribution is backward compatible" in {
-      val attr = TwitterAttribution(BasicTweet.fromRawTweet(tweetJs.as[RawTweet]))
+      val attr = TwitterAttribution(PrettyTweet.fromRawTweet(tweetJs.as[RawTweet]))
       val obj = SourceAttribution.deprecatedWrites.writes((attr, None))
       (obj \ "twitter" \ "idString").as[String] === "505809542656303104"
       (obj \ "twitter" \ "screenName").as[TwitterHandle] === connerdelights


### PR DESCRIPTION
Simple translation from `<@UDR8IPO>: go to <#CG6GAJS>` to `<@bob>: Go to <#jokes>`. Backwards compatible with clients because clients currently strip this out. Incoming next are smarter clients (I'll do site and extension).

@leogrim @ryanpbrewster Léo suggested that `BasicSlackMessage` gets renamed to `PrettySlackMessage` because it's no longer a subset of the data. Seems reasonable.
