### PR TITLE
keep recipient widget improvements

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/net.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/net.js
@@ -128,7 +128,7 @@ angular.module('kifi')
       getMessagesForKeepDiscussion: get(shoebox, '/keeps/:id/messages?limit=:limit&fromId=:fromId'), // ?limit={{number}}&fromId={{Option(String))}}
       deleteMessageFromKeepDiscussion: post(shoebox, '/keeps/:id/messages/delete'),
       markDiscussionAsRead: post(shoebox, '/keeps/markAsRead'),
-      suggestRecipientsForKeep: get(api, '/1/keeps/suggestRecipients')
+      suggestRecipientsForKeep: get(api, '/1/keeps/suggestRecipients', 60)
     };
 
     function get(base, pathSpec, cacheSec) {

--- a/kifi-backend/modules/shoebox/angular/src/keep/sendKeepSuggestionItem.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/sendKeepSuggestionItem.styl
@@ -1,47 +1,51 @@
+.kf-skw-suggestion
+  display: flex
+  align-items: center
+  color: black
+  height: 50px
+  border-bottom: 1px solid #e7e7e7
+
+  &:last-child
+    border-bottom: none
+
+  &:hover
+    background-color: #e7e7e7
+
 .kf-skw-suggestion-content
-  display:inline-block
-  position: absolute
-  margin-top: 7px
+  display: flex
+  flex-direction: column
+  justify-content: center
+  color: black
+  font-size: 12px
 
 .kf-skw-suggestion-content-row1
+  display: flex
+  align-items: center
   * + *
     margin-left: 3px
 
-.kf-skw-suggestion-name
-  display: inline-block
-  position: relative
-  max-width: 200px
-  font-size: 12px
-  font-weight: 600
-  overflow: hidden
-  text-overflow: ellipsis
-  white-space: nowrap
-
-.kf-skw-suggestion-subname
-  display: block
-
-.kf-skw-suggestion-img
-  position: relative
-  display: inline-block
+.kf-skw-suggestion-img-container
   margin: 10px
   width: 30px
   height: 30px
 
-.kf-skw-suggestion-user-img
+.kf-skw-suggestion-img
   width: 30px
   height: 30px
+
+.kf-skw-suggestion-img-user
   -webkit-border-radius: 17px
   border-radius: 17px
-  border: none
-  outline: none
 
-.kf-skw-library-org-img
-  width: 30px
-  height: 30px
+.kf-skw-library-card
+  position: relative
+  left: 3px
+  width: 23px
+  height: 31px
+  border-radius: 4px
+  box-shadow: 0 1px #f5f5f5, 0 3px #c9ccc0
 
-.kf-skw-suggestion-email-img
-  width: 30px
-  height: 30px
+.kf-skw-suggestion-img-email
   border-radius: 100%
   background-image: url(/img/mail.2x.png)
   background-position: center 9px
@@ -49,30 +53,28 @@
   background-size: 60% 45%
   background-color: #e36766
 
-.kf-skw-library-card
-  position: relative
-  left: 3px
-  width: 23px
-  height: 31px
-  vertical-align: top
-  border-radius: 4px
-  box-shadow: 0 1px #f5f5f5, 0 3px #c9ccc0
+.kf-skw-suggestion-name
+  max-width: 200px
+  font-size: 12px
+  font-weight: 600
+  overflow: hidden
+  text-overflow: ellipsis
+  white-space: nowrap
 
 .kf-skw-library-privacy
   position: relative
-  bottom: 0px
-  display: inline
+  bottom: 1px
   width: 18px
   height: 18px
 
-.kf-skw-library-privacy-star
-
-  fill: textBlackColor
-
 .kf-skw-library-slack
-  display: inline
   position: relative
   width: 15px
   height: 15px
   bottom: 1px
+
+.kf-skw-suggestion-noresults
+  font-size: 14px
+  color: grey
+  margin-left: 20px
 

--- a/kifi-backend/modules/shoebox/angular/src/keep/sendKeepSuggestionItem.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/sendKeepSuggestionItem.tpl.html
@@ -1,6 +1,6 @@
-<div ng-if="suggestion.kind === 'user'">
-  <div class="kf-skw-suggestion-img">
-    <img class="kf-skw-suggestion-user-img" ng-src="{{suggestion|pic:100}}"/>
+<div class="kf-skw-suggestion" ng-if="suggestion.kind === 'user'">
+  <div class="kf-skw-suggestion-img-container">
+    <img class="kf-skw-suggestion-img kf-skw-suggestion-img-user" ng-src="{{suggestion|pic:100}}"/>
   </div>
   <span class="kf-skw-suggestion-content">
     <div class="kf-skw-suggestion-name" ng-bind="suggestion.name"></div>
@@ -10,24 +10,25 @@
 
   </span>
 </div>
-<div ng-if="suggestion.kind === 'library'">
-  <div class="kf-skw-suggestion-img">
+<div class="kf-skw-suggestion" ng-if="suggestion.kind === 'library'">
+  <div class="kf-skw-suggestion-img-container">
     <div class="kf-skw-library-card" ng-if="!suggestion.orgAvatar" ng-style="{ 'background-color': suggestion.color || 'grey' }"></div>
-    <img class="kf-skw-library-org-img" ng-src="{{ {avatarPath: suggestion.orgAvatar}|pic:100 }}" ng-if="suggestion.orgAvatar"/>
+    <img class="kf-skw-suggestion-img kf-skw-library-img-org" ng-src="{{ {avatarPath: suggestion.orgAvatar}|pic:100 }}" ng-if="suggestion.orgAvatar"/>
   </div>
   <span class="kf-skw-suggestion-content">
-    <div class="kf-skw-suggestion-content-row1 kf-flex-row">
+    <div class="kf-skw-suggestion-content-row1">
       <span class="kf-skw-suggestion-name" ng-bind="suggestion.name"></span>
       <svg class="kf-skw-library-privacy symbol-sprite" kf-symbol-sprite
-           icon="{{suggestion.visibility === 'discoverable' ? 'star' : (suggestion|libPrivacyIcon)}}"></svg>
+           ng-if="suggestion.visibility !== 'discoverable'"
+           icon="{{suggestion|libPrivacyIcon}}"></svg>
       <img class="kf-skw-library-slack" src="/img/slack-hash-black.png" ng-if="suggestion.slack" />
     </div>
     <span class="kf-skw-suggestion-subname" ng-bind="suggestion.spaceName"></span>
   </span>
 </div>
-<div ng-if="suggestion.kind === 'email'">
-  <div class="kf-skw-suggestion-img">
-    <div class="kf-skw-suggestion-email-img"></div>
+<div class="kf-skw-suggestion" ng-if="suggestion.kind === 'email'">
+  <div class="kf-skw-suggestion-img-container">
+    <div class="kf-skw-suggestion-img kf-skw-suggestion-img-email"></div>
   </div>
   <span class="kf-skw-suggestion-content">
     <div class="kf-skw-suggestion-name" ng-bind="suggestion.email"></div>

--- a/kifi-backend/modules/shoebox/angular/src/keep/sendKeepWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/sendKeepWidget.js
@@ -3,10 +3,10 @@
 angular.module('kifi')
 
 .directive('kfSendKeepWidget', [
-  '$document', '$templateCache', '$rootElement', '$location', '$timeout', '$window', '$compile', 'KEY', 'keepService', 'modalService',
-  function($document, $templateCache, $rootElement, $location, $timeout, $window, $compile, KEY, keepService, modalService) {
+  '$document', '$templateCache', '$rootElement', '$timeout', '$window', '$compile', 'KEY', 'keepService', 'modalService',
+  function($document, $templateCache, $rootElement, $timeout, $window, $compile, KEY, keepService, modalService) {
 
-    var NUM_SUGGESTIONS = 3;
+    var NUM_SUGGESTIONS = 5;
 
     return {
       restrict: 'A',
@@ -27,53 +27,6 @@ angular.module('kifi')
         }
 
         function initWidget() {
-          widget = angular.element($templateCache.get('keep/sendKeepWidget.tpl.html'));
-          $rootElement.find('html').append(widget);
-          $compile(widget)(scope);
-          widget.hide();
-
-          //
-          // Position widget.
-          //
-
-          var desiredMarginTop = 60;
-          var desiredShiftVertical = 30;
-
-          var elementOffsetTop = element.offset().top;
-          var distanceFromBottom = $window.innerHeight - elementOffsetTop;
-
-          var elementOffsetLeft = element.offset().left;
-          var distanceFromRight = $window.innerWidth - elementOffsetLeft;
-
-          refreshSuggestions(null, NUM_SUGGESTIONS).then(function () {
-            // wait for the suggestions to populate the widget before looking at its height
-            $timeout(function () {
-
-              // Place the widget such that 1) it's on the screen, and 2) does not obscure the keep members UI on the keep card.
-              // If the widget can be placed above the keep members chips, set the bottom to be above it.
-              // Else if the widget can be placed below the keep members chips, set the bottom s.t. the top is below it.
-              // Else, do our best by placing the widget in middle of the keep
-              var widgetHeight = widget.height();
-              var bottom = null;
-
-              if (elementOffsetTop - widgetHeight - desiredShiftVertical >= desiredMarginTop) {
-                bottom = distanceFromBottom + desiredShiftVertical;
-              } else if (distanceFromBottom - widgetHeight - desiredShiftVertical >= 0) {
-                bottom = distanceFromBottom - widgetHeight - desiredShiftVertical;
-              } else {
-                bottom = distanceFromBottom - (widgetHeight/2);
-              }
-
-              widget.css({ bottom: bottom + 'px', right: distanceFromRight  + 'px' });
-              widget.show();
-
-              $timeout(function() {
-                resetInput();
-              }, 0);
-            }, 0);
-          });
-
-          scope.$error = false;
           scope.success = false;
           scope.sending = false;
           scope.suggestions = [];
@@ -83,6 +36,52 @@ angular.module('kifi')
 
           scope.typeahead = '';
           currPage = 0;
+
+          refreshSuggestions(null, NUM_SUGGESTIONS);
+
+          widget = angular.element($templateCache.get('keep/sendKeepWidget.tpl.html'));
+          $rootElement.find('html').append(widget);
+          $compile(widget)(scope);
+          widget.hide();
+
+          // Try to load the first batch of suggestions before calculating the widget position,
+          // if we can't, go with a height estimate
+          $timeout(function() {
+            var desiredMarginTop = 60;
+            var desiredShiftVertical = 30;
+
+            var elementOffsetTop = element.offset().top;
+            var distanceFromBottom = $window.innerHeight - elementOffsetTop;
+
+            var elementOffsetLeft = element.offset().left;
+            var distanceFromRight = $window.innerWidth - elementOffsetLeft;
+
+            // Place the widget such that 1) it's on the screen, and 2) does not obscure the keep members UI on the keep card.
+            // If the widget can be placed above the keep members chips, set the bottom to be above it.
+            // Else if the widget can be placed below the keep members chips, set the bottom s.t. the top is below it.
+            // Else, do our best by placing the widget in middle of the keep
+            var widgetHeight;
+
+            if (scope.suggestions.length) {
+              widgetHeight = widget.height();
+            } else {
+              var suggestionItem = widget.find('.kf-skw-suggestion'); // the No Results Found element
+              widgetHeight = widget.height() + ((NUM_SUGGESTIONS-3) * suggestionItem.height());
+            }
+
+            var bottom = null;
+
+            if (elementOffsetTop - widgetHeight - desiredShiftVertical >= desiredMarginTop) {
+              bottom = distanceFromBottom + desiredShiftVertical;
+            } else if (distanceFromBottom - widgetHeight - desiredShiftVertical >= 0) {
+              bottom = distanceFromBottom - widgetHeight - desiredShiftVertical;
+            } else {
+              bottom = distanceFromBottom - (widgetHeight/2);
+            }
+
+            widget.css({ bottom: bottom + 'px', right: distanceFromRight  + 'px' });
+          }, 0);
+
 
           $document.on('mousedown', onClick);
         }
@@ -123,12 +122,13 @@ angular.module('kifi')
               return filteredSuggestions.indexOf(suggestion.id || suggestion.email) === -1;
             });
 
-            if (nonMemberResults.length > 1) {
-              scope.suggestions = nonMemberResults;
-            } else if (nonMemberResults.length === 1 || resultData.mayHaveMore) {
+            if (nonMemberResults.length === 0 && resultData.mayHaveMore) {
               refreshSuggestions(query, limit, (offset || 0) + limit);
             } else {
-              refreshSuggestions('', NUM_SUGGESTIONS, 0);
+              scope.suggestions = nonMemberResults;
+              if (widget) {
+                widget.show();
+              }
             }
           });
         }
@@ -144,11 +144,11 @@ angular.module('kifi')
         function resizeInput() {
           var input = widget.find('.kf-skw-input');
           if (scope.selections.length === 0) {
-            input.width(156); // fit the placeholder text
+            input.css('width', ''); // reset to fit the placeholder text
           } else {
             var shadowInput = widget.find('.kf-skw-input-shadow');
             shadowInput[0].innerHTML = input[0].value;
-            input.width(shadowInput.width() + 10);
+            input.css('width', shadowInput.width() + 10);
           }
         }
 
@@ -200,7 +200,9 @@ angular.module('kifi')
               break;
             case KEY.ENTER:
               event.preventDefault();
-              scope.onSend();
+              if (scope.selections.length) {
+                scope.onSend();
+              }
               break;
           }
         };

--- a/kifi-backend/modules/shoebox/angular/src/keep/sendKeepWidget.styl
+++ b/kifi-backend/modules/shoebox/angular/src/keep/sendKeepWidget.styl
@@ -1,32 +1,28 @@
 .kf-send-keep-widget
   position: absolute
-  border: 1px solid black
+  border: 1px solid alpha(black, 1)
   border-radius: 8px
   overflow: hidden
   background: white
-  width: 300px
   text-align: left
   z-index: 2
+  width: 300px
 
 .kf-skw-header
+  display: flex
+  justify-content: space-between
+  align-items: center
   background-color: #333
-  padding 10px 16px
+  padding 12px 10px
 
 .kf-skw-header-txt
   font-size: 14px
   color: white
-  text-align: left
 
 .kf-skw-close
-  display: inline
-  position: relative
-  float: right
   height: 16px
   width: 16px
-  border-radius: 20px
-  padding: 2px
-  bottom: 18px
-  left: 10px
+  margin-left: auto
 
   &:hover
     fill: white
@@ -40,21 +36,78 @@
   display: flex
   flex-wrap: wrap
   background-color: #fcfcfc
-  border: 1px solid lightGrey
   padding: 10px
-  width: 280px
+  border-top: 1px solid lightGrey
+
+.kf-skw-recipient-container
+  display: inline-flex
+  align-items: center
+  margin-bottom: 4px
+  margin-right: 3px
+
+.kf-skw-recipient
+  display: inline-flex
+  align-items: center
+  justify-content: space-between
+  cursor: default
+  font-size: 12px
+  padding: 3px 4px
+  border: 0px
+  border-radius: 4px
+  color: white
 
   * + *
-    margin-left: 0px
+    margin-left: 3px
+
+.kf-skw-recipient-txt
+  white-space: nowrap
+  overflow: hidden
+  text-overflow: ellipsis
+  max-width: 210px
+
+.kf-skw-recipient-email
+  background-color: #e36766
+
+.kf-skw-recipient-library
+  > svg
+    width: 15px
+    height: 15px
+    fill: white
+
+  > img
+    width: 12px
+    height: 12px
+    margin-top: -1px
+
+.kf-skw-recipient-user
+  background: alpha(gray, .5)
+  color: white
+  border-radius: 4px
+
+  > img
+    position: relative
+    width: 15px
+    height: 15px
+    border-radius: 100%
+    bottom: 1px
+
+.kf-skw-recipient-remove
+  display: inline
+  position: relative
+  cursor: pointer
+  bottom: .5px
+
+  &:hover
+    color: alpha(black, .2)
 
 .kf-skw-input
   display: inline
+  position: relative
+  bottom: 2px
   border: 0px
   font-size: 12px
-  background-color: #fcfcfc
-  margin-top: 3px
-  margin-left: 2px
-  margin-bottom: 5px
+  background-color: inherit
+  width: 162px // fit placeholder text width
 
 .kf-skw-input-shadow
   position: absolute
@@ -78,6 +131,7 @@
   text-align: center
   position: relative
   height: 15px
+  margin-top: 2px
 
   &:hover
     border: 1px solid lightGrey
@@ -106,81 +160,3 @@
   color: libraryGreen
   font-size: 12px
   margin-bottom: 5px
-
-.kf-skw-suggestion
-  color: black
-  font-size: 10px
-  position: relative
-  height: 50px
-  width: 100%
-  border-bottom: 1px solid #e7e7e7
-
-  &:hover
-    background-color: #e7e7e7
-
-.kf-skw-recipient-list
-  display: inline
-  margin-right: 0
-
-.kf-skw-recipient
-  display: inline-block
-  cursor: default
-  font-size: 12px
-  padding: 3px 4px
-  padding-right: 4px
-  border: 0px solid black
-  border-radius: 4px
-  margin-bottom: 1px
-
-  * + *
-    margin-left: 3px
-
-.kf-skw-recipient-txt
-  display: inline-flex
-  white-space: nowrap
-  overflow: hidden
-  text-overflow: ellipsis
-  max-width: 210px
-
-.kf-skw-recipient-email
-  color: white
-  background-color: #e36766
-
-.kf-skw-recipient-library
-  font-size: 12px
-  display: inline
-  color: white
-
-  > svg
-    width: 15px
-    height: 15px
-    flex-shrink: 0
-    fill: white
-
-  > img
-    width: 12px
-    height: 12px
-    flex-shrink: 0
-    margin-top: -1px
-
-.kf-skw-recipient-user
-  background: alpha(gray, .5)
-  color: white
-  border-radius: 4px
-
-  > img
-    position: relative
-    width: 15px
-    height: 15px
-    border-radius: 100%
-    bottom: 1px
-
-.kf-skw-recipient-remove
-  display: inline
-  position: relative
-  bottom: 1px
-  right: 1px
-  cursor: pointer
-
-  &:hover
-    color: alpha(black, .2)

--- a/kifi-backend/modules/shoebox/angular/src/keep/sendKeepWidget.tpl.html
+++ b/kifi-backend/modules/shoebox/angular/src/keep/sendKeepWidget.tpl.html
@@ -5,36 +5,35 @@
   </div>
 
   <ul class="kf-skw-suggestions">
-    <li class="kf-skw-suggestion" ng-repeat="suggestion in suggestions" ng-if="!suggestion.isSelected" ng-click="onClickSuggestion(suggestion)">
+    <li ng-repeat="suggestion in suggestions" ng-if="!suggestion.isSelected" ng-click="onClickSuggestion(suggestion)">
       <div ng-include="'keep/sendKeepSuggestionItem.tpl.html'"></div>
+    </li>
+    <li class="kf-skw-suggestion" ng-if="suggestions.length === 0">
+      <div class="kf-skw-suggestion-noresults">No results found...</div>
     </li>
   </ul>
 
   <div class="kf-skw-input-container">
-    <span class="kf-skw-recipient-list">
-      <span class="kf-skw-recipient" ng-repeat="selection in selections">
-        <span class="kf-skw-recipient" ng-init="library = selection;" ng-if="selection.kind === 'library'" ng-style="{'background-color': library.color || 'grey' }">
-          <span class="kf-skw-recipient-library">
-            <svg kf-symbol-sprite
-                 ng-if="library && library|libPrivacyIcon"
-                 icon="{{::library|libPrivacyIcon}}"></svg>
-            <img
-              class="kf-skw-recipient-library-slack"
-              ng-if="library && library.slack"
-              src="/img/slack-hash-white.png"/>
-            <span class="kf-skw-recipient-txt" ng-bind="library.name"></span>
-            <span class="kf-skw-recipient-remove" ng-click="removeSelection(selection)">x</span>
-          </span>
-        </span>
-        <span class="kf-skw-recipient kf-skw-recipient-user" ng-init="user = selection;" ng-if="selection.kind === 'user'">
-          <img class="kf-skw-recipient-user-img" ng-src="{{user|pic:100}}"/>
-          <span class="kf-skw-recipient-txt" ng-bind="user.name"></span>
-          <span class="kf-skw-recipient-remove" ng-click="removeSelection(selection)">x</span>
-        </span>
-        <span class="kf-skw-recipient kf-skw-recipient-email" ng-init="email = selection;" ng-if="selection.kind === 'email'">
-          <span class="kf-skw-recipient-txt" ng-bind="email.email"></span>
-          <span class="kf-skw-recipient-remove" ng-click="removeSelection(selection)">x</span>
-        </span>
+    <span class="kf-skw-recipient-container" ng-repeat="selection in selections">
+      <span class="kf-skw-recipient kf-skw-recipient-library" ng-init="library = selection;" ng-if="selection.kind === 'library'" ng-style="{'background-color': library.color || 'grey' }">
+        <svg kf-symbol-sprite
+             ng-if="library.visibility !== 'discoverable'"
+             icon="{{library|libPrivacyIcon}}"></svg>
+        <img
+          class="kf-skw-recipient-library-slack"
+          ng-if="library && library.slack"
+          src="/img/slack-hash-white.png"/>
+        <span class="kf-skw-recipient-txt" ng-bind="library.name"></span>
+        <span class="kf-skw-recipient-remove" ng-click="removeSelection(selection)">x</span>
+      </span>
+      <span class="kf-skw-recipient kf-skw-recipient-user" ng-init="user = selection;" ng-if="selection.kind === 'user'">
+        <img class="kf-skw-recipient-user-img" ng-src="{{user|pic:100}}"/>
+        <span class="kf-skw-recipient-txt" ng-bind="user.name"></span>
+        <span class="kf-skw-recipient-remove" ng-click="removeSelection(selection)">x</span>
+      </span>
+      <span class="kf-skw-recipient kf-skw-recipient-email" ng-init="email = selection;" ng-if="selection.kind === 'email'">
+        <span class="kf-skw-recipient-txt" ng-bind="email.email"></span>
+        <span class="kf-skw-recipient-remove" ng-click="removeSelection(selection)">x</span>
       </span>
     </span>
     <input class="kf-skw-input" ng-model="typeahead" ng-change="onTypeaheadInputChanged(typeahead)" ng-keydown="processKeyEvent($event)" autofocus="autofocus" placeholder="{{ selections.length ? '' : 'Enter a user, library, or email...' }}">


### PR DESCRIPTION
@cvializ @andrewconner 

1) made the initial load of the widget faster: use a heuristic to calculate the height instead of waiting for the default suggestions. after that the default suggestions are cached and it's fast to wait for them.

2) made some refactors/improvements to the css/html layout. There were some overlooked Firefox discrepancies... and the selected user+library chips are now (basically) inline vs inline-block, so the typeahead input sits right next to them if it can.

3) added a "No Results Found" element for unsuccessful typeaheads. Previously I was reloading the default suggestions, which in hindsight is confusing.
