### PR TITLE
Use latest activity for activity at the top of the keeps

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/activityEvent/activityEvent.styl
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/activityEvent/activityEvent.styl
@@ -97,10 +97,9 @@
 .kf-keep-activity-event-page-link
   display: inline
 
-  &.kf-link
-    &:hover
-      text-decoration: none
-      opacity: .7
+  &:hover
+    text-decoration: none
+    opacity: .7
 
 .kf-keep-activity-event-actions
   position: relative

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/activityEvent/activityEvent.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/activityEvent/activityEvent.tpl.html
@@ -9,7 +9,7 @@
         <span kf-structured-text segments="activity">
         </span>
         <span class="kf-keep-activity-event-time" ng-if="::activityEvent.timestamp || activityEvent.source">·</span>
-        <a class="kf-keep-activity-event-page-link kf-link" ng-if="::showKeepPageLink && activityEvent.timestamp" ng-href="{{::keep.path}}">
+        <a class="kf-keep-activity-event-page-link" ng-if="::showKeepPageLink && activityEvent.timestamp" ng-href="{{::keep.path}}">
           <time class="kf-keep-activity-event-time"
                 ng-attr-datetime="{{::activityEvent.timestamp}}" am-time-ago="::activityEvent.timestamp"
                 title="{{::activityEvent.timestamp|localTime}}" ng-href="{{::keep.path}}"></time>
@@ -19,7 +19,13 @@
               title="{{::activityEvent.timestamp|localTime}}" ng-if="::activityEvent.timestamp && !showKeepPageLink"></time>
         <!--Add a space between the time and source-->
         <span></span>
-        <span class="kf-keep-activity-event-time" ng-if="::activityEvent.source.kind" ng-bind-template=" via {{::activityEvent.source.kind}}"></span>
+        <a class="kf-keep-activity-event-time"
+           ng-class="{
+            'kf-keep-activity-event-page-link': keep.activity.latestEvent.source.url
+           }"
+           ng-if="::activityEvent.source.kind"
+           ng-href="{{::activityEvent.source.url}}"
+           ng-bind-template=" via {{::activityEvent.source.kind}}"></a>
       </div>
       <span class="kf-keep-activity-event-actions" kf-click-menu ng-if="eventActionItems.length > 0">
         <menu class="kf-dropdown-menu kf-keep-activity-event-actions-menu">

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCardActivityAttribution.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCardActivityAttribution.styl
@@ -26,3 +26,15 @@
   width: 100%
   margin-bottom: 2px
   margin-top: 6px
+
+.kf-keep-card-activity-attribution-time
+  color: #ABABAB
+  font-size: 12px
+
+.kf-keep-card-activity-attribution-page-link
+  display: inline
+  color: #ABABAB
+
+  &:hover
+    text-decoration: none
+    opacity: .7

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCardActivityAttribution.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCardActivityAttribution.tpl.html
@@ -1,5 +1,29 @@
 <div class="kf-keep-card-activity-attribution">
-  <div class="kf-keep-card-activity-attribution-wrapper" ng-if="lastComment">
+  <div class="kf-keep-card-activity-attribution-wrapper"
+       ng-if="keep.activity.latestEvent">
+    <a class="kf-keep-card-attribution-keeper-pic"
+      ng-href="{{::keep.activity.latestEvent.author.url|pathFromUrl}}"
+      ng-style="{ 'background-image' : 'url(' + (keep.activity.latestEvent.author.picture) + ')' }"></a>
+    <div class="kf-keep-card-activity-attribution-message">
+      <span kf-structured-text segments="keep.activity.latestEvent.header"></span>
+      <span ng-if="::keep.activity.latestEvent.timestamp" class="kf-keep-card-activity-attribution-time">·
+        <a class="kf-keep-card-activity-attribution-page-link" ng-if="showKeepPageLink" ng-href="{{::keep.path}}">
+          <time ng-attr-datetime="{{::keep.activity.latestEvent.timestamp}}" am-time-ago="::keep.activity.latestEvent.timestamp"
+            title="{{::keep.activity.latestEvent.timestamp|localTime}}"></time>
+        </a>
+        <span ng-if="!showKeepPageLink"><time ng-attr-datetime="{{::keep.activity.latestEvent.timestamp}}" am-time-ago="::keep.activity.latestEvent.timestamp"
+            title="{{::keep.activity.latestEvent.timestamp|localTime}}"></time></span>
+        <a ng-class="{
+            'kf-keep-card-activity-attribution-page-link': keep.activity.latestEvent.source.url
+           }"
+           ng-if="::keep.activity.latestEvent.source.kind"
+           ng-href="{{::keep.activity.latestEvent.source.url}}"
+           ng-bind-template=" via {{::keep.activity.latestEvent.source.kind}}"></a>
+      </span>
+    </div>
+  </div>
+  <div class="kf-keep-card-activity-attribution-wrapper"
+       ng-if="!keep.activity.latestEvent && lastComment">
     <a class="kf-keep-card-attribution-keeper-pic"
       ng-href="{{::lastComment.sentBy|profileUrl}}"
       ng-style="{ 'background-image' : 'url(' + (lastComment.sentBy|pic:100) + ')' }"></a>
@@ -26,5 +50,5 @@
        is-first-item="::isFirstItem"
        title-only="false"
        short-message="true"
-       ng-if="!lastComment"></div>
+       ng-if="!keep.activity.latestEvent && !lastComment"></div>
 </div>


### PR DESCRIPTION
For those in the activity_log experiment, the activity at the top of keep cards will be pulled from `keep.activity.latestEvent` instead of computing it on the client.
