### PR TITLE
Correctly un-escape ingested Slack titles

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/slack/models/SlackMessage.scala
+++ b/kifi-backend/modules/common/app/com/keepit/slack/models/SlackMessage.scala
@@ -141,20 +141,15 @@ object SlackAttachment {
 }
 
 case class SlackMessage(
-    messageType: SlackMessageType,
-    userId: SlackUserId,
-    username: SlackUsername,
-    timestamp: SlackTimestamp,
-    channel: SlackChannelIdAndName,
-    rawText: String,
-    attachments: Seq[SlackAttachment],
-    permalink: String,
-    originalJson: JsValue) {
-  def text: String = rawText.replaceAllLiterally("&amp;" -> "&")
-  // NB: the below line is technically more correct, but our ingestion relies on "dumb" regular expressions that may break
-  // if we unescape the angle-brackets. If we decide that this is a relevant concern, fix the regexs and switch to that line
-  // def text: String = rawText.replaceAllLiterally("&lt;" -> "<", "&gt;" -> ">", "&amp;" -> "&")
-}
+  messageType: SlackMessageType,
+  userId: SlackUserId,
+  username: SlackUsername,
+  timestamp: SlackTimestamp,
+  channel: SlackChannelIdAndName,
+  text: String,
+  attachments: Seq[SlackAttachment],
+  permalink: String,
+  originalJson: JsValue)
 
 object SlackMessage {
   private val reads: Reads[SlackMessage] = (

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/commanders/MessagingCommander.scala
@@ -315,7 +315,7 @@ class MessagingCommanderImpl @Inject() (
         throw NotAuthorizedException("Wrong code path for system Messages.")
     }
 
-    log.info(s"Sending message from $from to ${initialThread.participants}")
+    log.info(s"Sending message from $from on keep ${initialThread.keepId}, csTime = ${time.time} so createdAt = ${Ord.max(clock.now, time.time)}")
     val (message, thread) = db.readWrite { implicit session =>
       val msg = messageRepo.save(ElizaMessage(
         createdAt = Ord.max(clock.now, time.time),

--- a/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaDiscussionController.scala
+++ b/kifi-backend/modules/eliza/app/com/keepit/eliza/controllers/internal/ElizaDiscussionController.scala
@@ -87,7 +87,7 @@ class ElizaDiscussionController @Inject() (
       contextBuilder.build
     }
     implicit val time = input.time
-    discussionCommander.sendMessage(input.userId, input.text, input.keepId, source = input.source).map { msg =>
+    discussionCommander.sendMessage(input.userId, input.text, input.keepId, source = input.source)(time = time, context = context).map { msg =>
       val output = Response(msg)
       Ok(Json.toJson(output))
     }

--- a/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackIngestingActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/slack/SlackIngestingActor.scala
@@ -272,7 +272,7 @@ class SlackIngestingActor @Inject() (
         case url if !ignoreUrl(url, blacklist) =>
           val title = linksFromText.get(url).flatten orElse linksFromAttachments.get(url).flatMap(_.title.map(_.value))
           RawBookmarkRepresentation(
-            title = title,
+            title = title.map(_.replaceAllLiterally("&amp;", "&")),
             url = url,
             canonical = None,
             openGraph = None,


### PR DESCRIPTION
Previously we were only un-escaping the actual message text.
This led to issues whenever we derived a keep's title from the auto-unfurled
attachment titles (which we did not un-escape).

New behavior is to escape the derived title, regardless of its origin.
