### PR TITLE
Fix unread count > 0 with no displayable notifs

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationDeliveryCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationDeliveryCommander.scala
@@ -318,8 +318,7 @@ class NotificationDeliveryCommander @Inject() (
   }
 
   def getLatestUnreadSendableNotifications(userId: Id[User], howMany: Int, includeUriSummary: Boolean): Future[(Seq[NotificationJson], Int)] = {
-    val noticesFuture = getNotificationsByUser(userId, UserThreadQuery(onlyUnread = Some(true), limit = howMany), includeUriSummary)
-    new SafeFuture(noticesFuture map { notices =>
+    getNotificationsByUser(userId, UserThreadQuery(onlyUnread = Some(true), limit = howMany), includeUriSummary).map { notices =>
       val numTotal = if (notices.length < howMany) {
         notices.length
       } else {
@@ -328,7 +327,7 @@ class NotificationDeliveryCommander @Inject() (
         }
       }
       (notices, numTotal)
-    })
+    }
   }
 
   def getUnreadSendableNotificationsBefore(userId: Id[User], time: DateTime, howMany: Int, includeUriSummary: Boolean): Future[Seq[NotificationJson]] = {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThread.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/UserThread.scala
@@ -33,6 +33,7 @@ case class UserThread(
   startedBy: Id[User], // denormalized from MessageThread
   accessToken: ThreadAccessToken = ThreadAccessToken())
     extends Model[UserThread] with ModelWithState[UserThread] with ParticipantThread {
+  def isActive = state == UserThreadStates.ACTIVE
 
   def withId(id: Id[UserThread]): UserThread = this.copy(id = Some(id))
   def withUpdateTime(updateTime: DateTime) = this.copy(updatedAt = updateTime)
@@ -51,7 +52,7 @@ object UserThread {
     keepId = mt.keepId,
     uriId = Some(mt.uriId),
     lastSeen = None,
-    unread = true,
+    unread = user != mt.startedBy,
     latestMessageId = None,
     startedBy = mt.startedBy
   )

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/MessagingControllerTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/MessagingControllerTest.scala
@@ -17,7 +17,7 @@ import com.keepit.eliza.FakeElizaServiceClientModule
 import com.keepit.eliza.controllers.internal.MessagingController
 import com.keepit.eliza.model._
 import com.keepit.heimdal.FakeHeimdalServiceClientModule
-import com.keepit.model.{ MessageThreadFactory, NormalizedURI, User }
+import com.keepit.model.{ UserThreadFactory, MessageThreadFactory, NormalizedURI, User }
 import com.keepit.realtime.{ FakeAppBoyModule }
 import com.keepit.rover.FakeRoverServiceClientModule
 import com.keepit.search.FakeSearchServiceClientModule
@@ -105,11 +105,11 @@ class MessagingControllerTest extends TestKitSupport with SpecificationLike with
         val sender1 = Id[User](43)
         val sender2 = Id[User](44)
 
-        val threadList = db.readWrite { implicit rw =>
-          Seq("Reddit", "HackerNews").zipWithIndex.map {
+        db.readWrite { implicit rw =>
+          Seq("HackerNews", "Reddit").zipWithIndex.map {
             case (title, idx) =>
-              val thread = createMessageThread(title, sender1)
-              val userThread = createUserThread(thread, userId)
+              val thread = MessageThreadFactory.thread().withTitle(title).withOnlyStarter(sender1).saved
+              val userThread = UserThreadFactory.userThread().withThread(thread).forUserId(userId).unread().saved
               val messages = Seq(
                 createMessage(thread, sender1, s"check out $title"),
                 createMessage(thread, sender2, s"look here $title")

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/model/UserThreadRepoTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/model/UserThreadRepoTest.scala
@@ -62,7 +62,8 @@ class UserThreadRepoTest extends Specification with ElizaTestInjector {
           userThreadRepo.getUserStats(user1) === UserThreadStats(0, 0, 0)
           userThreadRepo.getUserStats(user2) === UserThreadStats(0, 0, 0)
           val thread1 = MessageThreadFactory.thread().saved
-          userThreadRepo.save(UserThread.forMessageThread(thread1)(user1))
+          val ut1 = userThreadRepo.save(UserThread.forMessageThread(thread1)(user1))
+          userThreadRepo.markUnread(user1, thread1.keepId)
           userThreadRepo.count === 1
           val toMail = userThreadRepo.getUserThreadsForEmailing(clock.now().plusMinutes(16))
           toMail.size === 1
@@ -85,7 +86,7 @@ class UserThreadRepoTest extends Specification with ElizaTestInjector {
         }
         db.readWrite { implicit s =>
           val thread1 = MessageThreadFactory.thread().withOnlyStarter(user1).saved
-          userThreadRepo.save(UserThread.forMessageThread(thread1)(user1).copy(lastActive = Some(inject[Clock].now)))
+          userThreadRepo.save(UserThread.forMessageThread(thread1)(user1).copy(lastActive = Some(inject[Clock].now), unread = true))
         }
         db.readOnlyMaster { implicit s =>
           userThreadRepo.getUserStats(user1) === UserThreadStats(3, 2, 1)

--- a/kifi-backend/modules/eliza/test/com/keepit/model/UserThreadFactory.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/model/UserThreadFactory.scala
@@ -15,7 +15,7 @@ object UserThreadFactory {
       keepId = Id[Keep](idx.incrementAndGet()),
       uriId = Some(Id[NormalizedURI](idx.incrementAndGet())),
       lastSeen = None,
-      unread = true,
+      unread = false,
       latestMessageId = None,
       startedBy = Id[User](idx.incrementAndGet())
     ))
@@ -25,6 +25,8 @@ object UserThreadFactory {
   case class PartialUserThread(ut: UserThread) {
     def withThread(thread: MessageThread) = this.copy(ut = ut.copy(keepId = thread.keepId, startedBy = thread.startedBy))
     def forUser(user: User) = this.copy(ut = ut.copy(user = user.id.get))
+    def forUserId(userId: Id[User]) = this.copy(ut = ut.copy(user = userId))
+    def unread() = this.copy(ut = ut.copy(unread = true))
     def saved(implicit injector: Injector, session: RWSession): UserThread = {
       injector.getInstance(classOf[UserThreadRepo]).save(ut)
     }


### PR DESCRIPTION
This issue happened when a user thread was marked as unread, but the
message thread had no messages (and was thus ignored for display purposes).

The fix is just to have user threads with unread=false for the creator of the
message thread, by default. They are set to unread=true when a message is sent

@andrewconner 
