### PR TITLE
filter inactive keeps from keep info assembly

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/data/assemblers/KeepInfoAssembler.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/data/assemblers/KeepInfoAssembler.scala
@@ -170,7 +170,7 @@ class KeepInfoAssemblerImpl @Inject() (
       }
       keepSet.toSeq.augmentWith { keepId =>
         for {
-          keep <- keepsById.get(keepId).withLeft(KeepFail.KEEP_NOT_FOUND: KeepFail)
+          keep <- keepsById.get(keepId).filter(_.isActive).withLeft(KeepFail.KEEP_NOT_FOUND: KeepFail)
           permissions <- RightBias.right(permissionsByKeep.getOrElse(keepId, Set.empty)).filter(_.contains(KeepPermission.VIEW_KEEP), KeepFail.INSUFFICIENT_PERMISSIONS: KeepFail)
           author <- sourceByKeep.get(keepId).map {
             case (attr, userOpt) => BasicAuthor(attr, userOpt)


### PR DESCRIPTION
@ryanpbrewster the query that fetches these is called on `activeRows`, so seems like there is a caching issue at play, but this ensures that the right error is sent to clients (currently a 403 when should be 404 or 410).
