### PR TITLE
keep stream: omit limit when null instead of using an empty string

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/net.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/net.js
@@ -75,7 +75,9 @@ angular.module('kifi')
       removeOrgDomain: post(shoebox, '/organizations/:id/removeDomain'),
       sendMemberConfirmationEmail: post(shoebox, '/organizations/:id/sendMemberConfirmationEmail'),
 
-      getKeepStream: get(shoebox, '/keeps/stream?limit=:limit&beforeId=:beforeId&afterId=:afterId&filterKind=:filterKind&filterId=:filterId', 60),
+      // pass in limit={int} optionally in the separate query params object, since constructPath converts null param values into empty strings
+      getKeepStream: get(shoebox, '/keeps/stream?beforeId=:beforeId&afterId=:afterId&filterKind=:filterKind&filterId=:filterId', 60),
+
 
       getKeep: get(shoebox, '/keeps/:id?authToken=:authToken'),
       getActivityForKeepId: get(shoebox, '/keeps/:keepId/activity'),

--- a/kifi-backend/modules/shoebox/angular/src/feed/feedService.js
+++ b/kifi-backend/modules/shoebox/angular/src/feed/feedService.js
@@ -34,7 +34,8 @@ angular.module('kifi')
           new ml.Expect('Feed returns a list', function(data) { return typeof data.length !== 'undefined'; })
         ]);
 
-        return net.getKeepStream(limit, beforeId || '', afterId || '', (filter || {}).value, (filter || {}).id)
+        var limitOpt = limit && { limit: limit }; // limit should be omitted if null, so pass it in the optional query param object
+        return net.getKeepStream(beforeId || '', afterId || '', (filter || {}).value, (filter || {}).id, limitOpt)
         .then(function (response) {
           ml.specs.getsFeed.respond([null, response.data.keeps]);
           return response.data;

--- a/kifi-backend/modules/shoebox/conf/shoeboxService.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxService.routes
@@ -392,7 +392,7 @@ GET     /assets/sitemap.xml                     @com.keepit.controllers.website.
 GET     /assets/sitemap-libraries-0.xml         @com.keepit.controllers.website.SiteMapController.librariesSitemap()
 GET     /assets/sitemap-users-0.xml             @com.keepit.controllers.website.SiteMapController.usersSitemap()
 
-GET     /site/keeps/stream                    @com.keepit.controllers.website.KeepsController.getKeepStream(limit: Option[Int], beforeId: Option[String], afterId: Option[String], filterKind: Option[String] ?= None, filterId: Option[String] ?= None, maxMessagesShown: Int ?= 8)
+GET     /site/keeps/stream                    @com.keepit.controllers.website.KeepsController.getKeepStream(limit: Option[Int] ?= None, beforeId: Option[String], afterId: Option[String], filterKind: Option[String] ?= None, filterId: Option[String] ?= None, maxMessagesShown: Int ?= 8)
 POST    /site/keeps/personalExport            @com.keepit.controllers.website.KeepsController.exportPersonalKeeps()
 POST    /site/keeps/organizationExport        @com.keepit.controllers.website.KeepsController.exportOrganizationKeeps()
 POST    /site/keeps/markAsRead                @com.keepit.controllers.website.DiscussionController.markKeepsAsRead()


### PR DESCRIPTION
@andrewconner @cvializ this bit me, I suppose usually when we accept an optional string it's okay to use an empty string (not really but works most cases). Endpoints that accept an optional int are not as forgiving..
