### PR TITLE
make keep event migration safer

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/437.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/437.sql
@@ -1,0 +1,8 @@
+# SHOEBOX
+
+# --- !Ups
+
+alter table keep_event add message_id bigint(20) default null;
+create unique index keep_event_u_message_id on keep_event (message_id);
+
+# --- !Downs


### PR DESCRIPTION
@ryanpbrewster turns out eliza.message has a bunch of duplicate data for `start_with_emails` events. also turns out we don't want those events in `keep_event`. So I need to clean up and re-run the migration, this time ignoring those events and we should be good.
