### PR TITLE
ensure commenting on mobile adds a keep to user

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationDeliveryCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationDeliveryCommander.scala
@@ -99,24 +99,6 @@ class NotificationDeliveryCommander @Inject() (
         "unread" -> true,
         "category" -> NotificationCategory.User.MESSAGE.category
       )
-      db.readWrite { implicit session =>
-        newParticipants.map { pUserId =>
-          userThreadRepo.intern(UserThread.forMessageThread(thread)(user = pUserId))
-        }
-
-        newNonUserParticipants.foreach { nup =>
-          nonUserThreadRepo.save(NonUserThread(
-            createdBy = adderUserId,
-            participant = nup,
-            keepId = thread.keepId,
-            uriId = Some(thread.uriId),
-            notifiedCount = 0,
-            lastNotifiedAt = None,
-            threadUpdatedByOtherAt = Some(message.createdAt),
-            muted = false
-          ))
-        }
-      }
 
       Future.sequence(newParticipants.map { userId =>
         recreateNotificationForAddedParticipant(userId, thread)


### PR DESCRIPTION
@ryanpbrewster @leogrim mobile is using old eliza messaging endpoints that don't update KTUs (yet)

cc: @DerekBurch, but since we will all be moving over to new endpoints soon anyways I don't think this requires any immediate action for clients.
