### PR TITLE
cache basic libraries

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -241,6 +241,10 @@ object LibraryPathHelper {
     val handle = orgHandleOpt.map(Handle.fromOrganizationHandle).getOrElse(Handle.fromUsername(owner))
     s"/${handle.urlEncoded}/${slug.urlEncoded}"
   }
+
+  def formatLibraryPathForOrganization(orgHandle: OrganizationHandle, slug: LibrarySlug): String = {
+    s"/${orgHandle.value}/${slug.value}"
+  }
 }
 
 case class LibraryIdKey(id: Id[Library]) extends Key[Library] {
@@ -356,6 +360,7 @@ object DetailedLibraryView {
 
 case class BasicLibrary(id: PublicId[Library], name: String, path: String, visibility: LibraryVisibility, color: Option[LibraryColor], slack: Option[LiteLibrarySlackInfo]) {
   def isSecret = visibility == LibraryVisibility.SECRET
+  def withPath(path: String): BasicLibrary = this.copy(path = path)
 }
 
 object BasicLibrary {

--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -9,7 +9,7 @@ import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration, ModelWithPubl
 import com.keepit.common.db._
 import com.keepit.common.json.EnumFormat
 import com.keepit.common.logging.AccessLog
-import com.keepit.common.path.Path
+import com.keepit.common.path.{ EncodedPath, Path }
 import com.keepit.common.reflection.Enumerator
 import com.keepit.common.strings.UTF8
 import com.keepit.common.time._
@@ -232,20 +232,13 @@ object LibraryFilter {
 
 object LibraryPathHelper {
 
-  private def getHandle(owner: BasicUser, orgHandleOpt: Option[OrganizationHandle]): Handle = {
-    orgHandleOpt match {
-      case Some(orgHandle) => orgHandle
-      case None => owner.username
-    }
-  }
-
-  def formatLibraryPath(owner: BasicUser, orgHandleOpt: Option[OrganizationHandle], slug: LibrarySlug): String = {
-    val handle = getHandle(owner, orgHandleOpt)
+  def formatLibraryPath(owner: Username, orgHandleOpt: Option[OrganizationHandle], slug: LibrarySlug): String = {
+    val handle = orgHandleOpt.map(Handle.fromOrganizationHandle).getOrElse(Handle.fromUsername(owner))
     s"/${handle.value}/${slug.value}"
   }
 
-  def formatLibraryPathUrlEncoded(owner: BasicUser, orgHandleOpt: Option[OrganizationHandle], slug: LibrarySlug): String = {
-    val handle = getHandle(owner, orgHandleOpt)
+  def formatLibraryPathUrlEncoded(owner: Username, orgHandleOpt: Option[OrganizationHandle], slug: LibrarySlug): String = {
+    val handle = orgHandleOpt.map(Handle.fromOrganizationHandle).getOrElse(Handle.fromUsername(owner))
     s"/${handle.urlEncoded}/${slug.urlEncoded}"
   }
 }
@@ -367,7 +360,7 @@ case class BasicLibrary(id: PublicId[Library], name: String, path: String, visib
 
 object BasicLibrary {
   val fake = BasicLibrary(PublicId("l42424242"), "a deleted library", "/", LibraryVisibility.SECRET, None, None)
-  def apply(library: Library, owner: BasicUser, orgHandle: Option[OrganizationHandle], slack: Option[LiteLibrarySlackInfo])(implicit publicIdConfig: PublicIdConfiguration): BasicLibrary = {
+  def apply(library: Library, owner: Username, orgHandle: Option[OrganizationHandle], slack: Option[LiteLibrarySlackInfo])(implicit publicIdConfig: PublicIdConfiguration): BasicLibrary = {
     val path = LibraryPathHelper.formatLibraryPath(owner, orgHandle, library.slug)
     BasicLibrary(Library.publicId(library.id.get), library.name, path, library.visibility, library.color, slack)
   }

--- a/kifi-backend/modules/eliza/test/com/keepit/realtime/AppBoyTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/realtime/AppBoyTest.scala
@@ -139,7 +139,7 @@ class AppBoyTest extends Specification with TestInjector with ElizaTestInjector 
         val lib1 = inject[ShoeboxServiceClient].asInstanceOf[FakeShoeboxServiceClientImpl].saveLibraries(Library(name = "lib1", slug = LibrarySlug("lib1"), ownerId = user1.id.get, visibility = LibraryVisibility.PUBLISHED, memberCount = 1, keepCount = 0)).head
         val pubLibId1 = Library.publicId(lib1.id.get)(inject[PublicIdConfiguration])
 
-        val notification = LibraryUpdatePushNotification(unvisitedCount = 3, message = Some("pika"), libraryId = lib1.id.get, libraryUrl = LibraryPathHelper.formatLibraryPath(BasicUser.fromUser(user1), None, lib1.slug), sound = Some(MobilePushNotifier.DefaultNotificationSound), category = LibraryPushNotificationCategory.LibraryChanged, experiment = PushNotificationExperiment.Experiment1)
+        val notification = LibraryUpdatePushNotification(unvisitedCount = 3, message = Some("pika"), libraryId = lib1.id.get, libraryUrl = LibraryPathHelper.formatLibraryPath(user1.username, None, lib1.slug), sound = Some(MobilePushNotifier.DefaultNotificationSound), category = LibraryPushNotificationCategory.LibraryChanged, experiment = PushNotificationExperiment.Experiment1)
         val notifPushF = appBoy.notifyUser(user1.id.get, Seq(deviceApple, deviceAndroid), notification, false)
         Await.result(notifPushF, Duration(5, SECONDS))
         appBoyClient.jsons.size === 1

--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/mobile/MobileSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/mobile/MobileSearchController.scala
@@ -135,7 +135,7 @@ class MobileSearchController @Inject() (
                 val owner = usersById(library.ownerId)
                 val organization = library.orgId.map(organizationsById(_))
                 val details = libraryDetails(library.id)
-                val path = LibraryPathHelper.formatLibraryPath(owner, organization.map(_.handle), details.slug)
+                val path = LibraryPathHelper.formatLibraryPath(owner.username, organization.map(_.handle), details.slug)
 
                 val description = library.description.orElse(details.description).getOrElse("")
 

--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/util/SearchControllerUtil.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/util/SearchControllerUtil.scala
@@ -56,7 +56,7 @@ trait SearchControllerUtil {
   }.toMap
 
   protected def makeBasicLibrary(library: LibraryRecord, visibility: LibraryVisibility, owner: BasicUser, org: Option[BasicOrganization])(implicit publicIdConfig: PublicIdConfiguration): BasicLibrary = {
-    val path = LibraryPathHelper.formatLibraryPath(owner, org.map(_.handle), library.slug)
+    val path = LibraryPathHelper.formatLibraryPath(owner.username, org.map(_.handle), library.slug)
     BasicLibrary(Library.publicId(library.id), library.name, path, visibility, library.color, slack = None) // todo(cam): fetch this from shoebox
   }
 

--- a/kifi-backend/modules/search/app/com/keepit/search/controllers/website/WebsiteSearchController.scala
+++ b/kifi-backend/modules/search/app/com/keepit/search/controllers/website/WebsiteSearchController.scala
@@ -391,7 +391,7 @@ class WebsiteSearchController @Inject() (
                 val owner = usersById(library.ownerId)
                 val organization = library.orgId.map(organizationsById(_))
                 val details = libraryDetailsById(library.id)
-                val path = LibraryPathHelper.formatLibraryPath(owner, organization.map(_.handle), details.slug)
+                val path = LibraryPathHelper.formatLibraryPath(owner.username, organization.map(_.handle), details.slug)
                 val (collaboratorIds, followerIds) = libraryMembersById(hit.id)
                 val collaborators = orderWithPictureFirst(collaboratorIds.map(usersById(_)))
                 val followers = orderWithPictureFirst(followerIds.map(usersById(_)))

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepDecorator.scala
@@ -156,7 +156,7 @@ class KeepDecoratorImpl @Inject() (
           case (libId, library) =>
             val orgOpt = basicOrgByLibId.get(libId)
             val user = idToBasicUser(library.ownerId)
-            libId -> BasicLibrary(library, user, orgOpt.map(_.handle), idToLibrarySlackInfo.get(libId))
+            libId -> BasicLibrary(library, user.username, orgOpt.map(_.handle), idToLibrarySlackInfo.get(libId))
         }
         val libraryCardByLibId = {
           val libraries = idToLibrary.values.toSeq

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInfoCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryInfoCommander.scala
@@ -307,7 +307,7 @@ class LibraryInfoCommanderImpl @Inject() (
           whoCanInvite = whoCanInvite,
           whoCanComment = lib.whoCanComment,
           modifiedAt = lib.updatedAt,
-          path = LibraryPathHelper.formatLibraryPath(owner = owner, orgHandleOpt = orgViewOpt.map(_.basicOrganization.handle), slug = lib.slug),
+          path = LibraryPathHelper.formatLibraryPath(owner = owner.username, orgHandleOpt = orgViewOpt.map(_.basicOrganization.handle), slug = lib.slug),
           org = orgViewOpt,
           orgMemberAccess = if (lib.organizationId.isDefined) Some(lib.organizationMemberAccess.getOrElse(LibraryAccess.READ_WRITE)) else None,
           membership = membershipByLibraryId.flatMap(_.get(libId)),

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryQueryCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/LibraryQueryCommander.scala
@@ -89,7 +89,7 @@ class LibraryQueryCommanderImpl @Inject() (
     }
     val libsById = libRepo.getActiveByIds(sortedLibIds.toSet)
     val basicUser = basicUserRepo.load(userId)
-    sortedLibIds.flatMap(libsById.get).map(lib => BasicLibrary(lib, basicUser, None, slack = None))
+    sortedLibIds.flatMap(libsById.get).map(lib => BasicLibrary(lib, basicUser.username, None, slack = None))
   }
 
   def getLHRLibrariesForOrg(userId: Id[User], orgId: Id[Organization], arrangement: Arrangement, fromIdOpt: Option[Id[Library]], offset: Offset, limit: Limit, windowSize: Option[Int])(implicit session: RSession): Seq[BasicLibrary] = {
@@ -103,7 +103,7 @@ class LibraryQueryCommanderImpl @Inject() (
     val libs = sortedLibIds.flatMap(libsById.get)
     val libOwners = basicUserRepo.loadAll(libs.map(_.ownerId).toSet)
     val orgHandle = orgRepo.get(orgId).primaryHandle.get.normalized
-    libs.map(lib => BasicLibrary(lib, libOwners(lib.ownerId), Some(orgHandle), slack = None))
+    libs.map(lib => BasicLibrary(lib, libOwners(lib.ownerId).username, Some(orgHandle), slack = None))
   }
 
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PathCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PathCommander.scala
@@ -127,7 +127,7 @@ class PathCommander @Inject() (
       val org = lib.organizationId.map(orgRepo.get)
       (user, org)
     }
-    LibraryPathHelper.formatLibraryPath(user, org.map(_.handle), lib.slug)
+    LibraryPathHelper.formatLibraryPath(user.username, org.map(_.handle), lib.slug)
   }
 
   // todo: remove this as well
@@ -138,7 +138,7 @@ class PathCommander @Inject() (
       (user, org)
     }
 
-    LibraryPathHelper.formatLibraryPathUrlEncoded(user, org.map(_.handle), lib.slug)
+    LibraryPathHelper.formatLibraryPathUrlEncoded(user.username, org.map(_.handle), lib.slug)
   }
 }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/gen/BasicLibraryGen.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/gen/BasicLibraryGen.scala
@@ -2,23 +2,36 @@ package com.keepit.commanders.gen
 
 import com.google.inject.Inject
 import com.keepit.commanders.PathCommander
+import com.keepit.common.cache.{ ImmutableJsonCacheImpl, FortyTwoCachePlugin, CacheStatistics, Key }
 import com.keepit.common.core.mapExtensionOps
 import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick.DBSession.RSession
+import com.keepit.common.logging.AccessLog
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.model._
 import com.keepit.slack.SlackInfoCommander
+
+import scala.concurrent.duration.Duration
 
 class BasicLibraryGen @Inject() (
     libRepo: LibraryRepo,
     orgRepo: OrganizationRepo,
     basicUserRepo: BasicUserRepo,
+    basicLibraryCache: BasicLibraryByIdCache,
     slackInfoCommander: SlackInfoCommander,
     pathCommander: PathCommander,
     implicit val publicIdConfig: PublicIdConfiguration) {
 
   def getBasicLibraries(libIds: Set[Id[Library]])(implicit session: RSession): Map[Id[Library], BasicLibrary] = {
+    basicLibraryCache.bulkGetOrElse(libIds.map(BasicLibraryByIdKey)) { missingKeys =>
+      generateBasicLibraries(missingKeys.map(_.libraryId)).map { case (libId, basicLibrary) => BasicLibraryByIdKey(libId) -> basicLibrary }
+    }.map { case (BasicLibraryByIdKey(libId), basicLibrary) => libId -> basicLibrary }
+  }
+
+  def getBasicLibrary(libId: Id[Library])(implicit session: RSession): Option[BasicLibrary] = getBasicLibraries(Set(libId)).get(libId)
+
+  private def generateBasicLibraries(libIds: Set[Id[Library]])(implicit session: RSession): Map[Id[Library], BasicLibrary] = {
     val libById = libRepo.getActiveByIds(libIds)
     val orgById = {
       val orgSet = libById.values.flatMap(_.organizationId).toSet
@@ -43,6 +56,13 @@ class BasicLibraryGen @Inject() (
       }
     }
   }
-
-  def getBasicLibrary(libId: Id[Library])(implicit session: RSession): Option[BasicLibrary] = getBasicLibraries(Set(libId)).get(libId)
 }
+
+case class BasicLibraryByIdKey(libraryId: Id[Library]) extends Key[BasicLibrary] {
+  override val version = 1
+  val namespace = "basic_library_by_id"
+  def toKey(): String = libraryId.id.toString
+}
+
+class BasicLibraryByIdCache(stats: CacheStatistics, accessLog: AccessLog, innermostPluginSettings: (FortyTwoCachePlugin, Duration), innerToOuterPluginSettings: (FortyTwoCachePlugin, Duration)*)
+  extends ImmutableJsonCacheImpl[BasicLibraryByIdKey, BasicLibrary](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -3,6 +3,7 @@ package com.keepit.common.cache
 import com.google.inject.{ Provides, Singleton }
 import com.keepit.classify.DomainCache
 import com.keepit.commanders._
+import com.keepit.commanders.gen.BasicLibraryByIdCache
 import com.keepit.common.logging.AccessLog
 import com.keepit.common.seo.SiteMapCache
 import com.keepit.common.usersegment.UserSegmentCache
@@ -485,4 +486,8 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
   @Provides @Singleton
   def internalSlackTeamInfo(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
     new InternalSlackTeamInfoCache(stats, accessLog, (outerRepo, 7 days))
+
+  @Provides @Singleton
+  def basicLibraryByIdCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
+    new BasicLibraryByIdCache(stats, accessLog, (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/cache/ShoeboxCacheModule.scala
@@ -489,5 +489,5 @@ case class ShoeboxCacheModule(cachePluginModules: CachePluginModule*) extends Ca
 
   @Provides @Singleton
   def basicLibraryByIdCache(stats: CacheStatistics, accessLog: AccessLog, innerRepo: InMemoryCachePlugin, outerRepo: FortyTwoCachePlugin) =
-    new BasicLibraryByIdCache(stats, accessLog, (outerRepo, 7 days))
+    new BasicLibraryByIdCache(stats, accessLog, (innerRepo, 10 seconds), (outerRepo, 7 days))
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/FullLibraryInfo.scala
@@ -209,7 +209,7 @@ object LibraryInfo {
       name = lib.name,
       visibility = lib.visibility,
       shortDescription = lib.description,
-      url = LibraryPathHelper.formatLibraryPath(owner, org.map(_.handle), lib.slug),
+      url = LibraryPathHelper.formatLibraryPath(owner.username, org.map(_.handle), lib.slug),
       color = lib.color,
       image = image,
       owner = owner,

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/LibraryRepo.scala
@@ -2,6 +2,7 @@ package com.keepit.model
 
 import com.google.inject.{ ImplementedBy, Inject, Singleton, Provider }
 import com.keepit.commanders._
+import com.keepit.commanders.gen.{ BasicLibraryByIdKey, BasicLibraryByIdCache }
 import com.keepit.common.core.anyExtensionOps
 import com.keepit.common.actor.ActorInstance
 import com.keepit.common.db.slick.DBSession.{ RWSession, RSession }
@@ -89,6 +90,7 @@ class LibraryRepoImpl @Inject() (
   val libraryInviteRepo: Provider[LibraryInviteRepoImpl],
   val libraryMembershipRepo: Provider[LibraryMembershipRepoImpl],
   val libraryMetadataCache: LibraryMetadataCache,
+  val basicLibraryCache: BasicLibraryByIdCache,
   val topLibsCache: TopFollowedLibrariesCache,
   relevantSuggestedLibrariesCache: RelevantSuggestedLibrariesCache,
   libraryResultTypeaheadCache: LibraryResultTypeaheadCache,
@@ -176,6 +178,7 @@ class LibraryRepoImpl @Inject() (
     library.id.map { id =>
       libraryResultTypeaheadCache.remove(LibraryResultTypeaheadKey(library.ownerId, id))
       libraryMetadataCache.remove(LibraryMetadataKey(id))
+      basicLibraryCache.remove(BasicLibraryByIdKey(id))
       idCache.remove(LibraryIdKey(id))
     }
     if (library.memberCount >= 5 + 1) {
@@ -188,6 +191,7 @@ class LibraryRepoImpl @Inject() (
     library.id.map { id =>
       libraryResultTypeaheadCache.remove(LibraryResultTypeaheadKey(library.ownerId, id))
       libraryMetadataCache.remove(LibraryMetadataKey(id))
+      basicLibraryCache.remove(BasicLibraryByIdKey(id))
       if (library.state == LibraryStates.INACTIVE) {
         deleteCache(library)
       } else {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserRepo.scala
@@ -1,6 +1,7 @@
 package com.keepit.model
 
 import com.google.inject.{ Provider, Inject, Singleton, ImplementedBy }
+import com.keepit.commanders.gen.{ PrecomputedInfo, BasicLibraryGen, BasicLibraryByIdKey, BasicLibraryByIdCache }
 import com.keepit.commanders.{ UserProfileTab, UserMetadataKey, UserMetadataCache, HandleOps }
 import com.keepit.common.actor.ActorInstance
 import com.keepit.common.db.slick.DBSession.RSession
@@ -20,6 +21,8 @@ import org.joda.time.DateTime
 import scala.slick.lifted.{ TableQuery, Tag }
 import scala.slick.jdbc.{ StaticQuery => Q }
 import com.keepit.common.time._
+
+import scala.util.Try
 
 @ImplementedBy(classOf[UserRepoImpl])
 trait UserRepo extends Repo[User] with RepoWithDelete[User] with ExternalIdColumnFunction[User] with SeqNumberFunction[User] {
@@ -58,9 +61,13 @@ class UserRepoImpl @Inject() (
   basicUserCache: BasicUserUserIdCache,
   userMetadataCache: UserMetadataCache,
   usernameCache: UsernameCache,
+  basicLibraryCache: BasicLibraryByIdCache,
+  basicLibraryGen: Provider[BasicLibraryGen],
   heimdal: HeimdalServiceClient,
   expRepoProvider: Provider[UserExperimentRepoImpl],
   emailRepo: Provider[UserEmailAddressRepo],
+  orgRepo: Provider[OrganizationRepo],
+  libraryRepo: Provider[LibraryRepo],
   slackMembershipRepo: Provider[SlackTeamMembershipRepo])
     extends DbRepo[User] with DbRepoWithDelete[User] with UserRepo with ExternalIdColumnDbFunction[User] with SeqNumberDbFunction[User] with Logging {
 
@@ -154,6 +161,7 @@ class UserRepoImpl @Inject() (
         usernameCache.remove(UsernameKey(username.original))
         basicUserCache.remove(BasicUserUserIdKey(id))
       }
+      deleteBasicLibrariesCache(user)
     }
     session.onTransactionSuccess {
       invalidateMixpanel(user.withState(UserStates.INACTIVE))
@@ -161,6 +169,7 @@ class UserRepoImpl @Inject() (
   }
 
   override def invalidateCache(user: User)(implicit session: RSession) = {
+
     if (user.state == UserStates.ACTIVE) {
       for (id <- user.id) {
         idCache.set(UserIdKey(id), user)
@@ -169,6 +178,7 @@ class UserRepoImpl @Inject() (
           usernameCache.set(UsernameKey(username.original), user)
           basicUserCache.set(BasicUserUserIdKey(id), BasicUser.fromUser(user))
         }
+        invalidateBasicLibrariesCache(user)
       }
       externalIdCache.set(UserExternalIdKey(user.externalId), user)
       session.onTransactionSuccess {
@@ -177,6 +187,41 @@ class UserRepoImpl @Inject() (
     } else {
       deleteCache(user)
     }
+  }
+
+  private def invalidateBasicLibrariesCache(user: User)(implicit session: RSession) = {
+    val usernameOpt = user.primaryUsername.map(_.original) // username may not be set
+    val libsById = libraryRepo.get().getAllByOwner(user.id.get).map { lib => lib.id.get -> lib }.toMap
+    val orgsById = orgRepo.get().getByIds(libsById.values.flatMap(_.organizationId).toSet)
+    val hitOptById = basicLibraryCache.bulkGet(libsById.keys.map(BasicLibraryByIdKey).toSet)
+
+    // invalidate hits
+    hitOptById.collect {
+      case (key, Some(basicLib)) =>
+        val lib = libsById(key.libraryId)
+        val orgHandleOpt = lib.organizationId.flatMap(orgsById.get).map(_.handle)
+        val pathOpt = {
+          usernameOpt.map(username => LibraryPathHelper.formatLibraryPath(username, orgHandleOpt, lib.slug))
+            .orElse(orgHandleOpt.map(handle => LibraryPathHelper.formatLibraryPathForOrganization(handle, lib.slug)))
+        }
+        pathOpt.map(path => basicLibraryCache.set(key, basicLib.withPath(path)))
+          .getOrElse {
+            if (user.isActive && lib.isActive) log.error(s"[basicLibCache#user] user ${user.id.get} owns active lib ${lib.id.get} which has no username or org handle")
+            basicLibraryCache.remove(key)
+          }
+    }
+
+    // refresh misses
+    val misses = hitOptById.collect { case (key, None) => key.libraryId }
+    val precomputedInfo = PrecomputedInfo.BuildForBasicLibrary(libraries = Some(libsById), organizations = Some(orgsById), usernames = usernameOpt.map(username => Map(user.id.get -> username)))
+    basicLibraryGen.get().generateBasicLibraries(misses.toSet, Some(precomputedInfo)).foreach {
+      case (id, basicLib) => basicLibraryCache.set(BasicLibraryByIdKey(id), basicLib)
+    }
+  }
+
+  private def deleteBasicLibrariesCache(user: User)(implicit session: RSession) = {
+    val libs = libraryRepo.get().getAllByOwner(user.id.get)
+    libs.foreach(lib => basicLibraryCache.remove(BasicLibraryByIdKey(lib.id.get)))
   }
 
   private def invalidateMixpanel(user: User) = SafeFuture {

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/UserRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/UserRepo.scala
@@ -155,7 +155,9 @@ class UserRepoImpl @Inject() (
         basicUserCache.remove(BasicUserUserIdKey(id))
       }
     }
-    invalidateMixpanel(user.withState(UserStates.INACTIVE))
+    session.onTransactionSuccess {
+      invalidateMixpanel(user.withState(UserStates.INACTIVE))
+    }
   }
 
   override def invalidateCache(user: User)(implicit session: RSession) = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackInfoCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackInfoCommander.scala
@@ -229,7 +229,7 @@ class SlackInfoCommanderImpl @Inject() (
         val orgIds = libs.flatMap(_.organizationId).toSet
         val basicOrgs = orgIds.flatMap { orgId => basicOrganizationGen.getBasicOrganizationHelper(orgId).map(orgId -> _) }.toMap
         libs.map { lib =>
-          lib.id.get -> BasicLibrary(lib, basicUserById(lib.ownerId), lib.organizationId.flatMap(basicOrgs.get).map(_.handle), slackInfoByLibId.get(lib.id.get))
+          lib.id.get -> BasicLibrary(lib, basicUserById(lib.ownerId).username, lib.organizationId.flatMap(basicOrgs.get).map(_.handle), slackInfoByLibId.get(lib.id.get))
         }.toMap
       }
       val integrationInfosByLib = generateLibrarySlackIntegrationInfos(viewerId, visibleSlackToLibs, visibleLibToSlacks)

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/models/LibraryToSlackChannel.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/models/LibraryToSlackChannel.scala
@@ -185,6 +185,7 @@ class LibraryToSlackChannelRepoImpl @Inject() (
   def table(tag: Tag) = new LibraryToSlackChannelTable(tag)
   initTable()
   override def deleteCache(info: LibraryToSlackChannel)(implicit session: RSession): Unit = {
+    basicLibraryCache.remove(BasicLibraryByIdKey(info.libraryId))
     integrationsCache.remove(SlackChannelIntegrationsKey(info.slackTeamId, info.slackChannelId))
   }
   override def invalidateCache(info: LibraryToSlackChannel)(implicit session: RSession): Unit = deleteCache(info)
@@ -193,7 +194,6 @@ class LibraryToSlackChannelRepoImpl @Inject() (
   private def workingRows = activeRows.filter(row => row.status === (SlackIntegrationStatus.On: SlackIntegrationStatus))
 
   override def save(model: LibraryToSlackChannel)(implicit session: RWSession): LibraryToSlackChannel = {
-    basicLibraryCache.remove(BasicLibraryByIdKey(model.libraryId))
     super.save(model)
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/models/LibraryToSlackChannel.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/models/LibraryToSlackChannel.scala
@@ -3,6 +3,7 @@ package com.keepit.slack.models
 import javax.crypto.spec.IvParameterSpec
 
 import com.google.inject.{ Inject, Singleton, ImplementedBy }
+import com.keepit.commanders.gen.{ BasicLibraryByIdKey, BasicLibraryByIdCache }
 import com.keepit.common.crypto.{ PublicIdGenerator, ModelWithPublicId }
 import com.keepit.common.db.slick.DBSession.{ RSession, RWSession }
 import com.keepit.common.db.slick.{ DbRepo, DataBaseComponent, Repo }
@@ -89,7 +90,8 @@ trait LibraryToSlackChannelRepo extends Repo[LibraryToSlackChannel] {
 class LibraryToSlackChannelRepoImpl @Inject() (
     val db: DataBaseComponent,
     val clock: Clock,
-    integrationsCache: SlackChannelIntegrationsCache) extends DbRepo[LibraryToSlackChannel] with LibraryToSlackChannelRepo {
+    integrationsCache: SlackChannelIntegrationsCache,
+    basicLibraryCache: BasicLibraryByIdCache) extends DbRepo[LibraryToSlackChannel] with LibraryToSlackChannelRepo {
 
   import com.keepit.common.db.slick.DBSession._
   import db.Driver.simple._
@@ -189,6 +191,11 @@ class LibraryToSlackChannelRepoImpl @Inject() (
 
   private def activeRows = rows.filter(row => row.state === LibraryToSlackChannelStates.ACTIVE)
   private def workingRows = activeRows.filter(row => row.status === (SlackIntegrationStatus.On: SlackIntegrationStatus))
+
+  override def save(model: LibraryToSlackChannel)(implicit session: RWSession): LibraryToSlackChannel = {
+    basicLibraryCache.remove(BasicLibraryByIdKey(model.libraryId))
+    super.save(model)
+  }
 
   def getByIds(ids: Set[Id[LibraryToSlackChannel]])(implicit session: RSession): Map[Id[LibraryToSlackChannel], LibraryToSlackChannel] = {
     rows.filter(row => row.id.inSet(ids)).list.map(r => (r.id.get, r)).toMap

--- a/kifi-backend/modules/shoebox/app/views/admin/graph/wanderView.scala.html
+++ b/kifi-backend/modules/shoebox/app/views/admin/graph/wanderView.scala.html
@@ -68,7 +68,7 @@
         <table class = "table table-bordered">
             <tr><th colspan="3"><h3>Library Collisions</h3></th></tr>
             <tr> <th>Public Id</th> <th>Title</th> <th>Owner</th><th>Score</th> </tr>
-            @libraries.map { case (library, owner, count) => <tr> <td>@library.id.get</td> <td><a href=https://www.kifi.com@{com.keepit.model.LibraryPathHelper.formatLibraryPath(com.keepit.social.BasicUser.fromUser(owner), None, library.slug)}>@library.name</a></td><td>@owner.fullName</td> <td>@count</td> </tr> }
+            @libraries.map { case (library, owner, count) => <tr> <td>@library.id.get</td> <td><a href=https://www.kifi.com@{com.keepit.model.LibraryPathHelper.formatLibraryPath(com.keepit.social.BasicUser.fromUser(owner).username, None, library.slug)}>@library.name</a></td><td>@owner.fullName</td> <td>@count</td> </tr> }
         </table>
     }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepActivityGenTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepActivityGenTest.scala
@@ -50,7 +50,7 @@ class KeepActivityGenTest extends Specification with ShoeboxTestInjector {
         val libIdsToAdd = libsToAdd.map(_.id.get).toSet
 
         val basicUserById = usersToAdd.map(usr => usr.id.get -> BasicUser.fromUser(usr)).toMap + (user.id.get -> basicUser)
-        val basicLibById = libsToAdd.map(lib => lib.id.get -> BasicLibrary(lib, basicUser, None, None)).toMap
+        val basicLibById = libsToAdd.map(lib => lib.id.get -> BasicLibrary(lib, basicUser.username, None, None)).toMap
 
         import com.keepit.common.util.DescriptionElements._
         val eventHeaders = db.readWrite { implicit s =>

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/seo/FeedControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/seo/FeedControllerTest.scala
@@ -95,7 +95,7 @@ class FeedControllerTest extends Specification with ShoeboxTestInjector {
         (channel \ "link").text.trim === s"http://dev.ezkeep.com:9000$path"
         val items = (elem \\ "item")
         items.size === 3
-        (items.head \ "link").text.trim === s"http://dev.ezkeep.com:9000${LibraryPathHelper.formatLibraryPath(BasicUser.fromUser(u2), None, lib3.slug)}"
+        (items.head \ "link").text.trim === s"http://dev.ezkeep.com:9000${LibraryPathHelper.formatLibraryPath(u2.username, None, lib3.slug)}"
 
       }
     }
@@ -116,7 +116,7 @@ class FeedControllerTest extends Specification with ShoeboxTestInjector {
         (channel \ "link").text.trim === s"http://dev.ezkeep.com:9000$path"
         val items = (elem \\ "item")
         items.size === 1
-        (items.head \ "link").text.trim === s"http://dev.ezkeep.com:9000${LibraryPathHelper.formatLibraryPath(BasicUser.fromUser(u1), None, lib1.slug)}"
+        (items.head \ "link").text.trim === s"http://dev.ezkeep.com:9000${LibraryPathHelper.formatLibraryPath(u1.username, None, lib1.slug)}"
 
       }
     }

--- a/kifi-backend/modules/shoebox/test/com/keepit/model/UserTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/UserTest.scala
@@ -50,7 +50,7 @@ class UserTest extends Specification with ShoeboxTestInjector {
           db.readOnlyMaster { implicit s => userRepoImpl.get(Id[User](1)) }
         }
         Try(db.readOnlyMaster { implicit s => userRepoImpl.get(Id[User](2)) })
-        sessionProvider.readOnlySessionsCreated === 1
+        sessionProvider.readOnlySessionsCreated === 3 // sessions created by invalidating BasicLibraryByIdCache
       }
     }
 

--- a/kifi-backend/modules/shoebox/test/com/keepit/shoebox/data/keep/KeepDataFormatTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/shoebox/data/keep/KeepDataFormatTest.scala
@@ -55,7 +55,7 @@ class KeepDataFormatTest extends TestKitSupport with SpecificationLike with Shoe
             "recipients" -> Json.obj(
               "users" -> Seq(BasicUser.fromUser(user)),
               "emails" -> Seq.empty[BasicContact],
-              "libraries" -> Seq(BasicLibrary(lib, BasicUser.fromUser(user), None, None))
+              "libraries" -> Seq(BasicLibrary(lib, user.username, None, None))
             ),
             "viewer" -> Json.obj(
               "permissions" -> db.readOnlyMaster { implicit s => permissionCommander.getKeepPermissions(keep.id.get, Some(user.id.get)) }


### PR DESCRIPTION
@leogrim @ryanpbrewster @andrewconner 

at first was hesitant about this due to invalidation, but realized that we have a `handle` table that will support redirects to the right page even if the `BasicLibrary` has a stale handle. Otherwise, we can go through all libraries in a space when that handle changes, but that'll be expensive for every org and user update.
