### PR TITLE
Add support for sending tags of the form #tag on the site

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comment/comment.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comment/comment.tpl.html
@@ -38,7 +38,7 @@
           <img class="kf-keep-comment-embedded-img" ng-src="{{part.data.src}}"/>
         </div>
 
-        <div ng-if="part.type === 'TEXT_PLAIN'" ng-bind="part.data.text" class="kf-keep-comment-inline"></div>
+        <div ng-if="part.type === 'TEXT_PLAIN'" ng-bind-html="part.data.text|noteHtml" class="kf-keep-comment-inline"></div>
 
         <div ng-if="part.type === 'EMAIL'" class="kf-keep-comment-inline">
           <a ng-href="mail-to:{{part.data.text}}" ng-bind="part.data.text" class="kf-link-blue kf-keep-comment-inline"></a>

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comments.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/comments/comments.js
@@ -64,10 +64,12 @@ angular.module('kifi')
             // else we continue normally
             var commentBox = getCommentBox(element);
             if (commentBox && !e.shiftKey && e.which === 13) {
+              var tagRe = /(?:\[(#\D[\w\-​_ ]+[\w])\])|(#\D[\w\-_​]{2,})/g;
+              var text = commentBox.textContent.replace(tagRe, '[$1$2]');
               var msg = {
                 sentAt: new Date().getTime(),
                 sentBy: profileService.me,
-                text: commentBox.textContent
+                text: text
               };
               $scope.comments.push(msg);
               $scope.visibleCount++;

--- a/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/keepActivity.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/directives/keepActivity/keepActivity.js
@@ -70,7 +70,8 @@ angular.module('kifi')
             // else we continue normally
             var commentBox = getCommentBox(element);
             if (commentBox && !e.shiftKey && e.which === 13) {
-              var text = commentBox.textContent;
+              var tagRe = /(?:\[(#\D[\w\-​_ ]+[\w])\])|(#\D[\w\-_​]{2,})/g;
+              var text = commentBox.textContent.replace(tagRe, '[$1$2]');
               var userPic = $filter('pic')(profileService.me);
               var userName = $filter('name')(profileService.me);
               var activityEvent = {


### PR DESCRIPTION
I included the regex in both the old and new comment code. Hopefully the old `comments.js` can be deleted in the near future (once activity log launches on the site).

@andrewconner 
