### PR TITLE
More conservative interning logic

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/KeepRecipients.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepRecipients.scala
@@ -29,6 +29,11 @@ case class KeepRecipients(
   def union(that: KeepRecipients): KeepRecipients = KeepRecipients(libraries = libraries ++ that.libraries, users = users ++ that.users, emails = emails ++ that.emails)
   def union(that: Option[KeepRecipients]): KeepRecipients = that.fold(this)(_ union this)
 
+  def --(that: KeepRecipients) = KeepRecipientsDiff(
+    users = DeltaSet.addOnly(users).removeAll(that.users),
+    libraries = DeltaSet.addOnly(libraries).removeAll(that.libraries),
+    emails = DeltaSet.addOnly(emails).removeAll(that.emails)
+  )
   def diffed(diff: KeepRecipientsDiff) = this.copy(
     users = users ++ diff.users.added -- diff.users.removed,
     emails = emails ++ diff.emails.added -- diff.emails.removed,
@@ -81,6 +86,11 @@ case class KeepRecipientsDiff(users: DeltaSet[Id[User]], libraries: DeltaSet[Id[
   def isEmpty = this.users.isEmpty && this.libraries.isEmpty && this.emails.isEmpty
   def nonEmpty = !isEmpty
   def allEntities = (users.all, libraries.all, emails.all)
+  def onlyAdditions = KeepRecipientsDiff(
+    users = DeltaSet.addOnly(users.added),
+    libraries = DeltaSet.addOnly(libraries.added),
+    emails = DeltaSet.addOnly(emails.added)
+  )
 }
 object KeepRecipientsDiff {
   def addUser(user: Id[User]) = KeepRecipientsDiff(users = DeltaSet.empty.add(user), libraries = DeltaSet.empty, emails = DeltaSet.empty)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -422,7 +422,7 @@ class KeepCommanderImpl @Inject() (
         (oldKeep, keepRepo.save(oldKeep.withTitle(Some(title.trim))))
       }
     }
-    result.getRight.foreach {
+    result.foreach {
       case (oldKeep, newKeep) =>
         db.readWrite { implicit s =>
           keepMutator.unsafeModifyKeepRecipients(keepId, KeepRecipientsDiff.addUser(userId), Some(userId))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepMutator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepMutator.scala
@@ -31,6 +31,7 @@ import scala.util.Try
 trait KeepMutator {
   def persistKeep(k: Keep)(implicit session: RWSession): Keep
   def unsafeModifyKeepRecipients(keepId: Id[Keep], diff: KeepRecipientsDiff, userAttribution: Option[Id[User]])(implicit session: RWSession): Keep
+  def updateKeepTitle(oldKeep: Keep, newTitle: String)(implicit session: RWSession): Keep
   def updateKeepNote(userId: Id[User], oldKeep: Keep, newNote: String, freshTag: Boolean = true)(implicit session: RWSession): Keep
   def setKeepOwner(keep: Keep, newOwner: Id[User])(implicit session: RWSession): Keep
   def updateLastActivityAtIfLater(keepId: Id[Keep], lastActivityAt: DateTime)(implicit session: RWSession): Keep
@@ -87,6 +88,10 @@ class KeepMutatorImpl @Inject() (
       Try(collectionRepo.collectionChanged(c.id, c.isNewKeep, c.inactivateIfEmpty)) // deadlock prone
     }
     keep
+  }
+
+  def updateKeepTitle(oldKeep: Keep, newTitle: String)(implicit session: RWSession): Keep = {
+    keepRepo.save(oldKeep.withTitle(Some(newTitle)))
   }
 
   def setKeepOwner(keep: Keep, newOwner: Id[User])(implicit session: RWSession): Keep = {


### PR DESCRIPTION
If a keep exists on the same URI with a "similar enough" set of recipients,
we just update the recipients on that keep. If the new keep was manual,
we also update the title/note as appropriate.

"Similar enough" is Léo's libraries-then-participants logic.

@leogrim 
