### PR TITLE
Ensure that messages are persisted later than the keep

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeepCommander.scala
@@ -17,7 +17,7 @@ import com.keepit.common.performance._
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.common.store.S3ImageConfig
 import com.keepit.common.time._
-import com.keepit.common.util.RightBias
+import com.keepit.common.util.{ Ord, RightBias }
 import com.keepit.common.util.RightBias.FromOption
 import com.keepit.discussion.{ Message, MessageSource }
 import com.keepit.eliza.ElizaServiceClient
@@ -260,7 +260,7 @@ class KeepCommanderImpl @Inject() (
       (keep, isNew) <- Future.fromTry(db.readWrite { implicit s => keepInterner.internKeepByRequest(internReq) })
       msgOpt <- Author.kifiUserId(internReq.author).fold(Future.successful(Option.empty[Message])) { user =>
         internReq.note.fold(Future.successful(Option.empty[Message])) { note =>
-          implicit val time = CrossServiceTime(clock.now)
+          implicit val time = CrossServiceTime(Ord.max(clock.now, keep.createdAt))
           eliza.sendMessageOnKeep(user, note, keep.id.get, source = MessageSource.fromKeepSource(internReq.source)).imap(Some(_))
         }
       }

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepToLibraryCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepToLibraryCommanderTest.scala
@@ -3,8 +3,9 @@ package com.keepit.commanders
 import com.google.inject.Injector
 import com.keepit.common.actor.TestKitSupport
 import com.keepit.common.db.Id
+import com.keepit.common.time._
 import com.keepit.heimdal.HeimdalContext
-import com.keepit.integrity.{ UriIntegrityPlugin }
+import com.keepit.integrity.UriIntegrityPlugin
 import com.keepit.model.KeepFactoryHelper._
 import com.keepit.model.LibraryFactoryHelper._
 import com.keepit.model.OrganizationFactoryHelper._
@@ -37,7 +38,7 @@ class KeepToLibraryCommanderTest extends TestKitSupport with SpecificationLike w
             val keep = KeepFactory.keep().withLibrary(userLib).saved
 
             val otherLib = LibraryFactory.library().withOwner(user).saved
-            val ktl = ktlCommander.internKeepInLibrary(keep, otherLib, Some(user.id.get))
+            val ktl = ktlCommander.internKeepInLibrary(keep, otherLib, Some(user.id.get), addedAt = fakeClock.now)
 
             ktl.keepId === keep.id.get
             ktl.addedBy === Some(user.id.get)
@@ -55,11 +56,11 @@ class KeepToLibraryCommanderTest extends TestKitSupport with SpecificationLike w
             val keep = KeepFactory.keep().withUser(user1).withLibrary(lib).saved
 
             // user1 re-interns the keep
-            ktlCommander.internKeepInLibrary(keep, lib, Some(user1.id.get)).addedBy === Some(user1.id.get)
+            ktlCommander.internKeepInLibrary(keep, lib, Some(user1.id.get), addedAt = fakeClock.now).addedBy === Some(user1.id.get)
             ktlRepo.getByKeepIdAndLibraryId(keep.id.get, lib.id.get).get.addedBy === Some(user1.id.get)
 
             // user2 re-interns the keep
-            ktlCommander.internKeepInLibrary(keep, lib, Some(user2.id.get)).addedBy === Some(user1.id.get)
+            ktlCommander.internKeepInLibrary(keep, lib, Some(user2.id.get), addedAt = fakeClock.now).addedBy === Some(user1.id.get)
             ktlRepo.getByKeepIdAndLibraryId(keep.id.get, lib.id.get).get.addedBy === Some(user1.id.get)
           }
           1 === 1
@@ -113,13 +114,13 @@ class KeepToLibraryCommanderTest extends TestKitSupport with SpecificationLike w
             for (i <- 1 to 10) {
               // lib1 -> lib2
               ktlCommander.removeKeepFromLibrary(keep.id.get, lib1.id.get)
-              ktlCommander.internKeepInLibrary(keep, lib2, Some(user.id.get))
+              ktlCommander.internKeepInLibrary(keep, lib2, Some(user.id.get), addedAt = fakeClock.now)
               ktlRepo.getByKeepIdAndLibraryId(keep.id.get, lib1.id.get) must beNone
               ktlRepo.getByKeepIdAndLibraryId(keep.id.get, lib2.id.get) must beSome
 
               // lib2 -> lib1
               ktlCommander.removeKeepFromLibrary(keep.id.get, lib2.id.get)
-              ktlCommander.internKeepInLibrary(keep, lib1, Some(user.id.get))
+              ktlCommander.internKeepInLibrary(keep, lib1, Some(user.id.get), addedAt = fakeClock.now)
               ktlRepo.getByKeepIdAndLibraryId(keep.id.get, lib1.id.get) must beSome
               ktlRepo.getByKeepIdAndLibraryId(keep.id.get, lib2.id.get) must beNone
             }
@@ -127,7 +128,7 @@ class KeepToLibraryCommanderTest extends TestKitSupport with SpecificationLike w
 
             for (i <- 1 to 10) {
               ktlCommander.removeKeepFromLibrary(keep.id.get, lib1.id.get)
-              ktlCommander.internKeepInLibrary(keep, lib1, Some(user.id.get))
+              ktlCommander.internKeepInLibrary(keep, lib1, Some(user.id.get), addedAt = fakeClock.now)
               ktlRepo.getByKeepIdAndLibraryId(keep.id.get, lib1.id.get) must beSome
               ktlRepo.getByKeepIdAndLibraryId(keep.id.get, lib2.id.get) must beNone
             }


### PR DESCRIPTION
Because Shoebox's DB rounds timestamps, we actually need to use `keep.createdAt` as the `CrossServiceTime` instead of `clock.now` (as the rounding happens in the db, not on the machine).
