### PR TITLE
Only recording libraries that were manually kept

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -215,8 +215,10 @@ class KeepInternerImpl @Inject() (
           libraryOpt.foreach { lib =>
             libraryNewFollowersCommander.notifyFollowersOfNewKeeps(lib, keeps.head)
             libToSlackProcessor.schedule(Set(lib.id.get))
-            keeps.groupBy(_.userId).keySet.flatten.foreach { userId =>
-              userInteractionCommander.addInteractions(userId, Seq(LibraryInteraction(lib.id.get) -> UserInteraction.KEPT_TO_LIBRARY))
+            if (KeepSource.manual.contains(keeps.head.source)) {
+              keeps.groupBy(_.userId).keySet.flatten.foreach { userId =>
+                userInteractionCommander.addInteractions(userId, Seq(LibraryInteraction(lib.id.get) -> UserInteraction.KEPT_TO_LIBRARY))
+              }
             }
           }
         }


### PR DESCRIPTION
After running it overnight, noticed that most of the libraries recorded are ingestions, like Twitter sync. Since you never really directly keep to those libraries, doesn't make a lot of sense to put them at the top of your list.

@leogrim 
