### PR TITLE
Don't start the progress bar if no change was made

### DIFF
--- a/packrat/scripts/message_context.js
+++ b/packrat/scripts/message_context.js
@@ -210,13 +210,8 @@ k.messageContext = k.messageContext || (function ($) {
       var data = $view.data();
       var val = input.value.trim();
 
-      if (val === '') {
-        return;
-      }
-
-      k.progress.emptyAndShow($view, deferred.promise);
-
       if (val && val !== data['title' in data.saving ? 'saving' : 'saved'].title) {
+        k.progress.emptyAndShow($view, deferred.promise);
         data.saving.title = val;
         api.port.emit('save_keepscussion_title', {keepId: keepId, newTitle: val}, function (success) {
           if (data.saving.title === val) {


### PR DESCRIPTION
If you deleted all the text in the title, then clicked away the old title would come back (as expected) but the progress bar would move like it was trying to save, even though it wasn't.
