### PR TITLE
send down tweet and slack message content with initial keep event

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/gen/KeepActivityGen.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/gen/KeepActivityGen.scala
@@ -51,17 +51,20 @@ object KeepActivityGen {
           )
       }
 
-      val source = sourceAttrOpt.map(_._1).collect {
-        case SlackAttribution(message, _) => KeepEventSource(KeepEventSourceKind.Slack, Some(message.permalink))
-        case TwitterAttribution(tweet) => KeepEventSource(KeepEventSourceKind.Twitter, Some(tweet.permalink))
+      val body = sourceAttrOpt.map {
+        case (ka: KifiAttribution, _) => ka.note.getOrElse("")
+        case (SlackAttribution(msg, _), _) => msg.text
+        case (TwitterAttribution(tweet), _) => tweet.text
       }
+
+      val source = sourceAttrOpt.flatMap { case (attr, bu) => KeepEventSource.fromSourceAttribution(attr) }
 
       BasicKeepEvent(
         id = BasicKeepEventId.initial,
         author = basicAuthor.get,
         KeepEventKind.Initial,
         header = header,
-        body = DescriptionElements(keep.note),
+        body = DescriptionElements(body),
         timestamp = keep.keptAt,
         source = source
       )


### PR DESCRIPTION
@ryanpbrewster @eishay seems like the site is using info on the `keep` object to populate these fields, so I wasn't aware it was an issue until today.
