### PR TITLE
add new web hook push "thread_recipients" which includes libraries

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -82,6 +82,7 @@ object Shoebox extends Service {
     def getUsers(ids: String) = ServiceRoute(GET, "/internal/shoebox/database/getUsers", Param("ids", ids))
     def getUserIdsByExternalIds() = ServiceRoute(POST, "/internal/shoebox/database/userIdsByExternalIds")
     def getBasicUsers() = ServiceRoute(POST, "/internal/shoebox/database/getBasicUsers")
+    def getRecipientsOnKeep(keepId: Id[Keep]) = ServiceRoute(GET, "/internal/shoebox/database/getRecipientsOnKeep", Param("keepId", keepId))
     def getEmailAddressesForUsers() = ServiceRoute(POST, "/internal/shoebox/database/getEmailAddressesForUsers")
     def getEmailAddressForUsers() = ServiceRoute(POST, "/internal/shoebox/database/getEmailAddressForUsers")
     def getUserOpt(id: ExternalId[User]) = ServiceRoute(GET, "/internal/shoebox/database/getUserOpt", Param("id", id))

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -390,6 +390,8 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, impli
     Future.successful(basicUsers)
   }
 
+  def getRecipientsOnKeep(keepId: Id[Keep]): Future[(Map[Id[User], BasicUser], Map[Id[Library], BasicLibrary], Set[EmailAddress])] = ???
+
   def getEmailAddressesForUsers(userIds: Set[Id[User]]): Future[Map[Id[User], Seq[EmailAddress]]] = {
     val m = userIds.map { id => id -> allUserEmails.getOrElse(id, Set.empty).toSeq }.toMap
     Future.successful(m)

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -623,6 +623,7 @@ POST    /internal/shoebox/database/internNormalizedURI                 @com.keep
 GET     /internal/shoebox/database/getUsers                            @com.keepit.controllers.internal.ShoeboxController.getUsers(ids: String)
 POST    /internal/shoebox/database/userIdsByExternalIds                @com.keepit.controllers.internal.ShoeboxController.getUserIdsByExternalIds()
 POST    /internal/shoebox/database/getBasicUsers                       @com.keepit.controllers.internal.ShoeboxController.getBasicUsers()
+GET     /internal/shoebox/database/getRecipientsOnKeep                 @com.keepit.controllers.internal.ShoeboxController.getRecipientsOnKeep(keepId: Id[Keep])
 POST    /internal/shoebox/database/getEmailAddressesForUsers           @com.keepit.controllers.internal.ShoeboxController.getEmailAddressesForUsers()
 POST    /internal/shoebox/database/getEmailAddressForUsers             @com.keepit.controllers.internal.ShoeboxController.getEmailAddressForUsers()
 GET     /internal/shoebox/database/getUserOpt                          @com.keepit.controllers.internal.ShoeboxController.getUserOpt(id: ExternalId[User])


### PR DESCRIPTION
@andrewconner @leogrim @ryanpbrewster 

this is a quick addition of libraries in thread recipient updates. the current notification delivery system needs to be reworked for the new `KeepEvent` flows, I started on that last week but stashed it in lieu of the demo.
