### PR TITLE
Include a machine time when making cross-service requests

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/time/CrossServiceTime.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/time/CrossServiceTime.scala
@@ -1,0 +1,14 @@
+package com.keepit.common.time
+
+import com.keepit.common.time
+import org.joda.time.DateTime
+import play.api.libs.json.{ Format, JsNumber, Reads, Writes }
+
+final case class CrossServiceTime(time: DateTime) extends AnyVal
+object CrossServiceTime {
+  implicit val format: Format[CrossServiceTime] = Format(
+    Reads { js => js.validate[Long].map(millis => CrossServiceTime(new DateTime(millis, time.DEFAULT_DATE_TIME_ZONE))) },
+    Writes { time => JsNumber(time.time.getMillis) }
+  )
+}
+

--- a/kifi-backend/modules/common/app/com/keepit/common/util/Ord.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/util/Ord.scala
@@ -6,4 +6,5 @@ object Ord {
   implicit val dateTimeOrdering: Ordering[DateTime] = Ordering.fromLessThan(_ isBefore _)
   def ascending[T](implicit ord: Ordering[T]) = ord
   def descending[T](implicit ord: Ordering[T]) = ord.reverse
+  def max[T](a: T, b: T)(implicit ord: Ordering[T]) = ord.max(a, b)
 }

--- a/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClientModule.scala
+++ b/kifi-backend/modules/common/app/com/keepit/eliza/ElizaServiceClientModule.scala
@@ -1,14 +1,14 @@
 package com.keepit.eliza
 
-import scala.concurrent.ExecutionContext
 import com.google.inject.{ Provides, Singleton }
 import com.keepit.common.healthcheck.AirbrakeNotifier
 import com.keepit.common.net.HttpClient
-import com.keepit.common.zookeeper.ServiceDiscovery
 import com.keepit.common.service.ServiceType
-import play.api.Play._
-import net.codingwell.scalaguice.ScalaModule
+import com.keepit.common.zookeeper.ServiceDiscovery
 import com.keepit.eliza.model.UserThreadStatsForUserIdCache
+import net.codingwell.scalaguice.ScalaModule
+
+import scala.concurrent.ExecutionContext
 
 trait ElizaServiceClientModule extends ScalaModule
 

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
@@ -29,7 +29,7 @@ trait ElizaDiscussionCommander {
   def getCrossServiceDiscussionsForKeeps(keepIds: Set[Id[Keep]], fromTime: Option[DateTime], maxMessagesShown: Int): Map[Id[Keep], CrossServiceDiscussion]
   def syncAddParticipants(keepId: Id[Keep], event: KeepEventData.ModifyRecipients, source: Option[KeepEventSource]): Future[Unit]
   def getEmailParticipantsForKeeps(keepIds: Set[Id[Keep]]): Map[Id[Keep], Map[EmailAddress, (Id[User], DateTime)]]
-  def sendMessage(userId: Id[User], txt: String, keepId: Id[Keep], source: Option[MessageSource])(implicit context: HeimdalContext): Future[Message]
+  def sendMessage(userId: Id[User], txt: String, keepId: Id[Keep], source: Option[MessageSource])(implicit time: CrossServiceTime, context: HeimdalContext): Future[Message]
   def editParticipantsOnKeep(keepId: Id[Keep], editor: Id[User], newUsers: Seq[Id[User]], newNonUsers: Seq[BasicContact], orgs: Seq[Id[Organization]], source: Option[KeepEventSource])(implicit context: HeimdalContext): Future[Boolean]
   def handleKeepEvent(keepId: Id[Keep], commonEvent: CommonKeepEvent, basicEvent: BasicKeepEvent, source: Option[KeepEventSource])(implicit context: HeimdalContext): Future[Unit]
   def muteThread(userId: Id[User], keepId: Id[Keep])(implicit context: HeimdalContext): Future[Boolean]
@@ -197,7 +197,7 @@ class ElizaDiscussionCommanderImpl @Inject() (
     }
   }
 
-  def sendMessage(userId: Id[User], txt: String, keepId: Id[Keep], source: Option[MessageSource] = None)(implicit context: HeimdalContext): Future[Message] = {
+  def sendMessage(userId: Id[User], txt: String, keepId: Id[Keep], source: Option[MessageSource] = None)(implicit time: CrossServiceTime, context: HeimdalContext): Future[Message] = {
     getOrCreateMessageThreadWithUser(keepId, userId).flatMap { thread =>
       val (_, message) = messagingCommander.sendMessage(userId, thread, txt, source, None)
       externalizeMessage(message)

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaDiscussionController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaDiscussionController.scala
@@ -80,9 +80,13 @@ class ElizaDiscussionController @Inject() (
   def sendMessageOnKeep() = Action.async(parse.tolerantJson) { request =>
     import SendMessageOnKeep._
     val input = request.body.as[Request]
-    val contextBuilder = heimdalContextBuilder.withRequestInfo(request)
-    input.source.foreach { src => contextBuilder += ("source", src.value) }
-    discussionCommander.sendMessage(input.userId, input.text, input.keepId, source = input.source)(contextBuilder.build).map { msg =>
+    implicit val context = {
+      val contextBuilder = heimdalContextBuilder.withRequestInfo(request)
+      input.source.foreach { src => contextBuilder += ("source", src.value) }
+      contextBuilder.build
+    }
+    implicit val time = input.time
+    discussionCommander.sendMessage(input.userId, input.text, input.keepId, source = input.source).map { msg =>
       val output = Response(msg)
       Ok(Json.toJson(output))
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -261,6 +261,7 @@ class KeepCommanderImpl @Inject() (
       (keep, isNew) <- Future.fromTry(db.readWrite { implicit s => keepInterner.internKeepByRequest(internReq) })
       msgOpt <- Author.kifiUserId(internReq.author).fold(Future.successful(Option.empty[Message])) { user =>
         internReq.note.fold(Future.successful(Option.empty[Message])) { note =>
+          implicit val time = CrossServiceTime(clock.now)
           eliza.sendMessageOnKeep(user, note, keep.id.get, source = MessageSource.fromKeepSource(internReq.source)).imap(Some(_))
         }
       }


### PR DESCRIPTION
Good practice for things that rely on a strict time ordering is to include the local time of the requesting machine.

This is slightly ugly right now because there are still clients hitting Eliza directly.
