### PR TITLE
remove the 'John commented on this page' header for keep events

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/KeepEventData.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepEventData.scala
@@ -178,7 +178,7 @@ object BasicKeepEvent {
       id = BasicKeepEventId.fromMsg(id),
       author = author,
       kind = KeepEventKind.Comment,
-      header = DescriptionElements(author, "commented on this page"),
+      header = DescriptionElements(),
       body = text,
       timestamp = sentAt,
       source = KeepEventSourceKind.fromMessageSource(source).map(KeepEventSource(_, url = None))

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/ElizaTasksPlugin.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/ElizaTasksPlugin.scala
@@ -1,11 +1,11 @@
 package com.keepit.eliza
 
-import com.google.inject.{Inject, Singleton}
+import com.google.inject.{ Inject, Singleton }
 import com.keepit.common.actor.ActorInstance
-import com.keepit.common.plugin.{SchedulerPlugin, SchedulingProperties}
+import com.keepit.common.plugin.{ SchedulerPlugin, SchedulingProperties }
 import com.keepit.eliza.integrity.ElizaMessageThreadByMessageIntegrityActor
 import com.keepit.eliza.shoebox.ElizaKeepIngestingActor
-import com.kifi.juggle.ConcurrentTaskProcessingActor.{Close, IfYouCouldJustGoAhead}
+import com.kifi.juggle.ConcurrentTaskProcessingActor.{ Close, IfYouCouldJustGoAhead }
 
 import scala.concurrent.duration._
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminBookmarkController.scala
@@ -293,7 +293,7 @@ class AdminBookmarksController @Inject() (
     val chunkSize = 100
     val numPages = limit / chunkSize
     val enum = ChunkedResponseHelper.chunkedFuture(1 to numPages) { page =>
-      val keeps = db.readOnlyMaster(implicit s => keepRepo.pageAscendingWithUserExcludingSources(fromId, page * chunkSize, excludeStates = Set.empty, excludeSources = Set(KeepSource.slack, KeepSource.twitterFileImport, KeepSource.twitterSync)))
+      val keeps = db.readOnlyMaster(implicit s => keepRepo.pageAscendingWithUserExcludingSources(fromId, chunkSize, excludeStates = Set.empty, excludeSources = Set(KeepSource.slack, KeepSource.twitterFileImport, KeepSource.twitterSync)))
       def mightBeDiscussion(k: Keep) = k.source == KeepSource.discussion || (k.isActive && k.recipients.libraries.isEmpty && k.recipients.users.exists(uid => !k.userId.contains(uid)))
       val (discussionKeeps, otherKeeps) = keeps.partition(mightBeDiscussion)
       val discussionConnectionsFut = eliza.getInitialRecipientsByKeepId(discussionKeeps.map(_.id.get).toSet).map { connectionsByKeep =>


### PR DESCRIPTION
sync'd with @JRuff42. this should clean things up in the activity log, and there shouldn't be any confusion since notes are becoming comments and all other events will have a header that differentiates them from comments.

it can get pretty repetitive / unnecessary when most of the events are comments:
![screen shot 2016-04-11 at 5 37 29 pm](https://cloud.githubusercontent.com/assets/8929238/14469024/7c37a0e0-0097-11e6-934b-e0058962c0a3.png)
