### PR TITLE
use one intersecting entity until we spec more

### DIFF
--- a/kifi-backend/modules/common/app/com/keepit/common/plugin/SchedulingPlugin.scala
+++ b/kifi-backend/modules/common/app/com/keepit/common/plugin/SchedulingPlugin.scala
@@ -31,8 +31,9 @@ trait SchedulerPlugin extends Plugin with Logging {
   private def scheduleTask(system: ActorSystem, initialDelay: FiniteDuration, frequency: FiniteDuration, taskName: String)(f: => Unit): Unit = _cancellables.synchronized {
     _cancellables +=
       NamedCancellable(system.scheduler.schedule(initialDelay, frequency) {
-        Try(f).recover { case ex: Throwable =>
-          log.error(s"[scheduleTask] Failed to execute task $taskName", ex)
+        Try(f).recover {
+          case ex: Throwable =>
+            log.error(s"[scheduleTask] Failed to execute task $taskName", ex)
         }
       }, taskName)
   }


### PR DESCRIPTION
@ryanpbrewster going YAGNI on the multiple keep recipients to filter on the intersection page, since it shouldn't be hard to add when we need it. please let me know if I'm messing up your `SchemaReads`.
