### PR TITLE
Naming files more helpfully so I can see why we get spurts of images that don't get deleted

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
+++ b/kifi-backend/modules/common/app/com/keepit/commanders/ProcessedImageHelper.scala
@@ -19,6 +19,7 @@ import play.api.libs.Files.TemporaryFile
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.iteratee.Iteratee
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
@@ -325,7 +326,8 @@ trait ProcessedImageHelper {
           if (headers.status != 200) {
             Future.failed(new RuntimeException(s"Image returned non-200 code, ${headers.status}, $imageUrl"))
           } else {
-            val tempFile = File.createTempFile("remote-file", "")
+            val urlname = imageUrl.drop(5).replaceAll("""\W""","").take(20)
+            val tempFile = File.createTempFile("rf-" + urlname, "")
             tempFile.deleteOnExit()
             cleanup.cleanup(tempFile)
             val outputStream = new FileOutputStream(tempFile)
@@ -516,7 +518,8 @@ class ImageCleanup @Inject() (
     purge()
   }
 
-  def purge(): Unit = {
+  @tailrec
+  private def purge(): Unit = {
     synchronized {
       if (images.headOption.exists(_._1.isBefore(clock.now.minusMinutes(cleanupAfterMin)))) {
         Some(images.dequeue()._2)
@@ -529,5 +532,6 @@ class ImageCleanup @Inject() (
         }
       }
     }
+    purge()
   }
 }

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterWaitlistCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterWaitlistCommander.scala
@@ -193,7 +193,7 @@ class TwitterWaitlistCommanderImpl @Inject() (
         if (headers.status != 200) {
           Future.failed(new RuntimeException(s"Image returned non-200 code, ${headers.status}, $imageUrl"))
         } else {
-          val tempFile = TemporaryFile(prefix = "remote-file")
+          val tempFile = TemporaryFile(prefix = s"tw-${handle.value}")
           tempFile.file.deleteOnExit()
           cleanup.cleanup(tempFile.file)
           val outputStream = new FileOutputStream(tempFile.file)


### PR DESCRIPTION
Also making purging more aggressive.

`ImageCleanup` is working as expected though, so the image leak is dead.
