### PR TITLE
update size of keep_source_attribution.attr_json to match bookmark.note

### DIFF
--- a/kifi-backend/modules/common/conf/evolutions/shoebox/445.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/445.sql
@@ -1,0 +1,9 @@
+# SHOEBOX
+
+# --- !Ups
+
+alter table keep_source_attribution modify column attr_json longtext not null;
+
+insert into evolutions(name, description) values ('445.sql', 'make keep_source_attribution.attr_json longtext (to match bookmark.note)');
+
+# --- !Downs


### PR DESCRIPTION
@leogrim @ryanpbrewster this is an edge case, but I'm running into errors when trying to persist a keep_source_attribution for bookmark 6012905, since the note is so large. `attr_json` should be at least as large as `bookmark.note`.
