### PR TITLE
Introduce KeepQueryCommander

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
@@ -97,6 +97,7 @@ object UserValueName {
   val PENDING_ORG_DOMAIN_OWNERSHIP_BY_EMAIL = UserValueName("pending_org_domain_ownership_by_email")
 
   val DEFAULT_LIBRARY_ARRANGEMENT = UserValueName("default_library_arrangement")
+  val DEFAULT_KEEP_ARRANGEMENT = UserValueName("default_keep_arrangement")
   val HORRIFYING_LOGGING_METHOD = UserValueName("horrifying_logging_method")
   val LAST_RECORDED_LOCATION = UserValueName("last_recorded_location")
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepQueryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepQueryCommander.scala
@@ -1,0 +1,94 @@
+package com.keepit.commanders
+
+import com.google.inject.{ ImplementedBy, Inject, Singleton }
+import com.keepit.common.core.tryExtensionOps
+import com.keepit.common.crypto.PublicIdConfiguration
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.DBSession.RSession
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.json.EnumFormat
+import com.keepit.common.reflection.Enumerator
+import com.keepit.model._
+import play.api.libs.json.{ Format, Json }
+import play.api.mvc.QueryStringBindable
+
+import scala.util.Try
+
+case class KeepQuery(
+    target: KeepQuery.Target,
+    arrangement: Option[KeepQuery.Arrangement] = None,
+    fromId: Option[Id[Keep]],
+    offset: Offset,
+    limit: Limit) {
+  def withArrangement(newArrangement: KeepQuery.Arrangement) = this.copy(arrangement = Some(newArrangement))
+}
+
+object KeepQuery {
+  sealed abstract class Target
+  case class ForLibrary(libId: Id[Library]) extends Target
+
+  case class Arrangement(ordering: KeepOrdering, direction: SortDirection)
+  object Arrangement {
+    implicit val format: Format[Arrangement] = Json.format[Arrangement]
+    val GLOBAL_DEFAULT = Arrangement(KeepOrdering.LAST_ACTIVITY_AT, SortDirection.DESCENDING)
+  }
+}
+
+sealed abstract class KeepOrdering(val value: String)
+
+object KeepOrdering extends Enumerator[KeepOrdering] {
+  case object LAST_ACTIVITY_AT extends KeepOrdering("last_activity_at")
+  case object KEPT_AT extends KeepOrdering("kept_at")
+
+  val all = _all
+  def fromStr(str: String): Option[KeepOrdering] = all.find(_.value == str)
+  def apply(str: String): KeepOrdering = fromStr(str).get
+
+  implicit val format: Format[KeepOrdering] = EnumFormat.format(fromStr, _.value)
+
+  implicit def queryStringBinder(implicit stringBinder: QueryStringBindable[String]) = new QueryStringBindable[KeepOrdering] {
+    override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, KeepOrdering]] = {
+      stringBinder.bind(key, params).map {
+        case Left(_) => Left("Could not bind a KeepOrdering")
+        case Right(str) => fromStr(str).map(ord => Right(ord)).getOrElse(Left("Could not bind a KeepOrdering"))
+      }
+    }
+    override def unbind(key: String, ordering: KeepOrdering): String = {
+      stringBinder.unbind(key, ordering.value)
+    }
+  }
+}
+
+@ImplementedBy(classOf[KeepQueryCommanderImpl])
+trait KeepQueryCommander {
+  def setPreferredArrangement(userId: Id[User], arrangement: KeepQuery.Arrangement): Unit
+  def getKeeps(requester: Option[Id[User]], query: KeepQuery)(implicit session: RSession): Seq[Id[Keep]]
+}
+
+@Singleton
+class KeepQueryCommanderImpl @Inject() (
+  db: Database,
+  userValueRepo: UserValueRepo,
+  keepRepo: KeepRepo,
+  implicit val publicIdConfig: PublicIdConfiguration,
+  implicit val airbrake: AirbrakeNotifier)
+    extends KeepQueryCommander {
+
+  def setPreferredArrangement(userId: Id[User], arrangement: KeepQuery.Arrangement): Unit = db.readWrite { implicit s =>
+    userValueRepo.setValue(userId, UserValueName.DEFAULT_KEEP_ARRANGEMENT, Json.stringify(Json.toJson(arrangement)))
+  }
+
+  def getKeeps(requester: Option[Id[User]], query: KeepQuery)(implicit session: RSession): Seq[Id[Keep]] = {
+    val preferredArrangement = query.arrangement.orElse {
+      for {
+        userId <- requester
+        preferredArrangementStr <- userValueRepo.getUserValue(userId, UserValueName.DEFAULT_KEEP_ARRANGEMENT).map(_.value)
+        preferredArrangementJson <- Try(Json.parse(preferredArrangementStr)).airbrakingOption
+        preferredArrangement <- Try(preferredArrangementJson.as[KeepQuery.Arrangement]).airbrakingOption
+      } yield preferredArrangement
+    }
+    val customizedQuery = preferredArrangement.fold(query)(query.withArrangement)
+    keepRepo.getKeepIdsForQuery(customizedQuery)
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/client/LibraryKeepsInfoController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/client/LibraryKeepsInfoController.scala
@@ -1,0 +1,59 @@
+package com.keepit.controllers.client
+
+import com.google.inject.Inject
+import com.keepit.commanders.{ KeepQuery, KeepQueryCommander, PermissionCommander }
+import com.keepit.common.controller.{ ShoeboxServiceController, UserActions, UserActionsHelper }
+import com.keepit.common.core.tryExtensionOps
+import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
+import com.keepit.common.db.Id
+import com.keepit.common.db.slick.Database
+import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.time._
+import com.keepit.common.util.RightBias
+import com.keepit.common.util.RightBias.FromOption
+import com.keepit.model._
+import com.keepit.shoebox.data.assemblers.KeepInfoAssembler
+import play.api.libs.json.Json
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+class LibraryKeepsInfoController @Inject() (
+  db: Database,
+  val userActionsHelper: UserActionsHelper,
+  keepRepo: KeepRepo,
+  keepQueryCommander: KeepQueryCommander,
+  keepInfoAssembler: KeepInfoAssembler,
+  permissionCommander: PermissionCommander,
+  clock: Clock,
+  implicit val airbrake: AirbrakeNotifier,
+  private implicit val defaultContext: ExecutionContext,
+  private implicit val publicIdConfig: PublicIdConfiguration)
+    extends UserActions with ShoeboxServiceController {
+
+  def getKeepsInLibrary(libPubId: PublicId[Library], fromPubKeepIdOpt: Option[String]) = MaybeUserAction.async { implicit request =>
+    val resultIfEverythingWentWell = for {
+      libId <- Library.decodePublicId(libPubId).toOption.withLeft(LibraryFail.INVALID_LIBRARY_ID: LibraryFail)
+      fromIdOpt <- fromPubKeepIdOpt.filter(_.nonEmpty).fold[RightBias[LibraryFail, Option[Id[Keep]]]](RightBias.right(None)) { pubKeepId =>
+        Keep.decodePublicIdStr(pubKeepId).airbrakingOption.withLeft(LibraryFail.INVALID_KEEP_ID).map(Some(_))
+      }
+      permissions = db.readOnlyMaster { implicit s =>
+        permissionCommander.getLibraryPermissions(libId, request.userIdOpt)
+      }
+      _ <- RightBias.unit.filter(_ => permissions.contains(LibraryPermission.VIEW_LIBRARY), LibraryFail.INSUFFICIENT_PERMISSIONS)
+    } yield {
+      val keepIds = db.readOnlyMaster { implicit s =>
+        keepQueryCommander.getKeeps(request.userIdOpt, KeepQuery(
+          target = KeepQuery.ForLibrary(libId),
+          arrangement = None,
+          fromId = fromIdOpt,
+          offset = Offset(0),
+          limit = Limit(10)
+        ))
+      }
+      keepInfoAssembler.assembleKeepViews(request.userIdOpt, keepSet = keepIds.toSet).map { viewMap =>
+        Ok(Json.obj("keeps" -> keepIds.flatMap(kId => viewMap.get(kId).flatMap(_.getRight))))
+      }
+    }
+    resultIfEverythingWentWell.getOrElse { fail => Future.successful(fail.asErrorResponse) }
+  }
+}

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
@@ -37,6 +37,11 @@ object LibraryError {
 case class LibraryFail(status: Int, message: String) extends Exception(message) {
   def asErrorResponse = Status(status)(Json.obj("error" -> message))
 }
+object LibraryFail {
+  val INVALID_LIBRARY_ID = LibraryFail(BAD_REQUEST, "invalid_library_id")
+  val INVALID_KEEP_ID = LibraryFail(BAD_REQUEST, "invalid_keep_id")
+  val INSUFFICIENT_PERMISSIONS = LibraryFail(FORBIDDEN, "insufficient_permissions")
+}
 
 case class ExternalLibraryInitialValues(
   name: String,

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToLibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToLibraryRepo.scala
@@ -112,7 +112,7 @@ class KeepToLibraryRepoImpl @Inject() (
   def table(tag: Tag) = new KeepToLibraryTable(tag)
   initTable()
 
-  private def activeRows = rows.filter(_.state === KeepToLibraryStates.ACTIVE)
+  def activeRows = rows.filter(_.state === KeepToLibraryStates.ACTIVE)
   def allActive(implicit session: RSession): Seq[KeepToLibrary] = activeRows.list
 
   private def getByKeepIdsHelper(keepIds: Set[Id[Keep]], excludeStateOpt: Option[State[KeepToLibrary]])(implicit session: RSession) = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -619,7 +619,7 @@ object LibraryOrdering extends Enumerator[LibraryOrdering] {
 
   implicit val format: Format[LibraryOrdering] = EnumFormat.format(fromStr, _.value)
 
-  implicit def queryStringBinder[T](implicit stringBinder: QueryStringBindable[String]) = new QueryStringBindable[LibraryOrdering] {
+  implicit def queryStringBinder(implicit stringBinder: QueryStringBindable[String]) = new QueryStringBindable[LibraryOrdering] {
     override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, LibraryOrdering]] = {
       stringBinder.bind(key, params) map {
         case Right(str) => Right(LibraryOrdering(str))

--- a/kifi-backend/modules/shoebox/conf/shoeboxClient.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxClient.routes
@@ -28,6 +28,12 @@ GET    /api/1/keeps/:id/activity     @com.keepit.controllers.client.KeepInfoCont
 GET    /api/1/keeps/export/personal  @com.keepit.controllers.client.KeepExportController.exportPersonalKeeps()
 GET    /api/1/keeps/export/org       @com.keepit.controllers.client.KeepExportController.exportOrganizationKeeps()
 
+##
+# LIBRARIES
+##
+
+GET    /api/1/libraries/:id/keeps              @com.keepit.controllers.client.LibraryKeepsInfoController.getKeepsInLibrary(id: PublicId[Library], fromId: Option[String] ?= None)
+
 
 
 ##


### PR DESCRIPTION
This serves a similar role to `LibraryQueryCommander`, namely to provide
a uniform API for user-defined ordering of keeps. Right now the
only area that it can serve is paging through keeps in a single library.

The default behavior is to order by `keep.lastActivityAt` in descending order.
There is currently no way to alter this behavior, but soon I will introduce
an endpoint to let users set their default behavior, and after that I will
work on allowing the frontend to send down custom orderings
