### PR TITLE
combine AddParticipants and AddLibraries => AddRecipients

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClient.scala
@@ -138,7 +138,7 @@ trait ElizaServiceClient extends ServiceClient {
   def getElizaKeepStream(userId: Id[User], limit: Int, beforeId: Option[Id[Keep]], filter: ElizaFeedFilter): Future[Map[Id[Keep], DateTime]]
   def editMessage(msgId: Id[Message], newText: String): Future[Message]
   def deleteMessage(msgId: Id[Message]): Future[Unit]
-  def saveKeepEvent(keepId: Id[Keep], userId: Id[User], event: KeepEventData, source: Option[KeepEventSourceKind]): Future[Unit]
+  def saveKeepEvent(keepId: Id[Keep], userId: Id[User], event: KeepEventData.EditTitle, source: Option[KeepEventSourceKind]): Future[Unit]
 
   def keepHasThreadWithAccessToken(keepId: Id[Keep], accessToken: String): Future[Boolean]
   def editParticipantsOnKeep(keepId: Id[Keep], editor: Id[User], newUsers: Set[Id[User]], newLibraries: Set[Id[Library]], source: Option[KeepEventSourceKind]): Future[Set[Id[User]]]
@@ -424,7 +424,7 @@ class ElizaServiceClientImpl @Inject() (
     }
   }
 
-  def saveKeepEvent(keepId: Id[Keep], userId: Id[User], event: KeepEventData, source: Option[KeepEventSourceKind]): Future[Unit] = {
+  def saveKeepEvent(keepId: Id[Keep], userId: Id[User], event: KeepEventData.EditTitle, source: Option[KeepEventSourceKind]): Future[Unit] = {
     import com.keepit.eliza.ElizaServiceClient.SaveKeepEvent._
     val request = Request(keepId, userId, event)
     call(Eliza.internal.saveKeepEvent, body = Json.toJson(request)).map(_ => ())
@@ -526,7 +526,7 @@ object ElizaServiceClient {
   }
 
   object SaveKeepEvent {
-    case class Request(keepId: Id[Keep], userId: Id[User], event: KeepEventData)
+    case class Request(keepId: Id[Keep], userId: Id[User], event: KeepEventData.EditTitle)
     implicit val requestFormat: Format[Request] = Json.format[Request]
   }
 }

--- a/kifi-backend/modules/common/test/com/keepit/eliza/FakeElizaServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/eliza/FakeElizaServiceClientImpl.scala
@@ -10,12 +10,11 @@ import com.keepit.common.zookeeper.ServiceCluster
 import com.keepit.common.time._
 import com.keepit.discussion.{CrossServiceKeepActivity, MessageSource, CrossServiceMessage, Discussion, Message}
 import com.keepit.eliza.model._
-import com.keepit.model.KeepEventData.{AddLibraries, AddParticipants}
+import com.keepit.model.KeepEventData.AddRecipients
 import com.keepit.model._
 import com.keepit.notify.model.event.NotificationEvent
 import com.keepit.notify.model.{GroupingNotificationKind, Recipient}
 import com.keepit.search.index.message.ThreadContent
-import com.keepit.social.BasicNonUser
 import org.joda.time.DateTime
 import play.api.libs.json.{JsArray, JsObject}
 
@@ -111,11 +110,9 @@ class FakeElizaServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, schedul
   )
 
   def editParticipantsOnKeep(keepId: Id[Keep], editor: Id[User], newUsers: Set[Id[User]], newLibraries: Set[Id[Library]], source: Option[KeepEventSourceKind]): Future[Set[Id[User]]] = {
-    val events: Stream[KeepEventData] = Stream(AddParticipants(editor, newUsers.toSeq, Seq.empty) -> newUsers.nonEmpty, AddLibraries(editor, newLibraries) -> newLibraries.nonEmpty).collect {
-      case (event, true) => event
-    }
-    val msgs = events.map(crossServiceMessageFromEvent(keepId, _, source))
-    keepEvents += (keepId -> (keepEvents(keepId) ++ msgs))
+    val event = AddRecipients(editor, KeepRecipients(newLibraries, emails = Set.empty, newUsers))
+    val msg = crossServiceMessageFromEvent(keepId, event, source)
+    keepEvents += (keepId -> (keepEvents(keepId) :+ msg))
     Future.successful(Set.empty)
   }
   def getCrossServiceKeepActivity(keepIds: Set[Id[Keep]], eventsBefore: Option[DateTime], maxEventsPerKeep: Int): Future[Map[Id[Keep], CrossServiceKeepActivity]] = {
@@ -125,7 +122,7 @@ class FakeElizaServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, schedul
     }.toMap
     Future.successful(activityByKeepId)
   }
-  def saveKeepEvent(keepId: Id[Keep], userId: Id[User], event: KeepEventData, source: Option[KeepEventSourceKind]): Future[Unit] = {
+  def saveKeepEvent(keepId: Id[Keep], userId: Id[User], event: KeepEventData.EditTitle, source: Option[KeepEventSourceKind]): Future[Unit] = {
     keepEvents += (keepId -> (keepEvents(keepId) :+ crossServiceMessageFromEvent(keepId, event, source)))
     Future.successful(())
   }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
@@ -26,7 +26,7 @@ trait ElizaDiscussionCommander {
   def getDiscussionForKeep(keepId: Id[Keep], maxMessagesShown: Int): Future[Discussion]
   def getDiscussionsForKeeps(keepIds: Set[Id[Keep]], maxMessagesShown: Int): Future[Map[Id[Keep], Discussion]]
   def getCrossServiceKeepActivity(keepIds: Set[Id[Keep]], eventsBefore: Option[DateTime], maxEventsPerKeep: Int): Future[Map[Id[Keep], CrossServiceKeepActivity]]
-  def saveKeepEvent(keepId: Id[Keep], userId: Id[User], event: KeepEventData): Future[Unit]
+  def saveKeepEvent(keepId: Id[Keep], userId: Id[User], event: KeepEventData.EditTitle): Future[Unit]
   def getEmailParticipantsForKeeps(keepIds: Set[Id[Keep]]): Map[Id[Keep], Map[EmailAddress, (Id[User], DateTime)]]
   def sendMessage(userId: Id[User], txt: String, keepId: Id[Keep], source: Option[MessageSource] = None)(implicit context: HeimdalContext): Future[Message]
   def addParticipantsToThread(adderUserId: Id[User], keepId: Id[Keep], newParticipantsExtIds: Seq[Id[User]], emailContacts: Seq[BasicContact], orgs: Seq[Id[Organization]], source: Option[KeepEventSourceKind])(implicit context: HeimdalContext): Future[Boolean]
@@ -147,7 +147,7 @@ class ElizaDiscussionCommanderImpl @Inject() (
     }
   }
 
-  def saveKeepEvent(keepId: Id[Keep], userId: Id[User], event: KeepEventData): Future[Unit] = {
+  def saveKeepEvent(keepId: Id[Keep], userId: Id[User], event: KeepEventData.EditTitle): Future[Unit] = {
     getOrCreateMessageThreadWithUser(keepId, userId).map { thread =>
       db.readWrite { implicit s =>
         messageRepo.save(ElizaMessage(

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
@@ -114,11 +114,9 @@ object SystemMessageData {
     case _ => None
   }
 
-  def fromKeepEvent(event: KeepEventData): Option[SystemMessageData] = event match {
-    case KeepEventData.AddParticipants(addedBy, addedUsers, addedNonUsers) => Some(AddParticipants(addedBy, addedUsers, addedNonUsers.map(NonUserParticipant.fromBasicNonUser)))
-    case KeepEventData.AddLibraries(addedBy, addedLibs) => Some(AddLibraries(addedBy, addedLibs))
-    case KeepEventData.EditTitle(addedBy, original, updated) => Some(EditTitle(addedBy, original, updated))
-    case _ => None
+  def fromKeepEvent(event: KeepEventData.EditTitle): Option[SystemMessageData] = {
+    val KeepEventData.EditTitle(editedBy, original, updated) = event
+    Some(EditTitle(editedBy, original, updated))
   }
 
   def isFullySupported(data: SystemMessageData): Boolean = data match {

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepEventCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepEventCommander.scala
@@ -5,6 +5,7 @@ import com.keepit.common.db.Id
 import com.keepit.common.db.slick.DBSession.RWSession
 import com.keepit.common.db.slick.Database
 import com.keepit.eliza.ElizaServiceClient
+import com.keepit.model.KeepEventData.EditTitle
 import com.keepit.model.{ KeepRecipients, KeepEventData, KeepEvent, KeepEventRepo, KeepEventSourceKind, User, Keep }
 import com.keepit.common.time._
 
@@ -23,7 +24,7 @@ class KeepEventCommanderImpl @Inject() (
     db: Database,
     implicit val ec: ExecutionContext) extends KeepEventCommander {
   def updatedKeepTitle(keepId: Id[Keep], userId: Id[User], oldTitle: Option[String], newTitle: Option[String], source: Option[KeepEventSourceKind])(implicit session: RWSession): Unit = {
-    val eventData = KeepEventData.EditTitle(userId, oldTitle, newTitle)
+    val eventData: EditTitle = KeepEventData.EditTitle(userId, oldTitle, newTitle)
     val event = KeepEvent(keepId = keepId, eventData = eventData, eventTime = currentDateTime, source = source)
     eventRepo.save(event)
     session.onTransactionSuccess(eliza.saveKeepEvent(keepId, userId, eventData, source))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/gen/KeepActivityGen.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/gen/KeepActivityGen.scala
@@ -6,8 +6,8 @@ import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.store.S3ImageConfig
 import com.keepit.common.util.{ Ord, DescriptionElements, DescriptionElement }
 import com.keepit.discussion.{ Message, CrossServiceKeepActivity }
-import com.keepit.model.{KeepRecipients, KeepEventSourceKind, BasicKeepEvent, KeepEventSource, KeepEventKind, KeepActivity, TwitterAttribution, SlackAttribution, BasicOrganization, BasicLibrary, Library, User, KeepToUser, KeepToLibrary, SourceAttribution, Keep}
-import com.keepit.model.KeepEventData.{AddRecipients, EditTitle, AddLibraries, AddParticipants}
+import com.keepit.model.{ KeepRecipients, KeepEventSourceKind, BasicKeepEvent, KeepEventSource, KeepEventKind, KeepActivity, TwitterAttribution, SlackAttribution, BasicOrganization, BasicLibrary, Library, User, KeepToUser, KeepToLibrary, SourceAttribution, Keep }
+import com.keepit.model.KeepEventData.{ AddRecipients, EditTitle, AddLibraries, AddParticipants }
 import com.keepit.social.{ BasicUser, BasicAuthor }
 
 object KeepActivityGen {

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtKeepController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtKeepController.scala
@@ -61,6 +61,7 @@ class ExtKeepController @Inject() (
   }
 
   def modifyConnectionsForKeep(pubId: PublicId[Keep]) = UserAction.async(parse.tolerantJson) { implicit request =>
+    import com.keepit.common.http._
     (for {
       keepId <- Keep.decodePublicId(pubId).map(Future.successful).getOrElse(Future.failed(DiscussionFail.INVALID_KEEP_ID))
       input <- request.body.validate[ExternalKeepRecipientsDiff].map(Future.successful).getOrElse(Future.failed(DiscussionFail.COULD_NOT_PARSE))
@@ -69,7 +70,7 @@ class ExtKeepController @Inject() (
         val libraryIdMap = input.libraries.all.map(libPubId => libPubId -> Library.decodePublicId(libPubId).get).toMap
         KeepRecipientsDiff(users = input.users.map(userIdMap(_)), libraries = input.libraries.map(libraryIdMap(_)), emails = input.emails)
       }
-      _ <- discussionCommander.modifyConnectionsForKeep(request.userId, keepId, diff, input.source)
+      _ <- discussionCommander.modifyConnectionsForKeep(request.userId, keepId, diff, input.source.orElse(request.userAgentOpt.flatMap(KeepEventSourceKind.fromUserAgent)))
     } yield {
       NoContent
     }).recover {


### PR DESCRIPTION
@ryanpbrewster @leogrim 

looking to kill `AddParticipants` and `AddLibraries` from the `message` table today after backfilling `keep_event` with `AddRecipients`.
