### PR TITLE
don't duplicate events across eliza.message and shoebox.keep_event

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepEventCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepEventCommander.scala
@@ -26,8 +26,8 @@ class KeepEventCommanderImpl @Inject() (
     implicit val ec: ExecutionContext) extends KeepEventCommander {
   def updatedKeepTitle(keepId: Id[Keep], userId: Id[User], oldTitle: Option[String], newTitle: Option[String], source: Option[KeepEventSourceKind], eventTime: Option[DateTime])(implicit session: RWSession): Unit = {
     val eventData: EditTitle = KeepEventData.EditTitle(userId, oldTitle, newTitle)
-    val event = KeepEvent(keepId = keepId, eventData = eventData, eventTime = eventTime.getOrElse(currentDateTime), source = source)
-    eventRepo.save(event)
+    //val event = KeepEvent(keepId = keepId, eventData = eventData, eventTime = eventTime.getOrElse(currentDateTime), source = source)
+    //eventRepo.save(event) //todo(cam): add back in once eliza is migrated over
     session.onTransactionSuccess(eliza.saveKeepEvent(keepId, userId, eventData, source))
   }
 


### PR DESCRIPTION
@leogrim @ryanpbrewster populating these rows on both tables bit me in the ass, now I need to inactivate the edit title events in  `keep_event` and go with whatever's on `eliza` so that the migration doesn't duplicate events.
