### PR TITLE
Telling frontend when user needs to auth.

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/social/SocialNetworks.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/SocialNetworks.scala
@@ -36,7 +36,7 @@ object SocialNetworkType {
 
 object SocialNetworks {
   val ALL = Seq(FACEBOOK, TWITTER, LINKEDIN, FORTYTWO, EMAIL, SLACK)
-  val REFRESHING = Seq(FACEBOOK, TWITTER, LINKEDIN)
+  val REFRESHING = Seq(FACEBOOK, TWITTER)
   val verifiedEmailProviders: Set[SocialNetworkType] = Set(FACEBOOK, TWITTER, LINKEDIN, SLACK)
   val social: Set[SocialNetworkType] = Set(FACEBOOK, TWITTER, LINKEDIN)
   case object LINKEDIN extends SocialNetworkType("linkedin", "LinkedIn", "linkedin")


### PR DESCRIPTION
@DerekBurch Small change. Now, if you hit the endpoint to create a sync, and you've never authed Twitter, the frontend can now know this and (hopefully) handle the situation. You'll see a `auth` field in the response, with the place to send them.
