### PR TITLE
augment was_notified events with org info if they're from slack

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/heimdal/EventType.scala
+++ b/kifi-backend/modules/common/app/com/keepit/heimdal/EventType.scala
@@ -85,6 +85,7 @@ object VisitorEventTypes {
 object SlackEventTypes extends Enumerator[EventType] {
   val SEARCHED = EventType("searched")
   val CLICKED_SEARCH_RESULT = EventType("clicked_search_result")
+  val WAS_NOTIFIED = EventType("was_notified")
 
   def contains(eventType: EventType) = _all.contains(eventType)
 }


### PR DESCRIPTION
this is used by `SlackInfoAugmentor` in heimdal to add additional org info when a `slackTeamId` is tracked
