### PR TITLE
Fixes library typeahead being wrong on some mutation actions

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/FortyTwoGlobal.scala
+++ b/kifi-backend/modules/common/app/com/keepit/FortyTwoGlobal.scala
@@ -298,7 +298,7 @@ abstract class FortyTwoGlobal(val mode: Mode.Mode)
 
   private def speaksJson(request: RequestHeader) = {
     // todo: check if request.accepts works better
-    request.path.startsWith("/site/") || request.path.startsWith("/m/") || request.path.startsWith("/ext/") || request.path.startsWith("/search/") || request.path.startsWith("/eliza/")
+    request.path.startsWith("/site/") || request.path.startsWith("/m/") || request.path.startsWith("/ext/") || request.path.startsWith("/search/") || request.path.startsWith("/eliza/") || request.path.startsWith("/api/")
   }
 
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/typeahead/LibraryTypeahead.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/typeahead/LibraryTypeahead.scala
@@ -3,6 +3,7 @@ package com.keepit.typeahead
 import com.amazonaws.services.s3.AmazonS3
 import com.google.inject.{ Provider, Inject }
 import com.keepit.commanders._
+import com.keepit.common.concurrent.FutureHelpers
 import com.keepit.common.core._
 import com.keepit.common.akka.SafeFuture
 import com.keepit.common.cache.TransactionalCaching.Implicits.directCacheAccess
@@ -65,6 +66,17 @@ class LibraryTypeahead @Inject() (
       }
     }
     Future.successful(filterOpt.map(filter => PersonalTypeahead(userId, filter, getInfos(userId))))
+  }
+
+  // Useful on library creation, name changes, or when it's deleted
+  def refreshForAllCollaborators(libraryId: Id[Library]): Future[Unit] = {
+    db.readOnlyReplicaAsync { implicit s =>
+      libraryMembershipRepo.getCollaboratorsByLibrary(Set(libraryId)).values.headOption
+    }.flatMap {
+      case Some(userIds) =>
+        FutureHelpers.sequentialExec(userIds)(refresh)
+      case None => Future.successful(())
+    }
   }
 
   private def getInfos(userId: Id[User])(ids: Seq[Id[Library]]): Future[Seq[LibraryTypeaheadResult]] = {


### PR DESCRIPTION
@leogrim We have a bug where the typeahead doesn't get updated for some library actions (creation, deletion, modification). This should fix it. Currently, you have to wait as much as 15 minutes before it shows up.
