### PR TITLE
don't include keeper in initial recipients

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -49,7 +49,7 @@ object KeepInternRequest {
       author = Author.KifiUser(keeper),
       url = url,
       source = source,
-      attribution = RawKifiAttribution(keptBy = keeper, source = source, connections = recipients.plusUser(keeper)),
+      attribution = RawKifiAttribution(keptBy = keeper, source = source, connections = recipients),
       title = title,
       note = note,
       keptAt = keptAt,


### PR DESCRIPTION
@ryanpbrewster for the attribution, we already store `keptBy`, so `connections` would be easier to parse if we didn't include that user in there (don't have to filter).
