### PR TITLE
Remove logging to TEST-RYAN and simplify email

### DIFF
--- a/kifi-backend/modules/shoebox/app/com/keepit/export/FullExportProcessingActor.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/export/FullExportProcessingActor.scala
@@ -14,6 +14,7 @@ import com.keepit.common.logging.SlackLog
 import com.keepit.common.mail.{ SystemEmailAddress, ElectronicMail, LocalPostOffice }
 import com.keepit.common.strings.StringSplit
 import com.keepit.common.time._
+import com.keepit.common.util.{ LinkElement, DescriptionElements }
 import com.keepit.model._
 import com.keepit.slack.{ InhouseSlackChannel, InhouseSlackClient }
 import com.kifi.juggle.ConcurrentTaskProcessingActor
@@ -73,8 +74,8 @@ class FullExportProcessingActor @Inject() (
   }
 
   private def doExport(id: Id[FullExportRequest]): Future[Unit] = {
-    slackLog.info(s"Processing export request $id")
     val request = db.readOnlyMaster { implicit s => exportRequestRepo.get(id) }
+    slackLog.info(s"Processing export request $id for user ${request.userId}")
     val enum = exportCommander.fullExport(request.userId)
     val user = db.readOnlyMaster { implicit s => userRepo.get(request.userId) }
     val exportBase = s"[Kifi Export]${user.fullName.words.mkString("-")}-${user.externalId.id}"
@@ -111,7 +112,7 @@ class FullExportProcessingActor @Inject() (
             if (!existingEntries.contains(path)) {
               zip.putNextEntry(new ZipEntry(s"$exportBase/json/$path"))
               zip.write(content.getBytes("UTF-8"))
-              zip.closeEntry
+              zip.closeEntry()
             }
             existingEntries + path
         })
@@ -135,30 +136,28 @@ class FullExportProcessingActor @Inject() (
     }.map(_ => ())
   }
 
-  private def sendSuccessEmail(user: User, request: FullExportRequest): Future[Unit] = {
-    db.readOnlyMasterAsync { implicit s =>
-      exportRequestRepo.getByUser(user.id.get).flatMap(_.notifyEmail) orElse Try(userEmailAddressRepo.getByUser(user.id.get)).toOption
-    }.map {
-      _.fold(ifEmpty = ()) { userEmailAddress =>
-        val email = ElectronicMail(
+  private def sendSuccessEmail(user: User, request: FullExportRequest): Unit = {
+    import DescriptionElements._
+    db.readWrite { implicit s =>
+      val emailAddressOpt = exportRequestRepo.getByUser(user.id.get).flatMap(_.notifyEmail) orElse Try(userEmailAddressRepo.getByUser(user.id.get)).toOption
+      emailAddressOpt.foreach { userEmailAddress =>
+        val body = DescriptionElements.unlines(Seq(
+          DescriptionElements("Visit", "www.kifi.com/keepmykeeps" --> LinkElement("https://www.kifi.com/keepmykeeps"), "to download the file for your export."),
+          DescriptionElements("You can refresh your exported keeps up until the last day the Kifi service is fully operational on August 22nd, 2016."),
+          DescriptionElements(
+            "After that, an export file will be available for several weeks. The latest status is available on", "Kifi.com" --> LinkElement("https://www.kifi.com"),
+            "and you can", "learn more on our blog" --> LinkElement("https://medium.com/on-the-same-page-with-kifi"), "."
+          )
+        ))
+        postOffice.sendMail(ElectronicMail(
           from = SystemEmailAddress.NOTIFICATIONS,
           fromName = Some("Kifi"),
           to = Seq(userEmailAddress),
           subject = s"Your Kifi export is ready!",
-          htmlBody = s"""
-            |Visit <a href="https://www.kifi.com/keepmykeeps">www.kifi.com/keepmykeeps</a> to download the file for your export.
-            |You can refresh your exported keeps up until the last day the Kifi service is fully operational on August 22nd, 2016.
-            |After that, an export file will be available for several weeks. The latest status is available on <a href="https://www.kifi.com">Kifi.com</a> and you can <a href="https://medium.com/on-the-same-page-with-kifi">learn more on our blog</a>.
-          """.stripMargin,
-          textBody = Some(s"""
-            |Visit www.kifi.com/keepmykeeps to download the file for your export.
-            |You can refresh your exported keeps up until the last day the Kifi service is fully operational on August 22nd, 2016.
-            |After that, an export file will be available for several weeks. The latest status is available on Kifi.com and you can learn more on our blog (medium.com/on-the-same-page-with-kifi).
-          """.stripMargin),
+          htmlBody = DescriptionElements.formatAsHtml(body).body,
+          textBody = Some(DescriptionElements.formatPlain(body)),
           category = NotificationCategory.User.EXPORT_READY
-        )
-
-        db.readWriteAsync(implicit s => postOffice.sendMail(email)).map(_ => ())
+        ))
       }
     }
   }

--- a/kifi-backend/modules/shoebox/app/com/keepit/export/FullExportProducer.scala
+++ b/kifi-backend/modules/shoebox/app/com/keepit/export/FullExportProducer.scala
@@ -1,21 +1,21 @@
 package com.keepit.export
 
-import com.google.inject.{ ImplementedBy, Inject, Singleton }
+import com.google.inject.{ImplementedBy, Inject, Singleton}
 import com.keepit.commanders.TagCommander
 import com.keepit.commanders.gen.BasicOrganizationGen
 import com.keepit.common.crypto.PublicIdConfiguration
 import com.keepit.common.db.Id
 import com.keepit.common.db.slick._
-import com.keepit.common.logging.{ Logging, SlackLog }
+import com.keepit.common.logging.Logging
 import com.keepit.common.social.BasicUserRepo
 import com.keepit.common.time._
 import com.keepit.discussion.Message
 import com.keepit.eliza.ElizaServiceClient
 import com.keepit.model._
 import com.keepit.rover.RoverServiceClient
-import com.keepit.slack.{ InhouseSlackChannel, InhouseSlackClient }
+import com.keepit.slack.InhouseSlackClient
 import com.keepit.social.BasicUserLikeEntity
-import play.api.libs.iteratee.{ Enumeratee, Enumerator }
+import play.api.libs.iteratee.{Enumeratee, Enumerator}
 
 import scala.concurrent.ExecutionContext
 
@@ -51,11 +51,9 @@ class FullExportProducerImpl @Inject() (
   implicit val publicIdConfig: PublicIdConfiguration,
   implicit val inhouseSlackClient: InhouseSlackClient)
     extends FullExportProducer with Logging {
-  val slackLog = new SlackLog(InhouseSlackChannel.TEST_RYAN)
   import FullExportCommanderConfig._
 
   def fullExport(userId: Id[User]): FullStreamingExport.Root = {
-    slackLog.info(s"[${clock.now}] Export for user $userId")
     val user = db.readOnlyMaster { implicit s => userRepo.get(userId) }
     val spaces = spacesExport(userId)
     val keeps = looseKeepsExport(userId)


### PR DESCRIPTION
@camhashemi 

I think this is simpler, and persisting an email is very quick so it shouldn't add noticeable overhead (especially compared to the cost of assembling and uploading the export itself).

Thoughts?
