### PR TITLE
remove activity log check from keep cards

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/keepCard.js
@@ -285,7 +285,7 @@ angular.module('kifi')
           scope.$watch('keep.title', updateTitle);
           scope.defaultDescLines = 4;
           scope.me = profileService.me;
-          scope.showActivityEvents = keep.activity && profileService.hasExperiment('activity_log');
+          scope.showActivityEvents = keep.activity;
           scope.showOriginLibrary = scope.currentPageOrigin !== 'libraryPage' &&
             keep.library && keep.library.visibility !== 'discoverable' && keep.library.kind === 'system_secret';
           // Don't change until the link is updated to be a bit more secure:


### PR DESCRIPTION
This does not turn on activity log, but once the server sends the `activity` key for everyone clients will automatically switch to it.
