### PR TITLE
Rad SQL query to get the latest messages for several keeps

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/amazon/AmazonInstanceInfo.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/amazon/AmazonInstanceInfo.scala
@@ -8,7 +8,6 @@ import com.keepit.common.time._
 import com.keepit.common.service.IpAddress
 import com.keepit.common.reflection.Enumerator
 
-
 case class AmazonInstanceId(id: String) extends AnyVal {
   override def toString(): String = id
 }
@@ -111,7 +110,6 @@ object AmazonInstanceType extends Enumerator[AmazonInstanceType] {
   case object I2XLARGE extends AmazonInstanceType("i2.xlarge", 4, 14)
   case object I2XXLARGE extends AmazonInstanceType("i2.2xlarge", 8, 27)
   case object I2XXXXLARGE extends AmazonInstanceType("i2.4xlarge", 16, 53)
-
 
   case object UNKNOWN extends AmazonInstanceType("UNKNOWN", 6, 12)
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessageRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessageRepo.scala
@@ -38,6 +38,8 @@ trait MessageRepo extends Repo[ElizaMessage] with SeqNumberFunction[ElizaMessage
   def getByKeep(keepId: Id[Keep], fromId: Option[Id[ElizaMessage]], dir: SortDirection = SortDirection.DESCENDING, limit: Int)(implicit session: RSession): Seq[ElizaMessage]
   def getAllByKeep(keepId: Id[Keep])(implicit session: RSession): Seq[ElizaMessage]
 
+  def getRecentByKeeps(keepIds: Set[Id[Keep]], limitPerKeep: Int)(implicit session: RSession): Map[Id[Keep], Seq[Id[ElizaMessage]]]
+
   def getForKeepsBySequenceNumber(keepIds: Set[Id[Keep]], seq: SequenceNumber[ElizaMessage])(implicit session: RSession): Seq[ElizaMessage]
 }
 
@@ -187,6 +189,25 @@ class MessageRepoImpl @Inject() (
 
   def getForKeepsBySequenceNumber(keepIds: Set[Id[Keep]], seq: SequenceNumber[ElizaMessage])(implicit session: RSession): Seq[ElizaMessage] = {
     rows.filter(msg => msg.keepId.inSet(keepIds) && msg.seq > seq).sortBy(_.seq).list
+  }
+
+  def getRecentByKeeps(keepIds: Set[Id[Keep]], limitPerKeep: Int)(implicit session: RSession): Map[Id[Keep], Seq[Id[ElizaMessage]]] = {
+    import com.keepit.common.db.slick.StaticQueryFixed.interpolation
+    if (keepIds.isEmpty) Map.empty
+    else {
+      val keepIdSetStr = keepIds.mkString("(", ",", ")")
+      StaticQuery.queryNA[Int] { s""" SET @idx = 0; SET @curKeep = 0; """ }.first
+      StaticQuery.queryNA[(Id[Keep], Id[ElizaMessage])] {
+        s"""
+        SELECT keep_id, id FROM (
+          SELECT keep_id, id,
+              @idx := IF(@curKeep = keep_id, @idx + 1, 1) AS rank,
+              @curKeep := keep_id AS dummy
+          FROM (SELECT * FROM message WHERE keep_id IN $keepIdSetStr ORDER BY keep_id, created_at DESC, id DESC) x
+        ) sub WHERE sub.rank <= $limitPerKeep;
+        """
+      }.list.groupBy(_._1).mapValues(_.map(_._2))
+    }
   }
 
   def deactivate(message: ElizaMessage)(implicit session: RWSession): Unit = save(message.sanitizeForDelete)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessageRepo.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/MessageRepo.scala
@@ -191,17 +191,29 @@ class MessageRepoImpl @Inject() (
     rows.filter(msg => msg.keepId.inSet(keepIds) && msg.seq > seq).sortBy(_.seq).list
   }
 
+  /**
+   * Grabs the `limitPerKeep` most recent messages for each keep in `keepIds`
+   * This is a non-trivial thing to do in a SQL database, so this query abuses user-variables.
+   * The sad part is that this is both complicated AND sensitive to the exactly db engine being used
+   * The happy part is that it's actually quite efficient compared to `keepIds.size` independent queries
+   * Use it if you desire efficiency at the cost of happiness
+   */
   def getRecentByKeeps(keepIds: Set[Id[Keep]], limitPerKeep: Int)(implicit session: RSession): Map[Id[Keep], Seq[Id[ElizaMessage]]] = {
     import com.keepit.common.db.slick.StaticQueryFixed.interpolation
     if (keepIds.isEmpty) Map.empty
     else {
       val keepIdSetStr = keepIds.mkString("(", ",", ")")
       StaticQuery.queryNA[Int] { s""" SET @idx = 0; SET @curKeep = 0; """ }.first
+      val updateRankStatement = db match {
+        case _: com.keepit.common.db.slick.H2 => "@idx := CASEWHEN(@curKeep = keep_id, @idx + 1, 1) AS rank"
+        case _: com.keepit.common.db.slick.MySQL => "@idx := IF(@curKeep = keep_id, @idx + 1, 1) AS rank"
+        case _ => throw new RuntimeException("unexpected db type, not one of {H2, MySQL}")
+      }
       StaticQuery.queryNA[(Id[Keep], Id[ElizaMessage])] {
         s"""
         SELECT keep_id, id FROM (
           SELECT keep_id, id,
-              @idx := IF(@curKeep = keep_id, @idx + 1, 1) AS rank,
+              $updateRankStatement,
               @curKeep := keep_id AS dummy
           FROM (SELECT * FROM message WHERE keep_id IN $keepIdSetStr ORDER BY keep_id, created_at DESC, id DESC) x
         ) sub WHERE sub.rank <= $limitPerKeep;

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/model/MessageRepoTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/model/MessageRepoTest.scala
@@ -22,7 +22,6 @@ class MessageRepoTest extends Specification with ElizaTestInjector {
   "MessageRepo" should {
     def rand(lo: Int, hi: Int) = lo + Random.nextInt(hi - lo + 1)
     "grab recent messages grouped by keep" in {
-      skipped("To make this test pass, change the IF to a CASEWHEN")
       withDb(modules: _*) { implicit injector =>
         val now = inject[Clock].now
         db.readWrite { implicit s =>
@@ -39,9 +38,6 @@ class MessageRepoTest extends Specification with ElizaTestInjector {
           (1 to 10).foreach { _ =>
             val randomKeeps = Random.shuffle(keepIds).take(10)
             val numMsgs = rand(5, 15)
-            // NB: This will fail because our testing suite uses H2 as the database engine, and H2 does
-            // not have an IF statement. Instead, it has a CASEWHEN statement which is exactly the same.
-            // To get this test to pass, go to MessageRepo.getRecentByKeeps and change the IF to a CASEWHEN
             messageRepo.getRecentByKeeps(randomKeeps.toSet, numMsgs).foreach {
               case (keepId, recentMsgIds) => recentMsgIds === messagesByKeep(keepId).take(numMsgs)
             }

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/model/MessageRepoTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/model/MessageRepoTest.scala
@@ -1,0 +1,54 @@
+package com.keepit.eliza.model
+
+import com.keepit.common.util.Ord
+import org.specs2.mutable.Specification
+import com.keepit.model._
+import com.keepit.common.db.Id
+import play.api.libs.json.JsNull
+import com.keepit.shoebox.FakeShoeboxServiceModule
+import com.keepit.common.cache.ElizaCacheModule
+import com.keepit.common.time._
+import com.keepit.test.ElizaTestInjector
+import org.joda.time.{ DateTime, Days }
+
+import scala.util.Random
+
+class MessageRepoTest extends Specification with ElizaTestInjector {
+  val modules = Seq(
+    ElizaCacheModule(),
+    FakeShoeboxServiceModule()
+  )
+
+  "MessageRepo" should {
+    def rand(lo: Int, hi: Int) = lo + Random.nextInt(hi - lo + 1)
+    "grab recent messages grouped by keep" in {
+      skipped("To make this test pass, change the IF to a CASEWHEN")
+      withDb(modules: _*) { implicit injector =>
+        val now = inject[Clock].now
+        db.readWrite { implicit s =>
+          val keepIds = Random.shuffle(Seq.range(1, 1000).map(Id[Keep](_))).take(50)
+          val threads = keepIds.map { keepId =>
+            MessageThreadFactory.thread().withKeep(keepId).saved
+          }
+          val messagesByKeep = threads.map { thread =>
+            thread.keepId -> MessageFactory.messages(50).map { msg =>
+              msg.withThread(thread).withCreatedAt(now plusHours rand(-100, 100)).saved
+            }.sortBy(x => (x.createdAt.getMillis, x.id.get.id))(Ord.descending).map(_.id.get)
+          }.toMap
+
+          (1 to 10).foreach { _ =>
+            val randomKeeps = Random.shuffle(keepIds).take(10)
+            val numMsgs = rand(5, 15)
+            // NB: This will fail because our testing suite uses H2 as the database engine, and H2 does
+            // not have an IF statement. Instead, it has a CASEWHEN statement which is exactly the same.
+            // To get this test to pass, go to MessageRepo.getRecentByKeeps and change the IF to a CASEWHEN
+            messageRepo.getRecentByKeeps(randomKeeps.toSet, numMsgs).foreach {
+              case (keepId, recentMsgIds) => recentMsgIds === messagesByKeep(keepId).take(numMsgs)
+            }
+          }
+          1 === 1
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
@camhashemi @leogrim 
this is so cool

As an example, try running

```
SET @idx := 0, @curKeep := 0;
SELECT keep_id, id, rank, created_at FROM (
        SELECT @idx := if(@curKeep = keep_id, @idx + 1, 1) AS rank,
               @curKeep := keep_id AS dummy,
               keep_id, id, created_at
        FROM (SELECT * FROM message
              WHERE keep_id IN (7573955, 8366817, 6899408, 6898737, 6788999, 6896452, 6897223, 6787592, 6798744)
              ORDER BY keep_id, created_at DESC) x
      ) sub WHERE sub.rank <= 10
```
