### PR TITLE
don't persist system messages when only libraries are added

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationDeliveryCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/NotificationDeliveryCommander.scala
@@ -124,39 +124,43 @@ class NotificationDeliveryCommanderImpl @Inject() (
   def notifyAddParticipants(adderUserId: Id[User], newParticipants: Seq[Id[User]], newNonUserParticipants: Seq[NonUserParticipant], thread: MessageThread, message: ElizaMessage, source: Option[KeepEventSource]): Unit = {
     new SafeFuture(shoebox.getRecipientsOnKeep(thread.keepId).map {
       case (basicUsers, basicLibraries, emails) =>
-        val adderUserName = basicUsers.get(adderUserId).map { bu => bu.firstName + " " + bu.lastName }.get
-        val theTitle: String = thread.pageTitle.getOrElse("New conversation")
-        val participants: Seq[BasicUserLikeEntity] =
-          basicUsers.values.toSeq.map(u => BasicUserLikeEntity(u)) ++
-            thread.participants.allNonUsers.toSeq.map(nu => BasicUserLikeEntity(NonUserParticipant.toBasicNonUser(nu)))
-        val notificationJson = Json.obj(
-          "id" -> message.pubId,
-          "time" -> message.createdAt,
-          "thread" -> thread.pubKeepId,
-          "text" -> s"$adderUserName added you to a conversation.",
-          "url" -> message.sentOnUrl.getOrElse[String](thread.url),
-          "title" -> theTitle,
-          "author" -> basicUsers(adderUserId),
-          "participants" -> participants,
-          "locator" -> thread.deepLocator,
-          "unread" -> true,
-          "category" -> NotificationCategory.User.MESSAGE.category
-        )
+        if (message.auxData.isDefined) {
+          val adderUserName = basicUsers.get(adderUserId).map { bu => bu.firstName + " " + bu.lastName }.get
+          val theTitle: String = thread.pageTitle.getOrElse("New conversation")
+          val participants: Seq[BasicUserLikeEntity] =
+            basicUsers.values.toSeq.map(u => BasicUserLikeEntity(u)) ++
+              thread.participants.allNonUsers.toSeq.map(nu => BasicUserLikeEntity(NonUserParticipant.toBasicNonUser(nu)))
+          val notificationJson = Json.obj(
+            "id" -> message.pubId,
+            "time" -> message.createdAt,
+            "thread" -> thread.pubKeepId,
+            "text" -> s"$adderUserName added you to a conversation.",
+            "url" -> message.sentOnUrl.getOrElse[String](thread.url),
+            "title" -> theTitle,
+            "author" -> basicUsers(adderUserId),
+            "participants" -> participants,
+            "locator" -> thread.deepLocator,
+            "unread" -> true,
+            "category" -> NotificationCategory.User.MESSAGE.category
+          )
 
-        Future.sequence(newParticipants.map { userId =>
-          recreateNotificationForAddedParticipant(userId, thread)
-        }) map { permanentNotifications =>
-          newParticipants.zip(permanentNotifications) foreach {
-            case (userId, permanentNotification) =>
-              sendToUser(userId, Json.arr("notification", notificationJson, permanentNotification))
+          Future.sequence(newParticipants.map { userId =>
+            recreateNotificationForAddedParticipant(userId, thread)
+          }) map { permanentNotifications =>
+            newParticipants.zip(permanentNotifications) foreach {
+              case (userId, permanentNotification) =>
+                sendToUser(userId, Json.arr("notification", notificationJson, permanentNotification))
+            }
+            val messageWithBasicUser = basicMessageCommander.getMessageWithBasicUser(message, thread, basicUsers)
+            thread.participants.allUsers.par.foreach { userId =>
+              sendToUser(userId, Json.arr("message", thread.pubKeepId, messageWithBasicUser))
+              sendToUser(userId, Json.arr("thread_participants", thread.pubKeepId, participants))
+            }
+            emailCommander.notifyAddedEmailUsers(thread, newNonUserParticipants)
           }
-          val messageWithBasicUser = basicMessageCommander.getMessageWithBasicUser(message, thread, basicUsers)
-          thread.participants.allUsers.par.foreach { userId =>
-            sendToUser(userId, Json.arr("message", thread.pubKeepId, messageWithBasicUser))
-            sendToUser(userId, Json.arr("thread_participants", thread.pubKeepId, participants))
-            sendToUser(userId, Json.arr("thread_recipients", thread.pubKeepId, basicUsers.values, emails.toSeq, basicLibraries.values))
-          }
-          emailCommander.notifyAddedEmailUsers(thread, newNonUserParticipants)
+        }
+        thread.participants.allUsers.par.foreach { userId =>
+          sendToUser(userId, Json.arr("thread_recipients", thread.pubKeepId, basicUsers.values, emails.toSeq, basicLibraries.values))
         }
     })
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepEventCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepEventCommander.scala
@@ -41,7 +41,7 @@ class KeepEventCommanderImpl @Inject() (
       val basicEvent = keepActivityAssembler.assembleBasicKeepEvent(keepId, event)
       session.onTransactionSuccess {
         eventData match {
-          case mr: ModifyRecipients if mr.diff.users.added.nonEmpty || mr.diff.emails.added.nonEmpty => eliza.editParticipantsOnKeep(keepId, mr.addedBy, mr.diff, source)
+          case mr: ModifyRecipients if mr.diff.users.added.nonEmpty || mr.diff.emails.added.nonEmpty || mr.diff.libraries.added.nonEmpty => eliza.editParticipantsOnKeep(keepId, mr.addedBy, mr.diff, source)
           case _ =>
         }
         broadcastKeepEvent(keepId, usersToSendTo.toSet, basicEvent)


### PR DESCRIPTION
not very proud of this, but there's a nicer solution on the way. the problem is that old client notifications for `add_participants` depend on a "system message" to build from, which is something we want to kill and doesn't support our new `KeepRecipients` model which includes libraries. In order to have notifications for the new events, we need to be able to build notifications from keep events, without a system message (a big refactor I have stashed).

So now we are stuck in a limbo where we want to send notifications on events that system messages can't support, but need a system message to move forward with building notifications. That's what you see here.
