### PR TITLE
Personal digest iterating

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/util/RandomChoice.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/RandomChoice.scala
@@ -4,8 +4,9 @@ import org.apache.commons.math3.random.MersenneTwister
 
 object RandomChoice {
   implicit class RandomChoice(prng: MersenneTwister) {
-    def choice[T](xs: IndexedSeq[T]): Option[T] = {
+    def choiceOption[T](xs: IndexedSeq[T]): Option[T] = {
       if (xs.isEmpty) None else Some(xs(prng.nextInt(xs.length)))
     }
+    def choice[T](xs: IndexedSeq[T]): T = choiceOption(xs).getOrElse(throw new NoSuchElementException)
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -1,8 +1,5 @@
 package com.keepit.commanders
 
-import java.util.concurrent.{ Callable, TimeUnit }
-
-import com.google.common.cache.{ Cache, CacheBuilder }
 import com.google.inject.{ ImplementedBy, Inject, Singleton }
 import com.keepit.common.CollectionHelpers
 import com.keepit.common.akka.SafeFuture
@@ -13,25 +10,22 @@ import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.db._
 import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
 import com.keepit.common.db.slick._
-import com.keepit.common.healthcheck.{ AirbrakeNotifier, StackTrace }
+import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.logging.Logging
 import com.keepit.common.performance._
 import com.keepit.common.social.BasicUserRepo
-import com.keepit.common.store.{ ImageSize, S3ImageConfig }
+import com.keepit.common.store.S3ImageConfig
 import com.keepit.common.time._
-import com.keepit.common.strings._
 import com.keepit.eliza.ElizaServiceClient
 import com.keepit.heimdal._
 import com.keepit.integrity.UriIntegrityHelpers
 import com.keepit.model._
 import com.keepit.normalizer.NormalizedURIInterner
 import com.keepit.rover.RoverServiceClient
-import com.keepit.rover.model.RoverArticleSummary
 import com.keepit.search.SearchServiceClient
 import com.keepit.search.augmentation.{ AugmentableItem, ItemAugmentationRequest }
 import com.keepit.slack.LibraryToSlackChannelPusher
-import com.keepit.social.twitter.TwitterHandle
-import com.keepit.social.{ BasicAuthor, Author }
+import com.keepit.social.BasicAuthor
 import com.keepit.typeahead.{ HashtagHit, HashtagTypeahead, TypeaheadHit }
 import org.joda.time.DateTime
 import play.api.http.Status.{ FORBIDDEN, NOT_FOUND }
@@ -40,7 +34,7 @@ import play.api.libs.json._
 
 import scala.collection.mutable
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Try, Failure, Success }
+import scala.util.{ Failure, Success, Try }
 
 case class RawBookmarksWithCollection(
   collection: Option[Either[ExternalId[Collection], String]], keeps: Seq[RawBookmarkRepresentation])

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PathCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PathCommander.scala
@@ -100,6 +100,7 @@ class PathCommander @Inject() (
   def slackPersonalDigestToggle(slackTeamId: SlackTeamId, slackUserId: SlackUserId, turnOn: Boolean) = Path(s"s/pd/${slackTeamId.value}/${slackUserId.value}/${SlackTeamMembership.encodeTeamAndUser(slackTeamId, slackUserId)}").withQuery(Query("turnOn" -> turnOn.toString))
   def welcomePageViaSlack(basicUser: BasicUser, slackTeamId: SlackTeamId): Path = Path(s"s/${slackTeamId.value}/welcome/${basicUser.externalId.id}")
   def ownKeepsFeedPage: Path = Path(s"/?filter=own")
+  def ownKeepsFeedPageViaSlack(slackTeamId: SlackTeamId): Path = Path(s"s/${slackTeamId.value}/feed/own")
   def startWithSlackPath(slackTeamId: Option[SlackTeamId], extraScopes: Option[String]): Path = Path(com.keepit.controllers.core.routes.AuthController.startWithSlack(slackTeamId, extraScopes).url)
 
   /**

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPersonalDigestNotificationActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPersonalDigestNotificationActor.scala
@@ -21,6 +21,7 @@ import com.keepit.model._
 import com.keepit.slack.models._
 import com.keepit.social.Author
 import com.kifi.juggle._
+import org.apache.commons.math3.random.MersenneTwister
 import org.joda.time.Duration
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -225,10 +226,29 @@ class SlackPersonalDigestNotificationActor @Inject() (
     val linkToFeed = LinkElement(pathCommander.ownKeepsFeedPageViaSlack(digest.slackMembership.slackTeamId).withQuery(trackingParams("ownFeed")))
     val linkToUnsubscribe = LinkElement(pathCommander.slackPersonalDigestToggle(digest.slackMembership.slackTeamId, digest.slackMembership.slackUserId, turnOn = false).withQuery(trackingParams("turnOff")))
     val text = DescriptionElements.unlines(List(
+      prng.choice(puns),
       DescriptionElements("You've sent", digest.numIngestedMessages, "links", inTheLast(digest.digestPeriod), ".",
         "I", "archived them" --> linkToFeed, "for you, and indexed the pages so you can search for them more easily."),
       DescriptionElements("If you don't want to get any more of these notifications,", "click here" --> linkToUnsubscribe)
     ))
     SlackMessageRequest.fromKifi(DescriptionElements.formatForSlack(text))
   }
+
+  private val prng = new MersenneTwister(System.currentTimeMillis())
+  private val puns = IndexedSeq[DescriptionElements](
+    DescriptionElements("Look at this boatload :rowboat: of links!"),
+    DescriptionElements("Surprise! I brought you a gift :gift:! It's all the links you messaged to your team this week. I'm bad at keeping secrets"),
+    DescriptionElements("You're turning into a link finding factory :factory:!"),
+    DescriptionElements("Man, you really hit the links :golf: hard this week! See what I mean?!"),
+    DescriptionElements("You're making it rain :umbrella:! Check out all these links!"),
+    DescriptionElements("Since you stashed so many links, I think you should watch cat :cat: videos the rest of the day. Go ahead, you earned it."),
+    DescriptionElements("You must love The Legend of Zelda :princess: because this link obsession is obvi."),
+    DescriptionElements("You might wanna cool it on the caffeine :coffee:! I mean, this is a lot of hyperlinks."),
+    DescriptionElements("You're turning link capturing into a science :microscope:!"),
+    DescriptionElements("You racked up a baker's dozen :doughnut: links this week. Reward yourself with donut!"),
+    DescriptionElements("Wow! You've added more links than you can shake a stick at :ice_hockey_stick_and_puck:"),
+    DescriptionElements("No need to :fishing_pole_and_fish: for your links.  We've got your summary right here."),
+    DescriptionElements("Don't worry!  We didn't :maple_leaf: your links behind.  Here they are!"),
+    DescriptionElements("You've gotta be :cat2: kitten me, right meow.  Did you really save all those links?!")
+  )
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPersonalDigestNotificationActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPersonalDigestNotificationActor.scala
@@ -37,6 +37,8 @@ object SlackPersonalDigestConfig {
 
   val minDigestConcurrency = 1
   val maxDigestConcurrency = 10
+
+  val superAwesomeWelcomeMessageGIF = "https://d1dwdv9wd966qu.cloudfront.net/img/slack_initial_personal_digest.gif"
 }
 
 class SlackPersonalDigestNotificationActor @Inject() (
@@ -220,7 +222,7 @@ class SlackPersonalDigestNotificationActor @Inject() (
   private def messageForRegularDigest(digest: SlackPersonalDigest): SlackMessageRequest = {
     import DescriptionElements._
     def trackingParams(subaction: String) = SlackAnalytics.generateTrackingParams(digest.slackMembership.slackUserId.asChannel, NotificationCategory.NonUser.PERSONAL_DIGEST, Some(subaction))
-    val linkToFeed = LinkElement(pathCommander.ownKeepsFeedPage)
+    val linkToFeed = LinkElement(pathCommander.ownKeepsFeedPageViaSlack(digest.slackMembership.slackTeamId).withQuery(trackingParams("ownFeed")))
     val linkToUnsubscribe = LinkElement(pathCommander.slackPersonalDigestToggle(digest.slackMembership.slackTeamId, digest.slackMembership.slackUserId, turnOn = false).withQuery(trackingParams("turnOff")))
     val text = DescriptionElements.unlines(List(
       DescriptionElements("You've sent", digest.numIngestedMessages, "links", inTheLast(digest.digestPeriod), ".",

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPersonalDigestNotificationActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPersonalDigestNotificationActor.scala
@@ -5,6 +5,7 @@ import com.keepit.commanders.{ OrganizationInfoCommander, PathCommander }
 import com.keepit.common.akka.FortyTwoActor
 import com.keepit.common.core.{ mapExtensionOps, optionExtensionOps }
 import com.keepit.common.crypto.KifiUrlRedirectHelper
+import com.keepit.common.strings._
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.DBSession.RSession
 import com.keepit.common.db.slick.Database
@@ -144,6 +145,7 @@ class SlackPersonalDigestNotificationActor @Inject() (
       })
       digest = SlackPersonalDigest(
         slackMembership = membership,
+        slackTeam = slackTeam,
         digestPeriod = new Duration(membership.unnotifiedSince, clock.now),
         org = org,
         ingestedMessagesByChannel = getIngestedMessagesForSlackUser(membership)
@@ -183,8 +185,8 @@ class SlackPersonalDigestNotificationActor @Inject() (
     import DescriptionElements._
     val slackTeamId = digest.slackMembership.slackTeamId
     def trackingParams(subaction: String) = SlackAnalytics.generateTrackingParams(digest.slackMembership.slackUserId.asChannel, NotificationCategory.NonUser.PERSONAL_DIGEST, Some(subaction))
-    val mostRecentIngestedMsg = digest.ingestedMessagesByChannel.values.flatten.maxBy { case (kId, msg) => msg.timestamp }
-    val linkToMostRecentKeep = LinkElement(pathCommander.keepPageOnKifiViaSlack(mostRecentIngestedMsg._1, slackTeamId).withQuery(trackingParams("latestMessage")))
+    val (mostRecentKeep, mostRecentIngestedMsg) = digest.ingestedMessagesByChannel.values.flatten.maxBy { case (kId, msg) => msg.timestamp }
+    val linkToMostRecentKeep = LinkElement(pathCommander.keepPageOnKifiViaSlack(mostRecentKeep, slackTeamId).withQuery(trackingParams("latestMessage")))
     val linkToSquelch = LinkElement(pathCommander.slackPersonalDigestToggle(slackTeamId, digest.slackMembership.slackUserId, turnOn = false).withQuery(trackingParams("turnOff")))
     val text = DescriptionElements.unlines(Seq(
       DescriptionElements(
@@ -198,19 +200,14 @@ class SlackPersonalDigestNotificationActor @Inject() (
     val attachments = List(
       SlackAttachment(color = None, text = Some(DescriptionElements.formatForSlack(DescriptionElements(
         SlackEmoji.books, "Access to your archived links", "-",
-        "For example, check out the archive of your latest message",
-        mostRecentIngestedMsg._2.channel.name.map(chName => DescriptionElements("in", s"#${chName.value}")),
-        "here" --> linkToMostRecentKeep
+        "For example, here's the archive of your recent message",
+        mostRecentIngestedMsg.channel.name.map(chName => DescriptionElements("in", s"#${chName.value}:")),
+        mostRecentKeep.title.getOrElse(mostRecentKeep.url).abbreviate(60) --> linkToMostRecentKeep
       )))),
       SlackAttachment(color = None, text = Some(DescriptionElements.formatForSlack(DescriptionElements(
         SlackEmoji.magnifyingGlass, "Google search integration", "-",
         "See the pages your coworkers are shared on top of Google search results"
-      )))),
-      SlackAttachment(color = None, text = Some(DescriptionElements.formatForSlack(DescriptionElements(
-        SlackEmoji.pencil, "On the page", "-",
-        "Ever wonder if your coworkers are already talking about an article you're looking at?",
-        "If they are, I'll give you a link to the conversation."
-      )))),
+      )))).withImageUrl(superAwesomeWelcomeMessageGIF),
       SlackAttachment(color = None, text = Some(DescriptionElements.formatForSlack(DescriptionElements(
         SlackEmoji.robotFace,
         "Also, my binary code is a mess right now, so while I'm in the midst of spring cleaning I won't be responding to any messages you send my way  :zipper_mouth_face:.",
@@ -227,8 +224,8 @@ class SlackPersonalDigestNotificationActor @Inject() (
     val linkToUnsubscribe = LinkElement(pathCommander.slackPersonalDigestToggle(digest.slackMembership.slackTeamId, digest.slackMembership.slackUserId, turnOn = false).withQuery(trackingParams("turnOff")))
     val text = DescriptionElements.unlines(List(
       prng.choice(puns),
-      DescriptionElements("You've sent", digest.numIngestedMessages, "links", inTheLast(digest.digestPeriod), ".",
-        "I", "archived them" --> linkToFeed, "for you, and indexed the pages so you can search for them more easily."),
+      DescriptionElements("You've sent", s"${digest.numIngestedMessages} links" --> linkToFeed, inTheLast(digest.digestPeriod), ".",
+        "I archived them for you, and indexed the pages so you can search for them more easily."),
       DescriptionElements("If you don't want to get any more of these notifications,", "click here" --> linkToUnsubscribe)
     ))
     SlackMessageRequest.fromKifi(DescriptionElements.formatForSlack(text))

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackTeamDigestNotificationActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackTeamDigestNotificationActor.scala
@@ -249,7 +249,7 @@ class SlackTeamDigestNotificationActor @Inject() (
           topLibraries.map(lib => DescriptionElements(lib.name --> LinkElement(pathCommander.libraryPageViaSlack(lib, digest.slackTeam.slackTeamId).withQuery(trackingParams))))
         }
       )))).withFullMarkdown
-    ) ++ prng.choice(kifiSlackTipAttachments(digest.slackTeam.slackTeamId))
+    ) ++ prng.choiceOption(kifiSlackTipAttachments(digest.slackTeam.slackTeamId))
 
     SlackMessageRequest.fromKifi(DescriptionElements.formatForSlack(text), attachments).quiet
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/models/SlackDigests.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/models/SlackDigests.scala
@@ -23,6 +23,7 @@ case class SlackTeamDigest(
 
 case class SlackPersonalDigest(
     slackMembership: SlackTeamMembership,
+    slackTeam: SlackTeam,
     digestPeriod: Duration,
     org: BasicOrganization,
     ingestedMessagesByChannel: Map[SlackChannelIdAndPrettyName, Seq[(Keep, PrettySlackMessage)]]) {

--- a/kifi-backend/modules/shoebox/conf/site.routes
+++ b/kifi-backend/modules/shoebox/conf/site.routes
@@ -42,6 +42,7 @@ GET     /s/:teamId/oi/:orgId                @com.keepit.controllers.routing.Slac
 GET     /s/:teamId/l/:libId                 @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToLibrary(teamId: SlackTeamId, libId: PublicId[Library])
 GET     /s/:teamId/k/:keepId/:urlHash/kifi  @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToKeep(teamId: SlackTeamId, keepId: PublicId[Keep], urlHash: UrlHash, onKifi: Boolean = true)
 GET     /s/:teamId/k/:keepId/:urlHash/web   @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToKeep(teamId: SlackTeamId, keepId: PublicId[Keep], urlHash: UrlHash, onKifi: Boolean = false)
+GET     /s/:teamId/feed/own                 @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToOwnFeed(teamId: SlackTeamId)
 GET     /s/pd/:teamId/:userId/:hash         @com.keepit.controllers.routing.SlackAuthRouter.togglePersonalDigest(teamId: SlackTeamId, userId: SlackUserId, hash: String, turnOn: Boolean)
 
 # Note: If you add any routes below this /:handle they aren't going to get matched, since :handle will wildcard match anything


### PR DESCRIPTION
Added keep title to initial digest, puns to ongoing digests, and a special route to get to your "own keeps" feed via slack auth.

@leogrim @camhashemi 
