### PR TITLE
check current eliza instance for user web socket for new keep events

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -378,7 +378,7 @@ class MessagingCommanderImpl @Inject() (
     // send message through websockets immediately
     thread.participants.allUsers.foreach { user =>
       notificationDeliveryCommander.notifyMessage(user, message.pubKeepId, messageWithBasicUser)
-      eliza.sendKeepEvent(user, message.pubKeepId, event)
+      notificationDeliveryCommander.sendKeepEvent(user, message.pubKeepId, event)
     }
     // Anyone who got this new notification might have a NewKeep notification that is going to be
     // passively replaced by this message thread. The client will then have no way of ever marking or

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationDeliveryCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationDeliveryCommander.scala
@@ -49,6 +49,7 @@ trait NotificationDeliveryCommander {
   def notifyUnreadCount(userId: Id[User]): Unit
   def notifyRemoveThread(userId: Id[User], keepId: Id[Keep]): Unit
   def sendToUser(userId: Id[User], data: JsArray): Unit
+  def sendKeepEvent(userId: Id[User], keepId: PublicId[Keep], event: BasicKeepEvent): Unit
   def sendUserPushNotification(userId: Id[User], message: String, recipientUserId: ExternalId[User], username: Username, pictureUrl: String, pushNotificationExperiment: PushNotificationExperiment, category: UserPushNotificationCategory): Future[Int]
   def sendLibraryPushNotification(userId: Id[User], message: String, libraryId: Id[Library], libraryUrl: String, pushNotificationExperiment: PushNotificationExperiment, category: LibraryPushNotificationCategory, force: Boolean): Future[Int]
   def sendGeneralPushNotification(userId: Id[User], message: String, pushNotificationExperiment: PushNotificationExperiment, category: SimplePushNotificationCategory, force: Boolean): Future[Int]
@@ -192,6 +193,8 @@ class NotificationDeliveryCommanderImpl @Inject() (
 
   def sendToUser(userId: Id[User], data: JsArray): Unit =
     notificationRouter.sendToUser(userId, data)
+
+  def sendKeepEvent(userId: Id[User], keepId: PublicId[Keep], event: BasicKeepEvent): Unit = sendToUser(userId, Json.arr("event", keepId, event))
 
   def sendUserPushNotification(userId: Id[User], message: String, recipientUserId: ExternalId[User], username: Username, pictureUrl: String, pushNotificationExperiment: PushNotificationExperiment, category: UserPushNotificationCategory): Future[Int] = {
     val notification = UserPushNotification(message = Some(message), userExtId = recipientUserId, username = username, pictureUrl = pictureUrl, unvisitedCount = getTotalUnreadUnmutedCount(userId), category = category, experiment = pushNotificationExperiment)

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/ws/ElizaWebSocketTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/ws/ElizaWebSocketTest.scala
@@ -122,8 +122,12 @@ class ElizaWebSocketTest extends Specification with ElizaApplicationInjector wit
         val messageContent = message(2)
         (messageContent \ "text").as[String] === "So long and thanks for all the fish"
         (messageContent \ "participants").asInstanceOf[JsArray].value.length === 2
-        Set("notification", "event", "unread_notifications_count").contains(socket.out(0).as[String]) === true
-        Set("notification", "event", "unread_notifications_count").contains(socket.out(0).as[String]) === true
+        val first = socket.out(0).as[String]
+        val second = socket.out(0).as[String]
+        val third = socket.out(0).as[String]
+        first must beOneOf("event", "notification") // sent at the same time, so accept either for the first two events
+        second must beOneOf("event", "notification")
+        third === "unread_notifications_count"
         socket.close
         socket.out === Json.arr("bye", "session")
       }


### PR DESCRIPTION
@ryanpbrewster you were right about something being fishy: if you're on eliza you will eventually call other elizas but only if the desired user doesn't have a websocket with your current instance.
