### PR TITLE
Request a lot more tags, to avoid issues where we order them wrong across boundaries

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/tagManage/manageTagService.js
+++ b/kifi-backend/modules/shoebox/angular/src/tagManage/manageTagService.js
@@ -7,7 +7,7 @@ angular.module('kifi')
   function ($http, $q, $state, $analytics, routeService, undoService, Clutch) {
 
     var pageClutch = new Clutch(function (sort, offset) {
-      return $http.get(routeService.pageTags(sort, offset, 100)).then(function (res) {
+      return $http.get(routeService.pageTags(sort, offset, 300)).then(function (res) {
         return res.data.tags;
       });
     });
@@ -16,7 +16,7 @@ angular.module('kifi')
       if (!query || !query.trim()) {
         return $q.when([]);
       }
-      return $http.get(routeService.searchTags(query, 30)).then(function (res) {
+      return $http.get(routeService.searchTags(query, 100)).then(function (res) {
         return _.map(res.data.results, function (r) {
           return {name: r.tag, keeps: r.keepCount};
         });


### PR DESCRIPTION
@cvializ So right now, for boring technical reasons, tags come from two different tables. This makes paginating across them really hard, because each data source is ordered, but we don't know the ordering amongst those sources. So: we'll ask for a lot more tags, to minimize the problems. Not really a real fix, but should keep users feeling alright. This hybrid thing is going away soon
