### PR TITLE
maintain existing eliza pipelines

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -178,6 +178,7 @@ object Shoebox extends Service {
     def getSlackTeamInfo(slackTeamId: SlackTeamId) = ServiceRoute(GET, "/internal/shoebox/database/getSlackTeamInfo", Param("slackTeamId", slackTeamId.value))
     def internKeep() = ServiceRoute(POST, "/internal/shoebox/database/internKeep")
     def addUsersToKeep(adderId: Id[User], keepId: Id[Keep]) = ServiceRoute(POST, "/internal/shoebox/database/addUsersToKeep", Param("adderId", adderId), Param("keepId", keepId))
+    def editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], persistKeepEvent: Boolean, source: Option[KeepEventSourceKind]) = ServiceRoute(POST, "/internal/shoebox/database/editRecipientsOnKeep", Param("editorId", editorId), Param("keepId", keepId), Param("persistKeepEvent", persistKeepEvent), Param("source", source.map(_.value)))
     def registerMessageOnKeep() = ServiceRoute(POST, "/internal/shoebox/database/registerMessageOnKeep")
   }
 }

--- a/kifi-backend/modules/common/app/com/keepit/common/util/DeltaSet.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/DeltaSet.scala
@@ -24,7 +24,10 @@ object DeltaSet {
 
   def empty[T]: DeltaSet[T] = DeltaSet(DisjointSets.empty[T, AddOrRemove])
 
-  private def fromSets[T](added: Option[Set[T]], removed: Option[Set[T]]): DeltaSet[T] = DeltaSet.empty.addAll(added.getOrElse(Set.empty)).removeAll(removed.getOrElse(Set.empty))
+  def addOnly[T](items: Set[T]): DeltaSet[T] = DeltaSet.empty.addAll(items)
+  def removeOnly[T](items: Set[T]): DeltaSet[T] = DeltaSet.empty.removeAll(items)
+
+  private def fromSets[T](added: Option[Set[T]], removed: Option[Set[T]]): DeltaSet[T] = DeltaSet.addOnly(added.getOrElse(Set.empty)).removeAll(removed.getOrElse(Set.empty))
   private def toSets[T](delta: DeltaSet[T]): (Option[Set[T]], Option[Set[T]]) = (Some(delta.added).filter(_.isEmpty), Some(delta.removed).filter(_.isEmpty))
   implicit def format[T](implicit tReads: Reads[T], tWrites: Writes[T]): Format[DeltaSet[T]] = (
     (__ \ 'add).formatNullable[Set[T]] and

--- a/kifi-backend/modules/common/app/com/keepit/model/KeepEventData.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepEventData.scala
@@ -12,6 +12,7 @@ import com.kifi.macros.json
 import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import play.api.mvc.QueryStringBindable
 
 sealed abstract class KeepEventKind(val value: String)
 object KeepEventKind extends Enumerator[KeepEventKind] {
@@ -58,6 +59,19 @@ object KeepEventSourceKind extends Enumerator[KeepEventSourceKind] {
   }
 
   def fromUserAgent(userAgent: UserAgent): Option[KeepEventSourceKind] = fromStr(userAgent.name)
+
+  implicit def queryStringBinder[T](implicit stringBinder: QueryStringBindable[String]): QueryStringBindable[KeepEventSourceKind] = new QueryStringBindable[KeepEventSourceKind] {
+    override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, KeepEventSourceKind]] = {
+      stringBinder.bind(key, params) map {
+        case Right(value) => Right(KeepEventSourceKind(value))
+        case _ => Left("Unable to bind a KeepEventSourceKind")
+      }
+    }
+
+    override def unbind(key: String, source: KeepEventSourceKind): String = {
+      stringBinder.unbind(key, source.value)
+    }
+  }
 }
 
 sealed abstract class KeepEventData(val kind: KeepEventKind)

--- a/kifi-backend/modules/common/app/com/keepit/model/KeepSourceAttribution.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepSourceAttribution.scala
@@ -90,7 +90,7 @@ object RawSlackAttribution {
   implicit val format = Json.format[RawSlackAttribution]
 }
 
-case class RawKifiAttribution(keptBy: Id[User], connections: KeepRecipients, source: KeepSource) extends RawSourceAttribution
+case class RawKifiAttribution(keptBy: Id[User], note: Option[String], connections: KeepRecipients, source: KeepSource) extends RawSourceAttribution
 object RawKifiAttribution {
   implicit val format = Json.format[RawKifiAttribution]
 }

--- a/kifi-backend/modules/common/app/com/keepit/model/SourceAttribution.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/SourceAttribution.scala
@@ -104,7 +104,7 @@ object SlackAttribution {
   implicit val format = Json.format[SlackAttribution]
 }
 
-case class KifiAttribution(keptBy: BasicUser, users: Set[BasicUser], nonUsers: Set[EmailAddress], libraries: Set[BasicLibrary], source: KeepSource) extends SourceAttribution
+case class KifiAttribution(keptBy: BasicUser, note: Option[String], users: Set[BasicUser], nonUsers: Set[EmailAddress], libraries: Set[BasicLibrary], source: KeepSource) extends SourceAttribution
 object KifiAttribution {
   implicit val format = Json.format[KifiAttribution]
 }

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -139,6 +139,7 @@ trait ShoeboxServiceClient extends ServiceClient {
   // TODO(ryan): kill this once clients stop trying to create discussions through Eliza
   def internKeep(creator: Id[User], users: Set[Id[User]], emails: Set[EmailAddress], uriId: Id[NormalizedURI], url: String, title: Option[String], note: Option[String]): Future[CrossServiceKeep]
   def addUsersToKeep(adderId: Id[User], keepId: Id[Keep], newUsers: Set[Id[User]]): Future[Unit]
+  def editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], diff: KeepRecipientsDiff, persistKeepEvent: Boolean, source: Option[KeepEventSourceKind]): Future[Unit]
   def registerMessageOnKeep(keepId: Id[Keep], msg: CrossServiceMessage): Future[Unit]
 }
 
@@ -904,6 +905,11 @@ class ShoeboxServiceClientImpl @Inject() (
   def addUsersToKeep(adderId: Id[User], keepId: Id[Keep], newUsers: Set[Id[User]]): Future[Unit] = {
     call(Shoebox.internal.addUsersToKeep(adderId, keepId), body = Json.obj("users" -> newUsers)).map(_ => ())
   }
+  def editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], diff: KeepRecipientsDiff, persistKeepEvent: Boolean, source: Option[KeepEventSourceKind]): Future[Unit] = {
+    val jsRecipients = Json.toJson(diff)(KeepRecipientsDiff.internalFormat)
+    call(Shoebox.internal.editRecipientsOnKeep(editorId, keepId, persistKeepEvent, source), body = Json.obj("diff" -> jsRecipients)).map(_ => ())
+  }
+
   def registerMessageOnKeep(keepId: Id[Keep], msg: CrossServiceMessage): Future[Unit] = {
     import RegisterMessageOnKeep._
     val request = Request(keepId, msg)

--- a/kifi-backend/modules/common/app/com/keepit/social/Author.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/Author.scala
@@ -18,7 +18,7 @@ object Author {
   def fromSource(attr: RawSourceAttribution): Author = attr match {
     case RawTwitterAttribution(tweet) => TwitterUser(tweet.user.id)
     case RawSlackAttribution(msg, teamId) => SlackUser(teamId, msg.userId)
-    case RawKifiAttribution(userId, _, _) => KifiUser(userId)
+    case RawKifiAttribution(userId, _, _, _) => KifiUser(userId)
   }
 
   def toIndexableString(author: Author): String = {
@@ -95,7 +95,7 @@ object BasicAuthor {
       picture = StaticImageUrls.TWITTER_LOGO,
       url = tweet.permalink
     )
-    case KifiAttribution(keptBy, _, _, _, _) => fromUser(keptBy)
+    case KifiAttribution(keptBy, _, _, _, _, _) => fromUser(keptBy)
   }
   def fromNonUser(nonUser: BasicNonUser): BasicAuthor = nonUser.kind match {
     case NonUserKinds.email =>

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -738,5 +738,6 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, impli
   }
 
   def addUsersToKeep(adderId: Id[User], keepId: Id[Keep], newUsers: Set[Id[User]]): Future[Unit] = Future.successful(())
+  def editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], recipients: KeepRecipientsDiff, persistKeepEvent: Boolean, source: Option[KeepEventSourceKind]): Future[Unit] = Future.successful(())
   def registerMessageOnKeep(keepId: Id[Keep], msg: CrossServiceMessage): Future[Unit] = Future.successful(())
 }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -561,7 +561,7 @@ class MessagingCommanderImpl @Inject() (
           }
 
           if (updateShoebox) {
-            val newEmails = newNonUsers.map { case NonUserEmailParticipant(email) => email }
+            val newEmails = newNonUsers.map(NonUserParticipant.toEmailAddress)
             shoebox.editRecipientsOnKeep(adderUserId, keepId, KeepRecipientsDiff(DeltaSet.addOnly(newUsers.toSet), DeltaSet.addOnly(newLibraries), DeltaSet.addOnly(newEmails.toSet)), persistKeepEvent = true, source)
           }
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -15,6 +15,7 @@ import com.keepit.common.logging.Logging
 import com.keepit.common.mail.BasicContact
 import com.keepit.common.net.URI
 import com.keepit.common.time._
+import com.keepit.common.util.DeltaSet
 import com.keepit.discussion.MessageSource
 import com.keepit.eliza.model._
 import com.keepit.eliza.model.SystemMessageData._
@@ -545,20 +546,23 @@ class MessagingCommanderImpl @Inject() (
             ))
           }
 
-          if (updateShoebox) shoebox.addUsersToKeep(adderUserId, keepId, actuallyNewUsers.toSet)
-
-          Some((actuallyNewUsers, actuallyNewNonUsers, message, thread))
+          Some((actuallyNewUsers, actuallyNewNonUsers, actuallyNewLibraries, message, thread))
 
         }
       }
 
       resultInfoOpt.exists {
-        case (newUsers, newNonUsers, message, thread) =>
+        case (newUsers, newNonUsers, newLibraries, message, thread) =>
 
           SafeFuture {
             db.readOnlyMaster { implicit session =>
               messageRepo.refreshCache(thread.keepId)
             }
+          }
+
+          if (updateShoebox) {
+            val newEmails = newNonUsers.map { case NonUserEmailParticipant(email) => email }
+            shoebox.editRecipientsOnKeep(adderUserId, keepId, KeepRecipientsDiff(DeltaSet.addOnly(newUsers.toSet), DeltaSet.addOnly(newLibraries), DeltaSet.addOnly(newEmails.toSet)), persistKeepEvent = true, source)
           }
 
           if (newUsers.nonEmpty || newNonUsers.nonEmpty) {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NonUserThread.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/NonUserThread.scala
@@ -80,6 +80,10 @@ object NonUserParticipant {
   def fromBasicNonUser(nonUser: BasicNonUser) = nonUser.kind match {
     case NonUserKinds.email => NonUserEmailParticipant(EmailAddress(nonUser.id))
   }
+
+  def toEmailAddress(nonUser: NonUserParticipant) = nonUser match {
+    case NonUserEmailParticipant(email) => email
+  }
 }
 
 case class NonUserEmailParticipant(address: EmailAddress) extends NonUserParticipant {

--- a/kifi-backend/modules/search/app/com/keepit/search/index/graph/keep/KeepIndexable.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/index/graph/keep/KeepIndexable.scala
@@ -59,7 +59,7 @@ object KeepFields {
     def apply(source: SourceAttribution): String = source match {
       case TwitterAttribution(tweet) => Source(tweet.user.screenName)
       case SlackAttribution(message, teamId) => Source(teamId, message.channel.id)
-      case KifiAttribution(_, _, _, _, keepSource) => Source(keepSource)
+      case KifiAttribution(_, _, _, _, _, keepSource) => Source(keepSource)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
@@ -340,7 +340,7 @@ class AdminBookmarksController @Inject() (
       val discussionConnectionsFut = eliza.getInitialRecipientsByKeepId(discussionKeeps.map(_.id.get).toSet).map { connectionsByKeep =>
         discussionKeeps.flatMap { keep =>
           connectionsByKeep.get(keep.id.get).map { connections =>
-            keep.id.get -> (RawKifiAttribution(keep.userId.get, connections, keep.source), keep.state == KeepStates.ACTIVE)
+            keep.id.get -> (RawKifiAttribution(keep.userId.get, keep.note, connections, keep.source), keep.state == KeepStates.ACTIVE)
           }
         }.toMap
       }
@@ -352,7 +352,7 @@ class AdminBookmarksController @Inject() (
           case keep =>
             val firstLibrary = ktls(keep.id.get).minBy(_.addedAt).libraryId
             val firstUsers = ktus(keep.id.get).filter(ktu => !keep.userId.contains(ktu.userId) && keep.keptAt.getMillis > ktu.addedAt.minusSeconds(1).getMillis)
-            val rawAttribution = RawKifiAttribution(keptBy = keep.userId.get, KeepRecipients(Set(firstLibrary), Set.empty, firstUsers.map(_.userId).toSet), keep.source)
+            val rawAttribution = RawKifiAttribution(keptBy = keep.userId.get, keep.note, KeepRecipients(Set(firstLibrary), Set.empty, firstUsers.map(_.userId).toSet), keep.source)
             keep.id.get -> (rawAttribution, keep.state == KeepStates.ACTIVE)
         }.toMap
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -49,7 +49,7 @@ object KeepInternRequest {
       author = Author.KifiUser(keeper),
       url = url,
       source = source,
-      attribution = RawKifiAttribution(keptBy = keeper, source = source, connections = recipients.plusUser(keeper)),
+      attribution = RawKifiAttribution(keeper, note, recipients.plusUser(keeper), source),
       title = title,
       note = note,
       keptAt = keptAt,
@@ -218,7 +218,7 @@ class KeepInternerImpl @Inject() (
     thirdPartyAttribution: Option[RawSourceAttribution], note: Option[String])(implicit session: RWSession) = {
     airbrake.verify(userIdOpt.isDefined || thirdPartyAttribution.isDefined, s"interning a keep (uri ${uri.id.get}, lib ${libraryOpt.map(_.id.get)}) with no user AND no source?!?!?!")
 
-    val sourceAttribution = thirdPartyAttribution.orElse(userIdOpt.map(userId => RawKifiAttribution(userId, KeepRecipients(libraryOpt.map(_.id.get).toSet, Set.empty, usersAdded), source)))
+    val sourceAttribution = thirdPartyAttribution.orElse(userIdOpt.map(userId => RawKifiAttribution(userId, note, KeepRecipients(libraryOpt.map(_.id.get).toSet, Set.empty, usersAdded), source)))
 
     val existingKeepOpt = libraryOpt.flatMap { lib => keepRepo.getByUriAndLibrariesHash(uri.id.get, Set(lib.id.get)).headOption }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepSourceCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepSourceCommander.scala
@@ -65,7 +65,7 @@ class KeepSourceCommanderImpl @Inject() (
       val basicUserOpt = attr match {
         case TwitterAttribution(tweet) => userByTwitterId.get(tweet.user.id).flatMap(basicUserById.get)
         case SlackAttribution(message, teamId) => userBySlackIdentity.get((teamId, message.userId)).flatMap(basicUserById.get)
-        case KifiAttribution(keptBy, _, _, _, _) => Some(keptBy)
+        case KifiAttribution(keptBy, _, _, _, _, _) => Some(keptBy)
       }
       (attr, basicUserOpt)
     }
@@ -103,10 +103,10 @@ class KeepSourceAugmentor @Inject() (
   def rawToSourceAttribution(source: RawSourceAttribution)(implicit session: RSession): SourceAttribution = source match {
     case RawTwitterAttribution(tweet) => TwitterAttribution(PrettyTweet.fromRawTweet(tweet))
     case RawSlackAttribution(message, teamId) => SlackAttribution(genBasicSlackMessage(teamId, message), teamId)
-    case RawKifiAttribution(keptBy, KeepRecipients(libraries, nonUsers, users), keepSource) => {
+    case RawKifiAttribution(keptBy, note, KeepRecipients(libraries, nonUsers, users), keepSource) => {
       val userById = basicUserRepo.loadAll(users + keptBy)
       val libById = basicLibGen.getBasicLibraries(libraries)
-      KifiAttribution(userById(keptBy), users.flatMap(userById.get), nonUsers, libraries.flatMap(libById.get), keepSource)
+      KifiAttribution(userById(keptBy), note, users.flatMap(userById.get), nonUsers, libraries.flatMap(libById.get), keepSource)
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/eliza/ShoeboxMessageIngestionActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/eliza/ShoeboxMessageIngestionActor.scala
@@ -74,13 +74,13 @@ class ShoeboxMessageIngestionActor @Inject() (
               keepCommander.updateLastActivityAtIfLater(keepId, lastMessageTime)
             }
             def handleKeepEvents() = msgs.flatMap(_.auxData).foreach {
-              case KeepEventData.ModifyRecipients(addedBy, KeepRecipientsDiff(users, libraries, emails)) =>
+              case KeepEventData.ModifyRecipients(editor, KeepRecipientsDiff(users, libraries, emails)) =>
                 val diff = KeepRecipientsDiff(
                   users = DeltaSet.empty.addAll(users.added),
                   emails = DeltaSet.empty.addAll(emails.added),
                   libraries = DeltaSet.empty.addAll(libraries.added)
                 )
-                keepCommander.unsafeModifyKeepRecipients(keepId, diff, userAttribution = Some(addedBy))
+                keepCommander.unsafeModifyKeepRecipients(keepId, diff, userAttribution = Some(editor))
               case KeepEventData.EditTitle(_, _, _) =>
             }
 

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -727,6 +727,7 @@ GET      /internal/shoebox/database/getSlackTeamInfo               @com.keepit.c
 
 POST     /internal/shoebox/database/internKeep              @com.keepit.controllers.internal.ShoeboxController.internKeep()
 POST     /internal/shoebox/database/addUsersToKeep          @com.keepit.controllers.internal.ShoeboxController.addUsersToKeep(adderId: Id[User], keepId: Id[Keep])
+POST     /internal/shoebox/database/editRecipientsOnKeep     @com.keepit.controllers.internal.ShoeboxController.editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], persistKeepEvent: Boolean, source: Option[KeepEventSourceKind] ?= None)
 POST     /internal/shoebox/database/registerMessageOnKeep   @com.keepit.controllers.internal.ShoeboxController.registerMessageOnKeep()
 
 GET      /internal/shoebox/email/getUnsubscribeUrlForEmail @com.keepit.controllers.website.EmailOptOutController.getUnsubscribeUrlForEmail(email: EmailAddress)


### PR DESCRIPTION
@ryanpbrewster @leogrim we have to maintain existing system message pipelines via Eliza since old clients are going to look to her for "add_participants" and "start_with_emails" events. alternatively / eventually, we can mirror those endpoints and reformat `BasicKeepEvents` to match the old `message.auxData` formats.
