### PR TITLE
Single-file exports

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/export/FullStreamingExport.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/export/FullStreamingExport.scala
@@ -20,10 +20,10 @@ import scala.concurrent.Future
 import scala.util.Try
 
 object FullStreamingExport {
-  final case class Root(user: BasicUser, spaces: Enumerator[SpaceExport])
+  final case class Root(user: BasicUser, spaces: Enumerator[SpaceExport], looseKeeps: Enumerator[KeepExport])
   final case class SpaceExport(space: Either[BasicUser, BasicOrganization], libraries: Enumerator[LibraryExport])
   final case class LibraryExport(library: Library, keeps: Enumerator[KeepExport])
-  final case class KeepExport(keep: Keep, discussion: Option[CrossServiceDiscussion], uri: Option[RoverUriSummary])
+  final case class KeepExport(keep: Keep, messages: Seq[Message], uri: Option[RoverUriSummary])
 }
 
 case class KifiExportConfig(bucket: S3Bucket)

--- a/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToUserRepo.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/model/KeepToUserRepo.scala
@@ -15,6 +15,7 @@ trait KeepToUserRepo extends Repo[KeepToUser] {
   def getAllByUserId(userId: Id[User], excludeStateOpt: Option[State[KeepToUser]] = Some(KeepToUserStates.INACTIVE))(implicit session: RSession): Seq[KeepToUser]
   def getByKeepIdAndUserId(keepId: Id[Keep], userId: Id[User], excludeStateOpt: Option[State[KeepToUser]] = Some(KeepToUserStates.INACTIVE))(implicit session: RSession): Option[KeepToUser]
   def getByUserIdAndUriIds(userId: Id[User], uriIds: Set[Id[NormalizedURI]], excludeStateOpt: Option[State[KeepToUser]] = Some(KeepToUserStates.INACTIVE))(implicit session: RSession): Set[KeepToUser]
+  def pageByUserId(userId: Id[User], offset: Int, limit: Int)(implicit session: RSession): Seq[KeepToUser]
   def deactivate(model: KeepToUser)(implicit session: RWSession): Unit
 }
 
@@ -98,6 +99,9 @@ class KeepToUserRepoImpl @Inject() (
   }
   def getByUserIdAndUriIds(userId: Id[User], uriIds: Set[Id[NormalizedURI]], excludeStateOpt: Option[State[KeepToUser]] = Some(KeepToUserStates.INACTIVE))(implicit session: RSession): Set[KeepToUser] = {
     getByUserIdsAndUriIdsHelper(Set(userId), uriIds, excludeStateOpt).list.toSet
+  }
+  def pageByUserId(userId: Id[User], offset: Int, limit: Int)(implicit session: RSession): Seq[KeepToUser] = {
+    activeRows.filter(_.userId === userId).sortBy(_.id).drop(offset).take(limit).list
   }
 
   def deactivate(model: KeepToUser)(implicit session: RWSession): Unit = {

--- a/kifi-backend/modules/shoebox/app/com/keepit/shoebox/data/keep/NewKeepInfosForPage.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/shoebox/data/keep/NewKeepInfosForPage.scala
@@ -1,14 +1,14 @@
 package com.keepit.shoebox.data.keep
 
 import com.keepit.common.crypto.PublicId
-import com.keepit.common.db.{ Id, ExternalId }
+import com.keepit.common.db.{ ExternalId, Id }
 import com.keepit.common.json.{ JsonSchema, SchemaReads }
-import com.keepit.common.mail.{ EmailAddressHash, EmailAddress }
+import com.keepit.common.mail.{ EmailAddress, EmailAddressHash }
 import com.keepit.common.reflection.Enumerator
 import com.keepit.common.util.PaginationContext
-import com.keepit.model.{ KeepRecipients, User, Library, BasicLibrary, Keep }
+import com.keepit.model.{ BasicLibrary, Keep, KeepRecipients, Library, User }
 import com.keepit.social.BasicUser
-import play.api.libs.json.{ JsString, Json, Writes, Reads }
+import play.api.libs.json.{ JsString, Json, Reads, Writes }
 
 case class NewKeepInfosForPage(
   page: Option[NewPageInfo],

--- a/kifi-backend/modules/shoebox/test/com/keepit/export/FullExportFormatterTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/export/FullExportFormatterTest.scala
@@ -4,7 +4,6 @@ import com.google.inject.Injector
 import com.keepit.common.concurrent.FakeExecutionContextModule
 import com.keepit.common.json.EitherFormat
 import com.keepit.common.util.{ EnglishProperNouns, TimedComputation }
-import com.keepit.discussion.Message
 import com.keepit.model.KeepFactoryHelper._
 import com.keepit.model.LibraryFactoryHelper._
 import com.keepit.model.OrganizationFactoryHelper._
@@ -20,12 +19,12 @@ import play.api.libs.json._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, ExecutionContext, Future }
 
-class FullExportProducerTest extends Specification with ShoeboxTestInjector with ShoeboxInjectionHelpers {
+class FullExportFormatterTest extends Specification with ShoeboxTestInjector with ShoeboxInjectionHelpers {
   def modules = Seq(
     FakeExecutionContextModule()
   )
 
-  "FullExportProducer" should {
+  "FullExportFormatter" should {
     def setup()(implicit injector: Injector): (User, Organization, Seq[Library], Seq[Keep]) = db.readWrite { implicit session =>
       val owner = UserFactory.user().withName("Ryan", "Brewster").saved
       val rando = UserFactory.user().withName("Rando", "McRanderson").saved
@@ -48,64 +47,17 @@ class FullExportProducerTest extends Specification with ShoeboxTestInjector with
           KeepFactory.keep().withUser(owner).withLibrary(lib).saved,
           KeepFactory.keep().withUser(rando).withLibrary(lib).saved
         )
-      } :+ KeepFactory.keep().withUser(owner).saved
+      }
       (owner, org, libs, keeps)
     }
-    "provide a streaming export" in {
+    "produce a giant javascript file" in {
       withDb(modules: _*) { implicit injector =>
         val (user, org, libs, keeps) = setup()
-        val stream = TimedComputation.sync(inject[FullExportProducer].fullExport(user.id.get))
-        val root = TimedComputation.sync(Await.result(FullStaticExport.consume(stream.value), Duration.Inf))
-
-        // println(s"starting the stream took ${stream.millis}")
-        // println(s"computing the full export took ${root.millis}")
-        // println(Json.prettyPrint(FullStaticExport.writes.writes(root.value)))
-
-        root.value.spaces.flatMap(_.libraries).map(_.library.id.get).toSet === libs.map(_.id.get).toSet
-        (root.value.keeps ++ root.value.spaces.flatMap(_.libraries.flatMap(_.keeps))).map(_.keep.id.get).toSet === keeps.map(_.id.get).toSet
+        val stream = inject[FullExportProducer].fullExport(user.id.get)
+        val enum = inject[FullExportFormatter].assignments(stream)
+        Await.result(enum.run(Iteratee.foreach(println)), Duration.Inf)
+        1 === 1
       }
     }
-  }
-}
-
-object FullStaticExport {
-  final case class Root(user: BasicUser, spaces: Seq[SpaceExport], keeps: Seq[KeepExport])
-  final case class SpaceExport(space: Either[BasicUser, BasicOrganization], libraries: Seq[LibraryExport])
-  final case class LibraryExport(library: Library, keeps: Seq[KeepExport])
-  final case class KeepExport(keep: Keep, messages: Seq[Message], uri: Option[RoverUriSummary])
-
-  def consume(root: FullStreamingExport.Root)(implicit ec: ExecutionContext): Future[FullStaticExport.Root] = {
-    root.spaces.run(Iteratee.getChunks).flatMap { spaces =>
-      Future.sequence(spaces.map { space =>
-        space.libraries.run(Iteratee.getChunks).flatMap { libraries =>
-          Future.sequence(libraries.map { lib =>
-            lib.keeps.run(Iteratee.getChunks).map { keeps =>
-              FullStaticExport.LibraryExport(lib.library, keeps.map { keep =>
-                FullStaticExport.KeepExport(keep.keep, keep.messages, keep.uri)
-              })
-            }
-          }).map { libraries =>
-            FullStaticExport.SpaceExport(space.space, libraries)
-          }
-        }
-      }).flatMap { spaces =>
-        root.looseKeeps.run(Iteratee.getChunks).map { keeps =>
-          FullStaticExport.Root(root.user, spaces, keeps.map { keep =>
-            FullStaticExport.KeepExport(keep.keep, keep.messages, keep.uri)
-          })
-        }
-      }
-    }
-  }
-
-  implicit val writes: Writes[Root] = OWrites { root =>
-    Json.obj(
-      "user" -> root.user,
-      "spaces" -> JsObject(root.spaces.map { space =>
-        space.space.fold(_.fullName, _.name) -> JsObject(space.libraries.map { library =>
-          library.library.name -> JsArray(library.keeps.map(keep => JsString(keep.keep.url)))
-        })
-      })
-    )
   }
 }


### PR DESCRIPTION
A few performance optimizations (better use of parallelism)
Ensure that all keeps that the requester is a participant in are exported
Horrifying new format 😱 
