### PR TITLE
One solution for keeping the note editable and allowing new notes

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/activityEvent/activityEvent.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/activityEvent/activityEvent.tpl.html
@@ -41,14 +41,13 @@
       </span>
     </div>
     <div class="kf-keep-activity-event-body"
-         ng-if="body.length && activityEvent.kind !== 'note'"
+         ng-if="body.length && activityEvent.kind !== 'initial'"
          kf-activity-event-segments="body">
     </div>
-    <div class="kf-keep-card-note-container" ng-if="activityEvent.kind === 'note'">
+    <div class="kf-keep-card-note-container" ng-if="activityEvent.kind === 'initial'">
       <div class="kf-keep-card-note" ng-show="::keep.displayNote"><!--
           --><span ng-if="!keep.noteAttribution" ng-bind-html="::keep.displayNote|noteHtml"></span><!--
           --><span ng-if="keep.noteAttribution" ng-bind-html="::keep.displayNote"></span>
-          <span ng-if="keep.noteAttribution" class="kf-keep-card-note-via" ng-bind-template="(via {{keep.noteAttribution}})"></span>
       </div>
       <button class="kf-keep-card-add-note" ng-click="editKeepNote($event, keep)"
               ng-if="editKeepNote && !keep.displayNote && keep.author.id === me.id">Add a note


### PR DESCRIPTION
Ignore note events from the server and just go back to combining them with the initial event. This allows notes to remain editable (and allows new notes to be added). If we instead only allow editing of note events then no new notes can be added.
