### PR TITLE
improve keep source determination re: message keeps

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaDiscussionController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaDiscussionController.scala
@@ -171,7 +171,7 @@ class ElizaDiscussionController @Inject() (
       val threads = threadRepo.getByKeepIds(keepIds, excludeState = None)
       val recipientsByKeepId = threads.map {
         case (keepId, thread) =>
-          def addedNearStart(time: DateTime) = time.minusSeconds(1).getMillis < thread.createdAt.getMillis
+          def addedNearStart(time: DateTime) = time.minusSeconds(1).getMillis <= thread.createdAt.getMillis
           val firstUsers = thread.participants.userParticipants.collect { case (uid, added) if uid != thread.startedBy && addedNearStart(added) => uid }
           val firstNonUsers = thread.participants.nonUserParticipants.collect { case (NonUserEmailParticipant(email), added) if addedNearStart(added) => email }
           keepId -> KeepRecipients(libraries = Set.empty, firstNonUsers.toSet, firstUsers.toSet)

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
@@ -336,7 +336,7 @@ class AdminBookmarksController @Inject() (
     val chunkSize = 100
     val keepsToBackfill = db.readOnlyMaster(implicit s => keepRepo.pageAscendingWithUserExcludingSources(fromId, limit, excludeStates = Set.empty, excludeSources = Set(KeepSource.slack, KeepSource.twitterFileImport, KeepSource.twitterSync)))
     val enum = ChunkedResponseHelper.chunkedFuture(keepsToBackfill.grouped(chunkSize).toSeq) { keeps =>
-      val (discussionKeeps, otherKeeps) = keeps.partition(_.source == KeepSource.discussion)
+      val (discussionKeeps, otherKeeps) = keeps.partition(keep => keep.source == KeepSource.discussion || keep.recipients.libraries.isEmpty)
       val discussionConnectionsFut = eliza.getInitialRecipientsByKeepId(discussionKeeps.map(_.id.get).toSet).map { connectionsByKeep =>
         discussionKeeps.flatMap { keep =>
           connectionsByKeep.get(keep.id.get).map { connections =>


### PR DESCRIPTION
@ryanpbrewster @leogrim looks like `KeepSource.discussion` is not necessary for a keep to be created via discussion. this is a better way to know for sure.
