### PR TITLE
New fetchAsap logic for imports

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Keep.scala
@@ -223,7 +223,7 @@ object KeepSource extends Enumerator[KeepSource] {
   val bulk: Set[KeepSource] = imports ++ Set(UserCopied, Unknown, Discussion)
 
   // One-at-a-time keeps
-  val discrete: Set[KeepSource] = Set(Keeper, Site, Mobile, Email, TwitterSync)
+  val discrete: Set[KeepSource] = Set(Keeper, Site, Mobile, Email)
 
   val manual: Set[KeepSource] = Set(Keeper, Site, Mobile, Email)
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -360,12 +360,11 @@ class KeepInternerImpl @Inject() (
             keep.userId.map(uid => eliza.modifyRecipientsAndSendEvent(keep.id.get, uid, keep.recipients.toDiff, basicKeep.flatMap(_.source.map(_.kind)), basicKeep)).getOrElse(Future.successful(()))
           }
 
-
           // Prefer discrete, recent keeps. Take 20 best that are within the past 14 days.
           val fastfetchKeeps = keeps
-              .sortBy(k => (KeepSource.discrete.contains(k.source), k.keptAt))(implicitly[Ordering[(Boolean, DateTime)]].reverse)
-              .take(20)
-              .filter(_.keptAt.isAfter(clock.now.minusDays(14)))
+            .sortBy(k => (KeepSource.discrete.contains(k.source), k.keptAt))(implicitly[Ordering[(Boolean, DateTime)]].reverse)
+            .take(20)
+            .filter(_.keptAt.isAfter(clock.now.minusDays(14)))
           if (fastfetchKeeps.nonEmpty) {
             FutureHelpers.sequentialExec(fastfetchKeeps) { keep =>
               val nuri = db.readOnlyMaster { implicit session =>

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -359,11 +359,20 @@ class KeepInternerImpl @Inject() (
             val basicKeep = basicKeeps.get(keep.id.get)
             keep.userId.map(uid => eliza.modifyRecipientsAndSendEvent(keep.id.get, uid, keep.recipients.toDiff, basicKeep.flatMap(_.source.map(_.kind)), basicKeep)).getOrElse(Future.successful(()))
           }
-          FutureHelpers.sequentialExec(keeps.filter(k => KeepSource.discrete.contains(k.source))) { keep =>
-            val nuri = db.readOnlyMaster { implicit session =>
-              normalizedURIRepo.get(keep.uriId)
+
+
+          // Prefer discrete, recent keeps. Take 20 best that are within the past 14 days.
+          val fastfetchKeeps = keeps
+              .sortBy(k => (KeepSource.discrete.contains(k.source), k.keptAt))(implicitly[Ordering[(Boolean, DateTime)]].reverse)
+              .take(20)
+              .filter(_.keptAt.isAfter(clock.now.minusDays(14)))
+          if (fastfetchKeeps.nonEmpty) {
+            FutureHelpers.sequentialExec(fastfetchKeeps) { keep =>
+              val nuri = db.readOnlyMaster { implicit session =>
+                normalizedURIRepo.get(keep.uriId)
+              }
+              roverClient.fetchAsap(nuri.id.get, nuri.url)
             }
-            roverClient.fetchAsap(nuri.id.get, nuri.url)
           }
 
           // Update data-dependencies


### PR DESCRIPTION
The changes mean we take every keep batch (up to 500 keeps at once, but grouped by `(user, library)`) and prefer discrete (one-at-a-time, no longer includes twitter), recent keeps. Of those, we take up to 20 from the past 2 weeks.

This means for most twitter imports, only the most recent batch will fast fetch, and of those, the top 20 will be fetched. For bookmark imports and Slack, the same. For all other keeping, it'll be normal for everything to get fast fetched.

@leogrim 
