### PR TITLE
Being more aggressive and a bit more careful with library typeahead refreshments

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -113,6 +113,7 @@ class LibraryCommanderImpl @Inject() (
         SafeFuture {
           libraryAnalytics.createLibrary(ownerId, library, context)
           searchClient.updateLibraryIndex()
+          libraryTypeahead.refreshForAllCollaborators(library.id.get)
         }
         Right(library)
     }
@@ -204,8 +205,6 @@ class LibraryCommanderImpl @Inject() (
       val newMembership = LibraryMembership(libraryId = libraryId, userId = ownerId, access = LibraryAccess.OWNER, subscribedToUpdates = true, listed = newListed)
       libraryMembershipRepo.save(newMembership.copy(id = existingMembershipOpt.flatMap(_.id)))
     }
-
-    libraryTypeahead.refreshForAllCollaborators(newLib.id.get)
 
     newLib
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInviteCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInviteCommander.scala
@@ -21,6 +21,7 @@ import com.keepit.notify.NotificationInfoModel
 import com.keepit.notify.model._
 import com.keepit.notify.model.event._
 import com.keepit.social.BasicUser
+import com.keepit.typeahead.LibraryTypeahead
 import play.api.http.Status._
 import play.api.libs.json.Json
 import scala.util.Try
@@ -59,6 +60,7 @@ class LibraryInviteCommanderImpl @Inject() (
     libPathCommander: PathCommander,
     libraryImageCommander: LibraryImageCommander,
     kifiInstallationCommander: KifiInstallationCommander,
+    libraryTypeahead: LibraryTypeahead,
     implicit val s3ImageConfig: S3ImageConfig,
     implicit val defaultContext: ExecutionContext,
     implicit val publicIdConfig: PublicIdConfiguration) extends LibraryInviteCommander with Logging {
@@ -257,6 +259,8 @@ class LibraryInviteCommanderImpl @Inject() (
     }.toSeq
 
     val emailFutures = groupedInvitesWithExtras.flatMap((notifyInvitees _).tupled)
+
+    libraryTypeahead.refreshByIds(groupedInvitesWithExtras.flatMap(_._1.flatMap(_.userId)))
 
     val emailsF = Future.sequence(emailFutures)
     emailsF map (_.filter(_.isDefined).map(_.get))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryMembershipCommander.scala
@@ -198,9 +198,7 @@ class LibraryMembershipCommanderImpl @Inject() (
     libraryAnalytics.acceptLibraryInvite(userId, library, eventContext)
     libraryAnalytics.followLibrary(userId, library, eventContext)
     searchClient.updateLibraryIndex()
-    if (LibraryAccess.collaborativePermissions.contains(membership.access)) {
-      refreshTypeaheads(userId, libraryId)
-    }
+    refreshTypeaheads(userId, libraryId)
   }
 
   def leaveLibrary(libraryId: Id[Library], userId: Id[User])(implicit eventContext: HeimdalContext): Either[LibraryFail, Unit] = {
@@ -219,9 +217,7 @@ class LibraryMembershipCommanderImpl @Inject() (
         SafeFuture {
           libraryAnalytics.unfollowLibrary(userId, lib, eventContext)
           searchClient.updateLibraryIndex()
-          if (LibraryAccess.collaborativePermissions.contains(mem.access)) {
-            refreshTypeaheads(userId, libraryId)
-          }
+          refreshTypeaheads(userId, libraryId)
         }
         Right((): Unit)
     }


### PR DESCRIPTION
@leogrim For people's own libraries, seems there's a race where the db session may not have committed yet before the typeahead is refreshed. This should fix that.

For other people not being able to see the library: this may be that we don't refresh typeaheads for org members, just collaborators (and when you join). Adding some timing to see if it's reasonable to refresh for all org members (if they could join).
