### PR TITLE
Edit notes properly through KeepCommander

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/util/RightBias.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/RightBias.scala
@@ -25,7 +25,7 @@ final class RightBias[L, R](ethr: Either[L, R]) {
 }
 
 object RightBias {
-  val unit: RightBias[Nothing, Unit] = right(())
+  def unit[L]: RightBias[L, Unit] = right(())
 
   def cond[L, R](test: => Boolean, r: => R, l: => L): RightBias[L, R] = new RightBias(Either.cond(test, r, l))
   def right[L, R](r: => R): RightBias[L, R] = new RightBias(Right(r))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepMutator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepMutator.scala
@@ -74,7 +74,6 @@ class KeepMutatorImpl @Inject() (
   // Updates note on keep, making sure tags are in sync.
   // i.e., the note is the source of truth, and tags are added/removed appropriately
   def updateKeepNote(userId: Id[User], oldKeep: Keep, newNote: String)(implicit session: RWSession): Keep = {
-    // todo IMPORTANT: check permissions here, this lets anyone edit anyone's keep.
     val noteToPersist = Some(newNote.trim).filter(_.nonEmpty)
     val updatedKeep = oldKeep.withOwner(userId).withNote(noteToPersist)
 
@@ -84,7 +83,6 @@ class KeepMutatorImpl @Inject() (
 
     session.onTransactionSuccess {
       searchClient.updateKeepIndex()
-      slackPusher.schedule(oldKeep.recipients.libraries)
     }
 
     syncTagsFromNote(updatedKeep, userId)

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtLibraryController.scala
@@ -2,6 +2,7 @@ package com.keepit.controllers.ext
 
 import com.google.inject.Inject
 import com.keepit.commanders._
+import com.keepit.common.util.RightBias._
 import com.keepit.common.akka.SafeFuture
 import com.keepit.common.controller.{ UserActions, UserActionsHelper, ShoeboxServiceController, _ }
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
@@ -35,7 +36,6 @@ class ExtLibraryController @Inject() (
   libraryMembershipCommander: LibraryMembershipCommander,
   libraryImageCommander: LibraryImageCommander,
   keepsCommander: KeepCommander,
-  keepMutator: KeepMutator,
   basicUserRepo: BasicUserRepo,
   libRepo: LibraryRepo,
   libraryMembershipRepo: LibraryMembershipRepo,
@@ -308,21 +308,15 @@ class ExtLibraryController @Inject() (
   }
 
   def editKeepNote(libraryPubId: PublicId[Library], keepExtId: ExternalId[Keep]) = UserAction(parse.tolerantJson) { request =>
-    decode(libraryPubId) { libraryId =>
-      db.readOnlyMaster { implicit s =>
-        keepRepo.getOpt(keepExtId)
-      } match {
-        case None =>
-          NotFound(Json.obj("error" -> "keep_id_not_found"))
-        case Some(keep) =>
-          val body = request.body.as[JsObject]
-          val newNote = (body \ "note").as[String]
-          db.readWrite { implicit session =>
-            keepMutator.updateKeepNote(request.userId, keep, newNote)
-          }
-          NoContent
-      }
-    }
+    val resultIfEverythingWentWell = for {
+      keepId <- db.readOnlyMaster { implicit s => Try(keepRepo.convertExternalId(keepExtId)).toOption }.withLeft(KeepFail.INVALID_KEEP_ID: KeepFail)
+      newNote <- (request.body \ "note").asOpt[String].withLeft(KeepFail.COULD_NOT_PARSE: KeepFail)
+      updatedKeep <- keepsCommander.updateKeepNote(keepId, request.userId, newNote)
+    } yield updatedKeep
+    resultIfEverythingWentWell.fold(
+      fail => fail.asErrorResponse,
+      updatedKeep => NoContent
+    )
   }
 
   def suggestTags(pubId: PublicId[Library], keepId: ExternalId[Keep], query: Option[String], limit: Int) = (UserAction andThen LibraryWriteAction(pubId)).async { request =>


### PR DESCRIPTION
In the process I removed KeepMutator from most controllers.
My dream is to have all controllers interact with commanders,
which bundle business logic to handle user-initiated requests.

Any system-driven requests should be routed through KeepMutator,
which is essentially a write-only repo that handles multiple tables.

@leogrim this is why your keeps weren't being updated sometimes
