### PR TITLE
Fix Twitter attribution backfiller

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/model/RawKeepRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/RawKeepRepo.scala
@@ -17,6 +17,7 @@ trait RawKeepRepo extends Repo[RawKeep] {
   def setState(rawKeepId: Id[RawKeep], state: State[RawKeep])(implicit session: RWSession): Boolean
   def insertAll(rawKeeps: Seq[RawKeep])(implicit session: RWSession): Try[Int]
   def insertOne(rawKeep: RawKeep)(implicit session: RWSession): Try[Boolean]
+  def getByUserId(userId: Id[User])(implicit session: RSession): Seq[RawKeep]
 }
 
 @Singleton
@@ -86,5 +87,9 @@ class RawKeepRepoImpl @Inject() (val db: DataBaseComponent, val clock: Clock) ex
 
   def insertOne(rawKeep: RawKeep)(implicit session: RWSession): Try[Boolean] = {
     Try(rows.insert(sanitizeRawKeep(rawKeep)) == 1)
+  }
+
+  def getByUserId(userId: Id[User])(implicit session: RSession): Seq[RawKeep] = {
+    rows.filter(_.userId === userId).list
   }
 }

--- a/kifi-backend/modules/shoebox/conf/admin.routes
+++ b/kifi-backend/modules/shoebox/conf/admin.routes
@@ -22,7 +22,7 @@ GET     /admin/bookmarks/checkLibraryKeepVisibility             @com.keepit.cont
 POST    /admin/bookmarks/reattributeKeeps             @com.keepit.controllers.admin.AdminBookmarksController.reattributeKeeps(author: String, userId: Option[Long] ?= None, overwriteExistingOwner: Boolean ?= false, doIt: Boolean ?= false)
 POST    /admin/bookmarks/backfillKifiAttribution      @com.keepit.controllers.admin.AdminBookmarksController.backfillKifiSourceAttribution(startFrom: Option[Long] ?= None, limit: Int, dryRun: Boolean ?= true)
 POST    /admin/bookmarks/backfillKeepEventRepo        @com.keepit.controllers.admin.AdminBookmarksController.backfillKeepEventRepo(fromId: Id[Message], pageSize: Int, dryRun: Boolean ?= true)
-GET     /admin/bookmarks/backfillTwitterAttribution             @com.keepit.controllers.admin.AdminBookmarksController.backfillTwitterAttribution(page: Int ?= 0, pageSize: Int ?= 1000)
+GET     /admin/bookmarks/backfillTwitterAttribution             @com.keepit.controllers.admin.AdminBookmarksController.backfillTwitterAttribution(userIds: String)
 
 GET     /admin/uri/:uriId           @com.keepit.controllers.admin.UrlController.getURIInfo(uriId: Id[NormalizedURI])
 #GET     /admin/uri/article/        @com.keepit.controllers.admin.UrlController.getArticle(uriId: Id[NormalizedURI], kind: ArticleKind[_ <: Article], version: ArticleVersion)


### PR DESCRIPTION
@andrewconner I was using the wrong formatter. Also this processes raw keeps by user, since only a small subset are concerned, and should thus be faster than scanning the entire table.
