### PR TITLE
Way better library rankings

### DIFF
--- a/kifi-backend/modules/abook/app/com/keepit/abook/typeahead/EContactTypeahead.scala
+++ b/kifi-backend/modules/abook/app/com/keepit/abook/typeahead/EContactTypeahead.scala
@@ -90,10 +90,8 @@ class EContactTypeahead @Inject() (
   }
 
   protected def getInfos(ids: Seq[Id[EContact]]): Future[Seq[EContact]] = {
-    if (ids.isEmpty) Future.successful(Seq.empty) else {
-      db.readOnlyMasterAsync { implicit ro =>
-        econtactRepo.bulkGetByIds(ids).valuesIterator.toSeq
-      }
+    db.readOnlyMasterAsync { implicit ro =>
+      econtactRepo.bulkGetByIds(ids).valuesIterator.toSeq
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
@@ -18,7 +18,7 @@ import com.keepit.common.time.DateTimeJsonFormat
 import com.keepit.model.{ SocialUserConnectionsKey, _ }
 import com.keepit.search.SearchServiceClient
 import com.keepit.social.{ BasicUser, SocialNetworkType, SocialNetworks, TypeaheadUserHit }
-import com.keepit.typeahead.{ LibraryTypeahead, TypeaheadHit, KifiUserTypeahead, SocialUserTypeahead }
+import com.keepit.typeahead._
 import com.kifi.macros.json
 import org.joda.time.DateTime
 import play.api.libs.concurrent.Execution.Implicits._
@@ -310,8 +310,8 @@ class TypeaheadCommander @Inject() (
         }
         val rankedFriends = friends.imap {
           case (users, contacts) =>
-            val sortedUsers = users.sortBy(u => userOrder(u._1))
-            val sortedContacts = contacts.sortBy(c => contactOrder(c))
+            val sortedUsers = users.zipWithIndex.sortBy { case ((id, _), idx) => (userOrder(id), idx) }.map(_._1)
+            val sortedContacts = contacts.zipWithIndex.sortBy { case (c, idx) => (contactOrder(c), idx) }.map(_._1)
             (sortedUsers, sortedContacts)
         }
         rankedFriends
@@ -334,10 +334,11 @@ class TypeaheadCommander @Inject() (
     val limit = Some(limitOpt.map(Math.min(_, 20)).getOrElse(20))
     query.trim match {
       case q if q.isEmpty =>
+        libraryTypeahead.prefetch(userId)
         Future.successful(suggestResults(userId))
       case q =>
         val friendsF = searchFriendsAndContacts(userId, q, includeSelf = true, limit)
-        val librariesF = libraryTypeahead.topN(userId, q, limit)(TypeaheadHit.defaultOrdering[Library])
+        val librariesF = libraryTypeahead.topN(userId, q, limit)(TypeaheadHit.defaultOrdering[LibraryTypeaheadResult])
 
         val (userScore, emailScore, libScore) = {
           val interactions = interactionCommander.getRecentInteractions(userId).zipWithIndex
@@ -367,11 +368,23 @@ class TypeaheadCommander @Inject() (
             case (contact, idx) =>
               (emailScore(contact.email), idx + limit.get, EmailContactResult(email = contact.email, name = contact.name))
           }
-          val libRes = libToResult(userId, libraries.map(_.id.get)).zipWithIndex.map {
+          val libIdToImportance = libraries.map(r => r.id -> r.importance).toMap
+          val libRes = libToResult(userId, libraries.map(_.id)).zipWithIndex.map {
             case ((id, lib), idx) =>
-              (libScore(id), idx, lib)
+              (libScore(id), idx + libIdToImportance(id), lib)
           }
-          (userRes ++ emailRes ++ libRes).sortBy(d => (d._1, d._2)).map { case (_, _, res) => res }
+          val combined = (userRes ++ emailRes ++ libRes).sortBy(d => (d._1, d._2))
+
+          // For diagnosis, not for public release!
+          val summary = combined.map {
+            case (s1, s2, u: UserContactResult) => s"u($s1,$s2)"
+            case (s1, s2, e: EmailContactResult) => s"e($s1,$s2)"
+            case (s1, s2, l: LibraryResult) => s"l($s1,$s2)"
+          }.mkString(" ")
+          log.info(s"[searchForKeepRecipients] $userId q=$query, l=${combined.length}, s=$summary")
+          // For diagnosis, not for public release!
+
+          combined.map { case (_, _, res) => res }
         }
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -17,7 +17,7 @@ import com.keepit.shoebox.model.KeepImagesCache
 import com.keepit.slack.SlackAuthStateCache
 import com.keepit.slack.models._
 import com.keepit.social.{ BasicUserUserIdCache, IdentityUserIdCache }
-import com.keepit.typeahead.{ LibraryTypeaheadCache, KifiUserTypeaheadCache, SocialUserTypeaheadCache, UserHashtagTypeaheadCache }
+import com.keepit.typeahead._
 
 import scala.concurrent.duration._
 
@@ -285,7 +285,12 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Singleton
   @Provides
   def libraryTypeaheadCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new LibraryTypeaheadCache(stats, accessLog, (outerRepo, 1 hour))
+    new LibraryFilterTypeaheadCache(stats, accessLog, (outerRepo, 30 minutes))
+
+  @Singleton
+  @Provides
+  def libraryResultTypeaheadCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new LibraryResultTypeaheadCache(stats, accessLog, (innerRepo, 1 minute), (outerRepo, 1 hour))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/shoebox/app/com/keepit/typeahead/KifiUserTypeahead.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/typeahead/KifiUserTypeahead.scala
@@ -73,11 +73,8 @@ class KifiUserTypeahead @Inject() (
   }
 
   private def getInfos(ids: Seq[Id[User]]): Future[Seq[User]] = SafeFuture {
-    if (ids.isEmpty) Seq.empty
-    else {
-      db.readOnlyMaster { implicit ro =>
-        userRepo.getUsers(ids).valuesIterator.toVector
-      }
+    db.readOnlyMaster { implicit ro =>
+      userRepo.getUsers(ids).valuesIterator.toVector
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/typeahead/SocialUserTypeahead.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/typeahead/SocialUserTypeahead.scala
@@ -55,11 +55,8 @@ class SocialUserTypeahead @Inject() (
   }
 
   private def getInfos(ids: Seq[Id[SocialUserInfo]]): Future[Seq[SocialUserBasicInfo]] = {
-    if (ids.isEmpty) Future.successful(Seq.empty[SocialUserBasicInfo])
-    else {
-      db.readOnlyMasterAsync { implicit session =>
-        socialUserRepo.getSocialUserBasicInfos(ids).valuesIterator.toVector // do NOT use toSeq (=> toStream (lazy))
-      }
+    db.readOnlyMasterAsync { implicit session =>
+      socialUserRepo.getSocialUserBasicInfos(ids).valuesIterator.toVector // do NOT use toSeq (=> toStream (lazy))
     }
   }
 


### PR DESCRIPTION
Changed `LibraryTypeahead` to return a special data class that just represents the result. Inside, it holds `importance`, which helps with ordering using a simple scoring heuristic.

@leogrim 
