### PR TITLE
fix path to slack auth page

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/routing/SlackAuthRouter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/routing/SlackAuthRouter.scala
@@ -178,7 +178,7 @@ class SlackAuthRouter @Inject() (
       case _ => "=true"
     }
 
-    val slackAuthPage = pathCommander.orgPage(org) + s"?signUpWithSlack" + modelParams + s"&slackTeamId=${slackTeamId.value}"
+    val slackAuthPage = pathCommander.orgPage(org) + s"?signUpWithSlack=$modelParams&slackTeamId=${slackTeamId.value}"
 
     Redirect(slackAuthPage.absolute).withSession(request.session + (SecureSocial.OriginalUrlKey -> url)).withCookies(Cookie(PostRegIntent.onFailUrlKey, slackAuthPage.absolute))
   }


### PR DESCRIPTION
@ryanpbrewster thinking about how to make these new helper methods more flexible as to not create errors, having `query: Query` be a separate field broke what was here
