### PR TITLE
Better tag suggestion, faster backfiller

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/client/KeepInfoController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/client/KeepInfoController.scala
@@ -105,7 +105,7 @@ class KeepInfoController @Inject() (
 
   def suggestTags(keepIdStr: Option[String], query: Option[String], limit: Option[Int]) = UserAction.async { request =>
     val keepId = keepIdStr.flatMap(Keep.decodePublicIdStr(_).toOption)
-    keepCommander.suggestTags(request.userId, None, query, limit.getOrElse(10)).imap { tagsAndMatches =>
+    keepCommander.suggestTags(request.userId, keepId, query, limit.getOrElse(10)).imap { tagsAndMatches =>
       implicit val matchesWrites = TupleFormat.tuple2Writes[Int, Int]
       val result = JsArray(tagsAndMatches.map { case (tag, matches) => json.aggressiveMinify(Json.obj("tag" -> tag, "matches" -> matches)) })
       Ok(result)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/LibraryController.scala
@@ -554,7 +554,8 @@ class LibraryController @Inject() (
   }
 
   def suggestTags(pubId: PublicId[Library], keepId: ExternalId[Keep], query: Option[String], limit: Int) = (UserAction andThen LibraryWriteAction(pubId)).async { request =>
-    keepsCommander.suggestTags(request.userId, Some(keepId), query, limit).imap { tagsAndMatches =>
+    val keepIdOpt = db.readOnlyReplica { implicit s => keepRepo.getOpt(keepId).flatMap(_.id) }
+    keepsCommander.suggestTags(request.userId, keepIdOpt, query, limit).imap { tagsAndMatches =>
       implicit val matchesWrites = TupleFormat.tuple2Writes[Int, Int]
       val result = JsArray(tagsAndMatches.map { case (tag, matches) => json.aggressiveMinify(Json.obj("tag" -> tag, "matches" -> matches)) })
       Ok(result)


### PR DESCRIPTION
Allows tags to be suggested when no keep is provided, using the user's most recent tags.
