### PR TITLE
double hashtag on keep cards on site

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCardAttribution.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCardAttribution.tpl.html
@@ -62,7 +62,7 @@
 
     <span class="kf-keep-card-attribution-slack" ng-if="::keep.sourceAttribution.slack && !shortMessage">
       <a class="kf-link" ng-href="{{::keep.sourceAttribution.slack.message.permalink}}" target="_blank" ng-click="trackSlack()">
-        <span class="svg-slack kf-keep-card-attribution-slack-icon"></span>#<span ng-bind="keep.sourceAttribution.slack.message.channel.name"></span>
+        <span class="svg-slack kf-keep-card-attribution-slack-icon"></span><span ng-bind="keep.sourceAttribution.slack.message.channel.name"></span>
       </a>
     </span>
 


### PR DESCRIPTION
does keep.sourceAttribution.slack.message.channel.name supposed to hold the hashtag of the slack channel name now?

https://app.asana.com/0/86762801523563/103352990742774
