### PR TITLE
Json schema for client API endpoints

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
@@ -1,6 +1,10 @@
 package com.keepit.common
 
+import com.keepit.common.crypto.PublicId
+import com.keepit.common.db.ExternalId
 import com.keepit.common.healthcheck.AirbrakeNotifierStatic
+import com.keepit.common.mail.EmailAddress
+import com.keepit.model.{Library, User}
 import play.api.data.validation.ValidationError
 import play.api.http.Status._
 import play.api.libs.functional.syntax._
@@ -81,8 +85,12 @@ package object json {
     def trivial[T](description: String)(implicit reads: Reads[T]) =
       SchemaReads(reads, JsonSchema.Single(description))
     implicit def seq[T](implicit sr: SchemaReads[T]): SchemaReads[Seq[T]] = SchemaReads(Reads.seq(sr.reads), JsonSchema.Array(sr.schema))
+    implicit def set[T](implicit sr: SchemaReads[T]): SchemaReads[Set[T]] = SchemaReads(Reads.set(sr.reads), JsonSchema.Array(sr.schema))
     implicit val int: SchemaReads[Int] = trivial("int")
     implicit val str: SchemaReads[String] = trivial("str")
+    implicit val userId: SchemaReads[ExternalId[User]] = trivial("user_id")
+    implicit val libraryId: SchemaReads[PublicId[Library]] = trivial("library_id")
+    implicit val email: SchemaReads[EmailAddress] = trivial("email")
 
     implicit class PimpedJsPath(jsp: JsPath) {
       def readWithSchema[T](implicit sr: SchemaReads[T]) =

--- a/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/json/package.scala
@@ -3,6 +3,8 @@ package com.keepit.common
 import com.keepit.common.healthcheck.AirbrakeNotifierStatic
 import play.api.data.validation.ValidationError
 import play.api.http.Status._
+import play.api.libs.functional.syntax._
+import play.api.libs.functional._
 import play.api.libs.json._
 import play.api.mvc.Result
 import play.api.mvc.Results.Status
@@ -58,20 +60,50 @@ package object json {
     }
   }
 
-  sealed abstract class JsonSchema
-  object JsonSchema {
-    final case class Single(description: String) extends JsonSchema
-    final case class Optional(field: JsonSchema) extends JsonSchema
-    final case class Array(kind: Single) extends JsonSchema
-    final case class Object(fields: Seq[(String, JsonSchema)]) extends JsonSchema
+  sealed abstract class JsonSchema {
+    def asJson: JsValue
   }
-  final case class SchemaReads[T](reads: Reads[T], schema: JsonSchema)
+  object JsonSchema {
+    final case class Single(description: String) extends JsonSchema { def asJson = JsString(description) }
+    final case class Optional(field: JsonSchema) extends JsonSchema { def asJson = field.asJson }
+    final case class Array(kind: JsonSchema) extends JsonSchema { def asJson = Json.arr(kind.asJson) }
+    final case class Object(fields: Seq[(String, JsonSchema)]) extends JsonSchema {
+      def asJson = JsObject(fields.map {
+        case (name, JsonSchema.Optional(schema)) => (name + "?") -> schema.asJson
+        case (name, schema) => name -> schema.asJson
+      })
+    }
+  }
+  final case class SchemaReads[T](reads: Reads[T], schema: JsonSchema) {
+    def map[S](f: T => S) = this.copy(reads = reads.map(f))
+  }
   object SchemaReads {
+    def trivial[T](description: String)(implicit reads: Reads[T]) =
+      SchemaReads(reads, JsonSchema.Single(description))
+    implicit def seq[T](implicit sr: SchemaReads[T]): SchemaReads[Seq[T]] = SchemaReads(Reads.seq(sr.reads), JsonSchema.Array(sr.schema))
+    implicit val int: SchemaReads[Int] = trivial("int")
+    implicit val str: SchemaReads[String] = trivial("str")
+
     implicit class PimpedJsPath(jsp: JsPath) {
       def readWithSchema[T](implicit sr: SchemaReads[T]) =
-        SchemaReads(jsp.read(sr.reads), JsonSchema.Object(Seq(jsp.toJsonString -> sr.schema)))
+        SchemaReads(jsp.read(sr.reads), JsonSchema.Object(Seq(jsp.path.map(_.toJsonString).mkString.stripPrefix(".") -> sr.schema)))
+
       def readNullableWithSchema[T](implicit sr: SchemaReads[T]) =
-        SchemaReads(jsp.readNullable(sr.reads), JsonSchema.Object(Seq(jsp.toJsonString -> JsonSchema.Optional(sr.schema))))
+        SchemaReads(jsp.readNullable(sr.reads), JsonSchema.Object(Seq(jsp.path.map(_.toJsonString).mkString.stripPrefix(".") -> JsonSchema.Optional(sr.schema))))
+    }
+
+    implicit val fcbSchemaReads: FunctionalCanBuild[SchemaReads] = new FunctionalCanBuild[SchemaReads] {
+      def apply[A, B](ma: SchemaReads[A], mb: SchemaReads[B]): SchemaReads[~[A, B]] = {
+        val newReads = implicitly[FunctionalCanBuild[Reads]].apply(ma.reads, mb.reads)
+        val newSchema = (ma.schema, mb.schema) match {
+          case (JsonSchema.Object(as), JsonSchema.Object(bs)) => JsonSchema.Object(as ++ bs)
+          case _ => throw new Exception("cannot functionally combine non-object schemas")
+        }
+        SchemaReads[~[A, B]](newReads, newSchema)
+      }
+    }
+    implicit val functorSchemaReads: Functor[SchemaReads] = new Functor[SchemaReads] {
+      def fmap[A, B](ma: SchemaReads[A], f: A => B): SchemaReads[B] = SchemaReads(ma.reads.map(f), ma.schema)
     }
   }
   object EnumFormat {

--- a/kifi-backend/modules/common/test/com/keepit/common/json/JsonTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/json/JsonTest.scala
@@ -132,6 +132,18 @@ class JsonTest extends Specification {
         hinter.hint(Json.obj("x" -> 1, "y" -> Seq(1, 2, 3))) === Json.obj("obj.y" -> "expected a string", "obj.z" -> "required field")
       }
     }
+    "generate full schemas" in {
+      "trivially" in {
+        case class Foo(x: Int, y: String, z: Seq[String])
+        object Foo {
+          val schemaReads: SchemaReads[Foo] = (
+            (__ \ 'x).read[Int] and
+            (__ \ 'y).read[String] and
+            (__ \ 'z).read[Seq[String]]
+          )(Foo.apply _)
+        }
+      }
+    }
   }
 
 }

--- a/kifi-backend/modules/common/test/com/keepit/common/json/JsonTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/json/JsonTest.scala
@@ -133,15 +133,49 @@ class JsonTest extends Specification {
       }
     }
     "generate full schemas" in {
-      "trivially" in {
+      "for a simple case class" in {
         case class Foo(x: Int, y: String, z: Seq[String])
         object Foo {
+          import SchemaReads._
           val schemaReads: SchemaReads[Foo] = (
-            (__ \ 'x).read[Int] and
-            (__ \ 'y).read[String] and
-            (__ \ 'z).read[Seq[String]]
+            (__ \ 'x).readWithSchema[Int] and
+            (__ \ 'y).readWithSchema[String] and
+            (__ \ 'z).readWithSchema[Seq[String]]
           )(Foo.apply _)
         }
+        Foo.schemaReads.schema.asJson === Json.obj(
+          "x" -> "int",
+          "y" -> "str",
+          "z" -> Json.arr("str")
+        )
+        1 === 1
+      }
+      "for nested garbage" in {
+        case class A(b: B, c: C)
+        case class B(c: Option[C], D: D)
+        case class C(x: Int, y: Option[String])
+        case class D(value: Long)
+        object ABC {
+          import SchemaReads._
+          implicit val dsr: SchemaReads[D] = SchemaReads.trivial("D")(Reads.IntReads.map(D(_)))
+          implicit val csr: SchemaReads[C] = (
+            (__ \ 'x).readWithSchema[Int] and
+            (__ \ 'y).readNullableWithSchema[String]
+          )(C.apply _)
+          implicit val bsr: SchemaReads[B] = (
+            (__ \ 'c).readNullableWithSchema[C] and
+            (__ \ 'd).readWithSchema[D]
+          )(B.apply _)
+          implicit val asr: SchemaReads[A] = (
+            (__ \ 'b).readWithSchema[B] and
+            (__ \ 'c).readWithSchema[C]
+          )(A.apply _)
+        }
+        println(Json.prettyPrint(ABC.asr.schema.asJson))
+        ABC.dsr.schema.asJson === JsString("D")
+        ABC.csr.schema.asJson === Json.obj("x" -> "int", "y?" -> "str")
+        ABC.bsr.schema.asJson === Json.obj("c?" -> ABC.csr.schema.asJson, "d" -> "D")
+        ABC.asr.schema.asJson === Json.obj("b" -> ABC.bsr.schema.asJson, "c" -> ABC.csr.schema.asJson)
       }
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/client/PageInfoController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/client/PageInfoController.scala
@@ -4,6 +4,7 @@ import com.google.inject.Inject
 import com.keepit.commanders.KeepQuery.ForUri
 import com.keepit.common.json
 import com.keepit.common.core.anyExtensionOps
+import com.keepit.common.json.SchemaReads
 import com.keepit.common.performance.Stopwatch
 import com.keepit.common.util.RightBias
 import com.keepit.common.util.RightBias._
@@ -72,18 +73,21 @@ class PageInfoController @Inject() (
   }
 
   private object GetKeepsByUriAndRecipients {
+    import json.SchemaReads._
     final case class GetKeepsByUriAndRecipients(
       url: String,
       users: Set[ExternalId[User]],
       libraries: Set[PublicId[Library]],
       emails: Set[EmailAddress])
-    implicit val inputReads: Reads[GetKeepsByUriAndRecipients] = (
-      (__ \ 'url).read[String] and
-      (__ \ 'users).readNullable[Set[ExternalId[User]]].map(_ getOrElse Set.empty) and
-      (__ \ 'libraries).readNullable[Set[PublicId[Library]]].map(_ getOrElse Set.empty) and
-      (__ \ 'emails).readNullable[Set[EmailAddress]].map(_ getOrElse Set.empty)
+    val schemaReads: SchemaReads[GetKeepsByUriAndRecipients] = (
+      (__ \ 'url).readWithSchema[String] and
+      (__ \ 'users).readNullableWithSchema[Set[ExternalId[User]]].map(_ getOrElse Set.empty) and
+      (__ \ 'libraries).readNullableWithSchema[Set[PublicId[Library]]].map(_ getOrElse Set.empty) and
+      (__ \ 'emails).readNullableWithSchema[Set[EmailAddress]].map(_ getOrElse Set.empty)
     )(GetKeepsByUriAndRecipients.apply _)
-    val schema = json.schemaHelper(inputReads)
+    implicit val reads = schemaReads.reads
+    val schema = schemaReads.schema
+    val schemaHelper = json.schemaHelper(reads)
     val outputWrites: Writes[NewKeepInfosForPage] = NewKeepInfosForPage.writes
   }
   def getKeepsByUriAndRecipients() = UserAction.async(parse.tolerantJson) { implicit request =>
@@ -100,7 +104,7 @@ class PageInfoController @Inject() (
     } yield getKeepInfosForPage(request.userId, input.url, KeepRecipients.EMPTY)
 
     resultIfEverythingChecksOut.fold(
-      fail => Future.successful(BadRequest(Json.obj("err" -> fail, "hint" -> schema.hint(request.body)))),
+      fail => Future.successful(BadRequest(Json.obj("err" -> fail, "expected" -> schema.asJson, "hint" -> schemaHelper.hint(request.body)))),
       result => result.map(ans => Ok(outputWrites.writes(ans)))
     )
   }


### PR DESCRIPTION
This PR introduces three things:
    1. `JsonSchema`, which is an abstraction of the structure of a `case class` that can be serialized to a `JsValue`
    2. `SchemaReads[T]`, which is basically a pair `(Reads[T], JsonSchema)`, combining the deserialization with the input structure expected
    3. A functional combinator that allows pretty straightforward creation of complex `SchemaReads[T]`. It behaves exactly like the functional combinators for `Reads[T]`, `Writes[T]`, and `Format[T]`.

@andrewconner @camhashemi @leogrim 
