### PR TITLE
don't rely on cached BasicUser for keep source in KeepActivityGen

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/gen/KeepActivityGen.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/gen/KeepActivityGen.scala
@@ -26,8 +26,9 @@ object KeepActivityGen {
     import com.keepit.common.util.DescriptionElements._
 
     lazy val initialEventsBF = {
-      val basicAuthorBF = sourceAttrOpt.map {
-        case (sourceAttr, basicUserOpt) => BatchFetchable.trivial(BasicAuthor(sourceAttr, basicUserOpt))
+      val basicAuthorBF = sourceAttrOpt.flatMap {
+        case (ka: KifiAttribution, _) => None
+        case (sourceAttr, basicUserOpt) => Some(BatchFetchable.trivial(BasicAuthor(sourceAttr, basicUserOpt)))
       }.getOrElse {
         BatchFetchable.userOpt(keep.userId).map(_.map(BasicAuthor.fromUser).getOrElse(BasicAuthor.Fake))
       }


### PR DESCRIPTION
@leogrim this is a stop-gap in solving the `KifiAttribution` caching issue. I made a go at defining an `externalWrites` on it, and it looks to take a bit of work before it's clean, since search results and keep infos need to generate them with performance on the line.
