### PR TITLE
Sort by a unique identifier

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPersonalDigestNotificationActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPersonalDigestNotificationActor.scala
@@ -217,7 +217,7 @@ class SlackPersonalDigestNotificationActor @Inject() (
     val linkToUnsubscribe = LinkElement(pathCommander.slackPersonalDigestToggle(digest.slackMembership.slackTeamId, digest.slackMembership.slackUserId, turnOn = false).withQuery(trackingParams("turnOff")))
     val text = prng.choice(puns)
 
-    val (mostRecentKeep, mostRecentIngestedMsg) = digest.ingestedMessagesByChannel.values.flatten.maxBy { case (kId, msg) => msg.timestamp }
+    val (mostRecentKeep, mostRecentIngestedMsg) = digest.ingestedMessagesByChannel.values.flatten.maxBy { case (k, msg) => (msg.timestamp.value, k.id.get.id) }
     val linkToMostRecentKeep = LinkElement(pathCommander.keepPageOnKifiViaSlack(mostRecentKeep, digest.slackTeam.slackTeamId).withQuery(trackingParams("latestMessage")))
     val attachments = Seq(
       SlackAttachment.simple(DescriptionElements(


### PR DESCRIPTION
This solves an issue where multiple links in the same message were treated equivalently leading to undefined behavior.

@leogrim 
