### PR TITLE
Remove old notifs if they are being replaced

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/WsNotificationDelivery.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/notify/delivery/WsNotificationDelivery.scala
@@ -22,6 +22,13 @@ class WsNotificationDelivery @Inject() (
     notificationJsonFormat: Provider[NotificationJsonFormat],
     implicit val executionContext: ExecutionContext) {
 
+  def delete(recipient: Recipient, notifId: String): Unit = {
+    recipient match {
+      case UserRecipient(user) => notificationRouter.sendToUser(user, Json.arr("remove_notification", notifId))
+      case _ =>
+    }
+  }
+
   def deliver(recipient: Recipient, notif: NotificationWithItems): Future[Unit] = {
     notificationInfoGenerator.generateInfo(recipient, Seq(notif)).flatMap { infos =>
       notificationJsonFormat.get.extendedJson(infos.head).map { notifJson =>


### PR DESCRIPTION
This currently only happens for the second LibraryNewKeep event
in a short period of time.

This is the saddest code I've written in a while

@andrewconner 
