### PR TITLE
Filter out existing keep recipients in typeahead

### DIFF
--- a/kifi-backend/modules/shoebox/conf/shoeboxClient.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxClient.routes
@@ -20,7 +20,7 @@ POST    /api/1/keeps/:id/messages/:msgId/edit     @com.keepit.controllers.client
 
 # Info
 GET    /api/1/keeps/stream           @com.keepit.controllers.client.KeepInfoController.getKeepStream(fromId: Option[String] ?= None, limit: Option[Int], config: KeepViewAssemblyOptions)
-GET    /api/1/keeps/suggestRecipients @com.keepit.controllers.client.KeepInfoController.suggestRecipient(query: Option[String], limit: Option[Int], offset: Option[Int], requested: Option[String])
+GET    /api/1/keeps/suggestRecipients @com.keepit.controllers.client.KeepInfoController.suggestRecipient(keepId: Option[String] ?= None, query: Option[String], limit: Option[Int], offset: Option[Int], requested: Option[String])
 GET    /api/1/keeps/suggestTags     @com.keepit.controllers.client.KeepInfoController.suggestTags(keepId: Option[String], query: Option[String], limit: Option[Int])
 
 


### PR DESCRIPTION
Achieved by asking for more results than necessary and dropping bad ones
The existing endpoint now accepts an optional `PublicId[Keep]`, so

```
/api/1/keeps/suggestRecipients?keepId=k1234ABCD
```

@andrewconner @camhashemi 

My intuition is that this make typeahead requests noticeably more expensive, as they now involve 4 additional db queries. We'll see.
