### PR TITLE
Filtering tags to skip internal tags (that amazon applies)

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/data/keep/NewKeepInfosForPage.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/data/keep/NewKeepInfosForPage.scala
@@ -27,7 +27,7 @@ case class NewKeepInfosForIntersection(
   intersectionKeeps: Seq[NewKeepInfo],
   onThisPageKeeps: Seq[(NewKeepInfo, KeepProximitySection)],
   entityName: Option[String] // name of either user or library we're filtering on
-)
+  )
 
 object NewKeepInfosForIntersection {
   val empty = NewKeepInfosForIntersection(page = Option.empty, paginationContext = PaginationContext.empty, intersectionKeeps = Seq.empty, onThisPageKeeps = Seq.empty, entityName = None)

--- a/provisioning/templates/opt/kifi-node-setup.j2
+++ b/provisioning/templates/opt/kifi-node-setup.j2
@@ -43,7 +43,7 @@ def set_tags_from_spot_request(instance):
     spot_req = ec2_spot_request()
     if spot_req is not None:
         log("Spot request found: %s" % spot_req['SpotInstanceRequestId'])
-        spot_tags = spot_req['Tags']
+        spot_tags = [t for t in spot_req['Tags'] if t['Key'].find('aws:') == -1]
         log("Adding tags from spot request %s" % spot_tags)
         instance.create_tags(Tags=spot_tags)
         return True


### PR DESCRIPTION
New spot requests get a tag from Amazon, which we cannot apply to the instances. Skipping it.
