### PR TITLE
More defensiveness regarding inactive libraries

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
@@ -470,24 +470,25 @@ class TypeaheadCommander @Inject() (
 
       (libs, collaborators, memberships, permissions, basicUserById, orgAvatarsById)
     }
-    libs.map { lib =>
-      val collabs = (collaborators.getOrElse(lib.id.get, Set.empty) - userId).map(basicUserById(_)).toSeq
-      val orgAvatarPath = lib.organizationId.flatMap { orgId => orgAvatarsById.get(orgId).map(_.imagePath) }
-      val membershipInfo = memberships.get(lib.id.get).map { mem =>
-        LibraryMembershipInfo(mem.access, mem.listed, mem.subscribedToUpdates, permissions.getOrElse(lib.id.get, Set.empty))
-      }
+    libs.collect {
+      case lib if lib.isActive =>
+        val collabs = (collaborators.getOrElse(lib.id.get, Set.empty) - userId).map(basicUserById(_)).toSeq
+        val orgAvatarPath = lib.organizationId.flatMap { orgId => orgAvatarsById.get(orgId).map(_.imagePath) }
+        val membershipInfo = memberships.get(lib.id.get).map { mem =>
+          LibraryMembershipInfo(mem.access, mem.listed, mem.subscribedToUpdates, permissions.getOrElse(lib.id.get, Set.empty))
+        }
 
-      lib.id.get -> LibraryResult(
-        id = Library.publicId(lib.id.get),
-        name = lib.name,
-        color = lib.color,
-        visibility = lib.visibility,
-        path = pathCommander.getPathForLibrary(lib),
-        hasCollaborators = collabs.nonEmpty,
-        collaborators = collabs,
-        orgAvatar = orgAvatarPath,
-        membership = membershipInfo
-      )
+        lib.id.get -> LibraryResult(
+          id = Library.publicId(lib.id.get),
+          name = lib.name,
+          color = lib.color,
+          visibility = lib.visibility,
+          path = pathCommander.getPathForLibrary(lib),
+          hasCollaborators = collabs.nonEmpty,
+          collaborators = collabs,
+          orgAvatar = orgAvatarPath,
+          membership = membershipInfo
+        )
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -168,7 +168,7 @@ class LibraryRepoImpl @Inject() (
     idCache.bulkGetOrElse(ids.map(LibraryIdKey)) { missingKeys =>
       val q = rows.filter(lib => lib.id.inSet(missingKeys.map(_.id)) && lib.state === LibraryStates.ACTIVE)
       q.list.map { x => LibraryIdKey(x.id.get) -> x }.toMap
-    }.map { case (key, lib) => key.id -> lib }
+    }.collect { case (key, lib) if lib.isActive => key.id -> lib }
   }
 
   override def deleteCache(library: Library)(implicit session: RSession): Unit = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/typeahead/LibraryTypeahead.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/typeahead/LibraryTypeahead.scala
@@ -106,8 +106,8 @@ class LibraryTypeahead @Inject() (
   def getAllRelevantLibraries(id: Id[User]): Seq[(Id[Library], LibraryTypeaheadResult)] = {
     db.readOnlyReplica { implicit session =>
       libraryInfoCommander.get.getLibrariesUserCanKeepTo(id, includeOrgLibraries = true)
-    }.map {
-      case (l, mOpt, _) =>
+    }.collect {
+      case (l, mOpt, _) if l.isActive =>
         l.id.get -> LibraryTypeaheadResult(l.id.get, l.name, calcImportance(l, mOpt))
     }
   }


### PR DESCRIPTION
I'm finding deleted libraries in my suggested libraries list. Tracing it through, I can't find exactly what is mapping from `Id[Library]` to `Library` for deleted libraries, but it's happening (the Ids are coming from the append-only recent interactions list).

`libToResult` is indeed using `libraryRepo.getActiveByIds`, and that query does use `lib.state === LibraryStates.ACTIVE` (and in the db, it's `inactive`). So my only guess is a messed up cache or something equally as strange. Seeing if these simple filters fix it.

@eishay 
