### PR TITLE
Add in a placeholder redirect for Message push in Slack

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PathCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PathCommander.scala
@@ -10,6 +10,7 @@ import com.keepit.common.db.slick.Database
 import com.keepit.common.net.{ Query, Param }
 import com.keepit.common.path.Path
 import com.keepit.common.social.BasicUserRepo
+import com.keepit.discussion.Message
 import com.keepit.model.LibrarySpace.{ OrganizationSpace, UserSpace }
 import com.keepit.model._
 import com.keepit.slack.models.{ SlackTeamMembership, SlackUserId, SlackTeamId }
@@ -91,6 +92,10 @@ class PathCommander @Inject() (
   def keepPageOnKifiViaSlack(keep: Keep, slackTeamId: SlackTeamId): Path = keepPageViaSlack(keep, slackTeamId) + "/kifi"
   def keepPageOnUrlViaSlack(keep: Keep, slackTeamId: SlackTeamId): Path = keepPageViaSlack(keep, slackTeamId) + "/web"
   def userPageViaSlack(basicUser: BasicUser, slackTeamId: SlackTeamId): Path = Path(s"s/${slackTeamId.value}/u/${basicUser.externalId.id}")
+
+  def keepPageOnMessageViaSlack(keep: Keep, slackTeamId: SlackTeamId, messageId: Id[Message]) = {
+    Path(s"s/${slackTeamId.value}/k/${Keep.publicId(keep.id.get).id}/${UrlHash.hashUrl(keep.url).urlEncoded}/m/${Message.publicId(messageId).id}")
+  }
 
   /**
    * MISCELLANEOUS

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/routing/SlackAuthRouter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/routing/SlackAuthRouter.scala
@@ -13,6 +13,7 @@ import com.keepit.common.http._
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.controllers.core.PostRegIntent
 import com.keepit.controllers.website.{ DeepLinkRouter, DeepLinkRedirect }
+import com.keepit.discussion.Message
 import com.keepit.heimdal.{ HeimdalServiceClient, HeimdalContextBuilderFactory }
 import com.keepit.model._
 import com.keepit.shoebox.controllers.TrackingActions
@@ -158,6 +159,10 @@ class SlackAuthRouter @Inject() (
         }
       }
     }
+  }
+
+  def fromSlackToMessage(slackTeamId: SlackTeamId, keepId: PublicId[Keep], urlHash: UrlHash, msgId: PublicId[Message]) = {
+    fromSlackToKeep(slackTeamId, keepId, urlHash, onKifi = false)
   }
 
   def togglePersonalDigest(slackTeamId: SlackTeamId, slackUserId: SlackUserId, hash: String, turnOn: Boolean) = (MaybeUserAction andThen SlackClickTracking(Some(slackTeamId), "toggleDigest")) { implicit request =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPushingActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackPushingActor.scala
@@ -422,6 +422,7 @@ class SlackPushingActor @Inject() (
 
     val category = NotificationCategory.NonUser.NEW_COMMENT
     def keepLink(subaction: String) = LinkElement(pathCommander.keepPageOnUrlViaSlack(keep, slackTeamId).withQuery(SlackAnalytics.generateTrackingParams(items.slackChannelId, category, Some(subaction))))
+    def msgLink(subaction: String) = LinkElement(pathCommander.keepPageOnMessageViaSlack(keep, slackTeamId, msg.id).withQuery(SlackAnalytics.generateTrackingParams(items.slackChannelId, category, Some(subaction))))
 
     val keepElement = {
       DescriptionElements(
@@ -440,16 +441,16 @@ class SlackPushingActor @Inject() (
         if (msg.isDeleted) Seq(SlackAttachment.simple("[comment has been deleted]"))
         else SlackAttachment.simple(DescriptionElements(s"*$userStr:*", textAndLookHeres.map {
           case Left(str) => DescriptionElements(str)
-          case Right(Success((pointer, ref))) => pointer --> keepLink("lookHere")
-          case Right(Failure(fail)) => "look here" --> keepLink("lookHere")
+          case Right(Success((pointer, ref))) => pointer --> msgLink("lookHere")
+          case Right(Failure(fail)) => "look here" --> msgLink("lookHere")
         })).withFullMarkdown.withColor(LibraryColor.BLUE.hex) +: textAndLookHeres.collect {
           case Right(Success((pointer, ref))) =>
             imageUrlRegex.findFirstIn(ref) match {
               case Some(url) =>
-                SlackAttachment.simple(DescriptionElements(SlackEmoji.magnifyingGlass, pointer --> keepLink("lookHereImage"))).withImageUrl(url)
+                SlackAttachment.simple(DescriptionElements(SlackEmoji.magnifyingGlass, pointer --> msgLink("lookHereImage"))).withImageUrl(url)
               case None =>
                 SlackAttachment.simple(DescriptionElements(
-                  SlackEmoji.magnifyingGlass, pointer --> keepLink("lookHere"), ": ",
+                  SlackEmoji.magnifyingGlass, pointer --> msgLink("lookHere"), ": ",
                   DescriptionElements.unlines(ref.lines.toSeq.map(ln => DescriptionElements(s"_${ln}_")))
                 )).withFullMarkdown
             }

--- a/kifi-backend/modules/shoebox/conf/site.routes
+++ b/kifi-backend/modules/shoebox/conf/site.routes
@@ -34,16 +34,17 @@ GET     /url                       @com.keepit.controllers.routing.KifiSiteRoute
 
 GET     /k/:title/:id              @com.keepit.controllers.routing.KifiSiteRouter.serveWebAppIfKeepFound(title: String, id: PublicId[Keep], authToken: Option[String] ?= None)
 
-GET     /s/:teamId/i                        @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToInstallPage(teamId: SlackTeamId)
-GET     /s/:teamId/u/:userId                @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToUser(teamId: SlackTeamId, userId: ExternalId[User], isWelcomeMessage: Boolean = false)
-GET     /s/:teamId/welcome/:userId          @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToUser(teamId: SlackTeamId, userId: ExternalId[User], isWelcomeMessage: Boolean = true)
-GET     /s/:teamId/o/:orgId                 @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToOrg(teamId: SlackTeamId, orgId: PublicId[Organization])
-GET     /s/:teamId/oi/:orgId                @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToOrgIntegrations(teamId: SlackTeamId, orgId: PublicId[Organization])
-GET     /s/:teamId/l/:libId                 @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToLibrary(teamId: SlackTeamId, libId: PublicId[Library])
-GET     /s/:teamId/k/:keepId/:urlHash/kifi  @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToKeep(teamId: SlackTeamId, keepId: PublicId[Keep], urlHash: UrlHash, onKifi: Boolean = true)
-GET     /s/:teamId/k/:keepId/:urlHash/web   @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToKeep(teamId: SlackTeamId, keepId: PublicId[Keep], urlHash: UrlHash, onKifi: Boolean = false)
-GET     /s/:teamId/feed/own                 @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToOwnFeed(teamId: SlackTeamId)
-GET     /s/pd/:teamId/:userId/:hash         @com.keepit.controllers.routing.SlackAuthRouter.togglePersonalDigest(teamId: SlackTeamId, userId: SlackUserId, hash: String, turnOn: Boolean)
+GET     /s/:teamId/i                            @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToInstallPage(teamId: SlackTeamId)
+GET     /s/:teamId/u/:userId                    @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToUser(teamId: SlackTeamId, userId: ExternalId[User], isWelcomeMessage: Boolean = false)
+GET     /s/:teamId/welcome/:userId              @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToUser(teamId: SlackTeamId, userId: ExternalId[User], isWelcomeMessage: Boolean = true)
+GET     /s/:teamId/o/:orgId                     @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToOrg(teamId: SlackTeamId, orgId: PublicId[Organization])
+GET     /s/:teamId/oi/:orgId                    @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToOrgIntegrations(teamId: SlackTeamId, orgId: PublicId[Organization])
+GET     /s/:teamId/l/:libId                     @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToLibrary(teamId: SlackTeamId, libId: PublicId[Library])
+GET     /s/:teamId/k/:keepId/:urlHash/kifi      @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToKeep(teamId: SlackTeamId, keepId: PublicId[Keep], urlHash: UrlHash, onKifi: Boolean = true)
+GET     /s/:teamId/k/:keepId/:urlHash/web       @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToKeep(teamId: SlackTeamId, keepId: PublicId[Keep], urlHash: UrlHash, onKifi: Boolean = false)
+GET     /s/:teamId/k/:keepId/:urlHash/m/:msgId  @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToMessage(teamId: SlackTeamId, keepId: PublicId[Keep], urlHash: UrlHash, msgId: PublicId[Message])
+GET     /s/:teamId/feed/own                     @com.keepit.controllers.routing.SlackAuthRouter.fromSlackToOwnFeed(teamId: SlackTeamId)
+GET     /s/pd/:teamId/:userId/:hash             @com.keepit.controllers.routing.SlackAuthRouter.togglePersonalDigest(teamId: SlackTeamId, userId: SlackUserId, hash: String, turnOn: Boolean)
 
 # Note: If you add any routes below this /:handle they aren't going to get matched, since :handle will wildcard match anything
 GET     /:handle                   @com.keepit.controllers.routing.KifiSiteRouter.serveWebAppIfHandleFound(handle: Handle)

--- a/kifi-backend/project/Global.scala
+++ b/kifi-backend/project/Global.scala
@@ -130,7 +130,8 @@ object PlayGlobal {
     "com.keepit.rover.model._",
     "com.keepit.rover.article._",
     "com.keepit.common.store.ImageSize",
-    "com.keepit.slack.models.{SlackTeamId,SlackUserId}"
+    "com.keepit.slack.models.{SlackTeamId,SlackUserId}",
+    "com.keepit.discussion.Message"
   )
 
   val _templateImports = Seq(


### PR DESCRIPTION
@leogrim right now it behaves exactly the same as a keep redirect, but at least they'll be out there if we want to do something fancier later
