### PR TITLE
don't send new system messages to clients

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageFetchingCommander.scala
@@ -4,6 +4,7 @@ import com.google.inject.Inject
 import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.discussion.{ DiscussionFail, Message, DiscussionKeep }
+import com.keepit.eliza.model.SystemMessageData.AddLibraries
 import com.keepit.eliza.model._
 import com.keepit.common.logging.Logging
 import scala.concurrent.Future
@@ -62,7 +63,12 @@ class MessageFetchingCommander @Inject() (
     val userParticipantSet = thread.participants.allUsers
     log.info(s"[get_thread] got participants for keepId ${thread.keepId}: $userParticipantSet")
     val messagesFut: Future[Seq[MessageWithBasicUser]] = new SafeFuture(shoebox.getBasicUsers(userParticipantSet.toSeq) map { id2BasicUser =>
-      val messages = getThreadMessages(thread)
+      val messages = getThreadMessages(thread).filter {
+        _.auxData.forall {
+          case _: AddLibraries => false // todo(cam): add "Cam added LibraryX" formatting to the extension
+          case _ => true
+        }
+      }
       log.info(s"[get_thread] got raw messages for keepId ${thread.keepId}: ${messages.length}")
       messages.map { message => getMessageWithBasicUser(message, thread, id2BasicUser) }
     })


### PR DESCRIPTION
@andrewconner @leogrim 

the ext (mobile is fine) can't parse these messages like other system messages, and thus treats it like a normal (buggy) message. I can go in the ext and make it look more like the "Cam added Jen" message or we can wait until the ext has an activity log of its own.
