### PR TITLE
Allow users to set notifications as read without a message id

### DIFF
--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/ElizaDiscussionCommander.scala
@@ -285,7 +285,7 @@ class ElizaDiscussionCommanderImpl @Inject() (
       val (nUrlOpt, lastMsgOpt) = (messageThreadRepo.getByKeepId(keepId).map(_.nUrl), messageRepo.getLatest(keepId))
       session.onTransactionSuccess {
         uts.foreach { ut =>
-          for { nUrl <- nUrlOpt; lastMsg <- lastMsgOpt } notifDeliveryCommander.notifyRead(ut.user, ut.keepId, lastMsg.id.get, nUrl, lastMsg.createdAt)
+          for { nUrl <- nUrlOpt; lastMsg <- lastMsgOpt } notifDeliveryCommander.notifyRead(ut.user, ut.keepId, Some(lastMsg.id.get), nUrl, lastMsg.createdAt)
           notifDeliveryCommander.notifyRemoveThread(ut.user, ut.keepId)
         }
       }

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageThreadNotificationBuilder.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessageThreadNotificationBuilder.scala
@@ -113,22 +113,22 @@ object MessageThreadNotificationBuilder {
   object PrecomputedInfo {
     case class BuildForKeeps(
       threadById: Option[Map[Id[Keep], MessageThread]] = None,
+      userThreadById: Option[Map[Id[Keep], UserThread]] = None,
       lastMsgById: Option[Map[Id[Keep], ElizaMessage]] = None,
-      mutedById: Option[Map[Id[Keep], Boolean]] = None,
       threadActivityById: Option[Map[Id[Keep], Seq[UserThreadActivity]]] = None,
       msgCountById: Option[Map[Id[Keep], MessageCount]] = None,
       basicUserMap: Option[Map[Id[User], BasicUser]] = None)
     case class BuildForKeep(
         thread: Option[MessageThread] = None,
+        userThread: Option[UserThread] = None,
         lastMsg: Option[Option[ElizaMessage]] = None,
-        muted: Option[Boolean] = None,
         threadActivity: Option[Seq[UserThreadActivity]] = None,
         msgCount: Option[MessageCount] = None,
         basicUserMap: Option[Map[Id[User], BasicUser]] = None) {
       def pluralize(keepId: Id[Keep]) = BuildForKeeps(
         thread.map(x => Map(keepId -> x)),
+        userThread.map(x => Map(keepId -> x)),
         lastMsg.map(x => x.map(keepId -> _).toMap),
-        muted.map(x => Map(keepId -> x)),
         threadActivity.map(x => Map(keepId -> x)),
         msgCount.map(x => Map(keepId -> x)),
         basicUserMap
@@ -168,8 +168,8 @@ class MessageThreadNotificationBuilderImpl @Inject() (
         keepIds.flatAugmentWith(messageRepo.getLatest).toMap
       }.filterValues(_.auxData.forall(SystemMessageData.isFullySupported))
 
-      val mutedById = precomputed.flatMap(_.mutedById).getOrElse {
-        keepIds.map { keepId => keepId -> userThreadRepo.isMuted(userId, keepId) }.toMap
+      val userThreadById = precomputed.flatMap(_.userThreadById).getOrElse {
+        userThreadRepo.getAllForUserByKeepId(userId, keepIds)
       }
       val threadActivityById = precomputed.flatMap(_.threadActivityById).getOrElse {
         keepIds.map { keepId =>
@@ -185,10 +185,10 @@ class MessageThreadNotificationBuilderImpl @Inject() (
             keepId -> messageRepo.getMessageCounts(keepId, lastSeenOpt)
         }
       }
-      (threadsById, lastMsgById, mutedById, threadActivityById, msgCountById)
+      (threadsById, lastMsgById, userThreadById, threadActivityById, msgCountById)
     }
     for {
-      (threadsById, lastMsgById, mutedById, threadActivityById, msgCountById) <- infoFut
+      (threadsById, lastMsgById, userThreadById, threadActivityById, msgCountById) <- infoFut
       basicUserByIdMap <- precomputed.flatMap(_.basicUserMap).map(Future.successful).getOrElse {
         val allUsers = threadsById.values.flatMap(_.allParticipants).toSet
         shoebox.getBasicUsers(allUsers.toSeq)
@@ -196,11 +196,13 @@ class MessageThreadNotificationBuilderImpl @Inject() (
     } yield threadsById.map {
       case (keepId, thread) =>
         val thread = threadsById(keepId)
+        val userThreadOpt = userThreadById.get(keepId)
         val messageOpt = lastMsgById.get(keepId)
         val threadStarter = basicUserByIdMap(thread.startedBy).externalId
         val threadActivity = threadActivityById(keepId)
         val MessageCount(numMessages, numUnread) = msgCountById(keepId)
-        val muted = mutedById(keepId)
+        val muted = userThreadOpt.exists(_.muted)
+        val unread = userThreadOpt.map(_.unread).getOrElse(!messageOpt.exists(_.from.asUser.safely.contains(userId)))
 
         val author = messageOpt.map(_.from).collect {
           case MessageSender.User(id) => BasicUserLikeEntity(basicUserByIdMap(id))
@@ -231,13 +233,13 @@ class MessageThreadNotificationBuilderImpl @Inject() (
             author = Some(author),
             text = messageOpt.map { message =>
               message.auxData.map(SystemMessageData.generateMessageText(_, basicUserByIdMap)).getOrElse(message.messageText)
-            }.getOrElse(thread.url),
+            }.getOrElse(thread.pageTitle.getOrElse(thread.url)),
             threadId = thread.pubKeepId,
             locator = thread.deepLocator,
             url = messageOpt.flatMap(_.sentOnUrl).getOrElse(thread.url),
             title = thread.pageTitle,
             participants = orderedParticipants,
-            unread = !messageOpt.exists(_.from.asUser.safely.contains(userId)),
+            unread = unread,
             muted = muted,
             category = NotificationCategory.User.MESSAGE,
             firstAuthor = indexOfFirstAuthor,
@@ -257,7 +259,7 @@ class MessageThreadNotificationBuilderImpl @Inject() (
       val threadActivity = userThreadRepo.getThreadActivity(keepId).sortBy { uta => (-uta.lastActive.getOrElse(START_OF_TIME).getMillis, uta.id.id) }
       val messageCountByUser = userIds.map { userId =>
         val lastSeenOpt = threadActivity.find(_.userId == userId).flatMap(_.lastSeen)
-        userId -> messageRepo.getMessageCounts(keepId, lastSeenOpt) // todo(cam): optimize this
+        userId -> messageRepo.getMessageCounts(keepId, lastSeenOpt)
       }.toMap
       val mutedByUser = userThreadRepo.isMutedByUser(userIds, keepId)
 

--- a/kifi-backend/modules/eliza/test/com/keepit/eliza/notify/ElizaNotificationTest.scala
+++ b/kifi-backend/modules/eliza/test/com/keepit/eliza/notify/ElizaNotificationTest.scala
@@ -125,8 +125,9 @@ class ElizaNotificationTest extends Specification with ElizaApplicationInjector 
         (notif \ "unreadMessages").as[Int] === 1
 
         val externalId = (notif \ "id").as[String]
+        val threadId = (notif \ "thread").as[String]
 
-        socket.in(Json.arr("set_message_read", externalId))
+        socket.in(Json.arr("set_message_read", externalId, threadId))
 
         val out = socket.out
         out(0).as[String] === "message_read"

--- a/packrat/main.js
+++ b/packrat/main.js
@@ -1204,12 +1204,12 @@ api.port.on({
   activity_event_rendered: function(o, _, tab) {
     whenTabFocused(tab, o.keepId, function (tab) {
       markRead(o.keepId, o.eventId, o.time);
-      socket.send(['set_message_read', o.eventId]);
+      socket.send(['set_message_read', o.eventId, o.keepId]);
     });
   },
   set_message_read: function (o, _, tab) {
     markRead(o.threadId, o.messageId, o.time);
-    socket.send(['set_message_read', o.messageId]);
+    socket.send(['set_message_read', o.messageId, o.threadId]);
     if (o.from === 'toggle') {
       tracker.track('user_clicked_pane', {type: trackingLocatorFor(tab.id), action: 'markedRead', category: trackingCategory(o.category)});
     } else if (o.from === 'notice') {


### PR DESCRIPTION
@ryanpbrewster @andrewconner @leogrim 

This is a quick fix so that you can mark entire user threads as read/unread even if there are no messages on it. This loses some granularity but ensures that you can mark an initial send as read (an outstanding bug).
