### PR TITLE
add admin endpoint to send slack message to users who haven't exported

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/admin/AdminUserController.scala
@@ -13,17 +13,19 @@ import com.keepit.common.core.mapExtensionOps
 import com.keepit.common.db.slick.DBSession._
 import com.keepit.common.db.slick._
 import com.keepit.common.healthcheck.AirbrakeNotifier
+import com.keepit.common.logging.SlackLog
 import com.keepit.common.mail._
 import com.keepit.common.service.IpAddress
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.common.store.S3ImageStore
 import com.keepit.common.time._
+import com.keepit.common.util.{ LinkElement, DescriptionElements }
 import com.keepit.eliza.ElizaServiceClient
 import com.keepit.eliza.model.UserThreadStats
 import com.keepit.heimdal._
 import com.keepit.model.{ KeepToCollection, UserExperiment, _ }
 import com.keepit.search.SearchServiceClient
-import com.keepit.slack.{ SlackClientWrapper, SlackClient }
+import com.keepit.slack.{ InhouseSlackClient, InhouseSlackChannel, SlackClientWrapper, SlackClient }
 import com.keepit.slack.models._
 import com.keepit.social.{ BasicUser, SocialGraphPlugin, SocialId, SocialNetworks, SocialUserRawInfoStore }
 import com.keepit.typeahead.{ KifiUserTypeahead, SocialUserTypeahead, TypeaheadHit }
@@ -126,7 +128,10 @@ class AdminUserController @Inject() (
     slackTeamRepo: SlackTeamRepo,
     tagCommander: TagCommander,
     twitterPublishingCommander: TwitterPublishingCommander,
-    airbrake: AirbrakeNotifier) extends AdminUserActions with PaginationActions {
+    airbrake: AirbrakeNotifier,
+    private implicit val inhouseSlackClient: InhouseSlackClient) extends AdminUserActions with PaginationActions {
+
+  val slackLog = new SlackLog(InhouseSlackChannel.TEST_CAM)
 
   def merge = AdminUserPage { implicit request =>
     // This doesn't do a complete merge. It's designed for cases where someone accidentally creates a new user when
@@ -1093,5 +1098,37 @@ class AdminUserController @Inject() (
     }
 
     Ok.chunked(enum)
+  }
+
+  def sendWindDownSlackDM() = AdminUserAction.async(parse.tolerantJson) { implicit request =>
+    val dryRun = (request.body \ "dryRun").asOpt[Boolean].getOrElse(true)
+    val userId = (request.body \ "userId").asOpt[Id[User]]
+    val fromId = (request.body \ "fromId").asOpt[Id[SlackTeamMembership]]
+
+    val exportUrl = "https://www.kifi.com/keepyourdata"
+    val blogPostUrl = "https://www.kifi.com" // todo(cam): get the blog post link
+    val message = {
+      import DescriptionElements._
+      val msgText = DescriptionElements(
+        "Kifi is joining Google", "(learn more)" --> LinkElement(blogPostUrl), "! The last day to use the Kifi service is August 22nd, 2016.",
+        "Please visit", "Kifi.com/keepyourdata" --> LinkElement(exportUrl), "on your desktop to export all of your data within Kifi.",
+        "You can email support@kifi.com with questions."
+      )
+      SlackMessageRequest.fromKifi(formatForSlack(msgText))
+    }
+
+    val stms = db.readOnlyMaster { implicit request =>
+      //slackTeamMembershipRepo.getMembershipsOfKifiUsersWhoHaventExported(fromId) // ~4000 max
+      userId.map(slackTeamMembershipRepo.getByUserId).getOrElse(Seq.empty)
+    }
+
+    FutureHelpers.sequentialExec(stms.grouped(100).toSeq) { chunk =>
+      val messageFut = if (!dryRun) {
+        Future.sequence(chunk.map { stm =>
+          slackClient.sendToSlackHoweverPossible(stm.slackTeamId, stm.slackUserId.asChannel, message)
+        })
+      } else Future.successful(())
+      messageFut.map(_ => slackLog.info(s"sent to ${chunk.headOption.map(_.id.get)}-${chunk.lastOption.map(_.id.get)}"))
+    }.map { _ => Ok("done") }
   }
 }

--- a/kifi-backend/modules/shoebox/conf/admin.routes
+++ b/kifi-backend/modules/shoebox/conf/admin.routes
@@ -71,6 +71,7 @@ GET     /admin/users                @com.keepit.controllers.admin.AdminUserContr
 GET     /admin/users/message        @com.keepit.controllers.admin.AdminUserController.bulkMessageUsers()
 POST    /admin/users/announceToAllUsers  @com.keepit.controllers.admin.AdminUserController.announceToAllUsers()
 POST    /admin/users/reNormalizedUsername        @com.keepit.controllers.admin.AdminUserController.reNormalizedUsername(readOnly: Boolean ?= true, max: Int ?= 10)
+POST    /admin/users/sendWindDownSlackDM  @com.keepit.controllers.admin.AdminUserController.sendWindDownSlackDM()
 GET     /admin/realUsers            @com.keepit.controllers.admin.AdminUserController.allRegisteredUsersView
 GET     /admin/fakeUsers            @com.keepit.controllers.admin.AdminUserController.allFakeUsersView
 POST    /admin/users/merge          @com.keepit.controllers.admin.AdminUserController.merge

--- a/kifi-backend/modules/shoebox/test/com/keepit/slack/SlackTeamMembershipTest.scala
+++ b/kifi-backend/modules/shoebox/test/com/keepit/slack/SlackTeamMembershipTest.scala
@@ -65,6 +65,23 @@ class SlackTeamMembershipTest extends TestKitSupport with SpecificationLike with
           1 === 1
         }
       }
+
+      "return memberships for users who haven't exported" in {
+        withDb(modules: _*) { implicit injector =>
+
+          db.readWrite { implicit s =>
+            val teams = (1 to 10).map(_ => SlackTeamFactory.team().saved)
+            teams.flatMap(team => (1 to 10).map(_ => SlackTeamMembershipFactory.membership().withTeam(team).saved))
+          }
+
+          db.readOnlyMaster { implicit s =>
+            val stms = inject[SlackTeamMembershipRepo].getMembershipsOfKifiUsersWhoHaventExported(fromId = None)
+            stms.length === inject[SlackTeamMembershipRepo].aTonOfRecords().length
+          }
+
+          1 === 1
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
@leogrim @ryanpbrewster 

@JRuff42 still need an official copy. Right now I have:

"Kifi will be shutting down soon, and we want to make sure you 'keep' your data after we say goodbye. Check out our [blog post] to read more about the whys and hows, or click [here] to export your keeps."
