### PR TITLE
Introduce full kifi exports

### DIFF
--- a/kifi-backend/.sbtopts
+++ b/kifi-backend/.sbtopts
@@ -6,3 +6,4 @@
 -J-XX:+HeapDumpOnOutOfMemoryError
 -J-XX:+DoEscapeAnalysis
 -J-XX:+UseCodeCacheFlushing
+-J-XX:MaxMetaspaceSize=2g

--- a/kifi-backend/modules/shoebox/app/com/keepit/export/FullKifiExport.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/export/FullKifiExport.scala
@@ -1,0 +1,10 @@
+package com.keepit.export
+
+import com.keepit.common.db.Id
+import com.keepit.model.{ Keep, Library, NormalizedURI }
+import com.keepit.rover.model.RoverUriSummary
+
+final case class FullKifiExport(
+  libs: Map[Id[Library], Library],
+  keeps: Map[Id[Keep], Keep],
+  uris: Map[Id[NormalizedURI], RoverUriSummary])

--- a/kifi-backend/modules/shoebox/conf/shoeboxClient.routes
+++ b/kifi-backend/modules/shoebox/conf/shoeboxClient.routes
@@ -31,6 +31,7 @@ GET    /api/1/keeps/:id/activity     @com.keepit.controllers.client.KeepInfoCont
 # Exports
 GET    /api/1/keeps/export/personal  @com.keepit.controllers.client.KeepExportController.exportPersonalKeeps()
 GET    /api/1/keeps/export/org       @com.keepit.controllers.client.KeepExportController.exportOrganizationKeeps()
+GET    /api/1/keeps/export/full      @com.keepit.controllers.client.KeepExportController.fullKifiExport()
 
 ##
 # LIBRARIES

--- a/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepExportCommanderTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/commanders/KeepExportCommanderTest.scala
@@ -1,5 +1,7 @@
 package com.keepit.commanders
 
+import java.util.zip.{ ZipEntry, ZipOutputStream }
+
 import com.google.inject.Injector
 import com.keepit.abook.FakeABookServiceClientModule
 import com.keepit.common.concurrent.FakeExecutionContextModule
@@ -19,6 +21,7 @@ import com.keepit.model._
 import com.keepit.search.FakeSearchServiceClientModule
 import com.keepit.shoebox.{ FakeKeepImportsModule, FakeShoeboxServiceModule }
 import com.keepit.test.ShoeboxTestInjector
+import org.apache.commons.math3.random.MersenneTwister
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
 import play.api.libs.json.Json

--- a/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepExportControllerTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/controllers/website/KeepExportControllerTest.scala
@@ -1,0 +1,45 @@
+package com.keepit.controllers.website
+
+import com.google.inject.Injector
+import com.keepit.abook.FakeABookServiceClientModule
+import com.keepit.common.controller.FakeUserActionsHelper
+import com.keepit.common.crypto.PublicIdConfiguration
+import com.keepit.common.social.FakeSocialGraphModule
+import com.keepit.controllers.client.KeepExportController
+import com.keepit.heimdal.FakeHeimdalServiceClientModule
+import com.keepit.model.LibraryFactoryHelper._
+import com.keepit.model.UserFactoryHelper._
+import com.keepit.model._
+import com.keepit.test.ShoeboxTestInjector
+import org.specs2.mutable.Specification
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+
+class KeepExportControllerTest extends Specification with ShoeboxTestInjector {
+  def createFakeRequest(route: Call) = FakeRequest(route.method, route.url)
+  implicit def publicIdConfig(implicit injector: Injector) = inject[PublicIdConfiguration]
+  private def controller(implicit injector: Injector) = inject[KeepExportController]
+  private def route = com.keepit.controllers.client.routes.KeepExportController
+
+  val modules = Seq(
+    FakeHeimdalServiceClientModule(),
+    FakeABookServiceClientModule(),
+    FakeSocialGraphModule()
+  )
+
+  "OrganizationController" should {
+    "stream a zipped kifi export" in {
+      withDb(modules: _*) { implicit injector =>
+        val (user, lib) = db.readWrite { implicit s =>
+          val user = UserFactory.user().saved
+          val lib = LibraryFactory.library().withOwner(user).saved
+          (user, lib)
+        }
+        inject[FakeUserActionsHelper].setUser(user)
+        val request = createFakeRequest(route.fullKifiExport())
+        val resultFut = controller.fullKifiExport().apply(request)
+        1 === 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently these involve all of a user's libraries
(and all the keeps within those libraries), but no headless
keeps. The formatting is extremely minimal.

A full-export can be retrieved as a ZIP archive from

```
/api/1/keeps/export/full
```
