### PR TITLE
Fixing one class of tab/normalization issues

### DIFF
--- a/packrat/adapters/chrome/api.js
+++ b/packrat/adapters/chrome/api.js
@@ -633,7 +633,7 @@ var api = (function createApi() {
       anyAt: function (url) {
         for (var id in pages) {
           var page = pages[id];
-          if (page.url == url) {
+          if (page.url === url || page.nUri === url) {
             return page;
           }
         }

--- a/packrat/adapters/firefox/lib/api.js
+++ b/packrat/adapters/firefox/lib/api.js
@@ -330,7 +330,7 @@ exports.storage = require('sdk/simple-storage').storage;
 exports.tabs = {
   anyAt: function(url) {
     for each (let page in pages) {
-      if (page.url === url) {
+      if (page.url === url || page.nUri === url) {
         return page;
       }
     }

--- a/packrat/adapters/safari/api.js
+++ b/packrat/adapters/safari/api.js
@@ -574,7 +574,7 @@ var api = api || (function () {
       anyAt: function (url) {
         for (var id in pages) {
           var page = pages[id];
-          if (page.url === url) {
+          if (page.url === url || page.nUri === url) {
             return page;
           }
         }

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1837,7 +1837,7 @@ function awaitDeepLink(link, tabId, retrySec) {
     delete timeouts[tabId];
     var tab = api.tabs.get(tabId);
     var linkUrl = link.url || link.nUri;
-    if (tab && ((tab.nUri && sameOrLikelyRedirected(linkUrl, tab.nUri)) || (tab.url && sameOrLikelyRedirected(linkUrl, tab.url)))) {
+    if (tab && ((tab.nUri && sameOrSimilarBaseDomain(linkUrl, tab.nUri)) || (tab.url && sameOrSimilarBaseDomain(linkUrl, tab.url)))) {
       log('[awaitDeepLink]', tabId, link);
       if (loc.lastIndexOf('#guide/', 0) === 0) {
         var step = +loc.substr(7, 1);
@@ -2793,7 +2793,7 @@ function arrayBufferToBase64(buffer) {
 
 //                           |---- IP v4 address ---||- subs -||-- core --|  |----------- suffix -----------| |- name --|    |-- port? --|
 var domainRe = /^https?:\/\/(\d{1,3}(?:\.\d{1,3}){3}|[^:\/?#]*?([^.:\/?#]+)\.(?:[^.:\/?#]{2,}|com?\.[a-z]{2})|[^.:\/?#]+)\.?(?::\d{2,5})?(?:$|\/|\?|#)/;
-function sameOrLikelyRedirected(url1, url2) {
+function sameOrSimilarBaseDomain(url1, url2) {
   if (url1 === url2) {
     return true;
   }


### PR DESCRIPTION
@cvializ Good news bad news.

Good news: `page` often _does_ have a `.nUri`, so we can actually improve `api.tabs.anyAt`

Bad news: Doesn't fix medium's problem. At the time of click, the _known_ nUri is actually with the fragment, because it doesn't know any better (yet). So we're asking them to open `http://url.com/#hash1`, and there's already a tab with `http://url.com/#hash2`. I can't imagine why medium is doing it, so not sure if we should work around them.
