### PR TITLE
Less aggressive caching, refreshing more aggressively when libraries change

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/typeahead/Typeahead.scala
+++ b/kifi-backend/modules/common/app/com/keepit/typeahead/Typeahead.scala
@@ -78,8 +78,12 @@ trait Typeahead[T, E, I, P <: PersonalTypeahead[T, E, I]] extends Logging {
     }
   }
 
-  def prefetch(ownerId: Id[T]): Future[Unit] = {
-    getOrElseCreate(ownerId).map(_ => ())(ExecutionContext.immediate)
+  def prefetch(ownerId: Id[T], refreshAlways: Boolean): Future[Unit] = {
+    if (refreshAlways) {
+      refresh(ownerId)
+    } else {
+      getOrElseCreate(ownerId).map(_ => ())(ExecutionContext.immediate)
+    }
   }
 
   private[this] lazy val consolidateFetchReq = new RequestConsolidator[Id[T], P](fetchRequestConsolidationWindow)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
@@ -1,6 +1,6 @@
 package com.keepit.commanders
 
-import com.google.inject.{ Provider, Inject }
+import com.google.inject.{ Provider, Inject, Singleton }
 import com.keepit.abook.ABookServiceClient
 import com.keepit.abook.model.RichContact
 import com.keepit.common.cache.{ Key, JsonCacheImpl, FortyTwoCachePlugin, CacheStatistics }
@@ -30,6 +30,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ ExecutionContext, Future }
 
+@Singleton
 class TypeaheadCommander @Inject() (
     db: Database,
     airbrake: AirbrakeNotifier,

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TypeaheadCommander.scala
@@ -453,8 +453,8 @@ class TypeaheadCommander @Inject() (
 
   private def prefetchTypeaheads(userId: Id[User]): Unit = {
     Future {
-      libraryTypeahead.prefetch(userId).map { _ =>
-        kifiUserTypeahead.prefetch(userId)
+      libraryTypeahead.prefetch(userId, refreshAlways = true).map { _ =>
+        kifiUserTypeahead.prefetch(userId, refreshAlways = false)
       }
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -285,7 +285,7 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Singleton
   @Provides
   def libraryResultTypeaheadCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new LibraryResultTypeaheadCache(stats, accessLog, (innerRepo, 1 minute), (outerRepo, 1 hour))
+    new LibraryResultTypeaheadCache(stats, accessLog, (innerRepo, 20 seconds), (outerRepo, 30 minutes))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/shoebox/app/com/keepit/typeahead/HashtagTypeahead.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/typeahead/HashtagTypeahead.scala
@@ -5,7 +5,7 @@ import com.keepit.model.{ User, Hashtag }
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.db.Id
 import scala.concurrent.{ ExecutionContext, Future }
-import com.google.inject.Inject
+import com.google.inject.{ Inject, Singleton }
 import play.api.libs.json.Json
 import org.joda.time.DateTime
 import com.keepit.common.cache.{ JsonCacheImpl, FortyTwoCachePlugin, CacheStatistics, Key }
@@ -26,6 +26,7 @@ object UserHashtagTypeahead {
   }
 }
 
+@Singleton
 class HashtagTypeahead @Inject() (
     val airbrake: AirbrakeNotifier,
     cache: UserHashtagTypeaheadCache,

--- a/kifi-backend/modules/shoebox/app/com/keepit/typeahead/KifiUserTypeahead.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/typeahead/KifiUserTypeahead.scala
@@ -35,7 +35,7 @@ class KifiUserTypeahead @Inject() (
     UserCache: UserIdCache) extends Typeahead[User, User, User, UserUserTypeahead] with Logging { // User as info might be too heavy
   implicit val fj = ExecutionContext.fj
 
-  protected val refreshRequestConsolidationWindow = 0 seconds
+  protected val refreshRequestConsolidationWindow = 5 seconds
 
   protected val fetchRequestConsolidationWindow = 15 seconds
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/typeahead/LibraryTypeahead.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/typeahead/LibraryTypeahead.scala
@@ -54,7 +54,7 @@ class LibraryTypeahead @Inject() (
     implicit val ec: ExecutionContext,
     implicit val config: PublicIdConfiguration) extends Typeahead[User, Library, LibraryTypeaheadResult, UserLibraryTypeahead] with Logging {
 
-  protected val refreshRequestConsolidationWindow = 10 seconds
+  protected val refreshRequestConsolidationWindow = 20 seconds
 
   protected val fetchRequestConsolidationWindow = 30 seconds
 


### PR DESCRIPTION
@leogrim Refreshing Eishay's takes about a second, which is probably worst case. So going ahead and being a bit more aggressive with refreshes.

This should be fine because we actually prefetch the filter when the user asks for recommended libraries (giving us several seconds head start)
