### PR TITLE
Fixing the build

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -20,7 +20,7 @@ import com.keepit.eliza.ElizaServiceClient
 import com.keepit.heimdal._
 import com.keepit.integrity.UriIntegrityHelpers
 import com.keepit.model._
-import com.keepit.model.keep.KeepInfo
+import com.keepit.model.keep2.KeepInfo
 import com.keepit.normalizer.NormalizedURIInterner
 import com.keepit.rover.RoverServiceClient
 import com.keepit.search.SearchServiceClient

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
@@ -18,7 +18,7 @@ import com.keepit.common.util.Ord.dateTimeOrdering
 import com.keepit.discussion.{ Discussion, Message }
 import com.keepit.eliza.ElizaServiceClient
 import com.keepit.model._
-import com.keepit.model.keep.{ BasicLibraryWithKeptAt, KeepInfo }
+import com.keepit.model.keep2.{ BasicLibraryWithKeptAt, KeepInfo }
 import com.keepit.rover.RoverServiceClient
 import com.keepit.search.SearchServiceClient
 import com.keepit.search.augmentation.{ AugmentableItem, LimitedAugmentationInfo }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ActivityFeedEmailSender.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/emails/ActivityFeedEmailSender.scala
@@ -20,7 +20,7 @@ import com.keepit.common.performance._
 import com.keepit.curator.LibraryQualityHelper
 import com.keepit.eliza.ElizaServiceClient
 import com.keepit.model._
-import com.keepit.model.keep.KeepInfo
+import com.keepit.model.keep2.KeepInfo
 import com.keepit.social.BasicUser
 import play.twirl.api.Html
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/curator/model/RecommendationInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/curator/model/RecommendationInfo.scala
@@ -2,7 +2,7 @@ package com.keepit.curator.model
 
 import com.keepit.common.crypto.PublicId
 import com.keepit.common.db.{ Id, ExternalId }
-import com.keepit.model.keep.KeepInfo
+import com.keepit.model.keep2.KeepInfo
 import com.keepit.model.{ FullLibraryInfo, Library, NormalizedURI, URISummary }
 import com.keepit.social.BasicUser
 import com.kifi.macros.json

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileKeepsController.scala
@@ -10,7 +10,7 @@ import com.keepit.common.db._
 import com.keepit.common.db.slick._
 import com.keepit.model._
 import com.keepit.common.crypto.PublicIdConfiguration
-import com.keepit.model.keep.KeepInfo
+import com.keepit.model.keep2.KeepInfo
 
 import play.api.libs.json._
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileLibraryController.scala
@@ -20,7 +20,7 @@ import com.keepit.heimdal.{ HeimdalContext, HeimdalContextBuilderFactory }
 import com.keepit.inject.FortyTwoConfig
 import com.keepit.model.ExternalLibrarySpace.{ ExternalOrganizationSpace, ExternalUserSpace }
 import com.keepit.model._
-import com.keepit.model.keep.KeepInfo
+import com.keepit.model.keep2.KeepInfo
 import com.keepit.normalizer.NormalizedURIInterner
 import com.keepit.shoebox.controllers.LibraryAccessActions
 import com.keepit.social.BasicUser

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileRecommendationsController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/mobile/MobileRecommendationsController.scala
@@ -10,7 +10,7 @@ import com.keepit.common.net.UserAgent
 import com.keepit.common.time._
 import com.keepit.curator.model._
 import com.keepit.model._
-import com.keepit.model.keep.BasicLibraryWithKeptAt
+import com.keepit.model.keep2.BasicLibraryWithKeptAt
 import com.kifi.macros.json
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.{ JsString, Json }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -24,7 +24,7 @@ import com.keepit.heimdal.HeimdalContextBuilderFactory
 import com.keepit.inject.FortyTwoConfig
 import com.keepit.model.ExternalLibrarySpace.{ ExternalOrganizationSpace, ExternalUserSpace }
 import com.keepit.model._
-import com.keepit.model.keep.KeepInfo
+import com.keepit.model.keep2.KeepInfo
 import com.keepit.shoebox.controllers.LibraryAccessActions
 import com.keepit.social.BasicUser
 import org.joda.time.DateTime

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
@@ -4,7 +4,7 @@ import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.json
 import com.keepit.common.mail.BasicContact
 import com.keepit.discussion.Message
-import com.keepit.model.keep.KeepInfo
+import com.keepit.model.keep2.KeepInfo
 import com.keepit.slack.LibrarySlackInfo
 import com.keepit.slack.models.{ SlackIntegrationStatus, SlackChannelToLibrary, LibraryToSlackChannel, SlackChannelName }
 import com.keepit.social.BasicUser

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/keep2/KeepInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/keep2/KeepInfo.scala
@@ -1,4 +1,4 @@
-package com.keepit.model.keep
+package com.keepit.model.keep2
 
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
 import com.keepit.common.db.ExternalId

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/keep2/NewKeepInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/keep2/NewKeepInfo.scala
@@ -1,4 +1,4 @@
-package com.keepit.model.keep
+package com.keepit.model.keep2
 
 import com.keepit.common.crypto.PublicId
 import com.keepit.model.{ NormalizedURI, KeepPermission, Keep }


### PR DESCRIPTION
This is in a widely wildcard imported namespace and presents collisions. Because it's a package collision, scalac doesn't have great error messages (because there's not a class it can point to).

Also, we should keep classes for serialization outside of `com.keepit.model`. I'm just renaming to keep2 so the build will fix, but this should be moved out. @ryanpbrewster @leogrim 
