### PR TITLE
add activityLog.numComments, activityLog.numEvents

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/util/ActivityElements.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/ActivityElements.scala
@@ -75,11 +75,11 @@ object ActivityEvent {
   )(unlift(ActivityEvent.unapply))
 }
 
-case class ActivityLog(events: Seq[ActivityEvent])
+case class ActivityLog(events: Seq[ActivityEvent], numEvents: Int, numComments: Int)
 object ActivityLog {
-  val empty = ActivityLog(Seq.empty)
+  val empty = ActivityLog(Seq.empty, numEvents = 0, numComments = 0)
 
   implicit val writes = new Writes[ActivityLog] {
-    def writes(o: ActivityLog) = Json.obj("events" -> o.events)
+    def writes(o: ActivityLog) = Json.obj("events" -> o.events, "numEvents" -> o.numEvents, "numComments" -> o.numComments)
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/util/DescriptionElements.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/DescriptionElements.scala
@@ -135,7 +135,7 @@ case class LibraryElement(
   val url = Some(path.absolute)
 }
 object LibraryElement extends DescriptionElementHelper[LibraryElement]("library") {
-  implicit val writes: Writes[LibraryElement] = Writes { l => Json.obj("id" -> l.id, "text" -> l.text, "image" -> l.color, "url" -> l.url, "kind" -> kind) }
+  implicit val writes: Writes[LibraryElement] = Writes { l => Json.obj("id" -> l.id, "text" -> l.text, "color" -> l.color, "url" -> l.url, "kind" -> kind) }
 }
 
 case class OrganizationElement(

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
@@ -399,7 +399,8 @@ class KeepDecoratorImpl @Inject() (
     }
 
     val commentEvents = discussion.map(_.messages.map(ActivityEvent.fromComment)).getOrElse(Seq.empty)
-    ActivityLog(events = (commentEvents :+ initialKeepEvent))
+    val events = commentEvents :+ initialKeepEvent
+    ActivityLog(events = events, numEvents = events.size, numComments = commentEvents.size + keep.note.map(_ => 1).getOrElse(0))
   }
 }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -1038,6 +1038,8 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                 "members": ${Json.toJson(toSimpleKeepMembers(keep2, BasicUser.fromUser(user1), libraryCard(lib1.id.get)))},
                 "permissions": ${Json.toJson(keepPermissions(keep2.id.get))},
                 "activity": {
+                  "numEvents": 1,
+                  "numComments": 0,
                   "events": [
                     {
                       "kind":"initial",
@@ -1045,7 +1047,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                       "header":[
                         {"id":"${user1.externalId}","text":"Aaron Hsu","image":"http://localhost/users/${user1.externalId}/pics/200/0.jpg","url":"https://www.kifi.com/test","kind":"author"},
                         {"text":" kept this into ","url":null,"hover":null,"kind":"text"},
-                        {"id":"l7jlKlnA36Su","text":"${lib1.name}","image":null,"url":"https://www.kifi.com/test/${lib1.slug.value}","kind":"library"}
+                        {"id":"l7jlKlnA36Su","text":"${lib1.name}","color":null,"url":"https://www.kifi.com/test/${lib1.slug.value}","kind":"library"}
                       ],
                       "body": [],
                       "timestamp":${keep2.keptAt.getMillis}
@@ -1081,6 +1083,8 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                 "members": ${Json.toJson(toSimpleKeepMembers(keep1, BasicUser.fromUser(user1), libraryCard(lib1.id.get)))},
                 "permissions": ${Json.toJson(keepPermissions(keep1.id.get))},
                 "activity" : {
+                  "numEvents": 1,
+                  "numComments": 0,
                   "events":[
                     {
                       "kind":"initial",
@@ -1088,7 +1092,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                       "header":[
                         {"id":"${user1.externalId}","text":"Aaron Hsu","image":"http://localhost/users/${user1.externalId}/pics/200/0.jpg","url":"https://www.kifi.com/test","kind":"author"},
                         {"text":" kept this into ","url":null,"hover":null,"kind":"text"},
-                        {"id":"l7jlKlnA36Su","text":"${lib1.name}","image":null,"url":"https://www.kifi.com/test/${lib1.slug.value}","kind":"library"}
+                        {"id":"l7jlKlnA36Su","text":"${lib1.name}","color":null,"url":"https://www.kifi.com/test/${lib1.slug.value}","kind":"library"}
                       ],
                       "body": [],
                       "timestamp":${keep1.keptAt.getMillis}


### PR DESCRIPTION
@DerekBurch `numComments` is from the spec, should be the number of messages + events with a note + events with third party attribution. sending it down with what we have for now. cc: @ryanpbrewster 
