### PR TITLE
add a keep to user for title editors

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -424,7 +424,10 @@ class KeepCommanderImpl @Inject() (
     }
     result.getRight.foreach {
       case (oldKeep, newKeep) =>
-        db.readWrite(implicit s => eventCommander.registerKeepEvent(keepId, KeepEventData.EditTitle(userId, oldKeep.title, newKeep.title), source, eventTime = None))
+        db.readWrite { implicit s =>
+          keepMutator.unsafeModifyKeepRecipients(keepId, KeepRecipientsDiff.addUser(userId), Some(userId))
+          eventCommander.registerKeepEvent(keepId, KeepEventData.EditTitle(userId, oldKeep.title, newKeep.title), source, eventTime = None)
+        }
     }
     result.map(_._2)
   }


### PR DESCRIPTION
@leogrim @andrewconner @ryanpbrewster 

this enforces that anyone that interacts with a keep gets a `KeepToUser`, as opposed to just commenters. it makes sense to do but depends how we want to interpret `KeepToUser`. For example, we could end up creating `UserThreads` for everyone with a `KTU` and pushing updates on the keep to you if you edited the title. Right now, people who update the title will not be notified any updates to the keepscussion.
