### PR TITLE
deactivate keep source attribution with keeps

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/KeepSourceAttribution.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepSourceAttribution.scala
@@ -24,6 +24,7 @@ case class KeepSourceAttribution(
 
   def withId(id: Id[KeepSourceAttribution]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)
+  def withState(state: State[KeepSourceAttribution]) = this.copy(state = state)
 }
 
 case class UnknownAttributionTypeException(name: String) extends Exception(s"Unknown keep attribution type: $name")

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -145,6 +145,7 @@ class KeepCommanderImpl @Inject() (
     ktuCommander: KeepToUserCommander,
     kteCommander: KeepToEmailCommander,
     keepSourceCommander: KeepSourceCommander,
+    keepSourceRepo: KeepSourceAttributionRepo,
     collectionRepo: CollectionRepo,
     libraryAnalytics: LibraryAnalytics,
     heimdalClient: HeimdalServiceClient,
@@ -828,6 +829,7 @@ class KeepCommanderImpl @Inject() (
     ktlCommander.removeKeepFromAllLibraries(keep.id.get)
     ktuCommander.removeKeepFromAllUsers(keep)
     kteCommander.removeKeepFromAllEmails(keep)
+    keepSourceRepo.deactivateByKeepId(keep.id.get)
     collectionCommander.deactivateKeepTags(keep)
     keepRepo.deactivate(keep)
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepSourceCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepSourceCommander.scala
@@ -4,7 +4,7 @@ import com.google.inject.{ Inject, Singleton, ImplementedBy }
 import com.keepit.commanders.gen.BasicLibraryGen
 import com.keepit.common.concurrent.FutureHelpers
 import com.keepit.common.db.Id
-import com.keepit.common.db.slick.DBSession.RSession
+import com.keepit.common.db.slick.DBSession.{ RWSession, RSession }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.logging.Logging
 import com.keepit.common.social.BasicUserRepo


### PR DESCRIPTION
@ryanpbrewster 

as @leogrim suggested, I think returning an inactive `BasicUser` to clients is fine. Building ways to more gracefully do that (maybe a dedicated 410 status page) seems better than swallowing data/events as we do sometimes.
