### PR TITLE
Some prep work for Twitter insta syncs

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/TwitterWaitlistEntry.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/TwitterWaitlistEntry.scala
@@ -10,7 +10,7 @@ case class TwitterWaitlistEntry(
     createdAt: DateTime = currentDateTime,
     updatedAt: DateTime = currentDateTime,
     userId: Id[User],
-    twitterHandle: TwitterHandle,
+    twitterHandle: Option[TwitterHandle],
     state: State[TwitterWaitlistEntry] = TwitterWaitlistEntryStates.ACTIVE) extends ModelWithState[TwitterWaitlistEntry] {
   def withId(id: Id[TwitterWaitlistEntry]) = this.copy(id = Some(id))
   def withUpdateTime(now: DateTime) = this.copy(updatedAt = now)

--- a/kifi-backend/modules/common/conf/evolutions/shoebox/446.sql
+++ b/kifi-backend/modules/common/conf/evolutions/shoebox/446.sql
@@ -1,0 +1,9 @@
+# SHOEBOX
+
+# --- !Ups
+
+alter table twitter_waitlist modify column twitter_handle varchar(16);
+
+insert into evolutions(name, description) values ('446.sql', 'make twitter handle nullable in twitter_waitlist');
+
+# --- !Downs

--- a/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/TwitterWaitlistController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/controllers/website/TwitterWaitlistController.scala
@@ -176,13 +176,13 @@ class TwitterWaitlistController @Inject() (
           pollDbForTwitterHandle(ur.userId, iterations = 75).map { twRes =>
             twRes match {
               case Some(handle) =>
-                commander.addEntry(ur.userId, handle)
+                commander.addUserToWaitlist(ur.userId, Some(handle))
               case None => // we failed :(
                 log.warn(s"Couldn't get twitter handle in time, we'll try again. userId: ${ur.userId.id}. They want to be waitlisted.")
                 socialGraphPlugin.asyncFetch(twitterSui.get).onComplete { _ =>
                   pollDbForTwitterHandle(ur.userId, iterations = 75).onComplete {
                     case Success(Some(handle)) =>
-                      commander.addEntry(ur.userId, handle)
+                      commander.addUserToWaitlist(ur.userId, Some(handle))
                     case fail => // we failed :(
                       airbrakeNotifier.notify(s"Couldn't get twitter handle in time, failed retry. userId: ${ur.userId.id}. They want to be waitlisted. $fail")
                   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/TwitterWaitlistRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/TwitterWaitlistRepo.scala
@@ -33,7 +33,7 @@ class TwitterWaitlistRepoImpl @Inject() (
 
   class TwitterWaitlistRepoTable(tag: Tag) extends RepoTable[TwitterWaitlistEntry](db, tag, "twitter_waitlist") {
     def userId = column[Id[User]]("user_id")
-    def twitterHandle = column[TwitterHandle]("twitter_handle")
+    def twitterHandle = column[Option[TwitterHandle]]("twitter_handle", O.Nullable)
 
     def * = (id.?, createdAt, updatedAt, userId, twitterHandle, state) <> ((TwitterWaitlistEntry.apply _).tupled, TwitterWaitlistEntry.unapply _)
   }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/TwitterWaitlistCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/TwitterWaitlistCommanderTest.scala
@@ -56,20 +56,16 @@ class TwitterWaitlistCommanderTest extends TestKitSupport with ShoeboxTestInject
         val therealcaptainfalcon = TwitterHandle("therealcaptainfalcon")
 
         // add a new entry
-        val res1 = twitterWaitlistCommander.addEntry(user1.id.get, therealcaptainfalcon)
+        val res1 = twitterWaitlistCommander.addUserToWaitlist(user1.id.get, Some(therealcaptainfalcon))
         res1.isRight === true
-        val emailFuture = res1.right.get._2.get
-        Await.result(emailFuture, Duration(10, "seconds"))
         db.readOnlyMaster { implicit s =>
           twitterWaitlistRepo.getByUserAndHandle(user1.id.get, therealcaptainfalcon).nonEmpty === true
-          emailRepo.count === 1
         }
 
         // add a duplicate entry
-        twitterWaitlistCommander.addEntry(user1.id.get, therealcaptainfalcon).isRight === false
+        twitterWaitlistCommander.addUserToWaitlist(user1.id.get, Some(therealcaptainfalcon)).isRight === false
         db.readOnlyMaster { implicit s =>
           twitterWaitlistRepo.getByUserAndHandle(user1.id.get, therealcaptainfalcon).nonEmpty === true
-          emailRepo.count === 1
         }
       }
     }
@@ -82,10 +78,10 @@ class TwitterWaitlistCommanderTest extends TestKitSupport with ShoeboxTestInject
         }
         val t1 = new DateTime(2014, 8, 1, 7, 0, 0, 1, DEFAULT_DATE_TIME_ZONE)
         db.readWrite { implicit s =>
-          twitterWaitlistRepo.save(TwitterWaitlistEntry(userId = user1.id.get, twitterHandle = TwitterHandle("handle1"), state = TwitterWaitlistEntryStates.ACTIVE, createdAt = t1))
-          twitterWaitlistRepo.save(TwitterWaitlistEntry(userId = user1.id.get, twitterHandle = TwitterHandle("handle2"), state = TwitterWaitlistEntryStates.ACTIVE, createdAt = t1))
-          twitterWaitlistRepo.save(TwitterWaitlistEntry(userId = user1.id.get, twitterHandle = TwitterHandle("handle3"), state = TwitterWaitlistEntryStates.ACCEPTED, createdAt = t1))
-          twitterWaitlistRepo.save(TwitterWaitlistEntry(userId = user1.id.get, twitterHandle = TwitterHandle("handle4"), state = TwitterWaitlistEntryStates.INACTIVE, createdAt = t1))
+          twitterWaitlistRepo.save(TwitterWaitlistEntry(userId = user1.id.get, twitterHandle = Some(TwitterHandle("handle1")), state = TwitterWaitlistEntryStates.ACTIVE, createdAt = t1))
+          twitterWaitlistRepo.save(TwitterWaitlistEntry(userId = user1.id.get, twitterHandle = Some(TwitterHandle("handle2")), state = TwitterWaitlistEntryStates.ACTIVE, createdAt = t1))
+          twitterWaitlistRepo.save(TwitterWaitlistEntry(userId = user1.id.get, twitterHandle = Some(TwitterHandle("handle3")), state = TwitterWaitlistEntryStates.ACCEPTED, createdAt = t1))
+          twitterWaitlistRepo.save(TwitterWaitlistEntry(userId = user1.id.get, twitterHandle = Some(TwitterHandle("handle4")), state = TwitterWaitlistEntryStates.INACTIVE, createdAt = t1))
         }
 
         db.readOnlyMaster { implicit s =>


### PR DESCRIPTION
@leogrim I'm reusing the waitlist for people who want to sync, but it's not ready yet.

The whole complexity is because once someone twitter auths, we don't know their handle until—in a separate request—we fill the profile out. This is async _and_ can/does fail, so we just patiently wait until it's there, and then will go ahead.

Flow will be:
1. User says they want a twitter sync.
2. We either can immediately create it, or add them to the "waitlist" (will probably be renamed)
3. A cron runs to check if we can process the ones that are left behind.

This PR also stops the acceptance email, because it's really outdated and not used by Jen.
