### PR TITLE
Short TTL aggressive caching for suggestRecipients data.

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -1031,7 +1031,7 @@ class AdminUserController @Inject() (
 
   def suggestRecipient(userId: Id[User], query: Option[String], limit: Option[Int], drop: Option[Int], requested: Option[String]) = AdminUserAction.async { request =>
     val requestedSet = requested.map(_.split(",").map(_.trim).flatMap(TypeaheadRequest.applyOpt).toSet).filter(_.nonEmpty).getOrElse(TypeaheadRequest.all)
-    typeAheadCommander.searchForKeepRecipients(userId, query.getOrElse(""), limit, drop, requestedSet).map { suggestions =>
+    typeAheadCommander.searchAndSuggestKeepRecipients(userId, query.getOrElse(""), limit, drop, requestedSet).map { suggestions =>
       val body = suggestions.take(limit.getOrElse(20)).collect {
         case u: UserContactResult => Json.toJson(u)
         case e: EmailContactResult => Json.toJson(e)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryCommander.scala
@@ -82,6 +82,7 @@ class LibraryCommanderImpl @Inject() (
   ktlRepo: KeepToLibraryRepo,
   ktlCommander: KeepToLibraryCommander,
   countByLibraryCache: CountByLibraryCache,
+  relevantSuggestedLibrariesCache: RelevantSuggestedLibrariesCache,
   airbrake: AirbrakeNotifier,
   searchClient: SearchServiceClient,
   libraryAnalytics: LibraryAnalytics,
@@ -114,6 +115,7 @@ class LibraryCommanderImpl @Inject() (
           libraryAnalytics.createLibrary(ownerId, library, context)
           searchClient.updateLibraryIndex()
           libraryTypeahead.refreshForAllCollaborators(library.id.get)
+          relevantSuggestedLibrariesCache.direct.remove(RelevantSuggestedLibrariesKey(ownerId))
         }
         Right(library)
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryMembershipCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryMembershipCommander.scala
@@ -66,6 +66,7 @@ class LibraryMembershipCommanderImpl @Inject() (
     userInteractionCommander: UserInteractionCommander,
     kifiUserTypeahead: KifiUserTypeahead,
     libraryTypeahead: Provider[LibraryTypeahead],
+    relevantSuggestedLibrariesCache: RelevantSuggestedLibrariesCache,
     libraryAnalytics: LibraryAnalytics,
     elizaClient: ElizaServiceClient,
     searchClient: SearchServiceClient,
@@ -284,6 +285,7 @@ class LibraryMembershipCommanderImpl @Inject() (
 
   private def refreshTypeaheads(userId: Id[User], libraryId: Id[Library]): Future[Unit] = {
     libraryTypeahead.get.refresh(userId).map { _ =>
+      relevantSuggestedLibrariesCache.direct.remove(RelevantSuggestedLibrariesKey(userId))
       val collaboratorIds = db.readOnlyMaster { implicit session =>
         libraryMembershipRepo.getCollaboratorsByLibrary(Set(libraryId)).get(libraryId).toSet.flatten
       }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -290,7 +290,7 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Singleton
   @Provides
   def relevantSuggestedLibrariesCacheCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new RelevantSuggestedLibrariesCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 4 hour))
+    new RelevantSuggestedLibrariesCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 4 hours))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -290,7 +290,12 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Singleton
   @Provides
   def relevantSuggestedLibrariesCacheCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new RelevantSuggestedLibrariesCache(stats, accessLog, (innerRepo, 1 minute), (outerRepo, 1 hour))
+    new RelevantSuggestedLibrariesCache(stats, accessLog, (innerRepo, 10 minutes), (outerRepo, 4 hour))
+
+  @Singleton
+  @Provides
+  def libraryResultCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new LibraryResultCache(stats, accessLog, (innerRepo, 10 seconds))
 
   @Singleton
   @Provides

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/client/KeepInfoController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/client/KeepInfoController.scala
@@ -93,7 +93,7 @@ class KeepInfoController @Inject() (
   @json case class RecipientSuggestion(query: Option[String], results: Seq[JsObject /* TypeaheadResult */ ], mayHaveMore: Boolean, limit: Option[Int], offset: Option[Int])
   def suggestRecipient(query: Option[String], limit: Option[Int], offset: Option[Int], requested: Option[String]) = UserAction.async { request =>
     val requestedSet = requested.map(_.split(',').map(_.trim).flatMap(TypeaheadRequest.applyOpt).toSet).filter(_.nonEmpty).getOrElse(TypeaheadRequest.all)
-    typeaheadCommander.searchForKeepRecipients(request.userId, query.getOrElse(""), limit, offset, requestedSet).map { suggestions =>
+    typeaheadCommander.searchAndSuggestKeepRecipients(request.userId, query.getOrElse(""), limit, offset, requestedSet).map { suggestions =>
       val body = suggestions.take(limit.getOrElse(20)).collect {
         case u: UserContactResult => Json.toJson(u).as[JsObject] ++ Json.obj("kind" -> "user")
         case e: EmailContactResult => Json.toJson(e).as[JsObject] ++ Json.obj("kind" -> "email")

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtAuthController.scala
@@ -42,6 +42,7 @@ class ExtAuthController @Inject() (
   facebook: FacebookSocialGraph,
   linkedIn: LinkedInSocialGraph,
   twitter: TwitterSocialGraph,
+  typeaheadCommander: TypeaheadCommander,
   implicit val publicIdConfig: PublicIdConfiguration)
     extends UserActions with ShoeboxServiceController {
 
@@ -120,6 +121,10 @@ class ExtAuthController @Inject() (
 
         val ip = IpAddress.fromRequest(request).ip
         val encryptedIp: String = crypt.crypt(ipkey, ip).trim
+
+        SafeFuture { // Prefetch typeaheads on extension load.
+          typeaheadCommander.searchAndSuggestKeepRecipients(userId, "", None, None, TypeaheadRequest.all)
+        }
 
         Ok(Json.obj(
           "user" -> BasicUser.fromUser(request.user),

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/ext/ExtUserController.scala
@@ -76,7 +76,7 @@ class ExtUserController @Inject() (
   @json case class RecipientSuggestion(query: Option[String], results: Seq[JsObject /* TypeaheadResult */ ], mayHaveMore: Boolean, limit: Option[Int], drop: Option[Int])
   def suggestRecipient(query: Option[String], limit: Option[Int], drop: Option[Int], requested: Option[String]) = UserAction.async { request =>
     val requestedSet = requested.map(_.split(",").map(_.trim).flatMap(TypeaheadRequest.applyOpt).toSet).filter(_.nonEmpty).getOrElse(TypeaheadRequest.all)
-    typeAheadCommander.searchForKeepRecipients(request.userId, query.getOrElse(""), limit, drop, requestedSet).map { suggestions =>
+    typeAheadCommander.searchAndSuggestKeepRecipients(request.userId, query.getOrElse(""), limit, drop, requestedSet).map { suggestions =>
       val body = suggestions.take(limit.getOrElse(20)).collect {
         case u: UserContactResult => Json.toJson(u).as[JsObject] ++ Json.obj("kind" -> "user")
         case e: EmailContactResult => Json.toJson(e).as[JsObject] ++ Json.obj("kind" -> "email")


### PR DESCRIPTION
Adds some very aggressive, very short TTL in-memory caching. Useful because search results often occur again as the user keeps typing.

Still not happy with suggestion performance (mine takes 800ms), especially since this needs to be very quick. 

@leogrim 
