### PR TITLE
Use following-sibling selector to prevent flash

### DIFF
--- a/packrat/styles/keeper/thread.css
+++ b/packrat/styles/keeper/thread.css
@@ -37,10 +37,10 @@
 .kifi-message-sent-header-item a[href]:hover {
   text-decoration: underline!important;
 }
-.kifi-message-sent.kifi-message-sent.kifi-message-sent:last-of-type .kifi-message-sent-stamp {
+.kifi-message-sent:last-of-type .kifi-message-sent-stamp {
   display: block;
 }
-.kifi-messages-sent-inner:hover .kifi-message-sent:last-of-type .kifi-message-sent-stamp {
+.kifi-message-sent:hover ~ .kifi-message-sent:last-of-type .kifi-message-sent-stamp {
   display: none;
 }
 .kifi-message-sent.kifi-message-sent.kifi-message-sent:hover .kifi-message-sent-stamp {


### PR DESCRIPTION
@andrewconner this is more-correct behavior, and a bit more elegant.
