### PR TITLE
return back to referrer url upon slack auth failure (dm invite flow)

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSlackBox.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/orgProfile/orgProfileSlackBox.tpl.html
@@ -2,7 +2,7 @@
   <span class="kf-org-profile-slack-box-title">Get access to your Slack team's libraries of links on Kifi</span>
   <a
     class="kf-button kf-button-large kf-org-profile-slack-box-button"
-    ng-href="{{ 'https://www.kifi.com/signup/slack?slackTeamId=' + slackTeamId }}"
+    ng-href="{{ 'https://www.kifi.com/signup/slack?returnOnFail=true&slackTeamId=' + slackTeamId }}"
     target="_self"
     ng-click="linkSlack($event)"
     ng-show="!requestFailed"

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/routing/SlackAuthRouter.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/routing/SlackAuthRouter.scala
@@ -204,7 +204,7 @@ class SlackAuthRouter @Inject() (
 
     val slackAuthPage = pathCommander.orgPage(org) + s"?$modelParams&slackTeamId=${slackTeamId.value}"
 
-    Redirect(slackAuthPage.absolute).withSession(request.session + (SecureSocial.OriginalUrlKey -> url)).withCookies(Cookie(PostRegIntent.onFailUrlKey, slackAuthPage.absolute))
+    Redirect(slackAuthPage.absolute).withSession(request.session + (SecureSocial.OriginalUrlKey -> url))
   }
 
   private def notFound(request: MaybeUserRequest[_]): Result = {

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -55,7 +55,7 @@ GET     /link/:provider             @com.keepit.controllers.core.AuthController.
 
 GET     /slack-connect              @com.keepit.controllers.core.AuthController.connectWithSlack()
 GET     /slack-connect/go           @com.keepit.controllers.core.AuthController.connectWithSlackGo()
-GET     /integrations/slack/start   @com.keepit.controllers.core.AuthController.startWithSlack(slackTeamId: Option[SlackTeamId] ?= None, extraScopes: Option[String] ?= None)
+GET     /integrations/slack/start   @com.keepit.controllers.core.AuthController.startWithSlack(slackTeamId: Option[SlackTeamId] ?= None, extraScopes: Option[String] ?= None, returnOnFail: Boolean ?= false)
 
 GET     /signup/:provider           @com.keepit.controllers.core.AuthController.signup(provider: String, publicLibraryId: Option[String] ?= None, intent: Option[String] ?= None, libAuthToken: Option[String] ?= None, publicOrgId: Option[String] ?= None, orgAuthToken: Option[String] ?= None, publicKeepId: Option[String] ?= None, keepAuthToken: Option[String] ?= None, slackTeamId: Option[String] ?= None, slackExtraScopes: Option[String] ?= None)
 


### PR DESCRIPTION
@leogrim @cvializ previously we were only making the slack auth widget flow redirect back to a DM invite widget when you were routed through a Kifi redirect in slack. now you should be routed back to the DM invite no matter where you fail from.
