### PR TITLE
send thread_recipients events even if only a library is modified

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
@@ -27,7 +27,7 @@ trait ElizaDiscussionCommander {
   def syncAddParticipants(keepId: Id[Keep], event: KeepEventData.ModifyRecipients, source: Option[KeepEventSource]): Future[Unit]
   def getEmailParticipantsForKeeps(keepIds: Set[Id[Keep]]): Map[Id[Keep], Map[EmailAddress, (Id[User], DateTime)]]
   def sendMessage(userId: Id[User], txt: String, keepId: Id[Keep], source: Option[MessageSource] = None)(implicit context: HeimdalContext): Future[Message]
-  def editParticipantsOnKeep(keepId: Id[Keep], editor: Id[User], newUsers: Seq[Id[User]], newNonUsers: Seq[BasicContact], orgs: Seq[Id[Organization]], source: Option[KeepEventSource], updateShoebox: Boolean)(implicit context: HeimdalContext): Future[Boolean]
+  def editParticipantsOnKeep(keepId: Id[Keep], editor: Id[User], newUsers: Seq[Id[User]], newNonUsers: Seq[BasicContact], libraries: Seq[Id[Library]], orgs: Seq[Id[Organization]], source: Option[KeepEventSource], updateShoebox: Boolean)(implicit context: HeimdalContext): Future[Boolean]
   def muteThread(userId: Id[User], keepId: Id[Keep])(implicit context: HeimdalContext): Future[Boolean]
   def unmuteThread(userId: Id[User], keepId: Id[Keep])(implicit context: HeimdalContext): Future[Boolean]
   def markAsRead(userId: Id[User], keepId: Id[Keep], msgId: Id[ElizaMessage]): Option[Int]
@@ -237,11 +237,11 @@ class ElizaDiscussionCommanderImpl @Inject() (
     nonUserThreadRepo.getByAccessToken(accessToken).exists(_.keepId == keepId)
   }
 
-  def editParticipantsOnKeep(keepId: Id[Keep], editor: Id[User], newUsers: Seq[Id[User]], newNonUsers: Seq[BasicContact], orgs: Seq[Id[Organization]], source: Option[KeepEventSource], updateShoebox: Boolean)(implicit context: HeimdalContext): Future[Boolean] = {
+  def editParticipantsOnKeep(keepId: Id[Keep], editor: Id[User], newUsers: Seq[Id[User]], newNonUsers: Seq[BasicContact], newLibraries: Seq[Id[Library]], orgs: Seq[Id[Organization]], source: Option[KeepEventSource], updateShoebox: Boolean)(implicit context: HeimdalContext): Future[Boolean] = {
     implicit val context = HeimdalContext.empty
     for {
       thread <- getOrCreateMessageThreadWithUser(keepId, editor)
-      success <- messagingCommander.addParticipantsToThread(editor, keepId, newUsers.toSeq, newNonUsers.toSeq, orgs.toSeq, source, updateShoebox)
+      success <- messagingCommander.addParticipantsToThread(editor, keepId, newUsers, newNonUsers, newLibraries, orgs.toSeq, source, updateShoebox)
     } yield success
   }
   def deleteThreadsForKeeps(keepIds: Set[Id[Keep]]): Unit = db.readWrite { implicit s =>

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -76,7 +76,7 @@ trait MessagingCommander {
   def unmuteThreadForNonUser(id: Id[NonUserThread]): Boolean
   def setUserThreadMuteState(userId: Id[User], keepId: Id[Keep], mute: Boolean)(implicit context: HeimdalContext): Boolean
   def setNonUserThreadMuteState(id: Id[NonUserThread], mute: Boolean): Boolean
-  def addParticipantsToThread(adderUserId: Id[User], keepId: Id[Keep], newUsers: Seq[Id[User]], emailContacts: Seq[BasicContact],
+  def addParticipantsToThread(adderUserId: Id[User], keepId: Id[Keep], newUsers: Seq[Id[User]], emailContacts: Seq[BasicContact], newLibraries: Seq[Id[Library]],
     orgIds: Seq[Id[Organization]], source: Option[KeepEventSource], updateShoebox: Boolean)(implicit context: HeimdalContext): Future[Boolean]
 
   def getChatter(userId: Id[User], urls: Seq[String]): Future[Map[String, Seq[Id[Keep]]]]
@@ -482,7 +482,7 @@ class MessagingCommanderImpl @Inject() (
 
   // todo(cam): make this `editParticipantsOnThread` with inactivation behavior
   def addParticipantsToThread(adderUserId: Id[User], keepId: Id[Keep],
-    newUsers: Seq[Id[User]], emailContacts: Seq[BasicContact], orgIds: Seq[Id[Organization]],
+    newUsers: Seq[Id[User]], emailContacts: Seq[BasicContact], newLibraries: Seq[Id[Library]], orgIds: Seq[Id[Organization]],
     source: Option[KeepEventSource], updateShoebox: Boolean)(implicit context: HeimdalContext): Future[Boolean] = {
     val newUserParticipantsFuture = Future.successful(newUsers)
     val newNonUserParticipantsFuture = constructNonUserRecipients(adderUserId, emailContacts)
@@ -513,7 +513,7 @@ class MessagingCommanderImpl @Inject() (
         val actuallyNewUsers = (newUserParticipants ++ newOrgParticipants).filterNot(oldThread.containsUser)
         val actuallyNewNonUsers = newNonUserParticipants.filterNot(oldThread.containsNonUser)
 
-        if (actuallyNewNonUsers.isEmpty && actuallyNewUsers.isEmpty) {
+        if (actuallyNewNonUsers.isEmpty && actuallyNewUsers.isEmpty && newLibraries.isEmpty) {
           None
         } else {
           // this block might be unnecessary since ElizaDiscussionCommander.addParticipantsToThread is the only caller of this method and already does all this interning.
@@ -542,13 +542,13 @@ class MessagingCommanderImpl @Inject() (
             ))
           }
 
-          Some((actuallyNewUsers, actuallyNewNonUsers, message, thread))
+          Some((actuallyNewUsers, actuallyNewNonUsers, newLibraries, message, thread))
 
         }
       }
 
       resultInfoOpt.exists {
-        case (newUsers, newNonUsers, message, thread) =>
+        case (newUsers, newNonUsers, newLibraries, message, thread) =>
 
           SafeFuture {
             db.readOnlyMaster { implicit session =>
@@ -561,7 +561,7 @@ class MessagingCommanderImpl @Inject() (
             shoebox.editRecipientsOnKeep(adderUserId, keepId, KeepRecipientsDiff(DeltaSet.addOnly(newUsers.toSet), libraries = DeltaSet.empty, DeltaSet.addOnly(newEmails.toSet)), persistKeepEvent = true, source)
           }
 
-          if (newUsers.nonEmpty || newNonUsers.nonEmpty) {
+          if (newUsers.nonEmpty || newNonUsers.nonEmpty || newLibraries.nonEmpty) {
             notificationDeliveryCommander.notifyAddParticipants(adderUserId, newUsers, newNonUsers, thread, message, source)
             messagingAnalytics.addedParticipantsToConversation(adderUserId, newUsers, newNonUsers, thread, source, context)
           }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaDiscussionController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaDiscussionController.scala
@@ -124,8 +124,8 @@ class ElizaDiscussionController @Inject() (
     import EditParticipantsOnKeep._
     implicit val context = heimdalContextBuilder().build
     val input = request.body.as[Request]
-    val KeepRecipientsDiff(users, _, emails) = input.diff
-    discussionCommander.editParticipantsOnKeep(input.keepId, input.editor, users.added.toSeq, emails.added.map(BasicContact(_)).toSeq, orgs = Seq.empty, input.source, updateShoebox = false).map { success =>
+    val KeepRecipientsDiff(users, libraries, emails) = input.diff
+    discussionCommander.editParticipantsOnKeep(input.keepId, input.editor, users.added.toSeq, emails.added.map(BasicContact(_)).toSeq, libraries.added.toSeq, orgs = Seq.empty, input.source, updateShoebox = false).map { success =>
       val output = Response(success)
       Ok(Json.toJson(output))
     }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/mobile/MobileMessagingController.scala
@@ -360,7 +360,7 @@ class MobileMessagingController @Inject() (
         }.toSeq.partitionEithers
         for {
           userIds <- shoebox.getUserIdsByExternalIds(extUserIds.toSet).map(_.values.toList)
-          _ <- discussionCommander.editParticipantsOnKeep(keepId, request.userId, userIds, addReq.emails, orgIds, source, updateShoebox = true)(contextBuilder.build)
+          _ <- discussionCommander.editParticipantsOnKeep(keepId, request.userId, userIds, addReq.emails, Seq.empty, orgIds, source, updateShoebox = true)(contextBuilder.build)
         } yield Ok
       case _ => Future.successful(BadRequest("invalid_keep_id"))
     }
@@ -381,7 +381,7 @@ class MobileMessagingController @Inject() (
         }.partitionEithers
         for {
           userIds <- shoebox.getUserIdsByExternalIds(extUserIds.toSet).map(_.values.toList)
-          _ <- discussionCommander.editParticipantsOnKeep(keepId, request.userId, userIds, validEmails, orgIds, source, updateShoebox = true)(contextBuilder.build)
+          _ <- discussionCommander.editParticipantsOnKeep(keepId, request.userId, userIds, validEmails, Seq.empty, orgIds, source, updateShoebox = true)(contextBuilder.build)
         } yield Ok("")
       case Failure(_) => Future.successful(BadRequest("invalid_keep_id"))
     }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
@@ -115,7 +115,7 @@ class SharedWsMessagingController @Inject() (
             for {
               userIds <- shoebox.getUserIdsByExternalIds(users.toSet).map(_.values.toList)
               orgIds <- Future.successful(orgs.flatMap(pubId => Organization.decodePublicId(pubId).toOption))
-            } discussionCommander.editParticipantsOnKeep(keepId, socket.userId, userIds, emailContacts, orgIds, KeepEventSource.fromStr(socket.userAgent), updateShoebox = true)
+            } discussionCommander.editParticipantsOnKeep(keepId, socket.userId, userIds, emailContacts, Seq.empty, orgIds, KeepEventSource.fromStr(socket.userAgent), updateShoebox = true)
           }
         }
     },

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/MessagingTest.scala
@@ -147,7 +147,7 @@ class MessagingTest extends Specification with ElizaTestInjector with ElizaInjec
         waitFor(notificationDeliveryCommander.getLatestSendableNotifications(user3, 1, includeUriSummary = false)).length === 0
 
         val user3ExtId = Await.result(shoebox.getUser(user3), Duration(4, "seconds")).get.externalId
-        messagingCommander.addParticipantsToThread(user1, thread.keepId, Seq(user3), Seq.empty, Seq.empty, source = None, updateShoebox = true)
+        messagingCommander.addParticipantsToThread(user1, thread.keepId, Seq(user3), Seq.empty, Seq.empty, Seq.empty, source = None, updateShoebox = true)
         inject[WatchableExecutionContext].drain()
         waitFor(notificationDeliveryCommander.getLatestSendableNotifications(user3, 1, includeUriSummary = false)).length === 1
       }


### PR DESCRIPTION
@ryanpbrewster there is a big refactor I have stashed that will clean this logic up and consolidate with our new `KeepRecipients` models, waiting for after the demo.
