### PR TITLE
Add BasicKeepEventId to all events, split out note

### DIFF
--- a/kifi-backend/modules/common/test/com/keepit/common/util/DescriptionElementsTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/util/DescriptionElementsTest.scala
@@ -1,9 +1,10 @@
 package com.keepit.common.util
 
 import com.keepit.common.crypto.PublicId
+import com.keepit.common.db.Id
 import com.keepit.common.time._
 import com.keepit.model.BasicKeepEvent.BasicKeepEventId
-import com.keepit.model.{ BasicKeepEvent, KeepEventKind, LibraryVisibility, Library, BasicLibrary }
+import com.keepit.model._
 import com.keepit.social.BasicAuthor
 import org.joda.time.{ Duration, DateTime, Period }
 import org.specs2.mutable.Specification
@@ -51,7 +52,7 @@ class DescriptionElementsTest extends Specification {
       val body = DescriptionElements("Here is a note with [#hashtags] all over") // maybe todo(Cam): create a HashtagElement
 
       val event = BasicKeepEvent(
-        id = BasicKeepEventId.initial,
+        id = BasicKeepEventId.InitialId(PublicId[Keep]("k4RmCCOy1adz")),
         author = author,
         KeepEventKind.Initial,
         header = header,

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
@@ -109,9 +109,9 @@ object SystemMessageData {
       val emails = addedNonUsers.collect {
         case NonUserEmailParticipant(email) => email
       }.toSet
-      Some(KeepEventData.ModifyRecipients(addedBy, KeepRecipientsDiff(users = DeltaSet.empty.addAll(addedUsers.toSet), libraries = DeltaSet.empty, emails = DeltaSet.empty.addAll(emails))))
+      Some(KeepEventData.ModifyRecipients(addedBy, KeepRecipientsDiff(users = DeltaSet.addOnly(addedUsers.toSet), libraries = DeltaSet.empty, emails = DeltaSet.addOnly(emails))))
     case AddLibraries(addedBy, addedLibraries) =>
-      Some(KeepEventData.ModifyRecipients(addedBy, KeepRecipientsDiff(users = DeltaSet.empty, libraries = DeltaSet.empty.addAll(addedLibraries), emails = DeltaSet.empty)))
+      Some(KeepEventData.ModifyRecipients(addedBy, KeepRecipientsDiff(users = DeltaSet.empty, libraries = DeltaSet.addOnly(addedLibraries), emails = DeltaSet.empty)))
     case EditTitle(editedBy, original, updated) =>
       Some(KeepEventData.EditTitle(editedBy, original, updated))
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/data/assemblers/KeepActivityAssembler.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/data/assemblers/KeepActivityAssembler.scala
@@ -78,7 +78,7 @@ class KeepActivityAssemblerImpl @Inject() (
   }
 
   def getActivityForKeep(keepId: Id[Keep], fromTime: Option[DateTime], limit: Int): Future[KeepActivity] = {
-    getActivityForKeeps(Set(keepId), fromTime, limit).map(_.getOrElse(keepId, throw new Exception()))
+    getActivityForKeeps(Set(keepId), fromTime, limit).map(_.getOrElse(keepId, throw new Exception(s"Could not generate activity for keep $keepId")))
   }
 
   private def keepActivityAssemblyHelper(

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepActivityGenTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepActivityGenTest.scala
@@ -74,7 +74,7 @@ class KeepActivityGenTest extends Specification with ShoeboxTestInjector {
         implicit val info = SerializationInfo(basicUserById, basicLibById, orgByLibraryId = Map.empty)
         val activity = KeepActivityGen.generateKeepActivity(keep, sourceAttrOpt = None, events = events, discussionOpt = None, ktls = Seq.empty, ktus, maxEvents = 5)
 
-        activity.events.size === 5
+        activity.events.size === 5 // NB(ryan): There may be 6 events because of "event-splitting" with the note
         activity.events.map { event => DescriptionElements.formatPlain(event.header) } === (eventHeaders.reverse :+ "Benjamin Button kept this")
 
         val jsActivity = Json.toJson(activity)


### PR DESCRIPTION
All events now have an id. For "implicit" events (ones that are not explicitly
persisted in the keep_event table, i.e., initial/note events) there is a
pseudo-id of the form "init_<keep-id>" or "note_<keep-id>". This is simpler
to the frontend and more uniform on the backend.

The note event is always paired with the initial keep event. This means that
sometimes we will send down more than the requested number of events. Talked to
Carlos and I don't think this will be an issue.

@camhashemi @cvializ @leogrim 
