### PR TITLE
bump eliza message cache

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
@@ -330,7 +330,7 @@ object ElizaMessage extends CommonClassLinker[ElizaMessage, Message] {
 }
 
 case class MessagesKeepIdKey(keepId: Id[Keep]) extends Key[Seq[ElizaMessage]] {
-  override val version = 2
+  override val version = 3
   val namespace = "messages_by_keep_id"
   def toKey(): String = keepId.id.toString
 }


### PR DESCRIPTION
@ryanpbrewster eliza didn't fully deploy, and shoebox was telling her to persist messages she wouldn't have if the new code was deployed (no added recipients), I cleaned up the data, just need to clear the cache.
