### PR TITLE
maintain atomicity between event registry across eliza/shoebox

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/DiscussionCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/DiscussionCommander.scala
@@ -134,7 +134,7 @@ class DiscussionCommanderImpl @Inject() (
       errs.headOption.map(fail => Future.failed(fail)).getOrElse {
         db.readWrite { implicit s =>
           keepMutator.unsafeModifyKeepRecipients(keepId, diff, userAttribution = Some(userId))
-          eventCommander.registerKeepEvent(keepId, KeepEventData.ModifyRecipients(userId, diff), source, eventTime = None)
+          eventCommander.persistKeepEventAndUpdateEliza(keepId, KeepEventData.ModifyRecipients(userId, diff), source, eventTime = None)
         }
         Future.successful(Unit)
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -426,7 +426,7 @@ class KeepCommanderImpl @Inject() (
       case (oldKeep, newKeep) =>
         db.readWrite { implicit s =>
           keepMutator.unsafeModifyKeepRecipients(keepId, KeepRecipientsDiff.addUser(userId), Some(userId))
-          eventCommander.registerKeepEvent(keepId, KeepEventData.EditTitle(userId, oldKeep.title, newKeep.title), source, eventTime = None)
+          eventCommander.persistKeepEventAndUpdateEliza(keepId, KeepEventData.EditTitle(userId, oldKeep.title, newKeep.title), source, eventTime = None)
         }
     }
     result.map(_._2)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/internal/ShoeboxController.scala
@@ -658,7 +658,7 @@ class ShoeboxController @Inject() (
     val diff = (request.body \ "diff").as[KeepRecipientsDiff](KeepRecipientsDiff.internalFormat)
     db.readWrite { implicit s =>
       keepMutator.unsafeModifyKeepRecipients(keepId, diff, Some(editorId))
-      if (persistKeepEvent) keepEventCommander.registerKeepEvent(keepId, KeepEventData.ModifyRecipients(editorId, diff), source, eventTime = None)
+      if (persistKeepEvent) keepEventCommander.persistKeepEvent(keepId, KeepEventData.ModifyRecipients(editorId, diff), source, eventTime = None)
     }
     NoContent
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepActivityGenTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepActivityGenTest.scala
@@ -55,13 +55,13 @@ class KeepActivityGenTest extends Specification with ShoeboxTestInjector {
           Map(userIdsToAdd.take(2) -> true, libIdsToAdd.take(4) -> false, userIdsToAdd.takeRight(2) -> true, libIdsToAdd.takeRight(4) -> false).map {
             case (ids, true) => // users
               val adding = ids.map(id => Id[User](id.id))
-              keepEventCommander.registerKeepEvent(keep.id.get, KeepEventData.ModifyRecipients(user.id.get, KeepRecipientsDiff.addUsers(adding)), eventTime = Some(fakeClock.now()), source = None)
+              keepEventCommander.persistKeepEventAndUpdateEliza(keep.id.get, KeepEventData.ModifyRecipients(user.id.get, KeepRecipientsDiff.addUsers(adding)), eventTime = Some(fakeClock.now()), source = None)
               fakeClock += Hours.ONE
               val entities = adding.map(id => fromBasicUser(basicUserById(id))).toSeq
               DescriptionElements.formatPlain(DescriptionElements(basicUser, "added", unwordsPretty(entities), "to this discussion"))
             case (ids, false) => // libraries
               val adding = ids.map(id => Id[Library](id.id))
-              keepEventCommander.registerKeepEvent(keep.id.get, KeepEventData.ModifyRecipients(user.id.get, KeepRecipientsDiff.addLibraries(adding)), eventTime = Some(fakeClock.now()), source = None)
+              keepEventCommander.persistKeepEventAndUpdateEliza(keep.id.get, KeepEventData.ModifyRecipients(user.id.get, KeepRecipientsDiff.addLibraries(adding)), eventTime = Some(fakeClock.now()), source = None)
               fakeClock += Hours.ONE
               val entities = adding.map(id => fromBasicLibrary(basicLibById(id))).toSeq
               DescriptionElements.formatPlain(DescriptionElements(basicUser, "added", unwordsPretty(entities), "to this discussion"))


### PR DESCRIPTION
@ryanpbrewster @leogrim we need to ensure that Eliza only saves one `SystemMessage` per event, not super happy with this pattern but trying to make things as explicit as possible to prevent leaks.
