### PR TITLE
Allows slightly looser URL matching when determining when to open pane.

### DIFF
--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1535,15 +1535,18 @@ api.port.on({
       trackClick();
     } else {
       var tabs = tabsByUrl[link.nUri];
-      var browserTabs = [];
+      var exactUrls = [];
+      var similarUrls = [];
       api.tabs.each(function (page) {
-        if (verySimilarUrls(link.nUri, page.url) || verySimilarUrls(link.nUri, page.nUri)) {
-          browserTabs.push(page);
+        if ((page.url && link.nUri === page.url) || (page.nUri && link.nUri === page.nUri)) {
+          exactUrls.push(page);
+        } else if (verySimilarUrls(link.nUri, page.url) || verySimilarUrls(link.nUri, page.nUri)) {
+          similarUrls.push(page);
         }
       });
 
       var tabs = tabsByUrl[link.nUri];
-      var existingTab = tabs ? tabs[0] : browserTabs[0];
+      var existingTab = tabs ? tabs[0] : (exactUrls[0] || similarUrls[0]);
       if (existingTab && existingTab.id) {  // page's normalized URI may have changed
         tabIdWithLink = existingTab.id;
         awaitDeepLink(link, existingTab.id);

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1529,13 +1529,21 @@ api.port.on({
   },
   open_deep_link: function(link, _, tab) {
     var tabIdWithLink;
-    if (link.inThisTab || tab.nUri === link.nUri || tab.url === link.nUri) {
+    if (link.inThisTab || verySimilarUrls(tab.nUri, link.nUri) || verySimilarUrls(tab.url, link.nUri)) {
       tabIdWithLink = tab.id;
       awaitDeepLink(link, tab.id);
       trackClick();
     } else {
       var tabs = tabsByUrl[link.nUri];
-      var existingTab = tabs ? tabs[0] : api.tabs.anyAt(link.nUri);
+      var browserTabs = [];
+      api.tabs.each(function (page) {
+        if (verySimilarUrls(link.nUri, page.url) || verySimilarUrls(link.nUri, page.nUri)) {
+          browserTabs.push(page);
+        }
+      });
+
+      var tabs = tabsByUrl[link.nUri];
+      var existingTab = tabs ? tabs[0] : browserTabs[0];
       if (existingTab && existingTab.id) {  // page's normalized URI may have changed
         tabIdWithLink = existingTab.id;
         awaitDeepLink(link, existingTab.id);
@@ -1972,7 +1980,10 @@ function awaitDeepLink(link, tabId, retrySec) {
     delete timeouts[tabId];
     var tab = api.tabs.get(tabId);
     var linkUrl = link.url || link.nUri;
-    if (tab && ((tab.nUri && sameOrSimilarBaseDomain(linkUrl, tab.nUri)) || (tab.url && sameOrSimilarBaseDomain(linkUrl, tab.url)))) {
+    var nTabIsSame = tab && tab.nUri && sameOrSimilarBaseDomain(linkUrl, tab.nUri);
+    var uTabIsSame = tab && tab.url && sameOrSimilarBaseDomain(linkUrl, tab.url);
+
+    if (tab && (nTabIsSame || uTabIsSame)) {
       log('[awaitDeepLink]', tabId, link);
       if (loc.lastIndexOf('#guide/', 0) === 0) {
         var step = +loc.substr(7, 1);
@@ -3013,6 +3024,7 @@ function arrayBufferToBase64(buffer) {
 
 //                           |---- IP v4 address ---||- subs -||-- core --|  |----------- suffix -----------| |- name --|    |-- port? --|
 var domainRe = /^https?:\/\/(\d{1,3}(?:\.\d{1,3}){3}|[^:\/?#]*?([^.:\/?#]+)\.(?:[^.:\/?#]{2,}|com?\.[a-z]{2})|[^.:\/?#]+)\.?(?::\d{2,5})?(?:$|\/|\?|#)/;
+// Very loose matching. Allows for equality between completely different pages on the same domain.
 function sameOrSimilarBaseDomain(url1, url2) {
   if (url1 === url2) {
     return true;
@@ -3021,6 +3033,16 @@ function sameOrSimilarBaseDomain(url1, url2) {
   var m2 = url2.match(domainRe);
   // hostnames match exactly or core domain without subdomains and TLDs match (e.g. "google" in docs.google.fr and www.google.co.uk)
   return m1[1] === m2[1] || m1[2] === (m2[2] || 0);
+}
+
+var protoRe = /^(https?:|)\/\//;
+function verySimilarUrls(url1, url2) {
+  if (url1 && url2) {
+    var noHash1 = url1.replace(protoRe, '').split('#')[0];
+    var noHash2 = url2.replace(protoRe, '').split('#')[0];
+    return noHash1 === noHash2;
+  }
+  return false;
 }
 
 // ===== Session management


### PR DESCRIPTION
@cvializ This fixes the issue where we kept opening pages in new tabs for Medium, because they change their URL.

How deep link opening works now:
1. We check if you're already on the page that you want to open to. This matches without the URL fragment and without protocol — this can yield false positives, unfortunately, if a site uses fragments for navigation. Not a ton we can do outside of special casing Medium.
2. If not, we check if you have the page open in another tab, using the same logic as above. (False positives possible.)
3. If not, we open the page. Then we start to listen. Since we already know the tab id that it will open in, we become _much_ more forgiving, and open the pane on any page that we end up on that has the correct domain. This allows us to still open even if the user gets redirected to a login page.

The last improvement I can think of, which I didn't implement, is becoming more aggressive about keeping the deep link active for a longer period of time. Currently, if the user hits a page, the page renders, and the deep link fires, it's done. This fails when the user gets redirected away using a meta tag or Javascript — common in SPAs. The downside is that this is way more complicated to track, to make sure the user didn't close it and we re-open again. Just something to think about if we see more complaints
