### PR TITLE
[#115540530896398] Do not add wrapper span to DOM.

### DIFF
--- a/packrat/scripts/keep_note.js
+++ b/packrat/scripts/keep_note.js
@@ -400,7 +400,7 @@ k.keepNote = k.keepNote || (function () {
           }
           data.$suggestions
             .empty()
-            .append(k.formatting.parseStringToElement(results.map(formatTagSuggestion).join('')))
+            .append(k.formatting.parseStringToElement(results.map(formatTagSuggestion).join('')).childNodes)
             .position(data.$suggestions.data('position'));
           selectSuggestion(data, data.$suggestions[0].firstChild);
         } else if (data.$suggestions) {


### PR DESCRIPTION
An extra wrapper span was messing up code that assumed the `.kifi-tag-suggestion` elements were direct children of the `.kifi-tag-suggestions` element.
