### PR TITLE
bug fixes

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
@@ -73,7 +73,12 @@ case class Keep(
 
   def isOlderThan(other: Keep): Boolean = keptAt < other.keptAt || (keptAt == other.keptAt && id.get.id < other.id.get.id)
 
-  def titlePathString = this.title.getOrElse(this.url).trim.replaceAll("^https?://", "").replaceAll("[^A-Za-z0-9]", " ").replaceAll("  *", "-").replaceAll("^-|-$", "").take(40)
+  def titlePathString = {
+    Stream(this.title, Some(this.url))
+      .map(_.map(_.trim.replaceAll("^https?://", "").replaceAll("[^A-Za-z0-9]", " ").replaceAll("  *", "-").replaceAll("^-|-$", "").take(40)))
+      .find(_.nonEmpty)
+      .getOrElse("keep")
+  }
 
   def path(implicit config: PublicIdConfiguration) = Path(s"k/$titlePathString/${Keep.publicId(this.id.get).id}")
 

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/activityEvent/activityEvent.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/activityEvent/activityEvent.tpl.html
@@ -41,10 +41,10 @@
       </span>
     </div>
     <div class="kf-keep-activity-event-body"
-         ng-if="body.length && activityEvent.kind !== 'initial'"
+         ng-if="body.length && activityEvent.kind !== 'note'"
          kf-activity-event-segments="body">
     </div>
-    <div class="kf-keep-card-note-container" ng-if="activityEvent.kind === 'initial'">
+    <div class="kf-keep-card-note-container" ng-if="activityEvent.kind === 'note'">
       <div class="kf-keep-card-note" ng-show="::keep.displayNote"><!--
           --><span ng-if="!keep.noteAttribution" ng-bind-html="::keep.displayNote|noteHtml"></span><!--
           --><span ng-if="keep.noteAttribution" ng-bind-html="::keep.displayNote"></span>


### PR DESCRIPTION
@ryanpbrewster 1) made a keep such that `keep.title == ""`, so it was filtered out of `titlePathString` and broke `keep.path`, 2) the site uses `keep.note` for the initial event so that it can utilize the note/hashtag parser, which led to duplicates once we sent down a separate `event.kind == note` object. Soon enough we should have all comments using the hashtag parser.
