### PR TITLE
catch and handle errors when a user tries to steal another's slack membership

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/home/homeCtrl.js
+++ b/kifi-backend/modules/shoebox/angular/src/home/homeCtrl.js
@@ -14,6 +14,10 @@ angular.module('kifi')
           text = 'That Slack team is already connected to another Kifi team.' +
             ' Please try a different Slack team or contact support@kifi.com to resolve any conflicts.';
           break;
+        case 'slack_membership_exists':
+          text = 'It seems that your Slack account is already connected to a different Kifi account.' +
+            ' Please log in using the Kifi account associated with your Slack account, or contact support@kifi.com to resolve any conflicts.';
+          break;
         default:
           text = 'An error occurred. Please contact support@kifi.com if this error persists.';
           break;

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackActionFail.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackActionFail.scala
@@ -3,7 +3,7 @@ package com.keepit.slack
 import com.keepit.common.db.Id
 import com.keepit.common.path.Path
 import com.keepit.model.{ Organization, User }
-import com.keepit.slack.models.{ SlackTeamId, SlackTeamMembership, SlackTeamName }
+import com.keepit.slack.models.{ SlackUserId, SlackTeamId, SlackTeamMembership, SlackTeamName }
 import play.api.http.Status._
 import play.api.libs.json.Json
 import play.api.mvc.Results.Status
@@ -30,6 +30,9 @@ object SlackActionFail {
 
   case class InvalidMembership(userId: Id[User], slackTeamId: SlackTeamId, slackTeamName: SlackTeamName, membership: Option[SlackTeamMembership])
     extends SlackActionFail("invalid_slack_membership", s"User $userId is not a valid member of SlackTeam ${slackTeamName.value} (${slackTeamId.value}): $membership")
+
+  case class MembershipExists(userId: Id[User], ownerId: Id[User], slackTeamId: SlackTeamId, slackTeamName: SlackTeamName, slackUserId: SlackUserId, membership: SlackTeamMembership)
+    extends SlackActionFail("slack_membership_exists", s"$userId is trying to steal existing membership from $ownerId on SlackTeam ${slackTeamName.value} (${slackTeamId.value}): $membership")
 
   case class MissingWebhook(userId: Id[User])
     extends SlackActionFail("missing_webhook", s"User $userId tried to integrate with a library, but we did not get a webhook from Slack")

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/models/SlackTeamMembership.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/models/SlackTeamMembership.scala
@@ -12,6 +12,8 @@ import com.keepit.common.oauth.SlackIdentity
 import com.keepit.common.performance.StatsdTiming
 import com.keepit.common.reflection.Enumerator
 import com.keepit.common.time._
+import com.keepit.slack.SlackActionFail
+import com.keepit.slack.SlackActionFail._
 import com.keepit.model.User
 import com.keepit.social.{ IdentityUserIdCache, IdentityUserIdKey, UserIdentity }
 import org.joda.time.{ DateTime, Duration }
@@ -281,7 +283,7 @@ class SlackTeamMembershipRepoImpl @Inject() (
       case Some(membership) if membership.isActive =>
         membership.userId.foreach { ownerId =>
           request.userId.foreach { requesterId =>
-            if (requesterId != ownerId) throw new IllegalStateException(s"SlackMembership requested by user $requesterId is already owned by user $ownerId: $membership")
+            if (requesterId != ownerId) SlackActionFail.MembershipExists(requesterId, ownerId, request.slackTeamId, request.slackTeamName, request.slackUserId, membership)
           }
         }
         val updated = membership.copy(


### PR DESCRIPTION
@leogrim @ryanpbrewster 

this is something I'm running into when QA'ing the backfill scopes link. when a Kifi user is logged into a different account than the one that's linked to the slack user we send the message to, it blows up. This is the LHF such that the user can resolve their own issue, more complicated would be to enforce that you're logged in to the Kifi user we expect before entering this flow.
