### PR TITLE
properly refresh typeahead results

### DIFF
--- a/kifi-backend/modules/shoebox/angular/src/common/services/paginator.js
+++ b/kifi-backend/modules/shoebox/angular/src/common/services/paginator.js
@@ -35,7 +35,7 @@ angular.module('kifi')
       }
     };
 
-    Paginator.prototype.fetch = function (sourceFunction, pageNumber, pageSize) {
+    Paginator.prototype.fetch = function (sourceFunction, pageNumber, pageSize, refresh) {
       if (this.loading) {
         return this._cachedFetch;
       }
@@ -51,7 +51,13 @@ angular.module('kifi')
         .then(function (items) {
           this.hasMoreItems = this._calcServerHasMore(items, pageSize);
           this.init = true;
-          this.items = this.items.concat(items);
+
+          if (refresh) {
+            this.items = items;
+            this.fetchPageNumber = 1;
+          } else {
+            this.items = this.items.concat(items);
+          }
 
           return this.items;
         }.bind(this))

--- a/kifi-backend/modules/shoebox/angular/src/keep/sendKeepWidget.js
+++ b/kifi-backend/modules/shoebox/angular/src/keep/sendKeepWidget.js
@@ -19,7 +19,6 @@ angular.module('kifi')
         keep: '='
       },
       link: function(scope, element) {
-        var currPage = 0;
         var widget;
         var highlightedIndex = 0;
         var suggestionPaginator;
@@ -55,7 +54,6 @@ angular.module('kifi')
 
           scope.typeahead = '';
           scope.validEmail = false;
-          currPage = 0;
 
           widget = angular.element($templateCache.get('keep/sendKeepWidget.tpl.html'));
           keepCardElement = element.parents('.kf-keep');
@@ -153,9 +151,11 @@ angular.module('kifi')
         }
 
         function clearHighlights() {
-          scope.suggestions.forEach(function(suggestion) {
-            suggestion.isHighlighted = false;
-          });
+          if (scope.suggestions) {
+            scope.suggestions.forEach(function(suggestion) {
+              suggestion.isHighlighted = false;
+            });
+          }
         }
 
         function adjustScroll(selectedIndex) {
@@ -207,8 +207,8 @@ angular.module('kifi')
           }
         };
 
-        scope.fetchSuggestions = function () {
-          return suggestionPaginator.fetch().then(function(suggestions) {
+        scope.fetchSuggestions = function (refresh) {
+          return suggestionPaginator.fetch(null, null, null, refresh).then(function(suggestions) {
             scope.suggestions = suggestions;
             if (widget && !scope.init) {
               scope.init = true;
@@ -288,14 +288,13 @@ angular.module('kifi')
         scope.processKeyEvent = function (event) {
           switch (event.keyCode) {
             case KEY.BSPACE:
-              event.preventDefault();
               if (scope.selections.length && scope.typeahead === '') {
+                event.preventDefault();
                 scope.removeSelection(scope.selections[scope.selections.length-1]);
                 clearHighlights();
                 highlightedIndex++;
                 scope.suggestions[highlightedIndex].isHighlighted = true;
               } else if (scope.typeahead !== '') {
-                scope.typeahead = scope.typeahead.slice(0, -1);
                 scope.onTypeaheadInputChanged();
               }
               break;
@@ -383,9 +382,8 @@ angular.module('kifi')
 
 
         scope.onTypeaheadInputChanged = function() {
-          currPage = 0;
           suggestionPaginator.reset();
-          scope.fetchSuggestions().then(function () {
+          scope.fetchSuggestions(true).then(function () {
             clearHighlights();
             highlightedIndex = 0;
             if (scope.suggestions.length) {


### PR DESCRIPTION
@cvializ @andrewconner 

this adds the converse behavior of `Paginator.prototype.resetAndFetch()`. Since `fetch()` can be asynchronous and the callbacks may be executed after the request has become invalid (e.g. the typeahead has changed), sometimes we want `fetch()` to refresh the items instead of concatenating them.  
