### PR TITLE
sbt 0.13.11, scala 2.11.8

### DIFF
--- a/kifi-backend/project/Global.scala
+++ b/kifi-backend/project/Global.scala
@@ -29,10 +29,10 @@ object Global {
   )
 
   val macroParadiseSettings = Seq(
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.8",
     scalacOptions ++= _scalacOptions,
     resolvers += Resolver.sonatypeRepo("releases"),
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full)
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   )
 
   val _commonResolvers = Seq(
@@ -93,7 +93,7 @@ object Global {
 
   val settings = scalariformSettings ++ macroParadiseSettings ++ Seq(
     offline := false, // set to true to do work offline
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.8",
     version := Version.appVersion,
     libraryDependencies ++= commonDependencies,
     scalacOptions ++= _scalacOptions,

--- a/kifi-backend/project/build.properties
+++ b/kifi-backend/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11


### PR DESCRIPTION
You shouldn't need a clean for this, but your sbt launcher may need to update. If you use Paul Phillips's launcher (which I recommend), you can get an updated version here: https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt

Otherwise you may need to manually download the new version:

```
From  http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.11/sbt-launch.jar
To  ~/.sbt/launchers/0.13.11/sbt-launch.jar
```
