### PR TITLE
don't double track on user profiles and libraries

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/app.js
+++ b/kifi-backend/modules/shoebox/angular/src/app.js
@@ -219,7 +219,7 @@ angular.module('kifi', [
           // TODO: The above statement is now false, so we may want to standardize tracking of those page views.
           // This whole process up here ^^^ and down here vvv is all a bit bogus, should be refactored
           // to be able to have better page tracking with metadata
-          var ignore = ['library', 'userOrOrg', 'getStarted', 'orgProfile'];
+          var ignore = ['library', 'userOrOrg', 'getStarted', 'orgProfile', 'userProfile'];
           // if base state is not in the ignore list
           if (ignore.indexOf(toStateParts[0]) === -1) {
             var url = $analytics.settings.pageTracking.basePath + $location.url();

--- a/kifi-backend/modules/shoebox/angular/src/common/services/mixpanelService.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/mixpanelService.js
@@ -79,6 +79,7 @@
   }
 
   function trackPage(path, attributes) {
+    //$log.log(path, attributes);
     attributes = attributes || {};
     var origin = attributes.origin || $window.location.origin;
 

--- a/kifi-backend/modules/shoebox/angular/src/libraries/library.js
+++ b/kifi-backend/modules/shoebox/angular/src/libraries/library.js
@@ -521,7 +521,6 @@ angular.module('kifi')
     }
 
     libraryService.getRelatedLibraries(library.id).then(function (libraries) {
-      trackPageView({libraryRecCount: libraries.length});
       $scope.relatedLibraries = libraries;
       if (initParams.getAndClear('install') === '1' && !installService.installedVersion) {
         showInstallModal();
@@ -537,9 +536,10 @@ angular.module('kifi')
     $timeout(function() {
       libraryService.trackEvent('user_viewed_page', $scope.library, {
         type: 'library',
-        keepView: $scope.galleryView ? 'gallery' : 'list'
+        keepView: $scope.galleryView ? 'gallery' : 'list',
+        libraryRecCount: $scope.relatedLibraries && $scope.relatedLibraries.length
       });
-    });
+    }, 500);
 
     var deregisterUpdateLibrary;
     var knownUpdatesPending = 0;


### PR DESCRIPTION
@cvializ @DerekBurch @andrewconner for future reference, to see if a page is double tracking, uncomment the $log lines after `mixpanelService.trackPage` and `mixpanelService.trackEvent`. Not a huge deal but it can get out of hand https://app.asana.com/0/32728208409723/88215048593798
