### PR TITLE
Record more Twitter show fields

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/UserValue.scala
@@ -70,6 +70,8 @@ object UserValueName {
   val TWITTER_DESCRIPTION = UserValueName("twitter_description")
   val TWITTER_BANNER_IMAGE = UserValueName("twitter_banner_image")
   val TWITTER_PROTECTED_ACCOUNT = UserValueName("twitter_protected_account")
+  val TWITTER_STATUSES_COUNT = UserValueName("twitter_statuses_count")
+  val TWITTER_FAVOURITES_COUNT = UserValueName("twitter_favourites_count")
 
   // ↓↓↓↓ This should be combined with preferences. Why does it exist?
   // User Profile Settings (be sure to add to UserValueSettings.defaultSettings for default values)

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepInterner.scala
@@ -318,10 +318,10 @@ class KeepInternerImpl @Inject() (
   }
 
   private val reportingLock = new ReactiveLock(2)
-  private val debouncer = new Debouncing.Buffer[Seq[CrossServiceKeep]]
   private def reportNewKeeps(keeps: Seq[Keep], libraries: Seq[Library], ctx: HeimdalContext): Unit = {
     if (keeps.nonEmpty) {
       // Don't block keeping for these
+      log.info(s"[reportNewKeeps] Data updates for import ${reportingLock.waiting}")
       reportingLock.withLockFuture {
         SafeFuture {
           // Analytics & typeaheads

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/RawKeepImporterPlugin.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/RawKeepImporterPlugin.scala
@@ -74,7 +74,7 @@ private class RawKeepImporterActor @Inject() (
 
   private def fetchOldBatch() = {
     db.readOnlyReplica { implicit session =>
-      rawKeepRepo.getOldUnprocessed(batchSize, clock.now.minusMinutes(5))
+      rawKeepRepo.getOldUnprocessed(batchSize, clock.now.minusMinutes(10))
     }
   }
 

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterWaitlistCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterWaitlistCommander.scala
@@ -255,6 +255,12 @@ class TwitterWaitlistCommanderImpl @Inject() (
           show.profile_banner_url.foreach { img =>
             userValueRepo.setValue(userId, UserValueName.TWITTER_BANNER_IMAGE, img)
           }
+          show.statuses_count.foreach { cnt =>
+            userValueRepo.setValue(userId, UserValueName.TWITTER_STATUSES_COUNT, cnt)
+          }
+          show.favourites_count.foreach { cnt =>
+            userValueRepo.setValue(userId, UserValueName.TWITTER_FAVOURITES_COUNT, cnt)
+          }
           show.description.foreach { descr =>
             userValueRepo.setValue(userId, UserValueName.TWITTER_DESCRIPTION, descr)
           }
@@ -275,9 +281,12 @@ class TwitterWaitlistCommanderImpl @Inject() (
     log.info(s"[createSync] Got show for $userId, $show")
 
     db.readWrite(attempts = 3) { implicit session =>
-      // Update lib's description
+      // Update lib's description if it's the default
       show.description.foreach { desc =>
-        libraryRepo.save(libraryRepo.getNoCache(libraryId).copy(description = Some(desc)))
+        val lib = libraryRepo.getNoCache(libraryId)
+        if (lib.description.isEmpty || lib.description.exists(_.indexOf("Interesting pages") == 0)) {
+          libraryRepo.save(libraryRepo.getNoCache(libraryId).copy(description = Some(desc)))
+        }
       }
 
       // Update visibility, only reducing visibility

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterWaitlistCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/TwitterWaitlistCommander.scala
@@ -286,6 +286,7 @@ class TwitterWaitlistCommanderImpl @Inject() (
         val lib = libraryRepo.getNoCache(libraryId)
         if (lib.description.isEmpty || lib.description.exists(_.indexOf("Interesting pages") == 0)) {
           libraryRepo.save(libraryRepo.getNoCache(libraryId).copy(description = Some(desc)))
+          log.info(s"[updateLibraryFromShow] $libraryId ($userId): Description updated to $desc")
         }
       }
 
@@ -293,6 +294,7 @@ class TwitterWaitlistCommanderImpl @Inject() (
       show.`protected`.foreach { protectedProfile =>
         if (protectedProfile) {
           libraryRepo.save(libraryRepo.getNoCache(libraryId).copy(visibility = LibraryVisibility.SECRET))
+          log.info(s"[updateLibraryFromShow] $libraryId ($userId): Visibility updated to $protectedProfile")
         }
       }
     }
@@ -304,6 +306,7 @@ class TwitterWaitlistCommanderImpl @Inject() (
       }
       if (existing.isEmpty) {
         syncPic(userId, libraryId, image)
+        log.info(s"[updateLibraryFromShow] $libraryId ($userId): Image updated to $image")
       }
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/common/oauth/TwitterOAuthProvider.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/common/oauth/TwitterOAuthProvider.scala
@@ -20,7 +20,9 @@ import scala.concurrent.Future
   followers_count: Option[Int],
   description: Option[String],
   friends_count: Option[Int],
-  `protected`: Option[Boolean])
+  `protected`: Option[Boolean],
+  statuses_count: Option[Int],
+  favourites_count: Option[Int])
 
 object TwitterOAuthProvider {
   def toIdentity(auth: OAuth1Info, info: TwitterUserInfo): TwitterIdentity = {

--- a/kifi-backend/modules/shoebox/test/com/keepit/common/oauth/FakeOAuth2ConfigurationModule.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/common/oauth/FakeOAuth2ConfigurationModule.scala
@@ -41,7 +41,7 @@ class FakeLinkedInOAuthProvider extends LinkedInOAuthProvider with FakeOAuth2Pro
 class FakeSlackOAuthProvider extends SlackOAuthProvider with FakeOAuthProvider[SlackAuthorizationResponse, SlackIdentity]
 @Singleton
 class FakeTwitterOAuthProvider extends TwitterOAuthProvider with FakeOAuth1Provider[TwitterIdentity] {
-  def getUserShow(accessToken: OAuth1TokenInfo, screenName: TwitterHandle): Future[TwitterUserShow] = Future.successful(TwitterUserShow(None, None, None, None, None))
+  def getUserShow(accessToken: OAuth1TokenInfo, screenName: TwitterHandle): Future[TwitterUserShow] = Future.successful(TwitterUserShow(None, None, None, None, None, None, None))
 }
 
 


### PR DESCRIPTION
Records statuses count and favorites count from Twitter show. Goal is to auto-update show records every-so-often for syncs. Going to do a big manual batch first to make sure it works correctly, so that privacy settings are acknowledged. @eishay 
