### PR TITLE
Fix nano scroll source map error in dev mode

### DIFF
--- a/kifi-backend/modules/shoebox/angular/gulpfile.js
+++ b/kifi-backend/modules/shoebox/angular/gulpfile.js
@@ -394,7 +394,9 @@ gulp.task('lib-min-styles', function () {
 
 gulp.task('lib-scripts', function () {
   return gulp.src(devFiles(libJsFiles))
+    .pipe(sourcemaps.init())
     .pipe(concat('lib.js'))
+    .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest(outDir));
 });
 


### PR DESCRIPTION
This gets rid of the nano scroll source map error in dev mode (for me at least).

@cvializ let me know if generating the lib source map is a bad idea.
