### PR TITLE
ignore empty modify connections requests

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/util/DeltaSet.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/DeltaSet.scala
@@ -10,6 +10,8 @@ case class DeltaSet[T](djs: DisjointSets[T, DeltaSet.AddOrRemove]) {
   def add(items: T*) = addAll(items.toSet)
   def remove(items: T*) = removeAll(items.toSet)
 
+  def isEmpty: Boolean = djs.getSet(DeltaSet.Add).isEmpty && djs.getSet(DeltaSet.Remove).isEmpty
+  def nonEmpty: Boolean = !isEmpty
   def added: Set[T] = djs.getSet(DeltaSet.Add)
   def removed: Set[T] = djs.getSet(DeltaSet.Remove)
   def all: Set[T] = djs.elems.keySet

--- a/kifi-backend/modules/common/app/com/keepit/model/KeepRecipients.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepRecipients.scala
@@ -77,7 +77,10 @@ object KeepMembers {
   val empty = KeepMembers(Seq.empty, Seq.empty, Seq.empty)
 }
 
-case class KeepRecipientsDiff(users: DeltaSet[Id[User]], libraries: DeltaSet[Id[Library]], emails: DeltaSet[EmailAddress])
+case class KeepRecipientsDiff(users: DeltaSet[Id[User]], libraries: DeltaSet[Id[Library]], emails: DeltaSet[EmailAddress]) {
+  def isEmpty = this.users.isEmpty && this.libraries.isEmpty && this.emails.isEmpty
+  def nonEmpty = !isEmpty
+}
 object KeepRecipientsDiff {
   def addUser(user: Id[User]) = KeepRecipientsDiff(users = DeltaSet.empty.add(user), libraries = DeltaSet.empty, emails = DeltaSet.empty)
   def addUsers(users: Set[Id[User]]) = KeepRecipientsDiff(users = DeltaSet.empty.addAll(users), libraries = DeltaSet.empty, emails = DeltaSet.empty)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/DiscussionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/DiscussionCommander.scala
@@ -116,25 +116,28 @@ class DiscussionCommanderImpl @Inject() (
     }
   }
   def modifyConnectionsForKeep(userId: Id[User], keepId: Id[Keep], diff: KeepRecipientsDiff, source: Option[KeepEventSourceKind]): Future[Unit] = {
-    val (keepPermissions, uriCollisionsByLib) = db.readOnlyReplica { implicit s =>
-      val keepPermissions = permissionCommander.getKeepPermissions(keepId, Some(userId))
-      val uriCollisionsByLib = ktlRepo.getByLibraryIdsAndUriIds(diff.libraries.added, uriIds = Set(keepRepo.get(keepId).uriId)).groupBy(_.libraryId)
-      (keepPermissions, uriCollisionsByLib)
-    }
-    val errs: Stream[DiscussionFail] = Stream(
-      (diff.users.added.nonEmpty && !keepPermissions.contains(KeepPermission.ADD_PARTICIPANTS)) -> DiscussionFail.INSUFFICIENT_PERMISSIONS,
-      (diff.users.removed.nonEmpty && !keepPermissions.contains(KeepPermission.REMOVE_PARTICIPANTS)) -> DiscussionFail.INSUFFICIENT_PERMISSIONS,
-      (diff.libraries.added.nonEmpty && !keepPermissions.contains(KeepPermission.ADD_LIBRARIES)) -> DiscussionFail.INSUFFICIENT_PERMISSIONS,
-      (diff.libraries.removed.nonEmpty && !keepPermissions.contains(KeepPermission.REMOVE_LIBRARIES)) -> DiscussionFail.INSUFFICIENT_PERMISSIONS,
-      uriCollisionsByLib.nonEmpty -> DiscussionFail.URI_COLLISION
-    ).collect { case (true, fail) => fail }
-
-    errs.headOption.map(fail => Future.failed(fail)).getOrElse {
-      db.readWrite { implicit s =>
-        keepCommander.unsafeModifyKeepRecipients(keepId, diff, userAttribution = Some(userId))
-        eventCommander.modifyRecipients(keepId, userId, diff, source, eventTime = None)
+    if (diff.isEmpty) Future.successful(())
+    else {
+      val (keepPermissions, uriCollisionsByLib) = db.readOnlyReplica { implicit s =>
+        val keepPermissions = permissionCommander.getKeepPermissions(keepId, Some(userId))
+        val uriCollisionsByLib = ktlRepo.getByLibraryIdsAndUriIds(diff.libraries.added, uriIds = Set(keepRepo.get(keepId).uriId)).groupBy(_.libraryId)
+        (keepPermissions, uriCollisionsByLib)
       }
-      Future.successful(Unit)
+      val errs: Stream[DiscussionFail] = Stream(
+        (diff.users.added.nonEmpty && !keepPermissions.contains(KeepPermission.ADD_PARTICIPANTS)) -> DiscussionFail.INSUFFICIENT_PERMISSIONS,
+        (diff.users.removed.nonEmpty && !keepPermissions.contains(KeepPermission.REMOVE_PARTICIPANTS)) -> DiscussionFail.INSUFFICIENT_PERMISSIONS,
+        (diff.libraries.added.nonEmpty && !keepPermissions.contains(KeepPermission.ADD_LIBRARIES)) -> DiscussionFail.INSUFFICIENT_PERMISSIONS,
+        (diff.libraries.removed.nonEmpty && !keepPermissions.contains(KeepPermission.REMOVE_LIBRARIES)) -> DiscussionFail.INSUFFICIENT_PERMISSIONS,
+        uriCollisionsByLib.nonEmpty -> DiscussionFail.URI_COLLISION
+      ).collect { case (true, fail) => fail }
+
+      errs.headOption.map(fail => Future.failed(fail)).getOrElse {
+        db.readWrite { implicit s =>
+          keepCommander.unsafeModifyKeepRecipients(keepId, diff, userAttribution = Some(userId))
+          eventCommander.registerKeepEvent(keepId, KeepEventData.ModifyRecipients(userId, diff), source, eventTime = None)
+        }
+        Future.successful(Unit)
+      }
     }
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -467,7 +467,7 @@ class KeepCommanderImpl @Inject() (
     }
     result.getRight.foreach {
       case (oldKeep, newKeep) =>
-        db.readWrite(implicit s => eventCommander.updatedKeepTitle(keepId, userId, oldKeep.title, newKeep.title, source, eventTime = None))
+        db.readWrite(implicit s => eventCommander.registerKeepEvent(keepId, KeepEventData.EditTitle(userId, oldKeep.title, newKeep.title), source, eventTime = None))
     }
     result.map(_._2)
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepEventCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepEventCommander.scala
@@ -5,7 +5,7 @@ import com.keepit.common.db.Id
 import com.keepit.common.db.slick.DBSession.RWSession
 import com.keepit.common.db.slick.Database
 import com.keepit.eliza.ElizaServiceClient
-import com.keepit.model.KeepEventData.EditTitle
+import com.keepit.model.KeepEventData.{ ModifyRecipients, EditTitle }
 import com.keepit.model.{ KeepRecipientsDiff, KeepRecipients, KeepEventData, KeepEvent, KeepEventRepo, KeepEventSourceKind, User, Keep }
 import com.keepit.common.time._
 import org.joda.time.DateTime
@@ -14,8 +14,7 @@ import scala.concurrent.ExecutionContext
 
 @ImplementedBy(classOf[KeepEventCommanderImpl])
 trait KeepEventCommander {
-  def updatedKeepTitle(keepId: Id[Keep], userId: Id[User], oldTitle: Option[String], newTitle: Option[String], source: Option[KeepEventSourceKind], eventTime: Option[DateTime])(implicit session: RWSession): Unit
-  def modifyRecipients(keepId: Id[Keep], addedBy: Id[User], diff: KeepRecipientsDiff, source: Option[KeepEventSourceKind], eventTime: Option[DateTime])(implicit session: RWSession): Unit
+  def registerKeepEvent(keepId: Id[Keep], event: KeepEventData, source: Option[KeepEventSourceKind], eventTime: Option[DateTime])(implicit session: RWSession): Boolean
 }
 
 @Singleton
@@ -24,15 +23,18 @@ class KeepEventCommanderImpl @Inject() (
     eventRepo: KeepEventRepo,
     db: Database,
     implicit val ec: ExecutionContext) extends KeepEventCommander {
-  def updatedKeepTitle(keepId: Id[Keep], userId: Id[User], oldTitle: Option[String], newTitle: Option[String], source: Option[KeepEventSourceKind], eventTime: Option[DateTime])(implicit session: RWSession): Unit = {
-    val eventData: EditTitle = KeepEventData.EditTitle(userId, oldTitle, newTitle)
-    val event = KeepEvent(keepId = keepId, eventData = eventData, eventTime = eventTime.getOrElse(currentDateTime), source = source)
-    eventRepo.save(event)
-  }
 
-  def modifyRecipients(keepId: Id[Keep], addedBy: Id[User], diff: KeepRecipientsDiff, source: Option[KeepEventSourceKind], eventTime: Option[DateTime])(implicit session: RWSession): Unit = {
-    val eventData = KeepEventData.ModifyRecipients(addedBy, diff)
-    val event = KeepEvent(keepId = keepId, eventData = eventData, eventTime = eventTime.getOrElse(currentDateTime), source = source)
-    eventRepo.save(event)
+  def registerKeepEvent(keepId: Id[Keep], eventData: KeepEventData, source: Option[KeepEventSourceKind], eventTime: Option[DateTime])(implicit session: RWSession): Boolean = {
+    val isValidEvent = eventData match {
+      case ModifyRecipients(_, diff) if diff.isEmpty => false
+      case _ => true
+    }
+
+    if (isValidEvent) {
+      val event = KeepEvent(keepId = keepId, eventData = eventData, eventTime = eventTime.getOrElse(currentDateTime), source = source)
+      eventRepo.save(event)
+    }
+
+    isValidEvent
   }
 }


### PR DESCRIPTION
@ryanpbrewster the code in `DiscussionCommander` is an optimization (not sure how you feel about it, whether we should return a 400 failure or just :+1: with a smile), but the code in `KeepEventCommander` enforces an implicit constraint on these events.
