### PR TITLE
Wording and formatting changes

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/util/DescriptionElements.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/DescriptionElements.scala
@@ -121,7 +121,7 @@ object DescriptionElements {
     interpolatePunctuation(description.flatten).map { be =>
       be.url
         .map(u => s"<$u|${escapeSegment(be.text)}>")
-        .getOrElse(be.text)
+        .getOrElse(escapeSegment(be.text))
     }.mkString
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPushingActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPushingActor.scala
@@ -330,7 +330,9 @@ class SlackPushingActor @Inject() (
     item match {
       case PushItem.Digest(since) => Some(SlackMessageRequest.fromKifi(DescriptionElements.formatForSlack(DescriptionElements(
         items.lib.name, "has", (items.newKeeps.length, items.newMsgs.values.map(_.length).sum) match {
-          case (m, n) => DescriptionElements(m, "new keeps and", n, "new comments since", since, ".")
+          case (numKeeps, numMsgs) if numMsgs < 2 => DescriptionElements(numKeeps, "new keeps since", since, ".")
+          case (numKeeps, numMsgs) if numKeeps < 2 => DescriptionElements(numMsgs, "new comments since", since, ".")
+          case (numKeeps, numMsgs) => DescriptionElements(numKeeps, "new keeps and", numMsgs, "new comments since", since, ".")
         },
         "It's a bit too much to post here, but you can check it all out", "here" --> LinkElement(pathCommander.libraryPageViaSlack(items.lib, items.slackTeamId))
       ))))
@@ -381,7 +383,7 @@ class SlackPushingActor @Inject() (
     val keepLink = LinkElement(pathCommander.keepPageOnUrlViaSlack(keep, slackTeamId))
     val keepElement = {
       DescriptionElements(
-        "“_", keep.title.getOrElse(keep.url).abbreviate(KEEP_TITLE_MAX_DISPLAY_LENGTH), "_”",
+        "_", keep.title.getOrElse(keep.url).abbreviate(KEEP_TITLE_MAX_DISPLAY_LENGTH), "_",
         "  ",
         "View Article" --> keepLink,
         "•",


### PR DESCRIPTION
1. Escape all text sent to Slack, not just text that is linked
2. Remove quote marks around keep titles
3. Improve summary push (when there are too many push items)
