### PR TITLE
add DescriptionElement.internalFormat

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/path/Path.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/path/Path.scala
@@ -54,7 +54,7 @@ object Path {
 
   def apply(value: String): Path = {
     val (path, query) = splitQuery(value)
-    new Path("/" + path.stripPrefix(base).stripPrefix("/"), query)
+    new Path(path.stripPrefix(base).stripPrefix("/"), query)
   }
 
   def encode(value: String): EncodedPath = {

--- a/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/routes/Router.scala
@@ -178,8 +178,9 @@ object Shoebox extends Service {
     def getSlackTeamIds() = ServiceRoute(POST, "/internal/shoebox/database/getSlackTeamIds")
     def getSlackTeamInfo(slackTeamId: SlackTeamId) = ServiceRoute(GET, "/internal/shoebox/database/getSlackTeamInfo", Param("slackTeamId", slackTeamId.value))
     def internKeep() = ServiceRoute(POST, "/internal/shoebox/database/internKeep")
-    def editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], persistKeepEvent: Boolean, source: Option[KeepEventSource]) = ServiceRoute(POST, "/internal/shoebox/database/editRecipientsOnKeep", Param("editorId", editorId), Param("keepId", keepId), Param("persistKeepEvent", persistKeepEvent), Param("source", source.map(_.value)))
+    def editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep]) = ServiceRoute(POST, "/internal/shoebox/database/editRecipientsOnKeep", Param("editorId", editorId), Param("keepId", keepId))
     def registerMessageOnKeep() = ServiceRoute(POST, "/internal/shoebox/database/registerMessageOnKeep")
+    def persistModifyRecipients() = ServiceRoute(POST, "/internal/shoebox/database/persistModifyRecipients")
   }
 }
 
@@ -271,12 +272,11 @@ object Eliza extends Service {
     def editMessage() = ServiceRoute(POST, "/internal/eliza/editMessage")
     def deleteMessage() = ServiceRoute(POST, "/internal/eliza/deleteMessage")
     def keepHasAccessToken(keepId: Id[Keep], accessToken: String) = ServiceRoute(GET, "/internal/eliza/keepHasAccessToken", Param("keepId", keepId), Param("accessToken", accessToken))
-    def editParticipantsOnKeep() = ServiceRoute(POST, "/internal/eliza/editParticipantsOnKeep")
     def deleteThreadsForKeeps() = ServiceRoute(POST, "/internal/eliza/deleteThreadsForKeeps")
     def getMessagesChanged(seqNum: SequenceNumber[Message], fetchSize: Int) = ServiceRoute(GET, "/internal/eliza/getMessagesChanged", Param("seqNum", seqNum), Param("fetchSize", fetchSize))
     def convertNonUserThreadToUserThread(userId: Id[User], accessToken: String) = ServiceRoute(POST, "/internal/eliza/convertNonUserThreadToUserThread", Param("userId", userId), Param("accessToken", accessToken))
 
-    def syncAddParticipants = ServiceRoute(POST, "/internal/eliza/syncAddParticipants")
+    def handleKeepEvent = ServiceRoute(POST, "/internal/eliza/handleKeepEvent")
     def pageSystemMessages(fromId: Id[Message], pageSize: Int) = ServiceRoute(GET, "/internal/eliza/pageSystemMessages", Param("fromId", fromId.id), Param("pageSize", pageSize))
     def rpbTest = ServiceRoute(POST, "/internal/eliza/rpbTest")
 

--- a/kifi-backend/modules/common/app/com/keepit/common/util/DescriptionElements.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/DescriptionElements.scala
@@ -135,7 +135,7 @@ final case class NonUserElement(id: String) extends DescriptionElement(Descripti
   val url = None
 }
 object NonUserElementHelper extends DescriptionElementHelper[NonUserElement] {
-  val format = Json.format[NonUserElement]
+  val format: OFormat[NonUserElement] = Json.format[NonUserElement]
 }
 
 final case class AuthorElement(

--- a/kifi-backend/modules/common/app/com/keepit/common/util/DescriptionElements.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/DescriptionElements.scala
@@ -3,8 +3,10 @@ package com.keepit.common.util
 import com.keepit.common.core.jsObjectExtensionOps
 import com.keepit.common.crypto.PublicId
 import com.keepit.common.db.{ ExternalId, Id }
+import com.keepit.common.json.EnumFormat
 import com.keepit.common.mail.EmailAddress
 import com.keepit.common.path.Path
+import com.keepit.common.reflection.Enumerator
 import com.keepit.common.store.S3ImageConfig
 import com.keepit.common.strings.StringWithReplacements
 import com.keepit.macros.Location
@@ -15,7 +17,26 @@ import com.keepit.social.{ BasicAuthor, BasicNonUser, BasicUser }
 import org.joda.time.{ DateTime, Duration }
 import org.ocpsoft.prettytime.PrettyTime
 import play.api.libs.json._
+import play.api.libs.functional.syntax._
 import play.twirl.api.Html
+
+sealed abstract class DescriptionElementKind(val value: String)
+object DescriptionElementKind extends Enumerator[DescriptionElementKind] {
+  case object Text extends DescriptionElementKind("text")
+  case object Image extends DescriptionElementKind("image")
+  case object ShowOriginal extends DescriptionElementKind("showOriginal")
+  case object User extends DescriptionElementKind("user")
+  case object NonUser extends DescriptionElementKind("nonUser")
+  case object Author extends DescriptionElementKind("author")
+  case object Library extends DescriptionElementKind("library")
+  case object Organization extends DescriptionElementKind("organization")
+
+  val all = _all
+  def apply(str: String): DescriptionElementKind = all.find(_.value == str).get
+  def fromStr(str: String): Option[DescriptionElementKind] = all.find(_.value == str)
+
+  implicit val format: Format[DescriptionElementKind] = EnumFormat.format(fromStr, _.value, domain = all.map(_.value).toSet)
+}
 
 sealed trait DescriptionElements {
   def flatten: Seq[DescriptionElement]
@@ -26,25 +47,57 @@ final case class SequenceOfElements(elements: Seq[DescriptionElements]) extends 
 object SequenceOfElements {
   val empty = SequenceOfElements(Seq.empty)
 }
-sealed abstract class DescriptionElement(val kind: String) extends DescriptionElements {
+sealed abstract class DescriptionElement(val kind: DescriptionElementKind) extends DescriptionElements {
   def flatten = Seq(this).filterNot(_.isNull)
-  val text: String
-  val url: Option[String]
-  protected def isNull: Boolean = text.isEmpty // NB(ryan): named `isNull` because of scalac issues resolving str.isEmpty vs fromText(str).isEmpty when fromText is implicit
-  def asJson: JsObject
-}
-object DescriptionElement {
-  implicit val writes: OWrites[DescriptionElement] = OWrites { de => de.asJson.nonNullFields + ("kind" -> JsString(de.kind)) }
+  def text: String
+  def url: Option[String]
+  def isNull: Boolean = text.isEmpty // NB(ryan): named `isNull` because of scalac issues resolving str.isEmpty vs fromText(str).isEmpty when fromText is implicit
 }
 
-final case class TextElement(text: String, url: Option[String], hover: Option[DescriptionElements]) extends DescriptionElement("text") {
+object DescriptionElement {
+  implicit val format: Format[DescriptionElement] = Format(
+    Reads { js =>
+      (js \ "kind").validate[DescriptionElementKind].flatMap {
+        case DescriptionElementKind.Text => TextElementHelper.format.reads(js)
+        case DescriptionElementKind.Image => ImageElementHelper.format.reads(js)
+        case DescriptionElementKind.ShowOriginal => ShowOriginalElementHelper.format.reads(js)
+        case DescriptionElementKind.User => UserElementHelper.format.reads(js)
+        case DescriptionElementKind.NonUser => NonUserElementHelper.format.reads(js)
+        case DescriptionElementKind.Author => AuthorElementHelper.format.reads(js)
+        case DescriptionElementKind.Library => LibraryElementHelper.format.reads(js)
+        case DescriptionElementKind.Organization => OrganizationElementHelper.format.reads(js)
+      }
+    },
+    Writes { de =>
+      val specificFields = de match {
+        case v: TextElement => TextElementHelper.format.writes(v)
+        case v: ImageElement => ImageElementHelper.format.writes(v)
+        case v: ShowOriginalElement => ShowOriginalElementHelper.format.writes(v)
+        case v: UserElement => UserElementHelper.format.writes(v)
+        case v: NonUserElement => NonUserElementHelper.format.writes(v)
+        case v: AuthorElement => AuthorElementHelper.format.writes(v)
+        case v: LibraryElement => LibraryElementHelper.format.writes(v)
+        case v: OrganizationElement => OrganizationElementHelper.format.writes(v)
+      }
+      Json.obj("kind" -> de.kind, "text" -> de.text, "url" -> de.url).nonNullFields ++ specificFields
+    }
+  )
+}
+
+sealed abstract class DescriptionElementHelper[A <: DescriptionElement] {
+  val format: OFormat[A]
+}
+
+case class TextElement(text: String, url: Option[String], hover: Option[DescriptionElements]) extends DescriptionElement(DescriptionElementKind.Text) {
   override def flatten = Seq(simplify)
   private def simplify = this.copy(url = url.filter(_.nonEmpty), hover = hover.filter(_.flatten.nonEmpty))
 
   def -->(link: LinkElement): TextElement = this.copy(url = Some(link.url))
   def -->(hover: Hover): TextElement = this.copy(hover = Some(hover.elements))
-
-  def asJson = Json.obj("text" -> text, "url" -> url, "hover" -> hover)
+}
+object TextElementHelper extends DescriptionElementHelper[TextElement] {
+  private implicit val hoverFormat = DescriptionElements.format
+  val format: OFormat[TextElement] = Json.format[TextElement]
 }
 
 final case class LinkElement(url: String)
@@ -53,63 +106,71 @@ object LinkElement {
 }
 final case class Hover(elements: DescriptionElements*)
 
-final case class ImageElement(override val url: Option[String], image: String) extends DescriptionElement("image") {
-  override protected def isNull = image.isEmpty
-
-  val text = ""
-  def asJson = Json.obj("text" -> text, "image" -> image, "url" -> url)
+case class ImageElement(override val url: Option[String], image: String) extends DescriptionElement(DescriptionElementKind.Image) {
+  override def isNull = image.isEmpty
+  def text = ""
+}
+object ImageElementHelper extends DescriptionElementHelper[ImageElement] {
+  val format: OFormat[ImageElement] = Json.format[ImageElement]
 }
 
-final case class ShowOriginalElement(original: String, updated: String) extends DescriptionElement("showOriginal") {
+final case class ShowOriginalElement(original: String, updated: String) extends DescriptionElement(DescriptionElementKind.ShowOriginal) {
   val text = s"“$original” --> “$updated”"
   val url = None
-
-  def asJson = Json.obj("text" -> text, "original" -> original, "updated" -> updated)
+}
+object ShowOriginalElementHelper extends DescriptionElementHelper[ShowOriginalElement] {
+  val format: OFormat[ShowOriginalElement] = Json.format[ShowOriginalElement]
 }
 
-final case class UserElement(
-    id: ExternalId[User],
-    name: String,
-    image: String,
-    path: Path) extends DescriptionElement("user") {
+final case class UserElement(id: ExternalId[User], name: String, image: String, path: Path) extends DescriptionElement(DescriptionElementKind.User) {
   val text = name
   val url = Some(path.absolute)
-  def asJson = Json.obj("id" -> id, "text" -> text, "image" -> image, "url" -> url)
+}
+object UserElementHelper extends DescriptionElementHelper[UserElement] {
+  val format: OFormat[UserElement] = Json.format[UserElement]
 }
 
-final case class NonUserElement(id: String) extends DescriptionElement("nonUser") {
+final case class NonUserElement(id: String) extends DescriptionElement(DescriptionElementKind.NonUser) {
   val text = id
   val url = None
-  def asJson = Json.obj("text" -> text)
+}
+object NonUserElementHelper extends DescriptionElementHelper[NonUserElement] {
+  val format = Json.format[NonUserElement]
 }
 
 final case class AuthorElement(
     id: String,
     name: String,
     image: String,
-    override val url: Option[String]) extends DescriptionElement("author") {
+    override val url: Option[String]) extends DescriptionElement(DescriptionElementKind.Author) {
   val text = name
-  def asJson = Json.obj("id" -> id, "text" -> text, "image" -> image, "url" -> url)
+}
+object AuthorElementHelper extends DescriptionElementHelper[AuthorElement] {
+  val format: OFormat[AuthorElement] = Json.format[AuthorElement]
 }
 
 final case class LibraryElement(
     id: PublicId[Library],
     name: String,
     color: Option[LibraryColor],
-    path: Path) extends DescriptionElement("library") {
+    path: Path) extends DescriptionElement(DescriptionElementKind.Library) {
   val text = name
   val url = Some(path.absolute)
-  def asJson = Json.obj("id" -> id, "text" -> text, "color" -> color, "url" -> url)
+}
+object LibraryElementHelper extends DescriptionElementHelper[LibraryElement] {
+  val format: OFormat[LibraryElement] = Json.format[LibraryElement]
 }
 
 final case class OrganizationElement(
     id: PublicId[Organization],
     name: String,
     image: String,
-    path: Path) extends DescriptionElement("organization") {
+    path: Path) extends DescriptionElement(DescriptionElementKind.Organization) {
   val text = name
   val url = Some(path.absolute)
-  def asJson = Json.obj("id" -> id, "text" -> text, "image" -> image, "url" -> url)
+}
+object OrganizationElementHelper extends DescriptionElementHelper[OrganizationElement] {
+  val format: OFormat[OrganizationElement] = Json.format[OrganizationElement]
 }
 
 object DescriptionElements {
@@ -188,7 +249,7 @@ object DescriptionElements {
         case (l, r) if leftEnds.exists(l.endsWith) || rightStarts.exists(r.startsWith) => ""
         case _ => " "
       }.map(TextElement(_, None, None))
-      intersperse(els, interpolatedPunctuation).filterNot(_.text.isEmpty)
+      intersperse(els, interpolatedPunctuation).filterNot(_.isNull)
     }
   }
   def formatPlain(description: DescriptionElements): String = interpolatePunctuation(description.flatten).map(_.text).mkString
@@ -228,7 +289,11 @@ object DescriptionElements {
       case _ => x +: simplifyElements(y +: rs)
     }
   }
-  implicit val flatWrites: Writes[DescriptionElements] = Writes { dsc =>
-    JsArray(simplifyElements(interpolatePunctuation(dsc.flatten)).map(DescriptionElement.writes.writes))
-  }
+
+  implicit val format: Format[DescriptionElements] = Format(
+    Reads { js => js.validate[Seq[DescriptionElement]].map(SequenceOfElements(_)) },
+    Writes { dsc =>
+      JsArray(simplifyElements(interpolatePunctuation(dsc.flatten)).map(DescriptionElement.format.writes))
+    }
+  )
 }

--- a/kifi-backend/modules/common/app/com/keepit/model/KeepEventData.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/KeepEventData.scala
@@ -2,7 +2,7 @@ package com.keepit.model
 
 import javax.crypto.spec.IvParameterSpec
 
-import com.keepit.common.crypto.{ PublicIdGenerator, PublicId }
+import com.keepit.common.crypto.{ PublicIdConfiguration, PublicIdGenerator, PublicId }
 import com.keepit.common.db.Id
 import com.keepit.common.json.{ SchemaReads, EitherFormat, EnumFormat }
 import com.keepit.common.net.UserAgent
@@ -119,11 +119,17 @@ object KeepEventSource extends Enumerator[KeepEventSource] {
   }
 }
 
-sealed abstract class KeepEventData(val kind: KeepEventKind)
+sealed abstract class KeepEventData(val kind: KeepEventKind) {
+  def isValid: Boolean
+}
 object KeepEventData {
   implicit val diffFormat = KeepRecipientsDiff.internalFormat
-  @json case class ModifyRecipients(addedBy: Id[User], diff: KeepRecipientsDiff) extends KeepEventData(KeepEventKind.ModifyRecipients)
-  @json case class EditTitle(editedBy: Id[User], original: Option[String], updated: Option[String]) extends KeepEventData(KeepEventKind.EditTitle)
+  @json case class ModifyRecipients(editedBy: Id[User], diff: KeepRecipientsDiff) extends KeepEventData(KeepEventKind.ModifyRecipients) {
+    def isValid = diff.nonEmpty
+  }
+  @json case class EditTitle(editedBy: Id[User], original: Option[String], updated: Option[String]) extends KeepEventData(KeepEventKind.EditTitle) {
+    def isValid = original != updated
+  }
   implicit val format = Format[KeepEventData](
     Reads {
       js =>
@@ -141,10 +147,22 @@ object KeepEventData {
   )
 }
 
-case class CommonKeepEvent()
+case class CommonKeepEvent(
+  id: Id[CommonKeepEvent],
+  keepId: Id[Keep],
+  timestamp: DateTime,
+  eventData: KeepEventData,
+  source: Option[KeepEventSource])
 object CommonKeepEvent extends PublicIdGenerator[CommonKeepEvent] {
   val publicIdIvSpec: IvParameterSpec = new IvParameterSpec(Array(125, 15, 73, -1, 17, -36, 81, -84, -126, 92, 65, -97, 127, 47, -113, 58))
   val publicIdPrefix = "kev"
+  val format: Format[CommonKeepEvent] = (
+    (__ \ 'id).format[Id[CommonKeepEvent]] and
+    (__ \ 'keepId).format[Id[Keep]] and
+    (__ \ 'timestamp).format[DateTime] and
+    (__ \ 'eventData).format[KeepEventData] and
+    (__ \ 'source).formatNullable[KeepEventSource]
+  )(CommonKeepEvent.apply, unlift(CommonKeepEvent.unapply))
 }
 
 //case class BasicKeepEventId(id: Option[Either[PublicId[Message], PublicId[CommonKeepEvent]]])
@@ -171,7 +189,7 @@ object BasicKeepEvent {
     final case class EventId(id: PublicId[CommonKeepEvent]) extends BasicKeepEventId
     final case class InitialId(id: PublicId[Keep]) extends BasicKeepEventId
     final case class NoteId(id: PublicId[Keep]) extends BasicKeepEventId
-    implicit val writes: Writes[BasicKeepEventId] = Writes {
+    private val writes: Writes[BasicKeepEventId] = Writes {
       case InitialId(kId) => JsString(s"init_${kId.id}")
       case NoteId(kId) => JsString(s"note_${kId.id}")
       case MessageId(msgId) => JsString(msgId.id)
@@ -184,11 +202,16 @@ object BasicKeepEvent {
       js.validate[String].filter(_.startsWith("note_")).flatMap(s => Keep.readsPublicId.reads(JsString(s.stripPrefix("note_"))).map(NoteId(_)))
     ).reduce(_ orElse _))
 
-    def fromMsg(id: PublicId[Message]) = MessageId(id)
-    def fromEvent(id: PublicId[CommonKeepEvent]) = EventId(id)
+    implicit val format: Format[BasicKeepEventId] = Format(reads, writes)
+
+    def fromMsg(id: Id[Message])(implicit config: PublicIdConfiguration) = MessageId(Message.publicId(id))
+    def fromEvent(id: Id[CommonKeepEvent])(implicit config: PublicIdConfiguration) = EventId(CommonKeepEvent.publicId(id))
+    def fromPubMsg(id: PublicId[Message]) = MessageId(id)
+    def fromPubEvent(id: PublicId[CommonKeepEvent]) = EventId(id)
   }
 
   implicit val idFormat = EitherFormat(Message.formatPublicId, CommonKeepEvent.formatPublicId)
+
   private val bareWrites: OWrites[BasicKeepEvent] = (
     (__ \ 'id).write[BasicKeepEventId] and
     (__ \ 'author).write[BasicAuthor] and
@@ -207,6 +230,16 @@ object BasicKeepEvent {
 
   implicit val writes: OWrites[BasicKeepEvent] = OWrites { o => bareWrites.writes(o) ++ extraWrites.writes(o) }
 
+  val format: Format[BasicKeepEvent] = (
+    (__ \ 'id).format[BasicKeepEventId](BasicKeepEventId.format) and
+    (__ \ 'author).format[BasicAuthor] and
+    (__ \ 'kind).format[KeepEventKind] and
+    (__ \ 'header).format[DescriptionElements](DescriptionElements.format) and
+    (__ \ 'body).format[DescriptionElements](DescriptionElements.format) and
+    (__ \ 'timestamp).format[DateTime] and
+    (__ \ 'source).formatNullable[BasicKeepEventSource]
+  )(BasicKeepEvent.apply, unlift(BasicKeepEvent.unapply))
+
   def fromMessage(message: Message)(implicit imageConfig: S3ImageConfig): BasicKeepEvent = {
     val author = message.sentBy.fold(BasicAuthor.fromNonUser, BasicAuthor.fromUser)
     generateCommentEvent(message.pubId, author, message.text, message.sentAt, message.source)
@@ -214,7 +247,7 @@ object BasicKeepEvent {
 
   def generateCommentEvent(id: PublicId[Message], author: BasicAuthor, text: String, sentAt: DateTime, source: Option[MessageSource]): BasicKeepEvent = {
     BasicKeepEvent(
-      id = BasicKeepEventId.fromMsg(id),
+      id = BasicKeepEventId.fromPubMsg(id),
       author = author,
       kind = KeepEventKind.Comment,
       header = DescriptionElements(author),
@@ -223,6 +256,12 @@ object BasicKeepEvent {
       source = source.flatMap(KeepEventSource.fromMessageSource).map(BasicKeepEventSource(_, url = None))
     )
   }
+}
+
+@json case class CommonAndBasicKeepEvent(commonEvent: CommonKeepEvent, basicEvent: BasicKeepEvent)
+object CommonAndBasicKeepEvent {
+  implicit val basicEventFormat = BasicKeepEvent.format
+  implicit val commonEventFormat = CommonKeepEvent.format
 }
 
 case class KeepActivity(latestEvent: BasicKeepEvent, events: Seq[BasicKeepEvent], numComments: Int)

--- a/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
+++ b/kifi-backend/modules/common/app/com/keepit/shoebox/ShoeboxServiceClient.scala
@@ -18,12 +18,13 @@ import com.keepit.common.store.ImageSize
 import com.keepit.common.usersegment.{ UserSegment, UserSegmentCache, UserSegmentFactory, UserSegmentKey }
 import com.keepit.common.zookeeper._
 import com.keepit.discussion.{ CrossServiceMessage, DiscussionKeep }
+import com.keepit.model.KeepEventData.ModifyRecipients
 import com.keepit.model._
 import com.keepit.model.cache.{ UserSessionViewExternalIdCache, UserSessionViewExternalIdKey }
 import com.keepit.model.view.{ LibraryMembershipView, UserSessionView }
 import com.keepit.rover.model.BasicImages
 import com.keepit.search.{ ActiveExperimentsCache, ActiveExperimentsKey, SearchConfigExperiment }
-import com.keepit.shoebox.ShoeboxServiceClient.{ RegisterMessageOnKeep, InternKeep, GetPersonalKeepRecipientsOnUris, GetSlackTeamInfo }
+import com.keepit.shoebox.ShoeboxServiceClient.{ PersistModifyRecipients, RegisterMessageOnKeep, InternKeep, GetPersonalKeepRecipientsOnUris, GetSlackTeamInfo }
 import com.keepit.shoebox.model.ids.UserSessionExternalId
 import com.keepit.shoebox.model.{ IngestableUserIpAddress, KeepImagesCache, KeepImagesKey }
 import com.keepit.slack.models._
@@ -141,7 +142,8 @@ trait ShoeboxServiceClient extends ServiceClient {
 
   // TODO[keepscussions]: kill these methods once Eliza endpoints are deprecated
   def internKeep(creator: Id[User], users: Set[Id[User]], emails: Set[EmailAddress], uriId: Id[NormalizedURI], url: String, title: Option[String], note: Option[String], source: Option[KeepSource]): Future[CrossServiceKeep]
-  def editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], diff: KeepRecipientsDiff, persistKeepEvent: Boolean, source: Option[KeepEventSource]): Future[Unit]
+  def editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], diff: KeepRecipientsDiff): Future[Unit]
+  def persistModifyRecipients(keepId: Id[Keep], eventData: ModifyRecipients, source: Option[KeepEventSource]): Future[Option[CommonAndBasicKeepEvent]]
   def registerMessageOnKeep(keepId: Id[Keep], msg: CrossServiceMessage): Future[Unit]
 }
 
@@ -912,15 +914,24 @@ class ShoeboxServiceClientImpl @Inject() (
     }
   }
 
-  def editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], diff: KeepRecipientsDiff, persistKeepEvent: Boolean, source: Option[KeepEventSource]): Future[Unit] = {
+  def editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], diff: KeepRecipientsDiff): Future[Unit] = {
     val jsRecipients = Json.toJson(diff)(KeepRecipientsDiff.internalFormat)
-    call(Shoebox.internal.editRecipientsOnKeep(editorId, keepId, persistKeepEvent, source), body = Json.obj("diff" -> jsRecipients)).map(_ => ())
+    call(Shoebox.internal.editRecipientsOnKeep(editorId, keepId), body = Json.obj("diff" -> jsRecipients)).map(_ => ())
   }
 
   def registerMessageOnKeep(keepId: Id[Keep], msg: CrossServiceMessage): Future[Unit] = {
     import RegisterMessageOnKeep._
     val request = Request(keepId, msg)
     call(Shoebox.internal.registerMessageOnKeep(), body = Json.toJson(request)).map(_ => ())
+  }
+
+  def persistModifyRecipients(keepId: Id[Keep], eventData: ModifyRecipients, source: Option[KeepEventSource]): Future[Option[CommonAndBasicKeepEvent]] = {
+    import PersistModifyRecipients._
+    if (!eventData.isValid) Future.successful(None)
+    else {
+      val request = Request(keepId, eventData, source)
+      call(Shoebox.internal.persistModifyRecipients(), body = Json.toJson(request)).map { _.json.as[Response].internalAndExternalEvent }
+    }
   }
 }
 
@@ -948,6 +959,13 @@ object ShoeboxServiceClient {
 
   object GetRecipientsOnKeep {
     case class Response(users: Map[Id[User], BasicUser], libraries: Map[Id[Library], BasicLibrary], emails: Set[EmailAddress])
+    implicit val responseFormat: Format[Response] = Json.format[Response]
+  }
+
+  object PersistModifyRecipients {
+    case class Request(keepId: Id[Keep], eventData: ModifyRecipients, source: Option[KeepEventSource])
+    case class Response(internalAndExternalEvent: Option[CommonAndBasicKeepEvent]) // None if event was not created
+    implicit val requestFormat: Format[Request] = Json.format[Request]
     implicit val responseFormat: Format[Response] = Json.format[Response]
   }
 }

--- a/kifi-backend/modules/common/test/com/keepit/common/util/DescriptionElementsTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/util/DescriptionElementsTest.scala
@@ -1,5 +1,6 @@
 package com.keepit.common.util
 
+import com.google.inject.Injector
 import com.keepit.common.crypto.PublicId
 import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.path.Path
@@ -11,6 +12,8 @@ import com.keepit.social.{ BasicUser, BasicAuthor }
 import org.joda.time.{ Duration, DateTime, Period }
 import org.specs2.mutable.Specification
 import play.api.libs.json.{ JsObject, Json }
+
+import scala.util.Try
 
 class DescriptionElementsTest extends Specification {
 

--- a/kifi-backend/modules/common/test/com/keepit/common/util/DescriptionElementsTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/util/DescriptionElementsTest.scala
@@ -1,16 +1,21 @@
 package com.keepit.common.util
 
 import com.keepit.common.crypto.PublicId
-import com.keepit.common.db.Id
+import com.keepit.common.db.{ ExternalId, Id }
+import com.keepit.common.path.Path
+import com.keepit.common.store.{ S3ImageConfig, ImagePath }
 import com.keepit.common.time._
 import com.keepit.model.BasicKeepEvent.BasicKeepEventId
 import com.keepit.model._
-import com.keepit.social.BasicAuthor
+import com.keepit.social.{ BasicUser, BasicAuthor }
 import org.joda.time.{ Duration, DateTime, Period }
 import org.specs2.mutable.Specification
 import play.api.libs.json.{ JsObject, Json }
 
 class DescriptionElementsTest extends Specification {
+
+  implicit val imageConfig = S3ImageConfig("", "http://dev.ezkeep.com:9000", isLocal = true)
+
   "DescriptionElements" should {
     "format time periods properly" in {
       import DescriptionElements._
@@ -62,6 +67,32 @@ class DescriptionElementsTest extends Specification {
       val jsEvent = Json.toJson(event)
       (jsEvent \ "header").as[Seq[JsObject]].map { o => (o \ "text").as[String] } === Seq(author.name, " kept in ", library.name)
       (jsEvent \ "body").as[Seq[JsObject]].map { o => (o \ "text").as[String] } === Seq("Here is a note with [#hashtags] all over")
+    }
+
+    "internally format elements" in {
+      import com.keepit.common.util.DescriptionElements._
+      val user1 = BasicUser(ExternalId[User](), "Hank", "Paulson", "0.jpg", Username("hank"))
+      val author = BasicAuthor.fromUser(user1)
+      val library = BasicLibrary(PublicId[Library]("l1234567"), "Paper Street Soap Company", "/paulson/soap", LibraryVisibility.DISCOVERABLE, color = None, slack = None)
+      val org = BasicOrganization(PublicId[Organization]("o7654321"), user1.externalId, OrganizationHandle("paperstreetsoap"), "Paper Street Soap Company", description = None, avatarPath = ImagePath("/"))
+
+      def exampleForKind(kind: DescriptionElementKind): DescriptionElement = kind match {
+        case DescriptionElementKind.Image => ImageElement(url = Some("https://www.flickr.com"), image = "/flickrImage")
+        case DescriptionElementKind.ShowOriginal => ShowOriginalElement("first comes first", "second come second")
+        case DescriptionElementKind.User => fromBasicUser(user1)
+        case DescriptionElementKind.NonUser => NonUserElement("hankpaulson@paperstreet.club")
+        case DescriptionElementKind.Author => fromBasicAuthor(author)
+        case DescriptionElementKind.Library => fromBasicLibrary(library)
+        case DescriptionElementKind.Organization => fromBasicOrg(org)
+        case DescriptionElementKind.Text => TextElement("testing one two three", url = Some("https://www.testing.com"), hover = Some(DescriptionElements("woo look at me!")))
+      }
+
+      for (kind <- DescriptionElementKind.all) {
+        val ex = exampleForKind(kind)
+        val payload = DescriptionElement.format.writes(ex)
+        DescriptionElement.format.reads(payload).asEither must beRight(ex)
+      }
+      1 === 1
     }
   }
 }

--- a/kifi-backend/modules/common/test/com/keepit/common/util/DescriptionElementsTest.scala
+++ b/kifi-backend/modules/common/test/com/keepit/common/util/DescriptionElementsTest.scala
@@ -94,5 +94,17 @@ class DescriptionElementsTest extends Specification {
       }
       1 === 1
     }
+    "format invertably" in {
+      import com.keepit.common.util.DescriptionElements._
+      val orig: DescriptionElements = {
+        val ryan = BasicUser(ExternalId[User](), "Ryan", "Brewster", "0.jpg", Username("ryanpbrewster"))
+        val myMainLibrary = BasicLibrary(PublicId[Library]("l1234567"), "My Main Library", "/ryanpbrewster/main", LibraryVisibility.DISCOVERABLE, color = None, slack = None)
+        DescriptionElements("Hello, I'm", ryan, "and I created", myMainLibrary)
+      }
+      val iter1 = Json.toJson(orig).as[DescriptionElements]
+      val iter2 = Json.toJson(iter1).as[DescriptionElements]
+
+      iter2 === iter1
+    }
   }
 }

--- a/kifi-backend/modules/common/test/com/keepit/eliza/FakeElizaServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/eliza/FakeElizaServiceClientImpl.scala
@@ -107,8 +107,8 @@ class FakeElizaServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, schedul
   def getMessagesChanged(seqNum: SequenceNumber[Message], fetchSize: Int): Future[Seq[CrossServiceMessage]] = Future.successful(Seq.empty)
   def convertNonUserThreadToUserThread(userId: Id[User], accessToken: String): Future[(Option[EmailAddress], Option[Id[User]])] = Future.successful((None, Some(Id[User](1)))) // should be different userId than arg
   def getInitialRecipientsByKeepId(keepIds: Set[Id[Keep]]): Future[Map[Id[Keep], KeepRecipients]] = ???
-  def editParticipantsOnKeep(keepId: Id[Keep], editor: Id[User], diff: KeepRecipientsDiff, source: Option[KeepEventSource]): Future[Boolean] = Future.successful(true)
-  def syncAddParticipants(keepId: Id[Keep], event: KeepEventData.ModifyRecipients, source: Option[KeepEventSource]): Future[Unit] = ???
+  def editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], diff: KeepRecipientsDiff): Future[Unit] = ???
+  def handleKeepEvent(keepId: Id[Keep], commonEvent: CommonKeepEvent, basicEvent: BasicKeepEvent, source: Option[KeepEventSource]): Future[Unit] = Future.successful(Unit)
   def pageSystemMessages(fromId: Id[Message], pageSize: Int): Future[Seq[CrossServiceMessage]] = ???
   def rpbTest(keepIds: Set[Id[Keep]], numPerKeep: Int): Future[Map[Id[Keep], Seq[Id[Message]]]] = ???
 }

--- a/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
+++ b/kifi-backend/modules/common/test/com/keepit/shoebox/FakeShoeboxServiceClientImpl.scala
@@ -16,6 +16,7 @@ import com.keepit.common.time._
 import com.keepit.common.usersegment.UserSegment
 import com.keepit.common.zookeeper.ServiceCluster
 import com.keepit.discussion.{ CrossServiceMessage, DiscussionKeep }
+import com.keepit.model.KeepEventData.ModifyRecipients
 import com.keepit.model._
 import com.keepit.model.view.{ LibraryMembershipView, UserSessionView }
 import com.keepit.rover.model.BasicImages
@@ -739,6 +740,7 @@ class FakeShoeboxServiceClientImpl(val airbrakeNotifier: AirbrakeNotifier, impli
     ))
   }
 
-  def editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], recipients: KeepRecipientsDiff, persistKeepEvent: Boolean, source: Option[KeepEventSource]): Future[Unit] = Future.successful(())
-  def registerMessageOnKeep(keepId: Id[Keep], msg: CrossServiceMessage): Future[Unit] = Future.successful(())
+  def editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], diff: KeepRecipientsDiff): Future[Unit] = Future.successful(Unit)
+  def persistModifyRecipients(keepId: Id[Keep], eventData: ModifyRecipients, source: Option[KeepEventSource]): Future[Option[CommonAndBasicKeepEvent]] = Future.successful(None)
+  def registerMessageOnKeep(keepId: Id[Keep], msg: CrossServiceMessage): Future[Unit] = Future.successful(Unit)
 }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
@@ -14,6 +14,7 @@ import com.keepit.common.time._
 import com.keepit.discussion._
 import com.keepit.eliza.model._
 import com.keepit.heimdal.HeimdalContext
+import com.keepit.model.KeepEventData.{ EditTitle, ModifyRecipients }
 import com.keepit.model._
 import com.keepit.shoebox.ShoeboxServiceClient
 import com.keepit.social.BasicUserLikeEntity
@@ -28,7 +29,8 @@ trait ElizaDiscussionCommander {
   def syncAddParticipants(keepId: Id[Keep], event: KeepEventData.ModifyRecipients, source: Option[KeepEventSource]): Future[Unit]
   def getEmailParticipantsForKeeps(keepIds: Set[Id[Keep]]): Map[Id[Keep], Map[EmailAddress, (Id[User], DateTime)]]
   def sendMessage(userId: Id[User], txt: String, keepId: Id[Keep], source: Option[MessageSource])(implicit context: HeimdalContext): Future[Message]
-  def editParticipantsOnKeep(keepId: Id[Keep], editor: Id[User], newUsers: Seq[Id[User]], newNonUsers: Seq[BasicContact], libraries: Seq[Id[Library]], orgs: Seq[Id[Organization]], source: Option[KeepEventSource], updateShoebox: Boolean)(implicit context: HeimdalContext): Future[Boolean]
+  def editParticipantsOnKeep(keepId: Id[Keep], editor: Id[User], newUsers: Seq[Id[User]], newNonUsers: Seq[BasicContact], orgs: Seq[Id[Organization]], source: Option[KeepEventSource])(implicit context: HeimdalContext): Future[Boolean]
+  def handleKeepEvent(keepId: Id[Keep], commonEvent: CommonKeepEvent, basicEvent: BasicKeepEvent, source: Option[KeepEventSource])(implicit context: HeimdalContext): Future[Unit]
   def muteThread(userId: Id[User], keepId: Id[Keep])(implicit context: HeimdalContext): Future[Boolean]
   def unmuteThread(userId: Id[User], keepId: Id[Keep])(implicit context: HeimdalContext): Future[Boolean]
   def markAsRead(userId: Id[User], keepId: Id[Keep], msgId: Id[ElizaMessage]): Option[Int]
@@ -116,7 +118,7 @@ class ElizaDiscussionCommanderImpl @Inject() (
   }
 
   def syncAddParticipants(keepId: Id[Keep], event: KeepEventData.ModifyRecipients, source: Option[KeepEventSource]): Future[Unit] = {
-    getOrCreateMessageThreadWithUser(keepId, event.addedBy).map { thread =>
+    getOrCreateMessageThreadWithUser(keepId, event.editedBy).map { thread =>
       db.readWrite { implicit s =>
         messageRepo.save(ElizaMessage(
           keepId = thread.keepId,
@@ -252,13 +254,44 @@ class ElizaDiscussionCommanderImpl @Inject() (
     nonUserThreadRepo.getByAccessToken(accessToken).exists(_.keepId == keepId)
   }
 
-  def editParticipantsOnKeep(keepId: Id[Keep], editor: Id[User], newUsers: Seq[Id[User]], newNonUsers: Seq[BasicContact], newLibraries: Seq[Id[Library]], orgs: Seq[Id[Organization]], source: Option[KeepEventSource], updateShoebox: Boolean)(implicit context: HeimdalContext): Future[Boolean] = {
+  // path for modifying participants from old clients: client --> eliza (thread updates) -> shoebox (keep event updates) -> eliza (event notifications)
+  def editParticipantsOnKeep(keepId: Id[Keep], editor: Id[User], newUsers: Seq[Id[User]], newNonUsers: Seq[BasicContact], orgs: Seq[Id[Organization]], source: Option[KeepEventSource])(implicit context: HeimdalContext): Future[Boolean] = {
     implicit val context = HeimdalContext.empty
     for {
       thread <- getOrCreateMessageThreadWithUser(keepId, editor)
-      success <- messagingCommander.addParticipantsToThread(editor, keepId, newUsers, newNonUsers, newLibraries, orgs.toSeq, source, updateShoebox)
+      diffOpt <- messagingCommander.addParticipantsToThread(editor, keepId, newUsers, newNonUsers, orgs.toSeq, source)
+      success <- diffOpt.map { diff =>
+        shoebox.persistModifyRecipients(keepId, ModifyRecipients(editor, diff), source).map {
+          case None => false
+          case Some(CommonAndBasicKeepEvent(commonEvent, basicEvent)) =>
+            val updatedThread = thread.withParticipants(currentDateTime, diff.users.added, diff.emails.added.map(NonUserEmailParticipant))
+            notifDeliveryCommander.notifyAddParticipants(editor, diff, updatedThread, commonEvent, basicEvent, source)
+            true
+        }
+      }.getOrElse(Future.successful(false))
     } yield success
   }
+
+  // path for modifying participants: client -> shoebox (keep event updates) -> eliza (thread updates + event notifications)
+  def handleKeepEvent(keepId: Id[Keep], commonEvent: CommonKeepEvent, basicEvent: BasicKeepEvent, source: Option[KeepEventSource])(implicit context: HeimdalContext): Future[Unit] = {
+    implicit val context = HeimdalContext.empty
+    commonEvent.eventData match {
+      case et: EditTitle =>
+        getOrCreateMessageThreadWithUser(keepId, et.editedBy).map { thread =>
+          thread.participants.allUsers.foreach { uid => notifDeliveryCommander.sendKeepEvent(uid, Keep.publicId(keepId), basicEvent) }
+        }
+      case ModifyRecipients(editor, proposedDiff) =>
+        getOrCreateMessageThreadWithUser(keepId, editor).flatMap { thread =>
+          messagingCommander.addParticipantsToThread(editor, keepId, proposedDiff.users.added.toSeq, proposedDiff.emails.added.map(BasicContact(_)).toSeq, orgIds = Seq.empty, source).map {
+            case None => Unit
+            case Some(realDiff) =>
+              val updatedThread = thread.withParticipants(currentDateTime, realDiff.users.added, realDiff.emails.added.map(NonUserEmailParticipant))
+              notifDeliveryCommander.notifyAddParticipants(editor, realDiff, updatedThread, commonEvent, basicEvent, source)
+          }
+        }
+    }
+  }
+
   def deleteThreadsForKeeps(keepIds: Set[Id[Keep]])(implicit session: RWSession): Unit = {
     keepIds.foreach { keepId =>
       val uts = userThreadRepo.getByKeep(keepId)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageThreadNotificationBuilder.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageThreadNotificationBuilder.scala
@@ -7,10 +7,10 @@ import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.db.slick.Database
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.time._
-import com.keepit.discussion.Message
-import com.keepit.eliza.model.SystemMessageData.AddLibraries
 import com.keepit.eliza.model._
 import com.keepit.model._
+import com.keepit.model.BasicKeepEvent.BasicKeepEventId
+import com.keepit.model.{ CommonKeepEvent, DeepLocator, Keep, NotificationCategory, User }
 import com.keepit.shoebox.ShoeboxServiceClient
 import com.keepit.social.{ BasicUser, BasicUserLikeEntity }
 import org.joda.time.DateTime
@@ -23,7 +23,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 // "notification" card that summarizes a message thread
 case class MessageThreadNotification(
   // Info about the most recent message
-  id: Option[PublicId[Message]],
+  id: Option[BasicKeepEventId],
   time: DateTime,
   author: Option[BasicUserLikeEntity],
   text: String,
@@ -45,8 +45,38 @@ case class MessageThreadNotification(
   numUnreadMessages: Int, // used only for client bookkeeping
   forceOverwrite: Boolean) // this flag will tell the extension to overwrite any existing notifications with this keep id
 object MessageThreadNotification {
+  def apply(thread: MessageThread, threadStarter: ExternalId[User], messageWithBasicUser: MessageWithBasicUser,
+    unread: Boolean, numUnseenAuthors: Int, numAuthors: Int,
+    numMessages: Int, numUnread: Int, muted: Boolean)(implicit publicIdConfig: PublicIdConfiguration, airbrake: AirbrakeNotifier): MessageThreadNotification = {
+    val orderedParticipants = messageWithBasicUser.participants.sortBy(x => x.fold(nu => (nu.firstName.getOrElse(""), nu.lastName.getOrElse("")), u => (u.firstName, u.lastName)))
+    val indexOfFirstAuthor = orderedParticipants.zipWithIndex.collectFirst {
+      case (Right(user), idx) if user.externalId == threadStarter => idx
+    }.getOrElse {
+      airbrake.notify(s"Thread starter is not one of the participants for keep ${thread.keepId}")
+      0
+    }
+    MessageThreadNotification(
+      id = Some(messageWithBasicUser.id),
+      time = messageWithBasicUser.createdAt,
+      author = Some(messageWithBasicUser.user),
+      text = messageWithBasicUser.text,
+      threadId = thread.pubKeepId,
+      locator = thread.deepLocator,
+      url = thread.url,
+      title = thread.pageTitle,
+      participants = orderedParticipants,
+      unread = unread,
+      muted = muted,
+      category = NotificationCategory.User.MESSAGE,
+      firstAuthor = indexOfFirstAuthor,
+      numAuthors = numAuthors,
+      numUnseenAuthors = numUnseenAuthors,
+      numMessages = numMessages,
+      numUnreadMessages = numUnread,
+      forceOverwrite = false)
+  }
   implicit def writes: Writes[MessageThreadNotification] = (
-    (__ \ 'id).write[String].contramap[Option[PublicId[Message]]](_.map(_.id) getOrElse "msg_fake_4242") and
+    (__ \ 'id).writeNullable[BasicKeepEventId] and
     (__ \ 'time).write[DateTime] and
     (__ \ 'author).writeNullable[BasicUserLikeEntity] and
     (__ \ 'text).write[String] and
@@ -73,6 +103,7 @@ trait MessageThreadNotificationBuilder {
 
   def buildForKeeps(userId: Id[User], keepIds: Set[Id[Keep]], precomputed: Option[PrecomputedInfo.BuildForKeeps] = None): Future[Map[Id[Keep], MessageThreadNotification]]
   def buildForUsers(keepId: Id[Keep], userIds: Set[Id[User]], precomputed: Option[PrecomputedInfo.BuildForUsers] = None): Future[Map[Id[User], MessageThreadNotification]]
+  def buildForUsersFromEvent(userIds: Set[Id[User]], keepId: Id[Keep], event: CommonKeepEvent, precomputedInfo: Option[PrecomputedInfo.BuildForEvent] = None): Future[Map[Id[User], MessageThreadNotification]]
 
   // Convenience methods, just wrappers around the real methods above
   def buildForKeep(userId: Id[User], keepId: Id[Keep], precomputed: Option[PrecomputedInfo.BuildForKeep] = None): Future[Option[MessageThreadNotification]]
@@ -103,6 +134,10 @@ object MessageThreadNotificationBuilder {
         basicUserMap
       )
     }
+    case class BuildForEvent(
+      thread: Option[MessageThread] = None,
+      basicUserById: Option[Map[Id[User], BasicUser]] = None,
+      messageWithBasicUser: Option[MessageWithBasicUser] = None)
 
     case class BuildForUsers(dummy: Int)
   }
@@ -193,7 +228,7 @@ class MessageThreadNotificationBuilderImpl @Inject() (
             0
           }
           MessageThreadNotification(
-            id = messageOpt.map(_.pubId),
+            id = messageOpt.map(msg => BasicKeepEventId.fromPubMsg(msg.pubId)),
             time = messageOpt.map(_.createdAt).getOrElse(thread.createdAt),
             author = Some(author),
             text = messageOpt.map { message =>
@@ -215,6 +250,50 @@ class MessageThreadNotificationBuilderImpl @Inject() (
             forceOverwrite = false
           )
         }
+    }
+  }
+
+  def buildForUsersFromEvent(userIds: Set[Id[User]], keepId: Id[Keep], event: CommonKeepEvent, precomputedInfo: Option[PrecomputedInfo.BuildForEvent] = None): Future[Map[Id[User], MessageThreadNotification]] = {
+    val (thread, threadActivity, messageCountByUser, mutedByUser) = db.readOnlyMaster { implicit s =>
+      val thread = precomputedInfo.flatMap(_.thread).getOrElse(messageThreadRepo.getByKeepId(keepId).get)
+      val threadActivity = userThreadRepo.getThreadActivity(keepId).sortBy { uta => (-uta.lastActive.getOrElse(START_OF_TIME).getMillis, uta.id.id) }
+      val messageCountByUser = userIds.map { userId =>
+        val lastSeenOpt = threadActivity.find(_.userId == userId).flatMap(_.lastSeen)
+        userId -> messageRepo.getMessageCounts(keepId, lastSeenOpt) // todo(cam): optimize this
+      }.toMap
+      val mutedByUser = userThreadRepo.isMutedByUser(userIds, keepId)
+
+      (thread, threadActivity, messageCountByUser, mutedByUser)
+    }
+
+    for {
+      basicUserById <- precomputedInfo.flatMap(_.basicUserById).map(Future.successful)
+        .getOrElse(shoebox.getBasicUsers(thread.allParticipants.toSeq))
+    } yield {
+      val message = precomputedInfo.flatMap(_.messageWithBasicUser).getOrElse(messageFetchingCommander.getMessageWithBasicUser(Left(event), thread, basicUserById))
+
+      userIds.map { userId =>
+        val authorActivityInfos = threadActivity.filter(_.lastActive.isDefined)
+        val lastSeenOpt = threadActivity.find(_.userId == userId).flatMap(_.lastSeen)
+        val unseenAuthors = lastSeenOpt match {
+          case Some(lastSeen) => authorActivityInfos.count(uta => uta.userId != userId && uta.lastActive.get.isAfter(lastSeen))
+          case None => authorActivityInfos.count(_.userId != userId)
+        }
+        val MessageCount(numMessages, numUnread) = messageCountByUser(userId)
+
+        userId -> MessageThreadNotification(
+          thread = thread,
+          threadStarter = basicUserById(thread.startedBy).externalId,
+          messageWithBasicUser = message,
+          unread = !message.user.right.toOption.exists(_.externalId == basicUserById(userId).externalId),
+          numUnseenAuthors = unseenAuthors,
+          numAuthors = authorActivityInfos.length,
+          numMessages = numMessages,
+          numUnread = numUnread,
+          muted = mutedByUser(userId)
+        )
+      }.toMap
+
     }
   }
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageWithBasicUser.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageWithBasicUser.scala
@@ -1,7 +1,7 @@
 package com.keepit.eliza.commanders
 
-import com.keepit.common.crypto.PublicId
 import com.keepit.discussion.{ MessageSource, Message }
+import com.keepit.model.BasicKeepEvent.BasicKeepEventId
 import org.joda.time.DateTime
 
 import com.keepit.common.time._
@@ -12,27 +12,27 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 case class MessageWithBasicUser(
-  id: PublicId[Message],
+  id: BasicKeepEventId,
   createdAt: DateTime,
   text: String,
   source: Option[MessageSource],
   auxData: Option[JsArray],
   url: String,
   nUrl: String,
-  user: Option[BasicUserLikeEntity],
+  user: BasicUserLikeEntity,
   participants: Seq[BasicUserLikeEntity])
 
 object MessageWithBasicUser {
   implicit val basicUserLikeEntityFormat = BasicUserLikeEntity.format
   implicit val format = (
-    (__ \ 'id).format(Message.formatPublicId) and
+    (__ \ 'id).format[BasicKeepEventId] and
     (__ \ 'createdAt).format(DateTimeJsonFormat) and
     (__ \ 'text).format[String] and
     (__ \ 'source).formatNullable[MessageSource] and
     (__ \ 'auxData).formatNullable[JsArray] and
     (__ \ 'url).format[String] and
     (__ \ 'nUrl).format[String] and
-    (__ \ 'user).formatNullable[BasicUserLikeEntity] and
+    (__ \ 'user).format[BasicUserLikeEntity] and
     (__ \ 'participants).format[Seq[BasicUserLikeEntity]]
   )(MessageWithBasicUser.apply, unlift(MessageWithBasicUser.unapply))
 }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -22,6 +22,8 @@ import com.keepit.eliza.ElizaServiceClient
 import com.keepit.eliza.model._
 import com.keepit.eliza.model.SystemMessageData._
 import com.keepit.heimdal.{ HeimdalContext, HeimdalContextBuilder }
+import com.keepit.model.BasicKeepEvent.BasicKeepEventId
+import com.keepit.model.KeepEventData.ModifyRecipients
 import com.keepit.model._
 import com.keepit.notify.model.Recipient
 import com.keepit.notify.model.event.LibraryNewKeep
@@ -73,8 +75,8 @@ trait MessagingCommander {
   def unmuteThreadForNonUser(id: Id[NonUserThread]): Boolean
   def setUserThreadMuteState(userId: Id[User], keepId: Id[Keep], mute: Boolean)(implicit context: HeimdalContext): Boolean
   def setNonUserThreadMuteState(id: Id[NonUserThread], mute: Boolean): Boolean
-  def addParticipantsToThread(adderUserId: Id[User], keepId: Id[Keep], newUsers: Seq[Id[User]], emailContacts: Seq[BasicContact], newLibraries: Seq[Id[Library]],
-    orgIds: Seq[Id[Organization]], source: Option[KeepEventSource], updateShoebox: Boolean)(implicit context: HeimdalContext): Future[Boolean]
+  def addParticipantsToThread(adderUserId: Id[User], keepId: Id[Keep], newUsers: Seq[Id[User]], emailContacts: Seq[BasicContact],
+    orgIds: Seq[Id[Organization]], source: Option[KeepEventSource])(implicit context: HeimdalContext): Future[Option[KeepRecipientsDiff]]
 
   def validateUsers(rawUsers: Seq[JsValue]): Seq[JsResult[ExternalId[User]]]
   def validateEmailContacts(rawNonUsers: Seq[JsValue]): Seq[JsResult[BasicContact]]
@@ -334,7 +336,7 @@ class MessagingCommanderImpl @Inject() (
     SafeFuture {
       db.readOnlyMaster { implicit session => messageRepo.refreshCache(thread.keepId) }
       shoebox.registerMessageOnKeep(thread.keepId, ElizaMessage.toCrossServiceMessage(message))
-      from.asUser.foreach(user => shoebox.editRecipientsOnKeep(editorId = user, keepId = thread.keepId, diff = KeepRecipientsDiff.addUser(user), persistKeepEvent = false, source = source.flatMap(KeepEventSource.fromMessageSource)))
+      from.asUser.foreach(user => shoebox.editRecipientsOnKeep(editorId = user, keepId = thread.keepId, diff = KeepRecipientsDiff.addUser(user)))
     }
 
     val participantSet = thread.participants.allUsers
@@ -350,7 +352,7 @@ class MessagingCommanderImpl @Inject() (
     }
 
     val messageWithBasicUser = MessageWithBasicUser(
-      message.pubId,
+      BasicKeepEventId.fromPubMsg(message.pubId),
       message.createdAt,
       message.messageText,
       source,
@@ -358,9 +360,9 @@ class MessagingCommanderImpl @Inject() (
       message.sentOnUrl.getOrElse(""),
       thread.nUrl,
       message.from match {
-        case MessageSender.User(id) => Some(BasicUserLikeEntity(id2BasicUser(id)))
-        case MessageSender.NonUser(nup) => Some(BasicUserLikeEntity(NonUserParticipant.toBasicNonUser(nup)))
-        case _ => Some(BasicUserLikeEntity(BasicUser(ExternalId[User]("42424242-4242-4242-4242-000000000001"), "Kifi", "", "0.jpg", Username("sssss"))))
+        case MessageSender.User(id) => BasicUserLikeEntity(id2BasicUser(id))
+        case MessageSender.NonUser(nup) => BasicUserLikeEntity(NonUserParticipant.toBasicNonUser(nup))
+        case _ => BasicUserLikeEntity(BasicUser(ExternalId[User]("42424242-4242-4242-4242-000000000001"), "Kifi", "", "0.jpg", Username("sssss")))
       },
       participantSet.toSeq.map(u => BasicUserLikeEntity(id2BasicUser(u))) ++ basicNonUserParticipants
     )
@@ -465,8 +467,8 @@ class MessagingCommanderImpl @Inject() (
 
   // todo(cam): make this `editParticipantsOnThread` with inactivation behavior
   def addParticipantsToThread(adderUserId: Id[User], keepId: Id[Keep],
-    newUsers: Seq[Id[User]], emailContacts: Seq[BasicContact], newLibraries: Seq[Id[Library]], orgIds: Seq[Id[Organization]],
-    source: Option[KeepEventSource], updateShoebox: Boolean)(implicit context: HeimdalContext): Future[Boolean] = {
+    newUsers: Seq[Id[User]], emailContacts: Seq[BasicContact], orgIds: Seq[Id[Organization]],
+    source: Option[KeepEventSource])(implicit context: HeimdalContext): Future[Option[KeepRecipientsDiff]] = {
     val newUserParticipantsFuture = Future.successful(newUsers)
     val newNonUserParticipantsFuture = constructNonUserRecipients(adderUserId, emailContacts)
 
@@ -477,13 +479,12 @@ class MessagingCommanderImpl @Inject() (
       }
     }).map(_.flatten)
 
-    val haveBeenAdded = for {
+    val addedOpt = for {
       newUserParticipants <- newUserParticipantsFuture
       newNonUserParticipants <- newNonUserParticipantsFuture
       newOrgParticipants <- newOrgParticipantsFuture
     } yield {
-
-      val resultInfoOpt = db.readWrite { implicit session =>
+      db.readWrite { implicit session =>
 
         val oldThread = threadRepo.getByKeepId(keepId).get
 
@@ -496,23 +497,9 @@ class MessagingCommanderImpl @Inject() (
         val actuallyNewUsers = (newUserParticipants ++ newOrgParticipants).filterNot(oldThread.containsUser)
         val actuallyNewNonUsers = newNonUserParticipants.filterNot(oldThread.containsNonUser)
 
-        if (actuallyNewNonUsers.isEmpty && actuallyNewUsers.isEmpty && newLibraries.isEmpty) {
-          None
-        } else {
-          // this block might be unnecessary since ElizaDiscussionCommander.addParticipantsToThread is the only caller of this method and already does all this interning.
+        if (actuallyNewNonUsers.isEmpty && actuallyNewUsers.isEmpty) None
+        else {
           val thread = threadRepo.save(oldThread.withParticipants(clock.now, actuallyNewUsers.toSet, actuallyNewNonUsers.toSet))
-          val messageTemplate = ElizaMessage(
-            keepId = thread.keepId,
-            commentIndexOnKeep = None,
-            from = MessageSender.System,
-            messageText = "",
-            source = source.flatMap(KeepEventSource.toMessageSource),
-            auxData = if (actuallyNewNonUsers.nonEmpty || actuallyNewUsers.nonEmpty) Some(AddParticipants(adderUserId, actuallyNewUsers, actuallyNewNonUsers)) else None,
-            sentOnUrl = None,
-            sentOnUriId = None
-          )
-          val message = if (actuallyNewUsers.nonEmpty || actuallyNewNonUsers.nonEmpty) messageRepo.save(messageTemplate) else messageTemplate
-
           actuallyNewUsers.foreach(pUserId => userThreadRepo.intern(UserThread.forMessageThread(thread)(user = pUserId)))
           actuallyNewNonUsers.foreach { nup =>
             nonUserThreadRepo.save(NonUserThread(
@@ -522,42 +509,24 @@ class MessagingCommanderImpl @Inject() (
               uriId = Some(thread.uriId),
               notifiedCount = 0,
               lastNotifiedAt = None,
-              threadUpdatedByOtherAt = Some(message.createdAt),
+              threadUpdatedByOtherAt = Some(thread.updatedAt),
               muted = false
             ))
           }
 
-          Some((actuallyNewUsers, actuallyNewNonUsers, newLibraries, message, thread))
+          val diff = KeepRecipientsDiff(DeltaSet.addOnly(actuallyNewUsers.toSet), libraries = DeltaSet.empty, DeltaSet.addOnly(actuallyNewNonUsers.flatMap(NonUserParticipant.toEmailAddress).toSet))
 
+          session.onTransactionSuccess {
+            messagingAnalytics.addedParticipantsToConversation(adderUserId, actuallyNewUsers, actuallyNewNonUsers, thread, source, context)
+            db.readOnlyMaster(implicit session => messageRepo.refreshCache(keepId))
+          }
+
+          Some(diff)
         }
       }
-
-      resultInfoOpt.exists {
-        case (newUsers, newNonUsers, newLibraries, message, thread) =>
-
-          SafeFuture {
-            db.readOnlyMaster { implicit session =>
-              messageRepo.refreshCache(thread.keepId)
-            }
-          }
-
-          if (updateShoebox) {
-            val newEmails = newNonUsers.flatMap(NonUserParticipant.toEmailAddress)
-            shoebox.editRecipientsOnKeep(adderUserId, keepId, KeepRecipientsDiff(DeltaSet.addOnly(newUsers.toSet), libraries = DeltaSet.empty, DeltaSet.addOnly(newEmails.toSet)), persistKeepEvent = true, source)
-          }
-
-          if (newUsers.nonEmpty || newNonUsers.nonEmpty || newLibraries.nonEmpty) {
-            notificationDeliveryCommander.notifyAddParticipants(adderUserId, newUsers, newNonUsers, thread, message, source)
-            messagingAnalytics.addedParticipantsToConversation(adderUserId, newUsers, newNonUsers, thread, source, context)
-          }
-
-          true
-
-      }
-
     }
 
-    new SafeFuture[Boolean](haveBeenAdded, Some("Adding Participants to Thread"))
+    new SafeFuture[Option[KeepRecipientsDiff]](addedOpt, Some("Adding Participants to Thread"))
   }
 
   def setRead(userId: Id[User], messageId: Id[ElizaMessage])(implicit context: HeimdalContext): Unit = {

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/shared/SharedWsMessagingController.scala
@@ -115,7 +115,7 @@ class SharedWsMessagingController @Inject() (
             for {
               userIds <- shoebox.getUserIdsByExternalIds(users.toSet).map(_.values.toList)
               orgIds <- Future.successful(orgs.flatMap(pubId => Organization.decodePublicId(pubId).toOption))
-            } discussionCommander.editParticipantsOnKeep(keepId, socket.userId, userIds, emailContacts, Seq.empty, orgIds, KeepEventSource.fromStr(socket.userAgent), updateShoebox = true)
+            } discussionCommander.editParticipantsOnKeep(keepId, socket.userId, userIds, emailContacts, orgIds, KeepEventSource.fromStr(socket.userAgent))
           }
         }
     },

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/model/ElizaMessage.scala
@@ -116,10 +116,12 @@ object SystemMessageData {
       Some(KeepEventData.EditTitle(editedBy, original, updated))
   }
 
-  def fromKeepEvent(event: KeepEventData.ModifyRecipients): Option[SystemMessageData] = {
-    val KeepRecipientsDiff(usersDelta, _, emailsDelta) = event.diff
-    val (usersAdded, emailsAdded) = (usersDelta.added.toSeq, emailsDelta.added.map(NonUserEmailParticipant).toSeq)
-    Some(AddParticipants(event.addedBy, usersAdded, emailsAdded))
+  def fromKeepEvent(event: KeepEventData): Option[SystemMessageData] = event match {
+    case _: KeepEventData.EditTitle => None
+    case mr: ModifyRecipients =>
+      val KeepRecipientsDiff(usersDelta, _, emailsDelta) = mr.diff
+      val (usersAdded, emailsAdded) = (usersDelta.added.toSeq, emailsDelta.added.map(NonUserEmailParticipant).toSeq)
+      Some(AddParticipants(mr.editedBy, usersAdded, emailsAdded))
   }
 
   def isFullySupported(data: SystemMessageData): Boolean = data match {
@@ -198,7 +200,7 @@ object SystemMessageData {
     }
   }
 
-  case class AddLibraries(addedBy: Id[User], libraries: Set[Id[Library]]) extends SystemMessageData(AddLibraries.kind)
+  case class AddLibraries(addedBy: Id[User], libraries: Set[Id[Library]]) extends SystemMessageData(AddLibraries.kind) //todo(cam): kill
   object AddLibraries {
     val kind = "add_libraries"
     val internalFormat: Format[AddLibraries] = Format(
@@ -207,7 +209,7 @@ object SystemMessageData {
     )
   }
 
-  case class EditTitle(editedBy: Id[User], original: Option[String], updated: Option[String]) extends SystemMessageData(EditTitle.kind)
+  case class EditTitle(editedBy: Id[User], original: Option[String], updated: Option[String]) extends SystemMessageData(EditTitle.kind) //todo(cam): kill
   object EditTitle {
     val kind = "edit_title"
     val internalFormat: Format[EditTitle] = Format(

--- a/kifi-backend/modules/eliza/conf/elizaService.routes
+++ b/kifi-backend/modules/eliza/conf/elizaService.routes
@@ -64,7 +64,6 @@ GET   /internal/eliza/getKeepIngestionSequenceNumber @com.keepit.eliza.controlle
 
 POST    /internal/eliza/getCrossServiceMessages     @com.keepit.eliza.controllers.internal.ElizaDiscussionController.getCrossServiceMessages
 POST    /internal/eliza/getCrossServiceDiscussionsForKeeps      @com.keepit.eliza.controllers.internal.ElizaDiscussionController.getCrossServiceDiscussionsForKeeps
-POST    /internal/eliza/syncAddParticipants         @com.keepit.eliza.controllers.internal.ElizaDiscussionController.syncAddParticipants()
 POST    /internal/eliza/markKeepsAsReadForUser      @com.keepit.eliza.controllers.internal.ElizaDiscussionController.markKeepsAsReadForUser()
 POST    /internal/eliza/sendMessageOnKeep           @com.keepit.eliza.controllers.internal.ElizaDiscussionController.sendMessageOnKeep()
 POST    /internal/eliza/getMessagesOnKeep           @com.keepit.eliza.controllers.internal.ElizaDiscussionController.getMessagesOnKeep
@@ -73,7 +72,7 @@ POST    /internal/eliza/getChangedMessagesFromKeeps @com.keepit.eliza.controller
 POST    /internal/eliza/editMessage                 @com.keepit.eliza.controllers.internal.ElizaDiscussionController.editMessage()
 POST    /internal/eliza/deleteMessage               @com.keepit.eliza.controllers.internal.ElizaDiscussionController.deleteMessage()
 GET     /internal/eliza/keepHasAccessToken          @com.keepit.eliza.controllers.internal.ElizaDiscussionController.keepHasAccessToken(keepId: Id[Keep], accessToken: String)
-POST    /internal/eliza/editParticipantsOnKeep      @com.keepit.eliza.controllers.internal.ElizaDiscussionController.editParticipantsOnKeep()
+POST    /internal/eliza/handleKeepEvent             @com.keepit.eliza.controllers.internal.ElizaDiscussionController.handleKeepEvent()
 GET     /internal/eliza/getMessagesChanged          @com.keepit.eliza.controllers.internal.ElizaDiscussionController.getMessagesChanged(seqNum: SequenceNumber[Message], fetchSize: Int)
 GET     /internal/eliza/getElizaKeepStream          @com.keepit.eliza.controllers.internal.ElizaDiscussionController.getElizaKeepStream(userId: Id[User], limit: Int, beforeId: Option[Long] ?= None, filter: ElizaFeedFilter)
 POST    /internal/eliza/getEmailParticipantsForKeeps @com.keepit.eliza.controllers.internal.ElizaDiscussionController.getEmailParticipantsForKeeps()

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/commanders/NotificationDeliveryCommanderTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/commanders/NotificationDeliveryCommanderTest.scala
@@ -11,6 +11,7 @@ import com.keepit.common.time._
 import com.keepit.discussion.MessageSource
 import com.keepit.eliza.FakeElizaServiceClientModule
 import com.keepit.heimdal.{ FakeHeimdalServiceClientModule, HeimdalContext }
+import com.keepit.model.BasicKeepEvent.BasicKeepEventId.MessageId
 import com.keepit.model._
 import com.keepit.rover.FakeRoverServiceModule
 import com.keepit.shoebox.FakeShoeboxServiceModule
@@ -55,7 +56,7 @@ class NotificationDeliveryCommanderTest extends TestKitSupport with Specificatio
           inject[WatchableExecutionContext].drain()
 
           val notif = Await.result(inject[MessageThreadNotificationBuilder].buildForKeep(user1, thread.keepId), Duration.Inf).get
-          notif.id === Some(msg.pubId)
+          notif.id === Some(MessageId(msg.pubId))
           notif.time === msg.createdAt
           notif.threadId === thread.pubKeepId
           notif.text === "I need this to work"
@@ -95,7 +96,7 @@ class NotificationDeliveryCommanderTest extends TestKitSupport with Specificatio
 
           val msg = db.readOnlyMaster { implicit s => messageRepo.all.last }
           val notif = notifs.last
-          notif.id === Some(msg.pubId)
+          notif.id === Some(MessageId(msg.pubId))
           notif.time === msg.createdAt
           notif.threadId === initThread.pubKeepId
           notif.text === s"Ruining Ryan's life! Yeah! ${uniqueTokens.last}"

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/mobile/MobileMessagingControllerTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/controllers/mobile/MobileMessagingControllerTest.scala
@@ -347,6 +347,7 @@ class MobileMessagingControllerTest extends Specification with ElizaTestInjector
           path3 === s"/m/2/eliza/thread/${thread.pubKeepId.id}?pageSize=3&fromMessageId=${messages(2).pubId.id}"
 
           val action3 = controller.getPagedThread(thread.pubKeepId, 3, Some(messages(2).pubId.id))
+          println(contentAsString(action3(FakeRequest())))
           val res3 = Json.parse(contentAsString(action3(FakeRequest())))
 
           (res3 \ "id").as[PublicId[Keep]] === thread.pubKeepId

--- a/kifi-backend/modules/rover/app/com/keepit/rover/model/ArticleInfoHelper.scala
+++ b/kifi-backend/modules/rover/app/com/keepit/rover/model/ArticleInfoHelper.scala
@@ -37,7 +37,7 @@ class ArticleInfoHelper @Inject() (articleInfoRepo: ArticleInfoRepo, articleImag
               val newInfo = RoverArticleInfo.initialize(url, uriId, kind).copy(id = inactiveArticleInfoOpt.flatMap(_.id))
               articleInfoRepo.save(newInfo)
             } catch {
-              case ex: MySQLIntegrityConstraintViolationException =>
+              case ex: Throwable =>
                 log.error(s"[articleInfoConstraint] failed interning url=$url with uriId=$uriId, kind=$kind, and hash=${UrlHash.hashUrl(url)}")
                 throw ex
             }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepEvent.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepEvent.scala
@@ -10,6 +10,7 @@ import com.keepit.common.logging.AccessLog
 import com.keepit.common.mail.EmailAddress
 import com.keepit.common.time._
 import com.keepit.discussion.Message
+import com.keepit.model.BasicKeepEvent.BasicKeepEventId
 import com.keepit.model.KeepEventData.{ EditTitle, ModifyRecipients }
 import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
@@ -48,6 +49,16 @@ object KeepEvent extends CommonClassLinker[KeepEvent, CommonKeepEvent] {
 
         (users ++ newUsers, libs ++ newLibs)
     }
+  }
+
+  def toCommonKeepEvent(event: KeepEvent) = {
+    CommonKeepEvent(
+      toCommonId(event.id.get),
+      event.keepId,
+      event.eventTime,
+      event.eventData,
+      event.source
+    )
   }
 
   def publicId(id: Id[KeepEvent])(implicit config: PublicIdConfiguration): PublicId[CommonKeepEvent] = CommonKeepEvent.publicId(KeepEvent.toCommonId(id))

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/data/assemblers/KeepActivityAssembler.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/data/assemblers/KeepActivityAssembler.scala
@@ -25,7 +25,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 trait KeepActivityAssembler {
   def getActivityForKeeps(keepIds: Set[Id[Keep]], fromTime: Option[DateTime], numEventsPerKeep: Int): Future[Map[Id[Keep], KeepActivity]]
   def getActivityForKeep(keepId: Id[Keep], fromTime: Option[DateTime], limit: Int): Future[KeepActivity]
-  def assembleBasicKeepEvent(keepId: Id[Keep], event: KeepEvent)(implicit session: RSession): BasicKeepEvent
+  def assembleBasicKeepEvent(event: KeepEvent)(implicit session: RSession): BasicKeepEvent
 }
 
 class KeepActivityAssemblerImpl @Inject() (
@@ -90,7 +90,7 @@ class KeepActivityAssemblerImpl @Inject() (
     KeepActivityGen.generateKeepActivity(keep, sourceAttrOpt, events, discussion, ktls, ktus, limit)
   }
 
-  def assembleBasicKeepEvent(keepId: Id[Keep], event: KeepEvent)(implicit session: RSession): BasicKeepEvent = {
-    basicULOBatchFetcher.runInPlace(KeepActivityGen.generateKeepEvent(keepId, event))
+  def assembleBasicKeepEvent(event: KeepEvent)(implicit session: RSession): BasicKeepEvent = {
+    basicULOBatchFetcher.runInPlace(KeepActivityGen.generateKeepEvent(event))
   }
 }

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -401,7 +401,6 @@ GET     /site/keeps/:keepId/messages          @com.keepit.controllers.website.Di
 GET     /site/keeps/:keepId/activity          @com.keepit.controllers.website.KeepsController.getActivityForKeep(keepId: PublicId[Keep], eventsBefore: Option[DateTime] ?= None, maxEvents: Int ?= 10)
 POST    /site/keeps/:keepId/messages/edit     @com.keepit.controllers.website.DiscussionController.editMessageOnKeep(keepId: PublicId[Keep])
 POST    /site/keeps/:keepId/messages/delete   @com.keepit.controllers.website.DiscussionController.deleteMessageOnKeep(keepId: PublicId[Keep])
-POST    /site/keeps/:keepId/participants/edit @com.keepit.controllers.website.DiscussionController.editParticipantsOnKeep(keepId: PublicId[Keep])
 POST    /site/keeps/:keepId/title             @com.keepit.controllers.website.KeepsController.updateKeepTitle(keepId: PublicId[Keep])
 POST    /site/keeps/:keepId/note              @com.keepit.controllers.website.KeepsController.editKeepNote(keepId: PublicId[Keep])
 GET     /site/keeps/:id                       @com.keepit.controllers.website.KeepsController.getKeepInfo(id: InternalOrExternalId[Keep], maxMessagesShown: Int ?= 8, authToken: Option[String] ?= None)
@@ -720,7 +719,8 @@ POST     /internal/shoebox/database/getSlackTeamIds                @com.keepit.c
 GET      /internal/shoebox/database/getSlackTeamInfo               @com.keepit.controllers.internal.ShoeboxController.getSlackTeamInfo(slackTeamId: SlackTeamId)
 
 POST     /internal/shoebox/database/internKeep              @com.keepit.controllers.internal.ShoeboxController.internKeep()
-POST     /internal/shoebox/database/editRecipientsOnKeep    @com.keepit.controllers.internal.ShoeboxController.editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep], persistKeepEvent: Boolean, source: Option[KeepEventSource] ?= None)
+POST     /internal/shoebox/database/editRecipientsOnKeep    @com.keepit.controllers.internal.ShoeboxController.editRecipientsOnKeep(editorId: Id[User], keepId: Id[Keep])
+POST     /internal/shoebox/database/persistModifyRecipients @com.keepit.controllers.internal.ShoeboxController.persistModifyRecipients()
 POST     /internal/shoebox/database/registerMessageOnKeep   @com.keepit.controllers.internal.ShoeboxController.registerMessageOnKeep()
 
 GET      /internal/shoebox/email/getUnsubscribeUrlForEmail @com.keepit.controllers.website.EmailOptOutController.getUnsubscribeUrlForEmail(email: EmailAddress)

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/LibraryControllerTest.scala
@@ -1045,6 +1045,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                    "header" : [ {
                      "id" : "${user1.externalId}",
                      "text" : "Aaron Hsu",
+                     "name" : "Aaron Hsu",
                      "image" : "http://localhost/users/${user1.externalId}/pics/200/0.jpg",
                      "url" : "https://www.kifi.com/test",
                      "kind" : "author"
@@ -1069,6 +1070,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                    "header" : [ {
                      "id" : "${user1.externalId}",
                      "text" : "Aaron Hsu",
+                     "name" : "Aaron Hsu",
                      "image" : "http://localhost/users/${user1.externalId}/pics/200/0.jpg",
                      "url" : "https://www.kifi.com/test",
                      "kind" : "author"
@@ -1077,7 +1079,9 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                      "kind" : "text"
                    }, {
                      "id" : "l7jlKlnA36Su",
+                     "name" : "${lib1.name}",
                      "text" : "${lib1.name}",
+                     "path" : "/test/${lib1.slug.value}",
                      "url" : "https://www.kifi.com/test/${lib1.slug.value}",
                      "kind" : "library"
                    } ],
@@ -1126,6 +1130,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                      "header" : [ {
                        "id" : "${user1.externalId}",
                        "text" : "Aaron Hsu",
+                       "name" : "Aaron Hsu",
                        "image" : "http://localhost/users/${user1.externalId}/pics/200/0.jpg",
                        "url" : "https://www.kifi.com/test",
                        "kind" : "author"
@@ -1150,6 +1155,7 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                      "header" : [ {
                        "id" : "${user1.externalId}",
                        "text" : "Aaron Hsu",
+                       "name" : "Aaron Hsu",
                        "image" : "http://localhost/users/${user1.externalId}/pics/200/0.jpg",
                        "url" : "https://www.kifi.com/test",
                        "kind" : "author"
@@ -1158,7 +1164,9 @@ class LibraryControllerTest extends Specification with ShoeboxTestInjector {
                        "kind" : "text"
                      }, {
                        "id" : "l7jlKlnA36Su",
+                       "name" : "${lib1.name}",
                        "text" : "${lib1.name}",
+                       "path": "/test/${lib1.slug.value}",
                        "url" : "https://www.kifi.com/test/${lib1.slug.value}",
                        "kind" : "library"
                      } ],


### PR DESCRIPTION
@ryanpbrewster @leogrim @andrewconner 

This is needed for the new keep event notification flows. When a keep event is triggered, we'll generate and send the `BasicKeepEvent` to Eliza such that she can serialize and websocket a notification for that event. The alternative is passing around already-serialized `JsValues`, which IMO has been painful in handling notifications.
