### PR TITLE
don't send back StartWithEmails as events

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
@@ -102,11 +102,7 @@ object SystemMessageData {
   }
 
   def toKeepEvent(data: SystemMessageData): Option[KeepEventData] = data match {
-    case StartWithEmails(addedBy, addedUsers, addedNonUsers) =>
-      val emails = addedNonUsers.collect {
-        case NonUserEmailParticipant(email) => email
-      }.toSet
-      Some(KeepEventData.AddRecipients(addedBy, KeepRecipients(libraries = Set.empty, emails, addedUsers.toSet)))
+    case StartWithEmails(addedBy, addedUsers, addedNonUsers) => None
     case AddParticipants(addedBy, addedUsers, addedNonUsers) =>
       val emails = addedNonUsers.collect {
         case NonUserEmailParticipant(email) => email


### PR DESCRIPTION
@ryanpbrewster these are akin to initial keep events versus standard keep events, we shouldn't put them in the log
