### PR TITLE
Keep activity log fixes

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/activityEvent/activityEventSegments.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/activityEvent/activityEventSegments.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .directive('kfActivityEventSegments', [
-  'RecursionHelper',
-  function (RecursionHelper) {
+  'extensionLiaison', 'RecursionHelper',
+  function (extensionLiaison, RecursionHelper) {
     return {
       restrict: 'A',
       replace: true,
@@ -13,7 +13,13 @@ angular.module('kifi')
         segments: '=kfActivityEventSegments'
       },
       compile: function (element) {
-        return RecursionHelper.compile(element);
+        function link($scope) {
+          $scope.openLookHere = function(event, segment) {
+            event.preventDefault();
+            extensionLiaison.openDeepLink(segment.url, segment.locator);
+          };
+        }
+        return RecursionHelper.compile(element, link);
       }
     };
   }

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/keepActivity.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/keepActivity.js
@@ -7,7 +7,12 @@ angular.module('kifi')
     function ($filter, $window, $timeout, $rootScope, $stateParams, profileService, keepService, signupService) {
       var MARK_READ_TIMEOUT = 3000;
 
-      function bySentAt(a, b) {
+      function eventComparator(a, b) {
+        if (a.kind === 'initial') {
+          return -1;
+        } else if (b.kind === 'initial') {
+          return 1;
+        }
         return a.timestamp - b.timestamp;
       }
 
@@ -51,7 +56,7 @@ angular.module('kifi')
             };
           }
 
-          $scope.activity = $scope.keep.activity.events.slice().sort(bySentAt); // don't mutate the original array, in case we need it later
+          $scope.activity = $scope.keep.activity.events.slice().sort(eventComparator); // don't mutate the original array, in case we need it later
 
           $scope.visibleCount = Math.min($scope.maxInitialComments || 3, $scope.activity.length);
           $scope.hasMoreToFetch = $scope.activity[0].kind !== 'initial';
@@ -182,7 +187,7 @@ angular.module('kifi')
                 fetchMessages(batchOldest.timestamp);
               }
 
-              var updatedActivity = _.uniq($scope.activity.concat(o.activity.events), 'id').sort(bySentAt);
+              var updatedActivity = _.uniq($scope.activity.concat(o.activity.events), 'id').sort(eventComparator);
               if (o.activity.events.length === 0 || o.activity.events[o.activity.events.length - 1].kind === 'initial') {
                 $scope.hasMoreToFetch = false; // We're at the beginning, can't possible paginate more.
               } else if (updatedActivity.length > $scope.visibleCount) {

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/structuredText/structuredTextSegment.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/structuredText/structuredTextSegment.js
@@ -3,8 +3,8 @@
 angular.module('kifi')
 
 .directive('kfStructuredTextSegment', [
-  'extensionLiaison', 'RecursionHelper',
-  function (extensionLiaison, RecursionHelper) {
+  'RecursionHelper',
+  function (RecursionHelper) {
     return {
       restrict: 'A',
       replace: true,
@@ -25,12 +25,6 @@ angular.module('kifi')
           $scope.isSegmentHover = function (segment) {
             return !!segment.hover && segment.hover.length > 0;
           };
-
-          $scope.openLookHere = function(event, segment) {
-            event.preventDefault();
-            extensionLiaison.openDeepLink(segment.url, segment.locator);
-          };
-
         }
 
         return RecursionHelper.compile(element, link);

--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
@@ -285,7 +285,7 @@ angular.module('kifi')
           scope.$watch('keep.title', updateTitle);
           scope.defaultDescLines = 4;
           scope.me = profileService.me;
-          scope.showActivityEvents = profileService.hasExperiment('activity_log');
+          scope.showActivityEvents = keep.activity && profileService.hasExperiment('activity_log');
           scope.showOriginLibrary = scope.currentPageOrigin !== 'libraryPage' &&
             keep.library && keep.library.visibility !== 'discoverable' && keep.library.kind === 'system_secret';
           // Don't change until the link is updated to be a bit more secure:


### PR DESCRIPTION
- Makes sure the initial event is always the first item in the array
- Falls back to comments when no activity is provided (in search for example)
