### PR TITLE
`suggestRecipients` /api/ route, drop → offset

### DIFF
--- a/kifi-backend/modules/shoebox/conf/shoeboxClient.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxClient.routes
@@ -23,6 +23,8 @@ GET    /api/1/keeps/stream           @com.keepit.controllers.client.KeepInfoCont
 
 GET    /api/1/keeps/:id              @com.keepit.controllers.client.KeepInfoController.getKeepView(id: PublicId[Keep])
 GET    /api/1/keeps/:id/activity     @com.keepit.controllers.client.KeepInfoController.getActivityOnKeep(id: PublicId[Keep], limit: Int ?= 10, fromTime: Option[DateTime] ?= None)
+GET    /api/1/keeps/suggestRecipients @com.keepit.controllers.client.KeepInfoController.suggestRecipient(query: Option[String], limit: Option[Int], offset: Option[Int], requested: Option[String])
+
 
 # Exports
 GET    /api/1/keeps/export/personal  @com.keepit.controllers.client.KeepExportController.exportPersonalKeeps()


### PR DESCRIPTION
@DerekBurch @cvializ FYI, this exists now if you want to unify on /api/ endpoints. Take note that `drop` was renamed to `offset` at the quest of Derek.

Syntax examples:

Suggest 50 libraries:
https://www.kifi.com/api/1/keeps/suggestRecipients?query=&requested=library&limit=50

Suggest libraries 20 libraries, paginated after 50:
https://www.kifi.com/api/1/keeps/suggestRecipients?query=&requested=library&limit=20&offset=50

Suggest 40 people and libraries:
https://www.kifi.com/api/1/keeps/suggestRecipients?query=&limit=40

Suggest 40 people:
https://www.kifi.com/api/1/keeps/suggestRecipients?query=&requested=user,email&limit=40

Search through libraries, get 20:
https://www.kifi.com/api/1/keeps/suggestRecipients?query=gener&requested=library&limit=20

Search through people and libraries, get 15:
https://www.kifi.com/api/1/keeps/suggestRecipients?query=ge&limit=15
