### PR TITLE
Bump to 3.8.10 to release fixes and new lib elements

### DIFF
--- a/packrat/build.properties
+++ b/packrat/build.properties
@@ -1,1 +1,1 @@
-version=3.8.9
+version=3.8.10


### PR DESCRIPTION
fail fast
