### PR TITLE
[wip] expose intersection page links in social tooltip and ext search results

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/model/Library.scala
+++ b/kifi-backend/modules/common/app/com/keepit/model/Library.scala
@@ -384,6 +384,13 @@ object BasicLibrary {
   )
 }
 
+case class BasicLibraryWithUrlIntersection(library: BasicLibrary, urlHash: UrlHash)
+object BasicLibraryWithUrlIntersection {
+  implicit val writes: Writes[BasicLibraryWithUrlIntersection] = Writes {
+    case BasicLibraryWithUrlIntersection(lib, urlHash) => Json.toJson(lib).as[JsObject] ++ Json.obj("intersection" -> s"/int?url=${urlHash.hash}&library=${lib.id.id}")
+  }
+}
+
 // Replaced by BasicLibraryDetails, please remove dependencies on this
 case class BasicLibraryStatistics(memberCount: Int, keepCount: Int)
 object BasicLibraryStatistics {

--- a/kifi-backend/modules/common/app/com/keepit/social/BasicUser.scala
+++ b/kifi-backend/modules/common/app/com/keepit/social/BasicUser.scala
@@ -154,6 +154,13 @@ object BasicUser {
   }
 }
 
+case class BasicUserWithUrlIntersection(user: BasicUser, urlHash: UrlHash)
+object BasicUserWithUrlIntersection {
+  implicit val writes: Writes[BasicUserWithUrlIntersection] = Writes {
+    case BasicUserWithUrlIntersection(user, urlHash) => Json.toJson(user).as[JsObject] ++ Json.obj("intersection" -> s"/int?url=${urlHash.hash}&user=${user.externalId.id}")
+  }
+}
+
 case class BasicUserUserIdKey(userId: Id[User]) extends Key[BasicUser] {
   override val version = 13
   val namespace = "basic_user_userid"

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeeperInfo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/KeeperInfo.scala
@@ -1,7 +1,7 @@
 package com.keepit.commanders
 
 import com.keepit.common.store.ImagePath
-import com.keepit.social.BasicUser
+import com.keepit.social.{ BasicUserWithUrlIntersection, BasicUser }
 import com.keepit.common.crypto.PublicId
 import com.keepit.common.db.ExternalId
 import com.keepit.common.time.DateTimeJsonFormat
@@ -15,7 +15,7 @@ case class KeeperPageInfo(
   position: Option[JsObject],
   neverOnSite: Boolean,
   shown: Boolean,
-  keepers: Seq[BasicUser],
+  keepers: Seq[BasicUserWithUrlIntersection],
   keepersTotal: Int,
   libraries: Seq[JsObject],
   sources: Seq[SourceAttribution],
@@ -29,7 +29,7 @@ object KeeperPageInfo {
       (__ \ 'position).writeNullable[JsObject] and
       (__ \ 'neverOnSite).writeNullable[Boolean].contramap[Boolean](Some(_).filter(identity)) and
       (__ \ 'shown).writeNullable[Boolean].contramap[Boolean](Some(_).filter(identity)) and
-      (__ \ 'keepers).writeNullable[Seq[BasicUser]].contramap[Seq[BasicUser]](Some(_).filter(_.nonEmpty)) and
+      (__ \ 'keepers).writeNullable[Seq[BasicUserWithUrlIntersection]].contramap[Seq[BasicUserWithUrlIntersection]](Some(_).filter(_.nonEmpty)) and
       (__ \ 'keepersTotal).writeNullable[Int].contramap[Int](Some(_).filter(_ > 0)) and
       (__ \ 'libraries).writeNullable[Seq[JsObject]].contramap[Seq[JsObject]](Some(_).filter(_.nonEmpty)) and
       (__ \ 'sources).writeNullable[Seq[SourceAttribution]].contramap[Seq[SourceAttribution]](Some(_).filter(_.nonEmpty)) and

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PageCommander.scala
@@ -19,7 +19,7 @@ import com.keepit.model._
 import com.keepit.normalizer.NormalizedURIInterner
 import com.keepit.search.{ SearchFilter, SearchServiceClient }
 import com.keepit.slack.SlackInfoCommander
-import com.keepit.social.BasicUser
+import com.keepit.social.{ BasicUserWithUrlIntersection, BasicUser }
 import com.keepit.common.logging.{ AccessLog, Logging }
 import org.joda.time.DateTime
 import com.keepit.common.core._
@@ -92,13 +92,13 @@ class PageCommander @Inject() (
       nUriOpt.map { normUri =>
         augmentUriInfo(normUri, userId).map { info =>
           if (filteredPage(normUri.url)) {
-            KeeperPageInfo(nUriStr, position, neverOnSite, shown, Seq.empty[BasicUser], 0, Seq.empty[JsObject], Seq.empty[SourceAttribution], info.keeps)
+            KeeperPageInfo(nUriStr, position, neverOnSite, shown, Seq.empty[BasicUserWithUrlIntersection], 0, Seq.empty[JsObject], Seq.empty[SourceAttribution], info.keeps)
           } else {
             KeeperPageInfo(nUriStr, position, neverOnSite, shown, info.keepers, info.keepersTotal, info.libraries, info.sources, info.keeps)
           }
         }
       }.getOrElse {
-        Future.successful(KeeperPageInfo(nUriStr, position, neverOnSite, shown, Seq.empty[BasicUser], 0, Seq.empty[JsObject], Seq.empty[SourceAttribution], Seq.empty[KeepData]))
+        Future.successful(KeeperPageInfo(nUriStr, position, neverOnSite, shown, Seq.empty[BasicUserWithUrlIntersection], 0, Seq.empty[JsObject], Seq.empty[SourceAttribution], Seq.empty[KeepData]))
       }
     }
     infoF.flatten
@@ -202,6 +202,7 @@ class PageCommander @Inject() (
         val (basicUserMap, libraries, sources, followerCounts, paths, keepDatas) = db.readOnlyMaster { implicit session =>
           val relevantLibraries = Seq.empty[(Library, Id[User], DateTime)] //getRelevantLibraries(userId, info.libraries)
           val basicUserMap = basicUserRepo.loadAll(userIdSet ++ relevantLibraries.map(_._1.ownerId) ++ relevantLibraries.map(_._2))
+            .mapValuesStrict(bu => BasicUserWithUrlIntersection(bu, normUri.urlHash))
           val keepDatas = getWriteableKeepDatasForUri(userId, normUri.id.get)
 
           val sources = {
@@ -224,6 +225,7 @@ class PageCommander @Inject() (
         val libraryObjs = libraries.map {
           case (lib, addedBy, _) =>
             val followerCount: Int = followerCounts.getOrElse(lib.id.get, 0)
+            val intersectionPath = pathCommander.intersectionPageForLibrary(normUri.urlHash, Library.publicId(lib.id.get))
             Json.obj(
               "name" -> lib.name,
               "path" -> paths.get(lib.id.get).map(_.relativeWithLeadingSlash),
@@ -231,7 +233,9 @@ class PageCommander @Inject() (
               "color" -> lib.color,
               "owner" -> Json.toJson(basicUserMap.getOrElse(addedBy, basicUserMap(lib.ownerId))),
               "keeps" -> lib.keepCount,
-              "followers" -> followerCount)
+              "followers" -> followerCount,
+              "intersection" -> intersectionPath.relativeWithLeadingSlash
+            )
         }
         KeeperPagePartialInfo(keepers, otherKeepersTotal, libraryObjs, sources, keepDatas)
     }
@@ -269,7 +273,7 @@ class InferredKeeperPositionCache(stats: CacheStatistics, accessLog: AccessLog, 
   extends JsonCacheImpl[InferredKeeperPositionKey, JsObject](stats, accessLog, innermostPluginSettings, innerToOuterPluginSettings: _*)
 
 case class KeeperPagePartialInfo(
-  keepers: Seq[BasicUser],
+  keepers: Seq[BasicUserWithUrlIntersection],
   keepersTotal: Int,
   libraries: Seq[JsObject],
   sources: Seq[SourceAttribution],

--- a/kifi-backend/modules/shoebox/app/com/keepit/commanders/PathCommander.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/commanders/PathCommander.scala
@@ -4,9 +4,10 @@ import java.net.URLEncoder
 
 import com.google.inject.{ Inject, Singleton }
 import com.keepit.common.crypto.{ PublicId, PublicIdConfiguration }
-import com.keepit.common.db.Id
+import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.db.slick.DBSession.{ RWSession, RSession }
 import com.keepit.common.db.slick.Database
+import com.keepit.common.mail.EmailAddress
 import com.keepit.common.net.{ Query, Param }
 import com.keepit.common.path.Path
 import com.keepit.common.social.BasicUserRepo
@@ -112,6 +113,15 @@ class PathCommander @Inject() (
 
   def shortened(sp: ShortenedPath): Path = Path(s"/sp/${ShortenedPath.publicId(sp.id.get).id}")
   def shorten(path: Path)(implicit session: RWSession): ShortenedPath = shortenedPathRepo.intern(path)
+
+  /**
+   * INTERSECTION
+   */
+
+  def intersectionPage(urlHash: UrlHash): Path = Path(s"/int?url=${urlHash.hash}")
+  def intersectionPageForUser(urlHash: UrlHash, userId: ExternalId[User]): Path = Path(s"/int?url=${urlHash.hash}&user=${userId.id}")
+  def intersectionPageForLibrary(urlHash: UrlHash, libId: PublicId[Library]): Path = Path(s"/int?url=${urlHash.hash}&library=${libId.id}")
+  def intersectionPageForEmail(urlHash: UrlHash, email: EmailAddress): Path = Path(s"/int?url=${urlHash.hash}&email=${email.address}")
 
   /**
    * I'd prefer if you just didn't use these routes


### PR DESCRIPTION
@andrewconner @leogrim 

I added frontend and backend implementations, minus backend search. That's a bit tricky since we return search hits independently from the users + libraries they're connected to (a user or library object can be referenced by multiple urls). @leogrim if you have any recommendations for where to combine the `BasicUser` and `BasicLibrary` objects with the normalized url from the keep, I'd appreciate them.  Otherwise we can fairly easily generate the intersection page url on the clients.
