### PR TITLE
rename fake author

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/social/Author.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/Author.scala
@@ -63,7 +63,7 @@ sealed abstract class BasicAuthor(val kind: AuthorKind) {
 object BasicAuthor {
   val Fake = KifiUser(
     id = "42424242-4242-4242-424242424242",
-    name = "fake",
+    name = "Someone",
     picture = StaticImageUrls.KIFI_LOGO,
     url = Path.base
   )


### PR DESCRIPTION
@andrewconner @leogrim @ryanpbrewster 

I don't know if this is the best way to fallback, but it sort of works. I'm wrapping up a PR that will stop assuming `KeepToUsers` are all you need to generate user elements in the activity log, but I still need to see why he wasn't added to the keep in the first place.
