### PR TITLE
Filter intersector from "other discussions on this page"

### DIFF
--- a/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/model/KeepRepoTest.scala
@@ -9,6 +9,7 @@ import com.keepit.model.KeepFactory._
 import com.keepit.model.KeepFactoryHelper._
 import com.keepit.model.LibraryFactoryHelper._
 import com.keepit.model.OrganizationFactoryHelper._
+import com.keepit.shoebox.data.keep.KeepRecipientId
 import com.keepit.test._
 import org.joda.time.DateTime
 import org.specs2.mutable._
@@ -65,8 +66,9 @@ class KeepRepoTest extends Specification with ShoeboxTestInjector {
         // Just to ensure that the syntax is valid
         db.readOnlyMaster { implicit s =>
           (ktuRepo.count, ktlRepo.count, libraryMembershipRepo.count, orgMembershipRepo.count)
-          keepRepo.getSectionedKeepsOnUri(Id(1), Id(1), Set.empty, limit = 10)
-          keepRepo.getSectionedKeepsOnUri(Id(1), Id(1), Set(Id(42)), limit = 10)
+          keepRepo.getSectionedKeepsOnUri(Id(1), Id(1), Set.empty, limit = 10, None)
+          keepRepo.getSectionedKeepsOnUri(Id(1), Id(1), Set(Id(42)), limit = 10, None)
+          keepRepo.getSectionedKeepsOnUri(Id(1), Id(1), Set(Id(42)), limit = 10, Some(KeepRecipientId.UserId(Id(1))))
         }
         1 === 1
       }


### PR DESCRIPTION
@ryanpbrewster @leogrim 

when we're on an intersection page (e.g. https://www.kifi.com/int?user=c8c2cbdf-c180-45dd-8164-d72754e8cb11&url=http:%2F%2Fwww.google.com). the "other discussions on this page" widget is supposed to contain all keeps that are on that url but not connected to the intersected entity (user, library, email). 

I think this is the more accurate way to do it, but I'm logging the query time to see if having the client make requests until happy is better.
